### PR TITLE
github: remove triage label from flake template

### DIFF
--- a/.github/ISSUE_TEMPLATE/04-ci-flake.yml
+++ b/.github/ISSUE_TEMPLATE/04-ci-flake.yml
@@ -11,7 +11,7 @@ name: "Internal: CI flake"
 description: >
   A CI job that failed but eventually passed after retry.
 title: "<TEST-NAME> is flaky"
-labels: [C-bug, C-triage, ci-flake]
+labels: [C-bug, ci-flake]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
We've deprecated the triage label a while ago, because it is redundant given the bug label and GitHub project-based triaging.