### PR TITLE
storage: fix graceful sink restarts

### DIFF
--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -540,8 +540,9 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 // NOTE: If we want to share the load of async processing we
                 // have to change `handle_storage_command` and change this
                 // assert.
-                assert!(
-                    self.timely_worker.index() == 0,
+                assert_eq!(
+                    self.timely_worker.index(),
+                    0,
                     "only worker #0 is doing async processing"
                 );
                 internal_cmd_tx.broadcast(InternalStorageCommand::CreateIngestionDataflow {
@@ -554,8 +555,9 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 // NOTE: If we want to share the load of async processing we
                 // have to change `handle_storage_command` and change this
                 // assert.
-                assert!(
-                    self.timely_worker.index() == 0,
+                assert_eq!(
+                    self.timely_worker.index(),
+                    0,
                     "only worker #0 is doing async processing"
                 );
                 internal_cmd_tx

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -550,13 +550,24 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     resumption_frontier,
                 });
             }
+            AsyncStorageWorkerResponse::UpdatedSinkDesc(id, sink_desc) => {
+                // NOTE: If we want to share the load of async processing we
+                // have to change `handle_storage_command` and change this
+                // assert.
+                assert!(
+                    self.timely_worker.index() == 0,
+                    "only worker #0 is doing async processing"
+                );
+                internal_cmd_tx
+                    .broadcast(InternalStorageCommand::CreateSinkDataflow(id, sink_desc));
+            }
         }
     }
 
     /// Entry point for applying an internal storage command.
     pub fn handle_internal_storage_command(
         &mut self,
-        internal_cmd_tx: &mut dyn InternalCommandSender,
+        _internal_cmd_tx: &mut dyn InternalCommandSender,
         async_worker: &mut AsyncStorageWorker<mz_repr::Timestamp>,
         internal_cmd: InternalStorageCommand,
     ) {
@@ -612,14 +623,15 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         return;
                     }
 
-                    // This needs to be broadcast by one worker and go through
-                    // the internal command fabric, to ensure consistent
-                    // ordering of dataflow rendering across all workers.
+                    // This needs to be done by one worker, which will
+                    // broadcasts a `CreateSinkDataflow` command to all workers
+                    // based on the enriched/updates `StorageSinkDesc`.
+                    //
+                    // Doing this separately on each worker could lead to
+                    // differing resume_uppers which might lead to all kinds of
+                    // mayhem.
                     if self.timely_worker.index() == 0 {
-                        internal_cmd_tx.broadcast(InternalStorageCommand::CreateSinkDataflow(
-                            id,
-                            sink_description,
-                        ));
+                        async_worker.calculate_export_as_of(id, sink_description);
                     }
 
                     // Continue with other commands.
@@ -1051,14 +1063,15 @@ impl StorageState {
                         ),
                     );
 
-                    // This needs to be broadcast by one worker and go through
-                    // the internal command fabric, to ensure consistent
-                    // ordering of dataflow rendering across all workers.
+                    // This needs to be done by one worker, which will
+                    // broadcasts a `CreateSinkDataflow` command to all workers
+                    // based on the enriched/updates `StorageSinkDesc`.
+                    //
+                    // Doing this separately on each worker could lead to
+                    // differing resume_uppers which might lead to all kinds of
+                    // mayhem.
                     if worker_index == 0 {
-                        internal_cmd_tx.broadcast(InternalStorageCommand::CreateSinkDataflow(
-                            export.id,
-                            export.description,
-                        ));
+                        async_worker.calculate_export_as_of(export.id, export.description);
                     }
                 }
             }

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -109,14 +109,9 @@ impl<T: Timestamp + Lattice + Codec64> AsyncStorageWorker<T> {
                             ),
                         );
 
