### PR TITLE
storage: make pg-snapshot-partial-failure more realistic

### DIFF
--- a/test/cluster/pg-snapshot-partial-failure/03-verify-good-sub-source.td
+++ b/test/cluster/pg-snapshot-partial-failure/03-verify-good-sub-source.td
@@ -8,8 +8,17 @@
 # by the Apache License, Version 2.0.
 
 # The non-stalled sub-source should work.
-#
-# Unfortunately, we can't test that `two` is empty, as its
-# upper has _never_ been moved.
 > SELECT COUNT(*) FROM one;
 10
+
+$ set-regex match=(\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)) replacement=<>
+
+# Note that the above regex does NOT match timestamps that are `0`, and also that we check `can respond immediately` == `false`.
+# We are explicitly checking that the _upper_ of `two` has moved, but we see that we can't actually query any
+# data out of it yet.
+> EXPLAIN TIMESTAMP FOR SELECT * FROM two
+"                query timestamp: <> <>\n          oracle read timestamp: <> <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: false\n                       timeline: Some(EpochMilliseconds)\n\nsource materialize.public.two (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"
+
+# Here we note that the top-level source is also queryable,...
+> EXPLAIN TIMESTAMP FOR SELECT * FROM mz_source
+"                query timestamp: <> <>\n          oracle read timestamp: <> <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: true\n                       timeline: Some(EpochMilliseconds)\n\nsource materialize.public.mz_source (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"


### PR DESCRIPTION
When discussing an issue with: https://github.com/MaterializeInc/materialize/pull/17589, @petrosagg and I noticed that this test was not 100% realistic. Usually, we append a few empty batches and push the upper of the persist shard past `0` before we start to process the snapshot. This is not the behavior we want, but its critical that we _test_ that we inver the `resume_upper` correctly to an `lsn` of 0 so we can handle the partial failure case.

This change makes it so _empty_ batches are appended, but the snapshot for the partially failing subsource doesn't get processed, and uses `EXPLAIN TIMESTAMP` to ensure that the behavior we want is happening

### Motivation

   * This PR refactors existing code.
cleans up a test



### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

