### PR TITLE
storage: downgrade resumption frontier logging to debug!

### DIFF
--- a/src/storage/src/source/resumption.rs
+++ b/src/storage/src/source/resumption.rs
@@ -91,7 +91,7 @@ where
             let new_upper = calc.calculate_resumption_frontier(&mut calc_state).await;
 
             if PartialOrder::less_than(&upper, &new_upper) {
-                tracing::info!(
+                tracing::debug!(
                     resumption_frontier = ?new_upper,
                     "resumption({id}) {worker_id}/{worker_count}: calculated \
                     new resumption frontier",


### PR DESCRIPTION
This turns out to sometime be a red herring and cause concern. Downgrade to `debug!` so it doesn't show up with default logging settings.