### PR TITLE
compute: log export-dataflow ID mapping

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -199,10 +199,11 @@ Field           | Type       | Meaning
 
 The `mz_compute_exports` source describes the dataflows created by indexes, materialized views, and subscriptions in the system.
 
-Field       | Type       | Meaning
-------------|------------|--------
-`export_id` | [`text`]   | The ID of the index, materialized view, or subscription that created the dataflow. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), or [`mz_internal.mz_subscriptions`](#mz_subscriptions).
-`worker_id` | [`bigint`] | The ID of the worker thread hosting the corresponding [dataflow].
+Field         | Type       | Meaning
+--------------|------------|--------
+`export_id`   | [`text`]   | The ID of the index, materialized view, or subscription that created the dataflow. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), or [`mz_internal.mz_subscriptions`](#mz_subscriptions).
+`worker_id`   | [`bigint`] | The ID of the worker thread hosting the corresponding [dataflow].
+`dataflow_id` | [`bigint`] | The ID of the [dataflow]. Corresponds to [`mz_dataflows.local_id`](#mz_dataflows).
 
 ### `mz_compute_frontiers`
 

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -729,6 +729,7 @@ impl LogVariant {
             LogVariant::Compute(ComputeLog::DataflowCurrent) => RelationDesc::empty()
                 .with_column("export_id", ScalarType::String.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
+                .with_column("dataflow_id", ScalarType::UInt64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Compute(ComputeLog::DataflowDependency) => RelationDesc::empty()

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -194,3 +194,21 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 mv1             t1
 mv1             t2
 mv1_primary_idx mv1
+
+# Test that mz_compute_exports contains correct dataflow IDs.
+
+> CREATE MATERIALIZED VIEW my_unique_mv_name AS SELECT * FROM t1;
+
+> SELECT count(*)
+  FROM
+    mz_materialized_views mv,
+    mz_internal.mz_compute_exports exp,
+    mz_internal.mz_dataflows df
+  WHERE
+    mv.name = 'my_unique_mv_name' AND
+    mv.id = exp.export_id AND
+    exp.worker_id = 0 AND
+    exp.dataflow_id = df.local_id AND
+    df.worker_id = 0 AND
+    df.name LIKE '%my_unique_mv_name%';
+1


### PR DESCRIPTION
This PR adds a new `dataflow_id` field to the `mz_compute_exports` introspection source. This allows mapping catalog objects, like indexes and MVs, to dataflows and their operators.

From a UI point of view, the only change is the additional column in `mz_compute_exports`. Under the hood I refactored the logging code a bit to more clearly decouple dataflow exports from dataflows themselves. Prior to this commit, dataflows and exports where treated as equivalent, which is not actually correct as dataflows can, in principle, have multiple exports.

The purpose of this PR is to unblock @umanwizard on his external introspection work. This is not intended to be the final say on how our logging sources should look.

### Motivation

  * This PR adds a feature that has not yet been specified.

It should be possible to map catalog objects that create dataflows to their corresponding per-replica dataflow IDs.

### Tips for Reviewers

It is perhaps a bit confusing that  `dataflow_id` maps to `mz_dataflows.local_id`, not `mz_dataflows.id`. I plan to clean that up as part of the introspection epic (#17563), but didn't want to make more user-facing changes without a design doc.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add a new `dataflow_id` field to the `mz_compute_exports` introspection source. This allows mapping catalog objects, like indexes and MVs, to dataflows and their operators.
