### PR TITLE
Clippy deny some Differential and Timely APIs

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -16,6 +16,9 @@ disallowed-methods = [
     { path = "rdkafka::config::ClientConfig::new", reason = "use the `client::create_new_client_config` wrapper in `kafka_util` instead" },
 
     { path = "aws_sdk_s3::Client::new", reason = "use the `mz_aws_s3_util::new_client` function instead" },
+
+    { path = "differential_dataflow::Collection::consolidate", reason = "use the `differential_dataflow::Collection::consolidate_named` function instead" },
+    { path = "timely::worker::Worker::drop_dataflow", reason = "Might break logging dataflows, check with #team-compute." },
 ]
 
 disallowed-macros = [

--- a/clippy.toml
+++ b/clippy.toml
@@ -17,7 +17,17 @@ disallowed-methods = [
 
     { path = "aws_sdk_s3::Client::new", reason = "use the `mz_aws_s3_util::new_client` function instead" },
 
+    # Prevent access to Differential APIs that want to use the default trace.
     { path = "differential_dataflow::Collection::consolidate", reason = "use the `differential_dataflow::Collection::consolidate_named` function instead" },
+    { path = "differential_dataflow::operators::arrange::arrangement::Arrange::arrange", reason = "use the `arrange_named` function instead" },
+    { path = "differential_dataflow::operators::arrange::arrangement::ArrangeByKey::arrange_by_key", reason = "use the `Arrange::arrange_named` function instead" },
+    { path = "differential_dataflow::operators::arrange::arrangement::ArrangeByKey::arrange_by_key_named", reason = "use the `Arrange::arrange_named` function instead" },
+    { path = "differential_dataflow::operators::arrange::arrangement::ArrangeBySelf::arrange_by_self", reason = "use the `Arrange::arrange_named` function instead" },
+    { path = "differential_dataflow::operators::arrange::arrangement::ArrangeBySelf::arrange_by_self_named", reason = "use the `Arrange::arrange_named` function instead" },
+    { path = "differential_dataflow::operators::reduce::Count::count_core", reason = "use the `differential_dataflow::operators::reduce::ReduceCore::reduce_abelian` function instead" },
+    { path = "differential_dataflow::operators::reduce::Reduce::reduce_named", reason = "use the `differential_dataflow::operators::reduce::ReduceCore::reduce_abelian` function instead" },
+
+    # Prevent access to Timely APIs with untested semantics.
     { path = "timely::worker::Worker::drop_dataflow", reason = "Might break logging dataflows, check with #team-compute." },
 ]
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -17,15 +17,24 @@ disallowed-methods = [
 
     { path = "aws_sdk_s3::Client::new", reason = "use the `mz_aws_s3_util::new_client` function instead" },
 
-    # Prevent access to Differential APIs that want to use the default trace.
+    # Prevent access to Differential APIs that want to use the default trace or use a default name.
     { path = "differential_dataflow::Collection::consolidate", reason = "use the `differential_dataflow::Collection::consolidate_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::Arrange::arrange", reason = "use the `arrange_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::ArrangeByKey::arrange_by_key", reason = "use the `Arrange::arrange_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::ArrangeByKey::arrange_by_key_named", reason = "use the `Arrange::arrange_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::ArrangeBySelf::arrange_by_self", reason = "use the `Arrange::arrange_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::ArrangeBySelf::arrange_by_self_named", reason = "use the `Arrange::arrange_named` function instead" },
+    { path = "differential_dataflow::operators::reduce::Count::count", reason = "use the `differential_dataflow::operators::reduce::ReduceCore::reduce_abelian` function instead" },
     { path = "differential_dataflow::operators::reduce::Count::count_core", reason = "use the `differential_dataflow::operators::reduce::ReduceCore::reduce_abelian` function instead" },
+    { path = "differential_dataflow::operators::reduce::Reduce::reduce", reason = "use the `differential_dataflow::operators::reduce::ReduceCore::reduce_abelian` function instead" },
     { path = "differential_dataflow::operators::reduce::Reduce::reduce_named", reason = "use the `differential_dataflow::operators::reduce::ReduceCore::reduce_abelian` function instead" },
+    { path = "differential_dataflow::operators::reduce::Threshold::distinct", reason = "use the `differential_dataflow::operators::reduce::ReduceCore::reduce_abelian` function instead" },
+    { path = "differential_dataflow::operators::reduce::Threshold::distinct_core", reason = "use the `differential_dataflow::operators::reduce::ReduceCore::reduce_abelian` function instead" },
+    { path = "differential_dataflow::operators::reduce::Threshold::threshold", reason = "use the `differential_dataflow::operators::reduce::ReduceCore::reduce_abelian` function instead" },
+    { path = "differential_dataflow::operators::reduce::Threshold::threshold_named", reason = "use the `differential_dataflow::operators::reduce::ReduceCore::reduce_abelian` function instead" },
+    { path = "differential_dataflow::operators::reduce::join::Join::antijoin", reason = "use the `differential_dataflow::operators::join::Join::join_core` function instead" },
+    { path = "differential_dataflow::operators::reduce::join::Join::join_map", reason = "use the `differential_dataflow::operators::join::Join::join_core` function instead" },
+    { path = "differential_dataflow::operators::reduce::join::Join::semijoin", reason = "use the `differential_dataflow::operators::join::Join::join_core` function instead" },
 
     # Prevent access to Timely APIs with untested semantics.
     { path = "timely::worker::Worker::drop_dataflow", reason = "Might break logging dataflows, check with #team-compute." },

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -499,7 +499,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
             .timely_worker
             .dataflow_named("Dataflow: logging", |scope| {
                 Collection::<_, DataflowError, Diff>::empty(scope)
-                    .arrange()
+                    .arrange_named("Arrange logging err")
                     .trace
             });
 

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -650,7 +650,7 @@ where
                     &err.arrange_named::<ErrSpine<DataflowError, _, _>>("Arrange recursive err")
                         .reduce_abelian::<_, ErrSpine<_, _, _>>(
                             "Distinct recursive err",
-                            move |k, s, t| t.push(((), 1)),
+                            move |_k, _s, t| t.push(((), 1)),
                         )
                         .as_collection(|k, _| k.clone()),
                 );

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -556,12 +556,12 @@ where
                 let oks = oks
                     .as_collection(|k, v| (k.clone(), v.clone()))
                     .leave()
-                    .arrange();
+                    .arrange_named("Arrange export iterative");
                 oks.stream.probe_notify_with(probes);
                 let errs = errs
                     .as_collection(|k, v| (k.clone(), v.clone()))
                     .leave()
-                    .arrange();
+                    .arrange_named("Arrange export iterative err");
                 compute_state.traces.set(
                     idx_id,
                     TraceBundle::new(oks.trace, errs.trace).with_drop(needed_tokens),

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -156,11 +156,13 @@ where
         G::Timestamp: Lattice + Refines<T>,
         T: Timestamp + Lattice,
     {
-        let err = err_input.arrange_named("Arrange bundle err");
         match self {
             ArrangementOrCollection::Arrangement(arrangement) => CollectionBundle::from_columns(
                 0..key_arity,
-                ArrangementFlavor::Local(arrangement, err),
+                ArrangementFlavor::Local(
+                    arrangement,
+                    err_input.arrange_named("Arrange bundle err"),
+                ),
             ),
             ArrangementOrCollection::Collection(oks) => {
                 CollectionBundle::from_collections(oks, err_input)

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -12,7 +12,7 @@
 //! Consult [ThresholdPlan] documentation for details.
 
 use differential_dataflow::lattice::Lattice;
-use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
+use differential_dataflow::operators::arrange::{Arrange, Arranged, TraceAgent};
 use differential_dataflow::operators::reduce::ReduceCore;
 use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
@@ -71,8 +71,9 @@ where
         }
         ArrangementFlavor::Trace(_, oks, errs) => {
             let oks = threshold_arrangement(&oks, "Threshold trace", |count| *count > 0);
-            use differential_dataflow::operators::arrange::ArrangeBySelf;
-            let errs = errs.as_collection(|k, _| k.clone()).arrange_by_self();
+            let errs = errs
+                .as_collection(|k, _| k.clone())
+                .arrange_named("Arrange threshold basic err");
             CollectionBundle::from_expressions(key, ArrangementFlavor::Local(oks, errs))
         }
     }

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -9,18 +9,17 @@
 
 use std::collections::BTreeMap;
 use std::iter;
-use std::rc::Rc;
 
-use differential_dataflow::{
-    lattice::Lattice,
-    trace::BatchReader,
-    trace::{implementations::ord::OrdValBatch, Cursor},
-};
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::operators::arrange::Arranged;
+use differential_dataflow::trace::{Batch, BatchReader, Cursor, TraceReader};
 use differential_dataflow::{AsCollection, Collection};
 use itertools::{EitherOrBoth, Itertools};
 use maplit::btreemap;
 use once_cell::sync::Lazy;
-use timely::dataflow::{channels::pact::Pipeline, operators::Operator, Scope, Stream};
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::Operator;
+use timely::dataflow::{Scope, Stream};
 
 use mz_ore::cast::CastFrom;
 use mz_repr::{ColumnName, ColumnType, Datum, Diff, GlobalId, Row, RowPacker, ScalarType};
@@ -33,15 +32,18 @@ use crate::avro::DiffPair;
 // This is useful for some sink envelopes (e.g., Debezium and Upsert), which
 // need to do specific logic based on the _entire_ set of before/after diffs for
 // a given key at each timestamp.
-pub fn combine_at_timestamp<G: Scope>(
-    batches: Stream<G, Rc<OrdValBatch<Option<Row>, Row, G::Timestamp, Diff>>>,
+pub fn combine_at_timestamp<G: Scope, Tr>(
+    arranged: Arranged<G, Tr>,
 ) -> Collection<G, (Option<Row>, Vec<DiffPair<Row>>), Diff>
 where
     G::Timestamp: Lattice + Copy,
+    Tr: Clone + TraceReader<Key = Option<Row>, Val = Row, Time = G::Timestamp, R = Diff>,
+    Tr::Batch: Batch,
 {
     let mut rows_buf = vec![];
-    let x: Stream<G, ((Option<Row>, Vec<DiffPair<Row>>), G::Timestamp, Diff)> =
-        batches.unary(Pipeline, "combine_at_timestamp", move |_, _| {
+    let x: Stream<G, ((Option<Row>, Vec<DiffPair<Row>>), G::Timestamp, Diff)> = arranged
+        .stream
+        .unary(Pipeline, "combine_at_timestamp", move |_, _| {
             move |input, output| {
                 while let Some((cap, batches)) = input.next() {
                     let mut session = output.session(&cap);

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -347,6 +347,9 @@ where
                 //
                 // TODO(guswynn): consider using `AllowCompaction` here,
                 // if it works.
+                //
+                // TODO: Do not use `drop_dataflow`
+                #[allow(clippy::disallowed_methods)]
                 worker
                     .timely_worker
                     .drop_dataflow(worker.timely_worker.installed_dataflows()[0]);


### PR DESCRIPTION
Deny the following two functions:
* `differential_dataflow::Collection::consolidate`: Always use `consolidate_named` which allows to specify the arrangement type instead of relying on Differential's default.
* `timely::worker::Worker::drop_dataflow`: It's unclear what interactions it has with logging dataflows, and until we've investigated we should make sure the function is never used.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
