### PR TITLE
adapter: Set a max number of events OpenTelemetry records per-Span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5374,7 +5374,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.17.0"
-source = "git+https://github.com/MaterializeInc/opentelemetry-rust.git#fe99cd1c96bb4d0e00001b1575f897fd1e57a378"
+source = "git+https://github.com/MaterializeInc/opentelemetry-rust.git#c22fdfe5c90680f534ef958fb4c2f810a2fe2c56"
 dependencies = [
  "opentelemetry-api",
  "opentelemetry-sdk",
@@ -5383,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-api"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/opentelemetry-rust.git#fe99cd1c96bb4d0e00001b1575f897fd1e57a378"
+source = "git+https://github.com/MaterializeInc/opentelemetry-rust.git#c22fdfe5c90680f534ef958fb4c2f810a2fe2c56"
 dependencies = [
  "fnv",
  "futures-channel",
@@ -5429,7 +5429,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-sdk"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/opentelemetry-rust.git#fe99cd1c96bb4d0e00001b1575f897fd1e57a378"
+source = "git+https://github.com/MaterializeInc/opentelemetry-rust.git#c22fdfe5c90680f534ef958fb4c2f810a2fe2c56"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "tracing-opentelemetry"
 version = "0.17.4"
-source = "git+https://github.com/MaterializeInc/tracing.git?branch=v0.1.x#fa05cdc3a9757027b8cc93ed7989f8ee42d37f8d"
+source = "git+https://github.com/MaterializeInc/tracing.git?branch=v0.1.x#14b55d9aa9abec24cbb7f6d7ef4bc640398395d3"
 dependencies = [
  "once_cell",
  "opentelemetry",


### PR DESCRIPTION
### Motivation

Fixes #17497 

We noticed a slow OOM occurs when our OpenTelemetry logging is enabled, and we discovered this is because long lived Spans will continuously record `otel::Event`s and not flush them until the Span closes, which it might never do because the Span is long lived.

In https://github.com/MaterializeInc/tracing/pull/1 I updated the `OpenTelemetryLayer` so we can set a max number of events that a single Span will record, after we pass this max we start dropping old events.

This PR does two things:
1. Uses the new `max_events_per_span(...)` option to limit the number of events per Span
2. By default disables OpenTelemetry tracing for `h2` and `hyper` which is where we initially observed the long lived Spans

### Open Question
IIRC we saw long lived spans in `h2` and `hyper` at the Debug level, by default would we want to keep OpenTelemetry tracing enabled, by only at INFO and higher, as opposed to turning it off completely?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
