### PR TITLE
ci: Capture only journalctl entries from the current Buildkite step

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -20,7 +20,7 @@ if read_list BUILDKITE_PLUGIN_CLOUDTEST_ARGS; then
     done
 fi
 
-echo "system uptime: $(cut -f1 -d' ' /proc/uptime)"
+date +"%Y-%m-%d %H:%M:%S" > step_start_timestamp
 
 ci_collapsed_heading "kind: Make sure kind is running..."
 bin/ci-builder run stable test/cloudtest/setup

--- a/ci/plugins/cloudtest/hooks/post-command
+++ b/ci/plugins/cloudtest/hooks/post-command
@@ -27,7 +27,7 @@ kubectl get all > kubectl-get-all.log || true
 kubectl describe all > kubectl-describe-all.log || true
 
 # shellcheck disable=SC2024
-sudo journalctl --merge > journalctl-merge.log
+sudo journalctl --merge --since "$(cat step_start_timestamp)" > journalctl-merge.log
 
 artifacts=(kubectl-*.log journalctl-merge.log)
 for artifact in "${artifacts[@]}"; do

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -25,7 +25,7 @@ if read_list BUILDKITE_PLUGIN_MZCOMPOSE_ARGS; then
     done
 fi
 
-echo "system uptime: $(cut -f1 -d' ' /proc/uptime)"
+date +"%Y-%m-%d %H:%M:%S" > step_start_timestamp
 
 # Sometimes build cancellations prevent us from properly cleaning up the last
 # Docker Compose run, which can leave old containers or volumes around that will

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -21,7 +21,7 @@ run() {
 
 run logs --no-color > services.log
 # shellcheck disable=SC2024
-sudo journalctl --merge > journalctl-merge.log
+sudo journalctl --merge --since "$(cat step_start_timestamp)" > journalctl-merge.log
 netstat -ant > netstat-ant.log
 netstat -panelot > netstat-panelot.log
 ps aux > ps-aux.log


### PR DESCRIPTION
The journalctl may contain entries that were caused by an unrelated Buildkite step that previously ran on the same Buildkite host.

Any OOMs in those entries will be incorrectly attributed to the current Buildkite step.

Filter those out using `journalctl --since`, as `journalctl --reset` is not available on Amazon Linux.

### Motivation

  * This PR fixes a previously unreported bug.

The CI is reporting OOM errors that actually happened during other Buildkite steps.