### PR TITLE
ci: Fortify kafka-progress.td

### DIFF
--- a/test/testdrive/kafka-progress.td
+++ b/test/testdrive/kafka-progress.td
@@ -9,7 +9,7 @@
 
 # Create sources and verify they can ingest data while `environmentd` is online.
 
-$ kafka-create-topic topic=data
+$ kafka-create-topic topic=data partitions=1
 $ kafka-ingest format=bytes topic=data
 one
 


### PR DESCRIPTION
The results of the queries in this test depend on the number of partitions in the Kafka topic.

Explicitly specify that the topic is to have one partition, so that the test is made compatible with the --kafka-default-partitions 5 Nightly CI job.

### Motivation

  * This PR fixes a previously unreported bug.

Nightly CI was failing.

### Tips for reviewer

@def- to get the most bang out of our test/testdrive/*.td tests, we run them in Nightly under various other configurations, one of which is for all the Kafka topics to have 5 partitions. The output of some tests depends on the number of partitions (or number of cluster replicas, etc.) so those tests need to be coded defensively in various ways -- explicitly set `partitions` to `kafka-create-topic` or , for other tests, skip a part of the test or the entire test unless it runs with the default Mz and testdrive configuration.

As developers are not required to run Nightly as part of their PRs (even though some teams are experimenting with that), a Nightly-incompatible test may be pushed at any time. In those cases, I simply fix the test in a follow-up PR, like this one.