### PR TITLE
sql: Pull role attributes out of unsafe mode

### DIFF
--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -1,19 +1,12 @@
 ---
-title: "CREATE ROLE"
-description: "`CREATE ROLE` creates a new role."
+title: "ALTER ROLE"
+description: "`ALTER ROLE` alters the attributes of an existing role."
 menu:
   main:
     parent: commands
 ---
 
-`CREATE ROLE` creates a new role.
-
-## Conceptual framework
-
-A role is a user account in a Materialize instance.
-
-When you [connect to a Materialize instance](/integrations/psql), you must specify
-the name of a valid role in the system.
+`ALTER ROLE` alters the attributes of an existing role.
 
 {{< warning >}}
 Roles in Materialize are currently limited in functionality. In the future they
@@ -27,7 +20,7 @@ Attributes currently have no effect.
 
 ## Syntax
 
-{{< diagram "create-role.svg" >}}
+{{< diagram "alter-role.svg" >}}
 
 Field               | Use
 --------------------|-------------------------------------------------------------------------
@@ -57,18 +50,17 @@ the `CREATEDB` and `NOCREATEDB` options conflict.
 ## Examples
 
 ```sql
-CREATE ROLE rj;
+ALTER ROLE rj CREATEDB NOCREATECLUSTER;
 ```
 ```sql
-SELECT name FROM mz_roles;
+SELECT name, create_db, create_cluster FROM mz_roles WHERE name = 'rj';
 ```
 ```nofmt
-materialize
-rj
+rj  true  false
 ```
 
 ## Related pages
 
-- [ALTER ROLE](../alter-role)
+- [CREATE ROLE](../create-role)
 - [DROP ROLE](../drop-role)
 - [DROP USER](../drop-user)

--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -15,7 +15,9 @@ for details.
 {{< /warning >}}
 
 {{< warning >}}
-Attributes currently have no effect.
+RBAC is under development: currently no role attributes or privileges will be
+considered when executing statements, although these attributes are saved and
+will be considered in a later release.
 {{< /warning >}}
 
 ## Syntax

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -22,7 +22,9 @@ for details.
 {{< /warning >}}
 
 {{< warning >}}
-Attributes currently have no effect.
+RBAC is under development: currently no role attributes or privileges will be
+considered when executing statements, although these attributes are saved and
+will be considered in a later release.
 {{< /warning >}}
 
 ## Syntax

--- a/doc/user/content/sql/drop-role.md
+++ b/doc/user/content/sql/drop-role.md
@@ -23,5 +23,6 @@ You cannot drop the current role.
 
 ## Related pages
 
+- [ALTER ROLE](../alter-role)
 - [CREATE ROLE](../create-role)
 - [DROP USER](../drop-user)

