### PR TITLE
Get rid of `cpu_percent_normalized`

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -119,7 +119,6 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 | `replica_id`     | [`uint8`] | The ID of a cluster replica.                               |
 | `process_id`     | [`uint8`] | An identifier of a compute process within a replica.       |
 | `cpu_percent`    | [`uint8`] | Approximate CPU usage, in percent of the total allocation. |
-| `cpu_percent_normalized`    | [`uint8`] | Approximate CPU usage, in percent of the total number of timely workers. Can exceed 100, as threads other than timely workers may be scheduled. |
 | `memory_percent` | [`uint8`] | Approximate RAM usage, in percent of the total allocation. |
 
 ### `mz_dataflows`

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2393,7 +2393,6 @@ SELECT
     r.id AS replica_id,
     m.process_id,
     m.cpu_nano_cores::float8 / s.cpu_nano_cores * 100 AS cpu_percent,
-    m.cpu_nano_cores::float8 / (s.workers * 10000000) AS cpu_percent_normalized,
     m.memory_bytes::float8 / s.memory_bytes * 100 AS memory_percent
 FROM
     mz_cluster_replicas AS r

--- a/test/testdrive/metrics-cluster.td
+++ b/test/testdrive/metrics-cluster.td
@@ -15,7 +15,6 @@
       c.name,
       r.name,
       u.process_id,
-      u.cpu_percent_normalized >= 0.0,
       u.cpu_percent >= 0.0,
       u.memory_percent > 0.0
   FROM
@@ -26,11 +25,11 @@
               ON r.id = u.replica_id
   WHERE c.name IN ( 'foo', 'bar', 'xyzzy' )
   ORDER BY c.name, r.name, process_id
-foo size_1 0 true true true
-foo size_2_2 0 true true true
-foo size_2_2 1 true true true
-foo size_32 0 true true true
-xyzzy size_4 0 true true true
+foo size_1 0 true true
+foo size_2_2 0 true true
+foo size_2_2 1 true true
+foo size_32 0 true true
+xyzzy size_4 0 true true
 
 > DROP CLUSTER foo
 > DROP CLUSTER bar


### PR DESCRIPTION
IMO, this field is more confusing than it's worth. We added it as a hack to get semi-useful CPU metrics in the face of Hyper-Threading (see the discussion [here](https://gist.github.com/umanwizard/bdf188d1dfe4c362a6ec85a23b0c6691#hyper-threading-and-cpu_percent_normalized)).

However, we then found that due to idle merge skew (see the discussion [here](https://gist.github.com/umanwizard/bdf188d1dfe4c362a6ec85a23b0c6691#idle-merging-and-why-cpu-utilization-metrics-are-of-limited-usefulness)), CPU metrics were an unreliable proxy for fraction of available throughput used, so we aren't exposing them anyway. Thus, there's absolutely no reason to keep this around.

My recommendation, after we delete this column, is as follows:

1. publicly document (based on the gist linked above) the issues with interpreting CPU time.
1. Dial up our allocations to let Timely use all (or most) of the available logical cores on the machine, unless we have specific evidence that that will decrease performance for important workloads.
1.  Expose the CPU metrics, and link to the caveat doc from them.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Get rid of `cpu_percent_normalized` column in `mz_cluster_replica_utilization`