### PR TITLE
deps: upgrade timely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7302,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#6a736009d0276b181f0a069174390b99c8bd9ae1"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#5b808fff9bc83be29a2091c9a5d8910e009a6b15"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7320,12 +7320,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#6a736009d0276b181f0a069174390b99c8bd9ae1"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#5b808fff9bc83be29a2091c9a5d8910e009a6b15"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#6a736009d0276b181f0a069174390b99c8bd9ae1"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#5b808fff9bc83be29a2091c9a5d8910e009a6b15"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7341,7 +7341,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#6a736009d0276b181f0a069174390b99c8bd9ae1"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#5b808fff9bc83be29a2091c9a5d8910e009a6b15"
 dependencies = [
  "columnation",
  "serde",
@@ -7350,7 +7350,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#6a736009d0276b181f0a069174390b99c8bd9ae1"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#5b808fff9bc83be29a2091c9a5d8910e009a6b15"
 
 [[package]]
 name = "tiny-keccak"


### PR DESCRIPTION
This is to pick up https://github.com/TimelyDataflow/timely-dataflow/pull/505, which fixes a memory leak in environmentd.

### Motivation



  * This PR fixes a previously unreported bug.

Memory is leaked in the `read_capabilities` maintained for "retained metrics relations" due to `MutableAntichain` not consolidating its contents eagerly enough. See #17741.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
