### PR TITLE
doc: Add design doc for RBAC

### DIFF
--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -150,14 +150,13 @@ privileges of that role via `SET ROLE`. We will add the following SQL commands:
           this as future work.
     - Circular memberships are NOT allowed.
     - `GROUP` is ignored.
-- `REVOKE <group_role> FROM [ GROUP ] <role> [ CASCADE | RESTRICT ]`
+- `REVOKE <group_role> FROM [ GROUP ] <role>`
     - Removes `<role>` as a member from `<group_role>`.
     - Any role with the `CREATEROLE` attribute OR superusers can revoke membership from any other member.
         - `CREATEROLE` roles cannot revoke roles with `SUPERUSER`.
         - Note: PostgreSQL allows other roles to grant membership with the `WITH ADMIN OPTION` option. We will leave
           this as future work.
     - `GROUP` is ignored.
-    - Default is `RESTRICT`.
 
 We will modify `DROP ROLE <role_name>` so that when `<role_name>` is dropped, all other roles have their membership
 revoked.
@@ -193,6 +192,7 @@ NOTE: Since we won't support `SET ROLE` yet, these functions will all behave ide
 
 #### Out of Scope for Project
 
+- `CASCADE` and `RESTRICT` options in `REVOKE`.
 - `CURRENT_ROLE`, `CURRENT_USER`, and `SESSION_USER` aliases for `<role>` in `GRANT` and `REVOKE`.
 - `GRANTED BY` option for `GRANT` and `REVOKE`.
 - `[ WITH ADMIN OPTION ]` option for `GRANT`.

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -234,18 +234,18 @@ Below is a summary of the default owners and privileges of all builtin objects:
 
 - The `mz_system` cluster will be owned by the `mz_system` role.
 - The `mz_system` role will have `UC` privileges on the `mz_system` cluster.
-- The `mz_introspection` cluster will be owned by the `mz_introspection` role.
+- The `mz_introspection` cluster will be owned by the `mz_system` role.
 - The `mz_introspection` role will have `UC` privileges on the `mz_introspection` cluster.
 - All roles will have `U` privileges on the `mz_introspection` cluster.
 - The `default` cluster will be owned by the `mz_system` role.
 - The `mz_system` role will have `UC` privileges on the `default` cluster.
 - The `materialize` database will be owned by the `mz_system` role.
-- The `mz_sytem` role will have `UC` privileges on the `materialize` database.
+- The `mz_system` role will have `UC` privileges on the `materialize` database.
 - The `materialize.public` schema will be owned by the `mz_system` role.
 - The `mz_system` role will have `UC` privileges on the `materialize.public` schema.
 - The `mz_system` role will own all catalog schemas [`pg_catalog`, `mz_catalog`, `mz_internal`, `information_schema`].
-- All roles will have `U` privileges on all catalog schemas.
-- All roles will have `r` privileges on all objects within all catalog schemas.
+- The `PUBLIC` pseudo-role will have `U` privileges on all catalog schemas.
+- The `PUBLIC` pseudo-role will have `r` privileges on all objects within all catalog schemas.
 
 Here is a summary of all the privileges, attributes, and ownership needed to perform certain actions:
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -200,7 +200,14 @@ NOTE: Since we won't support `SET ROLE` yet, these functions will all behave ide
 - `SET ROLE`
 - `RESET ROLE`
 
