### PR TITLE
mz enable region: Fix pg_isready and other issues

### DIFF
--- a/src/mz/src/api.rs
+++ b/src/mz/src/api.rs
@@ -88,21 +88,6 @@ impl Environment {
         }
         url
     }
-
-    pub fn pg_isready_args(&self, profile: &ValidProfile) -> Vec<String> {
-        let mut hostport = self.environmentd_pgwire_address.split(':');
-        [
-            "-h",
-            hostport.next().unwrap(),
-            "-p",
-            hostport.next().unwrap(),
-            "-U",
-            profile.profile.get_email(),
-        ]
-        .into_iter()
-        .map(String::from)
-        .collect()
-    }
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/mz/src/api.rs
+++ b/src/mz/src/api.rs
@@ -70,6 +70,7 @@ pub struct Region {
 pub struct Environment {
     pub environmentd_pgwire_address: String,
     pub environmentd_https_address: String,
+    pub resolvable: bool,
 }
 
 impl Environment {
@@ -86,6 +87,21 @@ impl Environment {
             url.query_pairs_mut().append_pair("sslmode", "require");
         }
         url
+    }
+
+    pub fn pg_isready_args(&self, profile: &ValidProfile) -> Vec<String> {
+        let mut hostport = self.environmentd_pgwire_address.split(':');
+        [
+            "-h",
+            hostport.next().unwrap(),
+            "-p",
+            hostport.next().unwrap(),
+            "-U",
+            profile.profile.get_email(),
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect()
     }
 }
 

--- a/src/mz/src/bin/mz/main.rs
+++ b/src/mz/src/bin/mz/main.rs
@@ -337,17 +337,20 @@ async fn main() -> Result<()> {
                 .await
                 .with_context(|| "Enabling region.")?;
 
-                let environment = get_region_environment(&client, &valid_profile, &region)
-                    .await
-                    .with_context(|| "Retrieving environment data.")?;
+                loading_spinner.finish_with_message(format!("{cloud_provider_region} enabled"));
 
+                let health_spinner =
+                    run_loading_spinner("Waiting for region to come online...".to_string());
                 loop {
+                    let environment = get_region_environment(&client, &valid_profile, &region)
+                        .await
+                        .with_context(|| "Retrieving environment data.")?;
                     if check_environment_health(&valid_profile, &environment)? {
                         break;
                     }
                 }
 
-                loading_spinner.finish_with_message(format!("{cloud_provider_region} enabled"));
+                health_spinner.finish_with_message(format!("{cloud_provider_region} is online"));
                 profile.set_default_region(cloud_provider_region);
             }
 

--- a/src/mz/src/bin/mz/shell.rs
+++ b/src/mz/src/bin/mz/shell.rs
@@ -37,10 +37,13 @@ pub(crate) fn check_environment_health(
     valid_profile: &ValidProfile<'_>,
     environment: &Environment,
 ) -> Result<bool> {
+    if !environment.resolvable {
+        return Ok(false);
+    }
     let status = Command::new("pg_isready")
-        .arg(environment.sql_url(valid_profile).to_string())
-        .env("PGPASSWORD", valid_profile.app_password.clone())
         .arg("-q")
+        .args(environment.pg_isready_args(valid_profile))
+        .env("PGPASSWORD", valid_profile.app_password.clone())
         .output()
         .context("failed to execute pg_isready")?
         .status

--- a/src/mz/src/bin/mz/shell.rs
+++ b/src/mz/src/bin/mz/shell.rs
@@ -42,7 +42,8 @@ pub(crate) fn check_environment_health(
     }
     let status = Command::new("pg_isready")
         .arg("-q")
-        .args(environment.pg_isready_args(valid_profile))
+        .arg("-d")
+        .arg(environment.sql_url(valid_profile).to_string())
         .env("PGPASSWORD", valid_profile.app_password.clone())
         .output()
         .context("failed to execute pg_isready")?


### PR DESCRIPTION
This PR adjusts a few things about `mz enable region`'s behavior when waiting for the region to turn ready:

* Split the loading spinner in two: One spinner for enabling the region, one for checking that it's online.
* Use the `-d` command line option to tell pg_isready that this is a connection string.
* Only run pg_isready only after the environment is resolvable, to avoid poisoning the client's DNS cache (just like we do in the webface)

### Motivation

  * This PR fixes a previously unreported bug.

@philip-stoev found out that we're invoking pg_ishealthy with the wrong CLI args, which makes the tool spin forever while the region is already up; so now we're not doing that anymore & `mz enable region` correctly finishes when the region comes up.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
