### PR TITLE
platform checks: Do not run CREATE ROLE in upgrade context

### DIFF
--- a/misc/python/materialize/checks/roles.py
+++ b/misc/python/materialize/checks/roles.py
@@ -11,9 +11,13 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.util import MzVersion
 
 
 class CreateRole(Check):
+    def _can_run(self) -> bool:
+        return self.base_version >= MzVersion.parse("0.45.0-dev")
+
     def initialize(self) -> Testdrive:
         return Testdrive("")
 
@@ -43,6 +47,9 @@ class CreateRole(Check):
 
 
 class DropRole(Check):
+    def _can_run(self) -> bool:
+        return self.base_version >= MzVersion.parse("0.45.0-dev")
+
     def initialize(self) -> Testdrive:
         return Testdrive(
             dedent(


### PR DESCRIPTION
The accepted syntax for CREATE ROLE has changed recently: SUPERUSER or LOGIN is either required or disallowed, depending on the version. So, prevent the check from running against older Mz versions in upgrade contexts.

### Motivation


  * This PR fixes a previously unreported bug.
Nightly upgrade jobs were failing.