### PR TITLE
Doc/user: code color styles

### DIFF
--- a/doc/user/assets/sass/_base.scss
+++ b/doc/user/assets/sass/_base.scss
@@ -85,7 +85,8 @@ body.dark {
     --link: #9e7cf7;
 
     --code-block: var(--card-light);
-    --code-simple: #d4d4d4;
+    --code-simple: #c2c2c2;
+    --code-simple-bg: #292929;
     --code-red: #fc6e6c;
     --code-pink: #f97fe6;
     --code-blue: #4b73f8;
@@ -115,6 +116,7 @@ body.light {
 
     --code-block: var(--code-block-light);
     --code-simple: #505050;
+    --code-simple-bg: var(--code-block-light);
     --code-red: #c41a16;
     --code-pink: #a90d91;
     --code-blue: #1c01ce;

--- a/doc/user/assets/sass/_base.scss
+++ b/doc/user/assets/sass/_base.scss
@@ -85,7 +85,7 @@ body.dark {
     --link: #9e7cf7;
 
     --code-block: var(--card-light);
-    --code-simple: #ededed;
+    --code-simple: #d4d4d4;
     --code-red: #fc6e6c;
     --code-pink: #f97fe6;
     --code-blue: #4b73f8;
@@ -114,7 +114,7 @@ body.light {
     --link: var(--purple);
 
     --code-block: var(--code-block-light);
-    --code-simple: #000000;
+    --code-simple: #505050;
     --code-red: #c41a16;
     --code-pink: #a90d91;
     --code-blue: #1c01ce;
@@ -174,48 +174,63 @@ input[type="submit"] {
     font-family: inherit;
 }
 
-// a {
-//     color: var(--sub);
-
-//     &:not(.link-with-code) {
-//         text-decoration: none;
-//     }
-
-//     &:hover,
-//     &:focus {
-//         text-decoration: underline;
-
-//         &,
-//         code {
-//             color: var(--important);
-//         }
-//     }
-// }
-
-a {
-    &:not(.link-with-code) {
-        &:not(.btn) {
-            &:hover,
-            &:focus {
-                text-decoration: underline;
-                color: var(--link);
-            }
-        }
-        .btn {
-            color: var(--white);
-            text-decoration: none;
-        }
-    }
-
-    color: var(--sub);
+/**
+    The following section handles these cases:
+    1. Buttons with links
+    2. Links
+    3. Links with <code/>
+    4. Link in the index (<nav/>) with <code/>
+    5. Links inside notes
+    6. Links inside notes iwth <code/>
+**/
+.btn,
+.btn-ghost {
+    color: var(--white);
     text-decoration: none;
 
     &:hover,
     &:focus {
         text-decoration: underline;
-        color: var(--link);
+        color: var(--white);
     }
 }
+
+nav {
+    .link-with-code {
+        color: var(--sub);
+
+        &:hover,
+        &:focus {
+            text-decoration: underline;
+            color: var(--link);
+        }
+    }
+}
+
+p > a,
+.note > a,
+.link-with-code {
+    color: var(--link);
+
+    &:hover,
+    &:focus {
+        text-decoration: underline;
+        color: var(--sub);
+    }
+}
+
+a {
+    &:hover,
+    &:focus {
+        text-decoration: underline;
+        color: var(--link);
+    }
+
+    color: var(--sub);
+    text-decoration: none;
+}
+
+/*-------- Finish links color--------*/
 
 [class*="btn"] {
     display: inline-flex;

--- a/doc/user/assets/sass/_base.scss
+++ b/doc/user/assets/sass/_base.scss
@@ -85,6 +85,7 @@ body.dark {
     --link: #9e7cf7;
 
     --code-block: var(--card-light);
+    --code-simple: #ededed;
     --code-red: #fc6e6c;
     --code-pink: #f97fe6;
     --code-blue: #4b73f8;
@@ -96,7 +97,9 @@ body.dark {
     --highlight: #e0a5fb;
 
     --shadow-default: 0 0.625rem 1.5rem 0 rgba(0, 0, 0, 0.4);
-    --note: #fffad4;
+    --note: #fffad411;
+    --note-border: #b9a61545;
+    --note-gutter: #ffe600;
 }
 
 body.light {
@@ -111,6 +114,7 @@ body.light {
     --link: var(--purple);
 
     --code-block: var(--code-block-light);
+    --code-simple: #000000;
     --code-red: #c41a16;
     --code-pink: #a90d91;
     --code-blue: #1c01ce;
@@ -121,7 +125,9 @@ body.light {
     --body: var(--black-light);
     --highlight: var(--purple-dark);
 
-    --note: #fffad4;
+    --note: #fffad451;
+    --note-border: #b9a61545;
+    --note-gutter: #7b7b29;
 }
 
 *,
@@ -168,21 +174,46 @@ input[type="submit"] {
     font-family: inherit;
 }
 
-a {
-    color: var(--sub);
+// a {
+//     color: var(--sub);
 
+//     &:not(.link-with-code) {
+//         text-decoration: none;
+//     }
+
+//     &:hover,
+//     &:focus {
+//         text-decoration: underline;
+
+//         &,
+//         code {
+//             color: var(--important);
+//         }
+//     }
+// }
+
+a {
     &:not(.link-with-code) {
-        text-decoration: none;
+        &:not(.btn) {
+            &:hover,
+            &:focus {
+                text-decoration: underline;
+                color: var(--link);
+            }
+        }
+        .btn {
+            color: var(--white);
+            text-decoration: none;
+        }
     }
+
+    color: var(--sub);
+    text-decoration: none;
 
     &:hover,
     &:focus {
         text-decoration: underline;
-
-        &,
-        code {
-            color: var(--important);
-        }
+        color: var(--link);
     }
 }
 

--- a/doc/user/assets/sass/_base.scss
+++ b/doc/user/assets/sass/_base.scss
@@ -183,7 +183,7 @@ input[type="submit"] {
     3. Links with <code/>
     4. Link in the index (<nav/>) with <code/>
     5. Links inside notes
-    6. Links inside notes iwth <code/>
+    6. Links inside notes with <code/>
 **/
 .btn,
 .btn-ghost {

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -74,10 +74,14 @@ p+p {
         }
     }
 
+    a > code {
+        color: inherit;
+    }
+
     code {
         font-size: inherit;
-        color: inherit;
-        background: none;
+        color: var(--code-simple);
+        background: var(--card-light);
         border: none;
     }
 
@@ -388,6 +392,8 @@ p+p {
         box-sizing: border-box;
         border-radius: 2px;
         padding: 0.1rem 0.25rem 0rem;
+        color: var(--code-simple);
+        background: var(--card-light);
     }
 
     // Merge a highlighted code block followed by a non-highlighted code block,

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -379,17 +379,15 @@ p+p {
     }
 
     code {
-        color: var(--code-pink);
         font-family: "Fira Code", Courier, monospace;
         font-variant-ligatures: none;
         font-size: 1.3rem;
         font-weight: 500;
-        background: var(--card);
+        background: var(--code-block);
         border: 1px solid var(--divider-light);
         box-sizing: border-box;
         border-radius: 2px;
         padding: 0.1rem 0.25rem 0rem;
-        transition: all 0.2s 50ms;
     }
 
     // Merge a highlighted code block followed by a non-highlighted code block,
@@ -491,26 +489,29 @@ p+p {
 
     .note {
         background: var(--note);
-        color: var(--black);
-        border: 1px solid #d9d6c1;
+        border: 1px solid var(--note-border);
 
         a {
-            color: #4f0cff;
-
             &:hover,
             &:focus {
-                color: var(--black) !important;
-                border-bottom-color: var(--black) !important;
+                color: var(--sub) !important;
+            }
+
+            code {
+                &:hover,
+                &:focus {
+                    color: var(--sub) !important;
+                }
             }
         }
 
         &::after {
-            border-color: var(--bg) var(--bg) #d9d6c1 #d9d6c1;
-            background: #d9d6c1;
+            border-color: var(--bg) var(--bg) #fbe2d9 #fbe2d9;
+            background: #fbe2d9;
         }
 
         .gutter {
-            color: #5f5602;
+            color: var(--note-gutter);
         }
     }
 
@@ -977,11 +978,12 @@ body.dark .content {
 
     .note {
         a {
-            color: #4f0cff;
+            color: var(--link);
         }
 
         &::after {
-            border-color: var(--bg) var(--bg) var(--gray-mid) var(--note);
+            border-color: --var(--note-border);
+            // border-color: var(--bg) var(--bg) var(--gray-mid) var(--note);
             background: var(--note);
         }
     }
@@ -1003,16 +1005,6 @@ body.dark .content {
 
     pre code {
         color: var(--sub);
-    }
-
-    a {
-
-        &:hover,
-        &:focus {
-            code {
-                color: var(--important);
-            }
-        }
     }
 }
 

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -989,7 +989,6 @@ body.dark .content {
 
         &::after {
             border-color: --var(--note-border);
-            // border-color: var(--bg) var(--bg) var(--gray-mid) var(--note);
             background: var(--note);
         }
     }

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -81,7 +81,7 @@ p+p {
     code {
         font-size: inherit;
         color: var(--code-simple);
-        background: var(--card-light);
+        background: var(--code-simple-bg);
         border: none;
     }
 
@@ -393,7 +393,7 @@ p+p {
         border-radius: 2px;
         padding: 0.1rem 0.25rem 0rem;
         color: var(--code-simple);
-        background: var(--card-light);
+        background: var(--code-simple-bg);
     }
 
     // Merge a highlighted code block followed by a non-highlighted code block,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Improve legibility by:
- Turning the `<code/>` font color similar to normal text but keeping the color when it is a link.
- Removing underlining in `<code/>` with links when there is no hover or active, like normal links.
- Setting the same underline color as the text
- Change `{{ note }}` background to match `{{ warning }}` and `{{ beta }}`

[Link](https://preview.materialize.com/materialize/17954/)

### Before --> After:

### Home
<img width="1227" alt="Screenshot 2023-03-06 at 13 15 57" src="https://user-images.githubusercontent.com/11491779/223107870-f01c692a-6182-4631-89b7-3ee8aaf9e1c3.png">
<img width="1185" alt="Screenshot 2023-03-06 at 13 22 54" src="https://user-images.githubusercontent.com/11491779/223109330-7377f141-f8aa-4710-862a-633784591c4c.png">

### Sources
<img width="1449" alt="Screenshot 2023-03-06 at 13 17 09" src="https://user-images.githubusercontent.com/11491779/223108087-54ce98d9-8ad0-46ea-8b92-bf029322486c.png">
<img width="1444" alt="Screenshot 2023-03-06 at 13 21 59" src="https://user-images.githubusercontent.com/11491779/223109127-e81bd7c1-0d91-4f26-86b5-105ac7032a9b.png">

### Notes
<img width="1436" alt="Screenshot 2023-03-06 at 13 18 01" src="https://user-images.githubusercontent.com/11491779/223108282-ae5e785b-de13-4c8b-8364-75c9682fb901.png">
<img width="1434" alt="Screenshot 2023-03-06 at 13 19 00" src="https://user-images.githubusercontent.com/11491779/223108520-e98a6810-59b9-4e08-9223-616713367baf.png">

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Color suggestions and improvements are super welcome!

I'm still deciding between background and code font color.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
