### PR TITLE
.github: Route the "debugging experience" issues better (Part #2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/10-debugging-experience.yml
+++ b/.github/ISSUE_TEMPLATE/10-debugging-experience.yml
@@ -11,7 +11,7 @@ name: "Internal: Feedback on CI, Test Frameworks and Debuggability"
 description: |
   Record any frustrations with the CI, the test frameworks or the product when it comes to being able to debug CI/test failures and product bugs
 title: "<FUNCTIONALITY> required to better debug <FAILURES>"
-labels: [T-Testing, C-feature]
+labels: [T-testing, C-feature]
 assignees: [philip-stoev]
 body:
   - type: markdown


### PR DESCRIPTION
Fix the case of the T-testing label