### PR TITLE
bin/mz: Do not treat inability to open browser as a fatal error

### DIFF
--- a/src/mz/src/bin/mz/login.rs
+++ b/src/mz/src/bin/mz/login.rs
@@ -54,8 +54,11 @@ pub(crate) async fn login_with_browser(
 
     // Open the browser to login user.
     let url = endpoint.web_login_url(profile_name, port).to_string();
-    if let Err(err) = open::that(&url) {
-        bail!("An error occurred when opening '{}': {}", url, err)
+    if let Err(_err) = open::that(&url) {
+        println!(
+            "Could not open a browser to visit the login page <{}>: Please open the page yourself.",
+            url
+        )
     }
 
     // Wait for the browser to send the app password to our server.


### PR DESCRIPTION
When attempting to log in on a machine that can not display a browser (e.g. a terminal-only linux box), inability to open a browser is not fatal: It only means the user must manually visit the web page to authorize the CLI.

So, instead of bailing, let's show the URL and wait.

### Motivation

  * This PR fixes a previously unreported bug.

It's impossible to login to bin/mz with a machine that doesn't have a GUI running. This is similar to the plentiful AWS CLI bugs here: https://github.com/aws/aws-cli/issues/5301

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
