### PR TITLE
optimizer: hoist type knowledge into transform::normalize_lets

### DIFF
--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -262,7 +262,7 @@ mod support {
                             .column_types
                             .iter()
                             .zip(typ.column_types.iter())
-                            .all(|(t1, t2)| t1.scalar_type == t2.scalar_type)
+                            .all(|(t1, t2)| t1.scalar_type.base_eq(&t2.scalar_type))
                         {
                             Err(crate::TransformError::Internal(format!(
                                 "scalar types do not match: {:?} v {:?}",

--- a/test/sqllogictest/github-17762.slt
+++ b/test/sqllogictest/github-17762.slt
@@ -1,0 +1,27 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/17762
+mode cockroach
+
+query T
+SELECT
+	worker_id
+FROM
+	mz_internal.mz_scheduling_elapsed_internal
+	JOIN mz_indexes ON (NULL)
+	JOIN (
+			SELECT
+				worker_id AS a, CAST(NULLIF(records, CAST(NULL AS DECIMAL)) AS DECIMAL)
+			FROM
+				mz_internal.mz_records_per_dataflow
+		) ON (SELECT a IS NULL)
+WHERE
+	(SELECT a) IS NULL;
+----


### PR DESCRIPTION
Our type system has an unexpected corner in that the Eq implementation is derived but has no type knowledge, which necessitates using something other than `==` when determining type interoperability, i.e. a function named `base_eq`.

This patch fixes an instance of this in the optimizer, but probably warrants a more thorough investigation into where else it's used.

### Motivation

This PR fixes a recognized bug. Fixes #17762

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
