### PR TITLE
doc/user: Add install->get-started redirect

### DIFF
--- a/doc/user/content/get-started.md
+++ b/doc/user/content/get-started.md
@@ -9,6 +9,7 @@ menu:
 aliases:
   - /katacoda/
   - /quickstarts/
+  - /install/
 ---
 
 [//]: # "TODO(morsapaes) Once we're GA, add details about signing up and logging


### PR DESCRIPTION
### Motivation

Use hugo aliases to create a redirect from /docs/install to /docs/get-started

### Tips for reviewer

Go to the preview build and try and load the `/install/` page. It should redirect to `/get-started/`