### PR TITLE
cloudtest: Run with parallelism=2 in Buildkite

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -33,6 +33,7 @@ psutil==5.9.4
 pydantic==1.10.4
 PyMySQL==1.0.2
 pytest==7.2.1
+pytest-split==0.8.0
 pyyaml==6.0
 requests==2.28.1
 scipy==1.10.0

--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -13,7 +13,12 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-run_args=("--junitxml=junit_cloudtest_$BUILDKITE_JOB_ID.xml")
+run_args=(
+    "--junitxml=junit_cloudtest_$BUILDKITE_JOB_ID.xml"
+    "--splits=${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
+    "--group=$((${BUILDKITE_PARALLEL_JOB:-0}+1))"
+)
+
 if read_list BUILDKITE_PLUGIN_CLOUDTEST_ARGS; then
     for arg in "${result[@]}"; do
         run_args+=("$arg")

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -550,6 +550,7 @@ steps:
   - id: cloudtest
     label: Cloudtest
     depends_on: build-x86_64
+    parallelism: 2
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     inputs: [test/cloudtest, misc/python/materialize/cloudtest]


### PR DESCRIPTION
We have accumulated enough cloudtest to require them to be run in parallel in order to complete within a reasonable amount of time.

### Motivation

  * This PR fixes a previously unreported bug.


cloudtest runs were timing out at 30 min.