### PR TITLE
qa: (attempt to) speed up KillClusterdStorage scenario

### DIFF
--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -154,6 +154,8 @@ class KillClusterdStorage(Scenario):
     def actions(self) -> List[Action]:
         return [
             StartMz(),
+            StartClusterdCompute(),
+            UseClusterdCompute(),
             Initialize(self.checks()),
             KillClusterdStorageAction(),
             Manipulate(self.checks(), phase=1),


### PR DESCRIPTION
This scenario has been timing out regularly on many pr's (30 minutes). This may have been exacerbated by recent changes (re-connection _could_ plausibly be slightly slower now, or there could be other changes), and will only get worse when we switch the default storage size to `4-1` or `4-4`. Rather than increase the timeout, I noticed that we were also killing the default cluster (most) queries/mv's were running on, so fixed the scenario to keep the compute clusterd's running. This seems to make a material difference in speed

### Motivation

  * This PR fixes a previously unreported bug.
ci flake


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
