### PR TITLE
Add `mz_dataflow_channel_operators`.

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -158,6 +158,19 @@ Field           | Type       | Meaning
 `to_index`      | [`bigint`] | The scope-local index of the target operator. Corresponds to an address in [`mz_dataflow_addresses.address`](#mz_dataflow_addresses).
 `to_port`       | [`bigint`] | The target operator's input port.
 
+### `mz_dataflow_channel_operators`
+
+The `mz_dataflow_channel_operators` view associates
+[channels](#mz_dataflow_channels) with the operators that are their endpoints.
+
+| Field              | Type       | Meaning                                          |
+|--------------------|------------|--------------------------------------------------|
+| `id`               | [`bigint`] | The ID of the channel.                           |
+| `worker_id`        | [`bigint`] | The ID of the worker thread hosting the channel. |
+| `from_operator_id` | [`bigint`] | The ID of the source of the channel.             |
+| `to_operator_id`   | [`bigint`] | The ID of the target of the channel.             |
+
+
 ### `mz_dataflow_operators`
 
 The `mz_dataflow_operators` source describes the dataflow operators in the

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1853,6 +1853,31 @@ FROM mz_internal.mz_worker_compute_frontiers
 GROUP BY export_id",
 };
 
+pub const MZ_DATAFLOW_CHANNEL_OPERATORS: BuiltinView = BuiltinView {
+    name: "mz_dataflow_channel_operators",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_dataflow_channel_operators AS
+WITH
+channel_addresses(id, worker_id, address, from_index, to_index) AS (
+     SELECT id, worker_id, address, from_index, to_index
+     FROM mz_internal.mz_dataflow_channels mdc
+     INNER JOIN mz_internal.mz_dataflow_addresses mda
+     USING (id, worker_id)
+),
+operator_addresses(channel_id, worker_id, from_address, to_address) AS (
+     SELECT id AS channel_id, worker_id,
+            address || from_index AS from_address,
+            address || to_index AS to_address
+     FROM channel_addresses
+)
+SELECT channel_id AS id, oa.worker_id, from_ops.id AS from_operator_id, to_ops.id AS to_operator_id
+FROM operator_addresses oa INNER JOIN mz_internal.mz_dataflow_addresses mda_from ON oa.from_address = mda_from.address AND oa.worker_id = mda_from.worker_id
+                           INNER JOIN mz_internal.mz_dataflow_operators from_ops ON mda_from.id = from_ops.id AND oa.worker_id = from_ops.worker_id
+                           INNER JOIN mz_internal.mz_dataflow_addresses mda_to ON oa.to_address = mda_to.address AND oa.worker_id = mda_to.worker_id
+                           INNER JOIN mz_internal.mz_dataflow_operators to_ops ON mda_to.id = to_ops.id AND oa.worker_id = to_ops.worker_id
+"
+};
+
 pub const MZ_COMPUTE_IMPORT_FRONTIERS: BuiltinView = BuiltinView {
     name: "mz_compute_import_frontiers",
     schema: MZ_INTERNAL_SCHEMA,
@@ -3012,6 +3037,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&MZ_DATAFLOW_OPERATOR_REACHABILITY),
         Builtin::View(&MZ_CLUSTER_REPLICA_UTILIZATION),
         Builtin::View(&MZ_COMPUTE_FRONTIERS),
+        Builtin::View(&MZ_DATAFLOW_CHANNEL_OPERATORS),
         Builtin::View(&MZ_COMPUTE_IMPORT_FRONTIERS),
         Builtin::View(&MZ_MESSAGE_COUNTS),
         Builtin::View(&MZ_RAW_COMPUTE_OPERATOR_DURATIONS),

--- a/src/timely-util/src/replay.rs
+++ b/src/timely-util/src/replay.rs
@@ -101,16 +101,16 @@ where
                 }
             }
 
-            // TODO(benesch): remove this once this block no longer makes use of
-            // potentially dangerous `as` conversions.
-            #[allow(clippy::as_conversions)]
             if !started {
                 // The first thing we do is modify our capabilities to match the number of streams we manage.
                 // This should be a simple change of `self.event_streams.len() - 1`. We only do this once, as
                 // our very first action.
-                progress.internals[0]
-                    .update(S::Timestamp::minimum(), (event_streams.len() as i64) - 1);
-                progress_sofar.update(S::Timestamp::minimum(), (event_streams.len() as i64) - 1);
+                let len: i64 = event_streams
+                    .len()
+                    .try_into()
+                    .expect("Implausibly large vector");
+                progress.internals[0].update(S::Timestamp::minimum(), len - 1);
+                progress_sofar.update(S::Timestamp::minimum(), len);
                 started = true;
             }
 

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -244,6 +244,10 @@ mz_dataflow_addresses
 SOURCE
 materialize
 mz_internal
+mz_dataflow_channel_operators
+VIEW
+materialize
+mz_internal
 mz_dataflow_channels
 SOURCE
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -546,6 +546,7 @@ name
 mz_arrangement_sharing
 mz_arrangement_sizes
 mz_dataflows
+mz_dataflow_channel_operators
 mz_dataflow_operator_dataflows
 mz_dataflow_operator_reachability
 mz_cluster_replica_utilization


### PR DESCRIPTION
This view maps each dataflow channel to the operator IDs of its source and destination. It works as follows:

1. Gets the list of channel IDs and the addresses of the scopes they appear in,

2. Appends "from_index" and "to_index" to the address to get the addresses of the source and target operators, respectively,

3. Looks up all IDs corresponding to those addresses in `mz_dataflow_addresses`,

4. Looks up each such ID in `mz_dataflow_operators` to ensure that it in fact corresponds to an operator (and not another channel).


### Motivation

This information is often useful for interpreting other tables about channels (e.g., `mz_message_counts`). For example, the dataflow visualizer tool essentially needs to construct this mapping in JavaScript.

### Tips for reviewer

Let me know if you can think of a simpler SQL query.
