### PR TITLE
ci: logged-errors followup

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -32,4 +32,4 @@ bin/ci-builder run stable test/cloudtest/reset
 rm -f kubectl-*.log
 
 ci_uncollapsed_heading "+++ cloudtest: Running \`bin/pytest ${run_args[*]}\`"
-bin/ci-builder run stable bin/pytest "${run_args[@]}"
+bin/ci-builder run stable bin/pytest "${run_args[@]}" |& tee run.log

--- a/ci/plugins/cloudtest/hooks/post-command
+++ b/ci/plugins/cloudtest/hooks/post-command
@@ -29,7 +29,7 @@ kubectl describe all > kubectl-describe-all.log || true
 # shellcheck disable=SC2024
 sudo journalctl --merge --since "$(cat step_start_timestamp)" > journalctl-merge.log
 
-artifacts=(kubectl-*.log journalctl-merge.log)
+artifacts=(run.log kubectl-*.log journalctl-merge.log)
 for artifact in "${artifacts[@]}"; do
   buildkite-agent artifact upload "$artifact"
 done

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -48,4 +48,4 @@ fi
 
 ci_uncollapsed_heading ":docker: Running \`mzcompose run ${run_args[*]}\`"
 
-mzcompose run "${run_args[@]}" | tee run.log
+mzcompose run "${run_args[@]}" |& tee run.log

--- a/ci/release-qualification/pipeline.yml
+++ b/ci/release-qualification/pipeline.yml
@@ -48,6 +48,7 @@ steps:
     timeout_in_minutes: 2880
     agents:
       queue: linux-x86_64-large
+    artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
@@ -59,6 +60,7 @@ steps:
     timeout_in_minutes: 2880
     agents:
       queue: linux-x86_64-large
+    artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
@@ -69,6 +71,7 @@ steps:
     timeout_in_minutes: 2880
     agents:
       queue: linux-x86_64-large
+    artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
@@ -79,6 +82,7 @@ steps:
     timeout_in_minutes: 2880
     agents:
       queue: linux-x86_64-large
+    artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
@@ -89,7 +93,21 @@ steps:
     timeout_in_minutes: 2880
     agents:
       queue: linux-x86_64-large
+    artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=NoKilling, --actions=100000]
+
+  - wait: ~
+    continue_on_failure: true
+
+  - id: analyze
+    label: Analyze tests
+    plugins:
+      - junit-annotate#v2.0.2:
+          artifacts: "*junit_*.xml"
+          job-uuid-file-pattern: _([^_]*).xml
+    priority: 1
+    agents:
+      queue: linux-x86_64

--- a/doc/developer/README.md
+++ b/doc/developer/README.md
@@ -22,6 +22,9 @@ land, and then browsed as reference material as you skill up on the codebase.
 
 ## Table of contents
 
+* [ci-regexp.md](ci-regexp.md) describes how to mark a flaky CI issue with a
+  regular expression to ignore it in future CI runs.
+
 * [change-data-capture.md](change-data-capture.md) describes our change data
   capture (CDC) requirements.
 

--- a/doc/developer/ci-regexp.md
+++ b/doc/developer/ci-regexp.md
@@ -1,0 +1,12 @@
+# ci-regexp value
+
+For [Flaky CI issues](https://github.com/MaterializeInc/materialize/labels/ci-flake) we support a special `ci-regexp` line in the body of the issue to denote a unique error message indicating this issue. This regex is used by Python's [re module](https://docs.python.org/3/library/re.html), see the supported syntax there.
+
+Examples:
+
+```
+ci-regexp: updating cluster status cannot fail
+ci-regexp: failed to listen on address.*Address already in use (os error 98)
+ci-regexp: unexpected peek multiplicity
+ci-regexp: Expected identifier, found operator
+```

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -94,7 +94,7 @@ def annotate_logged_errors(log_files: List[str]) -> None:
         else:
             test_case = junit_xml.TestCase(f"log error {i + 1} (new)", suite_name)
             test_case.add_failure_info(
-                message=f"Unknown error in logs<br/>In {linked_file}:{error.line_nr}:",
+                message=f'Unknown error in logs (<a href="https://github.com/MaterializeInc/materialize/blob/main/doc/developer/ci-regexp.md">ci-regexp guide</a>)<br/>In {linked_file}:{error.line_nr}:',
                 output=error.line,
             )
         junit_suite.test_cases.append(test_case)

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -23,7 +23,25 @@ from materialize import ROOT, ci_util
 
 CI_RE = re.compile("ci-regexp: (.*)")
 ERROR_RE = re.compile(
-    r"(panicked at|internal error:|\* FATAL:|[Oo]ut [Oo]f [Mm]emory|cannot migrate from catalog)"
+    r"""
+    ( panicked\ at
+    | internal\ error:
+    | \*\ FATAL:
+    | [Oo]ut\ [Oo]f\ [Mm]emory
+    | cannot\ migrate\ from\ catalog
+    | halting\ process: # Rust unwrap
+    # From src/testdrive/src/action/sql.rs
+    | column\ name\ mismatch
+    | non-matching\ rows:
+    | wrong\ row\ count:
+    | wrong\ hash\ value:
+    | expected\ one\ statement
+    | query\ succeeded,\ but\ expected
+    | expected\ .*,\ got\ .*
+    | expected\ .*,\ but\ found\ none
+    | unsupported\ SQL\ type\ in\ testdrive:
+    )
+    """
 )
 
 


### PR DESCRIPTION
Fixes: https://github.com/MaterializeInc/materialize/issues/17798
### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
