### PR TITLE
Support rendering for nested and sequenced `LetRec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,7 +1713,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#e9e1157b7ab7d2548df699c9b95b578e0e64772a"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#cc88469a4834faa179725d52e2beb7ab677bdb37"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1790,7 +1790,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#e9e1157b7ab7d2548df699c9b95b578e0e64772a"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#cc88469a4834faa179725d52e2beb7ab677bdb37"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7312,7 +7312,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#5b808fff9bc83be29a2091c9a5d8910e009a6b15"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#f2ea9600f06eac46d2b43fcdbb3257593d3759ec"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7330,12 +7330,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#5b808fff9bc83be29a2091c9a5d8910e009a6b15"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#f2ea9600f06eac46d2b43fcdbb3257593d3759ec"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#5b808fff9bc83be29a2091c9a5d8910e009a6b15"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#f2ea9600f06eac46d2b43fcdbb3257593d3759ec"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7351,7 +7351,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#5b808fff9bc83be29a2091c9a5d8910e009a6b15"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#f2ea9600f06eac46d2b43fcdbb3257593d3759ec"
 dependencies = [
  "columnation",
  "serde",
@@ -7360,7 +7360,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#5b808fff9bc83be29a2091c9a5d8910e009a6b15"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#f2ea9600f06eac46d2b43fcdbb3257593d3759ec"
 
 [[package]]
 name = "tiny-keccak"

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1105,6 +1105,8 @@ impl<T: timely::progress::Timestamp> Plan<T> {
                     assert!(pre_existing.is_none());
                     lir_values.push(lir_value);
                 }
+                // As we exit the iterative scope, we must leave all arrangements behind,
+                // as they reference a timestamp coordinate that must be stripped off.
                 for id in ids.iter() {
                     arrangements.insert(Id::Local(*id), AvailableCollections::new_raw());
                 }

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1105,6 +1105,9 @@ impl<T: timely::progress::Timestamp> Plan<T> {
                     assert!(pre_existing.is_none());
                     lir_values.push(lir_value);
                 }
+                for id in ids.iter() {
+                    arrangements.insert(Id::Local(*id), AvailableCollections::new_raw());
+                }
                 // Plan the body using initial and `value` arrangements,
                 // and then remove reference to the value arrangements.
                 let (body, b_keys) = Plan::from_mir_inner(body, arrangements, debug_info)?;

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -600,7 +600,7 @@ where
     /// This method allows for `plan` to contain a `LetRec` variant at its root, and is planned
     /// in the context of `level` pre-existing iteration coordinates.
     ///
-    /// This method recursively descends `LetRec` nodes, establishing nested scopes for each 
+    /// This method recursively descends `LetRec` nodes, establishing nested scopes for each
     /// and establishing the appropriate recursive dependencies among the bound variables.
     /// Once non-`LetRec` nodes are reached it calls in to `render_plan` which will error if
     /// furher `LetRec` variants are found.

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -308,3 +308,129 @@ Explained Query:
         Get l0
 
 EOF
+
+## Tests for nested WITH MUTUALLY RECURSIVE
+
+statement ok
+CREATE TABLE edges (src int, dst int);
+
+statement ok
+INSERT INTO edges SELECT x, x + 1 FROM generate_series(0, 9) as x;
+
+statement ok
+INSERT INTO edges VALUES (4, 2), (8, 6);
+
+statement ok
+CREATE VIEW strongly_connected_components AS
+WITH MUTUALLY RECURSIVE
+    intra_edges (src int, dst int) as (
+        SELECT * FROM edges
+        EXCEPT ALL
+        SELECT * FROM edges_delayed
+        UNION ALL
+        SELECT src, dst
+        FROM
+            edges,
+            forward_labels f_src,
+            forward_labels f_dst,
+            reverse_labels r_src,
+            reverse_labels r_dst
+        WHERE src = f_src.node
+            AND src = r_src.node
+            AND dst = f_dst.node
+            AND dst = r_dst.node
+            AND f_src.label = f_dst.label
+            AND r_src.label = r_dst.label
+    ),
+    forward_labels (node int, label int) AS (
+        WITH MUTUALLY RECURSIVE
+            label (node int, comp int) AS (
+                SELECT dst, MIN(comp)
+                FROM (
+                    SELECT dst, dst AS comp FROM edges
+                    UNION ALL
+                    SELECT intra_edges.dst, label.comp
+                    FROM intra_edges, label
+                    WHERE intra_edges.src = label.node
+                )
+                GROUP BY dst
+            )
+        SELECT * FROM label
+    ),
+    reverse_labels (node int, label int) AS (
+        WITH MUTUALLY RECURSIVE
+            label (node int, comp int) AS (
+                SELECT src, MIN(comp)
+                FROM (
+                    SELECT src, src AS comp FROM edges
+                    UNION ALL
+                    SELECT intra_edges.src, label.comp
+                    FROM intra_edges, label
+                    WHERE intra_edges.dst = label.node
+                )
+                GROUP BY src
+            )
+        SELECT * FROM label
+    ),
+    edges_delayed (src int, dst int) AS (SELECT * FROM edges)
+SELECT * FROM forward_labels UNION SELECT * FROM reverse_labels;
+
+query II
+SELECT size, COUNT(*) FROM (
+    SELECT label, COUNT(*) as size
+    FROM strongly_connected_components
+    GROUP BY label
+)
+GROUP BY size;
+----
+1  5
+3  2
+
+query II
+SELECT label, COUNT(*) as size
+FROM strongly_connected_components
+GROUP BY label
+----
+0  1
+1  1
+2  3
+5  1
+6  3
+9  1
+10  1
+
+## Tests for sequenced WITH MUTUALLY RECURSIVE
+
+## We should not see any rounds greater than zero, because the fixed point
+## should have been reached in the first WITH MUTUALLY RECURSIVE.
+query II
+WITH MUTUALLY RECURSIVE
+    label (node int, comp int) AS (
+        SELECT dst, MIN(comp)
+        FROM (
+            SELECT dst, dst AS comp FROM edges
+            UNION ALL
+            SELECT edges.dst, label.comp
+            FROM edges, label
+            WHERE edges.src = label.node
+        )
+        GROUP BY dst
+    )
+SELECT round, COUNT(*) FROM (
+    WITH MUTUALLY RECURSIVE
+        relabel (node int, comp int, round int) AS (
+            SELECT DISTINCT ON(node) node, comp, round
+            FROM (
+                SELECT node, comp, 0 as round FROM label
+                UNION ALL
+                SELECT edges.dst, relabel.comp, relabel.round + 1
+                FROM edges, relabel
+                WHERE edges.src = relabel.node
+            )
+            ORDER BY node, comp
+        )
+    SELECT round FROM relabel
+)
+GROUP BY round;
+----
+0  10


### PR DESCRIPTION
The current rendering for `LetRec` requires that each dataflow contain at most one `LetRec`; it will error otherwise. This PR changes things to use the `PointStamp` timestamp type to allow dynamic scopes, and support arbitrarily nested and sequenced iterative scopes.

In theory. None of this has been tested more than very lightly in the DD repo.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
