### PR TITLE
storage: stop silently ignoring NULL keys in upsert source

### DIFF
--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -98,7 +98,7 @@ pub mod visit;
 pub use relation::canonicalize;
 
 pub use id::{Id, LocalId, PartitionId, SourceInstanceId};
-pub use id::{ProtoId, ProtoLocalId};
+pub use id::{ProtoId, ProtoLocalId, ProtoPartitionId};
 pub use linear::{
     memoize_expr,
     plan::{MfpPlan, MfpPushdown, SafeMfpPlan},

--- a/src/storage-client/src/types/errors.proto
+++ b/src/storage-client/src/types/errors.proto
@@ -10,6 +10,7 @@
 syntax = "proto3";
 
 import "expr/src/scalar.proto";
+import "expr/src/id.proto";
 import "repr/src/global_id.proto";
 import "repr/src/row.proto";
 
@@ -45,10 +46,15 @@ message ProtoUpsertValueError {
     mz_repr.row.ProtoRow for_key = 2;
 }
 
+message ProtoUpsertNullKeyError {
+    /* mz_expr.id.ProtoPartitionId partition_id = 1; */
+}
+
 message ProtoUpsertError {
     oneof kind {
         ProtoDecodeError key_decode = 1;
         ProtoUpsertValueError value = 2;
+        ProtoUpsertNullKeyError null_key = 3;
     }
 }
 

--- a/src/storage-client/src/types/errors.proto
+++ b/src/storage-client/src/types/errors.proto
@@ -47,7 +47,7 @@ message ProtoUpsertValueError {
 }
 
 message ProtoUpsertNullKeyError {
-    /* mz_expr.id.ProtoPartitionId partition_id = 1; */
+    mz_expr.id.ProtoPartitionId partition_id = 1;
 }
 
 message ProtoUpsertError {

--- a/src/storage-client/src/types/errors.rs
+++ b/src/storage-client/src/types/errors.rs
@@ -203,6 +203,32 @@ impl Display for UpsertValueError {
     }
 }
 
+/// A source contained a record with a NULL key, which we don't support.
+///
+/// NOTE: This does not contain additional (supposedly helpful) information, such as a partition ID
+/// or offset. We start out with keeping this error as generic as possible and, for example, a
+/// partition ID is a Kafka concept.
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub struct UpsertNullKeyError {}
+
+impl RustType<ProtoUpsertNullKeyError> for UpsertNullKeyError {
+    fn into_proto(&self) -> ProtoUpsertNullKeyError {
+        ProtoUpsertNullKeyError {
+            // partition_id: Some(PartitionId::None),
+        }
+    }
+
+    fn from_proto(_proto: ProtoUpsertNullKeyError) -> Result<Self, TryFromProtoError> {
+        Ok(Self {})
+    }
+}
+
+impl Display for UpsertNullKeyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "record with NULL key in UPSERT source")
+    }
+}
+
 /// An error that can be retracted by a future message using upsert logic.
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum UpsertError {
@@ -217,6 +243,7 @@ pub enum UpsertError {
     KeyDecode(DecodeError),
     /// Wrapper around an error related to the value.
     Value(UpsertValueError),
+    NullKey(UpsertNullKeyError),
 }
 
 impl RustType<ProtoUpsertError> for UpsertError {
@@ -226,6 +253,7 @@ impl RustType<ProtoUpsertError> for UpsertError {
             kind: Some(match self {
                 UpsertError::KeyDecode(err) => Kind::KeyDecode(err.into_proto()),
                 UpsertError::Value(err) => Kind::Value(Box::new(err.into_proto())),
+                UpsertError::NullKey(err) => Kind::NullKey(err.into_proto()),
             }),
         }
     }
@@ -241,6 +269,10 @@ impl RustType<ProtoUpsertError> for UpsertError {
                 let rust = RustType::from_proto(*proto)?;
                 Ok(Self::Value(rust))
             }
+            Some(Kind::NullKey(proto)) => {
+                let rust = RustType::from_proto(proto)?;
+                Ok(Self::NullKey(rust))
+            }
             None => Err(TryFromProtoError::missing_field("ProtoUpsertError::kind")),
         }
     }