-### Phase 3 - Privileges
+### Phase 3 - `PUBLIC` role
+
+See [Grant](https://www.postgresql.org/docs/current/sql-grant.html) for PostgreSQL `PUBLIC` details (grep for PUBLIC).
+
+`PUBLIC` is a special keyword that is accepted anywhere a role name would be accepted. The key word PUBLIC indicates
+that the changes are to be applied to all roles, including those that might be created later.
+
+### Phase 4 - Privileges
 
 See [Privileges](https://www.postgresql.org/docs/current/ddl-priv.html) for PostgreSQL privileges.
 
@@ -365,13 +372,6 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
     - `Table column`
     - `TABLESPACE`
 - Adding the necessary pg views to support all role based `psql` meta-commands.
-
-### Phase 4 - `PUBLIC` role
-
-See [Grant](https://www.postgresql.org/docs/current/sql-grant.html) for PostgreSQL `PUBLIC` details (grep for PUBLIC).
-
-`PUBLIC` is a special keyword that is accepted anywhere a role name would be accepted. The key word PUBLIC indicates
-that the changes are to be applied to all roles, including those that might be created later.
 
 ### Phase 5 - Utility Commands/Syntactic Sugar (Optional)
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -360,20 +360,24 @@ within that view.
 
 We will add the following SQL commands:
 
-- `GRANT <privilege> ON <object> TO [ GROUP ] <role>`
+- `GRANT <privilege> ON <object-type> <object> TO [ GROUP ] <role>`
     - Gives `<privilege>` on `<object>` to `<role>`.
     - Only the owner of `<object>` can grant privileges on it.
         - Note: PostgreSQL allows other roles to grant privileges with the `WITH GRANT OPTION` option.
     - `GROUP` is ignored.
-- `GRANT ALL [ PRIVILEGES ] ON <object> TO [ GROUP ] <role>`
+    - For tables, views, materialized, and source, the object type can be omitted. 
+    - For views, materialized views, and sources, the object type must be `TABLE` if not omitted.
+- `GRANT ALL [ PRIVILEGES ] ON <object-type> <object> TO [ GROUP ] <role>`
     - Same as grant above, but for all privileges.
     - `PRIVILEGES` is ignored.
-- `REVOKE <privilege> ON <object> FROM [ GROUP ] <role>`
+- `REVOKE <privilege> ON <object-type> <object> FROM [ GROUP ] <role>`
     - Revokes `<privilege>` on `<object>` from `<role>`.
     - Only the owner of `<object>` can revoke privileges from it.
         - Note: PostgreSQL allows other roles to revoke privileges with the `WITH GRANT OPTION` option.
     - `GROUP` is ignored.
-- `REVOKE ALL [ PRIVILEGES ] ON <object> FROM [ GROUP ] <role>`
+    - For tables, views, materialized, and source, the object type can be omitted. 
+    - For views, materialized views, and sources, the object type must be `TABLE` if not omitted.
+- `REVOKE ALL [ PRIVILEGES ] ON <object-type> <object> FROM [ GROUP ] <role>`
     - Same as revoke above but for all privileges.
     - `PRIVILEGES` is ignored.
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -97,6 +97,8 @@ cannot specify these attributes in `CREATE ROLE` or `ALTER ROLE`. We use the fol
   session.
 - When you log in to a role with Frontegg and your JWT has the "Organization Admin" role, you implicitly get
   the `SUPERUSER` attribute for that session.
+    - The `SUPERUSER` attribute will be periodically updated as part of the periodic Frontegg re-validation done for
+      pgwire connections.
 
 This differs from PostgreSQL, which treats these as normal role attributes that persists between sessions and can be
 specified in `CREATE ROLE` and `ALTER ROLE`.

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -230,6 +230,7 @@ We will support the following object types:
 | `VIEW`               | r              | Yes             |
 | `MATERIALIZED  VIEW` | r              | Yes             |
 | `INDEX`              |                | Yes             |
+| `TYPE`               | U              | Yes             |
 | `SOURCE`             | r              | No              |
 | `SINK`               |                | No              |
 | `CONNECTION`         | U              | No              |
@@ -259,6 +260,7 @@ Below is a summary of the default owners and privileges of all builtin objects:
 - The `mz_system` role will own all catalog schemas [`pg_catalog`, `mz_catalog`, `mz_internal`, `information_schema`].
 - The `PUBLIC` pseudo-role will have `U` privileges on all catalog schemas.
 - The `PUBLIC` pseudo-role will have `r` privileges on all objects within all catalog schemas.
+- The `PUBLIC` psuedo-role will have `U` privileges on all type.
 
 Here is a summary of all the privileges, attributes, and ownership needed to perform certain actions:
 
@@ -365,7 +367,6 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
     - `SEQUENCE`
     - `Table column`
     - `TABLESPACE`
-    - `TYPE`
 - Adding the necessary pg views to support all role based `psql` meta-commands.
 
 ### Phase 5 - Utility Commands (Optional)
@@ -431,8 +432,6 @@ This is an optional phase to add some utility commands present in PostgreSQL. We
 
 ## Open questions
 
-- PostgreSQL grants certain privileges on certain object types to all roles. None of those overlap with the set of
-  objects and privileges we have, but do we want to do something similar?
 - Do we want different `SELECT` privileges based on if a new dataflow will be spun up or if we can use an existing one?
     - Pros: We can differentiate between using existing compute resources vs creating new ones when reading.
     - Cons: Users (and the database) are unable to determine if they're allowed to execute a read until after that read

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -406,6 +406,9 @@ This is an optional phase to add some utility commands present in PostgreSQL. We
   if `RBAC_CHECK_ENABLED` is disabled.
 - Organizations can set up all the existing roles with their desired privileges and then toggle `RBAC_CHECKS_ENABLED` on
   and off to test that roles are set up properly.
+- A user role called `mz_default_owner` will be created in all existing deployments. A migrations will
+  assign `mz_default_owner` as the owner of all existing objects. Superusers will be able to re-assign ownership for all
+  of these objects.
 
 ## Testing Plan
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -399,18 +399,13 @@ This is an optional phase to add some utility commands present in PostgreSQL. We
 
 ## Rollout Plan
 
-- All new SQL commands will be gated by unsafe mode (or LaunchDarkly depending on the standard for feature flags when
-  this is implemented).
-- Specifying attributes in `CREATE ROLE` will be gated by unsafe mode (or LaunchDarkly depending on the standard for
-  feature flags when this is implemented).
-- All roles that authenticate through Frontegg will be given the `SUPERUSER` session attribute. This matches the
-  existing behavior where all roles have the `SUPERUSER` attribute.
-- Roles that are not authenticated through Frontegg, will not be given the `SUPERUSER` session attribute. This allows us
-  to test various permissions locally.
-- When we are ready to release this feature, we will do the following:
-    - Remove the unsafe gate from new SQL commands and role attributes.
-    - Modify the Frontegg authentication so that only roles that are Frontegg admins are given the `SUPERUSER` session
-      attribute.
+- There will be a boolean system variable called `RBAC_CHECKS_ENABLED` that can be toggled by any superuser. The flag
+  will determine whether the Coordinator checks role privileges before executing commands.
+- Existing environments will default to `false`, however new environments will default to `true`.
+- All new SQL commands will be available to all users. The SQL commands will update user privileges, but emit a notice
+  if `RBAC_CHECK_ENABLED` is disabled.
+- Organizations can set up all the existing roles with their desired privileges and then toggle `RBAC_CHECKS_ENABLED` on
+  and off to test that roles are set up properly.
 
 ## Testing Plan
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -200,14 +200,7 @@ NOTE: Since we won't support `SET ROLE` yet, these functions will all behave ide
 - `SET ROLE`
 - `RESET ROLE`
 
-### Phase 3 - `PUBLIC` role
-
-See [Grant](https://www.postgresql.org/docs/current/sql-grant.html) for PostgreSQL `PUBLIC` details (grep for PUBLIC).
-
-`PUBLIC` is a special keyword that is accepted anywhere a role name would be accepted. The key word PUBLIC indicates
-that the changes are to be applied to all roles, including those that might be created later.
-
-### Phase 4 - Privileges
+### Phase 3 - Privileges
 
 See [Privileges](https://www.postgresql.org/docs/current/ddl-priv.html) for PostgreSQL privileges.
 
@@ -372,6 +365,13 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
     - `Table column`
     - `TABLESPACE`
 - Adding the necessary pg views to support all role based `psql` meta-commands.
+
+### Phase 4 - `PUBLIC` role
+
+See [Grant](https://www.postgresql.org/docs/current/sql-grant.html) for PostgreSQL `PUBLIC` details (grep for PUBLIC).
+
+`PUBLIC` is a special keyword that is accepted anywhere a role name would be accepted. The key word PUBLIC indicates
+that the changes are to be applied to all roles, including those that might be created later.
 
 ### Phase 5 - Utility Commands/Syntactic Sugar (Optional)
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -398,11 +398,11 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
         - `grantee: RoleId`
         - `grantor: RoleId`
         - `privs: AclMode`
-    - We will encode it as text using the following format: "<grantee>=<privs>/<grantor>"
-        - "<grantee>" is the raw RoleId of `grantee`.
+    - We will encode it as text using the following format: `"<grantee>=<privs>/<grantor>"`
+        - `"<grantee>"` is the raw RoleId of `grantee`.
             - This will be left empty for the PUBLIC role (to match PostgreSQL). 
-        - "<grantor>" is the raw RoleId of `grantor`.
-        - "<privs>" is the letter codes of all the granted privileges concatenated together.
+        - `"<grantor>"` is the raw RoleId of `grantor`.
+        - `"<privs>"` is the letter codes of all the granted privileges concatenated together.
         - NOTE: This is not the same as PostgreSQL. PostgreSQL encodes `aclitem` to text using human
         read-able names instead of IDs. We are unable to do this because our encoder does not have 
         access to the catalog. We have the same issue with the `regtype` and `regproc` types.

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -81,7 +81,9 @@ We will add the following SQL statement:
         - `SUPERUSER` can run this without `CREATEROLE`.
     - `WITH` is ignored.
 
-When a new user logs in, we will create a new role for them with only the `INHERIT` attribute.
+When a new user logs in, as long as they were successfully authenticated through an external port, we will create a new
+role for them with only the `INHERIT` attribute. This will also allow us to delete the `materialize` role without
+breaking local development.
 
 We will also support the following session specific attributes:
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -204,8 +204,16 @@ NOTE: Since we won't support `SET ROLE` yet, these functions will all behave ide
 
 See [Grant](https://www.postgresql.org/docs/current/sql-grant.html) for PostgreSQL `PUBLIC` details (grep for PUBLIC).
 
-`PUBLIC` is a special keyword that is accepted anywhere a role name would be accepted. The key word PUBLIC indicates
-that the changes are to be applied to all roles, including those that might be created later.
+`PUBLIC` is a special keyword that is accepted in some locations where a role name would be accepted. The key word
+PUBLIC indicates that the changes are to be applied to all roles, including those that might be created later. `PUBLIC`
+is not allowed in `CREATE ROLE`, `ALTER ROLE`, `DROP ROLE`, `GRANT <group_role> TO <role>`,
+and `REVOKE <group_role> FROM <role>`.
+
+#### Implementation Details
+
+- A new variant to `RoleId` will be added called `Public`.
+- The `PUBLIC` role will be added to the catalog with an id of `RoleId::Public`.
+- The sequencer/catalog will reject the `RoleId::Public` variant in all disallowed operations.
 
 ### Phase 4 - Privileges
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -315,13 +315,14 @@ We will add the following SQL commands:
     - Requires `CREATE` privilege on all schemas and databases where all objects reside.
         - TODO: This isn't explicitly stated in th docs, but would make sense base on the `ALTER` privileges. I will
           double-check this.
-    - In PostgreSQL, this only affects the current database. We will diverge here and have it affect all databases.
+    - In PostgreSQL, this only affects the current database, and does not reassign the database itself. We will diverge
+      here and have it affect all databases, including the databases themselves.
 - `DROP OWNED BY <name> [ CASCADE | RESTRICT]`
     - Drops all objects owned by `<name>`.
     - Requires membership of `<name>`.
-    - In PostgreSQL, this only affects the current database. We will diverge here and have it affect all databases.
+    - In PostgreSQL, this only affects the current database, and does not drop the database itself. We will diverge here
+      and have it affect all databases, including the databases themselves.
     - Revokes all privileges granted to `<name>`.
-    - Does not drop owned databases or clusters.
     - Default is `RESTRICT`.
 
 We will update `DROP ROLE` so that roles cannot be dropped until it meets the following criteria:
@@ -380,5 +381,4 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
     - Cons: Users (and the database) are unable to determine if they're allowed to execute a read until after that read
       has been fully planned.
 - What views/functions/commands do we want to add to help users query the current set of privileges.
-- Do we want to change `DROP OWNED` so that it drops databases and clusters?
 - What are security labels in PostgreSQL and do we want them?

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -177,7 +177,12 @@ NOTE: Since we won't support `SET ROLE` yet, these functions will all behave ide
 
 #### Implementation Details
 
-- The catalog will store role membership.
+- The catalog will store role membership in a new table called `mz_auth_members` modeled
+  after [`pg-auth-members`](https://www.postgresql.org/docs/current/catalog-pg-auth-members.html), which has the
+  following columns:
+    - `roleid`: `RoleId`
+    - `member`: `RoleId`
+    - `grantor`: `RoleId`
 - When attributes are checked in the sequencer, we will check the attributes of all roles that the current role is a
   member of.
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -400,22 +400,22 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
         - `privs: AclMode`
     - We will encode it as text using the following format: `"<grantee>=<privs>/<grantor>"`
         - `"<grantee>"` is the raw RoleId of `grantee`.
-            - This will be left empty for the PUBLIC role (to match PostgreSQL). 
+            - This will be left empty for the PUBLIC role (to match PostgreSQL).
         - `"<grantor>"` is the raw RoleId of `grantor`.
         - `"<privs>"` is the letter codes of all the granted privileges concatenated together.
         - NOTE: This is not the same as PostgreSQL. PostgreSQL encodes `aclitem` to text using human
-        read-able names instead of IDs. We are unable to do this because our encoder does not have 
+        read-able names instead of IDs. We are unable to do this because our encoder does not have
         access to the catalog. We have the same issue with the `regtype` and `regproc` types.
     - We will encode it as binary matching PostgreSQL's binary encoding for `aclitem`, except
-    swapping out `oid`s for `RoleId`s. 
+    swapping out `oid`s for `RoleId`s.
     - The reason we need a custom type instead of reusing the PostgreSQL's `aclitem` type is because
     `aclitem` uses `oid` types, which Materialize does not use as a persistent identifier.
-- We will also add an array type with `maclitem` elements. 
+- We will also add an array type with `maclitem` elements.
 - We will add the following operators for `maclitem`:
     - `maclitem = maclitem → boolean`: Are `maclitems` equal?
     - `maclitem[] @> maclitem → boolean`: Does array contain the specified privileges?
 - We will support to following casts involving `maclitem`:
-    - From `maclitem` to `text`. 
+    - From `maclitem` to `text`.
 - The following catalog table/views will have an additional column called "acl" of type `maclitem[]`.
 that stores all privileges belonging to an object.
     - mz_sinks

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -392,6 +392,9 @@ This is an optional phase to add some utility commands present in PostgreSQL. We
 
 - `CURRENT_ROLE`, `CURRENT_USER`, `SESSION_USER`, aliases in `GRANT`, `REVOKE`, `ALTER`, `REASSIGN OWNED`
   and `DROP OWNED`.
+- Row level security policies (https://www.postgresql.org/docs/current/ddl-rowsecurity.html). If any catalog object
+  contains sensitive information, then all users will be able to read all the contents. As a follow-up project, we can
+  implement row level security to prevent this.
 
 ## Rollout Plan
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -365,7 +365,7 @@ We will add the following SQL commands:
     - Only the owner of `<object>` can grant privileges on it.
         - Note: PostgreSQL allows other roles to grant privileges with the `WITH GRANT OPTION` option.
     - `GROUP` is ignored.
-    - For tables, views, materialized, and source, the object type can be omitted. 
+    - For tables, views, materialized, and source, the object type can be omitted.
     - For views, materialized views, and sources, the object type must be `TABLE` if not omitted.
 - `GRANT ALL [ PRIVILEGES ] ON <object-type> <object> TO [ GROUP ] <role>`
     - Same as grant above, but for all privileges.
@@ -375,7 +375,7 @@ We will add the following SQL commands:
     - Only the owner of `<object>` can revoke privileges from it.
         - Note: PostgreSQL allows other roles to revoke privileges with the `WITH GRANT OPTION` option.
     - `GROUP` is ignored.
-    - For tables, views, materialized, and source, the object type can be omitted. 
+    - For tables, views, materialized, and source, the object type can be omitted.
     - For views, materialized views, and sources, the object type must be `TABLE` if not omitted.
 - `REVOKE ALL [ PRIVILEGES ] ON <object-type> <object> FROM [ GROUP ] <role>`
     - Same as revoke above but for all privileges.

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -159,8 +159,6 @@ privileges of that role via `SET ROLE`. We will add the following SQL commands:
     - `GROUP` is ignored.
     - Default is `RESTRICT`.
 
-We will add the following options to `CREATE ROLE`:`IN ROLE`,`IN GROUP`,`ROLE`,`USER`.
-
 We will modify `DROP ROLE <role_name>` so that when `<role_name>` is dropped, all other roles have their membership
 revoked.
 
@@ -191,6 +189,7 @@ NOTE: Since we won't support `SET ROLE` yet, these functions will all behave ide
 - `GRANT` privileges.
 - `REVOKE` privileges.
 - `PUBLIC` alias for `<role>` in `GRANT` and `REVOKE`.
+- The following options to `CREATE ROLE`:`IN ROLE`,`IN GROUP`,`ROLE`,`USER`.
 
 #### Out of Scope for Project
 
@@ -374,9 +373,10 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
     - `TABLESPACE`
 - Adding the necessary pg views to support all role based `psql` meta-commands.
 
-### Phase 5 - Utility Commands (Optional)
+### Phase 5 - Utility Commands/Syntactic Sugar (Optional)
 
-This is an optional phase to add some utility commands present in PostgreSQL. We will add the following SQL commands:
+This is an optional phase to add some utility commands and syntactic sugar present in PostgreSQL. We will add the
+following SQL commands and options to existing commands:
 
 - `REASSIGN OWNED BY <old_role> TO <new_role>`
     - Transfers ownership of all objects owned by `<old_role>` to `<new_role>`.
@@ -393,6 +393,7 @@ This is an optional phase to add some utility commands present in PostgreSQL. We
       and have it affect all databases, including the databases themselves.
     - Revokes all privileges granted to `<name>`.
     - Default is `RESTRICT`.
+- The following options to `CREATE ROLE`:`IN ROLE`,`IN GROUP`,`ROLE`,`USER`.
 
 #### Out of Scope for Project
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -310,15 +310,16 @@ useful. We remove privileges that don't make sense.
 
 Below is a summary of the default privileges of all builtin objects:
 
-- The `mz_system` role will have `UC` privileges on the `mz_system` cluster.
 - The `mz_introspection` role will have `UC` privileges on the `mz_introspection` cluster.
-- The `mz_system` role will have `UC` privileges on the `default` cluster.
-- The `mz_system` role will have `UC` privileges on the `materialize` database.
-- The `mz_system` role will have `UC` privileges on the `materialize.public` schema.
 - The `PUBLIC` pseudo-role will have `U` privileges on the `mz_introspection` cluster.
+- The `PUBLIC` psuedo-role will have `UC` privileges on the `default` cluster.
+- The `PUBLIC` psuedo-role will have `UC` privileges on the default `materialize` database.
+- The `PUBLIC` psuedo-role will have `UC` privileges on all `public` schemas (the default schema
+  created in every database).
 - The `PUBLIC` pseudo-role will have `U` privileges on all catalog schemas.
-- The `PUBLIC` pseudo-role will have `r` privileges on all objects within all catalog schemas.
-- The `PUBLIC` psuedo-role will have `U` privileges on all type.
+- The `PUBLIC` pseudo-role will have `r` privileges on all applicable objects within all catalog
+  schemas.
+- The `PUBLIC` psuedo-role will have `U` privileges on all types.
 
 Here is a summary of all the privileges, attributes, and ownership needed to perform certain actions:
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -245,22 +245,22 @@ We will update `DROP ROLE` so that roles cannot be dropped unless no objects are
 - The following catalog tables/views will have an additional column called "owner_id" of type string. It will be the
   role ID of the owner of the object. Additionally, the corresponding stash collections will have an "owner_id"
   field.
-  - mz_sinks
-  - mz_indexes
-  - mz_connections
-  - mz_types
-  - mz_functions
-  - mz_secrets
-  - mz_tables
-  - mz_sources
-  - mz_views
-  - mz_materialized_views
-  - mz_databases
-  - mz_clusters
-  - mz_cluster_replica
-  - mz_schemas
-  - mz_relations
-  - mz_objects
+    - mz_sinks
+    - mz_indexes
+    - mz_connections
+    - mz_types
+    - mz_functions
+    - mz_secrets
+    - mz_tables
+    - mz_sources
+    - mz_views
+    - mz_materialized_views
+    - mz_databases
+    - mz_clusters
+    - mz_cluster_replica
+    - mz_schemas
+    - mz_relations
+    - mz_objects
 - Ownership will be checked before operations in the sequencer.
 
 #### Out of Scope for Phase
@@ -382,7 +382,7 @@ We will update `ALTER <object_type> <object_name> OWNER TO <new_owner>` such tha
   - Rationale is that this is equivalent to `DROP` then `CREATE`.
 - Requires `CREATE` privilege on the database where `<object_name>` resides if the object is a database.
 
-We will update `DROP ROLE` so that roles cannot be dropped unless it the role contains no privileges.
+We will update `DROP ROLE` so that roles cannot be dropped unless the role contains no privileges.
 
 We will update `DROP <object>` so that it revokes all privileges on `<object>`.
 
@@ -395,29 +395,45 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
     - This is modeled after the `aclitem` item in PostgreSQL, see
     https://github.com/postgres/postgres/blob/3aa961378b4e517908a4400cdc476ca299693de9/src/include/utils/acl.h#L48-L59.
     - It will include the following fields:
-        - `grantee: ObjectId`
+        - `grantee: RoleId`
         - `grantor: RoleId`
         - `privs: AclMode`
+    - We will encode it as text using the following format: "<grantee>=<privs>/<grantor>"
+        - "<grantee>" is the raw RoleId of `grantee`.
+            - This will be left empty for the PUBLIC role (to match PostgreSQL). 
+        - "<grantor>" is the raw RoleId of `grantor`.
+        - "<privs>" is the letter codes of all the granted privileges concatenated together.
+        - NOTE: This is not the same as PostgreSQL. PostgreSQL encodes `aclitem` to text using human
+        read-able names instead of IDs. We are unable to do this because our encoder does not have 
+        access to the catalog. We have the same issue with the `regtype` and `regproc` types.
+    - We will encode it as binary matching PostgreSQL's binary encoding for `aclitem`, except
+    swapping out `oid`s for `RoleId`s. 
     - The reason we need a custom type instead of reusing the PostgreSQL's `aclitem` type is because
     `aclitem` uses `oid` types, which Materialize does not use as a persistent identifier.
+- We will also add an array type with `maclitem` elements. 
+- We will add the following operators for `maclitem`:
+    - `maclitem = maclitem → boolean`: Are `maclitems` equal?
+    - `maclitem[] @> maclitem → boolean`: Does array contain the specified privileges?
+- We will support to following casts involving `maclitem`:
+    - From `maclitem` to `text`. 
 - The following catalog table/views will have an additional column called "acl" of type `maclitem[]`.
 that stores all privileges belonging to an object.
-  - mz_sinks
-  - mz_indexes
-  - mz_connections
-  - mz_types
-  - mz_functions
-  - mz_secrets
-  - mz_tables
-  - mz_sources
-  - mz_views
-  - mz_materialized_views
-  - mz_databases
-  - mz_clusters
-  - mz_cluster_replica
-  - mz_schemas
-  - mz_relations
-  - mz_objects
+    - mz_sinks
+    - mz_indexes
+    - mz_connections
+    - mz_types
+    - mz_functions
+    - mz_secrets
+    - mz_tables
+    - mz_sources
+    - mz_views
+    - mz_materialized_views
+    - mz_databases
+    - mz_clusters
+    - mz_cluster_replica
+    - mz_schemas
+    - mz_relations
+    - mz_objects
 - Privileges will be checked before operations in the sequencer.
 
 #### Out of Scope for Project

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -346,6 +346,24 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
 
 #### Implementation Details
 
+- The following catalog tables/views will have an additional column called "owner_id" of type string. It will be the
+  role ID of the owner of the object. Additionally, the corresponding stash collections will have an "owner_id"
+  field.
+    - mz_sinks
+    - mz_indexes
+    - mz_connections
+    - mz_types
+    - mz_functions
+    - mz_secrets
+    - mz_relations
+    - mz_tables
+    - mz_sources
+    - mz_views
+    - mz_materialized_views
+    - mz_databases
+    - mz_clusters
+    - mz_cluster_replica
+    - mz_schemas
 - Privileges will be stored in the catalog.
 - Privileges will be checked before operations in the sequencer.
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -309,21 +309,6 @@ We will add the following SQL commands:
     - Requires `CREATE` privilege on the schema where `<object_name>` resides if the object resides in a schema.
         - Rationale is that this is equivalent to `DROP` then `CREATE`.
     - Requires `CREATE` privilege on the database where `<object_name>` resides if the object is a database.
-- `REASSIGN OWNED BY <old_role> TO <new_role>`
-    - Transfers ownership of all objects owned by `<old_role>` to `<new_role>`.
-    - Can only be run by a member of `<old_role>` and `<new_role>` or a superuser.
-    - Requires `CREATE` privilege on all schemas and databases where all objects reside.
-        - TODO: This isn't explicitly stated in th docs, but would make sense base on the `ALTER` privileges. I will
-          double-check this.
-    - In PostgreSQL, this only affects the current database, and does not reassign the database itself. We will diverge
-      here and have it affect all databases, including the databases themselves.
-- `DROP OWNED BY <name> [ CASCADE | RESTRICT]`
-    - Drops all objects owned by `<name>`.
-    - Requires membership of `<name>`.
-    - In PostgreSQL, this only affects the current database, and does not drop the database itself. We will diverge here
-      and have it affect all databases, including the databases themselves.
-    - Revokes all privileges granted to `<name>`.
-    - Default is `RESTRICT`.
 
 We will update `DROP ROLE` so that roles cannot be dropped until it meets the following criteria:
 
@@ -337,10 +322,13 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
 - Privileges will be stored in the catalog.
 - Privileges will be checked before operations in the sequencer.
 
+#### Out of Scope for Phase
+
+- `REASSIGN OWNED`
+- `DROP OWNED`
+
 #### Out of Scope for Project
 
-- `CURRENT_ROLE`, `CURRENT_USER`, `SESSION_USER`, aliases in `GRANT`, `REVOKE`, `ALTER`, `REASSIGN OWNED`
-  and `DROP OWNED`.
 - `GRANTED BY` option for `GRANT` and `REVOKE`.
 - `WITH GRANT OPTION` in `GRANT`.
 - `GRANT OPTION FOR` in `REVOKE`.
@@ -366,6 +354,31 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
     - `TABLESPACE`
     - `TYPE`
 - Adding the necessary pg views to support all role based `psql` meta-commands.
+
+### Phase 5 - Utility Commands (Optional)
+
+This is an optional phase to add some utility commands present in PostgreSQL. We will add the following SQL commands:
+
+- `REASSIGN OWNED BY <old_role> TO <new_role>`
+    - Transfers ownership of all objects owned by `<old_role>` to `<new_role>`.
+    - Can only be run by a member of `<old_role>` and `<new_role>` or a superuser.
+    - Requires `CREATE` privilege on all schemas and databases where all objects reside.
+        - TODO: This isn't explicitly stated in th docs, but would make sense base on the `ALTER` privileges. I will
+          double-check this.
+    - In PostgreSQL, this only affects the current database, and does not reassign the database itself. We will diverge
+      here and have it affect all databases, including the databases themselves.
+- `DROP OWNED BY <name> [ CASCADE | RESTRICT]`
+    - Drops all objects owned by `<name>`.
+    - Requires membership of `<name>`.
+    - In PostgreSQL, this only affects the current database, and does not drop the database itself. We will diverge here
+      and have it affect all databases, including the databases themselves.
+    - Revokes all privileges granted to `<name>`.
+    - Default is `RESTRICT`.
+
+#### Out of Scope for Project
+
+- `CURRENT_ROLE`, `CURRENT_USER`, `SESSION_USER`, aliases in `GRANT`, `REVOKE`, `ALTER`, `REASSIGN OWNED`
+  and `DROP OWNED`.
 
 ## Alternatives
 

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -101,12 +101,10 @@ cannot specify these attributes in `CREATE ROLE` or `ALTER ROLE`. We use the fol
   the `SUPERUSER` attribute for that session.
     - The `SUPERUSER` attribute will be periodically updated as part of the periodic Frontegg re-validation done for
       pgwire connections.
+    - The `mz_system` role will always have the `SUPERUSER` attribute.
 
 This differs from PostgreSQL, which treats these as normal role attributes that persists between sessions and can be
 specified in `CREATE ROLE` and `ALTER ROLE`.
-
-The system role `mz_system` will have all attributes (including `LOGIN` and `SUPERUSER`). The system
-role `mz_introspection` will only have the `LOGIN` attribute.
 
 We will add the following read-only session parameter:
 `IS_SUPERUSER`: True if the current role has superuser privileges.

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -312,9 +312,9 @@ Below is a summary of the default privileges of all builtin objects:
 
 - The `mz_introspection` role will have `UC` privileges on the `mz_introspection` cluster.
 - The `PUBLIC` pseudo-role will have `U` privileges on the `mz_introspection` cluster.
-- The `PUBLIC` psuedo-role will have `UC` privileges on the `default` cluster.
-- The `PUBLIC` psuedo-role will have `UC` privileges on the default `materialize` database.
-- The `PUBLIC` psuedo-role will have `UC` privileges on all `public` schemas (the default schema
+- The `PUBLIC` psuedo-role will have `U` privileges on the `default` cluster.
+- The `PUBLIC` psuedo-role will have `U` privileges on the default `materialize` database.
+- The `PUBLIC` psuedo-role will have `U` privileges on all `public` schemas (the default schema
   created in every database).
 - The `PUBLIC` pseudo-role will have `U` privileges on all catalog schemas.
 - The `PUBLIC` pseudo-role will have `r` privileges on all applicable objects within all catalog

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -354,4 +354,3 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
 - What do privileges look like for system objects? Probably everyone should get `SELECT` permission by default.
 - Do we want to change `DROP OWNED` so that it drops databases and clusters?
 - What are security labels in PostgreSQL and do we want them?
-    

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -48,7 +48,7 @@ the subsection headers, tables, and SQL statements.
 #### Implementation
 - [`acl.h`](https://github.com/postgres/postgres/blob/master/src/include/utils/acl.h)
 - [`acl.c`](https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/acl.c)
-- [`aclchk_internal`](https://github.com/postgres/postgres/blob/master/src/include/utils/aclchk_internal.h)
+- [`aclchk_internal.h`](https://github.com/postgres/postgres/blob/master/src/include/utils/aclchk_internal.h)
 - [`aclcheck.c`](https://github.com/postgres/postgres/blob/master/src/backend/catalog/aclchk.c)
 
 - Note: There may be more, but this is a good starting point.

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -12,7 +12,6 @@ rich and well tested RBAC design and implementation, which we will base our impl
 ## Non-Goals
 
 - Data governance.
-- Frontegg integration.
 
 ## Description
 
@@ -46,6 +45,7 @@ the subsection headers, tables, and SQL statements.
 - [`DROP OWNED`](https://www.postgresql.org/docs/current/sql-drop-owned.html)
 
 #### Implementation
+
 - [`acl.h`](https://github.com/postgres/postgres/blob/master/src/include/utils/acl.h)
 - [`acl.c`](https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/acl.c)
 - [`aclchk_internal.h`](https://github.com/postgres/postgres/blob/master/src/include/utils/aclchk_internal.h)
@@ -85,7 +85,8 @@ We will add the following SQL statement:
         - `SUPERUSER` can run this without `CREATEROLE`.
     - `WITH` is ignored.
 
-When a new user logs in, we will create a new role for them with only the `LOGIN` and `INHERIT` attributes.
+When a new user logs in, we will create a new role for them with only the `LOGIN` and `INHERIT` attributes. If that user
+is a frontegg admin, then the role will also have the `SUPERUSER` attribute.
 
 #### Implementation Details
 
@@ -168,17 +169,25 @@ NOTE: Since we won't support `SET ROLE` yet, these functions will all behave ide
 
 - `GRANT` privileges.
 - `REVOKE` privileges.
+- `PUBLIC` alias for `<role>` in `GRANT` and `REVOKE`.
 
 #### Out of Scope for Project
 
-- `CURRENT_ROLE`, `CURRENT_USER`, `SESSION_USER`, and `PUBLIC` aliases for `<role>` in `GRANT` and `REVOKE`.
+- `CURRENT_ROLE`, `CURRENT_USER`, and `SESSION_USER` aliases for `<role>` in `GRANT` and `REVOKE`.
 - `GRANTED BY` option for `GRANT` and `REVOKE`.
 - `[ WITH ADMIN OPTION ]` option for `GRANT`.
 - `[ADMIN OPTION FOR ]` option for `REVOKE`.
 - `SET ROLE`
 - `RESET ROLE`
 
-### Phase 3 - Privileges
+### Phase 3 - `PUBLIC` role
+
+See [Grant](https://www.postgresql.org/docs/current/sql-grant.html) for PostgreSQL `PUBLIC` details (grep for PUBLIC).
+
+`PUBLIC` is a special keyword that is accepted anywhere a role name would be accepted. The key word PUBLIC indicates
+that the changes are to be applied to all roles, including those that might be created later.
+
+### Phase 4 - Privileges
 
 See [Privileges](https://www.postgresql.org/docs/current/ddl-priv.html) for PostgreSQL privileges.
 
@@ -309,7 +318,7 @@ We will update `DROP <object>` so that it revokes all privileges on `<object>`.
 
 #### Out of Scope for Project
 
-- `CURRENT_ROLE`, `CURRENT_USER`, `SESSION_USER`, and `PUBLIC` aliases in `GRANT`, `REVOKE`, `ALTER`, `REASSIGN OWNED`
+- `CURRENT_ROLE`, `CURRENT_USER`, `SESSION_USER`, aliases in `GRANT`, `REVOKE`, `ALTER`, `REASSIGN OWNED`
   and `DROP OWNED`.
 - `GRANTED BY` option for `GRANT` and `REVOKE`.
 - `WITH GRANT OPTION` in `GRANT`.

--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -46,9 +46,12 @@ the subsection headers, tables, and SQL statements.
 - [`DROP OWNED`](https://www.postgresql.org/docs/current/sql-drop-owned.html)
 
 #### Implementation
+- [`acl.h`](https://github.com/postgres/postgres/blob/master/src/include/utils/acl.h)
+- [`acl.c`](https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/acl.c)
+- [`aclchk_internal`](https://github.com/postgres/postgres/blob/master/src/include/utils/aclchk_internal.h)
+- [`aclcheck.c`](https://github.com/postgres/postgres/blob/master/src/backend/catalog/aclchk.c)
 
-https://github.com/postgres/postgres/blob/master/src/backend/catalog/aclchk.c
-Note: There may be more, but this is a good starting point.
+- Note: There may be more, but this is a good starting point.
 
 ### Phase 1 - Attributes
 


### PR DESCRIPTION
Part of #11579

### Motivation
Design doc.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
