### PR TITLE
persist-client: silence unused-import warnings in release builds

### DIFF
--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -9,6 +9,7 @@
 
 //! A durable, truncatable log of versions of [State].
 
+#[cfg(debug_assertions)]
 use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::ops::ControlFlow::{Break, Continue};
@@ -32,9 +33,9 @@ use crate::internal::encoding::UntypedState;
 use crate::internal::machine::{retry_determinate, retry_external};
 use crate::internal::metrics::ShardMetrics;
 use crate::internal::paths::{BlobKey, PartialBlobKey, PartialRollupKey, RollupId};
-use crate::internal::state::{
-    HollowBatch, HollowBlobRef, HollowRollup, NoOpStateTransition, State, TypedState,
-};
+#[cfg(debug_assertions)]
+use crate::internal::state::HollowBatch;
+use crate::internal::state::{HollowBlobRef, HollowRollup, NoOpStateTransition, State, TypedState};
 use crate::internal::state_diff::{StateDiff, StateFieldValDiff};
 use crate::{Metrics, PersistConfig, ShardId};
 


### PR DESCRIPTION
Compiling the persist-client in release mode would produce unused-import warnings:

```
warning: unused import: `std::collections::BTreeSet`
  --> src/persist-client/src/internal/state_versions.rs:12:5
   |
12 | use std::collections::BTreeSet;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `HollowBatch`
  --> src/persist-client/src/internal/state_versions.rs:36:5
   |
36 |     HollowBatch, HollowBlobRef, HollowRollup, NoOpStateTransition, State, TypedState,
   |     ^^^^^^^^^^^
```

This PR silences those by gating the offending imports behind `#[cfg(debug_assertions)]`.

### Motivation

   * This PR removes unused-import warnings.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
