### PR TITLE
sql: Fix column constraints for read-then-writes

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -3492,9 +3492,11 @@ impl Coordinator {
                                             MutationKind::Insert => diffs.push((row, 1)),
                                         }
                                     }
-                                    for (row, _) in &diffs {
-                                        for (idx, datum) in row.iter().enumerate() {
-                                            desc.constraints_met(idx, &datum)?;
+                                    for (row, diff) in &diffs {
+                                        if *diff > 0 {
+                                            for (idx, datum) in row.iter().enumerate() {
+                                                desc.constraints_met(idx, &datum)?;
+                                            }
                                         }
                                     }
                                     Ok(diffs)

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -3474,7 +3474,6 @@ impl Coordinator {
                                                         ))
                                                     }
                                                 };
-                                                desc.constraints_met(*idx, &updated)?;
                                                 updates.push((*idx, updated));
                                             }
                                             for (idx, new_value) in updates {
@@ -3491,6 +3490,11 @@ impl Coordinator {
                                                 diffs.push((row, -1))
                                             }
                                             MutationKind::Insert => diffs.push((row, 1)),
+                                        }
+                                    }
+                                    for (row, _) in &diffs {
+                                        for (idx, datum) in row.iter().enumerate() {
+                                            desc.constraints_met(idx, &datum)?;
                                         }
                                     }
                                     Ok(diffs)

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -542,7 +542,7 @@ impl RelationDesc {
     /// Verifies that `d` meets all of the constraints for the `i`th column of `self`.
     ///
     /// n.b. The only constraint MZ currently supports in NOT NULL, but this
-    /// structure will  be simple to extend.
+    /// structure will be simple to extend.
     pub fn constraints_met(&self, i: usize, d: &Datum) -> Result<(), NotNullViolation> {
         let name = &self.names[i];
         let typ = &self.typ.column_types[i];

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -203,6 +203,15 @@ contains:null value in column "a" violates not-null constraint
 ! INSERT INTO s SELECT (case when now() = now() then NULL else 2 end);
 contains:null value in column "a" violates not-null constraint
 
+> CREATE TABLE n (a int);
+
+> INSERT INTO n VALUES (NULL);
+
+! INSERT INTO s SELECT * FROM n;
+contains:null value in column "a" violates not-null constraint
+
+> DROP TABLE n
+
 > CREATE TABLE v (a timestamptz);
 > INSERT INTO v VALUES (now());
 

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -200,6 +200,9 @@ contains:null value in column "a" violates not-null constraint
 ! INSERT INTO s VALUES (case when now() = now() then NULL else 2 end);
 contains:null value in column "a" violates not-null constraint
 
+! INSERT INTO s SELECT (case when now() = now() then NULL else 2 end);
+contains:null value in column "a" violates not-null constraint
+
 > CREATE TABLE v (a timestamptz);
 > INSERT INTO v VALUES (now());
 

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -197,6 +197,9 @@ a       b
 ! INSERT INTO s VALUES (1 + NULL);
 contains:null value in column "a" violates not-null constraint
 
+! INSERT INTO s VALUES (case when now() = now() then NULL else 2 end);
+contains:null value in column "a" violates not-null constraint
+
 > CREATE TABLE v (a timestamptz);
 > INSERT INTO v VALUES (now());
 


### PR DESCRIPTION
Previously, column constraints were only being checked for update read-then-write queries. Inserts and deletes were not being checked. It wasn't technically necessary for deletes, but it was necessary for inserts.

This commit updates read-then-write queries so that all variants check column constraints.

Fixes #17768

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
