### PR TITLE
sql: apply AST transforms to all expressions

### DIFF
--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -26,6 +26,13 @@ use crate::names::{Aug, PartialObjectName, ResolvedDataType};
 use crate::normalize;
 use crate::plan::{PlanError, StatementContext};
 
+pub fn transform_select_item<'a>(
+    scx: &StatementContext,
+    si: &'a mut SelectItem<Aug>,
+) -> Result<(), PlanError> {
+    run_transforms(scx, |t, si| t.visit_select_item_mut(si), si)
+}
+
 pub fn transform_query<'a>(
     scx: &StatementContext,
     query: &'a mut Query<Aug>,

--- a/test/sqllogictest/returning.slt
+++ b/test/sqllogictest/returning.slt
@@ -20,6 +20,11 @@ INSERT INTO t (b, a) VALUES (2, 1) RETURNING a
 ----
 1
 
+query I
+INSERT INTO t VALUES (2, 1) RETURNING (a)
+----
+2
+
 query III
 INSERT INTO t VALUES (3, 4) RETURNING a, *
 ----
@@ -62,7 +67,7 @@ INSERT INTO t (a) VALUES (100) RETURNING t.a
 query I
 INSERT INTO t SELECT count(*), 0 FROM t AS t RETURNING a
 ----
-9
+10
 
 # TODO(mjibson): This works in Postgres. We currently parse the RETURNING as a
 # table alias for t.
@@ -123,11 +128,12 @@ query II
 SELECT * FROM t ORDER BY a, b
 ----
 1  2
+2  1
 3  4
 5  6
 7  8
-9  0
 9  10
+10  0
 10  11
 100  11
 NULL  10

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -25,6 +25,9 @@ materialize.public.t  "CREATE TABLE \"materialize\".\"public\".\"t\" (\"a\" \"pg
 > CREATE TABLE s (a int DEFAULT 1)
 > DROP TABLE s;
 
+> CREATE TABLE s (a int DEFAULT (1))
+> DROP TABLE s;
+
 > CREATE TABLE s (a date DEFAULT now())
 > DROP TABLE s;
 


### PR DESCRIPTION
The SQL planner was failing to call `transform_expr` on several expressions: `DEFAULT` expressions in `CREATE TABLE` statements and `RETURNING` expressions in `INSERT` statements. This could lead to panics when e.g. the expression contained an `Expr::Nested`, which the planner expects to be transformed away by `transform_expr`.

~This class of bug has bitten us several times. This commit attempts to address the problem at its root, by transforming the entire statement at once at the start of planning or describing. (Previously each code path that dealt with untransformed queries or expressions was responsible for calling `transform_{query|expr}` before calling `plan_{query|expr}`, and over the years many of those code paths have failed to do so at their introduction.)~

~This approach isn't quite as robust as enforcing the transformation with the Rust type system, as @ggevay suggested [0], but I'm not sure how to implement @ggevay's suggestion. The approach taken here is at least a lot better than the currrent approach.~

This class of bug has bitten us several times. We should attempt a more robust solution (e.g., using the Rust type system as @ggevay suggests in [0] to distinguish between untransformed and transformed expressions), but doing so requires a substantial refactor that I don't have time for at the moment.

Fix #17706.

[0]: https://github.com/MaterializeInc/materialize/issues/17706#issuecomment-1434286617

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix a bug that could cause Materialize to crash when expressions in `CREATE TABLE ... DEFAULT` clauses or `INSERT ... RETURNING` clauses contained nested parentheses.
