### PR TITLE
compute: report errors through subscribe sinks

### DIFF
--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -13,9 +13,8 @@ use std::convert::Infallible;
 use std::ops::DerefMut;
 use std::rc::Rc;
 
+use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::Collection;
-
-use mz_timely_util::probe::{self, ProbeNotify};
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
@@ -28,6 +27,7 @@ use mz_compute_client::types::sinks::{ComputeSinkDesc, SinkAsOf, SubscribeSinkCo
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::errors::DataflowError;
+use mz_timely_util::probe::{self, ProbeNotify};
 
 use crate::render::sinks::SinkRender;
 
@@ -41,9 +41,7 @@ where
         sink: &ComputeSinkDesc<CollectionMetadata>,
         sink_id: GlobalId,
         sinked_collection: Collection<G, Row, Diff>,
-        // TODO(benesch): errors should stream out through the sink,
-        // if we figure out a protocol for that.
-        _err_collection: Collection<G, DataflowError, Diff>,
+        err_collection: Collection<G, DataflowError, Diff>,
         probes: Vec<probe::Handle<Timestamp>>,
     ) -> Option<Rc<dyn Any>>
     where
@@ -57,11 +55,13 @@ where
             sink_as_of: sink.as_of.frontier.clone(),
             subscribe_response_buffer: Some(Rc::clone(&compute_state.subscribe_response_buffer)),
             prev_upper: Antichain::from_elem(Timestamp::minimum()),