-                        match res {
-                            Ok(_) => {
-                                // All's well!
-                            }
-                            Err(_err) => {
-                                // Receiver must have hung up.
-                                break;
-                            }
+                        if let Err(_err) = res {
+                            // Receiver must have hung up.
+                            break;
                         }
                     }
                     AsyncStorageWorkerCommand::CalculateExportAsOf(id, mut sink_desc) => {
@@ -147,14 +142,9 @@ impl<T: Timestamp + Lattice + Codec64> AsyncStorageWorker<T> {
                         let res = response_tx
                             .send(AsyncStorageWorkerResponse::UpdatedSinkDesc(id, sink_desc));
 
-                        match res {
-                            Ok(_) => {
-                                // All's well!
-                            }
-                            Err(_err) => {
-                                // Receiver must have hung up.
-                                break;
-                            }
+                        if let Err(_err) = res {
+                            // Receiver must have hung up.
+                            break;
                         }
                     }
                 }

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -22,12 +22,17 @@ use tokio::sync::mpsc;
 use tracing::Instrument;
 
 use mz_persist_client::cache::PersistClientCache;
+use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::Codec64;
+use mz_repr::Diff;
 use mz_repr::GlobalId;
 use mz_service::local::Activatable;
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::controller::ResumptionFrontierCalculator;
+use mz_storage_client::types::sinks::MetadataFilled;
+use mz_storage_client::types::sinks::StorageSinkDesc;
 use mz_storage_client::types::sources::IngestionDescription;
+use mz_storage_client::types::sources::SourceData;
 
 /// A worker that can execute commands that come in on a channel and returns
 /// responses on another channel. This is useful in places where we can't
@@ -47,6 +52,8 @@ pub enum AsyncStorageWorkerCommand<T: Timestamp + Lattice + Codec64> {
         IngestionDescription<CollectionMetadata>,
         PhantomData<T>,
     ),
+    /// Calculate a recent as_of for the export/sink.
+    CalculateExportAsOf(GlobalId, StorageSinkDesc<MetadataFilled, T>),
 }
 
 /// Responses from [AsyncStorageWorker].
@@ -58,6 +65,8 @@ pub enum AsyncStorageWorkerResponse<T: Timestamp + Lattice + Codec64> {
         IngestionDescription<CollectionMetadata>,
         Antichain<T>,
     ),
+    /// A `StorageSinkDesc` with an updated, recent `as_of`.
+    UpdatedSinkDesc(GlobalId, StorageSinkDesc<MetadataFilled, T>),
 }
 
 impl<T: Timestamp + Lattice + Codec64> AsyncStorageWorker<T> {
@@ -110,6 +119,44 @@ impl<T: Timestamp + Lattice + Codec64> AsyncStorageWorker<T> {
                             }
                         }
                     }
+                    AsyncStorageWorkerCommand::CalculateExportAsOf(id, mut sink_desc) => {
+                        let persist_client = persist_clients
+                            .open(sink_desc.from_storage_metadata.persist_location.clone())
+                            .await
+                            .expect("error creating persist client");
+
+                        let from_read_handle = persist_client
+                            .open_leased_reader::<SourceData, (), T, Diff>(
+                                sink_desc.from_storage_metadata.data_shard,
+                                "graceful restart since",
+                                // This is also `from_desc`, but this would be
+                                // the _only_ usage of `from_desc` in storage,
+                                // and we try to be consistent about where we
+                                // get `RelationDesc`s for perist clients
+                                Arc::new(sink_desc.from_storage_metadata.relation_desc.clone()),
+                                Arc::new(UnitSchema),
+                            )
+                            .await
+                            .expect("from collection disappeared");
+
+                        let cached_as_of = &sink_desc.as_of;
+
+                        let from_since = from_read_handle.since();
+                        sink_desc.as_of = cached_as_of.maybe_fast_forward(from_since);
+
+                        let res = response_tx
+                            .send(AsyncStorageWorkerResponse::UpdatedSinkDesc(id, sink_desc));
+
+                        match res {
+                            Ok(_) => {
+                                // All's well!
+                            }
+                            Err(_err) => {
+                                // Receiver must have hung up.
+                                break;
+                            }
+                        }
+                    }
                 }
             }
             tracing::trace!("shutting down async storage worker task");
@@ -131,6 +178,18 @@ impl<T: Timestamp + Lattice + Codec64> AsyncStorageWorker<T> {
             id,
             ingestion,
             PhantomData,
+        ))
+    }
+
+    /// Updates the given `sink_desc` with a recent `as_of` by advancing it to
+    /// the `since` of the sinked persist shard.
+    pub fn calculate_export_as_of(
+        &self,
+        id: GlobalId,
+        sink_desc: StorageSinkDesc<MetadataFilled, T>,
+    ) {
+        self.send(AsyncStorageWorkerCommand::CalculateExportAsOf(
+            id, sink_desc,
         ))
     }
 


### PR DESCRIPTION
Before, we were not updating the `as_of` of the `StorageSinkDesc` when internally (internal to the timely cluster/replica) restarting a sink. This lead to "cannot serve requested as_of" panics, which would restart the whole timely cluster/replica.

Now, we go through the async worker to update the `as_of`, similar to how we update the resumption frontier for sources using the same path.

Fixes #17543

NOTE: We still haven't removed the equivalent code from `rehydration.rs`, same as for sources. Though we should do that soon.