### PR TITLE
Prune storage usage rows we don't wish to retain

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2733,8 +2733,8 @@ impl Catalog {
         catalog
             .storage()
             .await
-            .prune_storage_usage(|e| u128::from(e.timestamp()) <= cutoff_ts)
-            .await;
+            .prune_storage_usage(move |e| u128::from(e.timestamp()) <= cutoff_ts)
+            .await?;
 
         // To avoid reading over storage_usage() multiple times, do both the
         // table updates and most-recent-timestamp calculations on a single

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2724,22 +2724,14 @@ impl Catalog {
             builtin_table_updates.push(catalog.state.pack_audit_log_update(&event)?);
         }
 
-        // If no usage retention period is set, we set it to an unreasonably large number
-        // of milliseconds, so that the filter code is simpler.
-        let cutoff_ts = match config.storage_usage_retention_period {
-            None => u128::MIN,
-            Some(period) => u128::from(catalog.storage().await.boot_ts()) - period.as_millis(),
-        };
-        catalog
+        // To avoid reading over storage_usage events multiple times, do both
+        // the table updates and delete calculations in a single read over the
+        // data.
+        let storage_usage_events = catalog
             .storage()
             .await
-            .prune_storage_usage(move |e| u128::from(e.timestamp()) <= cutoff_ts)
+            .fetch_and_prune_storage_usage(config.storage_usage_retention_period)
             .await?;
-
-        // To avoid reading over storage_usage() multiple times, do both the
-        // table updates and most-recent-timestamp calculations on a single
-        // iterator.
-        let storage_usage_events = catalog.storage().await.storage_usage().await?;
         for event in storage_usage_events {
             builtin_table_updates.push(catalog.state.pack_storage_usage_update(&event)?);
         }

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2738,6 +2738,13 @@ impl Catalog {
             builtin_table_updates.push(catalog.state.pack_storage_usage_update(&event)?);
         }
 
+        // Now prune rows that we no longer wish to retain
+        catalog
+            .storage()
+            .await
+            .prune_storage_usage(|e| u128::from(e.timestamp()) <= cutoff_ts)
+            .await;
+
         for ip in &catalog.state.egress_ips {
             builtin_table_updates.push(catalog.state.pack_egress_ip_update(ip)?);
         }

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -702,26 +702,39 @@ impl Connection {
             .map(|ev| ev.event))
     }
 
+    /// Loads storage usage events and permanently deletes from the stash those
+    /// that happened more than the retention period ago from boot_ts.
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn storage_usage(
+    pub async fn fetch_and_prune_storage_usage(
         &mut self,
-    ) -> Result<impl Iterator<Item = VersionedStorageUsage>, Error> {
-        Ok(COLLECTION_STORAGE_USAGE
-            .peek_one(&mut self.stash)
-            .await?
-            .into_keys()
-            .map(|ev| ev.metric))
-    }
-
-    #[tracing::instrument(level = "info", skip_all)]
-    pub async fn prune_storage_usage<P>(&mut self, predicate: P) -> Result<(), Error>
-    where
-        P: Fn(&VersionedStorageUsage) -> bool + Clone + Sync + Send + 'static,
-    {
-        COLLECTION_STORAGE_USAGE
-            .delete(&mut self.stash, move |k, _v| predicate(&k.metric))
-            .await
-            .map_err(|e| e.into())
+        retention_period: Option<Duration>,
+    ) -> Result<Vec<VersionedStorageUsage>, Error> {
+        // If no usage retention period is set, set the cutoff to MIN so nothing
+        // is removed.
+        let cutoff_ts = match retention_period {
+            None => u128::MIN,
+            Some(period) => u128::from(self.boot_ts) - period.as_millis(),
+        };
+        Ok(self
+            .stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = COLLECTION_STORAGE_USAGE.from_tx(&tx).await?;
+                    let rows = tx.peek_one(collection).await?;
+                    let mut events = Vec::with_capacity(rows.len());
+                    let mut batch = collection.make_batch_tx(&tx).await?;
+                    for ev in rows.into_keys() {
+                        if u128::from(ev.metric.timestamp()) >= cutoff_ts {
+                            events.push(ev.metric);
+                        } else {
+                            collection.append_to_batch(&mut batch, &ev, &(), -1);
+                        }
+                    }
+                    tx.append(vec![batch]).await?;
+                    Ok(events)
+                })
+            })
+            .await?)
     }
 
     /// Load the persisted mapping of system object to global ID. Key is (schema-name, object-name).

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -713,6 +713,16 @@ impl Connection {
             .map(|ev| ev.metric))
     }
 
+    #[tracing::instrument(level = "info", skip_all)]
+    pub async fn prune_storage_usage<P>(&mut self, predicate: P) -> Result<(), StashError>
+    where
+        P: Fn(&VersionedStorageUsage) -> bool,
+    {
+        COLLECTION_STORAGE_USAGE
+            .delete(&mut self.stash, |k, _v| predicate(&k))
+            .await
+    }
+
     /// Load the persisted mapping of system object to global ID. Key is (schema-name, object-name).
     #[tracing::instrument(level = "info", skip_all)]
     pub async fn load_system_gids(


### PR DESCRIPTION
Adds a `prune_storage_usage` method that takes a user-specified
predicate and calls the storage usage `TypedCollection`'s `delete`
method with it. Then calls this method during initialization, to ensure
that records we don't want to retain are deleted.

### Motivation

Follow-up to #17622, closes https://github.com/MaterializeInc/cloud/issues/3716

### Tips for reviewer

This is a quick follow-up and I suspect that this functionality should actually be somewhere other than catalog initialization. I would love any feedback as to where else it should go! I'm also not sure how best to test it.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->