### PR TITLE
mzcompose: Increase environmentd startup waiting time to 600s

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -150,7 +150,7 @@ class Materialized(Service):
                     "test": ["CMD", "curl", "-f", "localhost:6878/api/readyz"],
                     "interval": "1s",
                     # A fully loaded Materialize can take a long time to start.
-                    "start_period": "300s",
+                    "start_period": "600s",
                 },
             }
         )


### PR DESCRIPTION
Fully-loaded Mz instances take forever to restart. Increase the docker healthcheck timeout to 10 minutes as otherwise long-running Zippy tests will error out.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


  * This PR fixes a previously unreported bug.

Release Qualification Tests were failing because Mz did not become healthy on time.