### PR TITLE
timely-util: more ergonomic async handle

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -548,9 +548,6 @@ where
     // will cause the changes of desired to be committed to persist.
 
     let shutdown_button = write_op.build(move |_capabilities| async move {
-        let mut buffer = Vec::new();
-        let mut batch_descriptions_buffer = Vec::new();
-
         // Contains `desired - persist`, reflecting the updates we would like to commit
         // to `persist` in order to "correct" it to track `desired`. This collection is
         // only modified by updates received from either the `desired` or `persist` inputs.
@@ -591,12 +588,11 @@ where
 
         loop {
             tokio::select! {
-                Some(event) = descriptions_input.next() => {
+                Some(event) = descriptions_input.next_mut() => {
                     match event {
                         Event::Data(cap, data) => {
                             // Ingest new batch descriptions.
-                            data.swap(&mut batch_descriptions_buffer);
-                            for description in batch_descriptions_buffer.drain(..) {
+                            for description in data.drain(..) {
                                 if sink_id.is_user() {
                                     trace!(
                                         "persist_sink {sink_id}/{shard_id}: \
@@ -632,12 +628,11 @@ where
                         }
                     }
                 }
-                Some(event) = desired_input.next() => {
+                Some(event) = desired_input.next_mut() => {
                     match event {
                         Event::Data(_cap, data) => {
                             // Extract desired rows as positive contributions to `correction`.
-                            data.swap(&mut buffer);
-                            if sink_id.is_user() && !buffer.is_empty() {
+                            if sink_id.is_user() && !data.is_empty() {
                                 trace!(
                                     "persist_sink {sink_id}/{shard_id}: \
                                         updates: {:?}, \
@@ -645,14 +640,14 @@ where
                                         desired_frontier: {:?}, \
                                         batch_descriptions_frontier: {:?}, \
                                         persist_frontier: {:?}",
-                                    buffer,
+                                    data,
                                     in_flight_batches,
                                     desired_frontier,
                                     batch_descriptions_frontier,
                                     persist_frontier
                                 );
                             }
-                            correction.append(&mut buffer);
+                            correction.append(data);
 
                             continue;
                         }
@@ -661,12 +656,11 @@ where
                         }
                     }
                 }
-                Some(event) = persist_input.next() => {
+                Some(event) = persist_input.next_mut() => {
                     match event {
                         Event::Data(_cap, data) => {
                             // Extract persist rows as negative contributions to `correction`.
-                            data.swap(&mut buffer);
-                            correction.extend(buffer.drain(..).map(|(d, t, r)| (d, t, -r)));
+                            correction.extend(data.drain(..).map(|(d, t, r)| (d, t, -r)));
 
                             continue;
                         }
@@ -888,9 +882,6 @@ where
 
         let mut cap_set = CapabilitySet::from_elem(capabilities.pop().expect("missing capability"));
 
-        let mut description_buffer = Vec::new();
-        let mut batch_buffer = Vec::new();
-
         // Contains descriptions of batches for which we know that we can
         // write data. We got these from the "centralized" operator that
         // determines batch descriptions for all writers.
@@ -929,12 +920,11 @@ where
 
         loop {
             tokio::select! {
-                Some(event) = descriptions_input.next() => {
+                Some(event) = descriptions_input.next_mut() => {
                     match event {
                         Event::Data(_cap, data) => {
                             // Ingest new batch descriptions.
-                            data.swap(&mut description_buffer);
-                            for batch_description in description_buffer.drain(..) {
+                            for batch_description in data.drain(..) {
                                 if sink_id.is_user() {
                                     trace!(
                                         "persist_sink {sink_id}/{shard_id}: \
@@ -964,12 +954,11 @@ where
                         }
                     }
                 }
-                Some(event) = batches_input.next() => {
+                Some(event) = batches_input.next_mut() => {
                     match event {
                         Event::Data(_cap, data) => {
                             // Ingest new written batches
-                            data.swap(&mut batch_buffer);
-                            for batch in batch_buffer.drain(..) {
+                            for batch in data.drain(..) {
                                 let batch = write.batch_from_hollow_batch(batch);
                                 let batch_description = (batch.lower().clone(), batch.upper().clone());
 

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -465,15 +465,11 @@ where
                 .await
         };
 
-        let mut buffer = Vec::new();
-
-        while let Some(event) = descs_input.next().await {
+        while let Some(event) = descs_input.next_mut().await {
             if let Event::Data(cap, data) = event {
                 // `LeasedBatchPart`es cannot be dropped at this point w/o
                 // panicking, so swap them to an owned version.
-                data.swap(&mut buffer);
-
-                for (_idx, part) in buffer.drain(..) {
+                for (_idx, part) in data.drain(..) {
                     let (token, fetched) = fetcher
                         .fetch_leased_part(fetcher.leased_part_from_exchangeable(part))
                         .await;

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -1066,8 +1066,6 @@ where
         internal_cmd_tx,
     );
 
-    let mut vector = Vec::new();
-
     // keep the latest progress updates, if any, in order to update
     // our internal state after the send loop
     let mut progress_update = None;
@@ -1129,13 +1127,12 @@ where
 
         s.update_status(SinkStatus::Running).await;
 
-        while let Some(event) = input.next().await {
+        while let Some(event) = input.next_mut().await {
             match event {
                 Event::Data(_, rows) => {
                     // Queue all pending rows waiting to be sent to kafka
                     assert!(is_active_worker);
-                    rows.swap(&mut vector);
-                    for ((key, value), time, diff) in vector.drain(..) {
+                    for ((key, value), time, diff) in rows.drain(..) {
                         let should_emit = if as_of.strict {
                             as_of.frontier.less_than(&time)
                         } else {


### PR DESCRIPTION
The pattern of managing an operator local buffer that gets swapped with every `RefOrMut` received is pervasive and only adds noise.

This PRs adds this feature to the handle itself so that users can call either `.next()` and get a normal reference or `.next_mut()` and get mutable reference to a pre-swapped container, eliminating the boilerplace.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
