### PR TITLE
ci: Use unbuffered python output

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -261,3 +261,7 @@ ENV RUST_BACKTRACE=1
 
 # Make the image as small as possible.
 RUN find /workdir /root -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+
+# Ensure that all python output is unbuffered, otherwise it is not
+# logged properly in Buildkite
+ENV PYTHONUNBUFFERED=1

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -246,6 +246,7 @@ class Composition:
                 stdout=stdout,
                 input=stdin,
                 text=True,
+                bufsize=1,
             )
         except subprocess.CalledProcessError as e:
             if e.stdout:


### PR DESCRIPTION
```
ci: Use unbuffered python output

Recently, the Buildkite step output has become garbled: output 
from mzcompose itself is comingled with the ouput of testdrive 
it is invoking.

Fix by forcing mzcompose to use unbuffered output throughout
the process callchain.
```
### Motivation

  * This PR fixes a previously unreported bug.

The CI output has become garbled for some reason. See for example 

https://buildkite.com/materialize/tests/builds/50490#0186926d-73bc-4fd6-899d-85af04442af4

a bunch of `manipulate()` and `validate()` lines are shown towards the end of the output without
the testdrive commands those operations are using. 

The output looks correct, that is, as it looked previously with the fix:

https://buildkite.com/materialize/tests/builds/50491#0186928f-8a39-45d8-9ae2-a241f760c363