### PR TITLE
feature benchmark: Add optbench TPCH runs

### DIFF
--- a/misc/python/materialize/feature_benchmark/action.py
+++ b/misc/python/materialize/feature_benchmark/action.py
@@ -41,7 +41,7 @@ class LambdaAction(Action):
         self,
         executor: Optional[Executor] = None,
     ) -> None:
-        e = executor if executor else self._executor
+        e = executor or self._executor
         assert e is not None
         e.Lambda(self._lambda)
         return None
@@ -57,7 +57,7 @@ class Kgen(Action):
         self,
         executor: Optional[Executor] = None,
     ) -> None:
-        getattr((executor if executor else self._executor), "Kgen")(
+        getattr((executor or self._executor), "Kgen")(
             topic=self._topic, args=self._args
         )
 
@@ -73,7 +73,7 @@ class TdAction(Action):
         self,
         executor: Optional[Executor] = None,
     ) -> None:
-        getattr((executor if executor else self._executor), "Td")(self._td_str)
+        getattr((executor or self._executor), "Td")(self._td_str)
 
 
 class DummyAction(Action):

--- a/misc/python/materialize/feature_benchmark/measurement_source.py
+++ b/misc/python/materialize/feature_benchmark/measurement_source.py
@@ -52,9 +52,7 @@ class Td(MeasurementSource):
         assert not (executor is None and self._executor is None)
         assert not (executor is not None and self._executor is not None)
 
-        td_output = getattr((executor if executor else self._executor), "Td")(
-            self._td_str
-        )
+        td_output = getattr((executor or self._executor), "Td")(self._td_str)
 
         lines = td_output.splitlines()
         lines = [l for l in lines if l]
@@ -100,7 +98,7 @@ class Lambda(MeasurementSource):
         self,
         executor: Optional[Executor] = None,
     ) -> Timestamp:
-        e = executor if executor else self._executor
+        e = executor or self._executor
         assert e is not None
         e.Lambda(self._lambda)
         return time.time()

--- a/misc/python/materialize/optbench/sql.py
+++ b/misc/python/materialize/optbench/sql.py
@@ -42,7 +42,7 @@ class Query:
         m = re.search(p, self.query, re.MULTILINE)
         return m.group("name") if m else "anonoymous"
 
-    def explain(self, timing: bool, dialect: Dialect) -> str:
+    def explain(self, timing: bool, dialect: Dialect = Dialect.MZ) -> str:
         """Prepends 'EXPLAIN ...' to the query respecting the given dialect."""
 
         if dialect == Dialect.PG:

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -21,6 +21,7 @@ sys.path.append(os.path.dirname(__file__))
 from scenarios import *  # noqa: F401 F403
 from scenarios import Scenario
 from scenarios_concurrency import *  # noqa: F401 F403
+from scenarios_optbench import *  # noqa: F401 F403
 
 from materialize.feature_benchmark.aggregation import Aggregation, MinAggregation
 from materialize.feature_benchmark.benchmark import Benchmark, Report, SingleReport

