### PR TITLE
[DO NOT MERGE] Introduce validating reductions at the MIR level

### DIFF
--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1284,6 +1284,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 aggregates,
                 monotonic,
                 expected_group_size,
+                has_validity_column: _, // TODO(vmarcos): chain this down to rendering
             } => {
                 let input_arity = input.arity();
                 let output_arity = group_key.len() + aggregates.len();

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -525,7 +525,8 @@ impl MirRelationExpr {
                 group_key,
                 aggregates,
                 expected_group_size,
-                monotonic: _, // TODO: monotonic should be an attribute
+                monotonic: _,           // TODO: monotonic should be an attribute
+                has_validity_column: _, // TODO(vmarcos): has_validity_column should be an attribute
                 input,
             } => {
                 FmtNode {

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -266,6 +266,7 @@ impl ColumnKnowledge {
                     aggregates,
                     monotonic: _,
                     expected_group_size: _,
+                    has_validity_column,
                 } => {
                     let input_knowledge = self.harvest(input, knowledge, knowledge_stack)?;
                     let input_typ = input.typ();
@@ -336,6 +337,12 @@ impl ColumnKnowledge {
                             }
                         };
                         output.push(knowledge);
+                    }
+                    if *has_validity_column {
+                        output.push(DatumKnowledge {
+                            value: None,
+                            nullable: false,
+                        });
                     }
                     Ok(output)
                 }

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -217,10 +217,15 @@ impl NonNullRequirements {
                     aggregates,
                     monotonic: _,
                     expected_group_size: _,
+                    has_validity_column,
                 } => {
                     let mut new_columns = BTreeSet::new();
-                    let (group_key_columns, aggr_columns): (Vec<usize>, Vec<usize>) =
-                        columns.iter().partition(|c| **c < group_key.len());
+                    let (group_key_columns, aggr_columns): (Vec<usize>, Vec<usize>) = columns
+                        .iter()
+                        .filter(|c| {
+                            !*has_validity_column || **c != group_key.len() + aggregates.len()
+                        })
+                        .partition(|c| **c < group_key.len());
                     for column in group_key_columns {
                         group_key[column].non_null_requirements(&mut new_columns);
                     }

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -78,6 +78,7 @@ impl NonNullable {
                 aggregates,
                 monotonic: _,
                 expected_group_size: _,
+                has_validity_column: _,
             } => {
                 let contains_isnull_or_count = aggregates
                     .iter()

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -286,6 +286,7 @@ impl PredicatePushdown {
                             aggregates,
                             monotonic: _,
                             expected_group_size: _,
+                            has_validity_column: _,
                         } => {
                             let mut retain = Vec::new();
                             let mut push_down = Vec::new();

--- a/src/transform/src/projection_extraction.rs
+++ b/src/transform/src/projection_extraction.rs
@@ -72,6 +72,7 @@ impl ProjectionExtraction {
             aggregates,
             monotonic: _,
             expected_group_size: _,
+            has_validity_column,
         } = relation
         {
             let mut projection = Vec::new();
@@ -105,6 +106,12 @@ impl ProjectionExtraction {
                     projection.push(group_key.len() + finger);
                     finger += 1;
                 }
+            }
+
+            // If we have a validating reduction, propagate the validity column to
+            // the projection as well.
+            if *has_validity_column {
+                projection.push(group_key.len() + aggregates.len());
             }
             if projection.iter().enumerate().any(|(i, p)| i != *p) {
                 *relation = relation.take_dangerous().project(projection);

--- a/src/transform/src/projection_lifting.rs
+++ b/src/transform/src/projection_lifting.rs
@@ -220,6 +220,7 @@ impl ProjectionLifting {
                     aggregates,
                     monotonic: _,
                     expected_group_size: _,
+                    has_validity_column: _,
                 } => {
                     // Reduce *absorbs* projections, which is amazing!
                     self.action(input, gets)?;

--- a/src/transform/src/projection_pushdown.rs
+++ b/src/transform/src/projection_pushdown.rs
@@ -254,6 +254,7 @@ impl ProjectionPushdown {
                 aggregates,
                 monotonic: _,
                 expected_group_size: _,
+                has_validity_column: _,
             } => {
                 let mut columns_to_pushdown = BTreeSet::new();
                 // Group keys determine aggregation granularity and are

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -285,6 +285,7 @@ impl RedundantJoin {
                     input,
                     group_key,
                     aggregates,
+                    has_validity_column,
                     ..
                 } => {
                     // Reduce yields its first few columns as a key, and produces
@@ -296,6 +297,10 @@ impl RedundantJoin {
                             .map(|key| prov.strict_dereference(key))
                             .collect_vec();
                         projection.extend((0..aggregates.len()).map(|_| None));
+                        if *has_validity_column {
+                            // If we produce an extra validity column, extend projection.
+                            projection.push(None);
+                        }
                         prov.dereferenced_projection = projection;
                     }
                     // TODO: For min, max aggregates, we could preserve provenance

--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -866,7 +866,8 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
                 ],
                 "aggregates": [],
                 "monotonic": false,
-                "expected_group_size": null
+                "expected_group_size": null,
+                "has_validity_column": false
               }
             },
             "inputs": [
@@ -931,7 +932,8 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
                       ],
                       "aggregates": [],
                       "monotonic": false,
-                      "expected_group_size": null
+                      "expected_group_size": null,
+                      "has_validity_column": false
                     }
                   }
                 }
@@ -1362,7 +1364,8 @@ SELECT abs(min(a) - max(a)) FROM t
                           }
                         ],
                         "monotonic": false,
