### PR TITLE
dev: Update .cargo/config to reserve 1 CPU core

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -6,3 +6,7 @@
 # See: https://github.com/rust-lang/rust/issues/56068
 # See: https://reviews.llvm.org/D74169#1990180
 rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi", "-Csymbol-mangling-version=v0"]
+
+[build]
+# Always reserve at least one thread so Cargo doesn't pin our CPU
+jobs = -1

--- a/.cargo/config
+++ b/.cargo/config
@@ -8,5 +8,5 @@
 rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi", "-Csymbol-mangling-version=v0"]
 
 [build]
-# Always reserve at least one thread so Cargo doesn't pin our CPU
+# Always reserve at least one core so Cargo doesn't pin our CPU
 jobs = -1


### PR DESCRIPTION
### Motivation
Not a necessary change, but something I thought would be nice :)

Setting `jobs = -1` in our `.cargo/config` file will limit the number of threads Cargo uses to `num_cpus() - 1`, this way when doing a ton of compilation we don't totally max our our CPU and can still do other things with less disruption than would be today.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
