### PR TITLE
persist: add timeouts to CRDB connection establishment and CaS queries

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5889,6 +5889,8 @@ impl Catalog {
         PersistParameters {
             blob_target_size: Some(config.persist_blob_target_size()),
             compaction_minimum_timeout: Some(config.persist_compaction_minimum_timeout()),
+            consensus_connect_timeout: Some(config.persist_consensus_connect_timeout()),
+            consensus_query_timeout: Some(config.persist_consensus_query_timeout()),
         }
     }
 }

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -378,12 +378,21 @@ const PERSIST_COMPACTION_MINIMUM_TIMEOUT: ServerVar<Duration> = ServerVar {
     safe: true,
 };
 
+/// Controls [`mz_persist_client::cfg::DynamicConfig::consensus_connect_timeout`].
+const PERSIST_CONSENSUS_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("persist_consensus_connect_timeout"),
+    value: &PersistConfig::DEFAULT_CONSENSUS_CONNECT_TIMEOUT,
+    description: "The time to connect to Consensus before timing out and retrying.",
+    internal: true,
+    safe: true,
+};
+
 /// Controls [`mz_persist_client::cfg::DynamicConfig::consensus_query_timeout`].
 const PERSIST_CONSENSUS_QUERY_TIMEOUT: ServerVar<Duration> = ServerVar {
     name: UncasedStr::new("persist_consensus_query_timeout"),
     value: &PersistConfig::DEFAULT_CONSENSUS_QUERY_TIMEOUT,
     description:
-        "The time to run a Consensus query (to Postgres/CRDB) before timing out and retrying",
+        "The time to run a Consensus query (to Postgres/CRDB) before timing out and retrying.",
     internal: true,
     safe: true,
 };
