### PR TITLE
[persist] Allow clients to request consolidation from the persist source

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -122,7 +122,7 @@ use mz_expr::Id;
 use mz_repr::{GlobalId, Row};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::source::persist_source;
-use mz_storage_client::source::persist_source::FlowControl;
+use mz_storage_client::source::persist_source::{Consolidation, FlowControl};
 use mz_storage_client::types::errors::DataflowError;
 use mz_timely_util::probe::{self, ProbeNotify};
 
@@ -221,6 +221,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                         dataflow.until.clone(),
                         mfp.as_mut(),
                         Some(flow_control),
+                        Consolidation::Maybe,
                         // Copy the logic in DeltaJoin/Get/Join to start.
                         |_timer, count| count > 1_000_000,
                     );

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -235,12 +235,15 @@ pub fn build_compute_dataflow<A: Allocate>(
                     // possible.
                     if let Some(logger) = compute_state.compute_logger.clone() {
                         let export_ids = dataflow.export_ids().collect();
-                        ok_stream = ok_stream.log_import_frontiers(logger, *source_id, export_ids);
+                        ok_stream = ok_stream
+                            .inner
+                            .log_import_frontiers(logger, *source_id, export_ids)
+                            .as_collection();
                     }
 
                     let (oks, errs) = (
-                        ok_stream.as_collection().leave_region().leave_region(),
-                        err_stream.as_collection().leave_region().leave_region(),
+                        ok_stream.leave_region().leave_region(),
+                        err_stream.leave_region().leave_region(),
                     );
 
                     imported_sources.push((mz_expr::Id::Global(*source_id), (oks, errs)));

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::lattice::Lattice;
-use differential_dataflow::{AsCollection, Collection, Hashable};
+use differential_dataflow::{Collection, Hashable};
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::{
     Broadcast, Capability, CapabilitySet, ConnectLoop, Feedback, Inspect,
@@ -94,7 +94,7 @@ where
     // `persist_source` to select an appropriate `as_of`. We only care about times beyond the
     // current shard upper anyway.
     let source_as_of = None;
-    let (persist_stream, token) = persist_source::persist_source_core(
+    let (persist_collection, token) = persist_source::persist_source_core(
         &desired_collection.scope(),
         sink_id,
         Arc::clone(&compute_state.persist_clients),
@@ -106,7 +106,6 @@ where
         // Copy the logic in DeltaJoin/Get/Join to start.
         |_timer, count| count > 1_000_000,
     );
-    let persist_collection = persist_stream.as_collection();
 
     Some(Rc::new((
         install_desired_into_persist(

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -36,6 +36,7 @@ use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::source::persist_source;
+use mz_storage_client::source::persist_source::Consolidation;
 use mz_storage_client::types::errors::DataflowError;
 use mz_storage_client::types::sources::SourceData;
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
@@ -103,6 +104,7 @@ where
         Antichain::new(), // we want all updates
         None,             // no MFP
         None,             // no flow control
+        Consolidation::Maybe,
         // Copy the logic in DeltaJoin/Get/Join to start.
         |_timer, count| count > 1_000_000,
     );

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
-use differential_dataflow::{AsCollection, Collection, Hashable};
+use differential_dataflow::{Collection, Hashable};
 use timely::dataflow::Scope;
 use tracing::warn;
 
@@ -68,8 +68,7 @@ pub(crate) fn render_sink<G: Scope<Timestamp = Timestamp>>(
     );
     needed_tokens.push(source_token);
 
-    let ok_collection =
-        apply_sink_envelope(sink_id, sink, &sink_render, ok_collection.as_collection());
+    let ok_collection = apply_sink_envelope(sink_id, sink, &sink_render, ok_collection);
 
     let healthchecker_args = HealthcheckerArgs {
         persist_clients: Arc::clone(&storage_state.persist_clients),
@@ -83,7 +82,7 @@ pub(crate) fn render_sink<G: Scope<Timestamp = Timestamp>>(
         sink,
         sink_id,
         ok_collection,
-        err_collection.as_collection(),
+        err_collection,
         healthchecker_args,
     );
 

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -26,6 +26,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistLocation, ShardId};
 use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::source::persist_source;
+use mz_storage_client::source::persist_source::Consolidation;
 use mz_storage_client::types::errors::DataflowError;
 use mz_storage_client::types::sinks::{
     MetadataFilled, SinkEnvelope, StorageSinkConnection, StorageSinkDesc,
@@ -63,6 +64,7 @@ pub(crate) fn render_sink<G: Scope<Timestamp = Timestamp>>(
         timely::progress::Antichain::new(),
         None,
         None,
+        Consolidation::Maybe,
         // Copy the logic in DeltaJoin/Get/Join to start.
         |_timer, count| count > 1_000_000,
     );

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -367,10 +367,8 @@ where
                                     // Copy the logic in DeltaJoin/Get/Join to start.
                                     |_timer, count| count > 1_000_000,
                                 );
-                            let (tx_source_ok, tx_source_err) = (
-                                tx_source_ok_stream.as_collection(),
-                                tx_source_err_stream.as_collection(),
-                            );
+                            let (tx_source_ok, tx_source_err) =
+                                (tx_source_ok_stream, tx_source_err_stream);
                             needed_tokens.push(tx_token);
                             error_collections.push(tx_source_err);
 
@@ -428,13 +426,13 @@ where
                             );
                             (stream, Some(tok))
                         } else {
-                            (std::iter::empty().to_stream(scope), None)
+                            (std::iter::empty().to_stream(scope).as_collection(), None)
                         };
                     let (upsert_ok, upsert_err) = super::upsert::upsert(
                         &transformed_results,
                         resume_upper,
                         upsert_envelope.clone(),
-                        previous_stream,
+                        previous_stream.inner,
                         previous_token,
                     );
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -25,6 +25,7 @@ use tokio::runtime::Handle as TokioHandle;
 use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::source::persist_source;
+use mz_storage_client::source::persist_source::Consolidation;
 use mz_storage_client::types::errors::{DataflowError, DecodeError, EnvelopeError};
 use mz_storage_client::types::sources::{encoding::*, *};
 use mz_timely_util::operator::{CollectionExt, StreamExt};
@@ -364,6 +365,7 @@ where
                                     Antichain::new(),
                                     None,
                                     None,
+                                    Consolidation::Maybe,
                                     // Copy the logic in DeltaJoin/Get/Join to start.
                                     |_timer, count| count > 1_000_000,
                                 );
@@ -421,6 +423,7 @@ where
                                 Antichain::new(),
                                 None,
                                 None,
+                                Consolidation::Maybe,
                                 // Copy the logic in DeltaJoin/Get/Join to start.
                                 |_timer, count| count > 1_000_000,
                             );


### PR DESCRIPTION
Adds a `Consolidation` enum to the sink interface. This will allow compute and others to express a requirement that the output of the source is consolidated. (Right now it uses the existing `consolidate` implementation; in the future it will do something slightly more clever and efficient.)

This slots in the consolidation step after the decode step but before MFP. (We want consolidation to happen first, since basically every interesting optimization we have for consolidation relies on sortedness properties that MFP destroys.) Note that this implies the output of the source might not be consolidated even if you pass `Consolidated` as a parameter, which might be surprising. Let me know if it bothers you and we'll figure something out.

A few small refactorings in support of this:
- Split `decode_and_mfp` into two different operators, to make it possible to slot consolidation in between.
- Since `consolidate` is a differential operation, we need to call it on a differential collection. (We could probably keep the existing interface with some extra work, but this way seems to involve fewer conversions total.)
- While doing the above I noticed a case where the source stream was being split apart and then immediately concatenated back together. It's easy enough and slightly more efficient to not do that.

### Motivation

This is in support of: https://github.com/MaterializeInc/materialize/issues/16858.

The motivation for this specific PR is that it unblocks some parallel work: Compute can start taking advantage of this interface where it makes sense, and Persist/Storage/I can rework the source to consolidate more efficiently.

### Tips for reviewer

You may wonder: why add the interface before a more-optimized implementation? There's no Clearly Best implementation of consolidation in Persist, and some of the more exiting ones depend on metadata we don't have yet. If we can push some consolidation into the source early, that means we'll see all those callers get faster as the source improves, and we can tune our source changes based on Compute's actual usage.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
