### PR TITLE
run.py: Optionally codesign binaries on macOS to support Instruments

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -40,6 +40,7 @@ MACOS_ENTITLEMENTS_DATA = """
 </plist>
 """
 
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         prog="run",
@@ -268,20 +269,22 @@ def _build(args: argparse.Namespace, extra_programs: list[str] = []) -> int:
     completed_proc = spawn.runv(command, env=env)
     return completed_proc.returncode
 
-def _macos_codesign(path: str):
+
+def _macos_codesign(path: str) -> None:
     env = dict(os.environ)
     command = ["codesign"]
     command.extend(["-s", "-", "-f", "--entitlements"])
 
     # write our entitlements file to a temp path
     temp = tempfile.NamedTemporaryFile()
-    temp.write(bytes(MACOS_ENTITLEMENTS_DATA, 'utf-8'))
+    temp.write(bytes(MACOS_ENTITLEMENTS_DATA, "utf-8"))
     temp.flush()
 
     command.append(temp.name)
     command.append(path)
 
     spawn.runv(command, env=env)
+
 
 def _cargo_command(args: argparse.Namespace, subcommand: str) -> list[str]:
     command = ["cargo"]

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -110,8 +110,8 @@ def main() -> int:
         action="store_true",
     )
     parser.add_argument(
-        "--mac-instruments",
-        help="Enables support for profiling with Instruments on macOS",
+        "--disable-mac-codesigning",
+        help="Disables the limited codesigning we do on macOS to support Instruments",
         action="store_true",
     )
     args = parser.parse_intermixed_args()
@@ -132,11 +132,13 @@ def main() -> int:
         else:
             path = ROOT / "target" / "debug" / args.program
 
-        if args.mac_instruments:
+        if args.disable_mac_codesigning:
             if sys.platform != "darwin":
-                print("Ignoring --mac-instruments since we're not on macOS")
+                print("Ignoring --disable-mac-codesigning since we're not on macOS")
             else:
-                _macos_codesign(path)
+                print("Disabled macOS Codesigning")
+        elif sys.platform == "darwin":
+            _macos_codesign(path)
 
         command = [str(path)]
         if args.tokio_console:


### PR DESCRIPTION
### Motivation
When working on #17497 I needed to profile `environmentd` to see where we were allocating memory. On macOS the tool to do this is [Instruments](https://en.wikipedia.org/wiki/Instruments_(software)), which is actually pretty powerful. Unfortunately newer Macs that use Apple Silicon [require binaries to be signed](https://eclecticlight.co/2020/08/22/apple-silicon-macs-will-require-signed-code/) with a [`com.apple.security.get-task-allow`](https://developer.apple.com/forums/thread/681687) key in order to use Instruments.

### Solution
This PR updates `run.py` and adds a `--mac-instruments` flag, which after building the `environmentd` binary, optionally signs it with the necessary entitlements, so we can profile it with Instruments

### Tips for reviewer
I added `tempfile` as a dependency to `run.py`, I see it's already used in our codebase, not sure if adding the dep to `run.py` would break anything though. The codesign-ing also shells out to use `codesign`, which should be available on all Macs, and we already shell out to `cargo`, so I figured this would be okay, but let me know if it's not!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
