### PR TITLE
Binary variadic introduces null

### DIFF
--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -21,6 +21,11 @@ CREATE TABLE str_table (col_null STRING, col_not_null STRING NOT NULL);
 statement ok
 CREATE TABLE ts_table (col_null TIMESTAMP, col_not_null TIMESTAMP NOT NULL);
 
+statement ok
+CREATE TABLE json_table (col_null JSONB, col_not_null JSONB NOT NULL);
+
+statement ok
+INSERT INTO json_table VALUES(null, '{}');
 
 #
 # Constants are NOT NULL
@@ -302,11 +307,38 @@ query T multiline
 EXPLAIN WITH(types, no_fast_path) SELECT col_not_null LIKE col_not_null, col_null LIKE col_not_null, col_not_null LIKE col_null FROM str_table;
 ----
 Explained Query:
-  Project (#2..=#4) // { types: "(boolean?, boolean?, boolean?)" }
-    Map ((#1 like #1), (#0 like #1), (#1 like #0)) // { types: "(text?, text, boolean?, boolean?, boolean?)" }
+  Project (#2..=#4) // { types: "(boolean, boolean?, boolean?)" }
+    Map ((#1 like #1), (#0 like #1), (#1 like #0)) // { types: "(text?, text, boolean, boolean?, boolean?)" }
       Get materialize.public.str_table // { types: "(text?, text)" }
 
 EOF
+
+# VARIADIC FUNCTIONS
+
+query T multiline
+EXPLAIN WITH(types, no_fast_path) SELECT col_not_null || col_not_null, substr(col_not_null, 3, 2), regexp_match(col_not_null, col_not_null), lpad(col_not_null, 3, col_not_null) FROM str_table;
+----
+Explained Query:
+  Project (#2..=#5) // { types: "(text, text, text[]?, text)" }
+    Map ((#1 || #1), substr(#1, 3, 2), regexp_match(#1, #1), lpad(#1, 3, #1)) // { types: "(text?, text, text, text, text[]?, text)" }
+      Get materialize.public.str_table // { types: "(text?, text)" }
+
+EOF
+
+# VARIADIC FUNCTIONS that introduce nulls
+
+query BBBBBBB
+SELECT COALESCE(NULLIF('a', 'a')) IS NULL, GREATEST(NULLIF('a', 'a')) IS NULL, LEAST(NULLIF('a', 'a')) IS NULL, MAKE_TIMESTAMP(2023, 1, 1, 0, 0, 11111) IS NULL, (ARRAY[1, 2])[3] IS NULL, (LIST[1, 2])[3] IS NULL, REGEXP_MATCH('a', 'b')  IS NULL;
+----
+true  true  true  true  true  true  true
+
+# BINARY FUNCTIONS that introduce nulls
+# MapGetValue and ListLengthMax not covered
+
+query BBBBBBBBB
+SELECT (col_not_null -> 'x')::int IS NULL, (col_not_null -> 'y')::text IS NULL, col_not_null #> '{z}' IS NULL, ('1'::JSONB) || ('2'::JSONB) IS NULL, ('1'::jsonb) - 1 IS NULL, ('1'::jsonb) - 'x' IS NULL, ARRAY_LENGTH(ARRAY[]::INT[], 1) IS NULL, ARRAY_LOWER(ARRAY[]::INT[], 1) IS NULL, ARRAY_UPPER(ARRAY[]::INT[], 1) IS NULL FROM json_table;
+----
+true  true  true  true  true  true  true  true  true
 
 #
 # REGEXP returns NULL on no match, so can not be NOT NULL

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -773,6 +773,12 @@ SELECT jsonb_build_object(jsonb_object_keys('{"a":2, "b":3}'), 1, 'c', 3), jsonb
 {"b":1,"c":3}  NULL
 {"a":1,"c":3}  {"a":1,"c":3}
 
+query TT
+SELECT jsonb_build_array(jsonb_object_keys('{"a":2, "b":3}')), jsonb_build_array(jsonb_object_keys('{"a":2}'));
+----
+["b"]  [null]
+["a"]  ["a"]
+
 query error table functions are not allowed in other table functions
 SELECT jsonb_array_elements(jsonb_array_elements('[[1,2],[3,4]]')), jsonb_array_elements(jsonb_array_elements('[[1],[3,4,5]]')) ORDER BY 1
 


### PR DESCRIPTION
### Motivation

This PR addresses #13929, making the `introduces_nulls` predicates explicit and complete for `BinaryFunc` and `VariadicFunc`.

I couldn't get tests to run locally (ancient laptop), so letting CI do its thing.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
