### PR TITLE
buildkite: Fix artifact url to be persistent

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -74,7 +74,10 @@ def annotate_logged_errors(log_files: List[str]) -> None:
     for i, error in enumerate(error_logs):
         for artifact in artifacts:
             if artifact["job_id"] == job and artifact["path"] == error.file:
-                linked_file = f'<a href="{artifact["url"]}">{error.file}</a>'
+                org = os.environ["BUILDKITE_ORGANIZATION_SLUG"]
+                pipeline = os.environ["BUILDKITE_PIPELINE_SLUG"]
+                build = os.environ["BUILDKITE_BUILD_NUMBER"]
+                linked_file = f'<a href="https://buildkite.com/organizations/{org}/pipelines/{pipeline}/builds/{build}/jobs/{artifact["job_id"]}/artifacts/{artifact["id"]}">{error.file}</a>'
                 break
         else:
             linked_file = error.file


### PR DESCRIPTION
Current one expires after 10 minutes

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