+            poison: None,
         })));
         let subscribe_protocol_weak = Rc::downgrade(&subscribe_protocol_handle);
 
         subscribe(
             sinked_collection,
+            err_collection,
             sink_id,
             sink.as_of.clone(),
             sink.up_to.clone(),
@@ -82,6 +82,7 @@ where
 
 fn subscribe<G>(
     sinked_collection: Collection<G, Row, Diff>,
+    err_collection: Collection<G, DataflowError, Diff>,
     sink_id: GlobalId,
     as_of: SinkAsOf,
     up_to: Antichain<G::Timestamp>,
@@ -95,48 +96,76 @@ fn subscribe<G>(
     // TODO: Replace `Infallible` with `!` once the latter is stabilized.
     let progress_stream: Stream<G, Infallible>;
 
-    let mut results = Vec::new();
+    let mut rows_to_emit = Vec::new();
+    let mut errors_to_emit = Vec::new();
     let mut finished = false;
-    let mut rows = Default::default();
-    progress_stream = sinked_collection.inner.unary_frontier(
+    let mut ok_buf = Default::default();
+    let mut err_buf = Default::default();
+    progress_stream = sinked_collection.inner.binary_frontier(
+        &err_collection.inner,
+        Pipeline,
         Pipeline,
         &format!("subscribe-{}", sink_id),
         move |_cap, _info| {
-            move |input, _output| {
+            move |ok_input, err_input, _output| {
                 if finished {
-                    // Drain the input, to avoid the operator being constantly rescheduled
-                    input.for_each(|_, _| {});
+                    // Drain the inputs, to avoid the operator being constantly rescheduled
+                    ok_input.for_each(|_, _| {});
+                    err_input.for_each(|_, _| {});
                     return;
                 }
-                input.for_each(|_, data| {
-                    data.swap(&mut rows);
-                    for (row, time, diff) in rows.drain(..) {
-                        let should_emit_as_of = if as_of.strict {
-                            as_of.frontier.less_than(&time)
-                        } else {
-                            as_of.frontier.less_equal(&time)
-                        };
-                        let should_emit = should_emit_as_of && !up_to.less_equal(&time);
-                        if should_emit {
-                            results.push((time, row, diff));
+
+                let mut frontier = ok_input.frontier().frontier().to_owned();
+                frontier.extend(err_input.frontier().frontier().iter().copied());
+
+                let should_emit = |time: &Timestamp| {
+                    let beyond_as_of = if as_of.strict {
+                        as_of.frontier.less_than(time)
+                    } else {
+                        as_of.frontier.less_equal(time)
+                    };
+                    let before_up_to = !up_to.less_equal(time);
+                    beyond_as_of && before_up_to
+                };
+
+                ok_input.for_each(|_, data| {
+                    data.swap(&mut ok_buf);
+                    for (row, time, diff) in ok_buf.drain(..) {
+                        if should_emit(&time) {
+                            rows_to_emit.push((time, row, diff));
+                        }
+                    }
+                });
+                err_input.for_each(|_, data| {
+                    data.swap(&mut err_buf);
+                    for (error, time, diff) in err_buf.drain(..) {
+                        if should_emit(&time) {
+                            errors_to_emit.push((time, error, diff));
                         }
                     }
                 });
 
                 if let Some(subscribe_protocol) = subscribe_protocol_handle.borrow_mut().deref_mut()
                 {
-                    subscribe_protocol
-                        .send_batch(input.frontier().frontier().to_owned(), &mut results);
+                    subscribe_protocol.send_batch(
+                        frontier.clone(),
+                        &mut rows_to_emit,
+                        &mut errors_to_emit,
+                    );
                 }
 
-                if PartialOrder::less_equal(&up_to.borrow(), &input.frontier().frontier()) {
+                if PartialOrder::less_equal(&up_to, &frontier) {
                     finished = true;
                     // We are done; indicate this by sending a batch at the
                     // empty frontier.
                     if let Some(subscribe_protocol) =
                         subscribe_protocol_handle.borrow_mut().deref_mut()
                     {
-                        subscribe_protocol.send_batch(Antichain::default(), &mut Vec::new());
+                        subscribe_protocol.send_batch(
+                            Antichain::default(),
+                            &mut Vec::new(),
+                            &mut Vec::new(),
+                        );
                     }
                 }
             }
@@ -148,25 +177,42 @@ fn subscribe<G>(
 
 /// A type that guides the transmission of rows back to the coordinator.
 ///
-/// A protocol instance may `send` rows indefinitely, and is consumed by `complete`,
-/// which is used only to indicate the end of a stream. The `Drop` implementation
-/// otherwise sends an indication that the protocol has finished without completion.
+/// A protocol instance may `send` rows indefinitely in response to `send_batch` calls.
+/// A `send_batch` call advancing the upper to the empty frontier is used to indicate the end of
+/// a stream. If the stream is not advanced to the empty frontier, the `Drop` implementation sends
+/// an indication that the protocol has finished without completion.
 struct SubscribeProtocol {
     pub sink_id: GlobalId,
     pub sink_as_of: Antichain<Timestamp>,
     pub subscribe_response_buffer: Option<Rc<RefCell<Vec<(GlobalId, SubscribeResponse)>>>>,
     pub prev_upper: Antichain<Timestamp>,
+    /// The error poisoning this subscribe, if any.
+    ///
+    /// As soon as a subscribe has encountered an error, it is poisoned: It will only return the
+    /// same error in subsequent batches, until it is dropped. The subscribe protocol currently
+    /// does not support retracting errors (#17781).
+    pub poison: Option<String>,
 }
 
 impl SubscribeProtocol {
     /// Attempt to send a batch of rows with the given `upper`.
     ///
-    /// This method might refuse to send the requested batch if `upper` has not advanced far
-    /// enough. If this is the case, the `rows` buffer is unchanged. Only if `rows` has been
-    /// drained after this call returns was the batch successfully sent. If `rows` has not been
-    /// drained the caller is expected to re-submit its contents, potentially along with new rows,
-    /// at a later `upper`.
-    fn send_batch(&mut self, upper: Antichain<Timestamp>, rows: &mut Vec<(Timestamp, Row, Diff)>) {
+    /// This method filters the updates to send based on the provided `upper`. Updates are only
+    /// sent when their times are before `upper`. If `upper` has not advanced far enough, no batch
+    /// will be sent. `rows` and `errors` that have been sent are drained from their respective
+    /// vectors, only entries that have not been sent remain after the call returns. The caller is
+    /// expected to re-submit these entries, potentially along with new ones, at a later `upper`.
+    ///
+    /// The subscribe protocol only supports reporting a single error. Because of this, it will
+    /// only actually send the first error received in a `SubscribeResponse`. Subsequent errors are
+    /// dropped. To simplify life for the caller, this method still maintains the illusion that
+    /// `errors` are handled the same way as `rows`.
+    fn send_batch(
+        &mut self,
+        upper: Antichain<Timestamp>,
+        rows: &mut Vec<(Timestamp, Row, Diff)>,
+        errors: &mut Vec<(Timestamp, DataflowError, Diff)>,
+    ) {
         // Only send a batch if both conditions hold:
         //  a) `upper` has reached or passed the sink's `as_of` frontier.
         //  b) `upper` is different from when we last sent a batch.
@@ -174,31 +220,46 @@ impl SubscribeProtocol {
             return;
         }
 
-        let mut ship = Vec::new();
-        let mut keep = Vec::new();
-        differential_dataflow::consolidation::consolidate_updates(rows);
-        for (time, data, diff) in rows.drain(..) {
-            if upper.less_equal(&time) {
-                keep.push((time, data, diff));
-            } else {
-                ship.push((time, data, diff));
-            }
-        }
-        *rows = keep;
+        consolidate_updates(rows);
+        consolidate_updates(errors);
 
-        let input_exhausted = upper.is_empty();
+        let (keep_rows, ship_rows) = rows.drain(..).partition(|u| upper.less_equal(&u.0));
+        let (keep_errors, ship_errors) = errors.drain(..).partition(|u| upper.less_equal(&u.0));
+        *rows = keep_rows;
+        *errors = keep_errors;
+
+        let updates = match (&self.poison, ship_errors.first()) {
+            (Some(error), _) => {
+                // The subscribe is poisoned; keep sending the same error.
+                Err(error.clone())
+            }
+            (None, Some((_, error, _))) => {
+                // The subscribe encountered its first error; poison it.
+                let error = error.to_string();
+                self.poison = Some(error.clone());
+                Err(error)
+            }
+            (None, None) => {
+                // No error encountered so for; ship the rows we have!
+                Ok(ship_rows)
+            }
+        };
+
         let buffer = self
             .subscribe_response_buffer
             .as_mut()
             .expect("The subscribe response buffer is only cleared on drop.");
+
         buffer.borrow_mut().push((
             self.sink_id,
             SubscribeResponse::Batch(SubscribeBatch {
                 lower: self.prev_upper.clone(),
                 upper: upper.clone(),
-                updates: Ok(ship),
+                updates,
             }),
         ));
+
+        let input_exhausted = upper.is_empty();
         self.prev_upper = upper;
         if input_exhausted {
             // The dataflow's input has been exhausted; clear the channel,

--- a/test/sqllogictest/subscribe_error.slt
+++ b/test/sqllogictest/subscribe_error.slt
@@ -1,0 +1,63 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that subscribes propagate query errors.
+
+mode cockroach
+
+statement ok
+CREATE TABLE t (a int)
+
+statement ok
+INSERT INTO t VALUES (1), (2), (0)
+
+statement ok
+CREATE VIEW v AS SELECT 1/a FROM t
+
+statement ok
+CREATE DEFAULT INDEX ON v
+
+statement ok
+CREATE MATERIALIZED VIEW mv AS SELECT 1/a FROM t
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE c CURSOR FOR SUBSCRIBE (SELECT 1/a FROM t)
+
+statement error Evaluation error: division by zero
+FETCH 1 c
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE c CURSOR FOR SUBSCRIBE v
+
+statement error Evaluation error: division by zero
+FETCH 1 c
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE c CURSOR FOR SUBSCRIBE mv
+
+statement error Evaluation error: division by zero
+FETCH 1 c
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
Prior to this change, subscribe sinks did not know how to handle dataflow errors in their input and simply ignored them. This could potentially cause correctness issues, since it is not clear what semantics a dataflow's `ok` collection has when the `err` collection is not empty.

This commit makes the subscribe sink handle errors by piggy-backing on the existing subscribe error reporting support originally introduced to error on too-large results. This way of error reporting is somewhat unsatisfactory, since it does not allow retraction of errors. At the moment this is fine, since adapter aborts subscribes upon seeing the first error anyway. Better subscribe error reporting is tracked in issue #17781.

### Motivation

  * This PR fixes a recognized bug.

Fixes #6292.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Change `SUBSCRIBE` to report and abort on errors discovered in the target collection.
