### PR TITLE
stash: configure connect timeout

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2402,6 +2402,14 @@ impl Catalog {
             )
             .await?;
 
+        // Now that LD is loaded, set the intended stash timeout.
+        // TODO: Move this into the stash constructor.
+        catalog
+            .storage()
+            .await
+            .set_connect_timeout(catalog.system_config().crdb_connect_timeout())
+            .await;
+
         catalog.load_builtin_types().await?;
 
         let persisted_builtin_ids = catalog.storage().await.load_system_gids().await?;

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -596,6 +596,10 @@ impl Connection {
         Ok(conn)
     }
 
+    pub async fn set_connect_timeout(&mut self, connect_timeout: Duration) {
+        self.stash.set_connect_timeout(connect_timeout).await;
+    }
+
     /// Returns the timestamp at which the storage layer booted.
     ///
     /// This is the timestamp that will have been used to write any data during


### PR DESCRIPTION
The place this setting is stored (LaunchDarkly) requires the stash to exist first, so the stash can't use the LD value. We should probably refactor things in the future.

See #17852 for motivation
Closes #17859

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a