### PR TITLE
adapter: Add a bit of tracing to cover gaps

### DIFF
--- a/misc/opentelemetry/README.md
+++ b/misc/opentelemetry/README.md
@@ -1,19 +1,62 @@
 # OpenTelemetry development environment
 
-An [mzcompose] composition for working with OpenTelemetry traces locally.
-Primarily adapted from the [basic-otlp-http example][otel-example] in the
-opentelemetry-rust repository.
+[OpenTelemetry] is a framework for collecting telemetry data (metrics, logs, traces,
+etc) from a program for analysis and alerting. Within our Rust code we use the 
+[`tracing`] crate to report metrics, and then [Jaeger] to collect and visualize them.
+
+> OpenTelemetry support is still in active development and bugs are to be expected. If 
+> you run into any issues please report them!
+
+To enable tracing when running `environmentd` you need to provide two arguments, an 
+OpenTelemetry compatible endpoint to report the traces, and a filter to specify what 
+"level" of traces you want reported. You can specify these via environment variables, or 
+command line arguments. Run `bin/environmentd -- --help` to see all the options.
+
+For local development the following options should suffice:
+```
+MZ_OPENTELEMETRY_ENDPOINT=http://localhost:4317
+MZ_OPENTELEMETRY_FILTER=debug
+```
+
+Then using [mzcompose] you can start a local instance of [Jaeger] to work with
+OpenTelemetry traces.
+
+> This composition was primarily adapted from the [basic-otlp-http example]
+> in the `opentelemetry-rust` repository.
 
 ### Usage
 
+
+#### starting Jaeger
 ```
 $ ./mzcompose up -d
-$ bin/environmentd <--reset> -- --opentelemetry-endpoint="http://localhost:4317"
+```
+
+#### start `environmentd`
+> Note: you can omit the `--opentelemetry-*` args if you set env variables
+```
+$ bin/environmentd --reset -- \
+$    --opentelemetry-endpoint="http://localhost:4317" \
+$    --opentelemtry-filter="debug"
 ```
 
 Use `./mzcompose web jaeger` to open your web browser to the Jaeger
 interface, where you can browse the traces. Alternatively, navigate
 directly to <http://localhost:16686> in your browser.
 
+### `psql`
+After connecting to Materialize, but before running any queries, you should set the following variable:
+
+```
+set emit_trace_id_notice=true;
+```
+
+After each query a `trace_id` will be emitted, which you can search for in 
+[Jaeger] and see _exactly_ what work `environmentd` did.
+
+
+[OpenTelemetry]: https://opentelemetry.io/
+[`tracing`]: https://docs.rs/tracing/latest/tracing/
+[Jaeger]: https://www.jaegertracing.io/
 [mzcompose]: ../../doc/developer/mzcompose.md
-[otel-example]: https://github.com/open-telemetry/opentelemetry-rust/tree/a767fd3a7f08f4d7312a1c0dbb5ac0580a108eb3/examples/basic-otlp-http
+[basic-otlp-http example]: https://github.com/open-telemetry/opentelemetry-rust/tree/a767fd3a7f08f4d7312a1c0dbb5ac0580a108eb3/examples/basic-otlp-http

--- a/misc/opentelemetry/README.md
+++ b/misc/opentelemetry/README.md
@@ -1,15 +1,15 @@
 # OpenTelemetry development environment
 
 [OpenTelemetry] is a framework for collecting telemetry data (metrics, logs, traces,
-etc) from a program for analysis and alerting. Within our Rust code we use the 
+etc) from a program for analysis and alerting. Within our Rust code we use the
 [`tracing`] crate to report metrics, and then [Jaeger] to collect and visualize them.
 
-> OpenTelemetry support is still in active development and bugs are to be expected. If 
+> OpenTelemetry support is still in active development and bugs are to be expected. If
 > you run into any issues please report them!
 
-To enable tracing when running `environmentd` you need to provide two arguments, an 
-OpenTelemetry compatible endpoint to report the traces, and a filter to specify what 
-"level" of traces you want reported. You can specify these via environment variables, or 
+To enable tracing when running `environmentd` you need to provide two arguments, an
+OpenTelemetry compatible endpoint to report the traces, and a filter to specify what
+"level" of traces you want reported. You can specify these via environment variables, or
 command line arguments. Run `bin/environmentd -- --help` to see all the options.
 
 For local development the following options should suffice:
