### PR TITLE
SQL-level invalid accumulation error in bucketed aggregates with a multi-level hierarchy

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -568,8 +568,11 @@ def workflow_test_github_15496(c: Composition) -> None:
             # Run a query that would generate a panic before the fix. Note that
             # we expect the query to succeed for now, but follow-up work might
             # eventually lead us to favor a SQL-level error for such a query, as
-            # tracked by https://github.com/MaterializeInc/materialize/issues/17178
-            > SELECT SUM(data), MAX(data) FROM data;
+            # tracked by issue #17178.
+            # Note that we employ below a query hint to hit the case of not yet
+            # generating a SQL-level error, given the partial fix to bucketed
+            # aggregates introduced in PR #17918.
+            > SELECT SUM(data), MAX(data) FROM data OPTIONS (EXPECTED GROUP SIZE = 1);
             <null> <null>
             """
             )


### PR DESCRIPTION
This PR makes the first stage of a bucketed hierarchical aggregation check for invalid accumulations and upon detection, output errors into a separate error stream. Note that the error stream is only produced when at least one hierarchical stage is built before the final mins-maxes reduction. Otherwise, the current behavior is maintained: The detection is performed in the final reduction, but no error stream is produced. The latter behavior is in place to prevent making the output arrangement of the final reduction unusable upstream.

The PR also changes the validation policy of invalid accumulations in bucketed aggregates. Previously, invalid accumulation checks were performed at every level of the hierarchy. However, this was redundant: A failed check at the first level would lead to the same detection at all further levels of the hierarchy. With the change, we perform the check at the first level of the hierarchy only, saving resources and reducing noise in the error logs.

Advances #17509. 

The PR uses some of the insights obtained by the work in the design document #17597. In particular, we maintain the desirable property of allowing reuse of the output arrangement of a reduction. At the same time, we employ one of the solution alternatives, namely encoding errors with `Result`, taking advantage of the observation that in some situations, intermediate output arrangements were not reused anyway. So in these complex reduction renderings, the most important downside of the solution alternative with use of `Result` is not relevant.

### Motivation

  * This PR advances the resolution of a recognized bug. The fix here will not prevent the bug from manifesting under all conditions, but should get most of the way there. https://github.com/MaterializeInc/materialize/issues/17509 

### Tips for reviewer

The commits of this PR can be looked at individually. Note that I tried to capture in an existing test the situation where we still produce errors by using query hints, in particular `OPTIONS (EXPECTED GROUP SIZE = 1)`. This hint makes us build a minimal bucketed hierarchical plan with only the final `ReduceMinsMaxes` and no intermediate hierarchical reductions. In this situation, the behavior is unchanged wrt. before this PR. However, when a hierarchical reduction is built, e.g., when a query hint is not supplied, then we can observe both SQL-level errors as well as output to the error logs. The latter is checked by a new `mzcompose` cluster test workflow.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc]( #17597).
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): 
    - Improved error reporting for invalid accumulations in MIN/MAX aggregations in the absence of query hints.
