### PR TITLE
adapter: load catalog items in less-Ord dependent way

### DIFF
--- a/src/repr/src/global_id.rs
+++ b/src/repr/src/global_id.rs
@@ -22,6 +22,11 @@ use mz_proto::{RustType, TryFromProtoError};
 include!(concat!(env!("OUT_DIR"), "/mz_repr.global_id.rs"));
 
 /// The identifier for a global dataflow.
+///
+/// WARNING: Despite the fact that `GlobalId` implements `Ord`, the ordering of
+/// IDs does not express any relationship between dependencies. We retain the
+/// `Ord` implementation exclusively to facilitate placing `GlobalId`s in
+/// maps/sets.
 #[derive(
     Arbitrary,
     Clone,


### PR DESCRIPTION
#15813 breaks the assumption that entries have IDs greater than all of their dependencies. To reinforce this notion, rewrite the process to load catalog items in a way that is almost entirely unreliant on `Ord` and could easily be rewritten if `GlobalId`s contained UUIDs.

### Motivation

This PR refactors existing code.

### Tips for reviewer

The first commit is just "code movement."

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
