### PR TITLE
Fallible reduce pair for invalid accumulation error checking in accumulable aggregations

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -65,7 +65,6 @@ where
 {
     let mut err_collection = err_input;
     // Convenience wrapper to render the right kind of hierarchical plan.
-    let mut err_collection = err_input;
     let mut build_hierarchical =
         |collection: Collection<G, (Row, Row), Diff>, expr: HierarchicalPlan| match expr {
             HierarchicalPlan::Monotonic(expr) => build_monotonic(debug_name, collection, expr),
@@ -104,17 +103,17 @@ where
             // First, we need to render our constituent aggregations.
             let mut to_collate = vec![];
 
-            if let Some(accumulable) = expr.accumulable {
-                let (arranged_output, errs) =
-                    build_accumulable(debug_name, collection.clone(), accumulable);
-                err_collection = err_collection.concat(&errs);
-                to_collate.push((ReductionType::Accumulable, arranged_output));
-            }
             if let Some(hierarchical) = expr.hierarchical {
                 to_collate.push((
                     ReductionType::Hierarchical,
                     build_hierarchical(collection.clone(), hierarchical),
                 ));
+            }
+            if let Some(accumulable) = expr.accumulable {
+                let (arranged_output, errs) =
+                    build_accumulable(debug_name, collection.clone(), accumulable);
+                err_collection = err_collection.concat(&errs);
+                to_collate.push((ReductionType::Accumulable, arranged_output));
             }
             if let Some(basic) = expr.basic {
                 to_collate.push((ReductionType::Basic, build_basic(collection.clone(), basic)));
@@ -791,7 +790,6 @@ where
         })
         .as_collection(|k,v| (k.clone(), v.clone()))
         .map_fallible("Checked Invalid Accumulations", |(key, result)| {
-            use mz_expr::EvalError;
             match result {
                 Err(message) => Err(EvalError::Internal(message).into()),
                 Ok(values) => Ok((key, values)),

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -12,7 +12,9 @@
 #![allow(missing_docs)]
 
 use differential_dataflow::operators::arrange::TraceAgent;
-use differential_dataflow::trace::implementations::ord::{ColKeySpine, ColValSpine, OrdKeySpine};
+use differential_dataflow::trace::implementations::ord::{
+    ColKeySpine, ColValSpine, OrdKeySpine, OrdValSpine,
+};
 
 use mz_repr::{Diff, Row, Timestamp};
 use mz_storage_client::types::errors::DataflowError;
@@ -20,6 +22,7 @@ use mz_storage_client::types::errors::DataflowError;
 pub type RowSpine<K, V, T, R, O = usize> = ColValSpine<K, V, T, R, O>;
 pub type RowKeySpine<K, T, R, O = usize> = ColKeySpine<K, T, R, O>;
 pub type ErrSpine<K, T, R, O = usize> = OrdKeySpine<K, T, R, O>;
+pub type ErrValSpine<K, T, R, O = usize> = OrdValSpine<K, DataflowError, T, R, O>;
 pub type TraceRowHandle<K, V, T, R> = TraceAgent<RowSpine<K, V, T, R>>;
 pub type TraceErrHandle<K, T, R> = TraceAgent<ErrSpine<K, T, R>>;
 pub type KeysValsHandle = TraceRowHandle<Row, Row, Timestamp, Diff>;

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -460,9 +460,7 @@ where
     if datums.peek().is_none() {
         Datum::Null
     } else {
-        let x: u128 = datums.map(|d| u128::from(d.unwrap_uint16())).sum();
-        // Note that we return here a numeric, but the value will be downcast
-        // as part of reduce planning to a uint8.
+        let x: u64 = datums.map(|d| u64::from(d.unwrap_uint16())).sum();
         Datum::from(x)
     }
 }
@@ -475,9 +473,7 @@ where
     if datums.peek().is_none() {
         Datum::Null
     } else {
-        let x: u128 = datums.map(|d| u128::from(d.unwrap_uint32())).sum();
-        // Note that we return here a numeric, but the value will be downcast
-        // as part of reduce planning to a uint8.
+        let x: u64 = datums.map(|d| u64::from(d.unwrap_uint32())).sum();
         Datum::from(x)
     }
 }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1194,58 +1194,12 @@ impl MirRelationExpr {
         aggregates: Vec<AggregateExpr>,
         expected_group_size: Option<usize>,
     ) -> Self {
-        // Check if we have an unsigned aggregation and add an appropriate cast here
-        // when the output is expected to be unsigned. This is done since rendering
-        // needs to accumulate to a signed number to deal with retractions, and we do
-        // not want to panic there (#17510).
-        let mut unsigned_sums = aggregates
-            .iter()
-            .enumerate()
-            .filter(|(_, agg)| {
-                agg.func == AggregateFunc::SumUInt16 || agg.func == AggregateFunc::SumUInt32
-            })
-            .map(|(idx, _)| idx)
-            .peekable();
-        if unsigned_sums.peek().is_some() {
-            let unsigned_sums: Vec<_> = unsigned_sums.collect();
-
-            // First, we build the cast expressions.
-            let key_arity = group_key.len();
-            let casts: Vec<_> = unsigned_sums
-                .iter()
-                .map(|idx| MirScalarExpr::CallUnary {
-                    func: crate::UnaryFunc::CastNumericToUint64(crate::func::CastNumericToUint64),
-                    expr: Box::new(MirScalarExpr::Column(key_arity + idx)),
-                })
-                .collect();
-
-            // Then, we create the reduction, followed by a map.
-            let expr_arity = key_arity + aggregates.len();
-            let reduce = MirRelationExpr::Reduce {
-                input: Box::new(self),
-                group_key: group_key.into_iter().map(MirScalarExpr::Column).collect(),
-                aggregates,
-                monotonic: false,
-                expected_group_size,
-            };
-            let map = reduce.map(casts);
-
-            // Finally, we create a projection keeping only the cast values.
-            let mut outputs = (0..expr_arity).collect::<Vec<_>>();
-            let mut offset = 0;
-            for idx in unsigned_sums {
-                outputs[key_arity + idx] = expr_arity + offset;
-                offset += 1;
-            }
-            map.project(outputs)
-        } else {
-            MirRelationExpr::Reduce {
-                input: Box::new(self),
-                group_key: group_key.into_iter().map(MirScalarExpr::Column).collect(),
-                aggregates,
-                monotonic: false,
-                expected_group_size,
-            }
+        MirRelationExpr::Reduce {
+            input: Box::new(self),
+            group_key: group_key.into_iter().map(MirScalarExpr::Column).collect(),
+            aggregates,
+            monotonic: false,
+            expected_group_size,
         }
     }
 

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -94,4 +94,5 @@ pub mod order;
 pub mod panic;
 pub mod probe;
 pub mod progress;
+pub mod reduce;
 pub mod replay;

--- a/src/timely-util/src/reduce.rs
+++ b/src/timely-util/src/reduce.rs
@@ -1,0 +1,83 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use differential_dataflow::difference::{Abelian, Semigroup};
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
+use differential_dataflow::operators::reduce::ReduceCore;
+use differential_dataflow::trace::{Batch, Trace, TraceReader};
+use differential_dataflow::Data;
+use timely::dataflow::Scope;
+
+/// Extension trait for `ReduceCore`, currently providing a reduction based
+/// on an operator-pair approach.
+pub trait ReduceExt<G: Scope, K: Data, V: Data, R: Semigroup>
+where
+    G::Timestamp: Lattice + Ord,
+{
+    /// This method produces a reduction pair based on the same input arrangement. Each reduction
+    /// in the pair operates with its own logic and the two output arrangements from the reductions
+    /// are produced as a result. The method is useful for reductions that need to present different
+    /// output views on the same input data. An example is producing an error-free reduction output
+    /// along with a separate error output indicating when the error-free output is valid.
+    fn reduce_pair<L1, T1, L2, T2>(
+        &self,
+        name1: &str,
+        name2: &str,
+        logic1: L1,
+        logic2: L2,
+    ) -> (Arranged<G, TraceAgent<T1>>, Arranged<G, TraceAgent<T2>>)
+    where
+        T1: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
+        T1::Val: Data,
+        T1::R: Abelian,
+        T1::Batch: Batch,
+        L1: FnMut(&K, &[(&V, R)], &mut Vec<(T1::Val, T1::R)>) + 'static,
+        T2: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
+        T2::Val: Data,
+        T2::R: Abelian,
+        T2::Batch: Batch,
+        L2: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val, T2::R)>) + 'static;
+}
+
+impl<G: Scope, K: Data, V: Data, Tr, R: Semigroup> ReduceExt<G, K, V, R> for Arranged<G, Tr>
+where
+    G::Timestamp: Lattice + Ord,
+    Tr: TraceReader<Key = K, Val = V, Time = G::Timestamp, R = R> + Clone + 'static,
+{
+    fn reduce_pair<L1, T1, L2, T2>(
+        &self,
+        name1: &str,
+        name2: &str,
+        logic1: L1,
+        logic2: L2,
+    ) -> (Arranged<G, TraceAgent<T1>>, Arranged<G, TraceAgent<T2>>)
+    where
+        T1: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
+        T1::Val: Data,
+        T1::R: Abelian,
+        T1::Batch: Batch,
+        L1: FnMut(&K, &[(&V, R)], &mut Vec<(T1::Val, T1::R)>) + 'static,
+        T2: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
+        T2::Val: Data,
+        T2::R: Abelian,
+        T2::Batch: Batch,
+        L2: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val, T2::R)>) + 'static,
+    {
+        let arranged1 = self.reduce_abelian::<L1, T1>(name1, logic1);
+        let arranged2 = self.reduce_abelian::<L2, T2>(name2, logic2);
+        (arranged1, arranged2)
+    }
+}

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -598,27 +598,21 @@ def workflow_test_github_17177(c: Composition) -> None:
 
     c.down(destroy_volumes=True)
     with c.override(
-        Clusterd(
-            name="clusterd_nopanic",
-            environment_extra=[
-                "MZ_SOFT_ASSERTIONS=0",
-            ],
-        ),
         Testdrive(no_reset=True),
     ):
         c.up("testdrive", persistent=True)
         c.up("materialized")
