### PR TITLE
storage: add a new system var for the future new persist_sink

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6131,6 +6131,9 @@ impl Catalog {
     /// Return the current storage configuration, derived from the system configuration.
     pub fn storage_config(&self) -> StorageParameters {
         StorageParameters {
+            enable_multi_worker_storage_persist_sink: self
+                .system_config()
+                .enable_multi_worker_storage_persist_sink(),
             persist: self.persist_config(),
         }
     }

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -16,4 +16,5 @@ package mz_storage_client.types.parameters;
 
 message ProtoStorageParameters {
     mz_persist_client.cfg.ProtoPersistParameters persist = 1;
+    bool enable_multi_worker_storage_persist_sink = 2;
 }

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -25,6 +25,9 @@ include!(concat!(
 /// Unset parameters should be interpreted to mean "use the previous value".
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StorageParameters {
+    /// Controls whether or not to use the new storage `persist_sink` implementation in storage
+    /// ingestions.
+    pub enable_multi_worker_storage_persist_sink: bool,
     /// Persist client configuration.
     pub persist: PersistParameters,
 }
@@ -32,6 +35,8 @@ pub struct StorageParameters {
 impl StorageParameters {
     /// Update the parameter values with the set ones from `other`.
     pub fn update(&mut self, other: StorageParameters) {
+        self.enable_multi_worker_storage_persist_sink =
+            other.enable_multi_worker_storage_persist_sink;
         self.persist.update(other.persist);
     }
 }
@@ -39,12 +44,15 @@ impl StorageParameters {
 impl RustType<ProtoStorageParameters> for StorageParameters {
     fn into_proto(&self) -> ProtoStorageParameters {
         ProtoStorageParameters {
+            enable_multi_worker_storage_persist_sink: self.enable_multi_worker_storage_persist_sink,
             persist: Some(self.persist.into_proto()),
         }
     }
 
     fn from_proto(proto: ProtoStorageParameters) -> Result<Self, TryFromProtoError> {
         Ok(Self {
+            enable_multi_worker_storage_persist_sink: proto
+                .enable_multi_worker_storage_persist_sink,
             persist: proto
                 .persist
                 .into_rust_if_some("ProtoStorageParameters::persist")?,

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -19,6 +19,18 @@ use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::sinks::{MetadataFilled, StorageSinkDesc};
 use mz_storage_client::types::sources::IngestionDescription;
 
+/// Storage instance configuration parameters that can affect
+/// dataflow rendering, and as such must be applied to
+/// `StorageWorker`s in a consistent order with source and sink
+/// creation.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DataflowParameters {
+    /// Whether or not to use the new multi-worker storage `persist_sink`
+    /// implementation in storage ingestions. Is applied only
+    /// when a cluster or dataflow is restarted.
+    pub enable_multi_worker_storage_persist_sink: bool,
+}
+
 /// Internal commands that can be sent by individual operators/workers that will
 /// be broadcast to all workers. The worker main loop will receive those and act
 /// on them.
@@ -49,6 +61,9 @@ pub enum InternalStorageCommand {
     ),
     /// Drop all state and operators for a dataflow.
     DropDataflow(GlobalId),
+
+    /// Update the configuration for rendering dataflows.
+    UpdateConfiguration(DataflowParameters),
 }
 
 /// Allows broadcasting [`internal commands`](InternalStorageCommand) to all

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -103,6 +103,13 @@ where
 
     let persist_clients = Arc::clone(&storage_state.persist_clients);
     let button = persist_op.build(move |_capabilities| async move {
+        // This may SEEM unnecessary, but metrics contains extra
+        // `DeleteOnDrop`-wrapped fields that will NOT be moved into this
+        // closure otherwise, dropping and destroying
+        // those metrics. This is because rust now only moves the
+        // explicitly-referenced fields into closures.
+        let metrics = metrics;
+
         let mut stashed_batches = BTreeMap::new();
 
         let mut write = persist_clients

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -82,6 +82,7 @@ impl KinesisMetrics {
 
 #[derive(Clone, Debug)]
 pub(super) struct SourceSpecificMetrics {
+    pub(super) enable_multi_worker_storage_persist_sink: IntGaugeVec,
     pub(super) capability: UIntGaugeVec,
     pub(super) resume_upper: IntGaugeVec,
     /// A timestamp gauge representing forward progress
@@ -98,6 +99,13 @@ pub(super) struct SourceSpecificMetrics {
 impl SourceSpecificMetrics {
     fn register_with(registry: &MetricsRegistry) -> Self {
         Self {
+            enable_multi_worker_storage_persist_sink: registry.register(metric!(
+                name: "mz_source_enable_multi_worker_storage_persist_sink",
+                help: "Whether or not the new multi-worker persist_sink is actively being used",
+                var_labels: ["source_id", "worker_id", "parent_source_id", "output"],
+            )),
+            // TODO(guswynn): some of these metrics are broken when there are more than 1
+            // worker-id, and need to be fixed
             capability: registry.register(metric!(
                 name: "mz_capability",
                 help: "The current capability for this dataflow. This corresponds to min(mz_partition_closed_ts)",


### PR DESCRIPTION
This pr is broken out of https://github.com/MaterializeInc/materialize/pull/17589, and only adds the system parameter (which will later be connected to a LaunchDarkly flag), that controls the new storage `persist_sink`. This is because this was non-trival:

- A new `InternalCommand::UpdateConfiguration`, which is required so different workers don't setup dataflows differently
- Some subtle changes to the persist sink metrics handling, so we can use a metric to track which impl a source is using
- Various other additions to system var handling, as this is the first non-persist storage var being added

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/materialize/pull/17589


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - Tested locally. note that this pr doesn't actually add any new functionality! 
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
https://github.com/MaterializeInc/materialize/blob/6b03c7d6fa75bc9ea1c7e8608a2585da818c3e02/doc/developer/design/20230210_storage_persist_sink_redux.md
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
