### PR TITLE
stash: improve error retry heuristics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4767,6 +4767,7 @@ dependencies = [
  "anyhow",
  "criterion",
  "differential-dataflow",
+ "fail",
  "futures",
  "mz-ore",
  "mz-postgres-util",

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -1622,6 +1622,11 @@ impl<'a> Transaction<'a> {
         assert!(prev.is_some());
     }
 
+    /// Commits the storage transaction to the stash. Any error returned
+    /// indicates the stash may be in an indeterminate state and needs to be
+    /// fully re-read before proceeding. In general, this must be fatal to the
+    /// calling process. We do not panic/halt inside this function itself so
+    /// that errors can bubble up during initialization.
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn commit(self) -> Result<(), Error> {
         async fn add_batch<'tx, K, V>(

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -294,7 +294,7 @@ impl ShouldHalt for crate::catalog::Error {
 
 impl ShouldHalt for StashError {
     fn should_halt(&self) -> bool {
-        self.is_fence()
+        self.is_unrecoverable()
     }
 }
 

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -12,6 +12,7 @@ harness = false
 
 [dependencies]
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 mz-ore = { path = "../ore", features = ["metrics", "network", "async", "test"] }
 mz-postgres-util = { path = "../postgres-util" }


### PR DESCRIPTION
The linked issue observed a stash with a diff of -1 for a catalog item while scaling down a cockroachdb cluster. This could have happened after cockroach committed a transaction but before the response was able to get back to the stash. The stash incorrectly attempted to retry, resulting in applying the delete twice.

Improve the stash retry heuristics by annotating which part of the transaction failed, since they all have different retryability semantics. To prevent this specific error, the COMMIT retry is greatly limited to only being retryable when cockroach specifically requests a retry.

Fixes #17754

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a