### PR TITLE
ci: Clean up all docker containers on job start, regardless of origin

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -22,6 +22,9 @@ fi
 
 date +"%Y-%m-%d %H:%M:%S" > step_start_timestamp
 
+ci_collapsed_heading ":docker: Purging all existing docker containers and volumes, regardless of origin"
+docker ps --all --quiet | xargs --no-run-if-empty docker rm --force --volumes
+
 ci_collapsed_heading "kind: Make sure kind is running..."
 bin/ci-builder run stable test/cloudtest/setup
 

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -35,6 +35,9 @@ mzcompose --mz-quiet kill
 mzcompose --mz-quiet rm --force -v
 mzcompose --mz-quiet down --volumes
 
+ci_collapsed_heading ":docker: Purging all existing docker containers and volumes, regardless of origin"
+docker ps --all --quiet | xargs --no-run-if-empty docker rm --force --volumes
+
 ci_collapsed_heading ":docker: Rebuilding non-mzbuild containers"
 mzcompose --mz-quiet build
 


### PR DESCRIPTION
Previous pre-job cleanup was either kind-only or
mzcompose composition-specific. This caused CI hosts to accumulate old running mzcompose containers which in turn could lead to OOMs and all sorts of other
issues for the CI job being run.

In order to collect more information about the situation in the CI, the new cleanup is explicitly set to run in addition to any existing cleanup actions even if it is more general than them.

### Motivation

  * This PR fixes a previously unreported bug.

There were CI jobs that were failing due to the OOM killer getting activated. The output of the OOM killer indicated that the buildkite host was in fact running multiple `environmentd`s, which was a clear indication
that old mzcompose workflows were not being cleaned up properly.