### PR TITLE
explain: correctly trace `optimize/local` entry + small timing fixes

### DIFF
--- a/misc/python/materialize/cli/optbench.py
+++ b/misc/python/materialize/cli/optbench.py
@@ -10,6 +10,7 @@
 import csv
 import re
 import tempfile
+from contextlib import closing
 from pathlib import Path
 from typing import Optional, cast
 
@@ -120,28 +121,41 @@ def init(
     info(f'Initializing "{scenario}" as the DB under test')
 
     try:
-        db = sql.Database(
-            port=db_port,
-            host=db_host,
-            user=db_user,
-            password=db_pass,
-            require_ssl=db_require_ssl,
-        )
+        # connect to the default database in order to re-create the
+        # database for the selected scenario
+        with closing(
+            sql.Database(
+                port=db_port,
+                host=db_host,
+                user=db_user,
+                database=None,
+                password=db_pass,
+                require_ssl=db_require_ssl,
+            )
+        ) as db:
+            db.drop_database(scenario)
+            db.create_database(scenario)
 
-        db.drop_database(scenario)
-        db.create_database(scenario)
-
-        db.set_database(scenario)
-
-        statements = sql.parse_from_file(scenario.schema_path())
-        if no_indexes:
-            idx_re = re.compile(r"(create|create\s+default|drop)\s+index\s+")
-            statements = [
-                statement
-                for statement in statements
-                if not idx_re.match(statement.lower())
-            ]
-        db.execute_all(statements)
+        # re-connect to the database for the selected scenario
+        with closing(
+            sql.Database(
+                port=db_port,
+                host=db_host,
+                user=db_user,
+                database=str(scenario),
+                password=db_pass,
+                require_ssl=db_require_ssl,
+            )
+        ) as db:
+            statements = sql.parse_from_file(scenario.schema_path())
+            if no_indexes:
+                idx_re = re.compile(r"(create|create\s+default|drop)\s+index\s+")
+                statements = [
+                    statement
+                    for statement in statements
+                    if not idx_re.match(statement.lower())
+                ]
+            db.execute_all(statements)
     except Exception as e:
         raise click.ClickException(f"init command failed: {e}")
 
@@ -172,38 +186,40 @@ def run(
     info(f'Running "{scenario}" scenario')
 
     try:
-        db = sql.Database(
-            port=db_port,
-            host=db_host,
-            user=db_user,
-            password=db_pass,
-            require_ssl=db_require_ssl,
-        )
-        db.set_database(scenario)
+        with closing(
+            sql.Database(
+                port=db_port,
+                host=db_host,
+                user=db_user,
+                database=str(scenario),
+                password=db_pass,
+                require_ssl=db_require_ssl,
+            )
+        ) as db:
+            db_version = db.mz_version() or db.version()
+            df = pd.DataFrame.from_records(
+                [
+                    (
+                        query.name(),
+                        sample,
+                        cast(
+                            np.timedelta64,
+                            db.explain(query, timing=True).optimization_time(),
+                        ).astype(int),
+                    )
+                    for sample in range(samples)
+                    for query in [
+                        sql.Query(query)
+                        for query in sql.parse_from_file(scenario.workload_path())
+                    ]
+                ],
+                columns=["query", "sample", "data"],
+            ).pivot(index="sample", columns="query", values="data")
 
-        df = pd.DataFrame.from_records(
-            [
-                (
-                    query.name(),
-                    sample,
-                    cast(
-                        np.timedelta64,
-                        db.explain(query, timing=True).optimization_time(),
-                    ).astype(int),
-                )
-                for sample in range(samples)
-                for query in [
-                    sql.Query(query)
-                    for query in sql.parse_from_file(scenario.workload_path())
-                ]
-            ],
-            columns=["query", "sample", "data"],
-        ).pivot(index="sample", columns="query", values="data")
+            if print_results:
+                print(df.to_string())
 
-        if print_results:
-            print(df.to_string())
-
-        results_path = util.results_path(repository, scenario, db.mz_version())
+        results_path = util.results_path(repository, scenario, db_version)
         info(f'Writing results to "{results_path}"')
         df.to_csv(results_path, index=False, quoting=csv.QUOTE_MINIMAL)
     except Exception as e:

--- a/misc/python/materialize/optbench/README.md
+++ b/misc/python/materialize/optbench/README.md
@@ -13,6 +13,20 @@ These two steps are modeled by the `init` and `run` commands.
 For example, for the `tpch` scenario, type
 
 ```bash
+# For a locally running Materialize, use the defaults
+
+# For Materialize Cloud (staging), use:
+PGHOST=$mz_orgid.$aws_region.aws.staging.materialize.cloud
+PGUSER=$mz_user
+PGPASSWORD=$mz_password
+PGPORT=6875
+PGREQUIRESSL=true
+
+# For a locally running Postgres, use:
+PGHOST=localhost
+PGUSER=$USER
+PGPORT=5432
+
 bin/optbench init tpch
 bin/optbench run tpch --repository="$HOME/optbench"
 ```

--- a/misc/python/materialize/optbench/sql.py
+++ b/misc/python/materialize/optbench/sql.py
@@ -10,6 +10,7 @@
 import logging
 import re
 import ssl
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
@@ -18,6 +19,11 @@ import pg8000
 import sqlparse
 
 from . import Scenario, util
+
+
+class Dialect(Enum):
+    PG = 0
+    MZ = 1
 
 
 class Query:
@@ -36,12 +42,19 @@ class Query:
         m = re.search(p, self.query, re.MULTILINE)
         return m.group("name") if m else "anonoymous"
 
-    def explain(self, timing: bool) -> str:
-        """Prepends 'EXPLAIN PLAN ... FOR' to the query."""
-        if timing:
-            return "\n".join([f"EXPLAIN PLAN WITH(timing) FOR", self.query])
+    def explain(self, timing: bool, dialect: Dialect) -> str:
+        """Prepends 'EXPLAIN ...' to the query respecting the given dialect."""
+
+        if dialect == Dialect.PG:
+            if timing:
+                return "\n".join([f"EXPLAIN (ANALYZE, TIMING TRUE)", self.query])
+            else:
+                return "\n".join([f"EXPLAIN", self.query])
         else:
-            return "\n".join([f"EXPLAIN PLAN FOR", self.query])
+            if timing:
+                return "\n".join([f"EXPLAIN WITH(timing)", self.query])
+            else:
+                return "\n".join([f"EXPLAIN", self.query])
 
 
 class ExplainOutput:
@@ -54,8 +67,8 @@ class ExplainOutput:
         return self.output
 
     def optimization_time(self) -> Optional[np.timedelta64]:
-        """Optionally, returns the optimization_time time for an 'EXPLAIN WITH(timing)' output."""
-        p = r"Optimization time\: (?P<time>\S+)"
+        """Optionally, returns the optimization_time time for an 'EXPLAIN' output."""
+        p = r"(Optimization time|Planning Time)\: (?P<time>[0-9]+(\.[0-9]+)?\s?\S+)"
         m = re.search(p, self.output, re.MULTILINE)
         return util.duration_to_timedelta(m["time"]) if m else None
 
@@ -69,6 +82,7 @@ class Database:
         host: str,
         user: str,
         password: Optional[str],
+        database: Optional[str],
         require_ssl: bool,
     ) -> None:
         logging.debug(f"Initialize Database with host={host} port={port}, user={user}")
@@ -80,13 +94,29 @@ class Database:
             ssl_context = None
 
         self.conn = pg8000.connect(
-            host=host, port=port, user=user, password=password, ssl_context=ssl_context
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            database=database,
+            ssl_context=ssl_context,
         )
         self.conn.autocommit = True
+        self.dialect = Dialect.MZ if "Materialize" in self.version() else Dialect.PG
 
-    def mz_version(self) -> str:
-        result = self.query_one("SELECT mz_version()")
+    def close(self) -> None:
+        self.conn.close()
+
+    def version(self) -> str:
+        result = self.query_one("SELECT version()")
         return cast(str, result[0])
+
+    def mz_version(self) -> Optional[str]:
+        if self.dialect == Dialect.MZ:
+            result = self.query_one("SELECT mz_version()")
+            return cast(str, result[0])
+        else:
+            return None
 
     def drop_database(self, scenario: Scenario) -> None:
         logging.debug(f'Drop database "{scenario}"')
@@ -96,13 +126,9 @@ class Database:
         logging.debug(f'Create database "{scenario}"')
         self.execute(f"CREATE DATABASE {scenario}")
 
-    def set_database(self, scenario: Scenario) -> None:
-        logging.debug(f'Set default database to "{scenario}"')
-        self.execute(f"SET DATABASE = {scenario}")
-
     def explain(self, query: Query, timing: bool) -> "ExplainOutput":
-        result = self.query_one(query.explain(timing))
-        return ExplainOutput(result[0])
+        result = self.query_all(query.explain(timing, self.dialect))
+        return ExplainOutput("\n".join([col for line in result for col in line]))
 
     def execute(self, statement: str) -> None:
         with self.conn.cursor() as cursor:

--- a/misc/python/materialize/optbench/util.py
+++ b/misc/python/materialize/optbench/util.py
@@ -26,7 +26,7 @@ def duration_to_timedelta(duration: str) -> Optional[np.timedelta64]:
         "ns": lambda frac: "0",  # ns units should not have frac
     }
 
