### PR TITLE
mzcompose: A workflow that tests CRDB rolling restarts

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -59,6 +59,7 @@ steps:
           - { value: cloud-canary }
           - { value: sqlsmith-2-joins }
           - { value: sqlsmith-explain }
+          - { value: crdb-restarts }
         multiple: true
         required: false
     if: build.source == "ui"
@@ -567,6 +568,15 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
           args: [--max-joins=15, --explain-only, --runtime=3600]
+
+  - id: crdb-restarts
+    label: "CRDB rolling restarts"
+    artifact_paths: junit_*.xml
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: crdb-restarts
 
   - wait: ~
     continue_on_failure: true

--- a/test/crdb-restarts/mzcompose
+++ b/test/crdb-restarts/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/crdb-restarts/mzcompose.py
+++ b/test/crdb-restarts/mzcompose.py
@@ -1,0 +1,156 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from dataclasses import dataclass
+from textwrap import dedent
+from typing import Callable
+
+from materialize.mzcompose import Composition, ServiceHealthcheck
+from materialize.mzcompose.services import Cockroach, Materialized, Testdrive
+from materialize.ui import UIError
+
+CRDB_NODE_COUNT = 4
+TESTDRIVE_TIMEOUT = (
+    "40s"  # We expect any CRDB disruption to not disrupt Mz for more than this timeout
+)
+
+COCKROACH_HEALTHCHECK_DISABLED = ServiceHealthcheck(
+    test="/bin/true",
+    interval="1s",
+    start_period="30s",
+)
+
+TESTDRIVE_SCRIPT = dedent(
+    """
+    # This source will persist throughout the CRDB rolling restart
+    > CREATE SOURCE IF NOT EXISTS s_old FROM LOAD GENERATOR COUNTER (TICK INTERVAL '0.1s') WITH (SIZE = '4-4');
+
+    > SELECT COUNT(*) > 1 FROM s_old;
+    true
+
+    # This source is recreated periodically
+    > DROP SOURCE IF EXISTS s_new CASCADE;
+    > CREATE SOURCE s_new FROM LOAD GENERATOR COUNTER (TICK INTERVAL '0.1s') WITH (SIZE ='4-4');
+
+    > SELECT COUNT(*) > 1 FROM s_new;
+    true
+    """
+)
+
+
+ALL_COCKROACH_NODES = ",".join(
+    [f"cockroach{id}:26257" for id in range(CRDB_NODE_COUNT)]
+)
+
+SERVICES = [
+    Testdrive(default_timeout=TESTDRIVE_TIMEOUT, no_reset=True),
+    Materialized(
+        depends_on=[f"cockroach{id}" for id in range(CRDB_NODE_COUNT)],
+        options=[
+            "--adapter-stash-url=postgres://root@cockroach:26257?options=--search_path=adapter",
+            "--storage-stash-url=postgres://root@cockroach:26257?options=--search_path=storage",
+            "--persist-consensus-url=postgres://root@cockroach:26257?options=--search_path=consensus",
+        ],
+    ),
+    *[
+        Cockroach(
+            setup_materialize=True,
+            name=f"cockroach{id}",
+            command=[
+                "start",
+                "--insecure",
+                f"--store=cockroach{id}",
+                "--listen-addr=0.0.0.0:26257",
+                f"--advertise-addr=cockroach{id}:26257",
+                "--http-addr=0.0.0.0:8080",
+                f"--join={ALL_COCKROACH_NODES}",
+            ],
+            healthcheck=COCKROACH_HEALTHCHECK_DISABLED,
+        )
+        for id in range(CRDB_NODE_COUNT)
+    ],
+]
+
+
+@dataclass
+class CrdbDisruption:
+    name: str
+    disruption: Callable
+
+
+DISRUPTIONS = [
+    CrdbDisruption(
+        name="sigkill",
+        disruption=lambda c, id: c.kill(f"cockroach{id}"),
+    ),
+    CrdbDisruption(
+        name="sigterm",
+        disruption=lambda c, id: c.kill(f"cockroach{id}", signal="SIGTERM"),
+    ),
+    CrdbDisruption(
+        name="drain",
+        disruption=lambda c, id: c.exec(
+            # Execute the 'drain' command on a different node from the one that we are draining
+            f"cockroach{(id % 2) + 1}",
+            "cockroach",
+            "node",
+            "drain",
+            str(id + 1),
+            "--insecure",
+        ),
+    ),
+]
+
+
+def workflow_default(c: Composition) -> None:
+    """Perform rolling restarts on a CRDB cluster with CRDB_NODE_COUNT nodes and
+    confirm that Mz does not hang for longer than the expected."""
+    for d in DISRUPTIONS:
+        run_disruption(c, d)
+
+
+def run_disruption(c: Composition, d: CrdbDisruption) -> None:
+    print(f"--- Running Disruption {d.name} ...")
+    c.down(destroy_volumes=True)
+
+    for id in range(CRDB_NODE_COUNT):
+        c.up(f"cockroach{id}")
+
+    c.exec("cockroach0", "cockroach", "init", "--insecure", "--host=localhost:26257")
+
+    for query in [
+        "SET CLUSTER SETTING sql.stats.forecasts.enabled = false",
+        "CREATE SCHEMA IF NOT EXISTS consensus",
+        "CREATE SCHEMA IF NOT EXISTS storage",
+        "CREATE SCHEMA IF NOT EXISTS adapter",
+    ]:
+        c.exec("cockroach0", "cockroach", "sql", "--insecure", "-e", query)
+
+    c.up("materialized")
+    c.up("testdrive", persistent=True)
+
+    # Messing with cockroach node #0 borks the cluster permanently, so we start from node #1
+    for id in range(1, CRDB_NODE_COUNT):
+        d.disruption(c, id)
+
+        # We expect the testdrive fragment to complete within Testdrive's default_timeout
+        # This will indicate that Mz has not hung for a prolonged period of time
+        # as a result of the disruption we just introduced
+        c.testdrive(input=TESTDRIVE_SCRIPT)
+
+        # Restart the node we just disrupted so that we can safely disrupt another node
+        try:
+            # Node may have died already, so we eat any docker-compose exceptions
+            c.kill(f"cockroach{id}")
+        except UIError:
+            pass
+        c.up(f"cockroach{id}")
+
+        # Confirm things continue to work after CRDB is back to full complement
+        c.testdrive(input=TESTDRIVE_SCRIPT)


