### PR TITLE
[persist] Revert "Merge pull request #17555 from danhhz/persist_usage"

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -99,7 +99,8 @@ use mz_ore::task::spawn;
 use mz_ore::thread::JoinHandleExt;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{stack, task};
-use mz_persist_client::usage::{ShardsUsage, StorageUsageClient};
+use mz_persist_client::usage::StorageUsageClient;
+use mz_persist_client::ShardId;
 use mz_repr::explain::ExplainFormat;
 use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
 use mz_secrets::SecretsController;
@@ -201,7 +202,7 @@ pub enum Message<T = mz_repr::Timestamp> {
     },
     LinearizeReads(Vec<PendingReadTxn>),
     StorageUsageFetch,
-    StorageUsageUpdate(ShardsUsage),
+    StorageUsageUpdate(BTreeMap<Option<ShardId>, u64>),
     RealTimeRecencyTimestamp {
         conn_id: ConnectionId,
         transient_revision: u64,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -340,13 +340,11 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
 
     // Initialize storage usage client.
     let storage_usage_client = StorageUsageClient::open(
-        config
-            .controller
-            .persist_clients
-            .open(config.controller.persist_location.clone())
-            .await
-            .context("opening storage usage client")?,
-    );
+        config.controller.persist_location.blob_uri.clone(),
+        &config.controller.persist_clients,
+    )
+    .await
+    .context("opening storage usage client")?;
 
     // TODO(teskje): Remove this migration in v0.42, since v0.41+ will only create orchestrator
     // resources in the "cluster" namespace.

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -133,7 +133,7 @@ impl PersistClientCache {
         Ok(consensus)
     }
 
