### PR TITLE
[persist] Always perform routine maintenance (take two)

### DIFF
--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -297,7 +297,8 @@ where
     /// Politely expires this reader, releasing its since capability.
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
     pub async fn expire(mut self) {
-        self.machine.expire_critical_reader(&self.reader_id).await;
+        let (_, maintenance) = self.machine.expire_critical_reader(&self.reader_id).await;
+        maintenance.start_performing(&self.machine, &self.gc);
     }
 }
 

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -12,6 +12,7 @@ use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::marker::PhantomData;
+use std::mem;
 use std::time::Instant;
 
 use differential_dataflow::difference::Semigroup;
@@ -28,12 +29,12 @@ use tokio::sync::{mpsc, oneshot, Semaphore};
 use tracing::{debug, debug_span, warn, Instrument, Span};
 
 use crate::internal::machine::{retry_external, Machine};
+use crate::internal::maintenance::RoutineMaintenance;
 use crate::internal::metrics::RetryMetrics;
 use crate::internal::paths::{BlobKey, PartialRollupKey, RollupId};
 use crate::ShardId;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GcReq {
     pub shard_id: ShardId,
     pub new_seqno_since: SeqNo,
@@ -41,7 +42,7 @@ pub struct GcReq {
 
 #[derive(Debug)]
 pub struct GarbageCollector<K, V, T, D> {
-    sender: UnboundedSender<(GcReq, oneshot::Sender<()>)>,
+    sender: UnboundedSender<(GcReq, oneshot::Sender<RoutineMaintenance>)>,
     _phantom: PhantomData<fn() -> (K, V, T, D)>,
 }
 
@@ -111,7 +112,7 @@ where
 {
     pub fn new(mut machine: Machine<K, V, T, D>) -> Self {
         let (gc_req_sender, mut gc_req_recv) =
-            mpsc::unbounded_channel::<(GcReq, oneshot::Sender<()>)>();
+            mpsc::unbounded_channel::<(GcReq, oneshot::Sender<RoutineMaintenance>)>();
 
         // spin off a single task responsible for executing GC requests.
         // work is enqueued into the task through a channel
@@ -148,7 +149,7 @@ where
 
                 let start = Instant::now();
                 machine.applier.metrics.gc.started.inc();
-                Self::gc_and_truncate(&mut machine, consolidated_req)
+                let mut maintenance = Self::gc_and_truncate(&mut machine, consolidated_req)
                     .instrument(gc_span)
                     .await;
                 machine.applier.metrics.gc.finished.inc();
@@ -163,8 +164,9 @@ where
                 // inform all callers who enqueued GC reqs that their work is complete
                 for sender in gc_completed_senders {
                     // we can safely ignore errors here, it's possible the caller
-                    // wasn't interested in waiting and dropped their receiver
-                    let _ = sender.send(());
+                    // wasn't interested in waiting and dropped their receiver.
+                    // maintenance will be somewhat-arbitrarily assigned to the first oneshot.
+                    let _ = sender.send(mem::take(&mut maintenance));
                 }
             }
         });
@@ -178,7 +180,10 @@ where
     /// Enqueues a [GcReq] to be consumed by the GC background task when available.
     ///
     /// Returns a future that indicates when GC has cleaned up to at least [GcReq::new_seqno_since]
-    pub fn gc_and_truncate_background(&self, req: GcReq) -> Option<oneshot::Receiver<()>> {
+    pub fn gc_and_truncate_background(
+        &self,
+        req: GcReq,
+    ) -> Option<oneshot::Receiver<RoutineMaintenance>> {
         let (gc_completed_sender, gc_completed_receiver) = oneshot::channel();
         let new_gc_sender = self.sender.clone();
         let send = new_gc_sender.send((req, gc_completed_sender));
@@ -196,7 +201,10 @@ where
         Some(gc_completed_receiver)
     }
 
-    pub async fn gc_and_truncate(machine: &mut Machine<K, V, T, D>, req: GcReq) {
+    pub async fn gc_and_truncate(
+        machine: &mut Machine<K, V, T, D>,
+        req: GcReq,
+    ) -> RoutineMaintenance {
         // There's also a bulk delete API in s3 if the performance of this
         // becomes an issue. Maybe make Blob::delete take a list of keys?
         //
@@ -284,7 +292,7 @@ where
                 "gc {} early returning, already GC'd past {}",
                 req.shard_id, req.new_seqno_since,
             );
-            return;
+            return RoutineMaintenance::default();
         }
 
         let mut deleteable_batch_blobs = BTreeSet::new();
@@ -392,7 +400,7 @@ where
             .state_versions
             .write_rollup_blob(&rollup)
             .await;
-        let applied = machine
+        let (applied, maintenance) = machine
             .add_and_remove_rollups(
                 (rollup.seqno, &rollup.to_hollow()),
                 &deleteable_rollup_blobs,
@@ -464,5 +472,7 @@ where
             .set(u64::cast_from(seqno_held_parts.len()));
         shard_metrics.gc_live_diffs.set(live_diffs);
         report_step_timing(&machine.applier.metrics.gc.steps.finish_seconds);
+
+        maintenance
     }
 }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -32,6 +32,7 @@ use crate::critical::CriticalReaderId;
 use crate::error::{CodecMismatch, InvalidUsage};
 use crate::internal::apply::Applier;
 use crate::internal::compact::CompactReq;
+use crate::internal::gc::GarbageCollector;
 use crate::internal::maintenance::{RoutineMaintenance, WriterMaintenance};
 use crate::internal::metrics::{CmdMetrics, Metrics, MetricsRetryStream, RetryMetrics};
 use crate::internal::paths::{PartialRollupKey, RollupId};
@@ -98,9 +99,9 @@ where
         self.applier.state().seqno_since()
     }
 
