### PR TITLE
mz: fetch regions from sync server

### DIFF
--- a/src/mz/src/bin/mz/main.rs
+++ b/src/mz/src/bin/mz/main.rs
@@ -380,7 +380,7 @@ async fn main() -> Result<()> {
                     .await
                     .with_context(|| "Retrieving cloud providers.")?;
                 let cloud_providers_regions =
-                    list_regions(&cloud_providers, &client, &valid_profile)
+                    list_regions(&cloud_providers.data, &client, &valid_profile)
                         .await
                         .with_context(|| "Listing regions.")?;
                 cloud_providers_regions

--- a/src/mz/src/bin/mz/region.rs
+++ b/src/mz/src/bin/mz/region.rs
@@ -22,11 +22,11 @@ pub(crate) fn print_region_enabled(cloud_provider_and_region: &CloudProviderAndR
     match region {
         Some(_) => println!(
             "{:}/{:}  enabled",
-            cloud_provider.provider, cloud_provider.region
+            cloud_provider.cloud_provider, cloud_provider.name
         ),
         None => println!(
             "{:}/{:}  disabled",
-            cloud_provider.provider, cloud_provider.region
+            cloud_provider.cloud_provider, cloud_provider.name
         ),
     };
 }

--- a/src/mz/src/configuration.rs
+++ b/src/mz/src/configuration.rs
@@ -37,7 +37,17 @@ pub struct Endpoint {
 impl Endpoint {
     /// Returns the URL for the cloud regions.
     pub fn cloud_regions_url(&self) -> Url {
-        self.with_path(&["_metadata", "cloud-regions.json"])
+        let host = self
+            .url
+            .host()
+            .to_owned()
+            .expect("endpoint url has a valid host");
+        let url_str = format!("https://sync.{host}");
+        let mut url = Url::parse(&url_str).expect("sync endpoint name should be valid");
+        url.path_segments_mut()
+            .expect("constructor validated URL can be a base")
+            .extend(["api", "cloud-regions"]);
+        url
     }
 
     /// Returns the URL for the OAuth token exchange.


### PR DESCRIPTION
Uses the new [sync server endpoint](https://www.notion.so/materialize/Cloud-sync-server-API-42d637552dce43478ef36d40d6ca35ef?pvs=4#1f262c6d0ee04f50baebfdedc68e3dbf) to fetch cloud regions. The current metadata file hosted by the frontend is going away as part of the Vercel migration.

### Motivation

  * This PR adds a known-desirable feature.
  * Fixes https://github.com/MaterializeInc/cloud/issues/5744

### Checklist

- [*] This cloud change must land before we can ship this change: https://github.com/MaterializeInc/cloud/pull/5750