@@ -1061,6 +1070,7 @@ pub struct SystemVars {
     // persist configuration
     persist_blob_target_size: SystemVar<usize>,
     persist_compaction_minimum_timeout: SystemVar<Duration>,
+    persist_consensus_connect_timeout: SystemVar<Duration>,
     persist_consensus_query_timeout: SystemVar<Duration>,
 
     // dataflow configuration
@@ -1093,6 +1103,7 @@ impl Default for SystemVars {
             allowed_cluster_replica_sizes: SystemVar::new(&ALLOWED_CLUSTER_REPLICA_SIZES),
             persist_blob_target_size: SystemVar::new(&PERSIST_BLOB_TARGET_SIZE),
             persist_compaction_minimum_timeout: SystemVar::new(&PERSIST_COMPACTION_MINIMUM_TIMEOUT),
+            persist_consensus_connect_timeout: SystemVar::new(&PERSIST_CONSENSUS_CONNECT_TIMEOUT),
             persist_consensus_query_timeout: SystemVar::new(&PERSIST_CONSENSUS_QUERY_TIMEOUT),
             dataflow_max_inflight_bytes: SystemVar::new(&DATAFLOW_MAX_INFLIGHT_BYTES),
             metrics_retention: SystemVar::new(&METRICS_RETENTION),
@@ -1188,6 +1199,8 @@ impl SystemVars {
             Ok(&self.persist_blob_target_size)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             Ok(&self.persist_compaction_minimum_timeout)
+        } else if name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name {
+            Ok(&self.persist_consensus_connect_timeout)
         } else if name == PERSIST_CONSENSUS_QUERY_TIMEOUT.name {
             Ok(&self.persist_consensus_query_timeout)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
@@ -1245,6 +1258,8 @@ impl SystemVars {
             self.persist_blob_target_size.is_default(value)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             self.persist_compaction_minimum_timeout.is_default(value)
+        } else if name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name {
+            self.persist_consensus_connect_timeout.is_default(value)
         } else if name == PERSIST_CONSENSUS_QUERY_TIMEOUT.name {
             self.persist_consensus_query_timeout.is_default(value)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
@@ -1311,6 +1326,8 @@ impl SystemVars {
             self.persist_blob_target_size.set(value)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             self.persist_compaction_minimum_timeout.set(value)
+        } else if name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name {
+            self.persist_consensus_connect_timeout.set(value)
         } else if name == PERSIST_CONSENSUS_QUERY_TIMEOUT.name {
             self.persist_consensus_query_timeout.set(value)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
@@ -1372,6 +1389,8 @@ impl SystemVars {
             Ok(self.persist_blob_target_size.reset())
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             Ok(self.persist_compaction_minimum_timeout.reset())
+        } else if name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name {
+            Ok(self.persist_consensus_connect_timeout.reset())
         } else if name == PERSIST_CONSENSUS_QUERY_TIMEOUT.name {
             Ok(self.persist_consensus_query_timeout.reset())
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
@@ -1468,6 +1487,16 @@ impl SystemVars {
     /// Returns the `persist_compaction_minimum_timeout` configuration parameter.
     pub fn persist_compaction_minimum_timeout(&self) -> Duration {
         *self.persist_compaction_minimum_timeout.value()
+    }
+
+    /// Returns the `persist_consensus_connect_timeout` configuration parameter.
+    pub fn persist_consensus_connect_timeout(&self) -> Duration {
+        *self.persist_consensus_connect_timeout.value()
+    }
+
+    /// Returns the `persist_consensus_query_timeout` configuration parameter.
+    pub fn persist_consensus_query_timeout(&self) -> Duration {
+        *self.persist_consensus_query_timeout.value()
     }
 
     /// Returns the `dataflow_max_inflight_bytes` configuration parameter.
@@ -2334,5 +2363,6 @@ pub(crate) fn is_storage_config_var(name: &str) -> bool {
 fn is_persist_config_var(name: &str) -> bool {
     name == PERSIST_BLOB_TARGET_SIZE.name()
         || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
+        || name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name()
         || name == PERSIST_CONSENSUS_QUERY_TIMEOUT.name()
 }

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -378,6 +378,16 @@ const PERSIST_COMPACTION_MINIMUM_TIMEOUT: ServerVar<Duration> = ServerVar {
     safe: true,
 };
 
+/// Controls [`mz_persist_client::cfg::DynamicConfig::consensus_query_timeout`].
+const PERSIST_CONSENSUS_QUERY_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("persist_consensus_query_timeout"),
+    value: &PersistConfig::DEFAULT_CONSENSUS_QUERY_TIMEOUT,
+    description:
+        "The time to run a Consensus query (to Postgres/CRDB) before timing out and retrying",
+    internal: true,
+    safe: true,
+};
+
 /// The maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
 const DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<usize> = ServerVar {
     name: UncasedStr::new("dataflow_max_inflight_bytes"),
@@ -1051,6 +1061,7 @@ pub struct SystemVars {
     // persist configuration
     persist_blob_target_size: SystemVar<usize>,
     persist_compaction_minimum_timeout: SystemVar<Duration>,
+    persist_consensus_query_timeout: SystemVar<Duration>,
 
     // dataflow configuration
     dataflow_max_inflight_bytes: SystemVar<usize>,
@@ -1082,6 +1093,7 @@ impl Default for SystemVars {
             allowed_cluster_replica_sizes: SystemVar::new(&ALLOWED_CLUSTER_REPLICA_SIZES),
             persist_blob_target_size: SystemVar::new(&PERSIST_BLOB_TARGET_SIZE),
             persist_compaction_minimum_timeout: SystemVar::new(&PERSIST_COMPACTION_MINIMUM_TIMEOUT),
+            persist_consensus_query_timeout: SystemVar::new(&PERSIST_CONSENSUS_QUERY_TIMEOUT),
             dataflow_max_inflight_bytes: SystemVar::new(&DATAFLOW_MAX_INFLIGHT_BYTES),
             metrics_retention: SystemVar::new(&METRICS_RETENTION),
             mock_audit_event_timestamp: SystemVar::new(&MOCK_AUDIT_EVENT_TIMESTAMP),
@@ -1176,6 +1188,8 @@ impl SystemVars {
             Ok(&self.persist_blob_target_size)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             Ok(&self.persist_compaction_minimum_timeout)
+        } else if name == PERSIST_CONSENSUS_QUERY_TIMEOUT.name {
+            Ok(&self.persist_consensus_query_timeout)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
             Ok(&self.dataflow_max_inflight_bytes)
         } else if name == METRICS_RETENTION.name {
@@ -1231,6 +1245,8 @@ impl SystemVars {
             self.persist_blob_target_size.is_default(value)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             self.persist_compaction_minimum_timeout.is_default(value)
+        } else if name == PERSIST_CONSENSUS_QUERY_TIMEOUT.name {
+            self.persist_consensus_query_timeout.is_default(value)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
             self.dataflow_max_inflight_bytes.is_default(value)
         } else if name == METRICS_RETENTION.name {
@@ -1295,6 +1311,8 @@ impl SystemVars {
             self.persist_blob_target_size.set(value)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             self.persist_compaction_minimum_timeout.set(value)
+        } else if name == PERSIST_CONSENSUS_QUERY_TIMEOUT.name {
+            self.persist_consensus_query_timeout.set(value)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
             self.dataflow_max_inflight_bytes.set(value)
         } else if name == METRICS_RETENTION.name {
@@ -1354,6 +1372,8 @@ impl SystemVars {
             Ok(self.persist_blob_target_size.reset())
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             Ok(self.persist_compaction_minimum_timeout.reset())
+        } else if name == PERSIST_CONSENSUS_QUERY_TIMEOUT.name {
+            Ok(self.persist_consensus_query_timeout.reset())
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
             Ok(self.dataflow_max_inflight_bytes.reset())
         } else if name == METRICS_RETENTION.name {
@@ -2312,5 +2332,7 @@ pub(crate) fn is_storage_config_var(name: &str) -> bool {
 
 /// Returns whether the named variable is a persist configuration parameter.
 fn is_persist_config_var(name: &str) -> bool {
-    name == PERSIST_BLOB_TARGET_SIZE.name() || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
+    name == PERSIST_BLOB_TARGET_SIZE.name()
+        || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
+        || name == PERSIST_CONSENSUS_QUERY_TIMEOUT.name()
 }

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -17,4 +17,5 @@ message ProtoPersistParameters {
     optional uint64 blob_target_size = 1;
     mz_proto.ProtoDuration compaction_minimum_timeout = 2;
     mz_proto.ProtoDuration consensus_query_timeout = 3;
+    mz_proto.ProtoDuration consensus_connect_timeout = 4;
 }

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -16,4 +16,5 @@ package mz_persist_client.cfg;
 message ProtoPersistParameters {
     optional uint64 blob_target_size = 1;
     mz_proto.ProtoDuration compaction_minimum_timeout = 2;
+    mz_proto.ProtoDuration consensus_query_timeout = 3;
 }

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -11,8 +11,9 @@
 
 //! The tunable knobs for persist.
 
+use prometheus::core::{Atomic, AtomicF64};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use mz_build_info::BuildInfo;
@@ -126,6 +127,7 @@ impl PersistConfig {
                 compaction_minimum_timeout: Self::DEFAULT_COMPACTION_MINIMUM_TIMEOUT,
                 consensus_connection_pool_ttl: Duration::from_secs(300),
                 consensus_connection_pool_ttl_stagger: Duration::from_secs(6),
+                consensus_query_timeout: RwLock::new(Duration::from_secs(12)),
                 gc_blob_delete_concurrency_limit: AtomicUsize::new(32),
                 state_versions_recent_live_diffs_limit: AtomicUsize::new(usize::cast_from(
                     30 * Self::NEED_ROLLUP_THRESHOLD,
@@ -166,6 +168,8 @@ impl PersistConfig {
     pub const DEFAULT_BLOB_TARGET_SIZE: usize = 128 * MB;
     /// Default value for [`DynamicConfig::compaction_minimum_timeout`].
     pub const DEFAULT_COMPACTION_MINIMUM_TIMEOUT: Duration = Duration::from_secs(90);
+    /// Default value for [`DynamicConfig::consensus_query_timeout`].
+    pub const DEFAULT_CONSENSUS_QUERY_TIMEOUT: Duration = Duration::from_secs(12);
 
     // Move this to a PersistConfig field when we actually have read leases.
     //
@@ -196,6 +200,14 @@ impl ConsensusKnobs for PersistConfig {
 
     fn connection_pool_ttl_stagger(&self) -> Duration {
         self.dynamic.consensus_connection_pool_ttl_stagger()
+    }
+
+    fn query_timeout(&self) -> Duration {
+        *self
+            .dynamic
+            .consensus_query_timeout
+            .read()
+            .expect("lock poisoned")
     }
 }
 
@@ -234,6 +246,7 @@ pub struct DynamicConfig {
     compaction_minimum_timeout: Duration,
     consensus_connection_pool_ttl: Duration,
     consensus_connection_pool_ttl_stagger: Duration,
+    consensus_query_timeout: RwLock<Duration>,
 }
 
 impl DynamicConfig {
@@ -314,6 +327,11 @@ impl DynamicConfig {
     pub fn consensus_connection_pool_ttl_stagger(&self) -> Duration {
         self.consensus_connection_pool_ttl_stagger
     }
+    /// The duration to wait for a Consensus Postgres/CRDB query to complete before
+    /// dropping the request and retrying.
+    pub fn consensus_query_timeout(&self) -> Duration {
+        *self.consensus_query_timeout.read().expect("lock poisoned")
+    }
 
     /// The maximum number of concurrent blob deletes during garbage collection.
     pub fn gc_blob_delete_concurrency_limit(&self) -> usize {
@@ -391,6 +409,8 @@ pub struct PersistParameters {
     pub blob_target_size: Option<usize>,
     /// Configures [`DynamicConfig::compaction_minimum_timeout`].
     pub compaction_minimum_timeout: Option<Duration>,
+    /// Configures [`DynamicConfig::consensus_query_timeout`].
+    pub consensus_query_timeout: Option<Duration>,
 }
 
 impl PersistParameters {
@@ -401,16 +421,21 @@ impl PersistParameters {
         let Self {
             blob_target_size: self_blob_target_size,
             compaction_minimum_timeout: self_compaction_minimum_timeout,
+            consensus_query_timeout: self_consensus_query_timeout,
         } = self;
         let Self {
             blob_target_size: other_blob_target_size,
             compaction_minimum_timeout: other_compaction_minimum_timeout,
+            consensus_query_timeout: other_consensus_query_timeout,
         } = other;
         if let Some(v) = other_blob_target_size {
             *self_blob_target_size = Some(v);
         }
         if let Some(v) = other_compaction_minimum_timeout {
             *self_compaction_minimum_timeout = Some(v);
+        }
+        if let Some(v) = other_consensus_query_timeout {
+            *self_consensus_query_timeout = Some(v);
         }
     }
 
@@ -423,8 +448,11 @@ impl PersistParameters {
         let Self {
             blob_target_size,
             compaction_minimum_timeout,
+            consensus_query_timeout,
         } = self;
-        blob_target_size.is_none() && compaction_minimum_timeout.is_none()
+        blob_target_size.is_none()
+            && compaction_minimum_timeout.is_none()
+            && consensus_query_timeout.is_none()
     }
 
     /// Applies the parameter values to persist's in-memory config object.
@@ -437,6 +465,7 @@ impl PersistParameters {
         let Self {
             blob_target_size,
             compaction_minimum_timeout,
+            consensus_query_timeout,
         } = self;
         if let Some(blob_target_size) = blob_target_size {
             cfg.dynamic
@@ -446,6 +475,14 @@ impl PersistParameters {
         if let Some(_compaction_minimum_timeout) = compaction_minimum_timeout {
             // TODO: Figure out how to represent Durations in DynamicConfig.
         }
+        if let Some(consensus_query_timeout) = consensus_query_timeout {
+            let mut timeout = cfg
+                .dynamic
+                .consensus_query_timeout
+                .write()
+                .expect("lock poisoned");
+            *timeout = *consensus_query_timeout;
+        }
     }
 }
 
@@ -454,6 +491,7 @@ impl RustType<ProtoPersistParameters> for PersistParameters {
         ProtoPersistParameters {
             blob_target_size: self.blob_target_size.into_proto(),
             compaction_minimum_timeout: self.compaction_minimum_timeout.into_proto(),
+            consensus_query_timeout: self.consensus_query_timeout.into_proto(),
         }
     }
 
@@ -461,6 +499,7 @@ impl RustType<ProtoPersistParameters> for PersistParameters {
         Ok(Self {
             blob_target_size: proto.blob_target_size.into_rust()?,
             compaction_minimum_timeout: proto.compaction_minimum_timeout.into_rust()?,
+            consensus_query_timeout: proto.consensus_query_timeout.into_rust()?,
         })
     }
 }

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -155,6 +155,8 @@ pub trait ConsensusKnobs: std::fmt::Debug + Send + Sync {
     /// Minimum time between TTLing connections. Helps stagger reconnections
     /// to avoid stampeding the backing store of [Consensus].
     fn connection_pool_ttl_stagger(&self) -> Duration;
+    /// Time to wait for a query to complete before retrying.
+    fn query_timeout(&self) -> Duration;
 }
 
 impl ConsensusConfig {

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -155,6 +155,8 @@ pub trait ConsensusKnobs: std::fmt::Debug + Send + Sync {
     /// Minimum time between TTLing connections. Helps stagger reconnections
     /// to avoid stampeding the backing store of [Consensus].
     fn connection_pool_ttl_stagger(&self) -> Duration;
+    /// Time to wait for a connection to be made before trying.
+    fn connect_timeout(&self) -> Duration;
     /// Time to wait for a query to complete before retrying.
     fn query_timeout(&self) -> Duration;
 }

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -97,5 +97,6 @@ pub mod metrics;
 pub mod postgres;
 pub mod retry;
 pub mod s3;
+pub mod timeout;
 pub mod unreliable;
 pub mod workload;

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -274,6 +274,14 @@ impl From<tokio::task::JoinError> for ExternalError {
     }
 }
 
+impl From<tokio::time::error::Elapsed> for ExternalError {
+    fn from(x: tokio::time::error::Elapsed) -> Self {
+        ExternalError::Indeterminate(Indeterminate {
+            inner: anyhow::Error::new(x),
+        })
+    }
+}
+
 /// Configuration of whether a [Blob::set] must occur atomically.
 #[derive(Debug)]
 pub enum Atomicity {

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -523,10 +523,9 @@ impl Consensus for PostgresConsensus {
 
 #[cfg(test)]
 mod tests {
+    use crate::location::tests::consensus_impl_test;
     use tracing::info;
     use uuid::Uuid;
-
-    use crate::location::tests::consensus_impl_test;
 
     use super::*;
 

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -146,6 +146,9 @@ impl PostgresConsensusConfig {
             fn connection_pool_ttl_stagger(&self) -> Duration {
                 Duration::MAX
             }
+            fn connect_timeout(&self) -> Duration {
+                Duration::MAX
+            }
             fn query_timeout(&self) -> Duration {
                 Duration::MAX
             }
@@ -177,7 +180,8 @@ impl PostgresConsensus {
     /// Open a Postgres [Consensus] instance with `config`, for the collection
     /// named `shard`.
     pub async fn open(config: PostgresConsensusConfig) -> Result<Self, ExternalError> {
-        let pg_config: Config = config.url.parse()?;
+        let mut pg_config: Config = config.url.parse()?;
+        pg_config.connect_timeout(config.knobs.connect_timeout());
         let tls = make_tls(&pg_config)?;
 
         let manager = Manager::from_config(

--- a/src/persist/src/timeout.rs
+++ b/src/persist/src/timeout.rs
@@ -1,0 +1,56 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Timeout utilities
+
+use std::future::Future;
+use std::time::Duration;
+
+/// Extension trait for future timeouts.
+pub trait TimeoutExt: Future {
+    /// Applies a timeout to the future.
+    fn timeout(self, duration: Duration) -> tokio::time::Timeout<Self>
+    where
+        Self: Sized;
+}
+
+impl<F: Future + Sized + Send> TimeoutExt for F {
+    fn timeout(self, duration: Duration) -> tokio::time::Timeout<Self> {
+        tokio::time::timeout(duration, self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use mz_ore::metric;
+    use mz_ore::metrics::{IntCounter, MetricsRegistry};
+
+    use crate::timeout::TimeoutExt;
+
+    #[tokio::test(start_paused = true)]
+    async fn times_out() {
+        let registry = MetricsRegistry::new();
+        let counter: IntCounter = registry.register(metric!(
+            name: "timeouts",
+            help: "timeouts",
+        ));
+        let fut = async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            1234
+        };
+        let fut = fut.timeout(Duration::from_secs(30));
+
+        tokio::time::advance(Duration::from_secs(31)).await;
+
+        assert!(fut.await.is_err());
+        assert_eq!(counter.get(), 1);
+    }
+}


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Adds timeouts to our connections to CRDB and our head + CaS queries.

TBD: if/how we bubble up timeout metrics and whether a retryer is stuck timing out on calls that simply take too long

### Motivation

* This PR fixes a recognized bug.

Will fix https://github.com/MaterializeInc/materialize/issues/17680 from the perspective of persist

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
