### PR TITLE
Fix the cloudtest upgrade CI job

### DIFF
--- a/misc/python/materialize/checks/identifiers.py
+++ b/misc/python/materialize/checks/identifiers.py
@@ -273,9 +273,9 @@ pg_catalog
 {dq_print(ident["schema"])}
 
 > SHOW SINKS FROM {dq(ident["schema"])};
-{dq_print(ident["sink0"])} kafka 4
-{dq_print(ident["sink1"])} kafka 4
-{dq_print(ident["sink2"])} kafka 4
+{dq_print(ident["sink0"])} kafka ${{arg.default-storage-size}}
+{dq_print(ident["sink1"])} kafka ${{arg.default-storage-size}}
+{dq_print(ident["sink2"])} kafka ${{arg.default-storage-size}}
 
 > SELECT * FROM {dq(ident["schema"])}.{dq(ident["mv0"])};
 3

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -54,11 +54,11 @@ class LiftClusterLimits(Action):
                 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 
                 $ postgres-execute connection=mz_system
-                ALTER SYSTEM SET max_tables = 100;
+                ALTER SYSTEM SET max_tables = 1000;
 
-                ALTER SYSTEM SET max_sources = 100;
+                ALTER SYSTEM SET max_sources = 1000;
 
-                ALTER SYSTEM SET max_materialized_views = 100;
+                ALTER SYSTEM SET max_materialized_views = 1000;
                 ALTER SYSTEM SET max_objects_per_schema = 1000;
                 """
             )

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -21,6 +21,9 @@ from materialize.checks.scenarios import Scenario
 from materialize.cloudtest.application import MaterializeApplication
 from materialize.cloudtest.k8s.environmentd import EnvironmentdStatefulSet
 from materialize.cloudtest.wait import wait
+from materialize.util import MzVersion
+
+LAST_RELEASED_VERSION = str(util.released_materialize_versions()[0])
 
 
 class ReplaceEnvironmentdStatefulSet(Action):
@@ -65,6 +68,9 @@ class LiftClusterLimits(Action):
 class CloudtestUpgrade(Scenario):
     """A Platform Checks scenario that performs an upgrade in cloudtest/K8s"""
 
+    def base_version(self) -> MzVersion:
+        return MzVersion.parse_mz(LAST_RELEASED_VERSION)
+
     def actions(self) -> List[Action]:
         return [
             LiftClusterLimits(),
@@ -79,9 +85,8 @@ class CloudtestUpgrade(Scenario):
 @pytest.mark.long
 def test_upgrade(aws_region: Optional[str]) -> None:
     """Test upgrade from the last released verison to the current source by running all the Platform Checks"""
-    last_released_version = str(util.released_materialize_versions()[0])
 
-    mz = MaterializeApplication(tag=last_released_version, aws_region=aws_region)
+    mz = MaterializeApplication(tag=LAST_RELEASED_VERSION, aws_region=aws_region)
     wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
 
     executor = CloudtestExecutor(application=mz)

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -35,7 +35,16 @@ SERVICES = [
         name="clusterd_compute_1"
     ),  # Started by some Scenarios, defined here only for the teardown
     Materialized(external_cockroach=True),
-    TestdriveService(default_timeout="300s", no_reset=True, seed=1),
+    TestdriveService(
+        default_timeout="300s",
+        no_reset=True,
+        seed=1,
+        entrypoint_extra=[
+            f"--var=replicas=1",
+            f"--var=default-replica-size={Materialized.Size.DEFAULT_SIZE}-{Materialized.Size.DEFAULT_SIZE}",
+            f"--var=default-storage-size={Materialized.Size.DEFAULT_SIZE}",
+        ],
+    ),
 ]
 
 


### PR DESCRIPTION
The cloudtest upgrade job was failing because it is leveraging platform checks, which was refactored recently.

### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI was failing.

### Tips for reviewer

See individual commit messages.