@@ -251,6 +283,7 @@ impl Display for UpsertError {
         match self {
             UpsertError::KeyDecode(err) => write!(f, "Key decode: {err}"),
             UpsertError::Value(err) => write!(f, "Value error: {err}"),
+            UpsertError::NullKey(err) => write!(f, "Null key: {err}"),
         }
     }
 }

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -22,13 +22,13 @@ use timely::dataflow::{Scope, Stream};
 use timely::order::PartialOrder;
 use timely::progress::frontier::AntichainRef;
 use timely::progress::{Antichain, ChangeBatch};
-use tracing::{error, info};
+use tracing::info;
 
 use mz_expr::{EvalError, MirScalarExpr};
 use mz_ore::permutations::inverse_argsort;
 use mz_repr::{Datum, DatumVec, DatumVecBorrow, Diff, Row, RowArena, Timestamp};
 use mz_storage_client::types::errors::{
-    DataflowError, DecodeError, EnvelopeError, UpsertError, UpsertValueError,
+    DataflowError, EnvelopeError, UpsertError, UpsertValueError,
 };
 use mz_storage_client::types::sources::{MzOffset, UpsertEnvelope, UpsertStyle};
 use mz_timely_util::operator::StreamExt;
@@ -38,7 +38,7 @@ use crate::source::types::DecodeResult;
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 struct UpsertSourceData {
     /// The actual value
-    value: Option<Result<Row, DataflowError>>,
+    value: Option<Result<Row, UpsertError>>,
     /// The source's reported position for this record
     position: MzOffset,
     /// The time that the upstream source believes that the message was created
@@ -120,8 +120,9 @@ where
     };
 
     // Break `previous` into:
