### PR TITLE
ore: handle multibyte haystacks in LexBuf::consume_str

### DIFF
--- a/src/ore/src/lex.rs
+++ b/src/ore/src/lex.rs
@@ -70,7 +70,7 @@ impl<'a> LexBuf<'a> {
     /// Advances the internal cursor past the next character in the buffer if
     /// the character is `ch`.
     ///
-    /// Returns whether the cursor was advanced.
+    /// Returns whether the cursor advanced.
     pub fn consume(&mut self, ch: char) -> bool {
         if self.peek() == Some(ch) {
             self.next();
@@ -80,19 +80,13 @@ impl<'a> LexBuf<'a> {
         }
     }
 
-    /// Advances the internal cusror past `s` if it exactly matches the next
-    /// elements in the buffer.
+    /// Advances the internal cursor past `s` if it exactly matches the next
+    /// characters in the buffer.
     ///
-    /// Returns whether the cusor advanced.
+    /// Returns whether the cursor advanced.
     pub fn consume_str(&mut self, s: &str) -> bool {
-        let start = self.pos;
-        let end = start + s.len();
-        if end > self.buf.len() {
-            return false;
-        }
-
-        if &self.buf[start..end] == s {
-            self.pos = end;
+        if self.buf[self.pos..].starts_with(s) {
+            self.pos += s.len();
             true
         } else {
             false

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -30,6 +30,9 @@ select pg_typeof('[0,100)'::int4range);
 ----
 int4range
 
+query error invalid input syntax for type range
+select '栬艷^Ằ['::int4range
+
 query T
 select 'empty'::int4range::text;
 ----


### PR DESCRIPTION
LexBuf::consume_str could panic if the haystack contained multibyte characters and the provided needle ended in the middle of one of those multibyte characters.

This commit fixes the issue by using the stdlib's `str::starts_with` method, which correctly handles this case.

Fix MaterializeInc/database-issues#5188.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Avoid panicking when attempting to parse a range from strings containing multibyte characters.
