### PR TITLE
doc: Add style guide for SQL functions

### DIFF
--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -147,6 +147,7 @@ We adhere to standards for our SQL functions.
 Naming standards:
 * If the function exists in PostgreSQL, then use the PostgreSQL function and argument names.
 * If the function is specific to Materialize internals, then the name should be prefixed with `mz_`. For example, `mz_now()`.
+* If the function does not exist in PostgreSQL, but it is not specific to Materialize internals, then the name does not need to be prefixed with `mz_`.
 
 ## Log message style
 

--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -147,7 +147,7 @@ We adhere to standards for our SQL functions.
 Naming standards:
 * If the function exists in PostgreSQL, then use the PostgreSQL function and argument names.
 * If the function is specific to Materialize internals, then the name should be prefixed with `mz_`. For example, `mz_now()`.
-* If the function does not exist in PostgreSQL, but it is not specific to Materialize internals, then the name does not need to be prefixed with `mz_`.
+* If the function does not exist in PostgreSQL, but it is not specific to Materialize internals, then the name does not need to be prefixed with `mz_`. However, it should not collide with an existing PostgreSQL function.
 
 ## Log message style
 

--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -140,6 +140,16 @@ Naming standards:
   * Examples of collective final nouns are `_usage`, `_history`, and `_utilization`.
   * A good example of these standards in practice is the set of relations `mz_sources`, `mz_source_statuses`, and `mz_source_status_history`.
 
+### Function Style
+
+We adhere to standards for our SQL functions.
+
+Naming standards:
+* If the function exists in PostgreSQL, then use the PostgreSQL function and argument names.
+* If the function is specific to Materialize internals, then the name should be prefixed with `mz_`. For example, `mz_now()`. 
+
+
+
 ## Log message style
 
 We use the [`tracing` crate](https://docs.rs/tracing/latest/tracing/)'s log

--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -146,7 +146,7 @@ We adhere to standards for our SQL functions.
 
 Naming standards:
 * If the function exists in PostgreSQL, then use the PostgreSQL function and argument names.
-* If the function is specific to Materialize internals, then the name should be prefixed with `mz_`. For example, `mz_now()`. 
+* If the function is specific to Materialize internals, then the name should be prefixed with `mz_`. For example, `mz_now()`.
 
 
 

--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -148,8 +148,6 @@ Naming standards:
 * If the function exists in PostgreSQL, then use the PostgreSQL function and argument names.
 * If the function is specific to Materialize internals, then the name should be prefixed with `mz_`. For example, `mz_now()`.
 
-
-
 ## Log message style
 
 We use the [`tracing` crate](https://docs.rs/tracing/latest/tracing/)'s log


### PR DESCRIPTION
### Motivation
Adds docs

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
