### PR TITLE
Eliminate panic from `uint2` and `uint4` sum aggregations under invalid accumulations

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -1396,7 +1396,14 @@ where
                             | (
                                 AggregateFunc::SumUInt64,
                                 Accum::SimpleNumber { accum, .. },
-                            ) => Datum::from(*accum),
+                            ) => {
+                                if accum.is_negative() {
+                                    warn!("[customer-data] ReduceAccumulable observed a negative sum \
+                                        accumulation over an unsigned type: {aggr:?}: {accum:?} in dataflow {debug_name}");
+                                    soft_assert_or_log!(false, "Invalid negative unsigned aggregation in ReduceAccumulable");
+                                }
+                                Datum::from(*accum)
+                            }
                             (
                                 AggregateFunc::SumFloat32,
                                 Accum::Float {

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -1392,8 +1392,8 @@ where
                             | (
                                 AggregateFunc::SumUInt32,
                                 Accum::SimpleNumber { accum, .. },
-                            ) => Datum::UInt64(u64::try_from(*accum).unwrap_or_else(|_| panic!("Invalid accumulated result {accum} for unsigned function in dataflow {debug_name}"))),
-                            (
+                            )
+                            | (
                                 AggregateFunc::SumUInt64,
                                 Accum::SimpleNumber { accum, .. },
                             ) => Datum::from(*accum),

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -59,6 +59,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-github-15799",
         "test-github-15930",
         "test-github-15496",
+        "test-github-17510",
         "test-remote-storage",
         "test-drop-default-cluster",
         "test-upsert",
@@ -576,6 +577,91 @@ def workflow_test_github_15496(c: Composition) -> None:
         # ensure that an error was put into the logs
         c1 = c.invoke("logs", "clusterd_nopanic", capture=True)
         assert "Mismatched aggregates for key in ReduceCollation" in c1.stdout
+
+
+def workflow_test_github_17510(c: Composition) -> None:
+    """
+    Test that sum aggregations over uint2 and uint4 types do not produce a panic, but
+    rather a SQL-level error when faced with invalid accumulations due to too many
+    retractions in a source. Additionally, we verify that in these cases, an adequate
+    error message is written to the logs.
+
+    Regression test for https://github.com/MaterializeInc/materialize/issues/17510.
+    """
+
+    c.down(destroy_volumes=True)
+    with c.override(
+        Clusterd(
+            name="clusterd_nopanic",
+            environment_extra=[
+                "MZ_SOFT_ASSERTIONS=0",
+            ],
+        ),
+        Testdrive(no_reset=True),
+    ):
+        c.up("testdrive", persistent=True)
+        c.up("materialized")
+        c.up("clusterd_nopanic")
+
+        # set up a test cluster and run a testdrive regression script
+        c.sql(
+            """
+            CREATE CLUSTER cluster1 REPLICAS (
+                r1 (
+                    STORAGECTL ADDRESSES ['clusterd_nopanic:2100'],
+                    STORAGE ADDRESSES ['clusterd_no_panic:2103'],
+                    COMPUTECTL ADDRESSES ['clusterd_nopanic:2101'],
+                    COMPUTE ADDRESSES ['clusterd_nopanic:2102'],
+                    WORKERS 2
+                )
+            );
+            -- Set data for test up
+            SET cluster = cluster1;
+            CREATE TABLE base (data2 uint2, data4 uint4, data8 uint8, diff bigint);
+            CREATE MATERIALIZED VIEW data AS
+              SELECT data2, data4, data8
+              FROM base, repeat_row(diff);
+            CREATE MATERIALIZED VIEW sum_types AS
+              SELECT SUM(data2) AS sum2, SUM(data4) AS sum4, SUM(data8) AS sum8
+              FROM data;
+            INSERT INTO base VALUES (1, 1, 1, 1);
+            INSERT INTO base VALUES (1, 1, 1, -1), (1, 1, 1, -1);
+            """
+        )
+        c.testdrive(
+            dedent(
+                f"""
+            > SET cluster = cluster1;
+
+            # Run a queries that would generate panics before the fix.
+
+            ! SELECT SUM(data2) FROM data;
+            contains:uint8 out of range
+
+            ! SELECT SUM(data4) FROM data;
+            contains:uint8 out of range
+
+            # The following statement succeeds with a negative accumulation,
+            # which is the behavior introduced in https://github.com/MaterializeInc/materialize/pull/16852
+            > SELECT SUM(data8) FROM data;
+            -1
+
+            # Ensure that the output types for uint sums are unaffected.
+            > SELECT c.name, c.type
+              FROM mz_materialized_views mv
+                   JOIN mz_columns c USING (id)
+              WHERE mv.name = 'sum_types'
+              ORDER BY c.type, c.name;
+            sum8 numeric
+            sum2 uint8
+            sum4 uint8
+            """
+            )
+        )
+
+        # ensure that an error was put into the logs
+        c1 = c.invoke("logs", "clusterd_nopanic", capture=True)
+        assert "Invalid negative unsigned aggregation in ReduceAccumulable" in c1.stdout
 
 
 def workflow_test_upsert(c: Composition) -> None:


### PR DESCRIPTION
This PR eliminates a panic raised when a sum aggregation of `uint2` or `uint4` is faced with a negative accumulation. Negative accumulations in reductions can arise due to, e.g., incomplete or invalid source data. The new strategy is to convert the invalid aggregation error into a query-level error instead of a panic by introduction of an MFP that performs appropriate casts and projections. The MFP is currently introduced at the level of `mir_to_lir` lowering, since the concern is closely connected to how rendering deals with invalid accumulations. The latter avoids needing to change how aggregate function evaluation is performed for constant folding, but comes with the trade-off that the MFP cannot be pulled up by the optimizer to be evaluated at a later stage in the plan.

Fixes #17510.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/17510

### Tips for reviewer

The commits can be looked at individually for this PR. Note that we should be very careful here before pressing merge, since we want the output types produced by `uint2` and `uint4` aggregations to be exactly the same as before. That way, we do not have to write a migration of user data. I added a check to that effect in the regression test introduced in the PR.

I struggled with the decision of whether to put this at the level of `mir_to_lir` lowering or whether to put this at the level of lowering from HIR to MIR (e.g., by porting the introduction of a map and a projection to `src/expr/src/relation/mod.rs`). A problem with the latter is that we'd need to cast in all cases, even when we are performing simple constant folding. So the way rendering handles these sum aggregates would percolate to their `AggregateFunc::eval` implementations. It was not clear to me that we wanted this to happen. On the other hand, now the MFP with the cast is put right after the reduction, and the optimizer does not get a chance to move it around. This placement might have undesirable effects, like avoiding arrangement reuse later in the plan. I am very much open to considering moving the introduction of the cast expressions closer to the SQL level, so please let me know if we should go that way.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
N/A
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A