### PR TITLE
stash: retry COMMIT indeterminate errors

### DIFF
--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -86,7 +86,6 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use mz_ore::soft_assert;
-use postgres::TransactionError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use timely::progress::Antichain;
@@ -188,7 +187,6 @@ impl StashError {
     pub fn is_unrecoverable(&self) -> bool {
         match &self.inner {
             InternalStashError::Fence(_) => true,
-            InternalStashError::Transaction(e) => !e.retryable(),
             _ => false,
         }
     }
@@ -197,7 +195,6 @@ impl StashError {
 #[derive(Debug)]
 enum InternalStashError {
     Postgres(::tokio_postgres::Error),
-    Transaction(Box<TransactionError>),
     Fence(String),
     PeekSinceUpper(String),
     Other(String),
@@ -211,7 +208,6 @@ impl fmt::Display for StashError {
             InternalStashError::Fence(e) => f.write_str(e),
             InternalStashError::PeekSinceUpper(e) => f.write_str(e),
             InternalStashError::Other(e) => f.write_str(e),
-            InternalStashError::Transaction(e) => e.fmt(f),
         }
     }
 }

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -15,7 +15,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use differential_dataflow::lattice::Lattice;
-use fail::fail_point;
 use futures::future::{self, BoxFuture};
 use futures::future::{FutureExt, TryFutureExt};
 use futures::{Future, StreamExt};
@@ -44,10 +43,11 @@ use crate::{
 const SCHEMA: &str = "
 CREATE TABLE fence (
     epoch bigint PRIMARY KEY,
-    nonce bytea
+    nonce bytea,
+    version bigint DEFAULT 1 NOT NULL
 );
--- Epochs are guaranteed to be non-zero, so start counting at 1
-INSERT INTO fence VALUES (1, '');
+-- Epochs and versions are guaranteed to be non-zero, so start counting at 1.
+INSERT INTO fence (epoch, nonce, version) VALUES (1, '', 1);
 
 -- bigserial is not ideal for Cockroach, but we have a stable number of
 -- collections, so our use of it here is fine and compatible with Postgres.
@@ -82,7 +82,7 @@ CREATE TABLE uppers (
 const RECONNECT_INTERVAL: Duration = Duration::from_secs(300);
 
 struct PreparedStatements {
-    select_epoch: Statement,
+    fetch_epoch: Statement,
     iter_key: Statement,
     since: Statement,
     upper: Statement,
@@ -94,8 +94,24 @@ struct PreparedStatements {
 }
 
 impl PreparedStatements {
-    async fn from(client: &Client) -> Result<Self, StashError> {
-        let select_epoch = client.prepare("SELECT epoch, nonce FROM fence").await?;
+    async fn from(client: &Client, mode: TransactionMode) -> Result<Self, StashError> {
+        let fetch_epoch = client
+            .prepare(match mode {
+                TransactionMode::Readonly | TransactionMode::Savepoint => {
+                    // For readonly and savepoint stashes, don't attempt to
+                    // increment the version and instead hard code it to 0 which
+                    // will always fail the version check, since the version
+                    // starts at 1 and goes up. Savepoint however will never
+                    // retry COMMITs (and otherwise they'd retry forever because
+                    // 0 will never succeed). Readonly can safely retry the
+                    // original transaction.
+                    "SELECT epoch, nonce, 0 AS version FROM fence"
+                }
+                TransactionMode::Writeable => {
+                    "UPDATE fence SET version=version+1 RETURNING epoch, nonce, version"
+                }
+            })
+            .await?;
         let iter_key = client
             .prepare(
                 "SELECT value, time, diff FROM data
@@ -124,7 +140,7 @@ impl PreparedStatements {
             .prepare("UPDATE sinces SET since = $1 WHERE collection_id = $2")
             .await?;
         Ok(PreparedStatements {
-            select_epoch,
+            fetch_epoch,
             iter_key,
             since,
             upper,
@@ -166,9 +182,9 @@ impl<'a> CountedStatements<'a> {
         }
     }
 
-    pub fn select_epoch(&self) -> &Statement {
-        self.inc("select_epoch");
-        &self.stmts.select_epoch
+    pub fn fetch_epoch(&self) -> &Statement {
+        self.inc("fetch_epoch");
+        &self.stmts.fetch_epoch
     }
     pub fn iter_key(&self) -> &Statement {
         self.inc("iter_key");
@@ -231,7 +247,7 @@ impl<'a> CountedStatements<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 enum TransactionMode {
     /// Transact operations occurs in a normal transaction.
     Writeable,
@@ -524,6 +540,22 @@ impl Stash {
                 }
                 tx.batch_execute(SCHEMA).await?;
             }
+
+            // Migration added in 0.45.0. This block can be removed anytime after that
+            // release.
+            {
+                // We can't add the column for other txn modes, and they don't
+                // even require it since they use the read-only fetch_epoch
+                // query.
+                if matches!(self.txn_mode, TransactionMode::Writeable) {
+                    tx
+                    .batch_execute(
+                        "ALTER TABLE fence ADD COLUMN IF NOT EXISTS version bigint DEFAULT 1 NOT NULL;",
+                    )
+                    .await?;
+                }
+            }
+
             let epoch = if matches!(self.txn_mode, TransactionMode::Writeable) {
                 // The `data`, `sinces`, and `uppers` tables can create and delete
                 // rows at a high frequency, generating many tombstoned rows. If
@@ -563,7 +595,7 @@ impl Stash {
             self.epoch = Some(epoch);
         }
 
-        self.statements = Some(PreparedStatements::from(&client).await?);
+        self.statements = Some(PreparedStatements::from(&client, self.txn_mode).await?);
 
         // In savepoint mode start a transaction that will never be committed.
         // Use a low priority so the rw stash won't ever block waiting for the
@@ -614,7 +646,7 @@ impl Stash {
             self.client = None;
         }
 
-        loop {
+        'transact_inner: loop {
             // Execute the operation in a transaction or savepoint.
             match self.transact_inner(&f).await {
                 Ok(r) => return Ok(r),
@@ -632,14 +664,26 @@ impl Stash {
                         .inc();
                     info!(
                         "tokio-postgres stash error, retry attempt {attempt}: {}, code: {:?}",
-                        e.inner(),
+                        e,
                         e.code(),
                     );
 
-                    // Savepoint is never retryable because we can't restore all previous
-                    // savepoints.
+                    // Savepoint is never retryable because we can't restore all
+                    // previous savepoints.
+                    //
+                    // TODO: This could be taught to retry if needed to make the
+                    // upgrade checker of stash-debug more resilient. Would need
+                    // to adjust fetch_epoch to attempt to increment the version
+                    // if we do that.
                     if matches!(self.txn_mode, TransactionMode::Savepoint) {
-                        return Err(e.into());
+                        match e {
+                            TransactionError::Commit { .. } => {
+                                return Err("indeterminate COMMIT".into())
+                            }
+                            TransactionError::Epoch(err)
+                            | TransactionError::Connect(err)
+                            | TransactionError::Txn(err) => return Err(err),
+                        }
                     }
 
                     if e.retryable() {
@@ -649,7 +693,38 @@ impl Stash {
                         // confirmation
                         retry.next().await;
                     } else {
-                        return Err(e.into());
+                        match e {
+                            TransactionError::Commit {
+                                committed_if_version,
+                                result,
+                            } => {
+                                // COMMIT is indeterminate. Check if it succeeded in a
+                                // new transaction.
+                                loop {
+                                    match self.determine_commit(committed_if_version).await {
+                                        Ok(succeeded) => {
+                                            if succeeded {
+                                                return Ok(result);
+                                            } else {
+                                                // COMMIT failed, retry the transaction.
+                                                continue 'transact_inner;
+                                            }
+                                        }
+                                        Err(err) => {
+                                            // If there was an error during COMMIT
+                                            // check, we might be able to retry it.
+                                            if err.is_unrecoverable() {
+                                                return Err(err);
+                                            }
+                                            // Implied `continue`.
+                                        }
+                                    }
+                                }
+                            }
+                            TransactionError::Epoch(err)
+                            | TransactionError::Connect(err)
+                            | TransactionError::Txn(err) => return Err(err),
+                        }
                     }
                 }
             }
@@ -657,7 +732,7 @@ impl Stash {
     }
 
     #[tracing::instrument(name = "stash::transact_inner", level = "debug", skip_all)]
-    async fn transact_inner<F, T>(&mut self, f: &F) -> Result<T, TransactionError>
+    async fn transact_inner<F, T>(&mut self, f: &F) -> Result<T, TransactionError<T>>
     where
         F: for<'a> Fn(
             &'a CountedStatements<'a>,
@@ -688,13 +763,13 @@ impl Stash {
             .map_err(|err| TransactionError::Txn(err.into()))?;
         // Pipeline the epoch query and closure.
         let epoch_fut = client
-            .query_one(stmts.select_epoch(), &[])
+            .query_one(stmts.fetch_epoch(), &[])
             .map_err(|err| err.into());
         let f_fut = f(&stmts, client, &self.collections);
-        let (row, res) = future::try_join(epoch_fut, f_fut)
+        let (epoch_row, res) = future::try_join(epoch_fut, f_fut)
             .await
             .map_err(TransactionError::Txn)?;
-        let current_epoch = NonZeroI64::new(row.get(0)).unwrap();
+        let current_epoch = NonZeroI64::new(epoch_row.get("epoch")).unwrap();
         if Some(current_epoch) != self.epoch {
             return Err(TransactionError::Epoch(
                 InternalStashError::Fence(format!(
@@ -704,7 +779,7 @@ impl Stash {
                 .into(),
             ));
         }
-        let current_nonce: Vec<u8> = row.get(1);
+        let current_nonce: Vec<u8> = epoch_row.get("nonce");
         if current_nonce != self.nonce {
             return Err(TransactionError::Epoch(
                 InternalStashError::Fence("unexpected fence nonce".into()).into(),
@@ -716,53 +791,112 @@ impl Stash {
                 counts = format!("{:?}", counts.lock().unwrap()),
             );
         }
-        client
-            .batch_execute(tx_end)
-            .await
-            .map_err(|err| TransactionError::Commit(err.into()))?;
 
-        fail_point!("stash_commit", |r| Err(TransactionError::Commit(
-            r.unwrap_or_else(|| "stash_commit failpoint".to_string())
-                .into()
-        )));
+        let committed_if_version: i64 = epoch_row.get("version");
+
+        // We can't use the failpoint macro here because we need to move `res`
+        // into the error return, but because `res` is generic and a T, we can't
+        // create one. Calling `res.clone()` would require `T: Clone` which
+        // forces `Data` to have `Clone` which we maybe don't want (unclear).
+        // Thus, use the hidden function that the macro calls.
+
+        // Have both a pre and post commit failpoint to simulate each kind of
+        // error.
+        if let Some(_) = fail::eval("stash_commit_pre", |_| "") {
+            return Err(TransactionError::Commit {
+                committed_if_version,
+                result: res,
+            });
+        }
+
+        if let Err(_) = client.batch_execute(tx_end).await {
+            return Err(TransactionError::Commit {
+                committed_if_version,
+                result: res,
+            });
+        }
+
+        if let Some(_) = fail::eval("stash_commit_post", |_| "") {
+            return Err(TransactionError::Commit {
+                committed_if_version,
+                result: res,
+            });
+        }
 
         Ok(res)
     }
+
+    /// Reports whether a COMMIT that returned an error actually succeeded. An
+    /// Err return from this function is retryable normally (if
+    /// `!err.is_unrecoverable()`).
+    #[tracing::instrument(name = "stash::determine_commit", level = "debug", skip_all)]
+    async fn determine_commit(&mut self, committed_if_version: i64) -> Result<bool, StashError> {
+        // Always reconnect.
+        self.connect().await?;
+
+        let client = self.client.as_mut().unwrap();
+        let row = client
+            .query_one("SELECT epoch, nonce, version FROM fence", &[])
+            .await?;
+
+        // TODO: figure out if version should be non zero or not. Probably not?
+        let epoch = NonZeroI64::new(row.get("epoch")).unwrap();
+        let nonce: Vec<u8> = row.get("nonce");
+        let version: i64 = row.get("version");
+        if Some(epoch) != self.epoch || nonce != self.nonce {
+            return Err(InternalStashError::Fence("unexpected epoch or nonce".into()).into());
+        }
+        Ok(version == committed_if_version)
+    }
 }
 
-#[derive(Debug)]
-pub(crate) enum TransactionError {
+pub(crate) enum TransactionError<T> {
     /// A failure occurred pre-transaction.
     Connect(StashError),
     /// The epoch check failed.
     Epoch(StashError),
     /// The transaction function failed and the commit was never started.
     Txn(StashError),
-    /// The commit was started and failed.
-    Commit(StashError),
+    /// The commit was started and failed but may have been committed. This is
+    /// an indeterminate error.
+    Commit {
+        // If the version field (in a new transaction) is this value, then the
+        // COMMIT succeeded, otherwise it failed.
+        committed_if_version: i64,
+        result: T,
+    },
 }
 
-impl From<TransactionError> for StashError {
-    fn from(err: TransactionError) -> StashError {
-        InternalStashError::Transaction(Box::new(err)).into()
-    }
-}
-
-impl TransactionError {
-    fn inner(&self) -> &StashError {
+impl<T> std::fmt::Display for TransactionError<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TransactionError::Connect(err)
             | TransactionError::Epoch(err)
-            | TransactionError::Txn(err)
-            | TransactionError::Commit(err) => err,
+            | TransactionError::Txn(err) => write!(f, "{err}"),
+            TransactionError::Commit {
+                committed_if_version,
+                ..
+            } => write!(
+                f,
+                "TransactionError::Commit{{ committed_if_version: {committed_if_version} }}"
+            ),
         }
     }
+}
 
+impl<T> TransactionError<T> {
     fn pgerr(&self) -> Option<&tokio_postgres::Error> {
-        if let InternalStashError::Postgres(err) = &self.inner().inner {
-            Some(err)
-        } else {
-            None
+        match self {
+            TransactionError::Connect(err)
+            | TransactionError::Epoch(err)
+            | TransactionError::Txn(err) => {
+                if let InternalStashError::Postgres(err) = &err.inner {
+                    Some(err)
+                } else {
+                    None
+                }
+            }
+            TransactionError::Commit { .. } => None,
         }
     }
 
@@ -791,7 +925,7 @@ impl TransactionError {
     pub fn retryable(&self) -> bool {
         // Only attempt to retry postgres-related errors. Others come from stash
         // code and can't be retried.
-        if !matches!(self.inner().inner, InternalStashError::Postgres(_)) {
+        if self.pgerr().is_none() {
             return false;
         }
 
@@ -812,7 +946,7 @@ impl TransactionError {
             TransactionError::Epoch(_) => false,
             // Retry inner transaction failures.
             TransactionError::Txn(_) => true,
-            TransactionError::Commit(_) => {
+            TransactionError::Commit { .. } => {
                 // If the failure occurred during the commit attempt, only retry
                 // if we got an explicit code from the database notifying us
                 // that this is possible. A connection error or perhaps any

--- a/src/stash/tests/stash.rs
+++ b/src/stash/tests/stash.rs
@@ -78,14 +78,16 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     convert::Infallible,
+    time::Duration,
 };
 
 use futures::Future;
 use postgres_openssl::MakeTlsConnector;
 use timely::progress::Antichain;
+use tokio::sync::oneshot;
 use tokio_postgres::Config;
 
-use mz_ore::{assert_contains, metrics::MetricsRegistry};
+use mz_ore::{assert_contains, metrics::MetricsRegistry, task::spawn};
 
 use mz_stash::{
     Stash, StashCollection, StashError, StashFactory, TableTransaction, Timestamp, TypedCollection,
@@ -160,15 +162,30 @@ async fn test_stash_postgres() {
         );
         let mut batch = col.make_batch(&mut stash).await.unwrap();
         col.append_to_batch(&mut batch, &1, &2, -1);
-        // Enable the failpoint, which should cause the commit to succeed but the stash call to fail.
-        fail::cfg("stash_commit", "return(commit failpoint)").unwrap();
-        assert_contains!(
-            stash.append(vec![batch]).await.unwrap_err().to_string(),
-            "commit failpoint"
-        );
-        fail::cfg("stash_commit", "off").unwrap();
-        // Even though the append return an Error, it applied its diff.
+
+        fail::cfg("stash_commit_pre", "return(commit failpoint)").unwrap();
+        fail::cfg("stash_commit_post", "return(commit failpoint)").unwrap();
+        // Because the commit error will either retry or discover it succeeded,
+        // it never returns an error. Thus, we need to re-enable the failpoint
+        // in another thread. Use both a pre and post commit error to test both
+        // commit success and fail paths. Use a channel to check that we haven't
+        // succeeded unexpectedly.
+        let (tx, mut rx) = oneshot::channel();
+        let handle = spawn(|| "stash_commit_enable", async {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            // Assert no success yet.
+            rx.try_recv().unwrap_err();
+            fail::cfg("stash_commit_post", "off").unwrap();
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            // Assert no success yet.
+            rx.try_recv().unwrap_err();
+            fail::cfg("stash_commit_pre", "off").unwrap();
+            rx.await.unwrap();
+        });
+        stash.append(vec![batch.clone()]).await.unwrap();
         assert_eq!(C1.peek_one(&mut stash).await.unwrap(), BTreeMap::new());
+        tx.send(()).unwrap();
+        handle.await.unwrap();
     }
     // Test readonly.
     {


### PR DESCRIPTION
On COMMIT error we now detect whether or not it succeeded by incrementing a version field on each transaction, then checking the version in a new transaction. On match, we can return success. On no match, we retry. Thus, there's no more top-level COMMIT error anymore.

Closes #17813
Fixes #17860

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a