### PR TITLE
doc/user: polish v0.45 release notes

### DIFF
--- a/doc/user/content/releases/v0.45.md
+++ b/doc/user/content/releases/v0.45.md
@@ -1,13 +1,98 @@
 ---
 title: "Materialize v0.45"
 date: 2023-03-08
-released: false
+released: true
 ---
-
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
 
 ## v0.45.0
 
-* No documented changes yet.
+#### 💦 Sources and sinks
+
+* Expose source progress metadata as a subsource that can be used to
+  monitor **ingestion progress**. The name of the progress subsource can be
+  specified using the `EXPOSE PROGRESS AS` clause in `CREATE SOURCE`;
+  otherwise, it will be named `<src_name>_progress` by default.
+
+  **Example**
+
+  ```sql
+  -- Given a "purchases" Kafka source, a "purchases_progress"
+  -- subsource is automatically created
+  SELECT partition, "offset"
+  FROM (
+	    SELECT upper(partition)::uint8 AS partition, "offset"
+	    FROM purchases_progress
+  )
+  WHERE partition IS NOT NULL;
+
+   partition |  offset
+  -----------+----------
+   0         | 13645902
+   1         | 13659722
+   2         | 13656787
+  ```
+
+For Kafka sources, the progress subsource returns the greatest offset consumed
+from each upstream partition, and for PostgreSQL sources it returns the last
+Log Sequence Number (LSN) consumed from the upstream replication stream.
+
+#### 🔮 SQL
+
+* Improve the behavior of the `search_path` session variable to match that of
+  [PostgreSQL](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH).
+  You can now specify multiple schemas and Materialize will correctly resolve
+  unqualified names by following the search path, as well as create objects in
+  the first schema named (i.e. the _current schema_).
+
+* Support `options` settings on connection startup. As an example, you can
+now specify the cluster to connect to in the `psql` connection string:
+
+```sql
+psql "postgres://user%40domain.com@host:6875/materialize?options=--cluster%3Dfoo"
+```
+
+* Add support for the `\du` meta-command, which lists all roles/users of the database.
+
+* Add support for new SQL functions:
+
+| Function                                        | Description                                                             |
+| ----------------------------------------------- | ----------------------------------------------------------------------- |
+| [`ceiling`](/sql/functions/#numbers-func)       | Works as an alias of the `ceil` function.                               |
+| [`uuid_generate_v5`](/sql/functions/#uuid-func) | Generates a UUID in the given namespace using the specified input name. |
+
+<br>
+
+* Remove the `CREATE USER` command, as well as the `LOGIN` and `SUPERUSER`
+  attributes from the [`CREATE ROLE`](/sql/create-role/) command. This is part
+  of the work to enable **Role-Based Access Control** (RBAC) in a future release
+  {{% gh 11579 %}}.
+
+#### 🐞 Bug fixes and other improvements
+
+* Improve the error message for naming collisions, specifying the catalog item
+  type.
+
+  **Example**
+
+  ```sql
+  CREATE VIEW foo AS SELECT 'bar';
+
+  ERROR:  view "materialize.public.foo" already exists
+  ```
+
+* Fix a bug where binding to a DNS name instead of `0.0.0.0` during cluster
+  initialization could prevent clusters from coming online {{% gh 17774 %}}.
+
+* Improve `SUBSCRIBE` error handling. Prior to this release, subscriptions
+  ignored errors in their input, which could lead to correctness issues.
+
+* Return an error rather than crashing if source data contains invalid
+  retractions, which might happen in the presence of e.g. incomplete or invalid
+  data {{% gh 17709 %}}.
+
+* Fix a bug that could cause Materialize to crash when expressions in `CREATE
+  TABLE ... DEFAULT` clauses or `INSERT ... RETURNING` clauses contained nested
+  parentheses {{% gh 17723 %}}.
+
+* Avoid panicking when attempting to parse a range from strings containing
+  multibyte characters {{% gh 17803 %}}.

--- a/doc/user/content/releases/v0.46.md
+++ b/doc/user/content/releases/v0.46.md
@@ -1,0 +1,13 @@
+---
+title: "Materialize v0.46"
+date: 2023-03-15
+released: false
+---
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}
+
+## v0.46.0
+
+* No documented changes yet.

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -16,15 +16,10 @@ When you [connect to a Materialize instance](/integrations/psql), you must speci
 the name of a valid role in the system.
 
 {{< warning >}}
-Roles in Materialize are currently limited in functionality. In the future they
-will be used for role-based access control. See GitHub issue {{% gh 677 %}}
-for details.
-{{< /warning >}}
-
-{{< warning >}}
-RBAC is under development: currently no role attributes or privileges will be
-considered when executing statements, although these attributes are saved and
-will be considered in a later release.
+Role-Based Access Control is under development {{% gh 11579 %}}. Currently, no
+role attributes or privileges are considered when executing `CREATE ROLE`
+statements, but these attributes are saved and will be considered in a future
+release.
 {{< /warning >}}
 
 ## Syntax
@@ -44,13 +39,13 @@ _role_name_         | A name for the role.
 
 ## Details
 
-Unlike PostgreSQL, materialize derives the `LOGIN` and `SUPERUSER`
+Unlike PostgreSQL, Materialize derives the `LOGIN` and `SUPERUSER`
 attributes for a role during authentication, every time that role tries
-to connect to Materialize. Therefore, you cannot specify either
+to connect. Therefore, you cannot specify either
 attribute when creating a new role. Additionally, we do not support
-`CREATE USER` because it implies a `LOGIN` attribute for the role.
+`CREATE USER` command, because it implies a `LOGIN` attribute for the role.
 
-Unlike PostgreSQL, materialize does not currently support `NOINHERIT`.
+Unlike PostgreSQL, Materialize does not currently support `NOINHERIT`.
 
 You may not specify redundant or conflicting sets of options. For example,
 Materialize will reject the statement `CREATE ROLE ... CREATEDB NOCREATEDB` because
@@ -59,14 +54,15 @@ the `CREATEDB` and `NOCREATEDB` options conflict.
 ## Examples
 
 ```sql
-CREATE ROLE rj;
+CREATE ROLE db_reader;
 ```
 ```sql
 SELECT name FROM mz_roles;
 ```
 ```nofmt
-materialize
-rj
+ db_reader
+ mz_system
+ mz_introspection
 ```
 
 ## Related pages

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -42,7 +42,7 @@ _role_name_         | A name for the role.
 Unlike PostgreSQL, Materialize derives the `LOGIN` and `SUPERUSER`
 attributes for a role during authentication, every time that role tries
 to connect. Therefore, you cannot specify either
-attribute when creating a new role. Additionally, we do not support
+attribute when creating a new role. Additionally, we do not support the
 `CREATE USER` command, because it implies a `LOGIN` attribute for the role.
 
 Unlike PostgreSQL, Materialize does not currently support `NOINHERIT`.

--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -67,7 +67,6 @@ Modifier | Description
 **arity** | Annotate each subplan with its number of produced columns. This is useful due to the use of offset-based column names.
 **join_impls** | Render details about the implementation strategy of optimized MIR `Join` nodes.
 **keys** | Annotate each subplan with its unique keys.
-**timing** | Annotate each plan with the time spent in optimization (including decorrelation).
 **types** | Annotate each subplan with its inferred type.
 
 ## Query compilation pipeline

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -508,12 +508,9 @@
 
 - type: UUID
   functions:
-  - signature: mz_environment_id() -> text
-    description: A string containing a `uuid` uniquely identifying this Materialize environment.
-    unmaterializable: true
 
   - signature: 'uuid_generate_v5(namespace: uuid, name: text) -> uuid'
-    description: 'Generates a [version 5 UUID](https://www.rfc-editor.org/rfc/rfc4122#page-7) (using SHA-1) in the given namespace using
+    description: 'Generates a [version 5 UUID](https://www.rfc-editor.org/rfc/rfc4122#page-7) (SHA-1) in the given namespace using
       the specified input name.'
 
 - type: JSON
@@ -673,6 +670,9 @@
 - type: System information
   description: Functions that return information about the system
   functions:
+  - signature: 'mz_environment_id() -> text'
+    description: Returns a string containing a `uuid` uniquely identifying the Materialize environment.
+    unmaterializable: true
   - signature: 'mz_uptime() -> interval'
     description: Returns the length of time that the materialized process has been running.
     unmaterializable: true

--- a/test/upgrade/check-from-v0.45.0-kafka-progress.td
+++ b/test/upgrade/check-from-v0.45.0-kafka-progress.td
@@ -13,7 +13,8 @@ $ set-regex match=\d+ replacement=<NUMBER>
 (<NUMBER>,) <NUMBER>
 [<NUMBER>,<NUMBER>] <NUMBER>
 
+$ set-regex match=testdrive-upgrade-kafka-source-.*?' replacement=<TOPIC>'
 > SHOW CREATE SOURCE kafka_source
-materialize.public.kafka_source "CREATE SOURCE \"materialize\".\"public\".\"kafka_source\" FROM KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-upgrade-kafka-source-current_source-<NUMBER>') FORMAT AVRO USING SCHEMA '{   \"type\": \"record\",   \"name\": \"cpx\",   \"fields\": [     {\"name\": \"a\", \"type\": \"long\"},     {\"name\": \"b\", \"type\": \"long\"}   ] }' ENVELOPE NONE EXPOSE PROGRESS AS \"materialize\".\"public\".\"kafka_source_progress\""
+materialize.public.kafka_source "CREATE SOURCE \"materialize\".\"public\".\"kafka_source\" FROM KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = '<TOPIC>') FORMAT AVRO USING SCHEMA '{   \"type\": \"record\",   \"name\": \"cpx\",   \"fields\": [     {\"name\": \"a\", \"type\": \"long\"},     {\"name\": \"b\", \"type\": \"long\"}   ] }' ENVELOPE NONE EXPOSE PROGRESS AS \"materialize\".\"public\".\"kafka_source_progress\""
 
 > DROP SOURCE kafka_source;


### PR DESCRIPTION
Release notes for v0.45. ⚡ 

There were a lot of user-facing changes in this release, and the current template makes it incredibly hard to organize them in a readable way. Broke changes out into three sections as a short-term solution (`Sources and sinks`, `SQL`, `Bug fixes and other improvements`). We should rethink the structure of the weekly release notes to make them easier to consume in the long-term (**cc:** @tr0njavolta).

Docs yet to be merged: https://github.com/MaterializeInc/materialize/pull/17788

## Tips for reviewer

Left out a couple of issue that had release notes, but didn't strike me as relevant for users. Adding the edited release notes here in case we want to include them:

* #17720 
  Fix a bug in decorrelation that could result in a panic or incorrect results
for a restricted class of queries {{% gh 17720 %}}.
* #17721
  Add the `BROKEN` clause to `EXPLAIN`. Using this clause allows taking the plan
snapshot at the early stages of query optimization, which is useful for
internal debugging.
* #17794
  Filter the imports reported in `mz_internal.mz_worker_compute_dependencies` to
  only contain identifiers imported into the respective dataflow, rather than
  dataflow-internal identifiers as well.
* #17833 

The recent syntax additions to `EXPLAIN` (`timing` in v0.44 (documented) and `BROKEN` in v0.45 (not documented)) made me question whether we should refrain from cluttering the docs with options that are meant for internal troubleshooting and testing. Right now, there's a bit of a mix. Maybe these should be documented under `doc/developer`? Also so they're more accessible to the Compute team. @aalexandrov 