### PR TITLE
Transform panic in `uint2` and `uint4` sums under invalid accumulations into SQL-level error

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -1396,7 +1396,14 @@ where
                             | (
                                 AggregateFunc::SumUInt64,
                                 Accum::SimpleNumber { accum, .. },
-                            ) => Datum::from(*accum),
+                            ) => {
+                                if accum.is_negative() {
+                                    warn!("[customer-data] ReduceAccumulable observed a negative sum \
+                                        accumulation over an unsigned type: {aggr:?}: {accum:?} in dataflow {debug_name}");
+                                    soft_assert_or_log!(false, "Invalid negative unsigned aggregation in ReduceAccumulable");
+                                }
+                                Datum::from(*accum)
+                            }
                             (
                                 AggregateFunc::SumFloat32,
                                 Accum::Float {

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -1392,8 +1392,8 @@ where
                             | (
                                 AggregateFunc::SumUInt32,
                                 Accum::SimpleNumber { accum, .. },
-                            ) => Datum::UInt64(u64::try_from(*accum).unwrap_or_else(|_| panic!("Invalid accumulated result {accum} for unsigned function in dataflow {debug_name}"))),
-                            (
+                            )
+                            | (
                                 AggregateFunc::SumUInt64,
                                 Accum::SimpleNumber { accum, .. },
                             ) => Datum::from(*accum),

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -460,7 +460,9 @@ where
     if datums.peek().is_none() {
         Datum::Null
     } else {
-        let x: u64 = datums.map(|d| u64::from(d.unwrap_uint16())).sum();
+        let x: u128 = datums.map(|d| u128::from(d.unwrap_uint16())).sum();
+        // Note that we return here a numeric, but the value will be downcast
+        // as part of reduce planning to a uint8.
         Datum::from(x)
     }
 }
@@ -473,7 +475,9 @@ where
     if datums.peek().is_none() {
         Datum::Null
     } else {
-        let x: u64 = datums.map(|d| u64::from(d.unwrap_uint32())).sum();
+        let x: u128 = datums.map(|d| u128::from(d.unwrap_uint32())).sum();
+        // Note that we return here a numeric, but the value will be downcast
+        // as part of reduce planning to a uint8.
         Datum::from(x)
     }
 }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -59,6 +59,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-github-15799",
         "test-github-15930",
         "test-github-15496",
+        "test-github-17510",
         "test-remote-storage",
         "test-drop-default-cluster",
         "test-upsert",
@@ -577,6 +578,91 @@ def workflow_test_github_15496(c: Composition) -> None:
         # ensure that an error was put into the logs
         c1 = c.invoke("logs", "clusterd_nopanic", capture=True)
         assert "Mismatched aggregates for key in ReduceCollation" in c1.stdout
