### PR TITLE
environmentd: allow cors *. prefixes

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -230,6 +230,8 @@ pub struct Args {
     /// The default allows all local connections.
     /// "*" allows all.
     /// "*.domain.com" allows connections from any matching subdomain.
+    ///
+    /// Wildcards in other positions (e.g., "https://*.foo.com" or "https://foo.*.com") have no effect.
     #[structopt(long, env = "CORS_ALLOWED_ORIGIN")]
     cors_allowed_origin: Vec<HeaderValue>,
     /// How stringently to demand TLS authentication and encryption.

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -226,6 +226,10 @@ pub struct Args {
     internal_http_listen_addr: SocketAddr,
     /// Enable cross-origin resource sharing (CORS) for HTTP requests from the
     /// specified origin.
+    ///
+    /// The default allows all local connections.
+    /// "*" allows all.
+    /// "*.domain.com" allows connections from any matching subdomain.
     #[structopt(long, env = "CORS_ALLOWED_ORIGIN")]
     cors_allowed_origin: Vec<HeaderValue>,
     /// How stringently to demand TLS authentication and encryption.
@@ -630,7 +634,21 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     {
         cors::Any.into()
     } else if !args.cors_allowed_origin.is_empty() {
-        AllowOrigin::list(args.cors_allowed_origin)
+        let allowed = args.cors_allowed_origin.clone();
+        AllowOrigin::predicate(move |origin: &HeaderValue, _request_parts: _| {
+            for val in &allowed {
+                // For each specified allow cors origin, check if it starts with
+                // a *. and allow anything from that glob. Otherwise check for
+                // an exact match.
+                if (val.as_bytes().starts_with(b"*.")
+                    && origin.as_bytes().ends_with(&val.as_bytes()[1..]))
+                    || origin == val
+                {
+                    return true;
+                }
+            }
+            false
+        })
     } else {
         let port = args.http_listen_addr.port();
         AllowOrigin::list([


### PR DESCRIPTION
 Fixes #17701

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a