### PR TITLE
workflows: add Slack notification for external issues

### DIFF
--- a/.github/workflows/slack_notify_labeled.yml
+++ b/.github/workflows/slack_notify_labeled.yml
@@ -19,7 +19,7 @@
 
 #     https://github.com/actions-ecosystem/action-slack-notifier/blob/fc778468d09c43a6f4d1b8cccaca59766656996a/README.md
 
-name: Slack Issue Notifications
+name: Slack Label Notifications
 
 on:
   issues:
@@ -34,26 +34,26 @@ jobs:
         if: ${{ github.event.label.name == 'P1' }}
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
+          channel: github-p1
           message: |
             `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}) (assigned to: ${{ github.event.issue.assignee.login || 'unassigned' }}).
-          channel: github-p1
           color: red
           verbose: false
       - uses: actions-ecosystem/action-slack-notifier@v1
         if: ${{ github.event.label.name == 'C-bug' }}
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
+          channel: github-bugs
           message: |
             `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}) (assigned to: ${{ github.event.issue.assignee.login || 'unassigned' }}).
-          channel: github-bugs
           color: red
           verbose: false
       - uses: actions-ecosystem/action-slack-notifier@v1
         if: ${{ github.event.label.name == 'release-blocker' }}
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
+          channel: release
           message: |
             `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}) (assigned to: ${{ github.event.issue.assignee.login || 'unassigned' }}).
-          channel: release
           color: red
           verbose: false

--- a/.github/workflows/slack_notify_labeled.yml
+++ b/.github/workflows/slack_notify_labeled.yml
@@ -30,7 +30,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-slack-notifier@v1
+      - uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         if: ${{ github.event.label.name == 'P1' }}
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
             `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}) (assigned to: ${{ github.event.issue.assignee.login || 'unassigned' }}).
           color: red
           verbose: false
-      - uses: actions-ecosystem/action-slack-notifier@v1
+      - uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         if: ${{ github.event.label.name == 'C-bug' }}
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
             `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}) (assigned to: ${{ github.event.issue.assignee.login || 'unassigned' }}).
           color: red
           verbose: false
-      - uses: actions-ecosystem/action-slack-notifier@v1
+      - uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         if: ${{ github.event.label.name == 'release-blocker' }}
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/slack_notify_opened.yml
+++ b/.github/workflows/slack_notify_opened.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Check membership
         id: is_organization_member
-        uses: jamessingleton/is-organization-member@v1
+        uses: jamessingleton/is-organization-member@fb5924a6287762ee5fc71bf9e95a60842af5528d
         with:
           organization: MaterializeInc
           username: ${{ github.event.issue.user.login }}
@@ -40,7 +40,7 @@ jobs:
       - name: Push to Slack
         if: |
           steps.is_organization_member.outputs.result == false
-        uses: actions-ecosystem/action-slack-notifier@v1
+        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           channel: devex

--- a/.github/workflows/slack_notify_opened.yml
+++ b/.github/workflows/slack_notify_opened.yml
@@ -1,0 +1,79 @@
+# Copyright 2020 The Actions Ecosystem Authors
+# Modifications Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Portions of this file are derived from the README examples in the Action
+# Slack Notifier project. The original source code was retrieved on
+# January 5, 2022 from:
+
+#     https://github.com/actions-ecosystem/action-slack-notifier/blob/fc778468d09c43a6f4d1b8cccaca59766656996a/README.md
+
+name: Slack Issue Notifications
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check membership
+        id: is_organization_member
+        uses: jamessingleton/is-organization-member@v1
+        with:
+          organization: MaterializeInc
+          username: ${{ github.event.issue.user.login }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push to Slack
+        if: |
+          steps.is_organization_member.outputs.result == false
+        uses: actions-ecosystem/action-slack-notifier@v1
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          channel: devex
+          custom_payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "An external user just opened a GitHub issue! :eyes-shaking:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "• *User:* ${{ github.event.issue.user.name }} ( ${{ github.event.issue.user.login }} )"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "• *Issue:* ${{ github.event.issue.title }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "• *URL:* ${{ github.event.issue.url }}"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
Moving external issue notification from Zapier to here, so we can check organization membership automatically. Having two separate workflows vs. two triggers in a single workflow sounded saner, but can consolidate.