### PR TITLE
adapter: prevent OOM found by SQLsmit

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2770,7 +2770,7 @@ impl RowSetFinishing {
             .unwrap_or(limit);
 
         // Bail early if we know our results won't fit into our Vec
-        // 
+        //
         // Note: this check is a _lower bound_ as to how much memory
         // we'll need for results. Calculating the actual answer would
         // require us to iterate through all of the rows

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2760,7 +2760,7 @@ impl RowSetFinishing {
             // Check that result fits into max_result_size.
             if num_bytes > max_result_size {
                 return Err(format!(
-                    "result would exceed max size of {}",
+                    "result exceeds max size of {}",
                     ByteSize::b(u64::cast_from(max_result_size))
                 ));
             }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2769,7 +2769,23 @@ impl RowSetFinishing {
             })
             .unwrap_or(limit);
 
-        let mut ret = Vec::with_capacity(return_size);
+        // Bail early if we know our results won't fit into our Vec
+        // 
+        // Note: this check is a _lower bound_ as to how much memory
+        // we'll need for results. Calculating the actual answer would
+        // require us to iterate through all of the rows
+        if return_size * std::mem::size_of::<Row>() > max_result_size {
+            return Err(format!(
+                "result would exceed max size of {}",
+                ByteSize::b(u64::cast_from(max_result_size))
+            ));
+        }
+
+        // The return Vec can sometimes be quite large, so we'll use the
+        // failable allocation APIs to prevent a panic
+        let mut ret = Vec::new();
+        ret.try_reserve(return_size).map_err(|e| e.to_string())?;
+
         let mut remaining = limit;
         let mut row_buf = Row::default();
         let mut datum_vec = mz_repr::DatumVec::new();

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2755,9 +2755,9 @@ impl RowSetFinishing {
         let mut num_bytes = 0;
         for (row, count) in &rows[offset_nth_row..] {
             num_rows += count.get();
-            num_bytes += row.byte_len();
+            num_bytes += count.get().saturating_mul(row.byte_len());
 
-            // Bail early if we know our results won't fit into our Vec.
+            // Check that result fits into max_result_size.
             if num_bytes > max_result_size {
                 return Err(format!(
                     "result would exceed max size of {}",

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2752,10 +2752,10 @@ impl RowSetFinishing {
         // if we don't have enough memory to expand the result, or break early from the
         // iteration once we pass our limit.
         let mut num_rows = 0;
-        let mut num_bytes = 0;
+        let mut num_bytes: usize = 0;
         for (row, count) in &rows[offset_nth_row..] {
             num_rows += count.get();
-            num_bytes += count.get().saturating_mul(row.byte_len());
+            num_bytes = num_bytes.saturating_add(count.get().saturating_mul(row.byte_len()));
 
             // Check that result fits into max_result_size.
             if num_bytes > max_result_size {


### PR DESCRIPTION
### Motivation

* This PR fixes a recognized bug:
    * Fixes #17898 

SQLsmith found a bug where we attempt to a `Vec` that wouldn't fit in memory, when returning some results. To fix this we use some heuristics to determine if we think our results would fit in memory, if we don't think this lower bound will fit, then we return an error

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
