### PR TITLE
sql: transform SHOW queries before planning

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -339,7 +339,7 @@ pub fn sql_impl(
 
         let (mut expr, _) = names::resolve(qcx.scx.catalog, expr.clone())?;
         // Desugar the expression
-        transform_ast::transform_expr(&scx, &mut expr)?;
+        transform_ast::transform(&scx, &mut expr)?;
 
         let ecx = ExprContext {
             qcx: &qcx,
@@ -417,7 +417,7 @@ fn sql_impl_table_func_inner(
 
         let query = query.clone();
         let (mut query, _) = names::resolve(qcx.scx.catalog, query)?;
-        transform_ast::transform_query(&scx, &mut query)?;
+        transform_ast::transform(&scx, &mut query)?;
 
         query::plan_nested_query(&mut qcx, &query)
     };

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -221,7 +221,7 @@ pub fn plan_create_table(
                     // Ensure expression can be planned and yields the correct
                     // type.
                     let mut expr = expr.clone();
-                    transform_ast::transform_expr(scx, &mut expr)?;
+                    transform_ast::transform(scx, &mut expr)?;
                     let _ = query::plan_default_expr(scx, &expr, &ty)?;
                     default = expr.clone();
                 }

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -38,7 +38,7 @@ use crate::names::{
 use crate::parse;
 use crate::plan::scope::Scope;
 use crate::plan::statement::{dml, StatementContext, StatementDesc};
-use crate::plan::{query, HirRelationExpr, Params, Plan, PlanError, SendRowsPlan};
+use crate::plan::{query, transform_ast, HirRelationExpr, Params, Plan, PlanError, SendRowsPlan};
 
 pub fn describe_show_create_view(
     _: &StatementContext,
@@ -621,7 +621,8 @@ impl<'a> ShowSelect<'a> {
             Statement::Select(select) => select,
             _ => panic!("ShowSelect::new called with non-SELECT statement"),
         };
-        let (stmt, _) = names::resolve(scx.catalog, stmt)?;
+        let (mut stmt, _) = names::resolve(scx.catalog, stmt)?;
+        transform_ast::transform(scx, &mut stmt)?;
         Ok(ShowSelect { scx, stmt })
     }
 

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -16,7 +16,7 @@
 use uuid::Uuid;
 
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
-use mz_sql_parser::ast::visit_mut::{self, VisitMut};
+use mz_sql_parser::ast::visit_mut::{self, VisitMut, VisitMutNode};
 use mz_sql_parser::ast::{
     Expr, Function, FunctionArgs, Ident, Op, OrderByExpr, Query, Select, SelectItem, TableAlias,
     TableFactor, TableFunction, TableWithJoins, UnresolvedObjectName, Value,
@@ -26,38 +26,16 @@ use crate::names::{Aug, PartialObjectName, ResolvedDataType};
 use crate::normalize;
 use crate::plan::{PlanError, StatementContext};
 
-pub fn transform_select_item<'a>(
-    scx: &StatementContext,
-    si: &'a mut SelectItem<Aug>,
-) -> Result<(), PlanError> {
-    run_transforms(scx, |t, si| t.visit_select_item_mut(si), si)
-}
-
-pub fn transform_query<'a>(
-    scx: &StatementContext,
-    query: &'a mut Query<Aug>,
-) -> Result<(), PlanError> {
-    run_transforms(scx, |t, query| t.visit_query_mut(query), query)
-}
-
-pub fn transform_expr(scx: &StatementContext, expr: &mut Expr<Aug>) -> Result<(), PlanError> {
-    run_transforms(scx, |t, expr| t.visit_expr_mut(expr), expr)
-}
-
-pub(crate) fn run_transforms<F, A>(
-    scx: &StatementContext,
-    mut f: F,
-    ast: &mut A,
-) -> Result<(), PlanError>
+pub(crate) fn transform<N>(scx: &StatementContext, node: &mut N) -> Result<(), PlanError>
 where
-    F: for<'ast> FnMut(&mut dyn VisitMut<'ast, Aug>, &'ast mut A),
+    N: for<'a> VisitMutNode<'a, Aug>,
 {
     let mut func_rewriter = FuncRewriter::new(scx);
-    f(&mut func_rewriter, ast);
+    node.visit_mut(&mut func_rewriter);
     func_rewriter.status?;
 
     let mut desugarer = Desugarer::new();
-    f(&mut desugarer, ast);
+    node.visit_mut(&mut desugarer);
     desugarer.status
 }
 


### PR DESCRIPTION
SHOW queries are internally translated to SELECT statements that are
planned through a special pathway. @jkosh44 noticed in https://github.com/MaterializeInc/materialize/pull/17723 that we
weren't correctly performing AST transforms on those queries. At
present, we're not constructing any SELECT statements that required AST
transformations to plan correctly, but best to be future proof.

### Motivation

  * This PR avoids a future bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