-    pub async fn add_rollup_for_current_seqno(&mut self) {
+    pub async fn add_rollup_for_current_seqno(&mut self) -> RoutineMaintenance {
         let rollup = self.applier.write_rollup_blob(&RollupId::new()).await;
-        let applied = self
+        let (applied, maintenance) = self
             .add_and_remove_rollups((rollup.seqno, &rollup.to_hollow()), &[])
             .await;
         if !applied {
@@ -111,18 +112,19 @@ where
                 .delete_rollup(&rollup.shard_id, &rollup.key)
                 .await;
         }
+        maintenance
     }
 
     pub async fn add_and_remove_rollups(
         &mut self,
         add_rollup: (SeqNo, &HollowRollup),
         remove_rollups: &[(SeqNo, PartialRollupKey)],
-    ) -> bool {
+    ) -> (bool, RoutineMaintenance) {
         // See the big SUBTLE comment in [Self::merge_res] for what's going on
         // here.
         let mut applied_ever_true = false;
         let metrics = Arc::clone(&self.applier.metrics);
-        let (_seqno, _applied, _maintenance) = self
+        let (_seqno, _applied, maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.add_and_remove_rollups, |_, _, state| {
                 let ret = state.add_and_remove_rollups(add_rollup, remove_rollups);
                 if let Continue(applied) = ret {
@@ -131,7 +133,7 @@ where
                 ret
             })
             .await;
-        applied_ever_true
+        (applied_ever_true, maintenance)
     }
 
     pub async fn register_leased_reader(
@@ -140,9 +142,9 @@ where
         purpose: &str,
         lease_duration: Duration,
         heartbeat_timestamp_ms: u64,
-    ) -> LeasedReaderState<T> {
+    ) -> (LeasedReaderState<T>, RoutineMaintenance) {
         let metrics = Arc::clone(&self.applier.metrics);
-        let (_seqno, reader_state, _maintenance) = self
+        let (_seqno, reader_state, maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.register, |seqno, cfg, state| {
                 state.register_leased_reader(
                     &cfg.hostname,
@@ -180,21 +182,21 @@ where
             reader_state.seqno,
             self.applier.state().seqno_since()
         );
-        reader_state
+        (reader_state, maintenance)
     }
 
     pub async fn register_critical_reader<O: Opaque + Codec64>(
         &mut self,
         reader_id: &CriticalReaderId,
         purpose: &str,
-    ) -> CriticalReaderState<T> {
+    ) -> (CriticalReaderState<T>, RoutineMaintenance) {
         let metrics = Arc::clone(&self.applier.metrics);
-        let (_seqno, state, _maintenance) = self
+        let (_seqno, state, maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.register, |_seqno, cfg, state| {
                 state.register_critical_reader::<O>(&cfg.hostname, reader_id, purpose)
             })
             .await;
-        state
+        (state, maintenance)
     }
 
     pub async fn register_writer(
@@ -203,9 +205,9 @@ where
         purpose: &str,
         lease_duration: Duration,
         heartbeat_timestamp_ms: u64,
-    ) -> (Upper<T>, WriterState<T>) {
+    ) -> (Upper<T>, WriterState<T>, RoutineMaintenance) {
         let metrics = Arc::clone(&self.applier.metrics);
-        let (_seqno, (shard_upper, writer_state), _maintenance) = self
+        let (_seqno, (shard_upper, writer_state), maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.register, |_seqno, cfg, state| {
                 state.register_writer(
                     &cfg.hostname,
@@ -227,7 +229,7 @@ where
             error!("Writer {writer_id} was registered at timestamp {heartbeat_timestamp_ms} but immediately expired.\
                     This implies {lease_duration:?} passed between the call and its completion, which should be rare.");
         }
-        (shard_upper, writer_state)
+        (shard_upper, writer_state, maintenance)
     }
 
     pub async fn compare_and_append(
@@ -489,7 +491,10 @@ where
         }
     }
 
-    pub async fn merge_res(&mut self, res: &FueledMergeRes<T>) -> ApplyMergeResult {
+    pub async fn merge_res(
+        &mut self,
+        res: &FueledMergeRes<T>,
+    ) -> (ApplyMergeResult, RoutineMaintenance) {
         let metrics = Arc::clone(&self.applier.metrics);
 
         // SUBTLE! If Machine::merge_res returns false, the blobs referenced in
@@ -521,7 +526,7 @@ where
         // anyway need a mechanism to clean up leaked blobs because of process
         // crashes.
         let mut merge_result_ever_applied = ApplyMergeResult::NotAppliedNoMatch;
-        let (_seqno, _apply_merge_result, _maintenance) = self
+        let (_seqno, _apply_merge_result, maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.merge_res, |_, _, state| {
                 let ret = state.apply_merge_res(res);
                 if let Continue(result) = ret {
@@ -539,7 +544,7 @@ where
                 ret
             })
             .await;
-        merge_result_ever_applied
+        (merge_result_ever_applied, maintenance)
     }
 
     pub async fn downgrade_since(
@@ -602,46 +607,6 @@ where
         (seqno, existed, maintenance)
     }
 
-    pub async fn start_reader_heartbeat_task(self, reader_id: LeasedReaderId) -> JoinHandle<()> {
-        let mut machine = self;
-        spawn(|| "persist::heartbeat_read", async move {
-            let sleep_duration = machine.applier.cfg.reader_lease_duration / 2;
-            loop {
-                let before_sleep = Instant::now();
-                tokio::time::sleep(sleep_duration).await;
-
-                let elapsed_since_before_sleeping = before_sleep.elapsed();
-                if elapsed_since_before_sleeping > sleep_duration + Duration::from_secs(60) {
-                    warn!(
-                        "reader ({}) of shard ({}) went {}s between heartbeats",
-                        reader_id,
-                        machine.shard_id(),
-                        elapsed_since_before_sleeping.as_secs_f64()
-                    );
-                }
-
-                let before_heartbeat = Instant::now();
-                let (_seqno, existed, _maintenance) = machine
-                    .heartbeat_leased_reader(&reader_id, (machine.applier.cfg.now)())
-                    .await;
-
-                let elapsed_since_heartbeat = before_heartbeat.elapsed();
-                if elapsed_since_heartbeat > Duration::from_secs(60) {
-                    warn!(
-                        "reader ({}) of shard ({}) heartbeat call took {}s",
-                        reader_id,
-                        machine.shard_id(),
-                        elapsed_since_heartbeat.as_secs_f64(),
-                    );
-                }
-
-                if !existed {
-                    return;
-                }
-            }
-        })
-    }
-
     pub async fn heartbeat_writer(
         &mut self,
         writer_id: &WriterId,
@@ -656,74 +621,40 @@ where
         (seqno, existed, maintenance)
     }
 
-    pub async fn start_writer_heartbeat_task(self, writer_id: WriterId) -> JoinHandle<()> {
-        let mut machine = self;
-        spawn(|| "persist::heartbeat_write", async move {
-            let sleep_duration = machine.applier.cfg.writer_lease_duration / 4;
-            loop {
-                let before_sleep = Instant::now();
-                tokio::time::sleep(sleep_duration).await;
-
-                let elapsed_since_before_sleeping = before_sleep.elapsed();
-                if elapsed_since_before_sleeping > sleep_duration + Duration::from_secs(60) {
-                    warn!(
-                        "writer ({}) of shard ({}) went {}s between heartbeats",
-                        writer_id,
-                        machine.shard_id(),
-                        elapsed_since_before_sleeping.as_secs_f64()
-                    );
-                }
-
-                let before_heartbeat = Instant::now();
-                let (_seqno, existed, _maintenance) = machine
-                    .heartbeat_writer(&writer_id, (machine.applier.cfg.now)())
-                    .await;
-
-                let elapsed_since_heartbeat = before_heartbeat.elapsed();
-                if elapsed_since_heartbeat > Duration::from_secs(60) {
-                    warn!(
-                        "writer ({}) of shard ({}) heartbeat call took {}s",
-                        writer_id,
-                        machine.shard_id(),
-                        elapsed_since_heartbeat.as_secs_f64(),
-                    );
-                }
-
-                if !existed {
-                    return;
-                }
-            }
-        })
-    }
-
-    pub async fn expire_leased_reader(&mut self, reader_id: &LeasedReaderId) -> SeqNo {
+    pub async fn expire_leased_reader(
+        &mut self,
+        reader_id: &LeasedReaderId,
+    ) -> (SeqNo, RoutineMaintenance) {
         let metrics = Arc::clone(&self.applier.metrics);
-        let (seqno, _existed, _maintenance) = self
+        let (seqno, _existed, maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.expire_reader, |_, _, state| {
                 state.expire_leased_reader(reader_id)
             })
             .await;
-        seqno
+        (seqno, maintenance)
     }
 
-    pub async fn expire_critical_reader(&mut self, reader_id: &CriticalReaderId) -> SeqNo {
+    pub async fn expire_critical_reader(
+        &mut self,
+        reader_id: &CriticalReaderId,
+    ) -> (SeqNo, RoutineMaintenance) {
         let metrics = Arc::clone(&self.applier.metrics);
-        let (seqno, _existed, _maintenance) = self
+        let (seqno, _existed, maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.expire_reader, |_, _, state| {
                 state.expire_critical_reader(reader_id)
             })
             .await;
-        seqno
+        (seqno, maintenance)
     }
 
-    pub async fn expire_writer(&mut self, writer_id: &WriterId) -> SeqNo {
+    pub async fn expire_writer(&mut self, writer_id: &WriterId) -> (SeqNo, RoutineMaintenance) {
         let metrics = Arc::clone(&self.applier.metrics);
-        let (seqno, _existed, _maintenance) = self
+        let (seqno, _existed, maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.expire_writer, |_, _, state| {
                 state.expire_writer(writer_id)
             })
             .await;
-        seqno
+        (seqno, maintenance)
     }
 
     pub async fn maybe_become_tombstone(&mut self) -> Option<RoutineMaintenance> {
@@ -879,6 +810,104 @@ where
                 }
             }
         }
+    }
+}
+
+impl<K, V, T, D> Machine<K, V, T, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Semigroup + Codec64 + Send + Sync,
+{
+    pub async fn start_reader_heartbeat_task(
+        self,
+        reader_id: LeasedReaderId,
+        gc: GarbageCollector<K, V, T, D>,
+    ) -> JoinHandle<()> {
+        let mut machine = self;
+        spawn(|| "persist::heartbeat_read", async move {
+            let sleep_duration = machine.applier.cfg.reader_lease_duration / 2;
+            loop {
+                let before_sleep = Instant::now();
+                tokio::time::sleep(sleep_duration).await;
+
+                let elapsed_since_before_sleeping = before_sleep.elapsed();
+                if elapsed_since_before_sleeping > sleep_duration + Duration::from_secs(60) {
+                    warn!(
+                        "reader ({}) of shard ({}) went {}s between heartbeats",
+                        reader_id,
+                        machine.shard_id(),
+                        elapsed_since_before_sleeping.as_secs_f64()
+                    );
+                }
+
+                let before_heartbeat = Instant::now();
+                let (_seqno, existed, maintenance) = machine
+                    .heartbeat_leased_reader(&reader_id, (machine.applier.cfg.now)())
+                    .await;
+                maintenance.start_performing(&machine, &gc);
+
+                let elapsed_since_heartbeat = before_heartbeat.elapsed();
+                if elapsed_since_heartbeat > Duration::from_secs(60) {
+                    warn!(
+                        "reader ({}) of shard ({}) heartbeat call took {}s",
+                        reader_id,
+                        machine.shard_id(),
+                        elapsed_since_heartbeat.as_secs_f64(),
+                    );
+                }
+
+                if !existed {
+                    return;
+                }
+            }
+        })
+    }
+
+    pub async fn start_writer_heartbeat_task(
+        self,
+        writer_id: WriterId,
+        gc: GarbageCollector<K, V, T, D>,
+    ) -> JoinHandle<()> {
+        let mut machine = self;
+        spawn(|| "persist::heartbeat_write", async move {
+            let sleep_duration = machine.applier.cfg.writer_lease_duration / 4;
+            loop {
+                let before_sleep = Instant::now();
+                tokio::time::sleep(sleep_duration).await;
+
+                let elapsed_since_before_sleeping = before_sleep.elapsed();
+                if elapsed_since_before_sleeping > sleep_duration + Duration::from_secs(60) {
+                    warn!(
+                        "writer ({}) of shard ({}) went {}s between heartbeats",
+                        writer_id,
+                        machine.shard_id(),
+                        elapsed_since_before_sleeping.as_secs_f64()
+                    );
+                }
+
+                let before_heartbeat = Instant::now();
+                let (_seqno, existed, maintenance) = machine
+                    .heartbeat_writer(&writer_id, (machine.applier.cfg.now)())
+                    .await;
+                maintenance.start_performing(&machine, &gc);
+
+                let elapsed_since_heartbeat = before_heartbeat.elapsed();
+                if elapsed_since_heartbeat > Duration::from_secs(60) {
+                    warn!(
+                        "writer ({}) of shard ({}) heartbeat call took {}s",
+                        writer_id,
+                        machine.shard_id(),
+                        elapsed_since_heartbeat.as_secs_f64(),
+                    );
+                }
+
+                if !existed {
+                    return;
+                }
+            }
+        })
     }
 }
 
@@ -1360,7 +1389,8 @@ pub mod datadriven {
             shard_id: datadriven.shard_id,
             new_seqno_since,
         };
-        GarbageCollector::gc_and_truncate(&mut datadriven.machine, req).await;
+        let maintenance = GarbageCollector::gc_and_truncate(&mut datadriven.machine, req).await;
+        datadriven.routine.push(maintenance);
 
         Ok(format!("{} ok\n", datadriven.machine.seqno()))
     }
@@ -1461,10 +1491,11 @@ pub mod datadriven {
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
         let reader_id = args.expect("reader_id");
-        let state = datadriven
+        let (state, maintenance) = datadriven
             .machine
             .register_critical_reader::<u64>(&reader_id, "tests")
             .await;
+        datadriven.routine.push(maintenance);
         Ok(format!(
             "{} {:?}\n",
             datadriven.machine.seqno(),
@@ -1477,7 +1508,7 @@ pub mod datadriven {
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
         let reader_id = args.expect("reader_id");
-        let reader_state = datadriven
+        let (reader_state, maintenance) = datadriven
             .machine
             .register_leased_reader(
                 &reader_id,
@@ -1486,6 +1517,7 @@ pub mod datadriven {
                 (datadriven.client.cfg.now)(),
             )
             .await;
+        datadriven.routine.push(maintenance);
         Ok(format!(
             "{} {:?}\n",
             datadriven.machine.seqno(),
@@ -1498,7 +1530,7 @@ pub mod datadriven {
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
         let writer_id = args.expect("writer_id");
-        let (upper, _state) = datadriven
+        let (upper, _state, maintenance) = datadriven
             .machine
             .register_writer(
                 &writer_id,
@@ -1507,6 +1539,7 @@ pub mod datadriven {
                 (datadriven.client.cfg.now)(),
             )
             .await;
+        datadriven.routine.push(maintenance);
         Ok(format!(
             "{} {:?}\n",
             datadriven.machine.seqno(),
@@ -1543,7 +1576,8 @@ pub mod datadriven {
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
         let reader_id = args.expect("reader_id");
-        let _ = datadriven.machine.expire_critical_reader(&reader_id).await;
+        let (_, maintenance) = datadriven.machine.expire_critical_reader(&reader_id).await;
+        datadriven.routine.push(maintenance);
         Ok(format!("{} ok\n", datadriven.machine.seqno()))
     }
 
@@ -1552,7 +1586,8 @@ pub mod datadriven {
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
         let reader_id = args.expect("reader_id");
-        let _ = datadriven.machine.expire_leased_reader(&reader_id).await;
+        let (_, maintenance) = datadriven.machine.expire_leased_reader(&reader_id).await;
+        datadriven.routine.push(maintenance);
         Ok(format!("{} ok\n", datadriven.machine.seqno()))
     }
 
@@ -1561,7 +1596,8 @@ pub mod datadriven {
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
         let writer_id = args.expect("writer_id");
-        let _ = datadriven.machine.expire_writer(&writer_id).await;
+        let (_, maintenance) = datadriven.machine.expire_writer(&writer_id).await;
+        datadriven.routine.push(maintenance);
         Ok(format!("{} ok\n", datadriven.machine.seqno()))
     }
 
@@ -1607,10 +1643,11 @@ pub mod datadriven {
             .get(input)
             .expect("unknown batch")
             .clone();
-        let merge_res = datadriven
+        let (merge_res, maintenance) = datadriven
             .machine
             .merge_res(&FueledMergeRes { output: batch })
             .await;
+        datadriven.routine.push(maintenance);
         Ok(format!(
             "{} {}\n",
             datadriven.machine.seqno(),

--- a/src/persist-client/src/internal/maintenance.rs
+++ b/src/persist-client/src/internal/maintenance.rs
@@ -187,34 +187,13 @@ where
         let gc = gc.clone();
         let compactor = compactor.cloned();
         mz_ore::task::spawn(|| "writer-maintenance", async move {
-            self.perform_in_background(&machine, &gc, compactor.as_ref())
-                .await
+            self.perform(&machine, &gc, compactor.as_ref()).await
         });
     }
 
     /// Performs any writer maintenance necessary. Returns when all background
     /// tasks have completed and the maintenance is done.
-    ///
-    /// Used for testing maintenance-related state transitions deterministically
-    #[cfg(test)]
     pub(crate) async fn perform<K, V, D>(
-        self,
-        machine: &Machine<K, V, T, D>,
-        gc: &GarbageCollector<K, V, T, D>,
-        compactor: Option<&Compactor<K, V, T, D>>,
-    ) where
-        K: Debug + Codec,
-        V: Debug + Codec,
-        D: Semigroup + Codec64 + Send + Sync,
-    {
-        self.perform_in_background(machine, gc, compactor).await
-    }
-
-    /// Initiates maintenance work in the background, either through spawned tasks
-    /// or by sending messages to existing tasks. The returned futures may be
-    /// awaited to know when the work is completed, but do not need to be polled
-    /// to drive the work to completion.
-    async fn perform_in_background<K, V, D>(
         self,
         machine: &Machine<K, V, T, D>,
         gc: &GarbageCollector<K, V, T, D>,

--- a/src/persist-client/src/internal/maintenance.rs
+++ b/src/persist-client/src/internal/maintenance.rs
@@ -21,6 +21,7 @@ use futures_util::FutureExt;
 use mz_persist::location::SeqNo;
 use mz_persist_types::{Codec, Codec64};
 use std::fmt::Debug;
+use std::mem;
 use timely::progress::Timestamp;
 
 /// Every handle to this shard may be occasionally asked to perform
@@ -34,13 +35,17 @@ use timely::progress::Timestamp;
 /// Operations that run regularly once a handle is registered, such
 /// as heartbeats, are expected to always perform maintenance.
 #[must_use]
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct RoutineMaintenance {
     pub(crate) garbage_collection: Option<GcReq>,
     pub(crate) write_rollup: Option<SeqNo>,
 }
 
 impl RoutineMaintenance {
+    pub(crate) fn is_empty(&self) -> bool {
+        self == &RoutineMaintenance::default()
+    }
+
     /// Initiates any routine maintenance necessary in background tasks
     pub(crate) fn start_performing<K, V, T, D>(
         self,
@@ -83,7 +88,7 @@ impl RoutineMaintenance {
         self,
         machine: &Machine<K, V, T, D>,
         gc: &GarbageCollector<K, V, T, D>,
-    ) -> Vec<BoxFuture<'static, ()>>
+    ) -> Vec<BoxFuture<'static, RoutineMaintenance>>
     where
         K: Debug + Codec,
         V: Debug + Codec,
@@ -95,7 +100,7 @@ impl RoutineMaintenance {
             if let Some(recv) = gc.gc_and_truncate_background(gc_req) {
                 // it's safe to ignore errors on the receiver. in the
                 // case of shutdown, the sender may have been dropped
-                futures.push(recv.map(|_| ()).boxed());
+                futures.push(recv.map(Result::unwrap_or_default).boxed());
             }
         }
 
@@ -114,9 +119,9 @@ impl RoutineMaintenance {
                         machine.seqno(),
                         rollup_seqno
                     );
-                    machine.add_rollup_for_current_seqno().await;
+                    machine.add_rollup_for_current_seqno().await
                 })
-                .map(|_| ())
+                .map(Result::unwrap_or_default)
                 .boxed(),
             );
         }
@@ -178,7 +183,13 @@ where
         V: Debug + Codec,
         D: Semigroup + Codec64 + Send + Sync,
     {
-        let _ = self.perform_in_background(machine, gc, compactor);
+        let machine = machine.clone();
+        let gc = gc.clone();
+        let compactor = compactor.cloned();
+        mz_ore::task::spawn(|| "writer-maintenance", async move {
+            self.perform_in_background(&machine, &gc, compactor.as_ref())
+                .await
+        });
     }
 
     /// Performs any writer maintenance necessary. Returns when all background
@@ -196,38 +207,47 @@ where
         V: Debug + Codec,
         D: Semigroup + Codec64 + Send + Sync,
     {
-        for future in self.perform_in_background(machine, gc, compactor) {
-            let _ = future.await;
-        }
+        self.perform_in_background(machine, gc, compactor).await
     }
 
     /// Initiates maintenance work in the background, either through spawned tasks
     /// or by sending messages to existing tasks. The returned futures may be
     /// awaited to know when the work is completed, but do not need to be polled
     /// to drive the work to completion.
-    fn perform_in_background<K, V, D>(
+    async fn perform_in_background<K, V, D>(
         self,
         machine: &Machine<K, V, T, D>,
         gc: &GarbageCollector<K, V, T, D>,
         compactor: Option<&Compactor<K, V, T, D>>,
-    ) -> Vec<BoxFuture<'static, ()>>
-    where
+    ) where
         K: Debug + Codec,
         V: Debug + Codec,
         D: Semigroup + Codec64 + Send + Sync,
     {
-        let mut futures = self.routine.perform_in_background(machine, gc);
+        let Self {
+            routine,
+            compaction,
+        } = self;
+        let mut more_maintenance = RoutineMaintenance::default();
+        for future in routine.perform_in_background(machine, gc) {
+            more_maintenance.merge(future.await);
+        }
 
         if let Some(compactor) = compactor {
-            for req in self.compaction {
+            for req in compaction {
                 if let Some(receiver) = compactor.compact_and_apply_background(req, machine) {
                     // it's safe to ignore errors on the receiver. in the
                     // case of shutdown, the sender may have been dropped
-                    futures.push(receiver.map(|_| ()).boxed());
+                    let _ = receiver.await;
                 }
             }
         }
 
-        futures
+        while !more_maintenance.is_empty() {
+            let maintenance = mem::take(&mut more_maintenance);
+            for future in maintenance.perform_in_background(machine, gc) {
+                more_maintenance.merge(future.await);
+            }
+        }
     }
 }

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -164,7 +164,7 @@ where
             cfg,
             metrics,
             machine: machine.clone(),
-            gc,
+            gc: gc.clone(),
             compact,
             blob,
             cpu_heavy_runtime,
@@ -172,7 +172,7 @@ where
             upper,
             last_heartbeat,
             explicitly_expired: false,
-            heartbeat_task: Some(machine.start_writer_heartbeat_task(writer_id).await),
+            heartbeat_task: Some(machine.start_writer_heartbeat_task(writer_id, gc).await),
         }
     }
 
@@ -630,7 +630,8 @@ where
     /// happens.
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
     pub async fn expire(mut self) {
-        self.machine.expire_writer(&self.writer_id).await;
+        let (_, maintenance) = self.machine.expire_writer(&self.writer_id).await;
+        maintenance.start_performing(&self.machine, &self.gc);
         self.explicitly_expired = true;
     }
 
@@ -732,6 +733,7 @@ where
             }
         };
         let mut machine = self.machine.clone();
+        let gc = self.gc.clone();
         let writer_id = self.writer_id.clone();
         // Spawn a best-effort task to expire this write handle. It's fine if
         // this doesn't run to completion, we'd just have to wait out the lease
@@ -742,7 +744,8 @@ where
         handle.spawn_named(
             || format!("WriteHandle::expire ({})", self.writer_id),
             async move {
-                machine.expire_writer(&writer_id).await;
+                let (_, maintenance) = machine.expire_writer(&writer_id).await;
+                maintenance.start_performing(&machine, &gc);
             }
             .instrument(expire_span),
         );

--- a/src/persist-client/tests/machine/empty_since
+++ b/src/persist-client/tests/machine/empty_since
@@ -133,12 +133,20 @@ error: Since(Antichain { elements: [] })
 # maintenance it needs.
 perform-maintenance
 ----
+v20 ok
 v21 ok
 v21 ok
 v21 ok
 v21 ok
 v21 ok
 v21 ok
+v21 ok
+v21 ok
+v22 ok
+v22 ok
+v22 ok
+v22 ok
+v22 ok
 v22 ok
 v22 ok
 v22 ok

--- a/src/persist-client/tests/machine/empty_upper
+++ b/src/persist-client/tests/machine/empty_upper
@@ -110,10 +110,16 @@ k2 2 1
 # maintenance it needs.
 perform-maintenance
 ----
+v14 ok
 v15 ok
 v15 ok
 v15 ok
 v15 ok
+v15 ok
+v15 ok
+v16 ok
+v16 ok
+v16 ok
 v16 ok
 v16 ok
 v16 ok


### PR DESCRIPTION
Unrevert of #16654. 

The original PR triggered an issue where a large number of handle expiries at once could cause a pathological blowup in the number of expiries performed and copies of state kept in memory. We've fixed the expiry issue, and incoming state management changes should prevent the recurrence of a similar issue elsewhere.

### Motivation

See the original PR for the motivation for these changes!

### Tips for reviewer

This cherry-picks the original squash commit, with just enough changes to get things compiling. Conflicts were minor, and mostly due to the expiry and state-management changes mentioned above.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
