### PR TITLE
When logging JSON, include the current span information

### DIFF
--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -255,7 +255,12 @@ where
                     .with_ansi(!no_color && atty::is(atty::Stream::Stderr)),
             )
         }
-        StderrLogFormat::Json => Box::new(fmt::layer().with_writer(io::stderr).json()),
+        StderrLogFormat::Json => Box::new(
+            fmt::layer()
+                .with_writer(io::stderr)
+                .json()
+                .with_current_span(true),
+        ),
     };
     let (stderr_log_filter, stderr_log_filter_reloader) =
         reload::Layer::new(config.stderr_log.filter);


### PR DESCRIPTION
This PR adds a configuration setting that makes tracing_subscriber include the current span (if there is one) in logged events. Ideally, we can use this information in our log aggregation tool to jump between log statements and traces that might have been collected.

### Motivation

  * This PR adds a feature that has not yet been specified.

There's a general vibe among us cloud runners that we'd like to be able to link traces and logs more - so this does it.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - I'll spin this change up in my personal stack once built & try it out!
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
