### PR TITLE
buildkite: Purge journalctl files at start of job

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -22,6 +22,10 @@ fi
 
 echo "system uptime: $(cut -f1 -d' ' /proc/uptime)"
 
+ci_collapsed_heading "journalctl: Purging logs ..."
+sudo journalctl --rotate
+sudo journalctl --vacuum-time=1s
+
 ci_collapsed_heading "kind: Make sure kind is running..."
 bin/ci-builder run stable test/cloudtest/setup
 

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -25,6 +25,10 @@ if read_list BUILDKITE_PLUGIN_MZCOMPOSE_ARGS; then
     done
 fi
 
+ci_collapsed_heading "journalctl: Purging logs ..."
+sudo journalctl --rotate
+sudo journalctl --vacuum-time=1s
+
 echo "system uptime: $(cut -f1 -d' ' /proc/uptime)"
 
 # Sometimes build cancellations prevent us from properly cleaning up the last


### PR DESCRIPTION
Purge journalctl files before starting a job so that OOM messages related to prevous jobs run on the same host do not appear in the job's artifacts.

### Motivation

  * This PR fixes a previously unreported bug.

The journalctl artifacts collected by Buildkite could potentially include log messages from a previous job that was run on the same agent.