### PR TITLE
expr: deterministic logical operators

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -201,18 +201,21 @@ pub fn and<'a>(
 ) -> Result<Datum<'a>, EvalError> {
     // If any is false, then return false. Else, if any is null, then return null. Else, return true.
     let mut null = false;
+    let mut err = None;
     for expr in exprs {
-        match expr.eval(datums, temp_storage)? {
-            Datum::False => return Ok(Datum::False), // short-circuit
-            Datum::True => {}
-            Datum::Null => null = true, // No return here, because we might still see a false
+        match expr.eval(datums, temp_storage) {
+            Ok(Datum::False) => return Ok(Datum::False), // short-circuit
+            Ok(Datum::True) => {}
+            // No return in these two cases, because we might still see a false
+            Ok(Datum::Null) => null = true,
+            Err(this_err) => err = std::cmp::max(err.take(), Some(this_err)),
             _ => unreachable!(),
         }
     }
-    if null {
-        Ok(Datum::Null)
-    } else {
-        Ok(Datum::True)
+    match (err, null) {
+        (Some(err), _) => Err(err),
+        (None, true) => Ok(Datum::Null),
+        (None, false) => Ok(Datum::True),
     }
 }
 
@@ -223,18 +226,21 @@ pub fn or<'a>(
 ) -> Result<Datum<'a>, EvalError> {
     // If any is true, then return true. Else, if any is null, then return null. Else, return false.
     let mut null = false;
+    let mut err = None;
     for expr in exprs {
-        match expr.eval(datums, temp_storage)? {
-            Datum::False => {}
-            Datum::True => return Ok(Datum::True), // short-circuit
-            Datum::Null => null = true, // No return here, because we might still see a true
+        match expr.eval(datums, temp_storage) {
+            Ok(Datum::False) => {}
+            Ok(Datum::True) => return Ok(Datum::True), // short-circuit
+            // No return in these two cases, because we might still see a true
+            Ok(Datum::Null) => null = true,
+            Err(this_err) => err = std::cmp::max(err.take(), Some(this_err)),
             _ => unreachable!(),
         }
     }
-    if null {
-        Ok(Datum::Null)
-    } else {
-        Ok(Datum::False)
+    match (err, null) {
+        (Some(err), _) => Err(err),
+        (None, true) => Ok(Datum::Null),
+        (None, false) => Ok(Datum::False),
     }
 }
 


### PR DESCRIPTION
The current implementation of logical operators suffers from non-determinism because there are two separate short-circuit execution paths and which one comes first is dependent on how the optimizer chooses to optimize an expression.

This PR keeps the short-circuit behavior of logical operators in the presence of `false` and `true` items for `AND` and `OR` respectively and removes the short-circuit path of errors. This means that in the absence of errors the implementation is just as fast and in the presence of errors we maintain our correctness properties.

The new implementation has the property that `A && B == B && A` and `A || B == B || A` in all cases. They implement the following truth tables:

```
| A    | B    | A && B      | B && A
|------|------|-------------|--------
| T    | T    | T           | T
| T    | F    | F           | F
| T    | null | null        | null
| T    | E    | E           | E
| F    | T    | F           | F
| F    | F    | F           | F
| F    | null | F           | F
| F    | E    | F           | F
| null | T    | null        | null
| null | F    | F           | F
| null | null | null        | null
| null | E    | E           | E
| E    | T    | E           | E
| E    | F    | F           | F
| E    | null | E           | E
| E1   | E2   | max(E1, E2) | max(E1, E2)
```

```
| A    | B    | A || B      | B || A
|------|------|-------------|--------
| T    | T    | T           | T
| T    | F    | T           | T
| T    | null | T           | T
| T    | E    | T           | T
| F    | T    | T           | T
| F    | F    | F           | F
| F    | null | null        | null
| F    | E    | E           | E
| null | T    | T           | T
| null | F    | null        | null
| null | null | null        | null
| null | E    | E           | E
| E    | T    | T           | T
| E    | F    | E           | E
| E    | null | E           | E
| E1   | E2   | max(E1, E2) | max(E1, E2)
```

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
