### PR TITLE
sql: Add pg_function_is_visible

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -750,6 +750,8 @@
     description: Reports whether the relation with the specified OID is visible in the search path.
   - signature: 'pg_type_is_visible(relation: oid) -> boolean'
     description: Reports whether the type with the specified OID is visible in the search path.
+  - signature: 'pg_function_is_visible(relation: oid) -> boolean'
+    description: Reports whether the function with the specified OID is visible in the search path.
   - signature: 'pg_typeof(expr: any) -> text'
     description: Returns the type of its input argument as a string.
   - signature: 'pg_encoding_to_char(encoding_id: integer) -> text'

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2162,6 +2162,13 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                      WHERE t.oid = $1)"
             ) => Bool, 2080;
         },
+        "pg_function_is_visible" => Scalar {
+            params!(Oid) => sql_impl_func(
+                "(SELECT s.name = ANY(pg_catalog.current_schemas(true))
+                     FROM mz_catalog.mz_functions f JOIN mz_catalog.mz_schemas s ON f.schema_id = s.id
+                     WHERE f.oid = $1)"
+            ) => Bool, 2081;
+        },
         "pg_typeof" => Scalar {
             params!(Any) => Operation::new(|ecx, exprs, params, _order_by| {
                 // pg_typeof reports the type *before* coercion.

--- a/test/testdrive/functions.td
+++ b/test/testdrive/functions.td
@@ -1,0 +1,21 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test pg_function_is_visible. Currently relies on _pg_expandarray living in the information_schema schema which is true
+# in postgres as well.
+
+> SELECT DISTINCT name, pg_table_is_visible(oid) AS visible FROM mz_catalog.mz_functions where name = '_pg_expandarray'
+name               visible
+--------------------------
+_pg_expandarray    false
+> SET search_path=information_schema,public
+> SELECT DISTINCT name, pg_table_is_visible(oid) AS visible FROM mz_catalog.mz_functions where name = '_pg_expandarray'
+name               visible
+--------------------------
+_pg_expandarray    true

--- a/test/testdrive/functions.td
+++ b/test/testdrive/functions.td
@@ -14,6 +14,7 @@
 name               visible
 --------------------------
 _pg_expandarray    false
+
 > SET search_path=information_schema,public
 > SELECT DISTINCT name, pg_table_is_visible(oid) AS visible FROM mz_catalog.mz_functions where name = '_pg_expandarray'
 name               visible

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -277,7 +277,7 @@ other_record_c
 > CREATE TABLE jsonb_array_list_t (a jsonb_array_list_c);
 > INSERT INTO jsonb_array_list_t VALUES (LIST[ARRAY['{"1":2}'::jsonb]]);
 
-# Test pg_table_is_visible.
+# Test pg_type_is_visible.
 
 > SELECT PG_TYPE_IS_VISIBLE('bool'::REGTYPE::OID);
 pg_type_is_visible


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
A simple starter task and progress on #9729
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer
Not totally happy about the tests for this. I can't think of anything better if we can't create new functions in a random schema.
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
