### PR TITLE
stroage: subset of commits from #15813

### DIFF
--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -528,7 +528,7 @@ where
             }
             StorageCommand::CreateSources(ingestions) => {
                 for ingestion in ingestions {
-                    for &export_id in ingestion.description.source_exports.keys() {
+                    for export_id in ingestion.description.subsource_ids() {
                         let mut frontier = MutableAntichain::new();
                         // TODO(guswynn): cluster-unification: fix this dangerous use of `as`, by
                         // merging the types that compute and storage use.

--- a/src/storage-client/src/controller/command_wals.rs
+++ b/src/storage-client/src/controller/command_wals.rs
@@ -144,11 +144,7 @@ where
             .await;
 
         // Determine all shards that are registered that are not in use.
-        let shard_id_desc_to_truncate: Vec<_> = registered_shards
-            .difference(&in_use_shards)
-            .cloned()
-            .collect();
-
-        self.finalize_shards(&shard_id_desc_to_truncate).await;
+        self.finalize_shards(registered_shards.difference(&in_use_shards).cloned())
+            .await;
     }
 }

--- a/src/storage-client/src/controller/command_wals.rs
+++ b/src/storage-client/src/controller/command_wals.rs
@@ -147,7 +147,6 @@ where
         let shard_id_desc_to_truncate: Vec<_> = registered_shards
             .difference(&in_use_shards)
             .cloned()
-            .map(|shard_id| (shard_id, "finalizing unused shard".to_string()))
             .collect();
 
         self.finalize_shards(&shard_id_desc_to_truncate).await;

--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -441,9 +441,8 @@ where
                 for ingestion in ingestions {
                     self.sources.insert(ingestion.id, ingestion.clone());
                     // Initialize the uppers we are tracking
-                    for &export_id in ingestion.description.source_exports.keys() {
-                        self.uppers
-                            .insert(export_id, Antichain::from_elem(T::minimum()));
+                    for id in ingestion.description.subsource_ids() {
+                        self.uppers.insert(id, Antichain::from_elem(T::minimum()));
                     }
                 }
             }

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -79,6 +79,23 @@ pub struct IngestionDescription<S = (), C = GenericSourceConnection> {
     pub instance_id: StorageInstanceId,
 }
 
+impl<S> IngestionDescription<S> {
+    /// Return an iterator over the `GlobalId`s of `self`'s subsources.
+    pub fn subsource_ids(&self) -> impl Iterator<Item = GlobalId> + '_ {
+        // Expand self so that any new fields added generate a compiler error to
+        // increase the likelihood of developers seeing this function.
+        let IngestionDescription {
+            desc: _,
+            source_imports: _,
+            ingestion_metadata: _,
+            source_exports,
+            instance_id: _,
+        } = &self;
+
+        source_exports.keys().copied()
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct SourceExport<S = ()> {
     /// The index of the exported output stream

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -542,7 +542,7 @@ where
         };
 
         while PartialOrder::less_than(&self.source_upper.frontier(), &new_source_upper) {
-            let (ts, upper) = self
+            let (ts, mut upper) = self
                 .clock_stream
                 .by_ref()
                 .skip_while(|(_ts, upper)| {
@@ -554,6 +554,11 @@ where
                 .next()
                 .await
                 .expect("clock stream ended without reaching the empty frontier");
+
+            // If source is closed, close remap shard as well.
+            if new_source_upper.is_empty() {
+                upper = Antichain::new();
+            }
 
             let mut updates = vec![];
             for src_ts in self.source_upper.frontier().iter().cloned() {


### PR DESCRIPTION
#15813 has continued to grow, so breaking out a subset of its commits that only refactor existing code so as to reduce the burden of review.

### Motivation

This PR refactors existing code.

### Tips for reviewer

The code in this PR that has changed since the last review of #17543 is:
- [sql: allow awaiting named dependencies w/o GlobalIds](https://github.com/MaterializeInc/materialize/commit/c442fad3d408cbe60700f1e7ac6d6099ca1db19e) which is necessary to handle opening the catalog in cases where dependencies have greater IDs than their dependents. We do not serialized all dependencies with `GlobalId`s and sometimes simply use the object's name.
- [storage: increase rewrite_collection_metadata parallelizability](https://github.com/MaterializeInc/materialize/commit/05517521ffdf40fb6f393dbc182ef85d6964dfdc), which is a refactor of how we rewrite collection metadata during a migration
- [adapter: initialize source + subsource read policies simultaneously](https://github.com/MaterializeInc/materialize/commit/d46015cb5b07bb120d518d6203ac27e7e011732a), which is new and provides some stability of understanding the `since`s of collections that contain subsources

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