-        c.up("clusterd_nopanic")
+        c.up("clusterd1")
 
         # set up a test cluster and run a testdrive regression script
         c.sql(
             """
             CREATE CLUSTER cluster1 REPLICAS (
                 r1 (
-                    STORAGECTL ADDRESSES ['clusterd_nopanic:2100'],
-                    STORAGE ADDRESSES ['clusterd_nopanic:2103'],
-                    COMPUTECTL ADDRESSES ['clusterd_nopanic:2101'],
-                    COMPUTE ADDRESSES ['clusterd_nopanic:2102'],
+                    STORAGECTL ADDRESSES ['clusterd1:2100'],
+                    STORAGE ADDRESSES ['clusterd1:2103'],
+                    COMPUTECTL ADDRESSES ['clusterd1:2101'],
+                    COMPUTE ADDRESSES ['clusterd1:2102'],
                     WORKERS 2
                 )
             );
@@ -638,7 +632,7 @@ def workflow_test_github_17177(c: Composition) -> None:
 
             > INSERT INTO base VALUES (1.01, -1);
 
-            # The query below would not fail previously, but now now should produce
+            # The query below would not fail previously, but now should produce
             # a SQL-level error that is observable by users.
             ! SELECT SUM(data) FROM data;
             contains:Invalid data in source, saw net-zero records for key
@@ -654,7 +648,7 @@ def workflow_test_github_17177(c: Composition) -> None:
         )
 
         # ensure that an error was put into the logs
-        c1 = c.invoke("logs", "clusterd_nopanic", capture=True)
+        c1 = c.invoke("logs", "clusterd1", capture=True)
         assert (
             "Net-zero records with non-zero accumulation in ReduceAccumulable"
             in c1.stdout
@@ -673,27 +667,21 @@ def workflow_test_github_17510(c: Composition) -> None:
 
     c.down(destroy_volumes=True)
     with c.override(
-        Clusterd(
-            name="clusterd_nopanic",
-            environment_extra=[
-                "MZ_SOFT_ASSERTIONS=0",
-            ],
-        ),
         Testdrive(no_reset=True),
     ):
         c.up("testdrive", persistent=True)
         c.up("materialized")
-        c.up("clusterd_nopanic")
+        c.up("clusterd1")
 
         # set up a test cluster and run a testdrive regression script
         c.sql(
             """
             CREATE CLUSTER cluster1 REPLICAS (
                 r1 (
-                    STORAGECTL ADDRESSES ['clusterd_nopanic:2100'],
-                    STORAGE ADDRESSES ['clusterd_nopanic:2103'],
-                    COMPUTECTL ADDRESSES ['clusterd_nopanic:2101'],
-                    COMPUTE ADDRESSES ['clusterd_nopanic:2102'],
+                    STORAGECTL ADDRESSES ['clusterd1:2100'],
+                    STORAGE ADDRESSES ['clusterd1:2103'],
+                    COMPUTECTL ADDRESSES ['clusterd1:2101'],
+                    COMPUTE ADDRESSES ['clusterd1:2102'],
                     WORKERS 2
                 )
             );
@@ -817,7 +805,7 @@ def workflow_test_github_17510(c: Composition) -> None:
         )
 
         # ensure that an error was put into the logs
