### PR TITLE
sql: Adding error messages if FOR ALL TABLES or FOR TABLES is specified fo…

### DIFF
--- a/test/testdrive/kafka-source-errors.td
+++ b/test/testdrive/kafka-source-errors.td
@@ -42,3 +42,15 @@ contains: non-existent-broker:9092
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-fawlty-csr-source-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION fawlty_csr_conn
 contains: failed to fetch schema subject
+
+# Check that for all tables clause is rejected
+! CREATE SOURCE bad_definition1
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'any_topic')
+  FORMAT BYTES FOR ALL TABLES WITH (SIZE = '1');
+contains: FOR ALL TABLES is only valid for multi-output sources
+
+# Check that for tables() clause is rejected
+! CREATE SOURCE bad_definition2
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'any_topic')
+  FORMAT BYTES FOR TABLES(t1);
+contains: FOR TABLES (..) is only valid for multi-output sources

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -18,6 +18,15 @@ bids                    subsource      <null>
 organizations           subsource      <null>
 users                   subsource      <null>
 
+# Adding test to check for tables() work
+> CREATE SCHEMA a;
+> CREATE SOURCE a.auction_bids FROM LOAD GENERATOR AUCTION FOR TABLES (bids as a.bids);
+
+> SHOW SOURCES FROM a;
+auction_bids            load-generator ${arg.default-storage-size}
+auction_bids_progress   subsource      <null>
+bids                    subsource      <null>
+
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}');
 
 # Validate that the ID column of the load generator data is usable as a key.
@@ -77,3 +86,15 @@ $ set-regex match=\d+ replacement=<NUMBER>
 $ set-regex match=(\d{13,20}|u\d{1,5}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
 > EXPLAIN TIMESTAMP FOR SELECT * FROM auction_house_progress
 "                query timestamp: <> <>\n          oracle read timestamp: <> <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: <>\n                       timeline: Some(EpochMilliseconds)\n\nsource materialize.public.auction_house_progress (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"
+
+# Check that for all tables clause is rejected with no subsources
+! CREATE SOURCE counter6
+  FROM LOAD GENERATOR COUNTER (MAX CARDINALITY 8, TICK INTERVAL '0.001s')
+  FOR ALL TABLES;
+contains: FOR ALL TABLES is only valid for multi-output sources
+
+# Check that for tables() clause is rejected with no subsources
+! CREATE SOURCE counter6
+  FROM LOAD GENERATOR COUNTER (MAX CARDINALITY 8, TICK INTERVAL '0.001s')
+  FOR TABLES(t1);
+contains: FOR TABLES (..) is only valid for multi-output sources


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Adding error messages if for all tables or for tables is specified for sources without multiple outputs like kafka and some load generators.

### Motivation

Fixes partially https://github.com/MaterializeInc/materialize/issues/15499.
Follow up PR to address the postgres behaviour https://github.com/MaterializeInc/materialize/pull/17935

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
