### PR TITLE
ci: Remove the Checks + Restart Redpanda from the per-push CI

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -559,19 +559,6 @@ steps:
       - ./ci/plugins/cloudtest:
           args: [--exitfirst, -m, "not long", --aws-region=us-east-2, test/cloudtest/]
 
-  - id: checks-restart-redpanda
-    label: "Checks + restart Redpanda & Debezium"
-    depends_on: build-x86_64
-    inputs: [misc/python/materialize/checks]
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartRedpandaDebezium, "--seed=$BUILDKITE_JOB_ID"]
-
   - id: source-sink-errors
     label: "Source/Sink Error Reporting"
     artifact_paths: junit_*.xml


### PR DESCRIPTION
Restarting containerized Redpanda is known to be flaky -- Redpanda fails to reliably come up, reporting an unwarranted TCP port conflict.

The Nightly CI pipeline already contains a similar job.

### Motivation

  * This PR fixes a previously unreported bug.
The Checks + restart redpanda job is known to be flaky.

### Tips for reviewer

@def- this is part of drive to refactor the CI pipelines a bit in order to increase the overall stability, and thus reputation of  the CI and reduce the opportunity for genuine failures to be lost in a sea of red.

I overloaded the CI with too many chaos-type tests and some of them fail due to no fault of Mz -- various external services, such as Redpanda and CRDB do not come up 100% after a restart. So the plan is to remove those build steps, get all the pipelines green and then re-introduce some chaos testing to the Release Qualification Pipeline.

Note that this activity only applies to chaos-type tests. We have many individual mzcompose jobs that introduce individual, more controlled disruptions of the various services and check that Mz is able to recover from those.