-        c1 = c.invoke("logs", "clusterd_nopanic", capture=True)
+        c1 = c.invoke("logs", "clusterd1", capture=True)
         assert "Invalid negative unsigned aggregation in ReduceAccumulable" in c1.stdout
 
 


### PR DESCRIPTION
This PR demonstrates the concept of executing a reduction pair over the same input arrangement to produce two output views of a reduction, being one for data and one for errors. This approach allows us to externalize invalid accumulation errors from accumulable reductions without requiring any changes to query planning nor any changes to DD's `reduce_abelian` operator. Importantly, the externalized errors can then be exposed as query-level errors, becoming visible to the user and preventing the output of incorrect data. Note that we cannot detect in our reduction operators all the possible ways in which source data might be incorrect by invalid accumulations. However, the approach in this PR shows that for all invalid accumulation errors that we can detect, a query-level error can be produced in addition to error logging to Sentry. 

Fixes #17177.

The use of operator pairs has the risk of introducing a performance impact, as the work of producing per-key, per-time value snapshots based on the input arrangement is performed twice (once for each `reduce_abelian` in the operator pair). Thus, to characterize this risk, the performance impact of this PR was evaluated in a local developer setup with query processing over a static TPC-H load generator source at scale factor 1. The queries used were mutations of CH-benCHmark's Q1. Details and results are documented in a [separate spreadsheet](https://docs.google.com/spreadsheets/d/1DohjjQeiJ7tByMhNUAnDlouFUciOrQLPB3tJWSQtoTo/edit?usp=sharing). We would expect an up to 2x performance hit if the construction of per-key snapshots by the reduce operator eventually turned out to be a dominating cost in query processing. However, in the setting evaluated, it was not possible to observe any performance degradation from the changes introduced by this PR.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/17177

