### PR TITLE
coord: add pg_auth_members VIEW

### DIFF
--- a/doc/user/content/sql/system-catalog/pg_catalog.md
+++ b/doc/user/content/sql/system-catalog/pg_catalog.md
@@ -12,6 +12,7 @@ system catalog](https://www.postgresql.org/docs/current/catalogs.html):
 
   * [`pg_am`](https://www.postgresql.org/docs/current/catalog-pg-am.html)
   * [`pg_attribute`](https://www.postgresql.org/docs/current/catalog-pg-attribute.html)
+  * [`pg_auth_members`](https://www.postgresql.org/docs/current/catalog-pg-auth-members.html)
   * [`pg_class`](https://www.postgresql.org/docs/current/catalog-pg-class.html)
   * [`pg_collation`](https://www.postgresql.org/docs/current/catalog-pg-collation.html)
   * [`pg_constraint`](https://www.postgresql.org/docs/current/catalog-pg-constraint.html)

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2324,6 +2324,17 @@ FROM (VALUES
 ) AS _ (name, setting)",
 };
 
+pub const PG_AUTH_MEMBERS: BuiltinView = BuiltinView {
+    name: "pg_auth_members",
+    schema: PG_CATALOG_SCHEMA,
+    sql: "CREATE VIEW pg_catalog.pg_auth_members AS SELECT
+    NULL::pg_catalog.oid as roleid,
+    NULL::pg_catalog.oid as memberid,
+    NULL::pg_catalog.oid as grantor,
+    NULL::pg_catalog.bool as admin_option
+WHERE false",
+};
+
 pub const MZ_SCHEDULING_ELAPSED: BuiltinView = BuiltinView {
     name: "mz_scheduling_elapsed",
     schema: MZ_INTERNAL_SCHEMA,
@@ -3142,6 +3153,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&PG_ENUM),
         Builtin::View(&PG_ATTRDEF),
         Builtin::View(&PG_SETTINGS),
+        Builtin::View(&PG_AUTH_MEMBERS),
         Builtin::View(&PG_CONSTRAINT),
         Builtin::View(&PG_TABLES),
         Builtin::View(&PG_ACCESS_METHODS),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2329,7 +2329,7 @@ pub const PG_AUTH_MEMBERS: BuiltinView = BuiltinView {
     schema: PG_CATALOG_SCHEMA,
     sql: "CREATE VIEW pg_catalog.pg_auth_members AS SELECT
     NULL::pg_catalog.oid as roleid,
-    NULL::pg_catalog.oid as memberid,
+    NULL::pg_catalog.oid as member,
     NULL::pg_catalog.oid as grantor,
     NULL::pg_catalog.bool as admin_option
 WHERE false",

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -424,6 +424,10 @@ pg_attribute
 VIEW
 materialize
 pg_catalog
+pg_auth_members
+VIEW
+materialize
+pg_catalog
 pg_authid
 VIEW
 materialize

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -147,3 +147,11 @@ name                nullable    type
  rolconnlimit       false       integer
  rolpassword        true        text
  rolvaliduntil      true        "timestamp with time zone"
+
+> SHOW COLUMNS FROM pg_auth_members
+name                nullable    type
+------------------------------------------------------------
+ roleid             false       oid         
+ memberid           false       oid
+ grantor            false       oid
+ admin_option       false       boolean

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -151,7 +151,7 @@ name                nullable    type
 > SHOW COLUMNS FROM pg_auth_members
 name                nullable    type
 ------------------------------------------------------------
- roleid             false       oid         
- memberid           false       oid
+ roleid             false       oid
+ member           false       oid
  grantor            false       oid
  admin_option       false       boolean


### PR DESCRIPTION
This PR is intended to make progress towards #9730 by implementing the `pg_auth_members` view.

Specifically this PR makes the following changes:
- add `pg_auth_members` view with all columns NULL
- update sqllogictest to assert `pg_auth_members` exists in `information_schema.tables`
- update testdrive test to assert the columns from `pg_auth_members` are correct. I references the [PostgreSQL Docs](https://www.postgresql.org/docs/current/catalog-pg-auth-members.html) to determine what were the necessary columns

Also built and tested manually by running the following steps:

1. In a terminal window, run `bin/environmentd`
2. In a new window run `psql "postgres://materialize@localhost:6875/materialize"`
3. In the `psql` shell run `\du`, output was
```
materialize=> \du
                                  List of roles
    Role name     |                    Attributes                     | Member of
------------------+---------------------------------------------------+-----------
 materialize      | No inheritance, Create role, Create DB            | {}
 mz_introspection | No inheritance, Create role, Create DB            | {}
 mz_system        | Superuser, No inheritance, Create role, Create DB | {}
```

### Motivation

  * This PR adds a known-desirable feature.
    * Fixes #9730

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
