### PR TITLE
timely-util: async output handles

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -460,9 +460,7 @@ where
                     batch_description
                 );
 
-                let mut output = output.activate();
-                let mut session = output.session(&cap);
-                session.give(batch_description);
+                output.give(&cap, batch_description).await;
 
                 // WIP: We downgrade our capability so that downstream
                 // operators (writer and appender) can know when all the
@@ -823,9 +821,7 @@ where
                             }
                         };
 
-                        let mut output = output.activate();
-                        let mut session = output.session(&cap);
-                        session.give(batch_or_data);
+                        output.give(&cap, batch_or_data).await;
                     }
                 }
             } else {

--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -582,9 +582,8 @@ where
                                 headers.as_deref(),
                             );
 
-                            let mut output = output.activate();
                             if value_bytes_remaining.is_empty() {
-                                output.session(&cap).give(DecodeResult {
+                                let result = DecodeResult {
                                     key: None,
                                     value: Some(value.map(|r| (r, 1)).map_err(|inner| {
                                         DecodeError {
@@ -596,11 +595,12 @@ where
                                     upstream_time_millis,
                                     partition: partition.clone(),
                                     metadata,
-                                });
+                                };
+                                output.give(&cap, result).await;
                                 value_buf = vec![];
                                 break;
                             } else {
-                                output.session(&cap).give(DecodeResult {
+                                let result = DecodeResult {
                                     key: None,
                                     value: Some(value.map(|r| (r, 1)).map_err(|inner| {
                                         DecodeError {
@@ -612,7 +612,8 @@ where
                                     upstream_time_millis,
                                     partition: partition.clone(),
                                     metadata,
-                                });
+                                };
+                                output.give(&cap, result).await;
                             }
                             if is_err {
                                 // If decoding has gone off the rails, we can no longer be sure that the delimiters are correct, so it
@@ -650,8 +651,7 @@ where
                                 headers.as_deref(),
                             );
 
-                            let mut output = output.activate();
-                            output.session(&cap).give(DecodeResult {
+                            let result = DecodeResult {
                                 key: None,
                                 value: Some(value.map(|r| (r, 1)).map_err(|inner| DecodeError {
                                     kind: inner,
@@ -661,7 +661,8 @@ where
                                 upstream_time_millis,
                                 partition: partition.clone(),
                                 metadata,
-                            });
+                            };
+                            output.give(&cap, result).await;
                         }
                     }
                 }

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -19,14 +19,16 @@ use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
 use timely::dataflow::operators::generic::{
     operator::{self, Operator},
-    InputHandle, OperatorInfo, OutputHandle, OutputWrapper,
+    InputHandle, OperatorInfo, OutputHandle,
 };
 use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, Stream};
 use timely::Data;
 
 use crate::buffer::ConsolidateBuffer;
-use crate::builder_async::{AsyncInputHandle, OperatorBuilder as OperatorBuilderAsync};
+use crate::builder_async::{
+    AsyncInputHandle, AsyncOutputHandle, OperatorBuilder as OperatorBuilderAsync,
+};
 
 /// Extension methods for timely [`Stream`]s.
 pub trait StreamExt<G, D1>
@@ -75,7 +77,7 @@ where
             Capability<G::Timestamp>,
             OperatorInfo,
             AsyncInputHandle<G::Timestamp, Vec<D1>, P::Puller>,
-            OutputWrapper<G::Timestamp, Vec<D2>, Tee<G::Timestamp, D2>>,
+            AsyncOutputHandle<G::Timestamp, Vec<D2>, Tee<G::Timestamp, D2>>,
         ) -> BFut,
         BFut: Future + 'static,
         P: ParallelizationContract<G::Timestamp, D1>;
@@ -99,7 +101,7 @@ where
             OperatorInfo,
             AsyncInputHandle<G::Timestamp, Vec<D1>, P1::Puller>,
             AsyncInputHandle<G::Timestamp, Vec<D2>, P2::Puller>,
-            OutputWrapper<G::Timestamp, Vec<D3>, Tee<G::Timestamp, D3>>,
+            AsyncOutputHandle<G::Timestamp, Vec<D3>, Tee<G::Timestamp, D3>>,
         ) -> BFut,
         BFut: Future + 'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
@@ -253,7 +255,7 @@ where
             Capability<G::Timestamp>,
             OperatorInfo,
             AsyncInputHandle<G::Timestamp, Vec<D1>, P::Puller>,
-            OutputWrapper<G::Timestamp, Vec<D2>, Tee<G::Timestamp, D2>>,
+            AsyncOutputHandle<G::Timestamp, Vec<D2>, Tee<G::Timestamp, D2>>,
         ) -> BFut,
         BFut: Future + 'static,
         P: ParallelizationContract<G::Timestamp, D1>,
@@ -289,7 +291,7 @@ where
             OperatorInfo,
             AsyncInputHandle<G::Timestamp, Vec<D1>, P1::Puller>,
             AsyncInputHandle<G::Timestamp, Vec<D2>, P2::Puller>,
-            OutputWrapper<G::Timestamp, Vec<D3>, Tee<G::Timestamp, D3>>,
+            AsyncOutputHandle<G::Timestamp, Vec<D3>, Tee<G::Timestamp, D3>>,
         ) -> BFut,
         BFut: Future + 'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
@@ -451,7 +453,7 @@ where
     B: FnOnce(
         Capability<G::Timestamp>,
         OperatorInfo,
-        OutputWrapper<G::Timestamp, Vec<D>, Tee<G::Timestamp, D>>,
+        AsyncOutputHandle<G::Timestamp, Vec<D>, Tee<G::Timestamp, D>>,
     ) -> BFut,
     BFut: Future + 'static,
 {


### PR DESCRIPTION
### Motivation

This PR replaces the synchronous timely handles with async ones. Their main benefit is that it is totally fine to hold handles active across await points which produces both better ergonomics and more efficient batch creation for the cases where we produce messages one by one.

All the methods on the handle that send data are marked `async` so that the handle can automatically trigger a yield. The fuel system is not implemented in this PR but it will follow soon after this merges.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
