### PR TITLE
adapter: Plumb frontegg admin status through auth

### DIFF
--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -63,6 +63,8 @@ pub struct ExternalUserMetadata {
     pub user_id: Uuid,
     /// The ID of the user's active group in the external system.
     pub group_id: Uuid,
+    /// Indicates if the user is an admin in the external system.
+    pub admin: bool,
 }
 
 impl PartialEq for User {
@@ -75,6 +77,15 @@ impl User {
     /// Returns whether this is an internal user.
     pub fn is_internal(&self) -> bool {
         INTERNAL_USER_NAMES.contains(&self.name)
+    }
+
+    /// Returns whether this user is an admin in an external system.
+    pub fn is_external_admin(&self) -> bool {
+        self.external_metadata
+            .as_ref()
+            .map(|metadata| metadata.admin)
+            .clone()
+            .unwrap_or(false)
     }
 }
 

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -289,6 +289,9 @@ pub struct Args {
     /// of all Frontegg passwords.
     #[clap(long, env = "FRONTEGG_PASSWORD_PREFIX", requires = "frontegg-tenant")]
     frontegg_password_prefix: Option<String>,
+    /// The name of the admin role in Frontegg.
+    #[clap(long, env = "FRONTEGG_ADMIN_ROLE", requires = "frontegg-tenant")]
+    frontegg_admin_role: Option<String>,
 
     // === Orchestrator options. ===
     /// The service orchestrator implementation to use.
@@ -623,6 +626,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 now: mz_ore::now::SYSTEM_TIME.clone(),
                 refresh_before_secs: 60,
                 password_prefix: args.frontegg_password_prefix.unwrap_or_default(),
+                admin_role: args.frontegg_admin_role.unwrap_or_default(),
             }))
         }
         _ => unreachable!("clap enforced"),

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -501,6 +501,7 @@ async fn auth(
                 external_metadata: Some(ExternalUserMetadata {
                     user_id: claims.best_user_id(),
                     group_id: claims.tenant_id,
+                    admin: claims.admin(frontegg.admin_role()),
                 }),
                 name: claims.email,
             }

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -100,6 +100,8 @@ pub struct FronteggConfig {
     pub refresh_before_secs: i64,
     /// Prefix that is expected to be present on all passwords.
     pub password_prefix: String,
+    /// Name of admin role.
+    pub admin_role: String,
 }
 
 #[derive(Clone, Derivative)]
@@ -113,6 +115,7 @@ pub struct FronteggAuthentication {
     validation: Validation,
     refresh_before_secs: i64,
     password_prefix: String,
+    admin_role: String,
 
     // Reqwest HTTP client pool.
     client: Client,
@@ -135,6 +138,7 @@ impl FronteggAuthentication {
             validation,
             refresh_before_secs: config.refresh_before_secs,
             password_prefix: config.password_prefix,
+            admin_role: config.admin_role,
             client: Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
@@ -329,6 +333,10 @@ impl FronteggAuthentication {
     pub fn tenant_id(&self) -> Uuid {
         self.tenant_id
     }
+
+    pub fn admin_role(&self) -> &str {
+        &self.admin_role
+    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -371,6 +379,11 @@ impl Claims {
     /// Extracts the most specific user ID present in the token.
     pub fn best_user_id(&self) -> Uuid {
         self.user_id.unwrap_or(self.sub)
+    }
+
+    /// Returns true if the claims belong to a frontegg admin.
+    pub fn admin(&self, admin_name: &str) -> bool {
+        self.roles.iter().any(|role| role == admin_name)
     }
 }
 

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -181,6 +181,7 @@ where
                 let external_metadata = Some(ExternalUserMetadata {
                     user_id: claims.best_user_id(),
                     group_id: claims.tenant_id,
+                    admin: claims.admin(frontegg.admin_role()),
                 });
                 (external_metadata, is_expired.left_future())
             }


### PR DESCRIPTION
This commit plumbs the frontegg admin status of users through authorization, so the value is saved in the user's session. This will be useful when creating new roles for RBAC.

Part of #11579

### Motivation
This PR adds a known-desirable feature.
### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
