### PR TITLE
persist: support uninitialized shards in `fetch_all_live_states`

### DIFF
--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -262,6 +262,7 @@ pub async fn fetch_state_rollups(args: &StateArgs) -> Result<impl serde::Seriali
     let mut state_iter = state_versions
         .fetch_all_live_states::<u64>(shard_id)
         .await
+        .expect("requested shard should exist")
         .check_ts_codec()?;
     while let Some(v) = state_iter.next(|_| {}) {
         for rollup in v.collections.rollups.values() {
@@ -301,6 +302,7 @@ pub async fn fetch_state_diffs(
     let mut state_iter = state_versions
         .fetch_all_live_states::<u64>(shard_id)
         .await
+        .expect("requested shard should exist")
         .check_ts_codec()?;
     while let Some(_) = state_iter.next(|_| {}) {
         live_states.push(state_iter.into_proto());
@@ -555,6 +557,7 @@ pub async fn unreferenced_blobs(args: &StateArgs) -> Result<impl serde::Serializ
     let mut state_iter = state_versions
         .fetch_all_live_states::<u64>(shard_id)
         .await
+        .expect("requested shard should exist")
         .check_ts_codec()?;
 
     let mut known_parts = BTreeSet::new();

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -253,6 +253,7 @@ where
             .state_versions
             .fetch_all_live_states::<T>(req.shard_id)
             .await
+            .expect("gc should only be called on an initialized shard")
             // TODO: Consider pulling the K, V, D params off of GC. If we do,
             // then we should be able to delete TypedStateVersionsIter (and
             // probably merge UntypedStateVersionsIter into StateVersionsIter).

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1051,6 +1051,7 @@ pub mod datadriven {
             .state_versions
             .fetch_all_live_states::<u64>(datadriven.shard_id)
             .await
+            .expect("should only be called on an initialized shard")
             .check_ts_codec()
             .expect("shard codecs should not change");
         let mut s = String::new();

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -17,7 +17,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use mz_ore::cast::CastFrom;
 use mz_persist::location::Blob;
 use tokio::sync::Semaphore;
-use tracing::info;
+use tracing::{error, info};
 
 use crate::cfg::PersistConfig;
 use crate::internal::paths::{BlobKey, BlobKeyPrefix, PartialBlobKey};
@@ -268,10 +268,36 @@ impl StorageUsageClient {
         blob_usage: &ShardBlobUsage,
     ) -> ShardUsage {
         let mut start = Instant::now();
-        let mut states_iter = self
+        let states_iter = self
             .state_versions
             .fetch_all_live_states::<u64>(shard_id)
-            .await
+            .await;
+        let states_iter = match states_iter {
+            Some(x) => x,
+            None => {
+                // It's unexpected for a shard to exist in blob but not in
+                // consensus, but it could happen. For example, if an initial
+                // rollup has been written but the initial CaS hasn't yet
+                // succeeded (or if a `bin/environmentd --reset` is interrupted
+                // in dev). Be loud because it's unexpected, but handle it
+                // because it can happen.
+                error!(
+                    concat!(
+                    "shard {} existed in blob but not in consensus. This should be quite rare in ",
+                    "prod, but is semi-expected in development if `bin/environmentd --reset` gets ",
+                    "interrupted"),
+                    shard_id
+                );
+                return ShardUsage {
+                    current_state_batches_bytes: 0,
+                    current_state_rollups_bytes: 0,
+                    referenced_not_current_state_bytes: 0,
+                    not_leaked_not_referenced_bytes: 0,
+                    leaked_bytes: blob_usage.total_bytes(),
+                };
+            }
+        };
+        let mut states_iter = states_iter
             .check_ts_codec()
             .expect("ts should be a u64 in all prod shards");
         let now = Instant::now();
@@ -555,8 +581,11 @@ impl std::fmt::Display for HumanBytes {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
+    use mz_persist::location::{Atomicity, SeqNo};
     use timely::progress::Antichain;
 
+    use crate::internal::paths::{PartialRollupKey, RollupId};
     use crate::tests::new_test_client;
     use crate::ShardId;
 
@@ -974,5 +1003,34 @@ mod tests {
             blob_usage_rollups: 0,
         }
         .run("3 0/3 0/3 3/0 0/0");
+    }
+
+    /// Regression test for (part of) #17752, where an interrupted
+    /// `bin/environmentd --reset` resulted in panic in persist usage code.
+    ///
+    /// This also tests a (hypothesized) race that's possible in prod where an
+    /// initial rollup is written for a shard, but the initial CaS hasn't yet
+    /// succeeded.
+    #[tokio::test]
+    async fn usage_regression_shard_in_blob_not_consensus() {
+        mz_ore::test::init_logging();
+        let client = new_test_client().await;
+        let shard_id = ShardId::new();
+
+        // Somewhat unsatisfying, we manually construct a rollup blob key.
+        let key = PartialRollupKey::new(SeqNo(1), &RollupId::new());
+        let key = key.complete(&shard_id);
+        let () = client
+            .blob
+            .set(&key, Bytes::from(vec![0, 1, 2]), Atomicity::RequireAtomic)
+            .await
+            .unwrap();
+        let usage = StorageUsageClient::open(client);
+        let shards_usage = usage.shards_usage().await;
+        assert_eq!(shards_usage.by_shard.len(), 1);
+        assert_eq!(
+            shards_usage.by_shard.get(&shard_id).unwrap().leaked_bytes,
+            3
+        );
     }
 }


### PR DESCRIPTION
It's unexpected that `fetch_all_live_states` is called on an uninitialized shard, but there are a couple of edge cases where it can:

- If a `bin/environmentd --reset` gets interrupted after consensus is wiped, but it hasn't finished wiping blob. This only affects dev, and it is believed that this is why we saw this panic in #17752.
- (Hypothesized) It's possible that a shard being initialized writes the initial rollup, but gets interrupted before successfully `compare_and_set`s it into consensus. This one could happen in prod if we try to use a shard before writing down the shard_id (otherwise it would fix itself when something finishes initializing the shard).

We intend not to do the latter, but there could always be bugs and also usage would be crashing in the interim, so good idea to be resilient here.

Closes #17752

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
