### PR TITLE
adapter: Prevent dropping a Compute Sink more than once

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -452,7 +452,9 @@ impl Coordinator {
     pub(crate) fn drop_compute_sinks(&mut self, sinks: impl IntoIterator<Item = ComputeSinkId>) {
         let mut by_cluster: BTreeMap<_, Vec<_>> = BTreeMap::new();
         for sink in sinks {
-            // Filter out sinks that have already been dropped.
+            // Filter out sinks that are currently being dropped. When dropping a sink
+            // we send a request to compute to drop it, but don't actually remove it from
+            // `active_subscribes` until compute responds, hence the `dropping` flag.
             //
             // Note: Ideally we'd use .filter(...) on the iterator, but that would
             // require simultaneously getting an immutable and mutable borrow of self

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -457,7 +457,7 @@ impl Coordinator {
             // `active_subscribes` until compute responds, hence the `dropping` flag.
             //
             // Note: Ideally we'd use .filter(...) on the iterator, but that would
-            // require simultaneously getting an immutable and mutable borrow of self
+            // require simultaneously getting an immutable and mutable borrow of self.
             let need_to_drop = self
                 .active_subscribes
                 .get(&sink.global_id)

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2765,6 +2765,7 @@ impl Coordinator {
             cluster_id,
             depends_on: depends_on.into_iter().collect(),
             start_time: SYSTEM_TIME(),
+            dropping: false,
         };
         self.add_active_subscribe(sink_id, active_subscribe).await;
 

--- a/src/adapter/src/subscribe.rs
+++ b/src/adapter/src/subscribe.rs
@@ -43,6 +43,8 @@ pub struct ActiveSubscribe {
     pub depends_on: BTreeSet<GlobalId>,
     /// The time when the subscribe was started.
     pub start_time: EpochMillis,
+    /// Are we already in the process of dropping the resources related to this subscribe.
+    pub dropping: bool,
 }
 
 impl ActiveSubscribe {

--- a/src/adapter/src/subscribe.rs
+++ b/src/adapter/src/subscribe.rs
@@ -44,7 +44,7 @@ pub struct ActiveSubscribe {
     pub depends_on: BTreeSet<GlobalId>,
     /// The time when the subscribe was started.
     pub start_time: EpochMillis,
-    /// Are we already in the process of dropping the resources related to this subscribe.
+    /// Whether we are already in the process of dropping the resources related to this subscribe.
     pub dropping: bool,
 }
 

--- a/src/adapter/src/subscribe.rs
+++ b/src/adapter/src/subscribe.rs
@@ -24,6 +24,7 @@ use crate::client::ConnectionId;
 use crate::coord::peek::PeekResponseUnary;
 
 /// A description of an active subscribe from coord's perspective
+#[derive(Debug)]
 pub struct ActiveSubscribe {
     /// The user of the session that created the subscribe.
     pub user: User,

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2459,7 +2459,7 @@ fn test_dont_drop_sinks_twice() {
     // By inserting 10_000 rows into t1 and t2, it's very likely that the response from
     // compute indicating whether or not we successfully dropped the sink, will get 
     // queued behind the responses for the row insertions, which should trigger the race
-    // condition we're trying to exercise here
+    // condition we're trying to exercise here.
     client_b
         .batch_execute("INSERT INTO t1 SELECT generate_series(0, 10000)")
         .unwrap();

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2457,7 +2457,7 @@ fn test_dont_drop_sinks_twice() {
     let mut client_b = server.connect(postgres::NoTls).unwrap();
 
     // By inserting 10_000 rows into t1 and t2, it's very likely that the response from
-    // compute indicating whether or not we successfully dropped the sink, will get 
+    // compute indicating whether or not we successfully dropped the sink, will get
     // queued behind the responses for the row insertions, which should trigger the race
     // condition we're trying to exercise here.
     client_b
@@ -2471,7 +2471,7 @@ fn test_dont_drop_sinks_twice() {
 
     // Drop our client so the notice channel closes.
     drop(_out);
-    drop(client_a);    
+    drop(client_a);
 
     // Assert we only got one message.
     let mut msgs = vec![];


### PR DESCRIPTION
### Motivation

* This PR fixes a recognized bug.
  * Fixes #17887 

Currently there is a race where we can ask compute to drop the same sink twice. This PR should fix that by adding a `dropping` field to our `ActiveSubscribe` struct which maintains metadata about our active subscribes, and only sends the request to compute if we haven't already attempted to drop the sink.

I ran through the example provided at the end of #17887 but couldn't repro the race, so while I believe this should fix the issue, I can't prove that it does. What I plan to do though is monitor Sentry to see if the error crops up again, it was already reported once, [example](https://materializeinc.sentry.io/discover/database-backend:931086577c4447cfad18c08f7416ab4d/?field=title&field=event.type&field=project&field=user.display&field=timestamp&homepage=true&name=All+Events&query=Instructed+to+drop+a+compute+sink+that+isn%27t+one&sort=-timestamp&statsPeriod=14d&yAxis=count%28%29).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
