### PR TITLE
.github: Route the "debugging experience" issues better

### DIFF
--- a/.github/ISSUE_TEMPLATE/10-debugging-experience.yml
+++ b/.github/ISSUE_TEMPLATE/10-debugging-experience.yml
@@ -11,7 +11,8 @@ name: "Internal: Feedback on CI, Test Frameworks and Debuggability"
 description: |
   Record any frustrations with the CI, the test frameworks or the product when it comes to being able to debug CI/test failures and product bugs
 title: "<FUNCTIONALITY> required to better debug <FAILURES>"
-labels: [C-bug]
+labels: [T-Testing, C-feature]
+assignees: [philip-stoev]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
- Label the issues in a way that will cause GitHub Project Workflows to put them in the QA Project

- put the TL as the assignee