+
+
+def workflow_test_github_17510(c: Composition) -> None:
+    """
+    Test that sum aggregations over uint2 and uint4 types do not produce a panic, but
+    rather a SQL-level error when faced with invalid accumulations due to too many
+    retractions in a source. Additionally, we verify that in these cases, an adequate
+    error message is written to the logs.
+
+    Regression test for https://github.com/MaterializeInc/materialize/issues/17510.
+    """
+
+    c.down(destroy_volumes=True)
+    with c.override(
+        Clusterd(
+            name="clusterd_nopanic",
+            environment_extra=[
+                "MZ_SOFT_ASSERTIONS=0",
+            ],
+        ),
+        Testdrive(no_reset=True),
+    ):
+        c.up("testdrive", persistent=True)
+        c.up("materialized")
+        c.up("clusterd_nopanic")
+
+        # set up a test cluster and run a testdrive regression script
+        c.sql(
+            """
+            CREATE CLUSTER cluster1 REPLICAS (
+                r1 (
+                    STORAGECTL ADDRESSES ['clusterd_nopanic:2100'],
+                    STORAGE ADDRESSES ['clusterd_no_panic:2103'],
+                    COMPUTECTL ADDRESSES ['clusterd_nopanic:2101'],
+                    COMPUTE ADDRESSES ['clusterd_nopanic:2102'],
+                    WORKERS 2
+                )
+            );
+            -- Set data for test up
+            SET cluster = cluster1;
+            CREATE TABLE base (data2 uint2, data4 uint4, data8 uint8, diff bigint);
+            CREATE MATERIALIZED VIEW data AS
+              SELECT data2, data4, data8
+              FROM base, repeat_row(diff);
+            CREATE MATERIALIZED VIEW sum_types AS
+              SELECT SUM(data2) AS sum2, SUM(data4) AS sum4, SUM(data8) AS sum8
+              FROM data;
+            INSERT INTO base VALUES (1, 1, 1, 1);
+            INSERT INTO base VALUES (1, 1, 1, -1), (1, 1, 1, -1);
+            """
+        )
+        c.testdrive(
+            dedent(
+                f"""
+            > SET cluster = cluster1;
+
+            # Run a queries that would generate panics before the fix.
+
+            ! SELECT SUM(data2) FROM data;
+            contains:uint8 out of range
+
+            ! SELECT SUM(data4) FROM data;
+            contains:uint8 out of range
+
+            # The following statement succeeds with a negative accumulation,
+            # which is the behavior introduced in https://github.com/MaterializeInc/materialize/pull/16852
+            > SELECT SUM(data8) FROM data;
+            -1
+
+            # Ensure that the output types for uint sums are unaffected.
+            > SELECT c.name, c.type
+              FROM mz_materialized_views mv
+                   JOIN mz_columns c USING (id)
+              WHERE mv.name = 'sum_types'
+              ORDER BY c.type, c.name;
+            sum8 numeric
+            sum2 uint8
+            sum4 uint8
+            """
+            )
+        )
+
+        # ensure that an error was put into the logs
+        c1 = c.invoke("logs", "clusterd_nopanic", capture=True)
+        assert "Invalid negative unsigned aggregation in ReduceAccumulable" in c1.stdout
 
 
 def workflow_test_upsert(c: Composition) -> None:

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -543,7 +543,7 @@ def workflow_test_github_15496(c: Composition) -> None:
             CREATE CLUSTER cluster1 REPLICAS (
                 r1 (
                     STORAGECTL ADDRESSES ['clusterd_nopanic:2100'],
-                    STORAGE ADDRESSES ['clusterd_no_panic:2103'],
+                    STORAGE ADDRESSES ['clusterd_nopanic:2103'],
                     COMPUTECTL ADDRESSES ['clusterd_nopanic:2101'],
                     COMPUTE ADDRESSES ['clusterd_nopanic:2102'],
                     WORKERS 2
@@ -610,7 +610,7 @@ def workflow_test_github_17510(c: Composition) -> None:
             CREATE CLUSTER cluster1 REPLICAS (
                 r1 (
                     STORAGECTL ADDRESSES ['clusterd_nopanic:2100'],
-                    STORAGE ADDRESSES ['clusterd_no_panic:2103'],
+                    STORAGE ADDRESSES ['clusterd_nopanic:2103'],
                     COMPUTECTL ADDRESSES ['clusterd_nopanic:2101'],
                     COMPUTE ADDRESSES ['clusterd_nopanic:2102'],
                     WORKERS 2
@@ -627,6 +627,16 @@ def workflow_test_github_17510(c: Composition) -> None:
               FROM data;
             INSERT INTO base VALUES (1, 1, 1, 1);
             INSERT INTO base VALUES (1, 1, 1, -1), (1, 1, 1, -1);
+            CREATE MATERIALIZED VIEW constant_sums AS
+              SELECT SUM(data2) AS sum2, SUM(data4) AS sum4, SUM(data8) AS sum8
+              FROM (
+                  SELECT * FROM (
+                      VALUES (1::uint2, 1::uint4, 1::uint8, 1),
+                          (1::uint2, 1::uint4, 1::uint8, -1),
+                          (1::uint2, 1::uint4, 1::uint8, -1)
+                  ) AS base (data2, data4, data8, diff),
+                  repeat_row(diff)
+              );
             """
         )
         c.testdrive(
@@ -635,23 +645,46 @@ def workflow_test_github_17510(c: Composition) -> None:
             > SET cluster = cluster1;
 
             # Run a queries that would generate panics before the fix.
-
             ! SELECT SUM(data2) FROM data;
             contains:uint8 out of range
 
             ! SELECT SUM(data4) FROM data;
             contains:uint8 out of range
 
+            ! SELECT * FROM constant_sums;
+            contains:constant folding encountered reduce on collection with non-positive multiplicities
+
             # The following statement succeeds with a negative accumulation,
             # which is the behavior introduced in https://github.com/MaterializeInc/materialize/pull/16852
             > SELECT SUM(data8) FROM data;
             -1
+
+            # Test repairs
+            > INSERT INTO base VALUES (1, 1, 1, 1), (1, 1, 1, 1);
+
+            > SELECT SUM(data2) FROM data;
+            1
+
+            > SELECT SUM(data4) FROM data;
+            1
+
+            > SELECT SUM(data8) FROM data;
+            1
 
             # Ensure that the output types for uint sums are unaffected.
             > SELECT c.name, c.type
               FROM mz_materialized_views mv
                    JOIN mz_columns c USING (id)
               WHERE mv.name = 'sum_types'
+              ORDER BY c.type, c.name;
+            sum8 numeric
+            sum2 uint8
+            sum4 uint8
+
+            > SELECT c.name, c.type
+              FROM mz_materialized_views mv
+                   JOIN mz_columns c USING (id)
+              WHERE mv.name = 'constant_sums'
               ORDER BY c.type, c.name;
             sum8 numeric
             sum2 uint8


### PR DESCRIPTION
This PR eliminates a panic raised when a sum aggregation of `uint2` or `uint4` is faced with a negative accumulation. Negative accumulations in reductions can arise due to, e.g., incomplete or invalid source data. The new strategy is to convert the invalid aggregation error into a query-level error instead of a panic by introduction of a map that performs appropriate casts and a projection. The change is carried out at the level of HIR-to-MIR lowering, since the casts may introduce errors and these will be later analyzed by transforms. Additionally, we give the optimizer the possibility to delay evaluation of the casts and projections to enable arrangement reuse. Finally, the PR adjusts the constant-folding behavior to output the same datum type as expected from rendering, thus making the casts sane in both evaluation alternatives.

Fixes #17510.

The approach taken in this PR is a specialized version of a more general approach advocated in a [design document](https://github.com/MaterializeInc/materialize/pull/17597). The PR fixes a panic while testing the waters for the more general implementation. The general implementation, to be pursued in a follow-up PR if the design document is approved, would eventually supersede the current change.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/17510

### Tips for reviewer

The commits in this PR can be looked at individually. Note that we should be very careful here before pressing merge, since we want the output types produced by `uint2` and `uint4` aggregations to be exactly the same as before. That way, we do not have to write a migration of user data. I added a check to that effect in the regression test introduced in the PR.

An alternative take of to this PR is presented in #17682, where the casts and projection are introduced at the MIR-to-LIR lowering level. My preference is, however, to merge this PR instead of that alternative, since here we ensure that expressions that can error are analyzed properly and that arrangement reuse is maximized.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Eliminated a replica crash when source data contained invalid retractions fed into unsigned sum aggregations.