--- a/doc/user/content/sql/drop-user.md
+++ b/doc/user/content/sql/drop-user.md
@@ -23,5 +23,6 @@ _role_name_ | The role you want to drop. For available roles, see [`mz_roles`](/
 
 ## Related pages
 
+- [ALTER ROLE](../alter-role)
 - [CREATE ROLE](../create-role)
 - [DROP ROLE](../drop-role)

--- a/doc/user/layouts/partials/sql-grammar/alter-role.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-role.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="421" height="419">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="66" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">ALTER</text>
+   <rect x="117" y="3" width="56" height="32" rx="10"/>
+   <rect x="115"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="125" y="21">ROLE</text>
+   <rect x="193" y="3" width="88" height="32"/>
+   <rect x="191" y="1" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="201" y="21">role_name</text>
+   <rect x="321" y="35" width="58" height="32" rx="10"/>
+   <rect x="319"
+         y="33"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="329" y="53">WITH</text>
+   <rect x="211" y="365" width="76" height="32" rx="10"/>
+   <rect x="209"
+         y="363"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="219" y="383">INHERIT</text>
+   <rect x="211" y="321" width="114" height="32" rx="10"/>
+   <rect x="209"
+         y="319"
+         width="114"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="219" y="339">CREATEROLE</text>
+   <rect x="211" y="277" width="134" height="32" rx="10"/>
+   <rect x="209"
+         y="275"
+         width="134"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="219" y="295">NOCREATEROLE</text>
+   <rect x="211" y="233" width="96" height="32" rx="10"/>
+   <rect x="209"
+         y="231"
+         width="96"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="219" y="251">CREATEDB</text>
+   <rect x="211" y="189" width="118" height="32" rx="10"/>
+   <rect x="209"
+         y="187"
+         width="118"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="219" y="207">NOCREATEDB</text>
+   <rect x="211" y="145" width="142" height="32" rx="10"/>
+   <rect x="209"
+         y="143"
+         width="142"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="219" y="163">CREATECLUSTER</text>
+   <rect x="211" y="101" width="162" height="32" rx="10"/>
+   <rect x="209"
+         y="99"
+         width="162"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="219" y="119">NOCREATECLUSTER</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-252 396 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h172 m-202 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m182 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-182 0 h10 m76 0 h10 m0 0 h86 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m114 0 h10 m0 0 h48 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m134 0 h10 m0 0 h28 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m96 0 h10 m0 0 h66 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m118 0 h10 m0 0 h44 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m142 0 h10 m0 0 h20 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m162 0 h10 m23 298 h-3"/>
+   <polygon points="411 413 419 409 419 417"/>
+   <polygon points="411 413 403 409 403 417"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/create-role.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-role.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="437" height="69">
+<svg xmlns="http://www.w3.org/2000/svg" width="431" height="419">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="76" height="32" rx="10"/>
@@ -28,8 +28,64 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="339" y="53">WITH</text>
+   <rect x="221" y="365" width="76" height="32" rx="10"/>
+   <rect x="219"
+         y="363"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="383">INHERIT</text>
+   <rect x="221" y="321" width="114" height="32" rx="10"/>
+   <rect x="219"
+         y="319"
+         width="114"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="339">CREATEROLE</text>
+   <rect x="221" y="277" width="134" height="32" rx="10"/>
+   <rect x="219"
+         y="275"
+         width="134"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="295">NOCREATEROLE</text>
+   <rect x="221" y="233" width="96" height="32" rx="10"/>
+   <rect x="219"
+         y="231"
+         width="96"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="251">CREATEDB</text>
+   <rect x="221" y="189" width="118" height="32" rx="10"/>
+   <rect x="219"
+         y="187"
+         width="118"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="207">NOCREATEDB</text>
+   <rect x="221" y="145" width="142" height="32" rx="10"/>
+   <rect x="219"
+         y="143"
+         width="142"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="163">CREATECLUSTER</text>
+   <rect x="221" y="101" width="162" height="32" rx="10"/>
+   <rect x="219"
+         y="99"
+         width="162"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="119">NOCREATECLUSTER</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m23 -32 h-3"/>
-   <polygon points="427 17 435 13 435 21"/>
-   <polygon points="427 17 419 13 419 21"/>
+         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-252 396 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h172 m-202 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m182 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-182 0 h10 m76 0 h10 m0 0 h86 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m114 0 h10 m0 0 h48 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m134 0 h10 m0 0 h28 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m96 0 h10 m0 0 h66 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m118 0 h10 m0 0 h44 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m142 0 h10 m0 0 h20 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m162 0 h10 m23 298 h-3"/>
+   <polygon points="421 413 429 409 429 417"/>
+   <polygon points="421 413 413 409 413 417"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -5,6 +5,8 @@ alter_rename ::=
   'ALTER' ('CONNECTION' | 'INDEX' | 'SOURCE' | 'SINK' | 'VIEW' | 'MATERIALIZED VIEW' | 'TABLE' | 'SECRET' ) name 'RENAME TO' new_name
 alter_index ::=
   'ALTER' 'INDEX' name 'SET' 'ENABLED'
+alter_role ::=
+    'ALTER' 'ROLE' role_name 'WITH'? ('INHERIT' | 'CREATEROLE' | 'NOCREATEROLE' | 'CREATEDB' | 'NOCREATEDB' | 'CREATECLUSTER' | 'NOCREATECLUSTER')*
 alter_secret ::=
   'ALTER' 'SECRET' 'IF EXISTS'? name AS value
 alter_sink ::=
@@ -76,7 +78,7 @@ create_materialized_view ::=
     ('IN CLUSTER' cluster_name)?
     'AS' select_stmt
 create_role ::=
-    'CREATE' 'ROLE' role_name 'WITH'?
+    'CREATE' 'ROLE' role_name 'WITH'? ('INHERIT' | 'CREATEROLE' | 'NOCREATEROLE' | 'CREATEDB' | 'NOCREATEDB' | 'CREATECLUSTER' | 'NOCREATECLUSTER')*
 create_secret ::=
     'CREATE' 'SECRET' ('IF NOT EXISTS')? name 'AS' value
 create_schema ::=

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -164,7 +164,13 @@ impl Coordinator {
                 );
             }
             Plan::CreateRole(plan) => {
-                tx.send(self.sequence_create_role(&session, plan).await, session);
+                let res = self.sequence_create_role(&session, plan).await;
+                if res.is_ok() {
+                    // Notice is intentionally sent here and not in sequence_create_role so that
+                    // no notice is sent during startup.
+                    session.add_notice(AdapterNotice::RbacDisabled);
+                }
+                tx.send(res, session);
             }
             Plan::CreateCluster(plan) => {
                 tx.send(self.sequence_create_cluster(&session, plan).await, session);
@@ -342,7 +348,11 @@ impl Coordinator {
                 tx.send(self.sequence_alter_index_reset_options(plan), session);
             }
             Plan::AlterRole(plan) => {
-                tx.send(self.sequence_alter_role(&session, plan).await, session);
+                let res = self.sequence_alter_role(&session, plan).await;
+                if res.is_ok() {
+                    session.add_notice(AdapterNotice::RbacDisabled);
+                }
+                tx.send(res, session);
             }
             Plan::AlterSecret(plan) => {
                 tx.send(self.sequence_alter_secret(&session, plan).await, session);

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -181,7 +181,12 @@ impl fmt::Display for AdapterNotice {
                 write!(f, "startup setting {name} not set: {reason}")
             }
             AdapterNotice::RbacDisabled => {
-                write!(f, "RBAC is unimplemented so no role attributes or privileges will be considered when executing statements")
+                write!(
+                    f,
+                    "RBAC is under development: currently no role attributes or privileges \
+                will be considered when executing statements, although these attributes are saved \
+                and will be considered in a later release"
+                )
             }
         }
     }

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -79,6 +79,7 @@ pub enum AdapterNotice {
         name: String,
         reason: String,
     },