### Tips for reviewer

The commits in this PR can be looked at individually. A few points that are worth considering:

- As per [a discussion below](https://github.com/MaterializeInc/materialize/pull/17990#discussion_r1131015999), `ReduceExt` was introduced to mark the use of the operator-pair pattern in the codebase, as opposed to being a mechanism to facilitate code reuse.
- In our `typedefs.rs`, I introduced `ErrValSpine` as the trace type for arrangements containing error values and normal keys, and kept `ErrSpine` with its current semantics of empty values and errors as keys. This deviates a bit from the choice made for `RowSpine` vs. `RowKeySpine`, but I felt it was better to leave the "default" use as the unqualified one.
- This PR improves on (and partly undoes) both PRs #16852 and #17709. For the former, it makes sure that we now produce errors instead of returning negative accumulations over unsigned data; for the latter, it continues to avoid the panic in `uint2` and `uint4` aggregations, but without requiring any changes to HIR-to-MIR lowering.
- Additionally, this PR also makes rendering behave similarly to constant-folding when it comes to producing errors due to invalid multiplicities or wrapping around when there is a legitimate overflow of unsigned integer data. This makes the behavior for unsigned integers more consistent with the current behavior for signed integers. I am, however, explicitly leaving out revising the behavior to produce error in a wider range of conditions, since this should be addressed as part of #17758.
- I am using issue #17177 to track the work of surfacing the errors logged by ReduceAccumulable as query-level errors. Under this interpretation, this PR fixes the referred issue. However, we may still see these errors in the logs, and they may still be indicative of either incorrect source data or bugs in Materialize. So we expect Sentry to generate more of these error reports in the future, but I am hopeful we can then collect those into another issue then.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated, up-to-date [design doc](https://github.com/MaterializeInc/materialize/pull/17597).
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improved error reporting for invalid accumulations in accumulable (e.g., SUM/COUNT/AVG) aggregations.