-                        "expected_group_size": null
+                        "expected_group_size": null,
+                        "has_validity_column": false
                       }
                     },
                     "body": {
@@ -1429,7 +1432,8 @@ SELECT abs(min(a) - max(a)) FROM t
                                                       "group_key": [],
                                                       "aggregates": [],
                                                       "monotonic": false,
-                                                      "expected_group_size": null
+                                                      "expected_group_size": null,
+                                                      "has_validity_column": false
                                                     }
                                                   }
                                                 }
@@ -1453,7 +1457,8 @@ SELECT abs(min(a) - max(a)) FROM t
                                                     "group_key": [],
                                                     "aggregates": [],
                                                     "monotonic": false,
-                                                    "expected_group_size": null
+                                                    "expected_group_size": null,
+                                                    "has_validity_column": false
                                                   }
                                                 }
                                               ]
@@ -1716,7 +1721,8 @@ SELECT abs(min(a) - max(a)) FROM t GROUP BY b
                       }
                     ],
                     "monotonic": false,
-                    "expected_group_size": null
+                    "expected_group_size": null,
+                    "has_validity_column": false
                   }
                 },
                 "body": {
@@ -1938,7 +1944,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                     ],
                                     "aggregates": [],
                                     "monotonic": false,
-                                    "expected_group_size": null
+                                    "expected_group_size": null,
+                                    "has_validity_column": false
                                   }
                                 },
                                 "body": {
@@ -2047,7 +2054,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                       ],
                                                       "aggregates": [],
                                                       "monotonic": false,
-                                                      "expected_group_size": null
+                                                      "expected_group_size": null,
+                                                      "has_validity_column": false
                                                     }
                                                   },
                                                   "scalars": [
@@ -2141,7 +2149,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                                                 ],
                                                                                 "aggregates": [],
                                                                                 "monotonic": false,
-                                                                                "expected_group_size": null
+                                                                                "expected_group_size": null,
+                                                                                "has_validity_column": false
                                                                               }
                                                                             }
                                                                           }
@@ -2176,7 +2185,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                                               ],
                                                                               "aggregates": [],
                                                                               "monotonic": false,
-                                                                              "expected_group_size": null
+                                                                              "expected_group_size": null,
+                                                                              "has_validity_column": false
                                                                             }
                                                                           }
                                                                         ]
@@ -2326,7 +2336,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                         ],
                         "aggregates": [],
                         "monotonic": false,
-                        "expected_group_size": null
+                        "expected_group_size": null,
+                        "has_validity_column": false
                       }
                     },
                     "body": {
@@ -2435,7 +2446,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                           ],
                                           "aggregates": [],
                                           "monotonic": false,
-                                          "expected_group_size": null
+                                          "expected_group_size": null,
+                                          "has_validity_column": false
                                         }
                                       },
                                       "scalars": [
@@ -2529,7 +2541,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                                     ],
                                                                     "aggregates": [],
                                                                     "monotonic": false,
-                                                                    "expected_group_size": null
+                                                                    "expected_group_size": null,
+                                                                    "has_validity_column": false
                                                                   }
                                                                 }
                                                               }
