### PR TITLE
pg sources: harden schema change detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3318,6 +3318,7 @@ dependencies = [
  "enum-kinds",
  "fail",
  "futures",
+ "hex",
  "itertools",
  "launchdarkly-server-sdk",
  "maplit",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -18,6 +18,7 @@ differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-
 enum-kinds = "0.5.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
+hex = "0.4.3"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 launchdarkly-server-sdk = { git = "https://github.com/MaterializeInc/rust-server-sdk", default_features = false, features = ["hypertls"] }

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2767,13 +2767,15 @@ impl Catalog {
             .unwrap_or_else(|| "new".to_string());
 
         if !config.skip_migrations {
-            migrate::migrate(&mut catalog).await.map_err(|e| {
-                Error::new(ErrorKind::FailedMigration {
-                    last_seen_version: last_seen_version.clone(),
-                    this_version: catalog.config().build_info.version,
-                    cause: e.to_string(),
-                })
-            })?;
+            migrate::migrate(&mut catalog, config.connection_context)
+                .await
+                .map_err(|e| {
+                    Error::new(ErrorKind::FailedMigration {
+                        last_seen_version: last_seen_version.clone(),
+                        this_version: catalog.config().build_info.version,
+                        cause: e.to_string(),
+                    })
+                })?;
             catalog
                 .storage()
                 .await
@@ -3646,6 +3648,7 @@ impl Catalog {
             system_parameter_frontend: None,
             // when debugging, no reaping
             storage_usage_retention_period: None,
+            connection_context: None,
         })
         .await?;
         Ok(catalog)

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -67,6 +67,13 @@ pub struct Config<'a> {
     pub system_parameter_frontend: Option<Arc<SystemParameterFrontend>>,
     /// How long to retain storage usage records
     pub storage_usage_retention_period: Option<Duration>,
+    /// Needed only for migrating PG source column metadata. If `None`, will
+    /// skip any migrations that require it, which will likely cause tests to
+    /// fail.
+    ///
+    /// TODO(migration): delete in version v.50 (released in v0.48 + 1
+    /// additional release)
+    pub connection_context: Option<mz_storage_client::types::connections::ConnectionContext>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -225,7 +225,7 @@ async fn pg_source_table_metadata_rewrite(
 
         // Get the current publication tables from the upstream PG source.
         let mut current_publication_tables =
-            match mz_postgres_util::publication_info(&config, publication).await {
+            match mz_postgres_util::publication_info(&config, publication, None).await {
                 Ok(v) => v,
                 Err(_) => {
                     warn!(

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -7,28 +7,39 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use futures::future::BoxFuture;
 use semver::Version;
 use std::collections::BTreeMap;
 use tracing::info;
 
 use mz_ore::collections::CollectionExt;
 use mz_sql::ast::display::AstDisplay;
-use mz_sql::ast::Raw;
+use mz_sql::ast::{Raw, Statement, Value};
+use mz_storage_client::types::connections::ConnectionContext;
 
 use crate::catalog::{Catalog, SerializedCatalogItem};
 
 use super::storage::Transaction;
+use super::ConnCatalog;
 
-fn rewrite_items<F>(tx: &mut Transaction, mut f: F) -> Result<(), anyhow::Error>
+async fn rewrite_items<F>(
+    tx: &mut Transaction<'_>,
+    cat: Option<&ConnCatalog<'_>>,
+    mut f: F,
+) -> Result<(), anyhow::Error>
 where
-    F: FnMut(&mut Transaction, &mut mz_sql::ast::Statement<Raw>) -> Result<(), anyhow::Error>,
+    F: for<'a> FnMut(
+        &'a mut Transaction<'_>,
+        &'a Option<&ConnCatalog<'_>>,
+        &'a mut mz_sql::ast::Statement<Raw>,
+    ) -> BoxFuture<'a, Result<(), anyhow::Error>>,
 {
     let mut updated_items = BTreeMap::new();
     let items = tx.loaded_items();
     for (id, name, SerializedCatalogItem::V1 { create_sql }) in items {
         let mut stmt = mz_sql::parse::parse(&create_sql)?.into_element();
 
-        f(tx, &mut stmt)?;
+        f(tx, &cat, &mut stmt).await?;
 
         let serialized_item = SerializedCatalogItem::V1 {
             create_sql: stmt.to_ast_string_stable(),
@@ -40,7 +51,10 @@ where
     Ok(())
 }
 
-pub(crate) async fn migrate(catalog: &mut Catalog) -> Result<(), anyhow::Error> {
+pub(crate) async fn migrate(
+    catalog: &mut Catalog,
+    connection_context: Option<ConnectionContext>,
+) -> Result<(), anyhow::Error> {
     let mut storage = catalog.storage().await;
     let catalog_version = storage.get_catalog_content_version().await?;
     let catalog_version = match catalog_version {
@@ -52,7 +66,7 @@ pub(crate) async fn migrate(catalog: &mut Catalog) -> Result<(), anyhow::Error> 
 
     let mut tx = storage.transaction().await?;
     // First, do basic AST -> AST transformations.
-    rewrite_items(&mut tx, |_tx, _stmt| Ok(()))?;
+    // rewrite_items(&mut tx, None, |_tx, _cat, _stmt| Box::pin(async { Ok(()) })).await?;
 
     // Then, load up a temporary catalog with the rewritten items, and perform
     // some transformations that require introspecting the catalog. These
@@ -60,8 +74,18 @@ pub(crate) async fn migrate(catalog: &mut Catalog) -> Result<(), anyhow::Error> 
     // it. You probably should be adding a basic AST migration above, unless
     // you are really certain you want one of these crazy migrations.
     let cat = Catalog::load_catalog_items(&mut tx, catalog)?;
-    let _conn_cat = cat.for_system_session();
-    rewrite_items(&mut tx, |_tx, _item| Ok(()))?;
+    let conn_cat = cat.for_system_session();
+    rewrite_items(&mut tx, Some(&conn_cat), |_tx, cat, item| {
+        let connection_context = connection_context.clone();
+        Box::pin(async move {
+            let conn_cat = cat.expect("must provide access to conn catalog");
+            if let Some(conn_cx) = connection_context {
+                pg_source_table_metadata_rewrite(conn_cat, &conn_cx, item).await;
+            }
+            Ok(())
+        })
+    })
+    .await?;
     tx.commit().await?;
     info!(
         "migration from catalog version {:?} complete",
@@ -94,3 +118,190 @@ pub(crate) async fn migrate(catalog: &mut Catalog) -> Result<(), anyhow::Error> 
 // ****************************************************************************
 // Semantic migrations -- Weird migrations that require access to the catalog
 // ****************************************************************************
+
+// Add the `col_num` to all PG column descriptions.
+//
+// Note that this will also populate column and table constraints from the
+// upstream database that were never used, so we must clear them out because
+// they were not used to generate the DDL for the subsources and it is now too
+// late to apply them.
+//
+// TODO(migration): delete in version v.50 (released in v0.48 + 1 additional
+// release)
+async fn pg_source_table_metadata_rewrite(
+    catalog: &ConnCatalog<'_>,
+    connection_context: &ConnectionContext,
+    stmt: &mut mz_sql::ast::Statement<Raw>,
+) {
+    use prost::Message;
+    use tracing::warn;
+
+    use mz_proto::RustType;
+    use mz_sql::ast::{CreateSourceConnection, PgConfigOption, PgConfigOptionName};
+    use mz_sql::plan::StatementContext;
+    use mz_storage_client::types::sources::{
+        PostgresSourcePublicationDetails, ProtoPostgresSourcePublicationDetails,
+    };
+
+    if let Statement::CreateSource(mz_sql::ast::CreateSourceStatement {
+        name,
+        connection:
+            CreateSourceConnection::Postgres {
+                connection,
+                options,
+            },
+        ..
+    }) = stmt
+    {
+        // Find the option containing the serialized details.
+        let details_idx = options
+            .iter()
+            .position(|PgConfigOption { name, .. }| name == &PgConfigOptionName::Details)
+            .expect("corrupt catalog");
+
+        // Examine the current details
+        let details = match &options[details_idx].value {
+            Some(mz_sql::ast::WithOptionValue::Value(mz_sql::ast::Value::String(details))) => {
+                details
+            }
+            _ => unreachable!("corrupt catalog"),
+        };
+
+        let details = hex::decode(details).expect("valid catalog");
+        let details =
+            ProtoPostgresSourcePublicationDetails::decode(&*details).expect("valid catalog");
+        let mut publication_details =
+            PostgresSourcePublicationDetails::from_proto(details).expect("valid catalog");
+
+        if publication_details
+            .tables
+            .iter()
+            .all(|t| t.columns.iter().all(|c| c.col_num.is_some()))
+        {
+            mz_ore::soft_assert!(
+                publication_details
+                    .tables
+                    .iter()
+                    .all(|t| t.columns.iter().all(|c| c.col_num != Some(0))),
+                "PG does not use attnum 0"
+            );
+            // If every column is present, then no need for this migration.
+            return;
+        }
+
+        // Get details to connect to the upstream PG instance, which we need to
+        // get the schema details.
+        let scx = StatementContext::new(None, &*catalog);
+        let connection = {
+            let item = scx.resolve_item(connection.clone()).expect("valid catalog");
+            match item.connection().expect("valid catalog") {
+                mz_storage_client::types::connections::Connection::Postgres(connection) => {
+                    connection
+                }
+                _ => unreachable!("corrupt catalog"),
+            }
+        };
+
+        let publication = options
+            .iter()
+            .find(|o| matches!(o.name, PgConfigOptionName::Publication))
+            .expect("valid catalog")
+            .value
+            .as_ref()
+            .expect("valid catalog");
+
+        let publication = match publication {
+            mz_sql::ast::WithOptionValue::Value(mz_sql::ast::Value::String(publication)) => {
+                publication
+            }
+            _ => unreachable!("corrupt catalog"),
+        };
+
+        // verify that we can connect upstream and snapshot publication metadata
+        let config = connection
+            .config(&*connection_context.secrets_reader)
+            .await
+            .expect("valid config");
+
+        // Get the current publication tables from the upstream PG source.
+        let mut current_publication_tables =
+            match mz_postgres_util::publication_info(&config, publication).await {
+                Ok(v) => v,
+                Err(_) => {
+                    warn!(
+                        "could not perform migration of PG source {name} due \
+                    to external dependency; this will render the source useless, \
+                    but might be fixable by restarting Materialize"
+                    );
+                    return;
+                }
+            };
+
+        // Convert current tables into map because we only care that the tables
+        // we know about about are the same.
+        let mut cur_tables: BTreeMap<_, _> = current_publication_tables
+            .iter_mut()
+            .map(|t| (t.oid, t))
+            .collect();
+
+        for prev_table in publication_details.tables.into_iter() {
+            match cur_tables.get_mut(&prev_table.oid) {
+                Some(cur_table) => {
+                    // We must undergo this torturous equality check because we
+                    // want to check equality for all fields except for the new
+                    // col_num field, but we also want to allow the current
+                    // schema to contain more columns than previous schema,
+                    // which is part of #17595.
+                    if prev_table.namespace != cur_table.namespace
+                        || prev_table.name != cur_table.name
+                        // Error if current table has fewer columns
+                        || cur_table.columns.len() < prev_table.columns.len()
+                        // Only match columns that are joined prefix of LHS
+                        || prev_table.columns.iter().zip(&cur_table.columns).any(
+                            |(prev_col, cur_col)| {
+                                prev_col.name != cur_col.name
+                                    || prev_col.type_oid != cur_col.type_oid
+                                    || prev_col.type_mod != cur_col.type_mod
+                            },
+                        )
+                    {
+                        warn!(
+                            "could not perform migration of PG source {name} due \
+                        to schema change; this source must be recreated, but the \
+                        schema in the warning where this occurs will have the wrong col_num."
+                        );
+                        return;
+                    }
+                    // No table in any previous version of Materialize was
+                    // defined with any keys, nor are we planning to test their
+                    // data sets to see if they can be retroactively applied.
+                    cur_table.keys.clear();
+                    // No column in any previous version of Materialize had a
+                    // NOT NULL constraint meaningfully applied.
+                    for c in cur_table.columns.iter_mut() {
+                        c.nullable = true;
+                    }
+                }
+                None => {
+                    warn!(
+                        "could not perform migration of PG source {name} due \
+                    to schema change; this source must be recreated, but the \
+                    schema in the warning where this occurs will have the wrong col_num."
+                    );
+                    return;
+                }
+            }
+        }
+
+        let _ = options.remove(details_idx).value.expect("valid catalog");
+
+        publication_details.tables = current_publication_tables;
+
+        options.push(PgConfigOption {
+            name: PgConfigOptionName::Details,
+            value: Some(mz_sql::ast::WithOptionValue::Value(Value::String(
+                hex::encode(publication_details.into_proto().encode_to_vec()),
+            ))),
+        });
+    }
+}

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1378,6 +1378,7 @@ pub async fn serve(
             aws_privatelink_availability_zones,
             system_parameter_frontend,
             storage_usage_retention_period,
+            connection_context: Some(connection_context.clone()),
         })
         .await?;
     let session_id = catalog.config().session_id;

--- a/src/postgres-util/src/desc.proto
+++ b/src/postgres-util/src/desc.proto
@@ -24,4 +24,6 @@ message ProtoPostgresColumnDesc {
     int32 type_mod = 3;
     bool nullable = 4;
     bool primary_key = 5;
+    // TODO(migration): remove optional in v0.48
+    optional uint32 col_num = 6;
 }

--- a/src/postgres-util/src/desc.proto
+++ b/src/postgres-util/src/desc.proto
@@ -33,6 +33,7 @@ message ProtoPostgresColumnDesc {
     uint32 type_oid = 2;
     int32 type_mod = 3;
     bool nullable = 4;
-    // TODO(migration): remove optional in v0.48
+    // TODO(migration): remove optional in version v.50 (released in v0.48 + 1
+    // additional release)
     optional uint32 col_num = 6;
 }

--- a/src/postgres-util/src/desc.proto
+++ b/src/postgres-util/src/desc.proto
@@ -27,11 +27,12 @@ message ProtoPostgresTableDesc {
 }
 
 message ProtoPostgresColumnDesc {
+    reserved 5;
+    reserved "primary_key";
     string name = 1;
     uint32 type_oid = 2;
     int32 type_mod = 3;
     bool nullable = 4;
-    bool primary_key = 5;
     // TODO(migration): remove optional in v0.48
     optional uint32 col_num = 6;
 }

--- a/src/postgres-util/src/desc.proto
+++ b/src/postgres-util/src/desc.proto
@@ -11,11 +11,19 @@ syntax = "proto3";
 
 package mz_postgres_util.desc;
 
+message ProtoPostgresKeyDesc {
+    uint32 oid = 1;
+    string name = 2;
+    repeated uint32 cols = 3;
+    bool is_primary = 4;
+}
+
 message ProtoPostgresTableDesc {
     string name = 1;
     string namespace = 2;
     uint32 oid = 3;
     repeated ProtoPostgresColumnDesc columns = 4;
+    repeated ProtoPostgresKeyDesc keys = 5;
 }
 
 message ProtoPostgresColumnDesc {

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -103,11 +103,6 @@ pub struct PostgresColumnDesc {
     pub type_mod: i32,
     /// True if the column lacks a `NOT NULL` constraint.
     pub nullable: bool,
-    /// Whether the column is part of the table's primary key.
-    ///
-    /// TODO(benesch): this doesn't look descriptive enough. The order of the
-    /// columns in the primary key matters too.
-    pub primary_key: bool,
 }
 
 impl RustType<ProtoPostgresColumnDesc> for PostgresColumnDesc {
@@ -118,7 +113,6 @@ impl RustType<ProtoPostgresColumnDesc> for PostgresColumnDesc {
             type_oid: self.type_oid,
             type_mod: self.type_mod,
             nullable: self.nullable,
-            primary_key: self.primary_key,
         }
     }
 
@@ -131,7 +125,6 @@ impl RustType<ProtoPostgresColumnDesc> for PostgresColumnDesc {
             type_oid: proto.type_oid,
             type_mod: proto.type_mod,
             nullable: proto.nullable,
-            primary_key: proto.primary_key,
         })
     }
 }
@@ -147,16 +140,14 @@ impl Arbitrary for PostgresColumnDesc {
             any::<u32>(),
             any::<i32>(),
             any::<bool>(),
-            any::<bool>(),
         )
             .prop_map(
-                |(name, col_num, type_oid, type_mod, nullable, primary_key)| PostgresColumnDesc {
+                |(name, col_num, type_oid, type_mod, nullable)| PostgresColumnDesc {
                     name,
                     col_num: Some(col_num),
                     type_oid,
                     type_mod,
                     nullable,
-                    primary_key,
                 },
             )
             .boxed()

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -26,7 +26,7 @@ pub struct PostgresTableDesc {
     pub namespace: String,
     /// The name of the table.
     pub name: String,
-    /// The description of each column, in order.
+    /// The description of each column, in order of their position in the table.
     pub columns: Vec<PostgresColumnDesc>,
 }
 
@@ -80,6 +80,10 @@ impl Arbitrary for PostgresTableDesc {
 pub struct PostgresColumnDesc {
     /// The name of the column.
     pub name: String,
+    /// The column's monotonic position in its table, i.e. "this was the _i_th
+    /// column created" irrespective of the current number of columns.
+    // TODO(migration): remove this Option in v0.48
+    pub col_num: Option<u16>,
     /// The OID of the column's type.
     pub type_oid: u32,
     /// The modifier for the column's type.
@@ -97,6 +101,7 @@ impl RustType<ProtoPostgresColumnDesc> for PostgresColumnDesc {
     fn into_proto(&self) -> ProtoPostgresColumnDesc {
         ProtoPostgresColumnDesc {
             name: self.name.clone(),
+            col_num: self.col_num.map(|c| c.into()),
             type_oid: self.type_oid,
             type_mod: self.type_mod,
             nullable: self.nullable,
@@ -107,6 +112,9 @@ impl RustType<ProtoPostgresColumnDesc> for PostgresColumnDesc {
     fn from_proto(proto: ProtoPostgresColumnDesc) -> Result<Self, TryFromProtoError> {
         Ok(PostgresColumnDesc {
             name: proto.name,
+            col_num: proto
+                .col_num
+                .map(|c| c.try_into().expect("values roundtrip")),
             type_oid: proto.type_oid,
             type_mod: proto.type_mod,
             nullable: proto.nullable,
@@ -122,14 +130,16 @@ impl Arbitrary for PostgresColumnDesc {
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         (
             any::<String>(),
+            any::<u16>(),
             any::<u32>(),
             any::<i32>(),
             any::<bool>(),
             any::<bool>(),
         )
             .prop_map(
-                |(name, type_oid, type_mod, nullable, primary_key)| PostgresColumnDesc {
+                |(name, col_num, type_oid, type_mod, nullable, primary_key)| PostgresColumnDesc {
                     name,
+                    col_num: Some(col_num),
                     type_oid,
                     type_mod,
                     nullable,

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -95,7 +95,8 @@ pub struct PostgresColumnDesc {
     pub name: String,
     /// The column's monotonic position in its table, i.e. "this was the _i_th
     /// column created" irrespective of the current number of columns.
-    // TODO(migration): remove this Option in v0.48
+    // TODO(migration): remove option in version v.50 (released in v0.48 + 1
+    // additional release)
     pub col_num: Option<u16>,
     /// The OID of the column's type.
     pub type_oid: u32,

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -262,14 +262,12 @@ pub async fn publication_info(
                 );
                 let type_mod: i32 = row.get("typmod");
                 let not_null: bool = row.get("not_null");
-                let primary_key = row.get("primary_key");
                 Ok(PostgresColumnDesc {
                     name,
                     col_num,
                     type_oid,
                     type_mod,
                     nullable: !not_null,
-                    primary_key,
                 })
             })
             .collect::<Result<Vec<_>, PostgresError>>()?;

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -235,6 +235,7 @@ pub async fn publication_info(
                 "SELECT
                         a.attname AS name,
                         a.atttypid AS typoid,
+                        a.attnum AS colnum,
                         a.atttypmod AS typmod,
                         a.attnotnull AS not_null,
                         b.oid IS NOT NULL AS primary_key
@@ -254,11 +255,17 @@ pub async fn publication_info(
             .map(|row| {
                 let name: String = row.get("name");
                 let type_oid = row.get("typoid");
+                let col_num = Some(
+                    row.get::<_, i16>("colnum")
+                        .try_into()
+                        .expect("non-negative values"),
+                );
                 let type_mod: i32 = row.get("typmod");
                 let not_null: bool = row.get("not_null");
                 let primary_key = row.get("primary_key");
                 Ok(PostgresColumnDesc {
                     name,
+                    col_num,
                     type_oid,
                     type_mod,
                     nullable: !not_null,

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -94,7 +94,7 @@ use mz_ore::task;
 use mz_repr::GlobalId;
 use mz_ssh_util::tunnel::SshTunnelConfig;
 
-use crate::desc::{PostgresColumnDesc, PostgresTableDesc};
+use crate::desc::{PostgresColumnDesc, PostgresKeyDesc, PostgresTableDesc};
 
 pub mod desc;
 
@@ -274,11 +274,78 @@ pub async fn publication_info(
             })
             .collect::<Result<Vec<_>, PostgresError>>()?;
 
+        // PG 15 adds UNIQUE NULLS NOT DISTINCT, which is a feature we cannot
+        // support: NULL = NULL must be true in Materialize for the sake of
+        // joins.
+        let pg_15_plus_keys = "
+        SELECT
+            pg_constraint.oid,
+            pg_constraint.conkey,
+            pg_constraint.conname,
+            pg_constraint.contype = 'p' AS is_primary
+        FROM
+            pg_constraint
+                JOIN
+                    pg_index
+                    ON pg_index.indexrelid = pg_constraint.conindid
+        WHERE
+            pg_constraint.conrelid = $1
+                AND
+            pg_constraint.contype =ANY (ARRAY['p', 'u'])
+                AND
+            NOT pg_index.indnullsnotdistinct;";
+
+        // As above but for versions of PG without indnullsnotdistinct.
+        let pg_14_minus_keys = "
+        SELECT
+            pg_constraint.oid,
+            pg_constraint.conkey,
+            pg_constraint.conname,
+            pg_constraint.contype = 'p' AS is_primary
+        FROM pg_constraint
+        WHERE
+            pg_constraint.conrelid = $1
+                AND
+            pg_constraint.contype =ANY (ARRAY['p', 'u']);";
+
+        let keys = match client.query(pg_15_plus_keys, &[&oid]).await {
+            Ok(keys) => keys,
+            Err(e)
+                // PG versions prior to 15 do not contain this column.
+                if e.to_string()
+                    == "db error: ERROR: column pg_index.indnullsnotdistinct does not exist" =>
+            {
+                client.query(pg_14_minus_keys, &[&oid]).await?
+            }
+            e => e?,
+        };
+
+        let keys = keys
+            .into_iter()
+            .map(|row| {
+                let oid: u32 = row.get("oid");
+                let cols: Vec<i16> = row.get("conkey");
+                let name: String = row.get("conname");
+                let is_primary: bool = row.get("is_primary");
+                let cols = cols
+                    .into_iter()
+                    .map(|col| u16::try_from(col).expect("non-negative colnums"))
+                    .collect();
+                PostgresKeyDesc {
+                    oid,
+                    name,
+                    cols,
+                    is_primary,
+                }
+            })
+            .collect();
+
         table_infos.push(PostgresTableDesc {
             oid,
             namespace: row.get("schemaname"),
             name: row.get("tablename"),
             columns,
+            keys,
         });
     }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -678,18 +678,41 @@ pub fn plan_create_source(
                         column: i,
                     });
 
-                    let cast_expr = plan_cast(
-                        &cast_ecx,
-                        CastContext::Explicit,
-                        col_expr,
-                        &scalar_type,
-                    )?
+                    let cast_expr =
+                        plan_cast(&cast_ecx, CastContext::Explicit, col_expr, &scalar_type)?;
+
+                    let cast = if column.nullable {
+                        cast_expr
+                    } else {
+                        // We must enforce nullability constraint on cast
+                        // because PG replication stream does not propagate
+                        // constraint changes and we want to error subsource if
+                        // e.g. the constraint is dropped and we don't notice
+                        // it.
+                        HirScalarExpr::CallVariadic {
+                            func: mz_expr::VariadicFunc::ErrorIfNull,
+                            exprs: vec![
+                                cast_expr,
+                                HirScalarExpr::literal(
+                                    mz_repr::Datum::from(
+                                        format!(
+                                            "PG column {}.{}.{} contained NULL data, despite having NOT NULL constraint",
+                                            table.namespace.clone(),
+                                            table.name.clone(),
+                                            column.name.clone())
+                                            .as_str(),
+                                    ),
+                                    ScalarType::String,
+                                ),
+                            ],
+                        }
+                    }
                     .lower_uncorrelated()
                     .expect(
                         "lower_uncorrelated should not fail given that there is no correlation \
                             in the input col_expr",
                     );
-                    column_casts.push(cast_expr);
+                    column_casts.push(cast);
                 }
                 let r = table_casts.insert(i + 1, column_casts);
                 assert!(r.is_none(), "cannot have table defined multiple times");

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -430,12 +430,20 @@ pub async fn purify_create_source(
                     };
 
                     let data_type = scx.resolve_type(ty)?;
+                    let mut options = vec![];
+
+                    if !c.nullable {
+                        options.push(mz_sql_parser::ast::ColumnOptionDef {
+                            name: None,
+                            option: mz_sql_parser::ast::ColumnOption::NotNull,
+                        });
+                    }
 
                     columns.push(ColumnDef {
                         name,
                         data_type,
                         collation: None,
-                        options: vec![],
+                        options,
                     });
                 }
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -269,11 +269,12 @@ pub async fn purify_create_source(
             let config = connection
                 .config(&*connection_context.secrets_reader)
                 .await?;
-            let publication_tables = mz_postgres_util::publication_info(&config, &publication)
-                .await
-                .map_err(|cause| PlanError::FetchingPostgresPublicationInfoFailed {
-                    cause: Arc::new(cause),
-                })?;
+            let publication_tables =
+                mz_postgres_util::publication_info(&config, &publication, None)
+                    .await
+                    .map_err(|cause| PlanError::FetchingPostgresPublicationInfoFailed {
+                        cause: Arc::new(cause),
+                    })?;
 
             // An index from table name -> schema name -> database name -> PostgresTableDesc
             let mut tables_by_name = BTreeMap::new();

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -315,18 +315,6 @@ pub async fn purify_create_source(
                     // The user manually selected a subset of upstream tables so we need to
                     // validate that the names actually exist and are not ambiguous
 
-                    // An index from table name -> schema name -> database name -> PostgresTableDesc
-                    let mut tables_by_name = BTreeMap::new();
-                    for table in &publication_tables {
-                        tables_by_name
-                            .entry(table.name.clone())
-                            .or_insert_with(BTreeMap::new)
-                            .entry(table.namespace.clone())
-                            .or_insert_with(BTreeMap::new)
-                            .entry(connection.database.clone())
-                            .or_insert(table);
-                    }
-
                     validated_requested_subsources
                         .extend(subsource_gen(subsources, &publication_catalog)?);
                 }

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -404,6 +404,7 @@ impl Usage {
             aws_privatelink_availability_zones: None,
             system_parameter_frontend: None,
             storage_usage_retention_period: None,
+            connection_context: None,
         })
         .await?;
 

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -809,7 +809,11 @@ fn validate_tables(
                         "Error validating table in publication. Expected: {:?} Actual: {:?}",
                         &info.desc, pub_schema
                     );
-                    bail!("Schema for table {} differs, recreate Materialize source to use new schema", info.desc.name)
+                    bail!(
+                        "source table {} with oid {} has been altered",
+                        info.desc.name,
+                        info.desc.oid
+                    )
                 }
             }
             None => {
@@ -818,9 +822,9 @@ fn validate_tables(
                     info.desc.name, id
                 );
                 bail!(
-                    "Publication missing expected table {} with oid {}",
+                    "source table {} with oid {} has been dropped",
                     info.desc.name,
-                    id
+                    info.desc.oid
                 )
             }
         }

--- a/test/cluster/pg-snapshot-resumption/01-configure-postgres.td
+++ b/test/cluster/pg-snapshot-resumption/01-configure-postgres.td
@@ -13,7 +13,8 @@ GRANT ALL PRIVILEGES ON DATABASE "postgres" TO debezium;
 GRANT ALL PRIVILEGES ON SCHEMA "public" TO debezium;
 
 CREATE PUBLICATION mz_source;
-CREATE PUBLICATION mz_source_alter;
+CREATE PUBLICATION mz_source_alter_add_col;
+CREATE PUBLICATION mz_source_alter_drop_constraint;
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP TABLE IF EXISTS ten;

--- a/test/pg-cdc-resumption/alter-table.td
+++ b/test/pg-cdc-resumption/alter-table.td
@@ -8,8 +8,8 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-ALTER TABLE to_be_altered_fail ADD COLUMN f2 INTEGER;
-INSERT INTO to_be_altered_fail VALUES (1, 2);
+ALTER TABLE alter_fail_add_col ADD COLUMN f2 INTEGER;
+INSERT INTO alter_fail_add_col VALUES (1, 2);
 
-ALTER TABLE to_be_altered_ok ALTER COLUMN f1 DROP NOT NULL;
-INSERT INTO to_be_altered_ok VALUES (NULL);
+ALTER TABLE alter_fail_drop_constraint ALTER COLUMN f1 DROP NOT NULL;
+INSERT INTO alter_fail_drop_constraint VALUES (NULL);

--- a/test/pg-cdc-resumption/alter-table.td
+++ b/test/pg-cdc-resumption/alter-table.td
@@ -8,5 +8,8 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-ALTER TABLE to_be_altered ADD COLUMN f2 INTEGER;
-INSERT INTO to_be_altered VALUES (1, 2);
+ALTER TABLE to_be_altered_fail ADD COLUMN f2 INTEGER;
+INSERT INTO to_be_altered_fail VALUES (1, 2);
+
+ALTER TABLE to_be_altered_ok ALTER COLUMN f1 DROP NOT NULL;
+INSERT INTO to_be_altered_ok VALUES (NULL);

--- a/test/pg-cdc-resumption/configure-materalize.td
+++ b/test/pg-cdc-resumption/configure-materalize.td
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> DROP SOURCE IF EXISTS mz_source CASCADE;
 > DROP SECRET IF EXISTS pgpass CASCADE;
 > DROP CONNECTION IF EXISTS pg CASCADE;
 
@@ -19,6 +18,9 @@
     PASSWORD SECRET pgpass
   );
 
+> DROP SOURCE IF EXISTS mz_source CASCADE;
+> DROP SOURCE IF EXISTS mz_source_alter_add_col CASCADE;
+> DROP SOURCE IF EXISTS mz_source_alter_drop_constraint CASCADE;
 
 > CREATE SOURCE mz_source
   FROM POSTGRES
@@ -26,10 +28,14 @@
   (PUBLICATION 'mz_source')
   FOR ALL TABLES;
 
-> DROP SOURCE IF EXISTS mz_source_alter CASCADE;
-
-> CREATE SOURCE mz_source_alter
+> CREATE SOURCE mz_source_alter_add_col
   FROM POSTGRES
   CONNECTION pg
-  (PUBLICATION 'mz_source_alter')
+  (PUBLICATION 'mz_source_alter_add_col')
+  FOR ALL TABLES;
+
+> CREATE SOURCE mz_source_alter_drop_constraint
+  FROM POSTGRES
+  CONNECTION pg
+  (PUBLICATION 'mz_source_alter_drop_constraint')
   FOR ALL TABLES;

--- a/test/pg-cdc-resumption/configure-postgres.td
+++ b/test/pg-cdc-resumption/configure-postgres.td
@@ -13,4 +13,5 @@ GRANT ALL PRIVILEGES ON DATABASE "postgres" TO debezium;
 GRANT ALL PRIVILEGES ON SCHEMA "public" TO debezium;
 
 CREATE PUBLICATION mz_source;
-CREATE PUBLICATION mz_source_alter;
+CREATE PUBLICATION mz_source_alter_add_col;
+CREATE PUBLICATION mz_source_alter_drop_constraint;

--- a/test/pg-cdc-resumption/populate-tables.td
+++ b/test/pg-cdc-resumption/populate-tables.td
@@ -32,9 +32,16 @@ ALTER PUBLICATION mz_source ADD TABLE t2;
 
 INSERT INTO t2 SELECT a1.f1 + a6.f1 , E'abc\nxyz' FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
 
-DROP TABLE IF EXISTS to_be_altered;
-CREATE TABLE to_be_altered (f1 INTEGER);
-ALTER TABLE to_be_altered REPLICA IDENTITY FULL;
+DROP TABLE IF EXISTS to_be_altered_fail;
+CREATE TABLE to_be_altered_fail (f1 INTEGER);
+ALTER TABLE to_be_altered_fail REPLICA IDENTITY FULL;
 
-INSERT INTO to_be_altered VALUES (1);
-ALTER PUBLICATION mz_source_alter ADD TABLE to_be_altered;
+INSERT INTO to_be_altered_fail VALUES (1);
+ALTER PUBLICATION mz_source_alter ADD TABLE to_be_altered_fail;
+
+DROP TABLE IF EXISTS to_be_altered_ok;
+CREATE TABLE to_be_altered_ok (f1 INTEGER NOT NULL);
+ALTER TABLE to_be_altered_ok REPLICA IDENTITY FULL;
+
+INSERT INTO to_be_altered_ok VALUES (1);
+ALTER PUBLICATION mz_source ADD TABLE to_be_altered_ok;

--- a/test/pg-cdc-resumption/populate-tables.td
+++ b/test/pg-cdc-resumption/populate-tables.td
@@ -32,16 +32,16 @@ ALTER PUBLICATION mz_source ADD TABLE t2;
 
 INSERT INTO t2 SELECT a1.f1 + a6.f1 , E'abc\nxyz' FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
 
-DROP TABLE IF EXISTS to_be_altered_fail;
-CREATE TABLE to_be_altered_fail (f1 INTEGER);
-ALTER TABLE to_be_altered_fail REPLICA IDENTITY FULL;
+DROP TABLE IF EXISTS alter_fail_add_col;
+CREATE TABLE alter_fail_add_col (f1 INTEGER);
+ALTER TABLE alter_fail_add_col REPLICA IDENTITY FULL;
 
-INSERT INTO to_be_altered_fail VALUES (1);
-ALTER PUBLICATION mz_source_alter ADD TABLE to_be_altered_fail;
+INSERT INTO alter_fail_add_col VALUES (1);
+ALTER PUBLICATION mz_source_alter_add_col ADD TABLE alter_fail_add_col;
 
-DROP TABLE IF EXISTS to_be_altered_ok;
-CREATE TABLE to_be_altered_ok (f1 INTEGER NOT NULL);
-ALTER TABLE to_be_altered_ok REPLICA IDENTITY FULL;
+DROP TABLE IF EXISTS alter_fail_drop_constraint;
+CREATE TABLE alter_fail_drop_constraint (f1 INTEGER NOT NULL);
+ALTER TABLE alter_fail_drop_constraint REPLICA IDENTITY FULL;
 
-INSERT INTO to_be_altered_ok VALUES (1);
-ALTER PUBLICATION mz_source ADD TABLE to_be_altered_ok;
+INSERT INTO alter_fail_drop_constraint VALUES (1);
+ALTER PUBLICATION mz_source_alter_drop_constraint ADD TABLE alter_fail_drop_constraint;

--- a/test/pg-cdc-resumption/verify-data.td
+++ b/test/pg-cdc-resumption/verify-data.td
@@ -12,9 +12,8 @@
 > SELECT COUNT(*) FROM t2;
 500000
 
-> SELECT * FROM to_be_altered_ok;
-1
-<null>
+! SELECT * FROM alter_fail_drop_constraint;
+contains:has been altered
 
-! SELECT * FROM to_be_altered_fail;
+! SELECT * FROM alter_fail_add_col;
 contains:has been altered

--- a/test/pg-cdc-resumption/verify-data.td
+++ b/test/pg-cdc-resumption/verify-data.td
@@ -12,5 +12,9 @@
 > SELECT COUNT(*) FROM t2;
 500000
 
-! SELECT * FROM to_be_altered;
-contains:altered
+> SELECT * FROM to_be_altered_ok;
+1
+<null>
+
+! SELECT * FROM to_be_altered_fail;
+contains:has been altered

--- a/test/pg-cdc/alter-table-after-source.td
+++ b/test/pg-cdc/alter-table-after-source.td
@@ -19,6 +19,10 @@
     PASSWORD SECRET pgpass
   )
 
+
+#
+# Add column
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
@@ -47,6 +51,10 @@ INSERT INTO add_columns VALUES (2, 'ab');
 contains:altered
 
 > DROP SOURCE mz_source;
+
+
+#
+# Remove column
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -77,6 +85,10 @@ contains:altered
 
 > DROP SOURCE mz_source;
 
+
+#
+# Alter column type
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
@@ -105,6 +117,10 @@ INSERT INTO alter_column VALUES (3, 'bc');
 contains:altered
 > DROP SOURCE mz_source;
 
+
+#
+# Drop NOT NULL
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
@@ -112,9 +128,9 @@ DROP PUBLICATION IF EXISTS mz_source;
 
 CREATE SCHEMA public;
 
-CREATE TABLE alter_nullability (f1 INTEGER NOT NULL);
-ALTER TABLE alter_nullability REPLICA IDENTITY FULL;
-INSERT INTO alter_nullability VALUES (1);
+CREATE TABLE alter_drop_nullability (f1 INTEGER NOT NULL);
+ALTER TABLE alter_drop_nullability REPLICA IDENTITY FULL;
+INSERT INTO alter_drop_nullability VALUES (1);
 
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
@@ -122,20 +138,58 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR ALL TABLES;
 
-> SELECT * from alter_nullability
+> SELECT * from alter_drop_nullability
 1
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-ALTER TABLE alter_nullability ALTER COLUMN f1 DROP NOT NULL;
-INSERT INTO alter_nullability VALUES (NULL);
+ALTER TABLE alter_drop_nullability ALTER COLUMN f1 DROP NOT NULL;
+INSERT INTO alter_drop_nullability VALUES (NULL);
 
-> SELECT * FROM alter_nullability WHERE f1 IS NOT NULL;
-1
+! SELECT * FROM alter_drop_nullability WHERE f1 IS NOT NULL;
+contains:altered
 
-> SELECT * FROM alter_nullability WHERE f1 IS NULL;
-<null>
+# We have guaranteed that this column is not null so the optimizer eagerly
+# returns the empty set.
+> SELECT * FROM alter_drop_nullability WHERE f1 IS NULL;
 
 > DROP SOURCE mz_source;
+
+
+#
+# Add NOT NULL
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_add_nullability (f1 INTEGER);
+ALTER TABLE alter_add_nullability REPLICA IDENTITY FULL;
+INSERT INTO alter_add_nullability VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * from alter_add_nullability
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_add_nullability ALTER COLUMN f1 SET NOT NULL;
+INSERT INTO alter_add_nullability VALUES (1);
+
+! SELECT * FROM alter_add_nullability;
+contains:altered
+
+> DROP SOURCE mz_source;
+
+
+#
+# Drop PK
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -161,12 +215,14 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE alter_drop_pk DROP CONSTRAINT alter_drop_pk_pkey;
 INSERT INTO alter_drop_pk VALUES (1);
 
-# Because ALTERing constraints does not show up in replication this does not cause an error
-> SELECT DISTINCT f1 FROM alter_drop_pk;
-1
+! SELECT f1 FROM alter_drop_pk;
+contains:altered
 
 > DROP SOURCE mz_source;
 
+
+#
+# Add PK
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -175,6 +231,165 @@ DROP PUBLICATION IF EXISTS mz_source;
 
 CREATE SCHEMA public;
 
+CREATE TABLE alter_add_pk (f1 INTEGER);
+ALTER TABLE alter_add_pk REPLICA IDENTITY FULL;
+INSERT INTO alter_add_pk VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * from alter_add_pk
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_add_pk ADD PRIMARY KEY(f1);
+INSERT INTO alter_add_pk VALUES (2);
+
+! SELECT * FROM alter_add_pk;
+contains:altered
+
+> DROP SOURCE mz_source;
+
+
+#
+# Cycle PK
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_cycle_pk (f1 INTEGER PRIMARY KEY);
+ALTER TABLE alter_cycle_pk REPLICA IDENTITY FULL;
+INSERT INTO alter_cycle_pk VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * from alter_cycle_pk
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_cycle_pk DROP CONSTRAINT alter_cycle_pk_pkey;
+ALTER TABLE alter_cycle_pk ADD PRIMARY KEY(f1);
+INSERT INTO alter_cycle_pk VALUES (2);
+
+! SELECT * FROM alter_cycle_pk;
+contains:altered
+
+> DROP SOURCE mz_source;
+
+
+#
+# Cycle PK off (no pk, pk, no pk)
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_cycle_pk_off (f1 INTEGER);
+ALTER TABLE alter_cycle_pk_off REPLICA IDENTITY FULL;
+INSERT INTO alter_cycle_pk_off VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * from alter_cycle_pk_off
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_cycle_pk_off ADD PRIMARY KEY(f1);
+ALTER TABLE alter_cycle_pk_off DROP CONSTRAINT alter_cycle_pk_off_pkey;
+INSERT INTO alter_cycle_pk_off VALUES (1);
+
+! SELECT * FROM alter_cycle_pk_off;
+contains:altered
+
+> DROP SOURCE mz_source;
+
+
+#
+# Drop unique
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_drop_unique (f1 INTEGER UNIQUE);
+ALTER TABLE alter_drop_unique REPLICA IDENTITY FULL;
+INSERT INTO alter_drop_unique VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * from alter_drop_unique
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_drop_unique DROP CONSTRAINT alter_drop_unique_f1_key;
+INSERT INTO alter_drop_unique VALUES (1);
+
+! SELECT f1 FROM alter_drop_unique;
+contains:altered
+
+> DROP SOURCE mz_source;
+
+
+#
+# Add unique
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_add_unique (f1 INTEGER);
+ALTER TABLE alter_add_unique REPLICA IDENTITY FULL;
+INSERT INTO alter_add_unique VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * from alter_add_unique
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_add_unique ADD UNIQUE(f1);
+INSERT INTO alter_add_unique VALUES (2);
+
+! SELECT * FROM alter_add_unique;
+contains:altered
+
+> DROP SOURCE mz_source;
+
+
+#
+# Extend column
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -206,6 +421,8 @@ contains:altered
 > DROP SOURCE mz_source;
 
 
+#
+# Alter decimal
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -237,6 +454,8 @@ contains:altered
 > DROP SOURCE mz_source;
 
 
+#
+# Alter set with OIDs
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -269,6 +488,8 @@ INSERT INTO alter_set_with_oids VALUES (2);
 > DROP SOURCE mz_source;
 
 
+#
+# Alter set without OIDs
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -301,6 +522,8 @@ INSERT INTO alter_set_without_oids VALUES (2);
 > DROP SOURCE mz_source;
 
 
+#
+# Alter table rename
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -344,6 +567,10 @@ INSERT INTO alter_table_renamed VALUES (3);
 
 > DROP SOURCE mz_source;
 
+
+#
+# Alter table rename colum
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
@@ -376,6 +603,8 @@ contains:altered
 > DROP SOURCE mz_source;
 
 
+#
+# Change column attnum
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -390,11 +619,11 @@ INSERT INTO alter_table_change_attnum (f1, f2) VALUES ('f1_orig','f2_orig');
 
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
-> CREATE SOURCE "test_slot_source"
+> CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES ("alter_table_change_attnum") WITH (size = '1');
 
-> SELECT * from alter_table_rename_column;
+> SELECT * from alter_table_change_attnum;
 f1_orig f2_orig
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
@@ -402,12 +631,7 @@ ALTER TABLE alter_table_change_attnum DROP COLUMN f2;
 ALTER TABLE alter_table_change_attnum ADD COLUMN f2 VARCHAR(10);
 INSERT INTO alter_table_change_attnum (f1, f2) VALUES ('f1_changed', 'f2_changed');
 
-# We have fooled the system into accepting this schema change
-# Results should be:
-# f1_orig <null>
-# f1_changed f2_changed
-> SELECT * FROM alter_table_change_attnum;
-f1_orig f2_orig
-f1_changed f2_changed
+! SELECT * from alter_table_change_attnum;
+contains:altered
 
 > DROP SOURCE mz_source;

--- a/test/pg-cdc/alter-table-after-source.td
+++ b/test/pg-cdc/alter-table-after-source.td
@@ -270,7 +270,6 @@ INSERT INTO alter_set_with_oids VALUES (2);
 
 
 
-
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
@@ -373,5 +372,42 @@ INSERT INTO alter_table_rename_column (f1, f2) VALUES ('f1_renamed', 'f2_renamed
 
 ! SELECT * FROM alter_table_rename_column;
 contains:altered
+
+> DROP SOURCE mz_source;
+
+
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_table_change_attnum (f1 VARCHAR(10), f2 VARCHAR(10));
+ALTER TABLE alter_table_change_attnum REPLICA IDENTITY FULL;
+INSERT INTO alter_table_change_attnum (f1, f2) VALUES ('f1_orig','f2_orig');
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE "test_slot_source"
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES ("alter_table_change_attnum") WITH (size = '1');
+
+> SELECT * from alter_table_rename_column;
+f1_orig f2_orig
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_table_change_attnum DROP COLUMN f2;
+ALTER TABLE alter_table_change_attnum ADD COLUMN f2 VARCHAR(10);
+INSERT INTO alter_table_change_attnum (f1, f2) VALUES ('f1_changed', 'f2_changed');
+
+# We have fooled the system into accepting this schema change
+# Results should be:
+# f1_orig <null>
+# f1_changed f2_changed
+> SELECT * FROM alter_table_change_attnum;
+f1_orig f2_orig
+f1_changed f2_changed
 
 > DROP SOURCE mz_source;


### PR DESCRIPTION
We previously determined if table schemas changed based only on their columns' names--this is, of course, very easy to trick.

Because the PG replication stream provided a minimal amount of information, we have a somewhat limited number of options to resolve this issue:
- Error on any schema change
  - Pro: simple
  - Con: Precludes supporting adding/removing uningested columns because we will never be able to know if the columns in `Relation` messages are new columns with the old columns' names.
  
  The con here is too severe, so do not suggest we take this approach.
- Reach out to the PG source to determine the table's current schema
  - Pro: robust
  - Con: complex semantics, e.g. we have no way of tying together the `Relation` message in the replication stream to the table's current schema in the source. I have inlined comments about why this approach is sane.
  
  Notably, this approach also suggests removing the constraint information from `PgColumnDesc`, which was unused and confusing. If we do **not** remove this, it is most sane to error on changes to ingested columns' constraints, even though those constraints are not use anywhere within Materialize––seems like an unnecessarily punitive approach.

### Motivation

This PR fixes a recognized bug. Fixes #17927

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
