### PR TITLE
Correctly inline lets

### DIFF
--- a/src/transform/src/monotonic.rs
+++ b/src/transform/src/monotonic.rs
@@ -136,7 +136,7 @@ impl MonotonicFlag {
                     while added {
                         added = false;
                         for (id, value) in ids.iter().zip(&mut *values) {
-                            if self.apply(value, mon_ids, locals)? {
+                            if !locals.contains(id) && self.apply(value, mon_ids, locals)? {
                                 added = true;
                                 locals.insert(*id);
                             }

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -579,6 +579,11 @@ mod inlining {
             } = expr
             {
                 if let Some(offer) = inline_offer.get_mut(id) {
+                    // It is important that we *not* continue to iterate
+                    // on the contents of `offer`, which has already been
+                    // maximally inlined. If we did, we could mis-inline
+                    // bindings into bodies that precede them, which would
+                    // change the semantics of the expression.
                     match offer {
                         InlineOffer::Take(value) => {
                             *expr = value.take().ok_or_else(|| {
@@ -587,11 +592,9 @@ mod inlining {
                                     id
                                 ))
                             })?;
-                            worklist.push(expr);
                         }
                         InlineOffer::Clone(value) => {
                             *expr = value.clone();
-                            worklist.push(expr);
                         }
                         InlineOffer::Unavailable(_) => {
                             // Do nothing.

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -479,6 +479,14 @@ mod inlining {
             //  3. The binding is not available for inlining.
             let mut inline_offer = BTreeMap::new();
 
+            // Each binding may require the expiration of inlining offers.
+            // This occurs when an inlined body references the next iterate of a binding,
+            // and inlining it would change the meaning to be the current iterate.
+            // Roughly, all inlining offers expire just after the binding of the least
+            // identifier they contain that is greater than the bound identifier itself.
+            let mut expire_offers = BTreeMap::new();
+            let mut expired_offers = Vec::new();
+
             // For each binding, inline `Get`s and then determine if *it* should be inlined.
             // It is important that we do the substitution in-order and before reasoning
             // about the inlineability of each binding, to ensure that our conclusion about
@@ -490,9 +498,30 @@ mod inlining {
             for (id, mut expr) in ids.drain(..).zip(values.drain(..)) {
                 // Substitute any appropriate prior let bindings.
                 inline_lets_helper(&mut expr, &mut inline_offer)?;
+
+                // Determine the first `id'` at which any inlining offer must expire.
+                // An inlining offer expires because it references an `id'` that is not yet bound,
+                // indicating a reference to the *next* iterate of that identifier. Inlining the
+                // expression once `id'` becomes bound would advance the reference to be to the
+                // *current* iterate of the identifier.
+                expr.visit_pre(|e| {
+                    if let MirRelationExpr::Get {
+                        id: Id::Local(referenced_id),
+                        ..
+                    } = e
+                    {
+                        if referenced_id >= &id {
+                            expire_offers
+                                .entry(*referenced_id)
+                                .or_insert_with(Vec::new)
+                                .push(id);
+                        }
+                    }
+                });
+
                 // Gets for `id` only occur in later expressions, so this should still be correct.
                 let num_gets = counts.get(&id).map(|x| *x).unwrap_or(0);
-                // Counts of zero or one lead to substitution; other wise certain simple structures
+                // Counts of zero or one lead to substitution; otherwise certain simple structures
                 // are cloned in to `Get` operators, and all others emitted as `Let` bindings.
                 if num_gets == 0 {
                 } else if num_gets == 1 {
@@ -516,9 +545,25 @@ mod inlining {
                         inline_offer.insert(id, InlineOffer::Unavailable(expr));
                     }
                 }
+
+                // We must now discard any offers that reference `id`, as it is no longer correct
+                // to inline such an offer as it would have access to this iteration's binding of
+                // `id` rather than next iteration's binding of `id`.
+                if let Some(expirations) = expire_offers.remove(&id) {
+                    for id in expirations.into_iter() {
+                        if let Some(offer) = inline_offer.remove(&id) {
+                            expired_offers.push((id, offer));
+                        }
+                    }
+                }
             }
             // Complete the inlining in the base relation.
             inline_lets_helper(body, &mut inline_offer)?;
+
+            // Re-introduce expired offers for the subsequent logic that expects to see them all.
+            for (id, offer) in expired_offers.into_iter() {
+                inline_offer.insert(id, offer);
+            }
 
             // We may now be able to discard some of `inline_offer` based on the remaining pattern of `Get` expressions.
             // Starting from `body` and working backwards, we can activate bindings that are still required because we

--- a/test/sqllogictest/github-17808.slt
+++ b/test/sqllogictest/github-17808.slt
@@ -10,7 +10,7 @@
 # Regression test for issues corrected by https://github.com/MaterializeInc/materialize/issues/17808.
 
 # The following query should not frustrate the system, although it did prior to
-# the associated PR being merged. It should product an empty result set.
+# the associated PR being merged. It should produce an empty result set.
 query I
 with mutually recursive
     a(x int) as (select * from a)

--- a/test/sqllogictest/github-17808.slt
+++ b/test/sqllogictest/github-17808.slt
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for issues corrected by https://github.com/MaterializeInc/materialize/issues/17808.
+
+# The following query should not frustrate the system, although it did prior to
+# the associated PR being merged. It should product an empty result set.
+query I
+with mutually recursive
+    a(x int) as (select * from a)
+select * from a;
+----
+
+
+statement ok
+CREATE TABLE foo (a int)
+
+# The following query should not inline `a` into `c`, as doing so would change
+# the reference to `b` from "the prior iterate" to "the current iterate", at which
+# point it could be canceled out, which would be incorrect.
+# This query may need to be improved as `with mutually recursive` analysis improves,
+# as it is not semantically complicated just syntactically complicated.
+query T multiline
+EXPLAIN with mutually recursive
+    a(x int) as (select * from b),
+    b(x int) as (select * from foo),
+    -- meant to contain `b` minus its previous iterate.
+    c(x int) as (select * from b except all select * from a)
+select * from c;
+----
+Explained Query:
+  Return
+    Threshold
+      Union
+        Get l1
+        Negate
+          Get l0
+  With Mutually Recursive
+    cte l1 =
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          Constant
+            - ()
+        ArrangeBy keys=[[]]
+          Get materialize.public.foo
+    cte l0 =
+      Get l1
+
+EOF


### PR DESCRIPTION
This PR corrects what I think are two bugs with let inlining (and a bonus `monotonic.rs` bug). ~Please await the tests before getting too excited.~ Tests are in, sourced from actual failing queries people typed.

Both of the bugs have the property that inlining a let binding changes the meaning of a `WITH MUTUALLY RECURSIVE` block, by changing *which iterate* of a binding they refer to.

Consider the following fragment:
```
with mutually recursive 
    a(x int) as (select * from b),
    b(x int) as <doesn't matter>,
    -- meant to contain `b` minus its previous iterate.
    c(x int) as (select * from b except all select * from a)
select * from c;
```
Here `a` captures the prior iterate of `b`, initially empty. Just after it `b` is updated. At this point, we must cease inlining the body of `a`, as references to `b` will no longer be to the prior iterate but instead to the current iterate. Specifically, inlining the body of `a` into `c` would result in an expression that would cancel out, where it should instead remain equal to the difference between successive iterates of `b`.

The fixes are 
1. Do not chase inlining actions with further inlining opportunities. This is ideally moot because,
2. Expire any offer of inlining the moment a binding it references would shift from *prior* to *current* iterate.

In the example above, we would allow `a` to be inlined into `b`, because in its definition it has access only to the prior iterate of `b`. But just after that, we would discard the offer and not inline `a` into `c`, because so doing would result in a reference to `b` being promoted from *prior* to *current*.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