@@ -2564,7 +2577,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                                   ],
                                                                   "aggregates": [],
                                                                   "monotonic": false,
-                                                                  "expected_group_size": null
+                                                                  "expected_group_size": null,
+                                                                  "has_validity_column": false
                                                                 }
                                                               }
                                                             ]
@@ -2820,7 +2834,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                               ],
                               "aggregates": [],
                               "monotonic": false,
-                              "expected_group_size": null
+                              "expected_group_size": null,
+                              "has_validity_column": false
                             }
                           },
                           "body": {
@@ -2860,7 +2875,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                   ],
                                   "aggregates": [],
                                   "monotonic": false,
-                                  "expected_group_size": null
+                                  "expected_group_size": null,
+                                  "has_validity_column": false
                                 }
                               },
                               "body": {
@@ -3071,7 +3087,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                         }
                                                                       ],
                                                                       "monotonic": false,
-                                                                      "expected_group_size": null
+                                                                      "expected_group_size": null,
+                                                                      "has_validity_column": false
                                                                     }
                                                                   },
                                                                   "predicates": [
@@ -3198,7 +3215,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                               ],
                                                                               "aggregates": [],
                                                                               "monotonic": false,
-                                                                              "expected_group_size": null
+                                                                              "expected_group_size": null,
+                                                                              "has_validity_column": false
                                                                             }
                                                                           }
                                                                         }
@@ -3233,7 +3251,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                             ],
                                                                             "aggregates": [],
                                                                             "monotonic": false,
-                                                                            "expected_group_size": null
+                                                                            "expected_group_size": null,
+                                                                            "has_validity_column": false
                                                                           }
                                                                         }
                                                                       ]
@@ -3373,7 +3392,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                               ],
                               "aggregates": [],
                               "monotonic": false,
-                              "expected_group_size": null
+                              "expected_group_size": null,
+                              "has_validity_column": false
                             }
                           },
                           "body": {
@@ -3413,7 +3433,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                   ],
                                   "aggregates": [],
                                   "monotonic": false,
-                                  "expected_group_size": null
+                                  "expected_group_size": null,
+                                  "has_validity_column": false
                                 }
                               },
                               "body": {
@@ -3624,7 +3645,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                         }
                                                                       ],
                                                                       "monotonic": false,
-                                                                      "expected_group_size": null
+                                                                      "expected_group_size": null,
+                                                                      "has_validity_column": false
                                                                     }
                                                                   },
                                                                   "predicates": [
@@ -3751,7 +3773,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                               ],
                                                                               "aggregates": [],
                                                                               "monotonic": false,
-                                                                              "expected_group_size": null
+                                                                              "expected_group_size": null,
+                                                                              "has_validity_column": false
                                                                             }
                                                                           }
                                                                         }
@@ -3786,7 +3809,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                             ],
                                                                             "aggregates": [],
                                                                             "monotonic": false,
-                                                                            "expected_group_size": null
+                                                                            "expected_group_size": null,
+                                                                            "has_validity_column": false
                                                                           }
                                                                         }
                                                                       ]
@@ -5577,7 +5601,8 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                 ],
                                 "aggregates": [],
                                 "monotonic": false,
-                                "expected_group_size": null
+                                "expected_group_size": null,
+                                "has_validity_column": false
                               }
                             },
                             "body": {
@@ -5942,7 +5967,8 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                             ],
                             "aggregates": [],
                             "monotonic": false,
-                            "expected_group_size": null
+                            "expected_group_size": null,
+                            "has_validity_column": false
                           }
                         },
                         "body": {
@@ -6584,7 +6610,8 @@ FROM
                         ],
                         "aggregates": [],
                         "monotonic": false,
-                        "expected_group_size": null
+                        "expected_group_size": null,
+                        "has_validity_column": false
                       }
                     },
                     "body": {
@@ -6693,7 +6720,8 @@ FROM
                                             }
                                           ],
                                           "monotonic": false,
-                                          "expected_group_size": null
+                                          "expected_group_size": null,
+                                          "has_validity_column": false
                                         }
                                       },
                                       "body": {
@@ -6768,7 +6796,8 @@ FROM
                                                                         ],
                                                                         "aggregates": [],
                                                                         "monotonic": false,
-                                                                        "expected_group_size": null
+                                                                        "expected_group_size": null,
+                                                                        "has_validity_column": false
                                                                       }
                                                                     }
                                                                   }
