### PR TITLE
adapter: Add migration to remove materialize role

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -329,6 +329,16 @@ async fn migrate(
             txn.cluster_replicas.update(|_k, v| Some(v.clone()))?;
             Ok(())
         },
+        // Remove the materialize role from existing deployments
+        //
+        // Introduced in v0.45.0
+        //
+        // TODO(jkosh44) Can be cleared (patched to be empty) in v0.46.0
+        |txn: &mut Transaction<'_>, _now, _bootstrap_args| {
+            txn.roles
+                .delete(|_role_key, role_value| &role_value.name == "materialize");
+            Ok(())
+        },
         // Add new migrations above.
         //
         // Migrations should be preceded with a comment of the following form:

--- a/test/sqllogictest/pg_catalog_roles.slt
+++ b/test/sqllogictest/pg_catalog_roles.slt
@@ -12,9 +12,9 @@ mode cockroach
 # Start from a pristine server
 reset-server
 
-query IT
-SELECT oid, rolname FROM pg_roles ORDER BY oid
+query T
+SELECT rolname FROM pg_roles ORDER BY oid
 ----
-20007  mz_system
-20008  mz_introspection
-20383  materialize
+mz_system
+mz_introspection
+materialize


### PR DESCRIPTION
Part of #11579

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
