### PR TITLE
adapter: ensure source + subsources created sequentially

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -621,7 +621,22 @@ impl Coordinator {
             GlobalId,
             Vec<(catalog::CatalogEntry, Vec<GlobalId>)>,
         > = BTreeMap::new();
+
         let mut loaded_items = BTreeSet::new();
+
+        // Subsources must be created immediately before their primary source
+        // without any intermediary collections between them. This version of MZ
+        // needs this because it sets tighter bounds on collections' sinces.
+        // Without this, dependent collections can place read holds on the
+        // subsource, which can result in panics if we adjust the subsource's
+        // since.
+        //
+        // This can likely be removed in the next version of Materialize
+        // (v0.46).
+        let mut entries_awaiting_dependent: BTreeMap<GlobalId, Vec<catalog::CatalogEntry>> =
+            BTreeMap::new();
+        let mut awaited_dependent_seen = BTreeSet::new();
+
         let mut unsorted_entries: VecDeque<_> = self
             .catalog
             .entries()
@@ -634,7 +649,16 @@ impl Coordinator {
         let mut entries = Vec::with_capacity(unsorted_entries.len());
 
         while let Some((entry, mut remaining_deps)) = unsorted_entries.pop_front() {
-            remaining_deps.retain(|dep| !loaded_items.contains(dep));
+            let awaiting_this_dep = entries_awaiting_dependent.get(&entry.id());
+            remaining_deps.retain(|dep| {
+                // Consider dependency filled if item is loaded or if this
+                // dependency is waiting on this entry.
+                !loaded_items.contains(dep)
+                    && awaiting_this_dep
+                        .map(|awaiting| awaiting.iter().all(|e| e.id() != *dep))
+                        .unwrap_or(true)
+            });
+
             // While you cannot assume anything about the ordering of
             // dependencies based on their GlobalId, it is not secret knowledge
             // that the most likely final dependency is that with the greatest
@@ -648,14 +672,59 @@ impl Coordinator {
                 }
                 None => {
                     let id = entry.id();
+
                     if let Some(waiting_on_this_dep) = entries_awaiting_dependencies.remove(&id) {
                         unsorted_entries.extend(waiting_on_this_dep);
                     }
+
+                    if let Some(waiting_on_this_dependent) = entries_awaiting_dependent.remove(&id)
+                    {
+                        mz_ore::soft_assert! {{
+                            let mut subsources =  entry.subsources();
+                            subsources.sort();
+                            let mut w: Vec<_> = waiting_on_this_dependent.iter().map(|e| e.id()).collect();
+                            w.sort();
+
+                            subsources == w
+                        }, "expect that items are exactly source's subsources"}
+
+                        // Re-enqueue objects and continue.
+                        for entry in
+                            std::iter::once(entry).chain(waiting_on_this_dependent.into_iter())
+                        {
+                            awaited_dependent_seen.insert(entry.id());
+                            unsorted_entries.push_front((entry, vec![]));
+                        }
+                        continue;
+                    }
+
+                    // Subsources wait on their primary source before being
+                    // added.
+                    if entry.is_subsource() && !awaited_dependent_seen.contains(&id) {
+                        let min = entry
+                            .used_by()
+                            .into_iter()
+                            .min()
+                            .expect("subsource always used");
+
+                        entries_awaiting_dependent
+                            .entry(*min)
+                            .or_default()
+                            .push(entry);
+                        continue;
+                    }
+
+                    awaited_dependent_seen.remove(&id);
                     loaded_items.insert(id);
                     entries.push(entry);
                 }
             }
         }
+
+        assert!(
+            entries_awaiting_dependent.is_empty() && entries_awaiting_dependencies.is_empty(),
+            "items not cleared from queue {entries_awaiting_dependent:?}, {entries_awaiting_dependencies:?}"
+        );
 
         let logs: BTreeSet<_> = BUILTINS::logs()
             .map(|log| self.catalog.resolve_builtin_log(log))


### PR DESCRIPTION
As discussed in #17879 and [Slack](https://materializeinc.slack.com/archives/C01CFKM1QRF/p1677774534356669), we introduced a panic-causing issue with installing dependencies/read holds between sources+source exports and their progress collections in 170bff9e1dc563c555894f1a1f6abb1efadd9cdc.

We can resolve this issue by ensuring that all subsources and their primary sources are created in sequence. This prevents any other collections from taking a read hold on the collection, which was the source of the issue. There is a more elegant way of doing this, but I've run out of steam for the night.

### Motivation

Fixes #17879 

### Tips for reviewer

Just substantiating the fix; think the code could be much improved.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