-    async fn open_blob(
+    pub(crate) async fn open_blob(
         &self,
         blob_uri: String,
     ) -> Result<Arc<dyn Blob + Send + Sync>, ExternalError> {

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -130,7 +130,6 @@ impl PersistConfig {
                 state_versions_recent_live_diffs_limit: AtomicUsize::new(usize::cast_from(
                     30 * Self::NEED_ROLLUP_THRESHOLD,
                 )),
-                usage_state_fetch_concurrency_limit: AtomicUsize::new(8),
             }),
             compaction_enabled: !compaction_disabled,
             compaction_concurrency_limit: 5,
@@ -228,7 +227,6 @@ pub struct DynamicConfig {
     compaction_memory_bound_bytes: AtomicUsize,
     gc_blob_delete_concurrency_limit: AtomicUsize,
     state_versions_recent_live_diffs_limit: AtomicUsize,
-    usage_state_fetch_concurrency_limit: AtomicUsize,
 
     // TODO: Figure out how to make these dynamic.
     compaction_minimum_timeout: Duration,
@@ -332,12 +330,6 @@ impl DynamicConfig {
     /// by GC.
     pub fn state_versions_recent_live_diffs_limit(&self) -> usize {
         self.state_versions_recent_live_diffs_limit
-            .load(Self::LOAD_ORDERING)
-    }
-
-    /// The maximum number of concurrent state fetches during usage computation.
-    pub fn usage_state_fetch_concurrency_limit(&self) -> usize {
-        self.usage_state_fetch_concurrency_limit
             .load(Self::LOAD_ORDERING)
     }
 

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -117,16 +117,13 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-pub(crate) fn info_log_non_zero_metrics(metric_families: &[MetricFamily]) {
+fn info_log_non_zero_metrics(metric_families: &[MetricFamily]) {
     for mf in metric_families {
         for m in mf.get_metric() {
             let val = match mf.get_field_type() {
                 MetricType::COUNTER => m.get_counter().get_value(),
                 MetricType::GAUGE => m.get_gauge().get_value(),
-                x => {
-                    warn!("unhandled {} metric type: {:?}", mf.get_name(), x);
-                    continue;
-                }
+                x => unimplemented!("unhandled metric type: {:?}", x),
             };
             if val == 0.0 {
                 continue;

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -31,7 +31,6 @@ use mz_persist_types::{Codec, Codec64};
 use mz_proto::RustType;
 use serde_json::json;
 
-use crate::async_runtime::CpuHeavyRuntime;
 use crate::cli::admin::{make_blob, make_consensus};
 use crate::error::CodecConcreteType;
 use crate::fetch::EncodedPart;
@@ -40,8 +39,7 @@ use crate::internal::paths::{
     BlobKey, BlobKeyPrefix, PartialBatchKey, PartialBlobKey, PartialRollupKey,
 };
 use crate::internal::state::{ProtoStateDiff, ProtoStateRollup, State};
-use crate::usage::{HumanBytes, StorageUsageClient};
-use crate::{Metrics, PersistClient, PersistConfig, ShardId, StateVersions};
+use crate::{Metrics, PersistConfig, ShardId, StateVersions};
 
 const READ_ALL_BUILD_INFO: BuildInfo = BuildInfo {
     version: "10000000.0.0+test",
@@ -263,7 +261,7 @@ pub async fn fetch_state_rollups(args: &StateArgs) -> Result<impl serde::Seriali
         .fetch_all_live_states::<u64>(shard_id)
         .await
         .check_ts_codec()?;
-    while let Some(v) = state_iter.next(|_| {}) {
+    while let Some(v) = state_iter.next() {
         for rollup in v.collections.rollups.values() {
             rollup_keys.insert(rollup.key.clone());
         }
@@ -302,7 +300,7 @@ pub async fn fetch_state_diffs(
         .fetch_all_live_states::<u64>(shard_id)
         .await
         .check_ts_codec()?;
-    while let Some(_) = state_iter.next(|_| {}) {
+    while let Some(_) = state_iter.next() {
         live_states.push(state_iter.into_proto());
     }
 
@@ -560,7 +558,7 @@ pub async fn unreferenced_blobs(args: &StateArgs) -> Result<impl serde::Serializ
     let mut known_parts = BTreeSet::new();
     let mut known_rollups = BTreeSet::new();
     let mut known_writers = BTreeSet::new();
-    while let Some(v) = state_iter.next(|_| {}) {
+    while let Some(v) = state_iter.next() {
         for writer_id in v.collections.writers.keys() {
             known_writers.insert(writer_id.clone());
         }
@@ -591,41 +589,180 @@ pub async fn unreferenced_blobs(args: &StateArgs) -> Result<impl serde::Serializ
 
 /// Returns information about blob usage for a shard
 pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
-    let shard_id = if args.shard_id.is_empty() {
-        None
-    } else {
-        Some(args.shard_id())
-    };
-    let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
-    let metrics_registry = MetricsRegistry::new();
-    let metrics = Arc::new(Metrics::new(&cfg, &metrics_registry));
-    let consensus =
-        make_consensus(&cfg, &args.consensus_uri, NO_COMMIT, Arc::clone(&metrics)).await?;
-    let blob = make_blob(&cfg, &args.blob_uri, NO_COMMIT, Arc::clone(&metrics)).await?;
-    let cpu_heavy_runtime = Arc::new(CpuHeavyRuntime::new());
-    let usage = StorageUsageClient::open(PersistClient::new(
-        cfg,
-        blob,
-        consensus,
-        metrics,
-        cpu_heavy_runtime,
-    )?);
+    let shard_id = args.shard_id();
+    let state_versions = args.open().await?;
 
-    if let Some(shard_id) = shard_id {
-        let usage = usage.shard_usage(shard_id).await;
-        println!("{}\n{}", shard_id, usage);
-    } else {
-        let usage = usage.shards_usage().await;
-        let mut by_shard = usage.by_shard.iter().collect::<Vec<_>>();
-        by_shard.sort_by_key(|(_, x)| x.total_bytes());
-        by_shard.reverse();
-        for (shard_id, usage) in by_shard {
-            println!("{}\n{}\n", shard_id, usage);
+    let mut s3_contents_before = BTreeMap::new();
+    let () = state_versions
+        .blob
+        .list_keys_and_metadata(&BlobKeyPrefix::Shard(&shard_id).to_string(), &mut |b| {
+            s3_contents_before.insert(b.key.to_owned(), usize::cast_from(b.size_in_bytes));
+        })
+        .await?;
+
+    let mut state_iter = state_versions
+        .fetch_all_live_states::<u64>(shard_id)
+        .await
+        .check_ts_codec()?;
+
+    let mut referenced_parts = BTreeMap::new();
+    let mut referenced_rollups = BTreeSet::new();
+    while let Some(state) = state_iter.next() {
+        state.collections.trace.map_batches(|b| {
+            for part in b.parts.iter() {
+                referenced_parts.insert(
+                    part.key.complete(&shard_id).to_string(),
+                    part.encoded_size_bytes,
+                );
+            }
+        });
+        for rollup in state.collections.rollups.values() {
+            referenced_rollups.insert(rollup.key.complete(&shard_id).to_string());
         }
-        println!("unattributable: {}", HumanBytes(usage.unattributable_bytes));
     }
 
+    let mut current_parts = BTreeMap::new();
+    let mut current_rollups = BTreeSet::new();
+    state_iter.state().collections.trace.map_batches(|b| {
+        for part in b.parts.iter() {
+            current_parts.insert(
+                part.key.complete(&shard_id).to_string(),
+                part.encoded_size_bytes,
+            );
+        }
+    });
+    for rollup in state_iter.state().collections.rollups.values() {
+        current_rollups.insert(rollup.key.complete(&shard_id).to_string());
+    }
+
+    // There's a bit of a race condition between fetching s3 and state, but
+    // probably fine for most cases?
+    let (mut referenced_by_state_count, mut referenced_by_state_bytes) = (0, 0);
+    let (mut current_writer_pending_count, mut current_writer_pending_bytes) = (0, 0);
+    let (mut leaked_count, mut leaked_bytes) = (0, 0);
+    for (key, bytes) in s3_contents_before.iter() {
+        let referenced_by_state =
+            referenced_parts.contains_key(key) || referenced_rollups.contains(key);
+        if referenced_by_state {
+            referenced_by_state_count += 1;
+            referenced_by_state_bytes += bytes;
+        } else {
+            let current_writer_pending =
+                match BlobKey::parse_ids(key).expect("key should be in known format") {
+                    (_, PartialBlobKey::Batch(writer_id, _)) => state_iter
+                        .state()
+                        .collections
+                        .writers
+                        .contains_key(&writer_id),
+                    (_, PartialBlobKey::Rollup(_, _)) => false,
+                };
+            if current_writer_pending {
+                current_writer_pending_count += 1;
+                current_writer_pending_bytes += bytes;
+            } else {
+                leaked_count += 1;
+                leaked_bytes += bytes;
+            }
+        }
+    }
+    let (mut gc_able_parts_count, mut gc_able_parts_bytes) = (0, 0);
+    let (current_parts_count, current_parts_bytes) =
+        (current_parts.len(), current_parts.values().sum::<usize>());
+    for (key, bytes) in referenced_parts.iter() {
+        if !current_parts.contains_key(key) {
+            gc_able_parts_count += 1;
+            gc_able_parts_bytes += bytes;
+        }
+    }
+    let (mut gc_able_rollups_count, mut gc_able_rollups_bytes) = (0, 0);
+    let (mut current_rollups_count, mut current_rollups_bytes) = (0, 0);
+    for key in referenced_rollups.iter() {
+        let Some(bytes) = s3_contents_before.get(key) else {
+            println!("unknown size due to race condition: {}", key);
+            continue;
+        };
+        if current_rollups.contains(key) {
+            current_rollups_count += 1;
+            current_rollups_bytes += *bytes;
+        } else {
+            gc_able_rollups_count += 1;
+            gc_able_rollups_bytes += *bytes;
+        }
+    }
+
+    println!(
+        "total s3 contents:        {} ({} blobs)",
+        human_bytes(s3_contents_before.values().sum::<usize>()),
+        s3_contents_before.len(),
+    );
+    println!(
+        "  leaked:                 {} ({} blobs)",
+        human_bytes(leaked_bytes),
+        leaked_count,
+    );
+    println!(
+        "  current writer pending: {} ({} blobs)",
+        human_bytes(current_writer_pending_bytes),
+        current_writer_pending_count,
+    );
+    println!(
+        "  referenced:             {} ({} blobs)",
+        human_bytes(referenced_by_state_bytes),
+        referenced_by_state_count,
+    );
+    println!(
+        "    gc-able:              {} ({} blobs)",
+        human_bytes(gc_able_parts_bytes + gc_able_rollups_bytes),
+        gc_able_parts_count + gc_able_rollups_count,
+    );
+    println!(
+        "      gc-able parts:      {} ({} blobs)",
+        human_bytes(gc_able_parts_bytes),
+        gc_able_parts_count,
+    );
+    println!(
+        "      gc-able rollups:    {} ({} blobs)",
+        human_bytes(gc_able_rollups_bytes),
+        gc_able_rollups_count,
+    );
+    println!(
+        "    current:              {} ({} blobs)",
+        human_bytes(current_parts_bytes + current_rollups_bytes),
+        current_parts_count + current_rollups_count,
+    );
+    println!(
+        "      current parts:      {} ({} blobs)",
+        human_bytes(current_parts_bytes),
+        current_parts_count,
+    );
+    println!(
+        "      current rollups:    {} ({} blobs)",
+        human_bytes(current_rollups_bytes),
+        current_rollups_count,
+    );
+
     Ok(())
+}
+
+fn human_bytes(bytes: usize) -> String {
+    if bytes < 10_240 {
+        return format!("{}B", bytes);
+    }
+    #[allow(clippy::as_conversions)]
+    let mut bytes = bytes as f64 / 1_024f64;
+    if bytes < 10_240f64 {
+        return format!("{:.1}KiB", bytes);
+    }
+    bytes = bytes / 1_024f64;
+    if bytes < 10_240f64 {
+        return format!("{:.1}MiB", bytes);
+    }
+    bytes = bytes / 1_024f64;
+    if bytes < 10_240f64 {
+        return format!("{:.1}GiB", bytes);
+    }
+    bytes = bytes / 1_024f64;
+    format!("{:.1}TiB", bytes)
 }
 
 // All `inspect` command are read-only.

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -459,9 +459,7 @@ where
         });
 
         let shard_metrics = machine.applier.metrics.shards.shard(&req.shard_id);
-        shard_metrics
-            .gc_seqno_held_parts
-            .set(u64::cast_from(seqno_held_parts.len()));
+        shard_metrics.set_gc_seqno_held_parts(seqno_held_parts.len());
         shard_metrics.gc_live_diffs.set(live_diffs);
         report_step_timing(&machine.applier.metrics.gc.steps.finish_seconds);
     }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1054,7 +1054,7 @@ pub mod datadriven {
             .check_ts_codec()
             .expect("shard codecs should not change");
         let mut s = String::new();
-        while let Some(x) = states.next(|_| {}) {
+        while let Some(x) = states.next() {
             if x.seqno < from {
                 continue;
             }

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1040,6 +1040,7 @@ pub struct ShardsMetrics {
     encoded_diff_size: mz_ore::metrics::IntCounterVec,
     batch_part_count: mz_ore::metrics::UIntGaugeVec,
     update_count: mz_ore::metrics::UIntGaugeVec,
+    encoded_batch_size: mz_ore::metrics::UIntGaugeVec,
     largest_batch_size: mz_ore::metrics::UIntGaugeVec,
     seqnos_held: mz_ore::metrics::UIntGaugeVec,
     gc_seqno_held_parts: mz_ore::metrics::UIntGaugeVec,
@@ -1047,11 +1048,6 @@ pub struct ShardsMetrics {
     gc_finished: mz_ore::metrics::IntCounterVec,
     compaction_applied: mz_ore::metrics::IntCounterVec,
     cmd_succeeded: mz_ore::metrics::IntCounterVec,
-    usage_current_state_batches_bytes: mz_ore::metrics::UIntGaugeVec,
-    usage_current_state_rollups_bytes: mz_ore::metrics::UIntGaugeVec,
-    usage_referenced_not_current_state_bytes: mz_ore::metrics::UIntGaugeVec,
-    usage_not_leaked_not_referenced_bytes: mz_ore::metrics::UIntGaugeVec,
-    usage_leaked_bytes: mz_ore::metrics::UIntGaugeVec,
     // We hand out `Arc<ShardMetrics>` to read and write handles, but store it
     // here as `Weak`. This allows us to discover if it's no longer in use and
     // so we can remove it from the map.
@@ -1104,6 +1100,11 @@ impl ShardsMetrics {
                 help: "count of updates by shard",
                 var_labels: ["shard"],
             )),
+            encoded_batch_size: registry.register(metric!(
+                name: "mz_persist_shard_encoded_batch_size",
+                help: "total encoded batch size by shard",
+                var_labels: ["shard"],
+            )),
             largest_batch_size: registry.register(metric!(
                 name: "mz_persist_shard_largest_batch_size",
                 help: "largest encoded batch size by shard",
@@ -1137,31 +1138,6 @@ impl ShardsMetrics {
             cmd_succeeded: registry.register(metric!(
                 name: "mz_persist_shard_cmd_succeeded",
                 help: "count of commands succeeded by shard",
-                var_labels: ["shard"],
-            )),
-            usage_current_state_batches_bytes: registry.register(metric!(
-                name: "mz_persist_shard_usage_current_state_batches_bytes",
-                help: "data in batches/parts referenced by current version of state",
-                var_labels: ["shard"],
-            )),
-            usage_current_state_rollups_bytes: registry.register(metric!(
-                name: "mz_persist_shard_usage_current_state_rollups_bytes",
-                help: "data in rollups referenced by current version of state",
-                var_labels: ["shard"],
-            )),
-            usage_referenced_not_current_state_bytes: registry.register(metric!(
-                name: "mz_persist_shard_usage_referenced_not_current_state_bytes",
-                help: "data referenced only by a previous version of state",
-                var_labels: ["shard"],
-            )),
-            usage_not_leaked_not_referenced_bytes: registry.register(metric!(
-                name: "mz_persist_shard_usage_not_leaked_not_referenced_bytes",
-                help: "data written by an active writer but not referenced by any version of state",
-                var_labels: ["shard"],
-            )),
-            usage_leaked_bytes: registry.register(metric!(
-                name: "mz_persist_shard_usage_leaked_bytes",
-                help: "data reclaimable by a leaked blob detector",
                 var_labels: ["shard"],
             )),
             shards,
@@ -1205,23 +1181,20 @@ impl ShardsMetrics {
 
 #[derive(Debug)]
 pub struct ShardMetrics {
-    pub shard_id: ShardId,
-    pub since: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
-    pub upper: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
-    pub largest_batch_size: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub latest_rollup_size: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub encoded_diff_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
-    pub batch_part_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub update_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub seqnos_held: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub gc_seqno_held_parts: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub gc_live_diffs: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub usage_current_state_batches_bytes: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub usage_current_state_rollups_bytes: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub usage_referenced_not_current_state_bytes:
-        DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub usage_not_leaked_not_referenced_bytes: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub usage_leaked_bytes: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    pub(crate) shard_id: ShardId,
+    since: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
+    upper: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
+    encoded_rollup_size: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    encoded_diff_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    batch_part_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    update_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    encoded_batch_size: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    largest_batch_size: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    seqnos_held: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    pub(crate) gc_seqno_held_parts: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    pub(crate) gc_live_diffs: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    // These are already counted elsewhere in aggregate, so delete them if we
+    // remove per-shard labels.
     pub gc_finished: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub compaction_applied: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub cmd_succeeded: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
@@ -1238,7 +1211,7 @@ impl ShardMetrics {
             upper: shards_metrics
                 .upper
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
-            latest_rollup_size: shards_metrics
+            encoded_rollup_size: shards_metrics
                 .encoded_rollup_size
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
             encoded_diff_size: shards_metrics
@@ -1249,6 +1222,9 @@ impl ShardMetrics {
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
             update_count: shards_metrics
                 .update_count
+                .get_delete_on_drop_gauge(vec![shard.clone()]),
+            encoded_batch_size: shards_metrics
+                .encoded_batch_size
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
             largest_batch_size: shards_metrics
                 .largest_batch_size
@@ -1270,22 +1246,7 @@ impl ShardMetrics {
                 .get_delete_on_drop_counter(vec![shard.clone()]),
             cmd_succeeded: shards_metrics
                 .cmd_succeeded
-                .get_delete_on_drop_counter(vec![shard.clone()]),
-            usage_current_state_batches_bytes: shards_metrics
-                .usage_current_state_batches_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
-            usage_current_state_rollups_bytes: shards_metrics
-                .usage_current_state_rollups_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
-            usage_referenced_not_current_state_bytes: shards_metrics
-                .usage_referenced_not_current_state_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
-            usage_not_leaked_not_referenced_bytes: shards_metrics
-                .usage_not_leaked_not_referenced_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
-            usage_leaked_bytes: shards_metrics
-                .usage_leaked_bytes
-                .get_delete_on_drop_gauge(vec![shard]),
+                .get_delete_on_drop_counter(vec![shard]),
         }
     }
 
@@ -1295,6 +1256,42 @@ impl ShardMetrics {
 
     pub fn set_upper<T: Codec64>(&self, upper: &Antichain<T>) {
         self.upper.set(encode_ts_metric(upper))
+    }
+
+    pub fn set_encoded_rollup_size(&self, encoded_rollup_size: usize) {
+        self.encoded_rollup_size
+            .set(u64::cast_from(encoded_rollup_size))
+    }
+
+    pub fn inc_encoded_diff_size(&self, encoded_diff_size: usize) {
+        self.encoded_diff_size
+            .inc_by(u64::cast_from(encoded_diff_size))
+    }
+
+    pub fn set_batch_part_count(&self, batch_count: usize) {
+        self.batch_part_count.set(u64::cast_from(batch_count))
+    }
+
+    pub fn set_gc_seqno_held_parts(&self, parts: usize) {
+        self.gc_seqno_held_parts.set(u64::cast_from(parts))
+    }
+
+    pub fn set_update_count(&self, update_count: usize) {
+        self.update_count.set(u64::cast_from(update_count))
+    }
+
+    pub fn set_encoded_batch_size(&self, encoded_batch_size: usize) {
+        self.encoded_batch_size
+            .set(u64::cast_from(encoded_batch_size))
+    }
+
+    pub fn set_largest_batch_size(&self, largest_batch_size: usize) {
+        self.largest_batch_size
+            .set(u64::cast_from(largest_batch_size))
+    }
+
+    pub fn set_seqnos_held(&self, seqnos_held: usize) {
+        self.seqnos_held.set(u64::cast_from(seqnos_held))
     }
 }
 
@@ -1313,21 +1310,10 @@ pub struct UsageAuditMetrics {
     pub blob_bytes: UIntGauge,
     /// Count of all blobs
     pub blob_count: UIntGauge,
-    /// Time spent fetching blob metadata
-    pub step_blob_metadata: Counter,
-    /// Time spent fetching state versions
-    pub step_state: Counter,
-    /// Time spent doing math
-    pub step_math: Counter,
 }
 
 impl UsageAuditMetrics {
     fn new(registry: &MetricsRegistry) -> Self {
-        let step_timings: CounterVec = registry.register(metric!(
-                name: "mz_persist_audit_step_seconds",
-                help: "time spent on individual steps of audit",
-                var_labels: ["step"],
-        ));
         UsageAuditMetrics {
             blob_batch_part_bytes: registry.register(metric!(
                 name: "mz_persist_audit_blob_batch_part_bytes",
@@ -1353,9 +1339,6 @@ impl UsageAuditMetrics {
                 name: "mz_persist_audit_blob_count",
                 help: "count of all blobs",
             )),
-            step_blob_metadata: step_timings.with_label_values(&["blob_metadata"]),
-            step_state: step_timings.with_label_values(&["state"]),
-            step_math: step_timings.with_label_values(&["math"]),
         }
     }
 }

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -256,13 +256,6 @@ pub struct HollowRollup {
     pub encoded_size_bytes: Option<usize>,
 }
 
-/// A pointer to a blob stored externally.
-#[derive(Debug)]
-pub enum HollowBlobRef<'a, T> {
-    Batch(&'a HollowBatch<T>),
-    Rollup(&'a HollowRollup),
-}
-
 /// A sentinel for a state transition that was a no-op.
 ///
 /// Critically, this also indicates that the no-op state transition was not
@@ -1081,22 +1074,8 @@ where
         self.collections.trace.num_updates()
     }
 
-    pub fn size_metrics(&self) -> StateSizeMetrics {
-        let mut ret = StateSizeMetrics::default();
-        self.map_blobs(|x| match x {
-            HollowBlobRef::Batch(x) => {
-                let mut batch_size = 0;
-                for x in x.parts.iter() {
-                    batch_size += x.encoded_size_bytes;
-                }
-                ret.largest_batch_bytes = std::cmp::max(ret.largest_batch_bytes, batch_size);
-                ret.state_batches_bytes += batch_size;
-            }
-            HollowBlobRef::Rollup(x) => {
-                ret.state_rollups_bytes += x.encoded_size_bytes.unwrap_or_default()
-            }
-        });
-        ret
+    pub fn batch_size_metrics(&self) -> (usize, usize) {
+        self.collections.trace.batch_size_metrics()
     }
 
     pub fn latest_rollup(&self) -> (&SeqNo, &HollowRollup) {
@@ -1263,22 +1242,6 @@ where
             None
         }
     }
-
-    pub(crate) fn map_blobs<F: for<'a> FnMut(HollowBlobRef<'a, T>)>(&self, mut f: F) {
-        self.collections
-            .trace
-            .map_batches(|x| f(HollowBlobRef::Batch(x)));
-        for x in self.collections.rollups.values() {
-            f(HollowBlobRef::Rollup(x));
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct StateSizeMetrics {
-    pub largest_batch_bytes: usize,
-    pub state_batches_bytes: usize,
-    pub state_rollups_bytes: usize,
 }
 
 #[derive(Default)]

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -24,9 +24,8 @@ use tracing::debug;
 use crate::critical::CriticalReaderId;
 use crate::internal::paths::PartialRollupKey;
 use crate::internal::state::{
-    CriticalReaderState, HollowBatch, HollowBlobRef, HollowRollup, LeasedReaderState,
-    ProtoStateField, ProtoStateFieldDiffType, ProtoStateFieldDiffs, State, StateCollections,
-    WriterState,
+    CriticalReaderState, HollowBatch, HollowRollup, LeasedReaderState, ProtoStateField,
+    ProtoStateFieldDiffType, ProtoStateFieldDiffs, State, StateCollections, WriterState,
 };
 use crate::internal::trace::{FueledMergeRes, Trace};
 use crate::read::LeasedReaderId;
@@ -168,30 +167,6 @@ impl<T: Timestamp + Lattice + Codec64> StateDiff<T> {
         diff_field_single(from_trace.since(), to_trace.since(), &mut diffs.since);
         diff_field_spine(from_trace, to_trace, &mut diffs.spine);
         diffs
-    }
-
-    pub(crate) fn map_blob_inserts<F: for<'a> FnMut(HollowBlobRef<'a, T>)>(&self, mut f: F) {
-        for spine_diff in self.spine.iter() {
-            match &spine_diff.val {
-                StateFieldValDiff::Insert(()) => {
-                    f(HollowBlobRef::Batch(&spine_diff.key));
-                }
-                StateFieldValDiff::Update((), ()) => {
-                    // No-op. Logically, we've removed and reinserted the same
-                    // key. We don't see this in practice, so it could also
-                    // easily be a panic, if necessary.
-                }
-                StateFieldValDiff::Delete(()) => {} // No-op
-            }
-        }
-        for rollups_diff in self.rollups.iter() {
-            match &rollups_diff.val {
-                StateFieldValDiff::Insert(x) | StateFieldValDiff::Update(_, x) => {
-                    f(HollowBlobRef::Rollup(x));
-                }
-                StateFieldValDiff::Delete(_) => {} // No-op
-            }
-        }
     }
 
     #[cfg(any(test, debug_assertions))]

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -163,6 +163,20 @@ impl<T> Trace<T> {
         });
         ret
     }
+
+    pub fn batch_size_metrics(&self) -> (usize, usize) {
+        let mut largest_batch_size = 0;
+        let mut encoded_batch_size = 0;
+        self.map_batches(|b| {
+            let mut this_batch_size = 0;
+            for part in b.parts.iter() {
+                this_batch_size += part.encoded_size_bytes;
+            }
+            largest_batch_size = std::cmp::max(largest_batch_size, this_batch_size);
+            encoded_batch_size += this_batch_size;
+        });
+        (largest_batch_size, encoded_batch_size)
+    }
 }
 
 impl<T: Timestamp + Lattice> Trace<T> {

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -11,152 +11,39 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::time::Instant;
-
-use futures::stream::{FuturesUnordered, StreamExt};
-use mz_ore::cast::CastFrom;
-use mz_persist::location::Blob;
-use tokio::sync::Semaphore;
 use tracing::info;
 
-use crate::cfg::PersistConfig;
+use crate::{retry_external, Metrics, ShardId};
+use mz_persist::location::{Blob, ExternalError};
+
+use crate::cache::PersistClientCache;
 use crate::internal::paths::{BlobKey, BlobKeyPrefix, PartialBlobKey};
-use crate::internal::state::HollowBlobRef;
-use crate::internal::state_versions::StateVersions;
-use crate::write::WriterId;
-use crate::{retry_external, Metrics, PersistClient, ShardId};
-
-/// A breakdown of the size of various contributions to a shard's blob (S3)
-/// usage.
-///
-/// This is structured as a "funnel", in which the steps are additive.
-/// Specifically `1=2a+2b`, `2a=3a+3b`, `3a=4a+4b`, `4a=5a+5b` (so the "a"s are
-/// the funnel and the "b"s are places where data splits out of the funnel).
-#[derive(Clone, Debug)]
-pub struct ShardUsage {
-    /// 5a: Data in batches/parts referenced by the most recent version of
-    /// state.
-    pub current_state_batches_bytes: u64,
-    /// 5b: Data in rollups referenced by the most recent version of state.
-    pub current_state_rollups_bytes: u64,
-    /// 4b: Data referenced by a live version of state that is not the most
-    /// recent.
-    ///
-    /// Possible causes:
-    /// - SeqNo hold
-    /// - Waiting for a GC run
-    pub referenced_not_current_state_bytes: u64,
-    /// 3b: Data not referenced by any live version of state.
-    ///
-    /// Possible causes:
-    /// - A batch or rollup that's about to be linked into state
-    /// - A batch leaked by a crash, but the writer has not yet been force
-    ///   expired
-    /// - A rollup leaked by a crash, but GC has not yet advanced past the
-    ///   SeqNo
-    pub not_leaked_not_referenced_bytes: u64,
-    /// 2b: Data that is eligible for reclamation by a (future) leaked blob
-    /// cleanup task (#17322).
-    ///
-    /// Possible causes:
-    /// - A batch or rollup written by a process which crashed (or was rolled)
-    ///   before it could be linked into state.
-    pub leaked_bytes: u64,
-}
-
-impl ShardUsage {
-    /// 4a: Data referenced by the most recent version of state.
-    pub fn current_state_bytes(&self) -> u64 {
-        self.current_state_batches_bytes + self.current_state_rollups_bytes
-    }
-
-    /// 3a: Data referenced by any live version of state.
-    pub fn referenced_bytes(&self) -> u64 {
-        self.current_state_bytes() + self.referenced_not_current_state_bytes
-    }
-
-    /// 2a: Data that would not be reclaimed by a (future) leaked blob
-    /// cleanup task (#17322).
-    pub fn not_leaked_bytes(&self) -> u64 {
-        self.referenced_bytes() + self.not_leaked_not_referenced_bytes
-    }
-
-    /// 1: Raw blob (S3) usage.
-    ///
-    /// NB: Due to race conditions between reads of blob and consensus in the
-    /// usage code, this might be a slight under-counting.
-    pub fn total_bytes(&self) -> u64 {
-        self.not_leaked_bytes() + self.leaked_bytes
-    }
-}
-
-/// The blob (S3) usage of all shards in an environment.
-#[derive(Clone, Debug)]
-pub struct ShardsUsage {
-    /// The data for each shard.
-    pub by_shard: BTreeMap<ShardId, ShardUsage>,
-    /// Data not attributable to any particular shard. This _should_ always be
-    /// 0; a nonzero value indicates either persist wrote an invalid blob key,
-    /// or another process is storing data under the same path (!)
-    pub unattributable_bytes: u64,
-}
-
-#[derive(Clone, Debug, Default)]
-struct BlobUsage {
-    by_shard: BTreeMap<ShardId, ShardBlobUsage>,
-    unattributable_bytes: u64,
-    batch_part_bytes: u64,
-    batch_part_count: u64,
-    rollup_size: u64,
-    rollup_count: u64,
-    total_size: u64,
-    total_count: u64,
-}
-
-#[derive(Clone, Debug, Default)]
-struct ShardBlobUsage {
-    by_writer: BTreeMap<WriterId, u64>,
-    rollup_bytes: u64,
-}
-
-impl ShardBlobUsage {
-    fn total_bytes(&self) -> u64 {
-        self.by_writer.values().copied().sum::<u64>() + self.rollup_bytes
-    }
-}
 
 /// Provides access to storage usage metrics for a specific Blob
 #[derive(Clone, Debug)]
 pub struct StorageUsageClient {
-    cfg: PersistConfig,
     blob: Arc<dyn Blob + Send + Sync>,
     metrics: Arc<Metrics>,
-    state_versions: Arc<StateVersions>,
 }
 
 impl StorageUsageClient {
-    /// Creates a new StorageUsageClient.
-    pub fn open(client: PersistClient) -> Self {
-        let state_versions = Arc::new(StateVersions::new(
-            client.cfg.clone(),
-            Arc::clone(&client.consensus),
-            Arc::clone(&client.blob),
-            Arc::clone(&client.metrics),
-        ));
-        StorageUsageClient {
-            cfg: client.cfg,
-            blob: client.blob,
-            metrics: client.metrics,
-            state_versions,
-        }
+    /// Creates a new StorageUsageClient pointed to a specific Blob
+    pub async fn open(
+        blob_uri: String,
+        client_cache: &PersistClientCache,
+    ) -> Result<StorageUsageClient, ExternalError> {
+        let blob = client_cache.open_blob(blob_uri).await?;
+        let metrics = Arc::clone(&client_cache.metrics);
+        Ok(StorageUsageClient { blob, metrics })
     }
 
-    /// Computes [ShardUsage] for a single shard.
-    pub async fn shard_usage(&self, shard_id: ShardId) -> ShardUsage {
-        let mut blob_usage = self.blob_raw_usage(BlobKeyPrefix::Shard(&shard_id)).await;
-        let blob_usage = blob_usage.by_shard.remove(&shard_id).unwrap_or_default();
-        self.shard_usage_given_blob_usage(shard_id, &blob_usage)
-            .await
+    /// Returns the size (in bytes) of all blobs owned by a given [ShardId]
+    pub async fn shard_size(&self, shard_id: &ShardId) -> u64 {
+        retry_external(
+            &self.metrics.retries.external.storage_usage_shard_size,
+            || self.size(BlobKeyPrefix::Shard(shard_id)),
+        )
+        .await
     }
 
     /// Returns a map of [ShardId] to its size (in bytes) stored in persist, as
@@ -164,227 +51,69 @@ impl StorageUsageClient {
     /// None) where the shard id is unknown. This latter count _should_ always
     /// be 0, so it being nonzero indicates either persist wrote an invalid blob
     /// key, or another process is storing data under the same path (!)
-    ///
-    /// TODO: Remove this in favor of using [Self::shards_usage] directly.
     pub async fn shard_sizes(&self) -> BTreeMap<Option<ShardId>, u64> {
-        let usage = self.shards_usage().await;
-        let mut ret = usage
-            .by_shard
-            .iter()
-            .map(|(id, usage)| (Some(*id), usage.total_bytes()))
-            .collect::<BTreeMap<_, _>>();
-        if usage.unattributable_bytes > 0 {
-            ret.insert(None, usage.unattributable_bytes);
-        }
-        ret
-    }
-
-    /// Computes [ShardUsage] for every shard in an env.
-    pub async fn shards_usage(&self) -> ShardsUsage {
-        let blob_usage = self.blob_raw_usage(BlobKeyPrefix::All).await;
-        self.metrics
-            .audit
-            .blob_batch_part_bytes
-            .set(blob_usage.batch_part_bytes);
-        self.metrics
-            .audit
-            .blob_batch_part_count
-            .set(blob_usage.batch_part_count);
-        self.metrics
-            .audit
-            .blob_rollup_bytes
-            .set(blob_usage.rollup_size);
-        self.metrics
-            .audit
-            .blob_rollup_count
-            .set(blob_usage.rollup_count);
-        self.metrics.audit.blob_bytes.set(blob_usage.total_size);
-        self.metrics.audit.blob_count.set(blob_usage.total_count);
-
-        let semaphore = Semaphore::new(self.cfg.dynamic.usage_state_fetch_concurrency_limit());
-        let by_shard_futures = FuturesUnordered::new();
-        for (shard_id, total_bytes) in blob_usage.by_shard.iter() {
-            let shard_usage_fut = async {
-                let _permit = semaphore
-                    .acquire()
-                    .await
-                    .expect("acquiring permit from open semaphore");
-                let shard_usage = self
-                    .shard_usage_given_blob_usage(*shard_id, total_bytes)
-                    .await;
-                (*shard_id, shard_usage)
-            };
-            by_shard_futures.push(shard_usage_fut);
-        }
-
-        let by_shard = by_shard_futures.collect().await;
-        ShardsUsage {
-            by_shard,
-            unattributable_bytes: blob_usage.unattributable_bytes,
-        }
-    }
-
-    async fn blob_raw_usage(&self, prefix: BlobKeyPrefix<'_>) -> BlobUsage {
         retry_external(
             &self.metrics.retries.external.storage_usage_shard_size,
             || async {
-                let mut start = Instant::now();
-                let mut keys = 0;
-                let mut usage = BlobUsage::default();
+                let mut shard_sizes = BTreeMap::new();
+                let mut batch_part_bytes = 0;
+                let mut batch_part_count = 0;
+                let mut rollup_size = 0;
+                let mut rollup_count = 0;
+                let mut total_size = 0;
+                let mut total_count = 0;
                 self.blob
-                    .list_keys_and_metadata(&prefix.to_string(), &mut |metadata| {
-                        // Increment the step timing metrics as we go, so it
-                        // doesn't all show up at the end.
-                        keys += 1;
-                        if keys % 100 == 0 {
-                            let now = Instant::now();
-                            self.metrics
-                                .audit
-                                .step_blob_metadata
-                                .inc_by(now.duration_since(start).as_secs_f64());
-                            start = now;
-                        }
-
+                    .list_keys_and_metadata(&BlobKeyPrefix::All.to_string(), &mut |metadata| {
                         match BlobKey::parse_ids(metadata.key) {
                             Ok((shard, partial_blob_key)) => {
-                                let shard_usage = usage.by_shard.entry(shard).or_default();
+                                *shard_sizes.entry(Some(shard)).or_insert(0) +=
+                                    metadata.size_in_bytes;
 
                                 match partial_blob_key {
-                                    PartialBlobKey::Batch(writer_id, _) => {
-                                        usage.batch_part_bytes += metadata.size_in_bytes;
-                                        usage.batch_part_count += 1;
-                                        *shard_usage.by_writer.entry(writer_id).or_default() +=
-                                            metadata.size_in_bytes;
+                                    PartialBlobKey::Batch(_, _) => {
+                                        batch_part_bytes += metadata.size_in_bytes;
+                                        batch_part_count += 1;
                                     }
                                     PartialBlobKey::Rollup(_, _) => {
-                                        usage.rollup_size += metadata.size_in_bytes;
-                                        usage.rollup_count += 1;
-                                        shard_usage.rollup_bytes += metadata.size_in_bytes;
+                                        rollup_size += metadata.size_in_bytes;
+                                        rollup_count += 1;
                                     }
                                 }
                             }
                             _ => {
                                 info!("unknown blob: {}: {}", metadata.key, metadata.size_in_bytes);
-                                usage.unattributable_bytes += metadata.size_in_bytes;
+                                *shard_sizes.entry(None).or_insert(0) += metadata.size_in_bytes;
                             }
                         }
-                        usage.total_size += metadata.size_in_bytes;
-                        usage.total_count += 1;
+                        total_size += metadata.size_in_bytes;
+                        total_count += 1;
                     })
                     .await?;
+
                 self.metrics
                     .audit
-                    .step_blob_metadata
-                    .inc_by(start.elapsed().as_secs_f64());
-                Ok(usage)
+                    .blob_batch_part_bytes
+                    .set(batch_part_bytes);
+                self.metrics
+                    .audit
+                    .blob_batch_part_count
+                    .set(batch_part_count);
+                self.metrics.audit.blob_rollup_bytes.set(rollup_size);
+                self.metrics.audit.blob_rollup_count.set(rollup_count);
+                self.metrics.audit.blob_bytes.set(total_size);
+                self.metrics.audit.blob_count.set(total_count);
+
+                Ok(shard_sizes)
             },
         )
         .await
-    }
-
-    async fn shard_usage_given_blob_usage(
-        &self,
-        shard_id: ShardId,
-        blob_usage: &ShardBlobUsage,
-    ) -> ShardUsage {
-        let mut start = Instant::now();
-        let mut states_iter = self
-            .state_versions
-            .fetch_all_live_states::<u64>(shard_id)
-            .await
-            .check_ts_codec()
-            .expect("ts should be a u64 in all prod shards");
-        let now = Instant::now();
-        self.metrics
-            .audit
-            .step_state
-            .inc_by(now.duration_since(start).as_secs_f64());
-        start = now;
-
-        let mut referenced_batches_bytes = BTreeMap::new();
-        let mut referenced_other_bytes = 0;
-        while let Some(_) = states_iter.next(|x| {
-            x.referenced_blob_fn(|x| match x {
-                HollowBlobRef::Batch(x) => {
-                    for part in x.parts.iter() {
-                        let parsed = BlobKey::parse_ids(&part.key.complete(&shard_id));
-                        if let Ok((_, PartialBlobKey::Batch(writer_id, _))) = parsed {
-                            let writer_referenced_batches_bytes =
-                                referenced_batches_bytes.entry(writer_id).or_default();
-                            *writer_referenced_batches_bytes +=
-                                u64::cast_from(part.encoded_size_bytes);
-                        } else {
-                            // Unexpected, but don't need to panic here.
-                            referenced_other_bytes += u64::cast_from(part.encoded_size_bytes);
-                        }
-                    }
-                }
-                HollowBlobRef::Rollup(x) => {
-                    referenced_other_bytes +=
-                        u64::cast_from(x.encoded_size_bytes.unwrap_or_default());
-                }
-            })
-        }) {}
-
-        let mut current_state_batches_bytes = 0;
-        let mut current_state_rollups_bytes = 0;
-        states_iter.state().map_blobs(|x| match x {
-            HollowBlobRef::Batch(x) => {
-                for part in x.parts.iter() {
-                    current_state_batches_bytes += u64::cast_from(part.encoded_size_bytes);
-                }
-            }
-            HollowBlobRef::Rollup(x) => {
-                current_state_rollups_bytes +=
-                    u64::cast_from(x.encoded_size_bytes.unwrap_or_default());
-            }
-        });
-        let current_state_bytes = current_state_batches_bytes + current_state_rollups_bytes;
-
-        let live_writers = &states_iter.state().collections.writers;
-        let ret = ShardUsage::from(ShardUsageCumulativeMaybeRacy {
-            current_state_batches_bytes,
-            current_state_bytes,
-            referenced_other_bytes,
-            referenced_batches_bytes: &referenced_batches_bytes,
-            live_writers,
-            blob_usage,
-        });
-
-        // Sanity check that we didn't obviously do anything wrong.
-        assert_eq!(ret.total_bytes(), blob_usage.total_bytes());
-
-        let shard_metrics = self.metrics.shards.shard(&shard_id);
-        shard_metrics
-            .usage_current_state_batches_bytes
-            .set(ret.current_state_batches_bytes);
-        shard_metrics
-            .usage_current_state_rollups_bytes
-            .set(ret.current_state_rollups_bytes);
-        shard_metrics
-            .usage_referenced_not_current_state_bytes
-            .set(ret.referenced_not_current_state_bytes);
-        shard_metrics
-            .usage_not_leaked_not_referenced_bytes
-            .set(ret.not_leaked_not_referenced_bytes);
-        shard_metrics.usage_leaked_bytes.set(ret.leaked_bytes);
-
-        self.metrics
-            .audit
-            .step_math
-            .inc_by(start.elapsed().as_secs_f64());
-        ret
     }
 
     /// Returns the size (in bytes) of a subset of blobs specified by
     /// [BlobKeyPrefix]
     ///
     /// Can be safely called within retry_external to ensure it succeeds
-    #[cfg(test)]
-    async fn size(
-        &self,
-        prefix: BlobKeyPrefix<'_>,
-    ) -> Result<u64, mz_persist::location::ExternalError> {
+    async fn size(&self, prefix: BlobKeyPrefix<'_>) -> Result<u64, ExternalError> {
         let mut total_size = 0;
         self.blob
             .list_keys_and_metadata(&prefix.to_string(), &mut |metadata| {
@@ -393,184 +122,24 @@ impl StorageUsageClient {
             .await?;
         Ok(total_size)
     }
-}
 
-#[derive(Debug)]
-struct ShardUsageCumulativeMaybeRacy<'a, T> {
-    current_state_batches_bytes: u64,
-    current_state_bytes: u64,
-    referenced_other_bytes: u64,
-    referenced_batches_bytes: &'a BTreeMap<WriterId, u64>,
-    live_writers: &'a BTreeMap<WriterId, T>,
-    blob_usage: &'a ShardBlobUsage,
-}
+    #[cfg(test)]
+    fn open_from_blob(blob: Arc<dyn Blob + Send + Sync>) -> StorageUsageClient {
+        use mz_build_info::DUMMY_BUILD_INFO;
+        use mz_ore::metrics::MetricsRegistry;
+        use mz_ore::now::SYSTEM_TIME;
 
-impl<T: std::fmt::Debug> From<ShardUsageCumulativeMaybeRacy<'_, T>> for ShardUsage {
-    fn from(x: ShardUsageCumulativeMaybeRacy<'_, T>) -> Self {
-        let mut not_leaked_bytes = 0;
-        let mut total_bytes = 0;
-        for (writer_id, bytes) in x.blob_usage.by_writer.iter() {
-            total_bytes += *bytes;
-            if x.live_writers.contains_key(writer_id) {
-                not_leaked_bytes += *bytes;
-            } else {
-                // This writer is no longer live, so it can never again link
-                // anything into state. As a result, we know that anything it
-                // hasn't linked into state is now leaked and eligible for
-                // reclamation by a (future) leaked blob detector.
-                not_leaked_bytes += x.referenced_batches_bytes.get(writer_id).map_or(0, |x| *x);
-            }
+        use crate::PersistConfig;
+        let cfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+        StorageUsageClient {
+            blob: Arc::clone(&blob),
+            metrics: Arc::new(Metrics::new(&cfg, &MetricsRegistry::new())),
         }
-        // For now, assume rollups aren't leaked. We could compute which rollups
-        // are leaked by plumbing things more precisely, if that's necessary.
-        total_bytes += x.blob_usage.rollup_bytes;
-        not_leaked_bytes += x.blob_usage.rollup_bytes;
-
-        let leaked_bytes = total_bytes
-            .checked_sub(not_leaked_bytes)
-            .expect("blob inputs should be cumulative");
-        let referenced_batches_bytes = x.referenced_batches_bytes.values().sum::<u64>();
-        let referenced_bytes = referenced_batches_bytes + x.referenced_other_bytes;
-        let mut referenced_not_current_state_bytes = referenced_bytes
-            .checked_sub(x.current_state_bytes)
-            .expect("state inputs should be cumulative");
-        let mut current_state_rollups_bytes = x
-            .current_state_bytes
-            .checked_sub(x.current_state_batches_bytes)
-            .expect("state inputs should be cumulative");
-        let mut current_state_batches_bytes = x.current_state_batches_bytes;
-
-        // If we could transactionally read both blob and consensus, the
-        // cumulative numbers would all line up. We can't, so we have to adjust
-        // them up a bit to account for the race condition. We read blob first,
-        // and then consensus, but the race could go either way: a blob that is
-        // currently in state could be deleted from both in between the reads,
-        // OR a blob could be written and linked into state in between the
-        // reads. We could do a blob-state-blob sandwich, and then use
-        // differences between the two blob reads to reason about what
-        // specifically happens in a race, but this: (a) takes memory
-        // proportional to `O(blobs)` and (b) is overkill. Instead, we adjust by
-        // category.
-        //
-        // In the event of a discrepancy, we ensure that numbers will only get
-        // smaller (by policy, we prefer to under-count for billing).
-        // Concretely:
-        // - If referenced_bytes (which comes from state) is > not_leaked_bytes
-        //   (which is a subset of what we read from blob), then we've
-        //   definitely hit the race and the funnel doesn't make sense (some of
-        //   the things that are supposed to be smaller are actually bigger).
-        //   Figure out how much we have to fix up the numbers and call it
-        //   "possible_over_count".
-        // - Then go "down" ("up"?) the funnel category by category (each of
-        //   which represented here by diffs from the previous category)
-        //   reducing them until we've adjusted them collectively down by
-        //   "possible_over_count".
-        // - First is not_leaked_not_referenced_bytes (the diff from
-        //   referenced_bytes to not_leaked_bytes).
-        // - Then, if necessary, carry the adjustment to
-        //   referenced_not_current_state_bytes (the diff from
-        //   current_state_bytes to referenced_bytes).
-        // - And so on.
-        // - Note that the largest possible value for possible_over_count is
-        //   referenced_bytes (e.g. if we read nothing from blob). Because all
-        //   the diffs add up to referenced_bytes, we're guaranteed that
-        //   "possible_over_count" will have reached 0 by the time we've
-        //   finished adjusting all the categories.
-        let mut not_leaked_not_referenced_bytes = not_leaked_bytes.saturating_sub(referenced_bytes);
-        let mut possible_over_count = referenced_bytes.saturating_sub(not_leaked_bytes);
-        fn adjust(adjustment: &mut u64, val: &mut u64) {
-            let x = std::cmp::min(*adjustment, *val);
-            *adjustment -= x;
-            *val -= x;
-        }
-        adjust(
-            &mut possible_over_count,
-            &mut not_leaked_not_referenced_bytes,
-        );
-        adjust(
-            &mut possible_over_count,
-            &mut referenced_not_current_state_bytes,
-        );
-        adjust(&mut possible_over_count, &mut current_state_rollups_bytes);
-        adjust(&mut possible_over_count, &mut current_state_batches_bytes);
-        assert_eq!(possible_over_count, 0);
-
-        let ret = ShardUsage {
-            current_state_batches_bytes,
-            current_state_rollups_bytes,
-            referenced_not_current_state_bytes,
-            not_leaked_not_referenced_bytes,
-            leaked_bytes,
-        };
-
-        // These ones are guaranteed to be equal.
-        debug_assert_eq!(ret.total_bytes(), total_bytes);
-        debug_assert_eq!(ret.not_leaked_bytes(), not_leaked_bytes);
-        // The rest might have been reduced because of the race condition.
-        debug_assert!(ret.referenced_bytes() <= referenced_bytes);
-        debug_assert!(ret.current_state_bytes() <= x.current_state_bytes);
-        debug_assert!(ret.current_state_batches_bytes <= x.current_state_batches_bytes);
-        ret
-    }
-}
-
-impl std::fmt::Display for ShardUsage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            concat!(
-                "total s3 contents:                  {}\n",
-                "  leaked:                           {}\n",
-                "  not leaked:                       {}\n",
-                "    not leaked not referenced:      {}\n",
-                "    referenced:                     {}\n",
-                "      referenced not current state: {}\n",
-                "      current state:                {}\n",
-                "        current rollups:            {}\n",
-                "        current batches:            {}",
-            ),
-            HumanBytes(self.total_bytes()),
-            HumanBytes(self.leaked_bytes),
-            HumanBytes(self.not_leaked_bytes()),
-            HumanBytes(self.not_leaked_not_referenced_bytes),
-            HumanBytes(self.referenced_bytes()),
-            HumanBytes(self.referenced_not_current_state_bytes),
-            HumanBytes(self.current_state_bytes()),
-            HumanBytes(self.current_state_rollups_bytes),
-            HumanBytes(self.current_state_batches_bytes),
-        )
-    }
-}
-
-pub(crate) struct HumanBytes(pub u64);
-
-impl std::fmt::Display for HumanBytes {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.0 < 1_240u64 {
-            return write!(f, "{}B", self.0);
-        }
-        #[allow(clippy::as_conversions)]
-        let mut bytes = self.0 as f64 / 1_024f64;
-        if bytes < 1_240f64 {
-            return write!(f, "{:.1}KiB", bytes);
-        }
-        bytes = bytes / 1_024f64;
-        if bytes < 1_240f64 {
-            return write!(f, "{:.1}MiB", bytes);
-        }
-        bytes = bytes / 1_024f64;
-        if bytes < 1_240f64 {
-            return write!(f, "{:.1}GiB", bytes);
-        }
-        bytes = bytes / 1_024f64;
-        write!(f, "{:.1}TiB", bytes)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use timely::progress::Antichain;
-
     use crate::tests::new_test_client;
     use crate::ShardId;
 
@@ -611,7 +180,7 @@ mod tests {
         write.expect_append(&data[4..], vec![0], vec![5]).await;
         let writer_two = write.writer_id.clone();
 
-        let usage = StorageUsageClient::open(client);
+        let usage = StorageUsageClient::open_from_blob(Arc::clone(&write.blob));
 
         let shard_one_size = usage
             .size(BlobKeyPrefix::Shard(&shard_id_one))
@@ -647,317 +216,12 @@ mod tests {
         );
         assert_eq!(all_size, shard_one_size + shard_two_size);
 
-        assert_eq!(
-            usage.shard_usage(shard_id_one).await.total_bytes(),
-            shard_one_size
-        );
-        assert_eq!(
-            usage.shard_usage(shard_id_two).await.total_bytes(),
-            shard_two_size
-        );
+        assert_eq!(usage.shard_size(&shard_id_one).await, shard_one_size);
+        assert_eq!(usage.shard_size(&shard_id_two).await, shard_two_size);
 
         let shard_sizes = usage.shard_sizes().await;
         assert_eq!(shard_sizes.len(), 2);
         assert_eq!(shard_sizes.get(&Some(shard_id_one)), Some(&shard_one_size));
         assert_eq!(shard_sizes.get(&Some(shard_id_two)), Some(&shard_two_size));
-    }
-
-    /// This is just a sanity check for the overall flow of computing ShardUsage.
-    /// The edge cases are exercised in separate tests.
-    #[tokio::test]
-    async fn usage_sanity() {
-        mz_ore::test::init_logging();
-
-        let data = vec![
-            (("1".to_owned(), "one".to_owned()), 1, 1),
-            (("2".to_owned(), "two".to_owned()), 2, 1),
-            (("3".to_owned(), "three".to_owned()), 3, 1),
-            (("4".to_owned(), "four".to_owned()), 4, 1),
-        ];
-
-        let shard_id = ShardId::new();
-        let client = new_test_client().await;
-
-        let (mut write0, _) = client
-            .expect_open::<String, String, u64, i64>(shard_id)
-            .await;
-        // Successfully link in a batch from a writer that stays registered.
-        write0.expect_compare_and_append(&data[..2], 0, 3).await;
-        // Leak a batch from a writer that stays registered.
-        let batch = write0
-            .batch(&data[..2], Antichain::from_elem(0), Antichain::from_elem(3))
-            .await
-            .unwrap();
-        std::mem::forget(batch);
-
-        let (mut write1, _) = client
-            .expect_open::<String, String, u64, i64>(shard_id)
-            .await;
-
-        // Successfully link in a batch from a writer that gets expired.
-        write1.expect_compare_and_append(&data[2..], 3, 5).await;
-        // Leak a batch from a writer that gets expired.
-        let batch = write1
-            .batch(&data[2..], Antichain::from_elem(3), Antichain::from_elem(5))
-            .await
-            .unwrap();
-        std::mem::forget(batch);
-        write1.expire().await;
-
-        let usage = StorageUsageClient::open(client);
-        let shard_usage = usage.shard_usage(shard_id).await;
-        // We've written data.
-        assert!(shard_usage.current_state_batches_bytes > 0);
-        // There's always at least one rollup.
-        assert!(shard_usage.current_state_rollups_bytes > 0);
-        // Sadly, it's tricky (and brittle) to ensure that there is data
-        // referenced by some live state, but no longer referenced by the
-        // current one, so no asserts on referenced_not_current_state_bytes for
-        // now.
-        //
-        // write0 wrote a batch, but never linked it in, but is still active.
-        assert!(shard_usage.not_leaked_not_referenced_bytes > 0);
-        // write0 wrote a batch, but never linked it in, and is now expired.
-        assert!(shard_usage.leaked_bytes > 0);
-    }
-
-    fn writer_id(x: char) -> WriterId {
-        let x = vec![x, x, x, x].iter().collect::<String>();
-        let s = format!("w{x}{x}-{x}-{x}-{x}-{x}{x}{x}");
-        s.parse().unwrap()
-    }
-
-    struct TestCase {
-        current_state_batches_bytes: u64,
-        current_state_bytes: u64,
-        referenced_other_bytes: u64,
-        referenced_batches_bytes: Vec<(char, u64)>,
-        live_writers: Vec<char>,
-        blob_usage_by_writer: Vec<(char, u64)>,
-        blob_usage_rollups: u64,
-    }
-
-    impl TestCase {
-        #[track_caller]
-        fn run(&self, expected: &str) {
-            let referenced_batches_bytes = self
-                .referenced_batches_bytes
-                .iter()
-                .map(|(id, b)| (writer_id(*id), *b))
-                .collect();
-            let live_writers = self
-                .live_writers
-                .iter()
-                .map(|id| (writer_id(*id), ()))
-                .collect();
-            let blob_usage = ShardBlobUsage {
-                by_writer: self
-                    .blob_usage_by_writer
-                    .iter()
-                    .map(|(id, b)| (writer_id(*id), *b))
-                    .collect(),
-                rollup_bytes: self.blob_usage_rollups,
-            };
-            let input = ShardUsageCumulativeMaybeRacy {
-                current_state_batches_bytes: self.current_state_batches_bytes,
-                current_state_bytes: self.current_state_bytes,
-                referenced_other_bytes: self.referenced_other_bytes,
-                referenced_batches_bytes: &referenced_batches_bytes,
-                live_writers: &live_writers,
-                blob_usage: &blob_usage,
-            };
-            let usage = ShardUsage::from(input);
-            let actual = format!(
-                "{} {}/{} {}/{} {}/{} {}/{}",
-                usage.total_bytes(),
-                usage.leaked_bytes,
-                usage.not_leaked_bytes(),
-                usage.not_leaked_not_referenced_bytes,
-                usage.referenced_bytes(),
-                usage.referenced_not_current_state_bytes,
-                usage.current_state_bytes(),
-                usage.current_state_rollups_bytes,
-                usage.current_state_batches_bytes
-            );
-            assert_eq!(actual, expected);
-        }
-    }
-
-    #[test]
-    fn usage_kitchen_sink() {
-        TestCase {
-            // - Some data in current batches
-            current_state_batches_bytes: 1,
-            // - Some data in current rollups: this - current_state_batches_bytes
-            current_state_bytes: 2,
-            // - Some data in a key we couldn't parse: this-(rollup)
-            //   - This one is unexpected in prod, but it seemed nicer than a
-            //     panic, ymmv
-            referenced_other_bytes: 3,
-            // - Some data written by a still active writer: (a, 4)
-            // - Some data written by a now-expired writer: (b, 5)
-            referenced_batches_bytes: vec![('a', 4), ('b', 5)],
-            live_writers: vec!['a'],
-            // - Some data leaked by a still active writer: (a, 7) - (a, 4)
-            // - Some data leaked by a now-expired writer: (b, 8) - (b, 5)
-            blob_usage_by_writer: vec![('a', 7), ('b', 8)],
-            // - Some data in rollups
-            blob_usage_rollups: 6,
-        }
-        .run("21 3/18 6/12 10/2 1/1");
-    }
-
-    #[test]
-    fn usage_funnel() {
-        // All data in current_state_batches_bytes
-        TestCase {
-            current_state_batches_bytes: 1,
-            current_state_bytes: 1,
-            referenced_other_bytes: 0,
-            referenced_batches_bytes: vec![('a', 1)],
-            live_writers: vec!['a'],
-            blob_usage_by_writer: vec![('a', 1)],
-            blob_usage_rollups: 0,
-        }
-        .run("1 0/1 0/1 0/1 0/1");
-
-        // All data in current_state_rollups_bytes
-        TestCase {
-            current_state_batches_bytes: 0,
-            current_state_bytes: 1,
-            referenced_other_bytes: 0,
-            referenced_batches_bytes: vec![('a', 1)],
-            live_writers: vec!['a'],
-            blob_usage_by_writer: vec![('a', 1)],
-            blob_usage_rollups: 0,
-        }
-        .run("1 0/1 0/1 0/1 1/0");
-
-        // All data in referenced_not_current_state_bytes
-        TestCase {
-            current_state_batches_bytes: 0,
-            current_state_bytes: 0,
-            referenced_other_bytes: 0,
-            referenced_batches_bytes: vec![('a', 1)],
-            live_writers: vec!['a'],
-            blob_usage_by_writer: vec![('a', 1)],
-            blob_usage_rollups: 0,
-        }
-        .run("1 0/1 0/1 1/0 0/0");
-
-        // All data in not_leaked_not_referenced_bytes
-        TestCase {
-            current_state_batches_bytes: 0,
-            current_state_bytes: 0,
-            referenced_other_bytes: 0,
-            referenced_batches_bytes: vec![],
-            live_writers: vec!['a'],
-            blob_usage_by_writer: vec![('a', 1)],
-            blob_usage_rollups: 0,
-        }
-        .run("1 0/1 1/0 0/0 0/0");
-
-        // All data in leaked_bytes
-        TestCase {
-            current_state_batches_bytes: 0,
-            current_state_bytes: 0,
-            referenced_other_bytes: 0,
-            referenced_batches_bytes: vec![],
-            live_writers: vec![],
-            blob_usage_by_writer: vec![('a', 1)],
-            blob_usage_rollups: 0,
-        }
-        .run("1 1/0 0/0 0/0 0/0");
-
-        // No data
-        TestCase {
-            current_state_batches_bytes: 0,
-            current_state_bytes: 0,
-            referenced_other_bytes: 0,
-            referenced_batches_bytes: vec![],
-            live_writers: vec![],
-            blob_usage_by_writer: vec![],
-            blob_usage_rollups: 0,
-        }
-        .run("0 0/0 0/0 0/0 0/0");
-    }
-
-    #[test]
-    fn usage_races() {
-        // We took a snapshot of blob, and then before getting our states, a
-        // bunch of interesting things happened to persist state. We adjust to
-        // account for the race down the funnel.
-
-        // Base case: no race
-        TestCase {
-            current_state_batches_bytes: 2,
-            current_state_bytes: 4,
-            referenced_other_bytes: 2,
-            referenced_batches_bytes: vec![('a', 4)],
-            live_writers: vec!['a'],
-            blob_usage_by_writer: vec![('a', 8), ('b', 2)],
-            blob_usage_rollups: 0,
-        }
-        .run("10 2/8 2/6 2/4 2/2");
-
-        // Race was enough to affect into leaked
-        TestCase {
-            current_state_batches_bytes: 2,
-            current_state_bytes: 4,
-            referenced_other_bytes: 2,
-            referenced_batches_bytes: vec![('a', 4)],
-            live_writers: vec!['a'],
-            blob_usage_by_writer: vec![('a', 8), ('b', 1)],
-            blob_usage_rollups: 0,
-        }
-        .run("9 1/8 2/6 2/4 2/2");
-
-        // Race was enough to affect into not_leaked_not_referenced_bytes
-        TestCase {
-            current_state_batches_bytes: 2,
-            current_state_bytes: 4,
-            referenced_other_bytes: 2,
-            referenced_batches_bytes: vec![('a', 4)],
-            live_writers: vec!['a'],
-            blob_usage_by_writer: vec![('a', 7)],
-            blob_usage_rollups: 0,
-        }
-        .run("7 0/7 1/6 2/4 2/2");
-
-        // Race was enough to affect into referenced_not_current_state_bytes
-        TestCase {
-            current_state_batches_bytes: 2,
-            current_state_bytes: 4,
-            referenced_other_bytes: 2,
-            referenced_batches_bytes: vec![('a', 4)],
-            live_writers: vec!['a'],
-            blob_usage_by_writer: vec![('a', 5)],
-            blob_usage_rollups: 0,
-        }
-        .run("5 0/5 0/5 1/4 2/2");
-
-        // Race was enough to affect into current_state_rollups_bytes
-        TestCase {
-            current_state_batches_bytes: 2,
-            current_state_bytes: 4,
-            referenced_other_bytes: 2,
-            referenced_batches_bytes: vec![('a', 4)],
-            live_writers: vec!['a'],
-            blob_usage_by_writer: vec![('a', 3)],
-            blob_usage_rollups: 0,
-        }
-        .run("3 0/3 0/3 0/3 1/2");
-
-        // Race was enough to affect into current_state_batches_bytes
-        TestCase {
-            current_state_batches_bytes: 2,
-            current_state_bytes: 4,
-            referenced_other_bytes: 2,
-            referenced_batches_bytes: vec![('a', 4)],
-            live_writers: vec!['a'],
-            blob_usage_by_writer: vec![('a', 1)],
-            blob_usage_rollups: 0,
-        }
-        .run("1 0/1 0/1 0/1 0/1");
     }
 }

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -159,6 +159,26 @@ impl StorageUsageClient {
             .await
     }
 
+    /// Returns a map of [ShardId] to its size (in bytes) stored in persist, as
+    /// well as the total bytes stored for unattributable data (the map key is
+    /// None) where the shard id is unknown. This latter count _should_ always
+    /// be 0, so it being nonzero indicates either persist wrote an invalid blob
+    /// key, or another process is storing data under the same path (!)
+    ///
+    /// TODO: Remove this in favor of using [Self::shards_usage] directly.
+    pub async fn shard_sizes(&self) -> BTreeMap<Option<ShardId>, u64> {
+        let usage = self.shards_usage().await;
+        let mut ret = usage
+            .by_shard
+            .iter()
+            .map(|(id, usage)| (Some(*id), usage.total_bytes()))
+            .collect::<BTreeMap<_, _>>();
+        if usage.unattributable_bytes > 0 {
+            ret.insert(None, usage.unattributable_bytes);
+        }
+        ret
+    }
+
     /// Computes [ShardUsage] for every shard in an env.
     pub async fn shards_usage(&self) -> ShardsUsage {
         let blob_usage = self.blob_raw_usage(BlobKeyPrefix::All).await;
@@ -636,22 +656,10 @@ mod tests {
             shard_two_size
         );
 
-        let shards_usage = usage.shards_usage().await;
-        assert_eq!(shards_usage.by_shard.len(), 2);
-        assert_eq!(
-            shards_usage
-                .by_shard
-                .get(&shard_id_one)
-                .map(|x| x.total_bytes()),
-            Some(shard_one_size)
-        );
-        assert_eq!(
-            shards_usage
-                .by_shard
-                .get(&shard_id_two)
-                .map(|x| x.total_bytes()),
-            Some(shard_two_size)
-        );
+        let shard_sizes = usage.shard_sizes().await;
+        assert_eq!(shard_sizes.len(), 2);
+        assert_eq!(shard_sizes.get(&Some(shard_id_one)), Some(&shard_one_size));
+        assert_eq!(shard_sizes.get(&Some(shard_id_two)), Some(&shard_two_size));
     }
 
     /// This is just a sanity check for the overall flow of computing ShardUsage.


### PR DESCRIPTION
This reverts commit 212ff8f4a0369a3285dce500e399cc0a332850c5, reversing changes made to b3a625d3075daea58bb10f25d113875eea1d0c17.

### Motivation

We're seeing panics in Persist that point to the new usage code. In particular:

```
environmentd thread 'tokio:work-0' panicked at 'blob inputs should be cumulative', /var/lib/buildkite-agent/builds/buildkite-builders-d43b1b5-i-0bb7f49852c7c6d14-1/materialize/tests/src/persist-client/src/usage.rs:409:28
```

```
thread 'tokio:work-5' panicked at 'fetch_live_states should only be called on an initialized shard', /home/alexander/workspace/materialize/src/persist-client/src/internal/state_versions.rs:437:25
...
  19:     0x555a40d19f47 - mz_persist_client::usage::StorageUsageClient::shard_usage_given_blob_usage::{{closure}}::ha64ab75bfbf99a11

```

Reverting to unblock the release.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
