### PR TITLE
adapter: Store role ID in session

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -82,8 +82,8 @@ use mz_transform::Optimizer;
 
 use crate::catalog::builtin::{
     Builtin, BuiltinLog, BuiltinRole, BuiltinTable, BuiltinType, Fingerprint, BUILTINS,
-    BUILTIN_PREFIXES, INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_TEMP_SCHEMA,
-    PG_CATALOG_SCHEMA,
+    BUILTIN_PREFIXES, INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_SYSTEM_ROLE,
+    MZ_TEMP_SCHEMA, PG_CATALOG_SCHEMA,
 };
 pub use crate::catalog::builtin_table_updates::BuiltinTableUpdate;
 pub use crate::catalog::config::{AwsPrincipalContext, ClusterReplicaSizeMap, Config};
@@ -531,7 +531,7 @@ impl CatalogState {
                 .ok()
                 .map(|db| db.id()),
             search_path: Vec::new(),
-            user: SYSTEM_USER.clone(),
+            role_id: self.resolve_builtin_role(&MZ_SYSTEM_ROLE),
             prepared_statements: None,
         };
         let stmt = mz_sql::parse::parse(&create_sql)?.into_element();
@@ -1046,6 +1046,13 @@ impl CatalogState {
         schema.items[builtin.name()].clone()
     }
 
+    /// Optimized lookup for a builtin role
+    ///
+    /// Panics if the builtin role doesn't exist in the catalog
+    pub fn resolve_builtin_role(&self, builtin: &'static BuiltinRole) -> RoleId {
+        self.roles_by_name[builtin.name]
+    }
+
     pub fn config(&self) -> &mz_sql::catalog::CatalogConfig {
         &self.config
     }
@@ -1294,7 +1301,7 @@ pub struct ConnCatalog<'a> {
     cluster: String,
     database: Option<DatabaseId>,
     search_path: Vec<(ResolvedDatabaseSpecifier, SchemaSpecifier)>,
-    user: User,
+    role_id: RoleId,
     prepared_statements: Option<Cow<'a, BTreeMap<String, PreparedStatement>>>,
 }
 
@@ -1314,7 +1321,7 @@ impl ConnCatalog<'_> {
             cluster: self.cluster,
             database: self.database,
             search_path: self.search_path,
-            user: self.user,
+            role_id: self.role_id,
             prepared_statements: self.prepared_statements.map(|s| Cow::Owned(s.into_owned())),
         }
     }
@@ -3592,12 +3599,12 @@ impl Catalog {
             cluster: session.vars().cluster().into(),
             database,
             search_path,
-            user: session.user().clone(),
+            role_id: session.role_id().clone(),
             prepared_statements: Some(Cow::Borrowed(session.prepared_statements())),
         }
     }
 
