### PR TITLE
adapter: implement pg_proc.prorettype

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2173,10 +2173,12 @@ pub const PG_PROC: BuiltinView = BuiltinView {
     mz_functions.name AS proname,
     mz_schemas.oid AS pronamespace,
     NULL::pg_catalog.oid AS proowner,
-    NULL::pg_catalog.text AS proargdefaults
+    NULL::pg_catalog.text AS proargdefaults,
+    ret_type.oid AS prorettype
 FROM mz_catalog.mz_functions
 JOIN mz_catalog.mz_schemas ON mz_functions.schema_id = mz_schemas.id
 LEFT JOIN mz_catalog.mz_databases d ON d.id = mz_schemas.database_id
+JOIN mz_catalog.mz_types AS ret_type ON mz_functions.return_type_id = ret_type.id
 WHERE mz_schemas.database_id IS NULL OR d.name = pg_catalog.current_database()",
 };
 

--- a/test/sqllogictest/pg_catalog_proc.slt
+++ b/test/sqllogictest/pg_catalog_proc.slt
@@ -9,12 +9,11 @@
 
 mode cockroach
 
-query TIIO colnames
-SELECT proname, pronamespace, oid, proargdefaults
+query TIIOI
+SELECT proname, pronamespace, oid, proargdefaults, prorettype
 FROM pg_catalog.pg_proc
 WHERE proname = 'substring'
 ORDER BY oid
 ----
-proname    pronamespace  oid  proargdefaults
-substring  20003         936  NULL
-substring  20003         937  NULL
+substring  20003  936  NULL  25
+substring  20003  937  NULL  25


### PR DESCRIPTION
Implement a bit more pg_catalog.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a