+    RbacDisabled,
 }
 
 impl AdapterNotice {
@@ -178,6 +179,9 @@ impl fmt::Display for AdapterNotice {
             }
             AdapterNotice::BadStartupSetting { name, reason } => {
                 write!(f, "startup setting {name} not set: {reason}")
+            }
+            AdapterNotice::RbacDisabled => {
+                write!(f, "RBAC is unimplemented so no role attributes or privileges will be considered when executing statements")
             }
         }
     }

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -468,10 +468,13 @@ fn test_empty_subscribe_notice() {
         .max_duration(Duration::from_secs(10))
         .retry(|_| {
             let Some(e) = rx.try_next().unwrap() else {
-                return Err("No notice received")
+                return Err("No notice received".to_string())
             };
-            assert!(e.message().contains("guaranteed to be empty"));
-            Ok(())
+            if e.message().contains("guaranteed to be empty") {
+                Ok(())
+            } else {
+                Err(format!("wrong notice received: {e:?}"))
+            }
         })
         .unwrap();
 }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -423,6 +423,7 @@ impl ErrorResponse {
             AdapterNotice::UnimplementedIsolationLevel { .. } => SqlState::WARNING,
             AdapterNotice::DroppedSubscribe { .. } => SqlState::WARNING,
             AdapterNotice::BadStartupSetting { .. } => SqlState::WARNING,
+            AdapterNotice::RbacDisabled => SqlState::WARNING,
         };
         ErrorResponse {
             severity: Severity::for_adapter_notice(&notice),
@@ -580,6 +581,7 @@ impl Severity {
             AdapterNotice::UnimplementedIsolationLevel { .. } => Severity::Notice,
             AdapterNotice::DroppedSubscribe { .. } => Severity::Notice,
             AdapterNotice::BadStartupSetting { .. } => Severity::Notice,
+            AdapterNotice::RbacDisabled => Severity::Notice,
         }
     }
 }


### PR DESCRIPTION
This commits removes the unsafe gate from role attributes, adds documentation, and adds a notice that indicates role attributes currently have no effect.

Part of #11579

### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer
* This PR was pulled out of #17929, which had gotten way to big.
* The `RbacDisabled` notice will useful when the RBAC feature flag is added to give a notice that RBAC is disabled.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release will add role attributes to `CREATE ROLE`.
  - This release will add the `ALTER ROLE` statement.
