### PR TITLE
persist: add connect timeout to CRDB connections

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5969,7 +5969,7 @@ impl Catalog {
         PersistParameters {
             blob_target_size: Some(config.persist_blob_target_size()),
             compaction_minimum_timeout: Some(config.persist_compaction_minimum_timeout()),
-            consensus_connect_timeout: Some(config.persist_consensus_connect_timeout()),
+            consensus_connect_timeout: Some(config.crdb_connect_timeout()),
         }
     }
 }

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5969,6 +5969,7 @@ impl Catalog {
         PersistParameters {
             blob_target_size: Some(config.persist_blob_target_size()),
             compaction_minimum_timeout: Some(config.persist_compaction_minimum_timeout()),
+            consensus_connect_timeout: Some(config.persist_consensus_connect_timeout()),
         }
     }
 }

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -1147,7 +1147,7 @@ impl SystemVars {
     /// Returns an iterator over the configuration parameters and their current
     /// values on disk.
     pub fn iter(&self) -> impl Iterator<Item = &dyn Var> {
-        let vars: [&dyn Var; 20] = [
+        let vars: [&dyn Var; 21] = [
             &self.config_has_synced_once,
             &self.max_aws_privatelink_connections,
             &self.max_tables,
@@ -1165,6 +1165,7 @@ impl SystemVars {
             &self.allowed_cluster_replica_sizes,
             &self.persist_blob_target_size,
             &self.persist_compaction_minimum_timeout,
+            &self.crdb_connect_timeout,
             &self.dataflow_max_inflight_bytes,
             &self.metrics_retention,
             &self.mock_audit_event_timestamp,

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -379,11 +379,13 @@ const PERSIST_COMPACTION_MINIMUM_TIMEOUT: ServerVar<Duration> = ServerVar {
     safe: true,
 };
 
-/// Controls [`mz_persist_client::cfg::DynamicConfig::consensus_connect_timeout`].
-const PERSIST_CONSENSUS_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("persist_consensus_connect_timeout"),
-    value: &PersistConfig::DEFAULT_CONSENSUS_CONNECT_TIMEOUT,
-    description: "The time to connect to Consensus before timing out and retrying.",
+/// Controls the connection timeout to Cockroach.
+///
+/// Used by persist as [`mz_persist_client::cfg::DynamicConfig::consensus_connect_timeout`].
+const CRDB_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("crdb_connect_timeout"),
+    value: &PersistConfig::DEFAULT_CRDB_CONNECT_TIMEOUT,
+    description: "The time to connect to CockroachDB before timing out and retrying.",
     internal: true,
     safe: true,
 };
@@ -1099,7 +1101,9 @@ pub struct SystemVars {
     // persist configuration
     persist_blob_target_size: SystemVar<usize>,
     persist_compaction_minimum_timeout: SystemVar<Duration>,
-    persist_consensus_connect_timeout: SystemVar<Duration>,
+
+    // crdb configuration
+    crdb_connect_timeout: SystemVar<Duration>,
 
     // dataflow configuration
     dataflow_max_inflight_bytes: SystemVar<usize>,
@@ -1131,7 +1135,7 @@ impl Default for SystemVars {
             allowed_cluster_replica_sizes: SystemVar::new(&ALLOWED_CLUSTER_REPLICA_SIZES),
             persist_blob_target_size: SystemVar::new(&PERSIST_BLOB_TARGET_SIZE),
             persist_compaction_minimum_timeout: SystemVar::new(&PERSIST_COMPACTION_MINIMUM_TIMEOUT),
-            persist_consensus_connect_timeout: SystemVar::new(&PERSIST_CONSENSUS_CONNECT_TIMEOUT),
+            crdb_connect_timeout: SystemVar::new(&CRDB_CONNECT_TIMEOUT),
             dataflow_max_inflight_bytes: SystemVar::new(&DATAFLOW_MAX_INFLIGHT_BYTES),
             metrics_retention: SystemVar::new(&METRICS_RETENTION),
             mock_audit_event_timestamp: SystemVar::new(&MOCK_AUDIT_EVENT_TIMESTAMP),
@@ -1226,8 +1230,8 @@ impl SystemVars {
             Ok(&self.persist_blob_target_size)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             Ok(&self.persist_compaction_minimum_timeout)
-        } else if name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name {
-            Ok(&self.persist_consensus_connect_timeout)
+        } else if name == CRDB_CONNECT_TIMEOUT.name {
+            Ok(&self.crdb_connect_timeout)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
             Ok(&self.dataflow_max_inflight_bytes)
         } else if name == METRICS_RETENTION.name {
@@ -1283,8 +1287,8 @@ impl SystemVars {
             self.persist_blob_target_size.is_default(input)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             self.persist_compaction_minimum_timeout.is_default(input)
-        } else if name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name {
-            self.persist_consensus_connect_timeout.is_default(input)
+        } else if name == CRDB_CONNECT_TIMEOUT.name {
+            self.crdb_connect_timeout.is_default(input)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
             self.dataflow_max_inflight_bytes.is_default(input)
         } else if name == METRICS_RETENTION.name {
@@ -1349,8 +1353,8 @@ impl SystemVars {
             self.persist_blob_target_size.set(input)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             self.persist_compaction_minimum_timeout.set(input)
-        } else if name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name {
-            self.persist_consensus_connect_timeout.set(input)
+        } else if name == CRDB_CONNECT_TIMEOUT.name {
+            self.crdb_connect_timeout.set(input)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
             self.dataflow_max_inflight_bytes.set(input)
         } else if name == METRICS_RETENTION.name {
@@ -1410,8 +1414,8 @@ impl SystemVars {
             Ok(self.persist_blob_target_size.reset())
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             Ok(self.persist_compaction_minimum_timeout.reset())
-        } else if name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name {
-            Ok(self.persist_consensus_connect_timeout.reset())
+        } else if name == CRDB_CONNECT_TIMEOUT.name {
+            Ok(self.crdb_connect_timeout.reset())
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
             Ok(self.dataflow_max_inflight_bytes.reset())
         } else if name == METRICS_RETENTION.name {
@@ -1512,9 +1516,9 @@ impl SystemVars {
         *self.persist_compaction_minimum_timeout.value()
     }
 
-    /// Returns the `persist_consensus_connect_timeout` configuration parameter.
-    pub fn persist_consensus_connect_timeout(&self) -> Duration {
-        *self.persist_consensus_connect_timeout.value()
+    /// Returns the `crdb_connect_timeout` configuration parameter.
+    pub fn crdb_connect_timeout(&self) -> Duration {
+        *self.crdb_connect_timeout.value()
     }
 
     /// Returns the `dataflow_max_inflight_bytes` configuration parameter.
@@ -2401,5 +2405,5 @@ pub(crate) fn is_storage_config_var(name: &str) -> bool {
 fn is_persist_config_var(name: &str) -> bool {
     name == PERSIST_BLOB_TARGET_SIZE.name()
         || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
-        || name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name()
+        || name == CRDB_CONNECT_TIMEOUT.name()
 }

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -379,6 +379,15 @@ const PERSIST_COMPACTION_MINIMUM_TIMEOUT: ServerVar<Duration> = ServerVar {
     safe: true,
 };
 
+/// Controls [`mz_persist_client::cfg::DynamicConfig::consensus_connect_timeout`].
+const PERSIST_CONSENSUS_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("persist_consensus_connect_timeout"),
+    value: &PersistConfig::DEFAULT_CONSENSUS_CONNECT_TIMEOUT,
+    description: "The time to connect to Consensus before timing out and retrying.",
+    internal: true,
+    safe: true,
+};
+
 /// The maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
 const DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<usize> = ServerVar {
     name: UncasedStr::new("dataflow_max_inflight_bytes"),
@@ -1090,6 +1099,7 @@ pub struct SystemVars {
     // persist configuration
     persist_blob_target_size: SystemVar<usize>,
     persist_compaction_minimum_timeout: SystemVar<Duration>,
+    persist_consensus_connect_timeout: SystemVar<Duration>,
 
     // dataflow configuration
     dataflow_max_inflight_bytes: SystemVar<usize>,
@@ -1121,6 +1131,7 @@ impl Default for SystemVars {
             allowed_cluster_replica_sizes: SystemVar::new(&ALLOWED_CLUSTER_REPLICA_SIZES),
             persist_blob_target_size: SystemVar::new(&PERSIST_BLOB_TARGET_SIZE),
             persist_compaction_minimum_timeout: SystemVar::new(&PERSIST_COMPACTION_MINIMUM_TIMEOUT),
+            persist_consensus_connect_timeout: SystemVar::new(&PERSIST_CONSENSUS_CONNECT_TIMEOUT),
             dataflow_max_inflight_bytes: SystemVar::new(&DATAFLOW_MAX_INFLIGHT_BYTES),
             metrics_retention: SystemVar::new(&METRICS_RETENTION),
             mock_audit_event_timestamp: SystemVar::new(&MOCK_AUDIT_EVENT_TIMESTAMP),
@@ -1215,6 +1226,8 @@ impl SystemVars {
             Ok(&self.persist_blob_target_size)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             Ok(&self.persist_compaction_minimum_timeout)
+        } else if name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name {
+            Ok(&self.persist_consensus_connect_timeout)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
             Ok(&self.dataflow_max_inflight_bytes)
         } else if name == METRICS_RETENTION.name {
@@ -1270,6 +1283,8 @@ impl SystemVars {
             self.persist_blob_target_size.is_default(input)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             self.persist_compaction_minimum_timeout.is_default(input)
+        } else if name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name {
+            self.persist_consensus_connect_timeout.is_default(input)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
             self.dataflow_max_inflight_bytes.is_default(input)
         } else if name == METRICS_RETENTION.name {
@@ -1334,6 +1349,8 @@ impl SystemVars {
             self.persist_blob_target_size.set(input)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             self.persist_compaction_minimum_timeout.set(input)
+        } else if name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name {
+            self.persist_consensus_connect_timeout.set(input)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
             self.dataflow_max_inflight_bytes.set(input)
         } else if name == METRICS_RETENTION.name {
@@ -1393,6 +1410,8 @@ impl SystemVars {
             Ok(self.persist_blob_target_size.reset())
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             Ok(self.persist_compaction_minimum_timeout.reset())
+        } else if name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name {
+            Ok(self.persist_consensus_connect_timeout.reset())
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
             Ok(self.dataflow_max_inflight_bytes.reset())
         } else if name == METRICS_RETENTION.name {
@@ -1491,6 +1510,11 @@ impl SystemVars {
     /// Returns the `persist_compaction_minimum_timeout` configuration parameter.
     pub fn persist_compaction_minimum_timeout(&self) -> Duration {
         *self.persist_compaction_minimum_timeout.value()
+    }
+
+    /// Returns the `persist_consensus_connect_timeout` configuration parameter.
+    pub fn persist_consensus_connect_timeout(&self) -> Duration {
+        *self.persist_consensus_connect_timeout.value()
     }
 
     /// Returns the `dataflow_max_inflight_bytes` configuration parameter.
@@ -2375,5 +2399,7 @@ pub(crate) fn is_storage_config_var(name: &str) -> bool {
 
 /// Returns whether the named variable is a persist configuration parameter.
 fn is_persist_config_var(name: &str) -> bool {
-    name == PERSIST_BLOB_TARGET_SIZE.name() || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
+    name == PERSIST_BLOB_TARGET_SIZE.name()
+        || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
+        || name == PERSIST_CONSENSUS_CONNECT_TIMEOUT.name()
 }

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -16,4 +16,5 @@ package mz_persist_client.cfg;
 message ProtoPersistParameters {
     optional uint64 blob_target_size = 1;
     mz_proto.ProtoDuration compaction_minimum_timeout = 2;
+    mz_proto.ProtoDuration consensus_connect_timeout = 3;
 }

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -126,7 +126,7 @@ impl PersistConfig {
                 compaction_minimum_timeout: Self::DEFAULT_COMPACTION_MINIMUM_TIMEOUT,
                 consensus_connection_pool_ttl: Duration::from_secs(300),
                 consensus_connection_pool_ttl_stagger: Duration::from_secs(6),
-                consensus_connect_timeout: RwLock::new(Self::DEFAULT_CONSENSUS_CONNECT_TIMEOUT),
+                consensus_connect_timeout: RwLock::new(Self::DEFAULT_CRDB_CONNECT_TIMEOUT),
                 gc_blob_delete_concurrency_limit: AtomicUsize::new(32),
                 state_versions_recent_live_diffs_limit: AtomicUsize::new(usize::cast_from(
                     30 * Self::NEED_ROLLUP_THRESHOLD,
@@ -168,7 +168,7 @@ impl PersistConfig {
     /// Default value for [`DynamicConfig::compaction_minimum_timeout`].
     pub const DEFAULT_COMPACTION_MINIMUM_TIMEOUT: Duration = Duration::from_secs(90);
     /// Default value for [`DynamicConfig::consensus_connect_timeout`].
-    pub const DEFAULT_CONSENSUS_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+    pub const DEFAULT_CRDB_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
     // Move this to a PersistConfig field when we actually have read leases.
     //

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -12,7 +12,7 @@
 //! The tunable knobs for persist.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use mz_build_info::BuildInfo;
@@ -126,6 +126,7 @@ impl PersistConfig {
                 compaction_minimum_timeout: Self::DEFAULT_COMPACTION_MINIMUM_TIMEOUT,
                 consensus_connection_pool_ttl: Duration::from_secs(300),
                 consensus_connection_pool_ttl_stagger: Duration::from_secs(6),
+                consensus_connect_timeout: RwLock::new(Self::DEFAULT_CONSENSUS_CONNECT_TIMEOUT),
                 gc_blob_delete_concurrency_limit: AtomicUsize::new(32),
                 state_versions_recent_live_diffs_limit: AtomicUsize::new(usize::cast_from(
                     30 * Self::NEED_ROLLUP_THRESHOLD,
@@ -166,6 +167,8 @@ impl PersistConfig {
     pub const DEFAULT_BLOB_TARGET_SIZE: usize = 128 * MB;
     /// Default value for [`DynamicConfig::compaction_minimum_timeout`].
     pub const DEFAULT_COMPACTION_MINIMUM_TIMEOUT: Duration = Duration::from_secs(90);
+    /// Default value for [`DynamicConfig::consensus_connect_timeout`].
+    pub const DEFAULT_CONSENSUS_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
     // Move this to a PersistConfig field when we actually have read leases.
     //
@@ -196,6 +199,14 @@ impl ConsensusKnobs for PersistConfig {
 
     fn connection_pool_ttl_stagger(&self) -> Duration {
         self.dynamic.consensus_connection_pool_ttl_stagger()
+    }
+
+    fn connect_timeout(&self) -> Duration {
+        *self
+            .dynamic
+            .consensus_connect_timeout
+            .read()
+            .expect("lock poisoned")
     }
 }
 
@@ -229,6 +240,7 @@ pub struct DynamicConfig {
     gc_blob_delete_concurrency_limit: AtomicUsize,
     state_versions_recent_live_diffs_limit: AtomicUsize,
     usage_state_fetch_concurrency_limit: AtomicUsize,
+    consensus_connect_timeout: RwLock<Duration>,
 
     // TODO: Figure out how to make these dynamic.
     compaction_minimum_timeout: Duration,
@@ -314,6 +326,13 @@ impl DynamicConfig {
     pub fn consensus_connection_pool_ttl_stagger(&self) -> Duration {
         self.consensus_connection_pool_ttl_stagger
     }
+    /// The duration to wait for a Consensus Postgres/CRDB connection to be made before retrying.
+    pub fn consensus_connect_timeout(&self) -> Duration {
+        *self
+            .consensus_connect_timeout
+            .read()
+            .expect("lock poisoned")
+    }
 
     /// The maximum number of concurrent blob deletes during garbage collection.
     pub fn gc_blob_delete_concurrency_limit(&self) -> usize {
@@ -391,6 +410,8 @@ pub struct PersistParameters {
     pub blob_target_size: Option<usize>,
     /// Configures [`DynamicConfig::compaction_minimum_timeout`].
     pub compaction_minimum_timeout: Option<Duration>,
+    /// Configures [`DynamicConfig::consensus_connect_timeout`].
+    pub consensus_connect_timeout: Option<Duration>,
 }
 
 impl PersistParameters {
@@ -401,16 +422,21 @@ impl PersistParameters {
         let Self {
             blob_target_size: self_blob_target_size,
             compaction_minimum_timeout: self_compaction_minimum_timeout,
+            consensus_connect_timeout: self_consensus_connect_timeout,
         } = self;
         let Self {
             blob_target_size: other_blob_target_size,
             compaction_minimum_timeout: other_compaction_minimum_timeout,
+            consensus_connect_timeout: other_consensus_connect_timeout,
         } = other;
         if let Some(v) = other_blob_target_size {
             *self_blob_target_size = Some(v);
         }
         if let Some(v) = other_compaction_minimum_timeout {
             *self_compaction_minimum_timeout = Some(v);
+        }
+        if let Some(v) = other_consensus_connect_timeout {
+            *self_consensus_connect_timeout = Some(v);
         }
     }
 
@@ -423,8 +449,11 @@ impl PersistParameters {
         let Self {
             blob_target_size,
             compaction_minimum_timeout,
+            consensus_connect_timeout,
         } = self;
-        blob_target_size.is_none() && compaction_minimum_timeout.is_none()
+        blob_target_size.is_none()
+            && compaction_minimum_timeout.is_none()
+            && consensus_connect_timeout.is_none()
     }
 
     /// Applies the parameter values to persist's in-memory config object.
@@ -437,6 +466,7 @@ impl PersistParameters {
         let Self {
             blob_target_size,
             compaction_minimum_timeout,
+            consensus_connect_timeout,
         } = self;
         if let Some(blob_target_size) = blob_target_size {
             cfg.dynamic
@@ -446,6 +476,14 @@ impl PersistParameters {
         if let Some(_compaction_minimum_timeout) = compaction_minimum_timeout {
             // TODO: Figure out how to represent Durations in DynamicConfig.
         }
+        if let Some(consensus_connect_timeout) = consensus_connect_timeout {
+            let mut timeout = cfg
+                .dynamic
+                .consensus_connect_timeout
+                .write()
+                .expect("lock poisoned");
+            *timeout = *consensus_connect_timeout;
+        }
     }
 }
 
@@ -454,6 +492,7 @@ impl RustType<ProtoPersistParameters> for PersistParameters {
         ProtoPersistParameters {
             blob_target_size: self.blob_target_size.into_proto(),
             compaction_minimum_timeout: self.compaction_minimum_timeout.into_proto(),
+            consensus_connect_timeout: self.consensus_connect_timeout.into_proto(),
         }
     }
 
@@ -461,6 +500,7 @@ impl RustType<ProtoPersistParameters> for PersistParameters {
         Ok(Self {
             blob_target_size: proto.blob_target_size.into_rust()?,
             compaction_minimum_timeout: proto.compaction_minimum_timeout.into_rust()?,
+            consensus_connect_timeout: proto.consensus_connect_timeout.into_rust()?,
         })
     }
 }

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -155,6 +155,8 @@ pub trait ConsensusKnobs: std::fmt::Debug + Send + Sync {
     /// Minimum time between TTLing connections. Helps stagger reconnections
     /// to avoid stampeding the backing store of [Consensus].
     fn connection_pool_ttl_stagger(&self) -> Duration;
+    /// Time to wait for a connection to be made before trying.
+    fn connect_timeout(&self) -> Duration;
 }
 
 impl ConsensusConfig {

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -74,7 +74,7 @@ pub struct PostgresConsensusMetrics {
     pub(crate) connpool_acquires: IntCounter,
     pub(crate) connpool_acquire_seconds: Counter,
     pub(crate) connpool_connections_created: Counter,
-    pub(crate) connpool_connection_timeouts: Counter,
+    pub(crate) connpool_connection_errors: Counter,
     pub(crate) connpool_ttl_reconnections: Counter,
 }
 
@@ -98,9 +98,9 @@ impl PostgresConsensusMetrics {
                 name: "mz_persist_postgres_connpool_connections_created",
                 help: "times a connection was created",
             )),
-            connpool_connection_timeouts: registry.register(metric!(
-                name: "mz_persist_postgres_connpool_connection_timeouts",
-                help: "number of timeouts while establishing new connections",
+            connpool_connection_errors: registry.register(metric!(
+                name: "mz_persist_postgres_connpool_connection_errors",
+                help: "number of errors when establishing a new connection",
             )),
             connpool_ttl_reconnections: registry.register(metric!(
                 name: "mz_persist_postgres_connpool_ttl_reconnections",

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -74,6 +74,7 @@ pub struct PostgresConsensusMetrics {
     pub(crate) connpool_acquires: IntCounter,
     pub(crate) connpool_acquire_seconds: Counter,
     pub(crate) connpool_connections_created: Counter,
+    pub(crate) connpool_connection_timeouts: Counter,
     pub(crate) connpool_ttl_reconnections: Counter,
 }
 
@@ -96,6 +97,10 @@ impl PostgresConsensusMetrics {
             connpool_connections_created: registry.register(metric!(
                 name: "mz_persist_postgres_connpool_connections_created",
                 help: "times a connection was created",
+            )),
+            connpool_connection_timeouts: registry.register(metric!(
+                name: "mz_persist_postgres_connpool_connection_timeouts",
+                help: "number of timeouts while establishing new connections",
             )),
             connpool_ttl_reconnections: registry.register(metric!(
                 name: "mz_persist_postgres_connpool_ttl_reconnections",

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -268,10 +268,8 @@ impl PostgresConsensus {
         let start = Instant::now();
         let res = self.pool.get().await;
         if let Err(PoolError::Backend(err)) = &res {
-            // sadly, there does not appear to be an easy way to match on the error kind
-            if err.to_string().contains("connection timed out") {
-                self.metrics.connpool_connection_timeouts.inc();
-            }
+            debug!("error establishing connection: {}", err);
+            self.metrics.connpool_connection_errors.inc();
         }
         self.metrics
             .connpool_acquire_seconds

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -143,6 +143,9 @@ impl PostgresConsensusConfig {
             fn connection_pool_ttl_stagger(&self) -> Duration {
                 Duration::MAX
             }
+            fn connect_timeout(&self) -> Duration {
+                Duration::MAX
+            }
         }
 
         let config = PostgresConsensusConfig::new(
@@ -170,7 +173,8 @@ impl PostgresConsensus {
     /// Open a Postgres [Consensus] instance with `config`, for the collection
     /// named `shard`.
     pub async fn open(config: PostgresConsensusConfig) -> Result<Self, ExternalError> {
-        let pg_config: Config = config.url.parse()?;
+        let mut pg_config: Config = config.url.parse()?;
+        pg_config.connect_timeout(config.knobs.connect_timeout());
         let tls = make_tls(&pg_config)?;
 
         let manager = Manager::from_config(


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

After [more investigation](https://github.com/MaterializeInc/materialize/issues/17680#issuecomment-1442297391) it seems all we need to do to reconnect more quickly to CRDB during rolling restarts is to have a short connect timeout set on our `tokio-postgres` connections so they don't get hung retrying in a `SYN-SENT` state.

Still TBD is if there's an easy way to capture these connect timeouts in our metrics... haven't figured out a good way to do this yet.

### Motivation

* Fixes https://github.com/MaterializeInc/materialize/issues/17680

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
