### PR TITLE
storage: report actual error for Kafka sink errors

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -940,7 +940,7 @@ impl KafkaSinkState {
                         });
 
                 self.update_status(SinkStatus::Stalled {
-                    error: error.to_string(),
+                    error: format!("{:#}", error),
                     hint,
                 })
                 .await;

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -291,7 +291,7 @@ impl SourceConnectionBuilder for KafkaSourceConnection {
                             Err(e) => {
                                 *status_report.lock().unwrap() =
                                     Some(HealthStatus::StalledWithError {
-                                        error: e.to_string(),
+                                        error: format!("{:#}", e),
                                         hint: None,
                                     });
                                 thread::park_timeout(metadata_refresh_frequency);


### PR DESCRIPTION
Before, the error reported in `mz_internal.mz_sink_status_history` would
only contain the context string, because that's what `to_string()` on
those errors seems to do. For example:

```
        occurred_at         | sink_id |  status  |                         error                          | details
----------------------------+---------+----------+--------------------------------------------------------+---------
 2023-02-23 15:53:46.022+00 | u5      | stalled  | retriable transaction error                            |
```

After this change, we print the full error, which is a bit unwieldy but
also seems quite a bit more helpful. For example:

```
        occurred_at         | sink_id |  status  |                         error                          | details
----------------------------+---------+----------+--------------------------------------------------------+---------
 2023-02-23 15:54:01.143+00 | u5      | stalled  | retriable transaction error                           +|
                            |         |          |                                                       +|
                            |         |          | Caused by:                                            +|
                            |         |          |     Failed to initialize Producer ID: Local: Timed out |
```

I noticed that we might have the same problem in one call-site in the source, and also fixed that one. Though it seems we also don't have tests for these so I don't know if I'm breaking things... :sweat_smile: 

Side note, we should eventually look into populating that sweet sweet
details column.

Touches https://github.com/MaterializeInc/materialize/issues/12389