@@ -51,7 +51,7 @@ After connecting to Materialize, but before running any queries, you should set 
 set emit_trace_id_notice=true;
 ```
 
-After each query a `trace_id` will be emitted, which you can search for in 
+After each query a `trace_id` will be emitted, which you can search for in
 [Jaeger] and see _exactly_ what work `environmentd` did.
 
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4255,7 +4255,6 @@ impl Catalog {
         })
     }
 
-
     #[tracing::instrument(name = "catalog::transact_inner", level = "debug", skip_all)]
     fn transact_inner(
         oracle_write_ts: mz_repr::Timestamp,

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4255,6 +4255,8 @@ impl Catalog {
         })
     }
 
+
+    #[tracing::instrument(name = "catalog::transact_inner", level = "debug", skip_all)]
     fn transact_inner(
         oracle_write_ts: mz_repr::Timestamp,
         session: Option<&Session>,

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -1043,7 +1043,7 @@ where
         .map(|v| v.ts))
 }
 
-#[tracing::instrument(name = "storage::transaction", level = "trace", skip_all)]
+#[tracing::instrument(name = "storage::transaction", level = "debug", skip_all)]
 pub async fn transaction<'a>(stash: &'a mut Stash) -> Result<Transaction<'a>, Error> {
     let (
         databases,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -480,6 +480,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn sequence_create_source(
         &mut self,
         session: &mut Session,
@@ -648,6 +649,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sequence_create_connection(
         &mut self,
         session: &mut Session,
@@ -732,6 +734,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sequence_create_database(
         &mut self,
         session: &mut Session,
@@ -757,6 +760,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sequence_create_schema(
         &mut self,
         session: &mut Session,
@@ -783,6 +787,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn sequence_create_role(
         &mut self,
         session: &Session,
@@ -819,6 +824,7 @@ impl Coordinator {
         first_argmin.clone()
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sequence_create_cluster(
         &mut self,
         session: &Session,
@@ -979,6 +985,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sequence_create_cluster_replica(
         &mut self,
         session: &Session,
@@ -1238,6 +1245,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sequence_create_secret(
         &mut self,
         session: &mut Session,
@@ -1290,6 +1298,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self, tx))]
     async fn sequence_create_sink(
         &mut self,
         mut session: Session,
@@ -1462,6 +1471,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sequence_create_view(
         &mut self,
         session: &mut Session,
@@ -1536,6 +1546,7 @@ impl Coordinator {
         Ok(ops)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sequence_create_materialized_view(
         &mut self,
         session: &mut Session,
@@ -1674,6 +1685,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sequence_create_index(
         &mut self,
         session: &mut Session,
@@ -1745,6 +1757,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sequence_create_type(
         &mut self,
         session: &Session,

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -384,6 +384,7 @@ impl Coordinator {
     /// Assign a timestamp for a write to a local input and increase the local ts.
     /// Writes following reads must ensure that they are assigned a strictly larger
     /// timestamp to ensure they are not visible to any real-time earlier reads.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn get_local_write_ts(&mut self) -> WriteTimestamp {
         self.global_timelines
             .get_mut(&Timeline::EpochMilliseconds)


### PR DESCRIPTION
### Motivation
This PR fixes #17611, by tracing a few more functions so there are no visible gaps in the trace waterfall

Note: there are two primary changes I made to reduce the gaps seen in the trace waterfall
1. Originally the traces were being filtered to just the `stash` and the `adapter` crates (i.e. `MZ_OPENTELEMETRY_FILTER=mz_stash=debug,mz_adapter=debug,info`). Stepping through the waterfall and code I realized some of the gaps existed because we'd call into the `storage` crate, whose traces we were filtering out. Changing the trace filter to just be `MZ_OPENTELEMETRY_FILTER=debug` helped fill some of those gaps. 
2. After enabling additional tracing from other crates, there were still a few gaps in the waterfall, for gaps that I could find I filled them by annotating functions with the `#[tracing::instrument]` proc macro

### Tips for reviewers
* To view the updated documentation in it's markdown format, you can use the ["Display rich diff"](https://github.com/community/community/discussions/16289) option on the "Files changed" tab

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
