### PR TITLE
sql: remove some unused dummy catalog stuff

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -3097,16 +3097,6 @@ pub mod BUILTINS {
         })
     }
 
-    // TODO(lh): Once we remove legacy logs, this function should not be needed anymore
-    pub fn variant_to_builtin(variant: LogVariant) -> Option<&'static BuiltinLog> {
-        for x in logs() {
-            if x.variant == variant {
-                return Some(x);
-            }
-        }
-        None
-    }
-
     pub fn types() -> impl Iterator<Item = &'static BuiltinType<NameReference>> {
         BUILTINS_STATIC.iter().filter_map(|b| match b {
             Builtin::Type(typ) => Some(*typ),

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -30,7 +30,7 @@ use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use mz_controller::clusters::{ClusterId, ReplicaId};
 use mz_expr::MirScalarExpr;
 use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO};
-use mz_repr::explain::{DummyHumanizer, ExprHumanizer};
+use mz_repr::explain::ExprHumanizer;
 use mz_repr::{ColumnName, GlobalId, RelationDesc, ScalarType};
 use mz_sql_parser::ast::Expr;
 use mz_sql_parser::ast::UnresolvedObjectName;
@@ -839,7 +839,7 @@ impl SessionCatalog for DummyCatalog {
     }
 
     fn active_database(&self) -> Option<&DatabaseId> {
-        Some(&DatabaseId(0))
+        None
     }
 
     fn active_cluster(&self) -> &str {
@@ -859,7 +859,7 @@ impl SessionCatalog for DummyCatalog {
     }
 
     fn get_database(&self, _: &DatabaseId) -> &dyn CatalogDatabase {
-        &DummyDatabase
+        unimplemented!()
     }
 
     fn resolve_schema(&self, _: Option<&str>, _: &str) -> Result<&dyn CatalogSchema, CatalogError> {
@@ -926,7 +926,7 @@ impl SessionCatalog for DummyCatalog {
     }
 
     fn now(&self) -> EpochMillis {
-        (self.config().now)()
+        0
     }
 
     fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName {
@@ -939,37 +939,16 @@ impl SessionCatalog for DummyCatalog {
 }
 
 impl ExprHumanizer for DummyCatalog {
-    fn humanize_id(&self, id: GlobalId) -> Option<String> {
-        DummyHumanizer.humanize_id(id)
+    fn humanize_id(&self, _: GlobalId) -> Option<String> {
+        None
     }
 
-    fn humanize_id_unqualified(&self, id: GlobalId) -> Option<String> {
-        DummyHumanizer.humanize_id_unqualified(id)
+    fn humanize_id_unqualified(&self, _: GlobalId) -> Option<String> {
+        None
     }
 
-    fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
-        DummyHumanizer.humanize_scalar_type(ty)
-    }
-}
-
-/// A dummy [`CatalogDatabase`] implementation.
-///
-/// This implementation is suitable for use in tests that plan queries which are
-/// not demanding of the catalog, as many methods are unimplemented.
-#[derive(Debug)]
-pub struct DummyDatabase;
-
-impl CatalogDatabase for DummyDatabase {
-    fn name(&self) -> &str {
-        "dummy"
-    }
-
-    fn id(&self) -> DatabaseId {
-        DatabaseId(0)
-    }
-
-    fn has_schemas(&self) -> bool {
-        true
+    fn humanize_scalar_type(&self, _: &ScalarType) -> String {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION


### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a