-    // On the one hand, "Ok" and "Err(UpsertError)", which we know how to deal with, and,
-    // On the other hand, "Err(everything eles)", which we don't.
+    //  - On the one hand, `Ok` and `Err(UpsertError)`, which we know how to
+    //   deal with, and,
+    //  - On the other hand, `Err(everything else)`, which we don't.
     let (previous, mut errs) = previous.inner.ok_err(|(d, t, r)| match d {
         Ok(row) => Ok((Ok(row), t, r)),
         Err(DataflowError::EnvelopeError(err)) => match *err {
@@ -202,13 +203,77 @@ fn evaluate(
     Ok(Some(row_buf.clone()))
 }
 
+/// Extracts the data that we need for UPSERT from the given collection of
+/// `DecodeResult`. While doing this, also lifts any errors into the appropriate
+/// `UpsertError`.
+fn extract_decode_results<G: Scope>(
+    input: &Collection<G, DecodeResult, Diff>,
+) -> Collection<
+    G,
+    (
+        (
+            Option<Result<Row, UpsertError>>,
+            Option<Result<Row, UpsertError>>,
+        ),
+        MzOffset,
+        Row,
+    ),
+    Diff,
+> {
+    input.flat_map(|decode_result| {
+        let DecodeResult {
+            key,
+            value,
+            position,
+            upstream_time_millis: _,
+            partition: _,
+            metadata,
+        } = decode_result;
+
+        let (key, value) = match key {
+            Some(Err(decode_error)) => (
+                Some(Err(UpsertError::KeyDecode(decode_error.clone()))),
+                value.map(|decode_result| {
+                    // Match what we do in `extract_kv_from_previous`, though
+                    // the value is not really important when we have a key
+                    // error. Plus, we can't map any value error to an
+                    // UpsertValueError because we don't have a real key that we
+                    // could give to it.
+                    decode_result.map_err(|_err| UpsertError::KeyDecode(decode_error.clone()))
+                }),
+            ),
+            Some(Ok(key)) => (
+                Some(Ok(key.clone())),
+                value.map(|decode_result| {
+                    decode_result.map_err(|err| {
+                        UpsertError::Value(UpsertValueError {
+                            for_key: key,
+                            inner: Box::new(DataflowError::DecodeError(Box::new(err))),
+                        })
+                    })
+                }),
+            ),
+            None => {
+                // We should not silently ignore NULL-keys. Will be fixed in
+                // next commit.
+                return None;
+            }
+        };
+
+        Some(((key, value), position, metadata))
+    })
+}
+
 /// Given a stream of rows and a description of the columns that form their key,
 /// produce a stream of keys and thinned values.
-fn extract_kv<G: Scope>(
+///
+/// This is used to re-extract a key-value-style collection from the (persisted)
+/// output of an UPSERT source.
+fn extract_kv_from_previous<G: Scope>(
     records: Collection<G, Result<Row, UpsertError>, Diff>,
     key_indices_sorted: Vec<usize>,
     key_indices: &[usize],
-) -> Collection<G, (Result<Row, DecodeError>, Result<Row, DataflowError>), Diff> {
+) -> Collection<G, (Result<Row, UpsertError>, Result<Row, UpsertError>), Diff> {
     debug_assert!({
         let mut verified_sorted = key_indices.to_vec();
         verified_sorted.sort_unstable();
@@ -256,16 +321,12 @@ fn extract_kv<G: Scope>(
                 (Ok(key_row_buf.clone()), Ok(row_buf.clone()))
             }
             Err(UpsertError::KeyDecode(err)) => (
-                Err(err.clone()),
-                Err(DataflowError::from(EnvelopeError::Upsert(
-                    UpsertError::KeyDecode(err),
-                ))),
+                Err(UpsertError::KeyDecode(err.clone())),
+                Err(UpsertError::KeyDecode(err)),
             ),
             Err(UpsertError::Value(UpsertValueError { inner, for_key })) => (
                 Ok(for_key.clone()),
-                Err(DataflowError::from(EnvelopeError::Upsert(
-                    UpsertError::Value(UpsertValueError { inner, for_key }),
-                ))),
+                Err(UpsertError::Value(UpsertValueError { inner, for_key })),
             ),
         }
     })
@@ -290,11 +351,13 @@ where
     let mut key_indices_sorted = upsert_envelope.key_indices.clone();
     key_indices_sorted.sort_unstable();
 
-    let previous_ok = extract_kv(
+    let previous_ok = extract_kv_from_previous(
         previous,
         key_indices_sorted.clone(),
         &upsert_envelope.key_indices,
     );
+
+    let input = extract_decode_results(input);
 
     // It's very important to hash the right thing. We have nested `Option` and
     // `Result` here. And, for example, `Some(key).hashed()` is not the same as
@@ -307,12 +370,13 @@ where
     // sources with multiple clusterd workers.
     let result_stream = input.inner.binary_frontier(
         &previous_ok.inner,
-        Exchange::new(move |(DecodeResult { key, .. }, _, _)| {
+        Exchange::new(move |(((key, _v), _pos, _meta), _t, _r)| {
             // N.B. We make the expected type explicit here to make sure it
             // cannot change by accident.
-            let key: &Option<Result<Row, DecodeError>> = key;
+            let key: &Option<Result<Row, UpsertError>> = key;
+
             // Another N.B. we use `as_ref()` here so that we're hashing a
-            // `Option<&Result<Row, DecodeError>`, like we do below. We don't
+            // `Option<&Result<Row, UpsertError>`, like we do below. We don't
             // stricly need it because the result is the same without but with
             // this we are extra future safe.
             key.as_ref().hashed()
@@ -320,7 +384,7 @@ where
         Exchange::new(|((key, _v), _t, _r)| {
             // N.B.  We make the expected type explicit here to make sure it
             // cannot change by accident.
-            let key: &Result<Row, DecodeError> = key;
+            let key: &Result<Row, UpsertError> = key;
             Some(key).hashed()
         }),
         "Upsert",
@@ -346,7 +410,7 @@ where
                 .map(|(idx, value_idx)| (*value_idx, idx))
                 .collect();
             let mut kdv = DatumVec::new();
-            // this is a map of (decoded key) -> (decoded_value). We store the
+            // This is a map of (decoded key) -> (decoded_value). We store the
             // latest value for a given key that way we know what to retract if
             // a new value with the same key comes along.
             //
@@ -400,6 +464,16 @@ where
                                 r == 1,
                                 "The upsert state should have exactly one value per key"
                             );
+
+                            // `current_values` will contain a `DataflowError`
+                            // for values, because those can result from
+                            // applying the MFP that we apply to values before
+                            // we store them. Technically, the MFP application
+                            // can result in an `EvalError`, and we already
+                            // potentially have `UpsertErrors`, and
+                            // `DataflowError` is the enum that wraps those two.
+                            let v = v.map_err(|err| EnvelopeError::Upsert(err).into());
+
                             match new_current_values.entry(k) {
                                 Entry::Occupied(_oe) => {
                                     panic!("The upsert state should have exactly one value per key")
@@ -471,38 +545,40 @@ where
 
 /// This function fills `pending_values` with new data
 /// from the timely operator input.
+///
+/// The given tuple contains key, value, a "position", and "metadata".
+// TODO(aljoscha): Turn this into a struct?
 fn process_new_data(
-    new_data: &mut Vec<(DecodeResult, Timestamp, Diff)>,
+    new_data: &mut Vec<(
+        (
+            (
+                Option<Result<Row, UpsertError>>,
+                Option<Result<Row, UpsertError>>,
+            ),
+            MzOffset,
+            Row,
+        ),
+        Timestamp,
+        Diff,
+    )>,
     pending_values: &mut BTreeMap<
         Timestamp,
         (
             Capability<Timestamp>,
-            BTreeMap<Option<Result<Row, DecodeError>>, UpsertSourceData>,
+            BTreeMap<Option<Result<Row, UpsertError>>, UpsertSourceData>,
         ),
     >,
     cap: &InputCapability<Timestamp>,
     as_of_frontier: &Antichain<Timestamp>,
 ) {
-    for (result, mut time, diff) in new_data.drain(..) {
+    for (((key, new_value), new_position, metadata), mut time, diff) in new_data.drain(..) {
         // TODO(petrosagg): any positive diff should be accepted
         assert_eq!(
             diff, 1,
             "Upsert should only be used with append-only sources"
         );
-        let DecodeResult {
-            key,
-            value: new_value,
-            position: new_position,
-            upstream_time_millis: _,
-            partition: _,
-            metadata,
-        } = result;
 
         time.advance_by(as_of_frontier.borrow());
-        if key.is_none() {
-            error!(?new_value, "Encountered empty key for value");
-            continue;
-        }
 
         let entry = pending_values
             .entry(time)
@@ -543,9 +619,9 @@ fn process_pending_values_batch(
     // are processing in this call.
     time: &Timestamp,
     cap: &mut Capability<Timestamp>,
-    map: &mut BTreeMap<Option<Result<Row, DecodeError>>, UpsertSourceData>,
+    map: &mut BTreeMap<Option<Result<Row, UpsertError>>, UpsertSourceData>,
     // The current map of values we use to perform the upsert comparision
-    current_values: &mut BTreeMap<Result<Row, DecodeError>, Result<Row, DataflowError>>,
+    current_values: &mut BTreeMap<Result<Row, UpsertError>, Result<Row, DataflowError>>,
     // A shared row used to pack new rows for evaluation and output
     row_packer: &mut Row,
     // A shared row used to build a Vec<Datum<'_>> for evaluation
@@ -584,16 +660,18 @@ fn process_pending_values_batch(
         if let Some(decoded_key) = key {
             let (decoded_key, decoded_value): (_, Result<_, DataflowError>) =
                 match (decoded_key, data.value) {
-                    (Err(key_decode_error), Some(_)) => {
-                        let err = DataflowError::from(EnvelopeError::Upsert(
-                            UpsertError::KeyDecode(key_decode_error.clone()),
-                        ));
-                        (Err(key_decode_error), Err(err))
-                    }
-                    (Err(key_decode_error), None) => (Err(key_decode_error), Ok(None)),
+                    // Make sure that the value is also an Err if they key is an
+                    // Err. Otherwise, any decoding logic that would try and
+                    // work on this can get flustered.
+                    (Err(upsert_error), Some(_)) => (
+                        Err(upsert_error.clone()),
+                        Err(EnvelopeError::Upsert(upsert_error).into()),
+                    ),
+                    (Err(upsert_error), None) => (Err(upsert_error), Ok(None)),
                     (Ok(decoded_key), None) => (Ok(decoded_key), Ok(None)),
                     (Ok(decoded_key), Some(value)) => {
                         let decoded_value = value
+                            .map_err(|err| EnvelopeError::Upsert(err).into())
                             .and_then(|row| {
                                 build_datum_vec_for_evaluation(
                                     dv,
@@ -604,16 +682,8 @@ fn process_pending_values_batch(
                                 .map_or(Ok(None), |mut datums| {
                                     datums.extend(data.metadata.iter());
                                     evaluate(&datums, predicates, position_or, row_packer)
-                                        .map_err(Into::into)
+                                        .map_err(DataflowError::from)
                                 })
-                            })
-                            .map_err(|err| {
-                                DataflowError::from(EnvelopeError::Upsert(UpsertError::Value(
-                                    UpsertValueError {
-                                        inner: Box::new(err),
-                                        for_key: decoded_key.clone(),
-                                    },
-                                )))
                             });
                         (Ok(decoded_key), decoded_value)
                     }

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -226,7 +226,7 @@ fn extract_decode_results<G: Scope>(
             value,
             position,
             upstream_time_millis: _,
-            partition: _,
+            partition,
             metadata,
         } = decode_result;
 
@@ -254,8 +254,11 @@ fn extract_decode_results<G: Scope>(
                 }),
             ),
             None => {
-                let key_error =
-                    UpsertError::NullKey(mz_storage_client::types::errors::UpsertNullKeyError {});
+                let key_error = UpsertError::NullKey(
+                    mz_storage_client::types::errors::UpsertNullKeyError::with_partition_id(
+                        partition,
+                    ),
+                );
                 (
                     None,
                     // Match what we do in `extract_kv_from_previous`, though

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -257,6 +257,14 @@ mammal1:
   VALUE FORMAT TEXT
   ENVELOPE UPSERT
 
+! select * from nullkey
+contains: record with NULL key in UPSERT source
+
+# Ingest a null value for our null key, to retract it.
+$ kafka-ingest format=bytes topic=nullkey key-format=bytes key-terminator=:
+:
+
+# Now we should be able to query the source.
 > select * from nullkey
 key           text
 -------------------


### PR DESCRIPTION
Before, we were logging an error and continuing, which, to the user, is "silent".

Now, we report an error when trying to query the source. And we support retracting them _too_.

There is some nuance to what we can feasibly report as the error. I have this `NOTE` in the code:

> NOTE: We need to make sure that when we see a "retraction" for this, that is, a
> message with _both_ a NULL key and NULL value, we can match this to the original
> `DecodeError`. Therefore, we cannot put more information in here than the
> partition. It would seem desirable to have more information, for example the
> offiset, but with that the future "retraction" message will not match this
> message and the original error will not go away.

Fixes #6350

As follow-up work, we might want to do more involved things with NULL keys.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
