### PR TITLE
adapter: make sure that subsources are created right before their main source

### DIFF
--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -25,7 +25,6 @@ from materialize.checks.drop_table import *  # noqa: F401 F403
 from materialize.checks.error import *  # noqa: F401 F403
 from materialize.checks.float_types import *  # noqa: F401 F403
 from materialize.checks.having import *  # noqa: F401 F403
-from materialize.checks.identifiers import *  # noqa: F401 F403
 from materialize.checks.insert_select import *  # noqa: F401 F403
 from materialize.checks.join_implementations import *  # noqa: F401 F403
 from materialize.checks.join_types import *  # noqa: F401 F403
@@ -45,7 +44,6 @@ from materialize.checks.rename_source import *  # noqa: F401 F403
 from materialize.checks.rename_table import *  # noqa: F401 F403
 from materialize.checks.rename_view import *  # noqa: F401 F403
 from materialize.checks.replica import *  # noqa: F401 F403
-from materialize.checks.roles import *  # noqa: F401 F403
 from materialize.checks.rollback import *  # noqa: F401 F403
 from materialize.checks.sink import *  # noqa: F401 F403
 from materialize.checks.source_errors import *  # noqa: F401 F403

--- a/src/storage-client/src/controller/remap_migration.rs
+++ b/src/storage-client/src/controller/remap_migration.rs
@@ -18,6 +18,7 @@ use mz_ore::now::EpochMillis;
 use mz_persist_types::Codec64;
 use mz_proto::RustType;
 use mz_repr::{GlobalId, TimestampManipulation};
+use tracing::info;
 
 use crate::client::{StorageCommand, StorageResponse};
 use crate::controller::{ProtoStorageCommand, ProtoStorageResponse};
@@ -58,6 +59,8 @@ where
         durable_metadata: &BTreeMap<GlobalId, DurableCollectionMetadata>,
         collections: &[(GlobalId, CollectionDescription<T>)],
     ) -> BTreeMap<GlobalId, DurableCollectionMetadata> {
+        info!("applying remap shard migration");
+
         let mut state_to_update = BTreeMap::new();
 
         let mut progress_collections_pending = BTreeSet::new();


### PR DESCRIPTION
A _slightly_ more readable version (IMO, of course) of #17928.

NOTE: This has the additional asserts that I added for diagnosing. Those have to be cleaned up removed, before merging. Same for the last two commits. I was a in a bit of a hurry and have to leave now. :sweat_smile: 