### PR TITLE
compute*: clean up mz_worker_compute_dependencies

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -215,7 +215,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                         time: timely::progress::Timestamp::minimum(),
                         diff: 1,
                     });
-                    for import_id in dataflow.depends_on(collection_id) {
+                    for import_id in dataflow.depends_on_imports(collection_id) {
                         logger.log(ComputeEvent::DataflowDependency {
                             dataflow: object_id,
                             source: import_id,

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -176,3 +176,21 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 > FETCH 1 c WITH (timeout='5s');
 <TIMESTAMP> 1 true
 > COMMIT
+
+# Test that the contents of mz_worker_compute_dependencies are correct.
+
+> CREATE TABLE t1 (a int)
+> CREATE TABLE t2 (b int)
+> CREATE MATERIALIZED VIEW mv1 AS SELECT * FROM t1, t2
+> CREATE DEFAULT INDEX ON mv1
+> CREATE MATERIALIZED VIEW mv2 AS SELECT 1;
+
+> SELECT export.name, import.name
+  FROM mz_internal.mz_worker_compute_dependencies dep
+  LEFT JOIN mz_objects export ON dep.export_id = export.id
+  LEFT JOIN mz_objects import ON dep.import_id = import.id
+  WHERE dep.worker_id = 0
+  ORDER BY export.name, import.name
+mv1             t1
+mv1             t2
+mv1_primary_idx mv1


### PR DESCRIPTION
#16656 changed the contents of the `mz_worker_compute_dependencies` introspection source by adding internal dependency identifiers. This change was not thoroughly discussed and there is no consensus that it was a good one, so we revert it until we get to a holistic design for the introspection sources.

### Motivation

  * This PR fixes a previously unreported bug.

The `mz_worker_compute_dependencies` entries for a dataflow can contain `import_id`s that are not in the set of identifiers imported by that dataflow.

See [discussion in Slack](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1675852661680059).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Filter the imports reported in `mz_internal.mz_worker_compute_dependencies` to only contain identifiers imported into the respective dataflow, rather then dataflow-internal identifiers as well.