### PR DESCRIPTION
Mz should be able to handle rolling restarts gracefully and not hang for longer than expected.

Relates to: MaterializeInc/database-issues#5151

### Motivation

  * This PR adds a known-desirable feature.

Previously in the CI, we were only using single-node CRDB clusters and restarting them in their entirety. Rolling restarts had not been tested.

### Tips for reviewer

@benesch , @pH14 this is the most comprehensive non-CRDB-cloud-using test that I could come up with. It fails right away on "main" and somewhat later in @pH14 's `crdb-rolling-restart-investigation` branch.

If you do not mind, I will take a break from this support incident altogether to get back a bit of my sanity. We can discuss next steps next week if you would like.

Basically, with respect to the test cases already posted in MaterializeInc/database-issues#5151, this test:
- uses an actual source and a separate source cluster, vs. just simple DDL
- disrupts the CRDB cluster in various different ways
- does not use Cockroach Cloud
- does not use a load balancer

In the process, I ran into issues that appear for me to be on the CRDB side. For some of them, no amount of waiting would cause the cluster to go back to being healty:
- messing with the first node of the cluster in any way caused CRDB to permanently stop serving queries. I was hoping that waiting for the 5 min raft timeout to go by would allow the rest of the cluster to move on, but it does not seem that this is the case
- sometimes CRDB will start returning a "no quorum" or related errors back to the SQL client, even though I am disrupting only 1 out of 4 nodes in the cluster. 