### PR TITLE
environmentd: Make admin role a required cmd arg

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -274,7 +274,7 @@ pub struct Args {
     #[clap(
         long,
         env = "FRONTEGG_TENANT",
-        requires_all = &["frontegg-jwk", "frontegg-api-token-url"],
+        requires_all = &["frontegg-jwk", "frontegg-api-token-url", "frontegg-admin-role"],
         value_name = "UUID",
     )]
     frontegg_tenant: Option<Uuid>,
@@ -285,14 +285,13 @@ pub struct Args {
     /// The full URL (including path) to the Frontegg api-token endpoint.
     #[clap(long, env = "FRONTEGG_API_TOKEN_URL", requires = "frontegg-tenant")]
     frontegg_api_token_url: Option<String>,
+    /// The name of the admin role in Frontegg.
+    #[clap(long, env = "FRONTEGG_ADMIN_ROLE", requires = "frontegg-tenant")]
+    frontegg_admin_role: Option<String>,
     /// A common string prefix that is expected to be present at the beginning
     /// of all Frontegg passwords.
     #[clap(long, env = "FRONTEGG_PASSWORD_PREFIX", requires = "frontegg-tenant")]
     frontegg_password_prefix: Option<String>,
-    /// The name of the admin role in Frontegg.
-    // TODO(jkosh44) Add this to requires_all for frontegg_tenant in v0.46.0
-    #[clap(long, env = "FRONTEGG_ADMIN_ROLE", requires = "frontegg-tenant")]
-    frontegg_admin_role: Option<String>,
 
     // === Orchestrator options. ===
     /// The service orchestrator implementation to use.
@@ -617,9 +616,10 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         args.frontegg_tenant,
         args.frontegg_api_token_url,
         args.frontegg_jwk,
+        args.frontegg_admin_role,
     ) {
-        (None, None, None) => None,
-        (Some(tenant_id), Some(admin_api_token_url), Some(jwk)) => {
+        (None, None, None, None) => None,
+        (Some(tenant_id), Some(admin_api_token_url), Some(jwk), Some(admin_role)) => {
             Some(FronteggAuthentication::new(FronteggConfig {
                 admin_api_token_url,
                 decoding_key: DecodingKey::from_rsa_pem(jwk.as_bytes())?,
@@ -627,7 +627,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 now: mz_ore::now::SYSTEM_TIME.clone(),
                 refresh_before_secs: 60,
                 password_prefix: args.frontegg_password_prefix.unwrap_or_default(),
-                admin_role: args.frontegg_admin_role,
+                admin_role,
             }))
         }
         _ => unreachable!("clap enforced"),

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -709,7 +709,7 @@ fn test_auth_expiry() {
         now: SYSTEM_TIME.clone(),
         refresh_before_secs: i64::try_from(REFRESH_BEFORE_SECS).unwrap(),
         password_prefix: "mzauth_".to_string(),
-        admin_role: Some("mzadmin".to_string()),
+        admin_role: "mzadmin".to_string(),
     });
     let frontegg_user = "user@_.com";
     let frontegg_password = &format!("mzauth_{client_id}{secret}");
@@ -855,7 +855,7 @@ fn test_auth_base() {
         now,
         refresh_before_secs: 0,
         password_prefix: "mzauth_".to_string(),
-        admin_role: Some("mzadmin".to_string()),
+        admin_role: "mzadmin".to_string(),
     });
     let frontegg_user = "user@_.com";
     let frontegg_password = &format!("mzauth_{client_id}{secret}");

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -101,7 +101,7 @@ pub struct FronteggConfig {
     /// Prefix that is expected to be present on all passwords.
     pub password_prefix: String,
     /// Name of admin role.
-    pub admin_role: Option<String>,
+    pub admin_role: String,
 }
 
 #[derive(Clone, Derivative)]
@@ -115,7 +115,7 @@ pub struct FronteggAuthentication {
     validation: Validation,
     refresh_before_secs: i64,
     password_prefix: String,
-    admin_role: Option<String>,
+    admin_role: String,
 
     // Reqwest HTTP client pool.
     client: Client,
@@ -334,8 +334,8 @@ impl FronteggAuthentication {
         self.tenant_id
     }
 
-    pub fn admin_role(&self) -> Option<&str> {
-        self.admin_role.as_deref()
+    pub fn admin_role(&self) -> &str {
+        &self.admin_role
     }
 }
 
@@ -382,12 +382,8 @@ impl Claims {
     }
 
     /// Returns true if the claims belong to a frontegg admin.
-    pub fn admin(&self, admin_name: Option<&str>) -> bool {
-        if let Some(admin_name) = admin_name {
-            self.roles.iter().any(|role| role == admin_name)
-        } else {
-            false
-        }
+    pub fn admin(&self, admin_name: &str) -> bool {
+        self.roles.iter().any(|role| role == admin_name)
     }
 }
 


### PR DESCRIPTION
This commit makes the Frontegg admin role command line argument a required argument, when using Frontegg.

Part of #11579

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