-    p = r"(?P<time>[0-9]+)(\.(?P<frac>[0-9]+))?(?P<unit>s|ms|µs|ns)"
+    p = r"(?P<time>[0-9]+)(\.(?P<frac>[0-9]+))?\s?(?P<unit>s|ms|µs|ns)"
     m = match(p, duration)
 
     if m is None:
@@ -38,9 +38,19 @@ def duration_to_timedelta(duration: str) -> Optional[np.timedelta64]:
         return time + frac
 
 
-def results_path(repository: Path, scenario: Scenario, mz_version: str) -> Path:
-    mz_version = mz_version.replace(" ", "-")
-    mz_version = mz_version.replace("(", "")
-    mz_version = mz_version.replace(")", "")
-    file = f"optbench-{scenario}-{mz_version}.csv"
+def results_path(repository: Path, scenario: Scenario, version: str) -> Path:
+    # default suffix
+    suffix = "unknown"
+
+    # try to match Postgres version syntax
+    m = match(r"PostgreSQL (?P<version>[0-9\.]+)", version)
+    if m:
+        suffix = f"pg-v{m['version']}"
+
+    # try to match Materialize version syntax
+    m = match(r"v(?P<version>[0-9\.]+(-dev)?) \((?P<commit>[0-9a-f]+)\)", version)
+    if m:
+        suffix = f"mz-v{m['version']}-{m['commit']}"
+
+    file = f"optbench-{scenario}-{suffix}.csv"
     return repository / file

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2856,7 +2856,7 @@ impl Coordinator {
                 tracing::span!(Level::INFO, "local").in_scope(|| -> Result<_, AdapterError> {
                     let optimized_plan = self.view_optimizer.optimize(decorrelated_plan);
                     if let Ok(ref optimized_plan) = optimized_plan {
-                        trace_plan(optimized_plan);
+                        trace_plan(optimized_plan.as_inner());
                     }
                     optimized_plan.map_err(Into::into)
                 })

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -69,6 +69,12 @@ pub fn optimize_dataflow(
 }
 
 /// Inline views used in one other view, and in no exported objects.
+#[tracing::instrument(
+    target = "optimizer",
+    level = "debug",
+    skip_all,
+    fields(path.segment = "inline_views")
+)]
 fn inline_views(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
     // We cannot inline anything whose `BuildDesc::id` appears in either the
     // `index_exports` or `sink_exports` of `dataflow`, because we lose our
@@ -161,6 +167,8 @@ fn inline_views(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
             dataflow.objects_to_build.remove(index);
         }
     }
+
+    mz_repr::explain::trace_plan(dataflow);
 
     Ok(())
 }
@@ -396,6 +404,8 @@ pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) -> Result<(), Tr
         )?;
     }
 
+    mz_repr::explain::trace_plan(dataflow);
+
     Ok(())
 }
 
@@ -468,5 +478,8 @@ fn optimize_dataflow_index_imports(
             false
         }
     });
+
+    mz_repr::explain::trace_plan(dataflow);
+
     Ok(())
 }


### PR DESCRIPTION
One bug and two minor `EXPLAIN OPTIMIZER TRACE` / `optbench` improvements.

### Motivation
* This PR fixes a previously unreported bug.

Fixes a bug in `EXPLAIN OPTIMIZER TRACE`, which since #17604 does not report result plan at the `optimize/local` stage correctly, and adds some missing stages from the `global` part of the pipeline.

### Tips for reviewer

In addition to the fix above this also includes two minor commits:

1. A commit that optimizes `PlanTrace::push` calls so they are a noop in contexts where we look for a single entry in the trace and that entry is different from the current path.
2. Rework the `optbench` commands so one can get reference nubmers from a Postgres datbase. It does not warrant an in-depth review as `optbench` is currently not part of a production- or CI-running code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
