### PR TITLE
storage: drop all ingestion exports when dropping IDed dataflow

### DIFF
--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -728,16 +728,34 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 );
             }
             InternalStorageCommand::DropDataflow(id) => {
-                // Clean up per-source / per-sink state.
-                self.storage_state.source_uppers.remove(&id);
-                self.storage_state.source_tokens.remove(&id);
-                self.storage_state.source_statistics.remove(&id);
+                let ids: BTreeSet<GlobalId> = match self.storage_state.ingestions.get(&id) {
+                    // Without the source dataflow running, all source exports
+                    // should also be considered dropped. n.b. `source_exports`
+                    // includes `id`
+                    Some(IngestionDescription { source_exports, .. }) => {
+                        source_exports.keys().cloned().collect()
+                    }
+                    None => {
+                        let mut ids = BTreeSet::new();
+                        ids.insert(id);
+                        ids
+                    }
+                };
 
-                self.storage_state.sink_tokens.remove(&id);
+                mz_ore::soft_assert!(ids.contains(&id));
+
+                for id in &ids {
+                    // Clean up per-source / per-sink state.
+                    self.storage_state.source_uppers.remove(id);
+                    self.storage_state.source_tokens.remove(id);
+                    self.storage_state.source_statistics.remove(id);
+
+                    self.storage_state.sink_tokens.remove(id);
+                }
 
                 // Report the dataflow as dropped once we went through the whole
                 // control flow from external command to this internal command.
-                self.storage_state.dropped_ids.push(id);
+                self.storage_state.dropped_ids.extend(ids);
             }
         }
     }


### PR DESCRIPTION
This was an uncontroversial change from #17327 that can just be broken out on its own.

### Motivation

This PR fixes a previously unreported bug. We were not communicating that dropping a source also drops all of its ingestion exports, as well.

There is not a meaningful way to test this currently, but @aljoscha has previously agreed that this should be done.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
