### PR TITLE
release qualification: Update workloads to match reality

### DIFF
--- a/ci/release-qualification/pipeline.yml
+++ b/ci/release-qualification/pipeline.yml
@@ -21,7 +21,7 @@ steps:
           - { value: zippy-dataflows-large }
           - { value: zippy-pg-cdc-large }
           - { value: zippy-cluster-replicas-large }
-          - { value: zippy-no-killing }
+          - { value: zippy-user-tables-large }
         multiple: true
         required: false
     if: build.source == "ui"
@@ -55,7 +55,7 @@ steps:
           args: [--scenario=KafkaSourcesLarge, --actions=100000]
 
   - id: zippy-dataflows-large
-    label: "Long running Zippy with complex dataflows"
+    label: "Large Zippy w/ complex dataflows"
     # 48h
     timeout_in_minutes: 2880
     agents:
@@ -64,10 +64,10 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=DataflowsLarge, --actions=100000]
+          args: [--scenario=DataflowsLarge, --actions=35000]
 
   - id: zippy-pg-cdc-large
-    label: "Longer Zippy PogresCdc test"
+    label: "Longer Zippy PogresCdc"
     timeout_in_minutes: 2880
     agents:
       queue: linux-x86_64-large
@@ -75,10 +75,10 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=PostgresCdc, --actions=100000]
+          args: [--scenario=PostgresCdcLarge, --actions=200000]
 
   - id: zippy-cluster-replicas-large
-    label: "Longer Zippy ClusterReplicas test"
+    label: "Longer Zippy ClusterReplicas"
     timeout_in_minutes: 2880
     agents:
       queue: linux-x86_64-large
@@ -86,10 +86,10 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=ClusterReplicas, --actions=100000]
+          args: [--scenario=ClusterReplicas, --actions=10000]
 
-  - id: zippy-no-killing
-    label: "Long Zippy scenario with no killing"
+  - id: zippy-user-tables-large
+    label: "Long Zippy w/ user tables"
     timeout_in_minutes: 2880
     agents:
       queue: linux-x86_64-large
@@ -97,7 +97,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=NoKilling, --actions=100000]
+          args: [--scenario=UserTablesLarge, --actions=200000]
 
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
- remove Postgres restarts from the longer pg-cdc test, as Postgres-side data corruption eventually occurs
- avoid mixing user tables and kafka topics in the same test as views that are joins over sources of both types are unlikely to return anything but an empty result
- remove killing of Mz from the workloads that appear unable to handle it (usual manifestation is CRDB failure due to sync issues)
- adjust the running time of the individual scenarios

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

@def- this is in order to get the Release Qualification Test green so that it can actually be used to qualify future releases. I am going to gradually extend the execution time and the chaos-ness as the product is able to handle it.