### PR TITLE
persist: trim down new (schema'd) parquet serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,6 +4325,7 @@ dependencies = [
  "anyhow",
  "arrow2",
  "bytes",
+ "parquet2",
  "workspace-hack",
 ]
 

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 arrow2 = { git = "https://github.com/jorgecarleitao/arrow2.git", features = ["io_ipc", "io_parquet"] }
 bytes = "1.3.0"
+parquet2 = { version = "0.16.3", default-features = false }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]


### PR DESCRIPTION
This abandons the `arrow2::io::parquet::write::FileWriter` wrapper in favor of directly using the underlying `parquet2::write::FileWriter`. This allows us to skip encoding the (redundant for our case) arrow schema in the parquet key-val metadata as well as skip the created_by string.

For the row::encoding::tests::parquet_roundtrip test, this lowers the encoded size of the parquet file from 1,567 bytes to 759. This latter is made up of 346 bytes to encode the actual columnar data and the rest are parquet metadata.


### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Still not ideal, but better than before!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