@@ -6803,7 +6832,8 @@ FROM
                                                                       ],
                                                                       "aggregates": [],
                                                                       "monotonic": false,
-                                                                      "expected_group_size": null
+                                                                      "expected_group_size": null,
+                                                                      "has_validity_column": false
                                                                     }
                                                                   }
                                                                 ]
@@ -7004,7 +7034,8 @@ FROM
                     ],
                     "aggregates": [],
                     "monotonic": false,
-                    "expected_group_size": null
+                    "expected_group_size": null,
+                    "has_validity_column": false
                   }
                 },
                 "body": {
@@ -7117,7 +7148,8 @@ FROM
                                         }
                                       ],
                                       "monotonic": false,
-                                      "expected_group_size": null
+                                      "expected_group_size": null,
+                                      "has_validity_column": false
                                     }
                                   },
                                   "body": {
@@ -7192,7 +7224,8 @@ FROM
                                                                     ],
                                                                     "aggregates": [],
                                                                     "monotonic": false,
-                                                                    "expected_group_size": null
+                                                                    "expected_group_size": null,
+                                                                    "has_validity_column": false
                                                                   }
                                                                 }
                                                               }
@@ -7227,7 +7260,8 @@ FROM
                                                                   ],
                                                                   "aggregates": [],
                                                                   "monotonic": false,
-                                                                  "expected_group_size": null
+                                                                  "expected_group_size": null,
+                                                                  "has_validity_column": false
                                                                 }
                                                               }
                                                             ]
@@ -7564,7 +7598,8 @@ FROM
                     ],
                     "aggregates": [],
                     "monotonic": false,
-                    "expected_group_size": null
+                    "expected_group_size": null,
+                    "has_validity_column": false
                   }
                 },
                 "body": {
@@ -7673,7 +7708,8 @@ FROM
                                         }
                                       ],
                                       "monotonic": false,
-                                      "expected_group_size": null
+                                      "expected_group_size": null,
+                                      "has_validity_column": false
                                     }
                                   },
                                   "body": {
@@ -7748,7 +7784,8 @@ FROM
                                                                     ],
                                                                     "aggregates": [],
                                                                     "monotonic": false,
-                                                                    "expected_group_size": null
+                                                                    "expected_group_size": null,
+                                                                    "has_validity_column": false
                                                                   }
                                                                 }
                                                               }
@@ -7783,7 +7820,8 @@ FROM
                                                                   ],
                                                                   "aggregates": [],
                                                                   "monotonic": false,
-                                                                  "expected_group_size": null
+                                                                  "expected_group_size": null,
+                                                                  "has_validity_column": false
                                                                 }
                                                               }
                                                             ]
@@ -7900,7 +7938,8 @@ FROM
                                           ],
                                           "aggregates": [],
                                           "monotonic": false,
-                                          "expected_group_size": null
+                                          "expected_group_size": null,
+                                          "has_validity_column": false
                                         }
                                       },
                                       "body": {
@@ -8017,7 +8056,8 @@ FROM
                                                               }
                                                             ],
                                                             "monotonic": false,
-                                                            "expected_group_size": null
+                                                            "expected_group_size": null,
+                                                            "has_validity_column": false
                                                           }
                                                         },
                                                         "body": {
@@ -8105,7 +8145,8 @@ FROM
                                                                                           ],
                                                                                           "aggregates": [],
                                                                                           "monotonic": false,
-                                                                                          "expected_group_size": null
+                                                                                          "expected_group_size": null,
+                                                                                          "has_validity_column": false
                                                                                         }
                                                                                       }
                                                                                     }
@@ -8148,7 +8189,8 @@ FROM
                                                                                         ],
                                                                                         "aggregates": [],
                                                                                         "monotonic": false,
-                                                                                        "expected_group_size": null
+                                                                                        "expected_group_size": null,
+                                                                                        "has_validity_column": false
                                                                                       }
                                                                                     }
                                                                                   ]

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -711,7 +711,8 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
                   ],
                   "aggregates": [],
                   "monotonic": false,
-                  "expected_group_size": null
+                  "expected_group_size": null,
+                  "has_validity_column": false
                 }
               },
               "inputs": [
@@ -755,7 +756,8 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
                         ],
                         "aggregates": [],
                         "monotonic": false,
-                        "expected_group_size": null
+                        "expected_group_size": null,
+                        "has_validity_column": false
                       }
                     }
                   }