-    pub fn for_sessionless_user(&self, user: User) -> ConnCatalog {
+    pub fn for_sessionless_user(&self, role_id: RoleId) -> ConnCatalog {
         ConnCatalog {
             state: Cow::Borrowed(&self.state),
             conn_id: SYSTEM_CONN_ID,
@@ -3607,7 +3614,7 @@ impl Catalog {
                 .ok()
                 .map(|db| db.id()),
             search_path: Vec::new(),
-            user,
+            role_id,
             prepared_statements: None,
         }
     }
@@ -3615,7 +3622,8 @@ impl Catalog {
     // Leaving the system's search path empty allows us to catch issues
     // where catalog object names have not been normalized correctly.
     pub fn for_system_session(&self) -> ConnCatalog {
-        self.for_sessionless_user(SYSTEM_USER.clone())
+        let role_id = self.resolve_builin_role(&MZ_SYSTEM_ROLE);
+        self.for_sessionless_user(role_id)
     }
 
     async fn storage<'a>(&'a self) -> MutexGuard<'a, storage::Connection> {
@@ -3780,6 +3788,11 @@ impl Catalog {
     /// Resolves a `BuiltinSource`.
     pub fn resolve_builtin_storage_collection(&self, builtin: &'static BuiltinSource) -> GlobalId {
         self.state.resolve_builtin_source(builtin)
+    }
+
+    /// Resolves a `BuiltinRole`.
+    pub fn resolve_builin_role(&self, builtin: &'static BuiltinRole) -> RoleId {
+        self.state.resolve_builtin_role(builtin)
     }
 
     /// Resolves `name` to a function [`CatalogEntry`].
@@ -6507,8 +6520,8 @@ impl ExprHumanizer for ConnCatalog<'_> {
 }
 
 impl SessionCatalog for ConnCatalog<'_> {
-    fn active_user(&self) -> &str {
-        &self.user.name
+    fn active_role_id(&self) -> &RoleId {
+        &self.role_id
     }
 
     fn get_prepared_statement_desc(&self, name: &str) -> Option<&StatementDesc> {
@@ -6588,6 +6601,10 @@ impl SessionCatalog for ConnCatalog<'_> {
             Some(id) => Ok(&self.state.roles_by_id[id]),
             None => Err(SqlCatalogError::UnknownRole(role_name.into())),
         }
+    }
+
+    fn try_get_role(&self, id: &RoleId) -> Option<&dyn CatalogRole> {
+        Some(self.state.roles_by_id.get(id)?)
     }
 
     fn get_role(&self, id: &RoleId) -> &dyn mz_sql::catalog::CatalogRole {

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -390,6 +390,7 @@ impl ErrorResponse {
             AdapterError::Storage(_) | AdapterError::Compute(_) | AdapterError::Orchestrator(_) => {
                 SqlState::INTERNAL_ERROR
             }
+            AdapterError::ConcurrentRoleDrop(_) => SqlState::UNDEFINED_OBJECT,
         };
         ErrorResponse {
             severity,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -73,8 +73,8 @@ use crate::plan::PlanError;
 /// [`get_item`]: Catalog::resolve_item
 /// [`resolve_item`]: SessionCatalog::resolve_item
 pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
-    /// Returns the name of the user who is issuing the query.
-    fn active_user(&self) -> &str;
+    /// Returns the id of the role that is issuing the query.
+    fn active_role_id(&self) -> &RoleId;
 
     /// Returns the database to use if one is not explicitly specified.
     fn active_database_name(&self) -> Option<&str> {
@@ -141,6 +141,9 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
 
     /// Resolves the named role.
     fn resolve_role(&self, role_name: &str) -> Result<&dyn CatalogRole, CatalogError>;
+
+    /// Gets a role by its ID.
+    fn try_get_role(&self, id: &RoleId) -> Option<&dyn CatalogRole>;
 
     /// Gets a role by its ID.
     ///
@@ -949,8 +952,8 @@ static DUMMY_CONFIG: Lazy<CatalogConfig> = Lazy::new(|| CatalogConfig {
 });
 
 impl SessionCatalog for DummyCatalog {
-    fn active_user(&self) -> &str {
-        "dummy"
+    fn active_role_id(&self) -> &RoleId {
+        &RoleId::User(0)
     }
 
     fn active_database(&self) -> Option<&DatabaseId> {
@@ -994,6 +997,10 @@ impl SessionCatalog for DummyCatalog {
     }
 
     fn get_role(&self, _: &RoleId) -> &dyn CatalogRole {
+        unimplemented!()
+    }
+
+    fn try_get_role(&self, _: &RoleId) -> Option<&dyn CatalogRole> {
         unimplemented!()
     }
 

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -101,7 +101,7 @@ statement ok
 DROP ROLE IF EXISTS nlb
 
 # No dropping the current role.
-statement error current user cannot be dropped
+statement error current role cannot be dropped
 DROP ROLE materialize
 
 # No creating roles that already exist.


### PR DESCRIPTION
This commit adds the role ID of the active role to the Session. Previously, only the role name was stored. The name is not sufficient to uniquely identify a role. For example, if someone drops a session's active role and then re-creates a new role with the same name, then the session will mistakenly think that the new session belongs to them.

Additionally, this commit adds an error, that forces a user to disconnect if their role was concurrently dropped.

Part of #11579

### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer

* This PR was pulled out of #17929, which had gotten way to big.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
