### PR TITLE
cloudtest: Disable all tests that use failpoints

### DIFF
--- a/test/cloudtest/test_compute.py
+++ b/test/cloudtest/test_compute.py
@@ -43,6 +43,7 @@ def test_cluster_sizing(mz: MaterializeApplication) -> None:
     "failpoint",
     ["", "after_catalog_drop_replica=panic", "after_sequencer_drop_replica=panic"],
 )
+@pytest.mark.skip(reason="Failpoints mess up the Mz intance #18000")
 def test_cluster_shutdown(mz: MaterializeApplication, failpoint: str) -> None:
     """Test that dropping a cluster or replica causes the associated clusterds to shut down."""
 

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -9,6 +9,7 @@
 
 from textwrap import dedent
 
+import pytest
 from pg8000.exceptions import InterfaceError
 
 from materialize.cloudtest.application import MaterializeApplication
@@ -62,6 +63,7 @@ def test_secrets(mz: MaterializeApplication) -> None:
 
 # Tests that secrets deleted from the catalog but not from k8s are cleaned up on
 # envd startup.
+@pytest.mark.skip(reason="Failpoints mess up the Mz intance #18000")
 def test_orphaned_secrets(mz: MaterializeApplication) -> None:
     # Use two separate failpoints. One that crashes after modifying the catalog
     # (drop_secrets), and one that fails during bootstrap (orphan_secrets) so

--- a/test/cloudtest/test_storage.py
+++ b/test/cloudtest/test_storage.py
@@ -104,6 +104,7 @@ def test_source_resizing(mz: MaterializeApplication) -> None:
 
 
 @pytest.mark.parametrize("failpoint", [False, True])
+@pytest.mark.skip(reason="Failpoints mess up the Mz intance #18000")
 def test_source_shutdown(mz: MaterializeApplication, failpoint: bool) -> None:
     print("Starting test_source_shutdown")
     if failpoint:


### PR DESCRIPTION
Failpoints, even if cleared, cause the Mz instance to hang

Relates to: #18000

### Motivation
  * This PR fixes a previously unreported bug.
cloudtest has timing out in CI