@@ -1010,7 +1012,8 @@ SELECT abs(min(a) - max(a)) FROM t
                 }
               ],
               "monotonic": false,
-              "expected_group_size": null
+              "expected_group_size": null,
+              "has_validity_column": false
             }
           },
           "body": {
@@ -1230,7 +1233,8 @@ SELECT abs(min(a) - max(a)) FROM t GROUP BY b
                     }
                   ],
                   "monotonic": false,
-                  "expected_group_size": null
+                  "expected_group_size": null,
+                  "has_validity_column": false
                 }
               },
               "scalars": [
@@ -1367,7 +1371,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                   ],
                                                   "aggregates": [],
                                                   "monotonic": false,
-                                                  "expected_group_size": null
+                                                  "expected_group_size": null,
+                                                  "has_validity_column": false
                                                 }
                                               },
                                               "keys": [
@@ -1469,7 +1474,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                             ],
                             "aggregates": [],
                             "monotonic": false,
-                            "expected_group_size": null
+                            "expected_group_size": null,
+                            "has_validity_column": false
                           }
                         },
                         "keys": [
@@ -1620,7 +1626,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                   ],
                                                   "aggregates": [],
                                                   "monotonic": false,
-                                                  "expected_group_size": null
+                                                  "expected_group_size": null,
+                                                  "has_validity_column": false
                                                 }
                                               },
                                               "keys": [
@@ -1722,7 +1729,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                             ],
                             "aggregates": [],
                             "monotonic": false,
-                            "expected_group_size": null
+                            "expected_group_size": null,
+                            "has_validity_column": false
                           }
                         },
                         "keys": [
@@ -1865,7 +1873,8 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                   ],
                   "aggregates": [],
                   "monotonic": false,
-                  "expected_group_size": null
+                  "expected_group_size": null,
+                  "has_validity_column": false
                 }
               },
               "body": {
@@ -3120,7 +3129,8 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                                     ],
                                                     "aggregates": [],
                                                     "monotonic": false,
-                                                    "expected_group_size": null
+                                                    "expected_group_size": null,
+                                                    "has_validity_column": false
                                                   }
                                                 },
                                                 "keys": [
@@ -3460,7 +3470,8 @@ FROM
                                                       ],
                                                       "aggregates": [],
                                                       "monotonic": false,
-                                                      "expected_group_size": null
+                                                      "expected_group_size": null,
+                                                      "has_validity_column": false
                                                     }
                                                   },
                                                   "keys": [
@@ -3538,7 +3549,8 @@ FROM
                                           }
                                         ],
                                         "monotonic": false,
-                                        "expected_group_size": null
+                                        "expected_group_size": null,
+                                        "has_validity_column": false
                                       }
                                     },
                                     "keys": [
@@ -3711,7 +3723,8 @@ FROM
                                                       ],
                                                       "aggregates": [],
                                                       "monotonic": false,
-                                                      "expected_group_size": null
+                                                      "expected_group_size": null,
+                                                      "has_validity_column": false
                                                     }
                                                   },
                                                   "keys": [
@@ -3789,7 +3802,8 @@ FROM
                                           }
                                         ],
                                         "monotonic": false,
-                                        "expected_group_size": null
+                                        "expected_group_size": null,
+                                        "has_validity_column": false
                                       }
                                     },
                                     "keys": [


### PR DESCRIPTION
This PR introduces an attribute in MIR Reduce nodes that indicates if the given reduction produces an extra validity column. Such a validating reduction would check its input for each key to detect invalid accumulations and then produce a corresponding boolean result in this extra validity column. The PR is presently inert in the sense that all reductions are marked as non-validating. However, it serves as a mapping of the extent of the changes that would be necessary to our optimizer transforms to support the concept properly. Note that the PR does not include hooking up validating reductions all the way to rendering.

Advances #17178.

### Motivation

  * This PR adds a known-desirable feature.

    This PR would be a possible step towards more gracefully handling invalid accumulation errors out of our reduction operators. #17178 

### Tips for reviewer

The PR could be subsumed by a choice of one of the alternative approaches outlined in design document #17597. So at present, it should be seen simply as a mapping of impact for introducing validating reductions at the MIR level. We can take the work here forward if we choose to go for this approach, or otherwise pivot to an alternative route (e.g., implementing fallible reduce operators in Materialize).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/pull/17597).
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
