### PR TITLE
http-util: make CORS test table-driven

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -99,7 +99,6 @@ use fail::FailScenario;
 use http::header::HeaderValue;
 use itertools::Itertools;
 use jsonwebtoken::DecodingKey;
-use mz_http_util::build_cors_allowed_origin;
 use once_cell::sync::Lazy;
 use opentelemetry::trace::TraceContextExt;
 use prometheus::IntGauge;
@@ -647,7 +646,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             HeaderValue::from_str(&format!("https://[::1]:{}", port)).unwrap(),
         ]
     };
-    let cors_allowed_origin = build_cors_allowed_origin(allowed_origins.iter());
+    let cors_allowed_origin = mz_http_util::build_cors_allowed_origin(&allowed_origins);
 
     // Configure controller.
     let (orchestrator, secrets_controller, cloud_resource_controller): (

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -7,12 +7,15 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-askama = { version = "0.11.1", default-features = false, features = ["config", "serde-json"] }
 anyhow = "1.0.66"
+askama = { version = "0.11.1", default-features = false, features = ["config", "serde-json"] }
 axum = { version = "0.6.1", features = ["headers"] }
 headers = "0.3.8"
 http = "0.2.8"
 hyper = { version = "0.14.23", features = ["http1", "server"] }
+include_dir = "0.7.3"
+mz-ore = { path = "../ore", default-features = false, features = ["metrics", "tracing_"] }
+prometheus = { version = "0.13.3", default-features = false, features = ["process"] }
 serde = "1.0.152"
 serde_json = { version = "1.0.89" }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
@@ -20,9 +23,6 @@ tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit"
 tower-http = { version = "0.3.5", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
-include_dir = "0.7.3"
-mz-ore = { path = "../ore", default-features = false, features = ["metrics", "tracing_"] }
-prometheus = { version = "0.13.3", default-features = false, features = ["process"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]


### PR DESCRIPTION
Use a table-driven approach in the test of the CORS layer to get better coverage, since the CORS behavior is quite subtle.

Follow up from #17779.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR improves test coverage.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
