### PR TITLE
Bind to `0.0.0.0`, not a DNS name.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ source = "git+https://github.com/jorgecarleitao/arrow2.git#0ba4f8e21547ed08b4468
 dependencies = [
  "ahash",
  "arrow-format",
- "base64",
+ "base64 0.13.1",
  "bytemuck",
  "chrono",
  "dyn-clone",
@@ -701,12 +701,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.1"
-source = "git+https://github.com/tokio-rs/axum.git#978ae6335862b264b4368e01a52177d98c42b2d9"
+version = "0.6.7"
+source = "git+https://github.com/tokio-rs/axum.git#1e2567c39fb9964a19574eed3465ded05eba5265"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64",
+ "base64 0.21.0",
  "bitflags",
  "bytes",
  "futures-util",
@@ -737,8 +737,8 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.0"
-source = "git+https://github.com/tokio-rs/axum.git#978ae6335862b264b4368e01a52177d98c42b2d9"
+version = "0.3.2"
+source = "git+https://github.com/tokio-rs/axum.git#1e2567c39fb9964a19574eed3465ded05eba5265"
 dependencies = [
  "async-trait",
  "bytes",
@@ -788,6 +788,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64-simd"
@@ -2397,7 +2403,7 @@ version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6490be71f07a5f62b564bc58e36953f675833df11c7e4a0647bee7a07ca1ec5e"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "flate2",
  "nom",
@@ -2410,7 +2416,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -2478,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -2524,9 +2530,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2693,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jobserver"
@@ -2744,7 +2750,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "pem",
  "ring",
  "serde",
@@ -2771,7 +2777,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "chrono",
  "http",
@@ -2801,7 +2807,7 @@ version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e80db3ca107e89da5f7eae37ea5274e06cefdcf9689d0ebd5ec3575a6f983e4e"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "chrono",
  "dirs-next",
@@ -3282,7 +3288,7 @@ version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9006c95034ccf7b903d955f210469119f6c3477fc9c9e7a7845ce38a3e665c2a"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bigdecimal",
  "bindgen",
  "bitflags",
@@ -3554,6 +3560,7 @@ dependencies = [
  "mz-timely-util",
  "once_cell",
  "prometheus",
+ "regex",
  "scopeguard",
  "serde",
  "smallvec",
@@ -3753,7 +3760,7 @@ dependencies = [
  "assert_cmd",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "bytesize",
  "cc",
@@ -3915,7 +3922,7 @@ name = "mz-frontegg-auth"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "derivative",
  "jsonwebtoken",
  "mz-ore",
@@ -4240,7 +4247,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
  "aws-types",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "deadpool-postgres",
  "differential-dataflow",
@@ -5564,7 +5571,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -5747,7 +5754,7 @@ name = "postgres-protocol"
 version = "0.6.4"
 source = "git+https://github.com/MaterializeInc/rust-postgres#9c9086235344fe794361a9985d97a64b42e61929"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -6032,7 +6039,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d378290cd658b119ce87621931ef448017ef1a0044d7b681159d779e7e07b8f6"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "prost",
  "prost-types",
  "serde",
@@ -6238,9 +6245,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6278,7 +6285,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -6753,7 +6760,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "chrono",
  "hex",
  "indexmap",
@@ -7542,7 +7549,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -7604,7 +7611,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "futures-core",
@@ -7763,7 +7770,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
@@ -7875,7 +7882,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "chunked_transfer",
  "log",
  "native-tls",
@@ -8190,7 +8197,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-http",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bstr",
  "byteorder",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6245,9 +6245,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ source = "git+https://github.com/jorgecarleitao/arrow2.git#0ba4f8e21547ed08b4468
 dependencies = [
  "ahash",
  "arrow-format",
- "base64 0.13.1",
+ "base64",
  "bytemuck",
  "chrono",
  "dyn-clone",
@@ -701,12 +701,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.7"
-source = "git+https://github.com/tokio-rs/axum.git#1e2567c39fb9964a19574eed3465ded05eba5265"
+version = "0.6.1"
+source = "git+https://github.com/tokio-rs/axum.git#978ae6335862b264b4368e01a52177d98c42b2d9"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64 0.21.0",
+ "base64",
  "bitflags",
  "bytes",
  "futures-util",
@@ -737,8 +737,8 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.2"
-source = "git+https://github.com/tokio-rs/axum.git#1e2567c39fb9964a19574eed3465ded05eba5265"
+version = "0.3.0"
+source = "git+https://github.com/tokio-rs/axum.git#978ae6335862b264b4368e01a52177d98c42b2d9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -788,12 +788,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64-simd"
@@ -2403,7 +2397,7 @@ version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6490be71f07a5f62b564bc58e36953f675833df11c7e4a0647bee7a07ca1ec5e"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "byteorder",
  "flate2",
  "nom",
@@ -2416,7 +2410,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bitflags",
  "bytes",
  "headers-core",
@@ -2484,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
@@ -2530,9 +2524,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2699,9 +2693,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jobserver"
@@ -2750,7 +2744,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "pem",
  "ring",
  "serde",
@@ -2777,7 +2771,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bytes",
  "chrono",
  "http",
@@ -2807,7 +2801,7 @@ version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e80db3ca107e89da5f7eae37ea5274e06cefdcf9689d0ebd5ec3575a6f983e4e"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bytes",
  "chrono",
  "dirs-next",
@@ -3288,7 +3282,7 @@ version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9006c95034ccf7b903d955f210469119f6c3477fc9c9e7a7845ce38a3e665c2a"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bigdecimal",
  "bindgen",
  "bitflags",
@@ -3760,7 +3754,7 @@ dependencies = [
  "assert_cmd",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64",
  "bytes",
  "bytesize",
  "cc",
@@ -3922,7 +3916,7 @@ name = "mz-frontegg-auth"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64",
  "derivative",
  "jsonwebtoken",
  "mz-ore",
@@ -4247,7 +4241,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
  "aws-types",
- "base64 0.13.1",
+ "base64",
  "bytes",
  "deadpool-postgres",
  "differential-dataflow",
@@ -5571,7 +5565,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
- "base64 0.13.1",
+ "base64",
 ]
 
 [[package]]
@@ -5754,7 +5748,7 @@ name = "postgres-protocol"
 version = "0.6.4"
 source = "git+https://github.com/MaterializeInc/rust-postgres#9c9086235344fe794361a9985d97a64b42e61929"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -6039,7 +6033,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d378290cd658b119ce87621931ef448017ef1a0044d7b681159d779e7e07b8f6"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "prost",
  "prost-types",
  "serde",
@@ -6285,7 +6279,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -6760,7 +6754,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap",
@@ -7549,7 +7543,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -7611,7 +7605,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bitflags",
  "bytes",
  "futures-core",
@@ -7770,7 +7764,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "byteorder",
  "bytes",
  "http",
@@ -7882,7 +7876,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "chunked_transfer",
  "log",
  "native-tls",
@@ -8197,7 +8191,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-http",
  "axum",
- "base64 0.13.1",
+ "base64",
  "bstr",
  "byteorder",
  "bytes",

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -29,7 +29,7 @@ mz-storage-client = { path = "../storage-client" }
 mz-timely-util = { path = "../timely-util" }
 once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
-regex = "1.7.1"
+regex = "1.7.0"
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -29,6 +29,7 @@ mz-storage-client = { path = "../storage-client" }
 mz-timely-util = { path = "../timely-util" }
 once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
+regex = "1.7.1"
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }

--- a/src/cluster/src/communication.rs
+++ b/src/cluster/src/communication.rs
@@ -141,12 +141,12 @@ async fn create_sockets(
     let mut results: Vec<_> = (0..addresses.len()).map(|_| None).collect();
 
     let my_address = &addresses[my_index_uz];
+
     // [btv] Binding to the address (which is of the form
     // `hostname:port`) unnecessarily involves a DNS query. We should
     // get the port from here, but otherwise just bind to `0.0.0.0`.
     // Previously we bound to `my_address`, which caused
     // https://github.com/MaterializeInc/cloud/issues/5070 .
-
     let bind_address = match regex::Regex::new(r":(\d{1,5})$")
         .unwrap()
         .captures(my_address)

--- a/src/cluster/src/communication.rs
+++ b/src/cluster/src/communication.rs
@@ -152,7 +152,7 @@ async fn create_sockets(
         .captures(my_address)
     {
         Some(cap) => {
-            let p: u16 = cap[1].parse().expect("Port out of range");
+            let p: u16 = cap[1].parse().context("Port out of range")?;
             format!("0.0.0.0:{p}")
         }
         None => {

--- a/src/cluster/src/communication.rs
+++ b/src/cluster/src/communication.rs
@@ -141,12 +141,29 @@ async fn create_sockets(
     let mut results: Vec<_> = (0..addresses.len()).map(|_| None).collect();
 
     let my_address = &addresses[my_index_uz];
+    // [btv] Binding to the address (which is of the form
+    // `hostname:port`) unnecessarily involves a DNS query. We should
+    // get the port from here, but otherwise just bind to `0.0.0.0`.
+    // Previously we bound to `my_address`, which caused c
+    // https://github.com/MaterializeInc/cloud/issues/5070 .
+
+    // Motivation for `unwrap` (and indexing) vs. `expect`:
+    // The `expect`s can fail if clusterd is invoked with bad
+    // arguments. The `unwrap` and indexing can only fail if there's
+    // a logic error in this code.
+    let my_port: u16 = regex::Regex::new(r":(\d{1-5})$")
+        .unwrap()
+        .captures(&my_address)
+        .expect("local address must end with a port number")[1]
+        .parse()
+        .expect("local address must end with a port number");
     let listener = loop {
         let mut tries = 0;
-        match Listener::bind(my_address.clone()).await {
+        let bind_address = format!("0.0.0.0:{my_port}");
+        match Listener::bind(&bind_address).await {
             Ok(ok) => break ok,
             Err(e) => {
-                warn!("failed to listen on address {my_address}: {e}");
+                warn!("failed to listen on address {bind_address}: {e}");
                 tries += 1;
                 if tries == 10 {
                     return Err(e.into());

--- a/src/cluster/src/communication.rs
+++ b/src/cluster/src/communication.rs
@@ -144,7 +144,7 @@ async fn create_sockets(
     // [btv] Binding to the address (which is of the form
     // `hostname:port`) unnecessarily involves a DNS query. We should
     // get the port from here, but otherwise just bind to `0.0.0.0`.
-    // Previously we bound to `my_address`, which caused c
+    // Previously we bound to `my_address`, which caused
     // https://github.com/MaterializeInc/cloud/issues/5070 .
 
     // Motivation for `unwrap` (and indexing) vs. `expect`:

--- a/src/cluster/src/communication.rs
+++ b/src/cluster/src/communication.rs
@@ -151,9 +151,9 @@ async fn create_sockets(
     // The `expect`s can fail if clusterd is invoked with bad
     // arguments. The `unwrap` and indexing can only fail if there's
     // a logic error in this code.
-    let my_port: u16 = regex::Regex::new(r":(\d{1-5})$")
+    let my_port: u16 = regex::Regex::new(r":(\d{1,5})$")
         .unwrap()
-        .captures(&my_address)
+        .captures(my_address)
         .expect("local address must end with a port number")[1]
         .parse()
         .expect("local address must end with a port number");

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -48,7 +48,7 @@ futures-task = { version = "0.3.25" }
 futures-util = { version = "0.3.25", features = ["channel", "io", "sink"] }
 globset = { version = "0.4.9", features = ["serde1"] }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["raw"] }
-hyper = { version = "0.14.23", features = ["full"] }
+hyper = { version = "0.14.24", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }
@@ -146,7 +146,7 @@ futures-task = { version = "0.3.25" }
 futures-util = { version = "0.3.25", features = ["channel", "io", "sink"] }
 globset = { version = "0.4.9", features = ["serde1"] }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["raw"] }
-hyper = { version = "0.14.23", features = ["full"] }
+hyper = { version = "0.14.24", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -48,7 +48,7 @@ futures-task = { version = "0.3.25" }
 futures-util = { version = "0.3.25", features = ["channel", "io", "sink"] }
 globset = { version = "0.4.9", features = ["serde1"] }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["raw"] }
-hyper = { version = "0.14.24", features = ["full"] }
+hyper = { version = "0.14.23", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }
@@ -146,7 +146,7 @@ futures-task = { version = "0.3.25" }
 futures-util = { version = "0.3.25", features = ["channel", "io", "sink"] }
 globset = { version = "0.4.9", features = ["serde1"] }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["raw"] }
-hyper = { version = "0.14.24", features = ["full"] }
+hyper = { version = "0.14.23", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }


### PR DESCRIPTION
As @benesch explains [here](https://github.com/MaterializeInc/cloud/issues/5070#issuecomment-1439039967), there is no reason to bind to a DNS name, and it introduces complexity to the system (an unnecessary DNS lookup before binding) which may be causing problems.

### Motivation

  * This PR fixes a recognized bug.
https://github.com/MaterializeInc/cloud/issues/5070 (Hopefully)
