### PR TITLE
storage: fix more race conditions around sinks

### DIFF
--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -416,7 +416,7 @@ where
             StorageCommand::AllowCompaction(frontiers) => {
                 for (id, frontier) in frontiers {
                     if let Some(export) = self.sinks.get_mut(id) {
-                        export.description.as_of.maybe_fast_forward(frontier);
+                        export.description.as_of.downgrade(frontier);
                     }
                 }
             }

--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -454,7 +454,13 @@ where
                         .insert(export.id, Antichain::from_elem(T::minimum()));
                 }
             }
-            StorageCommand::AllowCompaction(_frontiers) => {}
+            StorageCommand::AllowCompaction(frontiers) => {
+                for (id, frontier) in frontiers {
+                    if let Some(export) = self.sinks.get_mut(id) {
+                        export.description.as_of.maybe_fast_forward(frontier);
+                    }
+                }
+            }
         }
     }
 

--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -415,8 +415,12 @@ where
             }
             StorageCommand::AllowCompaction(frontiers) => {
                 for (id, frontier) in frontiers {
-                    if let Some(export) = self.sinks.get_mut(id) {
-                        export.description.as_of.downgrade(frontier);
+                    match self.sinks.get_mut(id) {
+                        Some(export) => {
+                            export.description.as_of.downgrade(frontier);
+                        }
+                        None if self.sources.contains_key(id) => continue,
+                        None => panic!("AllowCompaction command for non-existent {id}"),
                     }
                 }
             }

--- a/src/storage-client/src/types/sinks.rs
+++ b/src/storage-client/src/types/sinks.rs
@@ -169,15 +169,14 @@ pub struct SinkAsOf<T = mz_repr::Timestamp> {
 }
 
 impl<T: PartialOrder + Clone> SinkAsOf<T> {
-    pub fn maybe_fast_forward(&self, other_since: &Antichain<T>) -> Self {
+    /// Forwards the since frontier of this `SinkAsOf`. If it is already
+    /// sufficiently far advanced the downgrade is a no-op.
+    pub fn downgrade(&mut self, other_since: &Antichain<T>) {
         if PartialOrder::less_equal(&self.frontier, other_since) {
-            SinkAsOf {
-                frontier: other_since.to_owned(),
-                // If we're using the since, never read the snapshot
-                strict: true,
-            }
-        } else {
-            self.to_owned()
+            // TODO(aljoscha): Should this be meet_assign?
+            self.frontier.clone_from(other_since);
+            // If we're using the since, never read the snapshot
+            self.strict = true;
         }
     }
 }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1079,6 +1079,12 @@ impl StorageState {
             }
             StorageCommand::AllowCompaction(list) => {
                 for (id, frontier) in list {
+                    // Update our knowledge of the `as_of`, in case we need to
+                    // internally restart a sink in the future.
+                    if let Some(export_description) = self.exports.get_mut(&id) {
+                        export_description.as_of.maybe_fast_forward(&frontier);
+                    }
+
                     if frontier.is_empty() {
                         // Indicates that we may drop `id`, as there are no more valid times to read.
                         //

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1042,15 +1042,13 @@ impl StorageState {
                         Antichain::from_elem(mz_repr::Timestamp::minimum()),
                     );
 
-                    let initial_since = export.description.as_of.frontier.clone();
-
                     self.sink_handles.insert(
                         export.id,
                         SinkHandle::new(
                             export.id,
                             &export.description.from_storage_metadata,
                             export.description.from_storage_metadata.data_shard,
-                            initial_since,
+                            export.description.as_of.frontier.clone(),
                             Arc::clone(&self.persist_clients),
                         ),
                     );

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1071,7 +1071,7 @@ impl StorageState {
                     // Update our knowledge of the `as_of`, in case we need to
                     // internally restart a sink in the future.
                     if let Some(export_description) = self.exports.get_mut(&id) {
-                        export_description.as_of.maybe_fast_forward(&frontier);
+                        export_description.as_of.downgrade(&frontier);
 
                         // Sinks maintain a read handle over their input data to
                         // ensure that we can restart at the `as_of` that we

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1068,25 +1068,21 @@ impl StorageState {
                 for (id, frontier) in list {
                     match self.exports.get_mut(&id) {
                         Some(export_description) => {
-                            // Update our knowledge of the `as_of`, in case we
-                            // need to internally restart a sink in the future.
+                            // Update our knowledge of the `as_of`, in case we need to internally
+                            // restart a sink in the future.
                             export_description.as_of.downgrade(&frontier);
 
-                            // Sinks maintain a read handle over their input
-                            // data to ensure that we can restart at the `as_of`
-                            // that we store and update in the export
+                            // Sinks maintain a read handle over their input data to ensure that we
+                            // can restart at the `as_of` that we store and update in the export
                             // description.
                             //
-                            // Communication between the storage controller and
-                            // this here worker is asynchronous, so we might
-                            // learn that the controller downgraded a since
-                            // after it has downgraded it's handle. Keeping a
-                            // handle here ensures that we can restart based on
-                            // our local state.
+                            // Communication between the storage controller and this here worker is
+                            // asynchronous, so we might learn that the controller downgraded a
+                            // since after it has downgraded it's handle. Keeping a handle here
+                            // ensures that we can restart based on our local state.
                             //
-                            // NOTE: It's important that we always
-                            // update/downgrade the sink `as_of` and the
-                            // `SinkHandle` in lockstep.
+                            // NOTE: It's important that we only downgrade `SinkHandle` after
+                            // updating the sink `as_of`.
                             let sink_handle =
                                 self.sink_handles.get(&id).expect("missing SinkHandle");
                             sink_handle.downgrade_since(frontier.clone());


### PR DESCRIPTION
The individual commits have a good commit message, and comments in the code for explanation.

Even after this, we can still have panics, but they should be _very_ rare. And, it's good to remember: none of these panics/bugs lead to a situation where we cannot restart, that is where we fatally mess up our state.

Closes #17861