--- a/test/feature-benchmark/scenarios_optbench.py
+++ b/test/feature-benchmark/scenarios_optbench.py
@@ -1,0 +1,92 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Type
+
+from parameterized import parameterized_class  # type: ignore
+
+import materialize.optbench
+import materialize.optbench.sql
+from materialize.feature_benchmark.action import Action
+from materialize.feature_benchmark.executor import Executor
+from materialize.feature_benchmark.measurement_source import (
+    MeasurementSource,
+    Timestamp,
+)
+from materialize.feature_benchmark.scenario import Scenario
+
+
+class OptbenchInit(Action):
+    def __init__(self, scenario: str, no_indexes: bool = False) -> None:
+        self._executor: Optional[Executor] = None
+        self._scenario = scenario
+        self._no_indexes = no_indexes
+
+    def run(self, executor: Optional[Executor] = None) -> None:
+        e = executor or self._executor
+        statements = materialize.optbench.sql.parse_from_file(
+            Path(f"misc/python/materialize/optbench/schema/{self._scenario}.sql")
+        )
+        if self._no_indexes:
+            idx_re = re.compile(r"(create|create\s+default|drop)\s+index\s+")
+            statements = [
+                statement
+                for statement in statements
+                if not idx_re.match(statement.lower())
+            ]
+        e._composition.sql("\n".join(statements))  # type: ignore
+
+
+class OptbenchRun(MeasurementSource):
+    def __init__(self, optbench_scenario: str, query: int):
+        self._executor: Optional[Executor] = None
+        self._optbench_scenario = optbench_scenario
+        self._query = query
+
+    def run(self, executor: Optional[Executor] = None) -> List[Timestamp]:
+        assert not (executor is None and self._executor is None)
+        assert not (executor is not None and self._executor is not None)
+        e = executor or self._executor
+
+        queries = materialize.optbench.sql.parse_from_file(
+            Path(
+                f"misc/python/materialize/optbench/workload/{self._optbench_scenario}.sql"
+            )
+        )
+        assert 1 <= self._query <= len(queries)
+        query = queries[self._query - 1]
+        explain_query = materialize.optbench.sql.Query(query).explain(timing=True)
+        explain_output = materialize.optbench.sql.ExplainOutput(
+            e._composition.sql_query(explain_query)[0][0]  # type: ignore
+        )
+        # Optimization time is in microseconds, divide by 3 to get a more readable number (still in wrong unit)
+        timestamps = [0, float(explain_output.optimization_time()) / 3]  # type: ignore
+        return timestamps
+
+
+def name_with_query(cls: Type["OptbenchTPCH"], num: int, params_dict: Dict) -> str:
+    return f"OptbenchTPCHQ{params_dict['QUERY']:02d}"
+
+
+@parameterized_class(
+    [{"QUERY": i} for i in range(1, 23)], class_name_func=name_with_query
+)
+class OptbenchTPCH(Scenario):
+    """Run optbench TPCH for optimizer benchmarks"""
+
+    QUERY = 1
+
+    def init(self) -> List[Action]:
+        return [OptbenchInit("tpch")]
+
+    def benchmark(self) -> MeasurementSource:
+        return OptbenchRun("tpch", self.QUERY)


### PR DESCRIPTION
feature benchmark assumes 1 query only, while we would want to measure multiple queries on the same data set. Thus we are wasteful in recreating the tables. Is there a better solution?

Sample output:
```
+++ Benchmark Report for cycle 1:
NAME                      |    THIS     |    OTHER    |  Regression?  | 'THIS' is:
----------------------------------------------------------------------------------------------------
OptbenchTPCHQ01           | 1016617.000 |  981297.000 |      no       | 3.6 pct   slower
OptbenchTPCHQ02           | 6927291.000 | 7538235.000 |      no       | 8.1 pct   faster
OptbenchTPCHQ03           | 1516941.000 | 1788813.000 |      no       | 15.2 pct   faster
OptbenchTPCHQ04           | 2518549.000 | 2535249.000 |      no       | 0.7 pct   faster
OptbenchTPCHQ05           | 2234296.000 | 2265717.000 |      no       | 1.4 pct   faster
OptbenchTPCHQ06           | 1387980.000 | 1431501.000 |      no       | 3.0 pct   faster
OptbenchTPCHQ07           | 3565516.000 | 3527246.000 |      no       | 1.1 pct   slower
OptbenchTPCHQ08           | 3496096.000 | 3763327.000 |      no       | 7.1 pct   faster
OptbenchTPCHQ09           | 2148025.000 | 2244475.000 |      no       | 4.3 pct   faster
OptbenchTPCHQ10           | 1878435.000 | 1876495.000 |      no       | 0.1 pct   slower
OptbenchTPCHQ11           | 4191032.000 | 4669005.000 |      no       | 10.2 pct   faster
OptbenchTPCHQ12           | 1927317.000 | 1771566.000 |      no       | 8.8 pct   slower
OptbenchTPCHQ13           | 2705070.000 | 2795281.000 |      no       | 3.2 pct   faster
OptbenchTPCHQ14           | 2184158.000 | 2355360.000 |      no       | 7.3 pct   faster
OptbenchTPCHQ15           | 2706711.000 | 2858583.000 |      no       | 5.3 pct   faster
OptbenchTPCHQ16           | 4268408.000 | 4268420.000 |      no       | 0.0 pct   faster
OptbenchTPCHQ17           | 5864547.000 | 5661547.000 |      no       | 3.6 pct   slower
OptbenchTPCHQ18           | 3454687.000 | 4162530.000 |      no       | 17.0 pct   faster
OptbenchTPCHQ19           | 9177006.000 | 9858960.000 |      no       | 6.9 pct   faster
OptbenchTPCHQ20           | 7824751.000 | 7581530.000 |      no       | 3.2 pct   slower
OptbenchTPCHQ21           | 6963957.000 | 6955588.000 |      no       | 0.1 pct   slower
OptbenchTPCHQ22           | 7945984.000 | 7806523.000 |      no       | 1.8 pct   slower
```

Fixes #17641

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
