### PR TITLE
storage: work with `Collection` everywhere

### DIFF
--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -27,7 +27,7 @@ use futures::StreamExt as AsyncStreamExt;
 use regex::Regex;
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::Operator;
-use timely::dataflow::{Scope, Stream};
+use timely::dataflow::Scope;
 use timely::scheduling::SyncActivator;
 use tokio::runtime::Handle as TokioHandle;
 use tracing::error;
@@ -63,7 +63,7 @@ mod protobuf;
 /// also builds a differential dataflow collection that respects the
 /// data and progress messages in the underlying CDCv2 stream.
 pub fn render_decode_cdcv2<G: Scope<Timestamp = Timestamp>>(
-    stream: &Stream<G, SourceOutput<Option<Vec<u8>>, Option<Vec<u8>>, u32>>,
+    input: &Collection<G, SourceOutput<Option<Vec<u8>>, Option<Vec<u8>>>, u32>,
     schema: &str,
     registry: Option<CsrClient>,
     confluent_wire_format: bool,
@@ -73,8 +73,8 @@ pub fn render_decode_cdcv2<G: Scope<Timestamp = Timestamp>>(
     let channel = Rc::new(RefCell::new(VecDeque::new()));
     let activator: Rc<RefCell<Option<SyncActivator>>> = Rc::new(RefCell::new(None));
     let mut vector = Vec::new();
-    stream.sink(
-        SourceOutput::<Option<Vec<u8>>, Option<Vec<u8>>, u32>::position_value_contract(),
+    input.inner.sink(
+        Exchange::new(|(x, _, _): &(SourceOutput<_, _>, _, _)| x.position.hashed()),
         "CDCv2-Decode",
         {
             let channel = Rc::clone(&channel);
@@ -83,7 +83,7 @@ pub fn render_decode_cdcv2<G: Scope<Timestamp = Timestamp>>(
             move |input| {
                 input.for_each(|_time, data| {
                     data.swap(&mut vector);
-                    for data in vector.drain(..) {
+                    for (data, _time, _diff) in vector.drain(..) {
                         let value = match &data.value {
                             Some(value) => value,
                             None => continue,
@@ -124,11 +124,10 @@ pub fn render_decode_cdcv2<G: Scope<Timestamp = Timestamp>>(
         }
     }
     // this operator returns a thread-safe drop-token
-    let (token, stream) =
-        differential_dataflow::capture::source::build(stream.scope(), move |ac| {
-            *activator.borrow_mut() = Some(ac);
-            YieldingIter::new_from(VdIterator(channel), Duration::from_millis(10))
-        });
+    let (token, stream) = differential_dataflow::capture::source::build(input.scope(), move |ac| {
+        *activator.borrow_mut() = Some(ac);
+        YieldingIter::new_from(VdIterator(channel), Duration::from_millis(10))
+    });
     (stream.as_collection(), token)
 }
 
@@ -355,14 +354,17 @@ fn try_decode_delimited(
 /// (which is not always possible otherwise, since often gibberish strings can be interpreted as Avro,
 ///  so the only signal is how many bytes you managed to decode).
 pub fn render_decode_delimited<G>(
-    stream: &Stream<G, SourceOutput<Option<Vec<u8>>, Option<Vec<u8>>, u32>>,
+    input: &Collection<G, SourceOutput<Option<Vec<u8>>, Option<Vec<u8>>>, u32>,
     key_encoding: Option<DataEncoding>,
     value_encoding: DataEncoding,
     debug_name: &str,
     metadata_items: Vec<IncludedColumnSource>,
     metrics: DecodeMetrics,
     connection_context: &ConnectionContext,
-) -> (Stream<G, DecodeResult>, Option<Box<dyn Any + Send + Sync>>)
+) -> (
+    Collection<G, DecodeResult, Diff>,
+    Option<Box<dyn Any + Send + Sync>>,
+)
 where
     G: Scope,
 {
@@ -392,74 +394,78 @@ where
         connection_context,
     );
 
-    let dist = |x: &SourceOutput<Option<Vec<u8>>, Option<Vec<u8>>, u32>| x.value.hashed();
+    let dist =
+        |(x, _, _): &(SourceOutput<Option<Vec<u8>>, Option<Vec<u8>>>, _, _)| x.value.hashed();
 
-    let results = stream.unary_frontier(Exchange::new(dist), &op_name, move |_, _| {
-        move |input, output| {
-            let mut n_errors = 0;
-            let mut n_successes = 0;
-            input.for_each(|cap, data| {
-                let mut session = output.session(&cap);
-                for output in data.iter() {
-                    let SourceOutput {
-                        key,
-                        value,
-                        position,
-                        upstream_time_millis,
-                        partition,
-                        headers,
-                        diff,
-                    } = output;
+    let results = input
+        .inner
+        .unary_frontier(Exchange::new(dist), &op_name, move |_, _| {
+            move |input, output| {
+                let mut n_errors = 0;
+                let mut n_successes = 0;
+                input.for_each(|cap, data| {
+                    let mut session = output.session(&cap);
+                    for (output, ts, diff) in data.iter() {
+                        let SourceOutput {
+                            key,
+                            value,
+                            position,
+                            upstream_time_millis,
+                            partition,
+                            headers,
+                        } = output;
 
-                    let key = key_decoder.as_mut().and_then(|decoder| {
-                        try_decode_delimited(decoder, key.as_ref()).map(|result| {
-                            result.map_err(|inner| DecodeError {
-                                kind: inner,
-                                raw: key.clone(),
-                            })
-                        })
-                    });
-
-                    let value =
-                        try_decode_delimited(&mut value_decoder, value.as_ref()).map(|result| {
-                            result.map_err(|inner| DecodeError {
-                                kind: inner,
-                                raw: value.clone(),
+                        let key = key_decoder.as_mut().and_then(|decoder| {
+                            try_decode_delimited(decoder, key.as_ref()).map(|result| {
+                                result.map_err(|inner| DecodeError {
+                                    kind: inner,
+                                    raw: key.clone(),
+                                })
                             })
                         });
 
-                    if matches!(&key, Some(Err(_))) || matches!(&value, Some(Err(_))) {
-                        n_errors += 1;
-                    } else if matches!(&value, Some(Ok(_))) {
-                        n_successes += 1;
-                    }
+                        let value = try_decode_delimited(&mut value_decoder, value.as_ref()).map(
+                            |result| {
+                                result.map_err(|inner| DecodeError {
+                                    kind: inner,
+                                    raw: value.clone(),
+                                })
+                            },
+                        );
 
-                    session.give(DecodeResult {
-                        key,
-                        value: value.map(|s| s.map(|r| (r, 1))),
-                        position: *position,
-                        upstream_time_millis: *upstream_time_millis,
-                        partition: partition.clone(),
-                        metadata: to_metadata_row(
-                            &metadata_items,
-                            partition.clone(),
-                            *position,
-                            *upstream_time_millis,
-                            headers.as_deref(),
-                        ),
-                    });
+                        if matches!(&key, Some(Err(_))) || matches!(&value, Some(Err(_))) {
+                            n_errors += 1;
+                        } else if matches!(&value, Some(Ok(_))) {
+                            n_successes += 1;
+                        }
+
+                        let result = DecodeResult {
+                            key,
+                            value,
+                            position: *position,
+                            upstream_time_millis: *upstream_time_millis,
+                            partition: partition.clone(),
+                            metadata: to_metadata_row(
+                                &metadata_items,
+                                partition.clone(),
+                                *position,
+                                *upstream_time_millis,
+                                headers.as_deref(),
+                            ),
+                        };
+                        session.give((result, ts.clone(), Diff::from(*diff)));
+                    }
+                });
+                // Matching historical practice, we only log metrics on the value decoder.
+                if n_errors > 0 {
+                    value_decoder.log_errors(n_errors);
                 }
-            });
-            // Matching historical practice, we only log metrics on the value decoder.
-            if n_errors > 0 {
-                value_decoder.log_errors(n_errors);
+                if n_successes > 0 {
+                    value_decoder.log_successes(n_successes);
+                }
             }
-            if n_successes > 0 {
-                value_decoder.log_successes(n_successes);
-            }
-        }
-    });
-    (results, None)
+        });
+    (results.as_collection(), None)
 }
 
 /// Decode arbitrary chunks of bytes into rows.
@@ -478,13 +484,16 @@ where
 /// If the decoder does find a message, we verify (by asserting) that it consumed some bytes, to avoid
 /// the possibility of infinite loops.
 pub fn render_decode<G>(
-    stream: &Stream<G, SourceOutput<(), ByteStream, u32>>,
+    input: &Collection<G, SourceOutput<(), ByteStream>, u32>,
     value_encoding: DataEncoding,
     debug_name: &str,
     metadata_items: Vec<IncludedColumnSource>,
     metrics: DecodeMetrics,
     connection_context: &ConnectionContext,
-) -> (Stream<G, DecodeResult>, Option<Box<dyn Any + Send + Sync>>)
+) -> (
+    Collection<G, DecodeResult, Diff>,
+    Option<Box<dyn Any + Send + Sync>>,
+)
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -505,7 +514,7 @@ where
     // We therefore ignore it, and keep track ourselves of how many records we've seen (for filling in `mz_line_no`, etc).
     // Historically, non-delimited sources have their offset start at 1
     let mut n_seen = 1..;
-    let results = stream.unary_async(
+    let results = input.inner.unary_async(
         Pipeline,
         op_name,
         move |_, _, mut input, mut output| async move {
@@ -520,7 +529,7 @@ where
 
                 // Currently Kafka is the only kind of source that can have metadata, and it is
                 // always delimited, so we will never have metadata in `render_decode`
-                for item in data.drain(..) {
+                for (item, ts, diff) in data.drain(..) {
                     let SourceOutput {
                         key: _,
                         value,
@@ -528,8 +537,8 @@ where
                         upstream_time_millis,
                         partition,
                         headers,
-                        diff,
                     } = item;
+                    let diff = Diff::from(diff);
 
                     let Ok(mut stream) = Rc::try_unwrap(value.stream) else {
                         panic!("byte stream cloned unexpectedly");
@@ -586,35 +595,31 @@ where
                             if value_bytes_remaining.is_empty() {
                                 let result = DecodeResult {
                                     key: None,
-                                    value: Some(value.map(|r| (r, 1)).map_err(|inner| {
-                                        DecodeError {
-                                            kind: inner,
-                                            raw: None,
-                                        }
+                                    value: Some(value.map_err(|inner| DecodeError {
+                                        kind: inner,
+                                        raw: None,
                                     })),
                                     position: position.into(),
                                     upstream_time_millis,
                                     partition: partition.clone(),
                                     metadata,
                                 };
-                                output.give(&cap, result).await;
+                                output.give(&cap, (result, ts, diff)).await;
                                 value_buf = vec![];
                                 break;
                             } else {
                                 let result = DecodeResult {
                                     key: None,
-                                    value: Some(value.map(|r| (r, 1)).map_err(|inner| {
-                                        DecodeError {
-                                            kind: inner,
-                                            raw: None,
-                                        }
+                                    value: Some(value.map_err(|inner| DecodeError {
+                                        kind: inner,
+                                        raw: None,
                                     })),
                                     position: position.into(),
                                     upstream_time_millis,
                                     partition: partition.clone(),
                                     metadata,
                                 };
-                                output.give(&cap, result).await;
+                                output.give(&cap, (result, ts, diff)).await;
                             }
                             if is_err {
                                 // If decoding has gone off the rails, we can no longer be sure that the delimiters are correct, so it
@@ -654,7 +659,7 @@ where
 
                             let result = DecodeResult {
                                 key: None,
-                                value: Some(value.map(|r| (r, 1)).map_err(|inner| DecodeError {
+                                value: Some(value.map_err(|inner| DecodeError {
                                     kind: inner,
                                     raw: None,
                                 })),
@@ -663,7 +668,7 @@ where
                                 partition: partition.clone(),
                                 metadata,
                             };
-                            output.give(&cap, result).await;
+                            output.give(&cap, (result, ts, diff)).await;
                         }
                     }
                 }
@@ -677,7 +682,7 @@ where
             }
         },
     );
-    (results, None)
+    (results.as_collection(), None)
 }
 
 fn to_metadata_row(

--- a/src/storage/src/render/debezium.rs
+++ b/src/storage/src/render/debezium.rs
@@ -11,10 +11,10 @@ use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, VecDeque};
 use std::str::FromStr;
 
-use differential_dataflow::{Collection, Hashable};
+use differential_dataflow::{AsCollection, Collection, Hashable};
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::{Capability, OkErr, Operator};
-use timely::dataflow::{Scope, ScopeParent, Stream};
+use timely::dataflow::{Scope, ScopeParent};
 
 use mz_expr::EvalError;
 use mz_ore::cast::CastFrom;
@@ -29,17 +29,15 @@ use crate::source::types::DecodeResult;
 
 pub(crate) fn render<G: Scope>(
     envelope: &DebeziumEnvelope,
-    input: &Stream<G, DecodeResult>,
-) -> (
-    Stream<G, (Row, Timestamp, Diff)>,
-    Stream<G, (DataflowError, Timestamp, Diff)>,
-)
+    input: &Collection<G, DecodeResult, Diff>,
+) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
 where
     G: ScopeParent<Timestamp = Timestamp>,
 {
     let (before_idx, after_idx) = (envelope.before_idx, envelope.after_idx);
     // TODO(guswynn): !!! Correctly deduplicate even in the upsert case
-    input
+    let (oks, errs) = input
+        .inner
         .unary(Pipeline, "envelope-debezium", move |_, _| {
             let mut dedup_state = BTreeMap::new();
             let envelope = envelope.clone();
@@ -48,14 +46,17 @@ where
                 while let Some((cap, refmut_data)) = input.next() {
                     let mut session = output.session(&cap);
                     refmut_data.swap(&mut data);
-                    for result in data.drain(..) {
+                    for (result, time, diff) in data.drain(..) {
+                        // TODO(petrosagg): any positive diff should be accepted
+                        assert_eq!(
+                            diff, 1,
+                            "Debezium should only be used with append-only sources"
+                        );
+
                         let value = match result.value {
-                            Some(Ok((value, 1))) => value,
-                            Some(Ok(_)) => unreachable!(
-                                "Debezium should only be used with sources with no explicit diff"
-                            ),
+                            Some(Ok(value)) => value,
                             Some(Err(err)) => {
-                                session.give((Err(err.into()), cap.time().clone(), 1));
+                                session.give((Err(err.into()), time, diff));
                                 continue;
                             }
                             None => continue,
@@ -71,11 +72,7 @@ where
                                 match res {
                                     Ok(b) => b,
                                     Err(err) => {
-                                        session.give((
-                                            Err(DataflowError::from(err)),
-                                            cap.time().clone(),
-                                            1,
-                                        ));
+                                        session.give((Err(DataflowError::from(err)), time, 1));
                                         continue;
                                     }
                                 }
@@ -85,16 +82,12 @@ where
 
                         if should_use {
                             match value.iter().nth(before_idx).unwrap() {
-                                Datum::List(l) => {
-                                    session.give((Ok(Row::pack(&l)), cap.time().clone(), -1))
-                                }
+                                Datum::List(l) => session.give((Ok(Row::pack(&l)), time, -diff)),
                                 Datum::Null => {}
                                 d => panic!("type error: expected record, found {:?}", d),
                             }
                             match value.iter().nth(after_idx).unwrap() {
-                                Datum::List(l) => {
-                                    session.give((Ok(Row::pack(&l)), cap.time().clone(), 1))
-                                }
+                                Datum::List(l) => session.give((Ok(Row::pack(&l)), time, diff)),
                                 Datum::Null => {}
                                 d => panic!("type error: expected record, found {:?}", d),
                             }
@@ -106,17 +99,15 @@ where
         .ok_err(|(res, time, diff)| match res {
             Ok(v) => Ok((v, time, diff)),
             Err(e) => Err((e, time, diff)),
-        })
+        });
+    (oks.as_collection(), errs.as_collection())
 }
 
 pub(crate) fn render_tx<G: Scope>(
     envelope: &DebeziumEnvelope,
-    input: &Stream<G, DecodeResult>,
+    input: &Collection<G, DecodeResult, Diff>,
     tx_ok: Collection<G, Row, Diff>,
-) -> (
-    Stream<G, (Row, Timestamp, Diff)>,
-    Stream<G, (DataflowError, Timestamp, Diff)>,
-)
+) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
 where
     G: ScopeParent<Timestamp = Timestamp>,
 {
@@ -149,12 +140,14 @@ where
         _ => time.hashed(),
     };
 
-    let data_dist = move |result: &DecodeResult| {
+    let data_dist = move |(result, _, diff): &(DecodeResult, _, _)| {
+        // TODO(petrosagg): any positive diff should be accepted
+        assert_eq!(
+            *diff, 1,
+            "Debezium should only be used with append-only sources"
+        );
         let value = match &result.value {
-            Some(Ok((v, 1))) => Some(Ok(v)),
-            Some(Ok(_)) => {
-                unreachable!("Debezium should only be used with sources with no explicit diff")
-            }
+            Some(Ok(v)) => Some(Ok(v)),
             Some(Err(e)) => Some(Err(e)),
             None => None,
         };
@@ -181,10 +174,10 @@ where
             .hashed()
     };
 
-    tx_ok
+    let (oks, errs) = tx_ok
         .inner
         .binary_frontier(
-            input,
+            &input.inner,
             Exchange::new(tx_dist),
             Exchange::new(data_dist),
             "envelope-debezium-tx",
@@ -271,12 +264,12 @@ where
                             let data_cap = data_cap.retain();
                             data_buffer.extend(data.drain(..).map(|r| (r, data_cap.clone())));
                         }
-                        while let Some((result, data_cap)) = data_buffer.pop_front() {
+                        while let Some(((result, time, diff), data_cap)) = data_buffer.pop_front() {
+                            // TODO(petrosagg): any positive diff should be accepted
+                            assert_eq!(diff, 1, "Debezium should only be used with append-only sources");
+
                             let value = match result.value.clone() {
-                                Some(Ok((value, 1))) => value,
-                                Some(Ok(_)) => unreachable!(
-                                    "Debezium should only be used with sources with no explicit diff"
-                                ),
+                                Some(Ok(value)) => value,
                                 Some(Err(err)) => {
                                     output.session(&data_cap).give((
                                         Err(err.into()),
@@ -294,7 +287,7 @@ where
                                     let tx_time: Timestamp = match tx_mapping.get(&tx_id) {
                                         Some(time) => *time,
                                         None => {
-                                            data_buffer.push_front((result, data_cap));
+                                            data_buffer.push_front(((result, time, diff), data_cap));
                                             break;
                                         },
                                     };
@@ -400,7 +393,8 @@ where
         .ok_err(|(res, time, diff)| match res {
             Ok(v) => Ok((v, time, diff)),
             Err(e) => Err((e, time, diff)),
-        })
+        });
+    (oks.as_collection(), errs.as_collection())
 }
 
 /// Track whether or not we should skip a specific debezium message

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -39,9 +39,9 @@ use crate::source::{self, DelimitedValueSourceConnection, RawSourceCreationConfi
 /// as a type-level enum.
 enum SourceType<G: Scope> {
     /// A delimited source
-    Delimited(Stream<G, SourceOutput<Option<Vec<u8>>, Option<Vec<u8>>, ()>>),
+    Delimited(Stream<G, SourceOutput<Option<Vec<u8>>, Option<Vec<u8>>, u32>>),
     /// A bytestream source
-    ByteStream(Stream<G, SourceOutput<(), ByteStream, ()>>),
+    ByteStream(Stream<G, SourceOutput<(), ByteStream, u32>>),
     /// A source that produces Row's natively, and skips any `render_decode` stream adapters, and
     /// can produce retractions
     Row(Stream<G, SourceOutput<(), Row, Diff>>),

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -353,7 +353,7 @@ impl SourceReader for KafkaSourceReader {
     type Key = Option<Vec<u8>>;
     type Value = Option<Vec<u8>>;
     type Time = Partitioned<PartitionId, MzOffset>;
-    type Diff = ();
+    type Diff = u32;
 
     /// This function polls from the next consumer for which a message is available. This function
     /// polls the set round-robin: when a consumer is polled, it is placed at the back of the
@@ -734,7 +734,8 @@ impl KafkaSourceReader {
         &mut self,
         message: Result<SourceMessage<Option<Vec<u8>>, Option<Vec<u8>>>, SourceReaderError>,
         (partition, offset): (PartitionId, MzOffset),
-    ) -> NextMessage<Option<Vec<u8>>, Option<Vec<u8>>, Partitioned<PartitionId, MzOffset>, ()> {
+    ) -> NextMessage<Option<Vec<u8>>, Option<Vec<u8>>, Partitioned<PartitionId, MzOffset>, u32>
+    {
         // Offsets are guaranteed to be 1) monotonically increasing *unless* there is
         // a network issue or a new partition added, at which point the consumer may
         // start processing the topic from the beginning, or we may see duplicate offsets
@@ -791,7 +792,7 @@ impl KafkaSourceReader {
             let next_ts = Partitioned::with_partition(partition, offset + 1);
             part_data_cap.downgrade(&next_ts);
             part_upper_cap.downgrade(&next_ts);
-            NextMessage::Ready(SourceMessageType::Message(message, cap, ()))
+            NextMessage::Ready(SourceMessageType::Message(message, cap, 1))
         }
     }
 }

--- a/src/storage/src/source/s3.rs
+++ b/src/storage/src/source/s3.rs
@@ -898,7 +898,7 @@ impl SourceReader for S3SourceReader {
     type Key = ();
     type Value = ByteStream;
     type Time = MzOffset;
-    type Diff = ();
+    type Diff = u32;
 
     fn get_next_message(&mut self) -> NextMessage<Self::Key, Self::Value, Self::Time, Self::Diff> {
         if !self.active_read_worker {
@@ -920,7 +920,7 @@ impl SourceReader for S3SourceReader {
                 let next_ts = ts + 1;
                 self.data_capability.downgrade(&next_ts);
                 self.upper_capability.downgrade(&next_ts);
-                NextMessage::Ready(SourceMessageType::Message(Ok(msg), cap, ()))
+                NextMessage::Ready(SourceMessageType::Message(Ok(msg), cap, 1))
             }
             Some(Some(Err(e))) => match e {
                 S3Error::GetObjectError { .. } => {
@@ -939,7 +939,7 @@ impl SourceReader for S3SourceReader {
                     let next_ts = not_definite_ts + 1;
                     self.data_capability.downgrade(&next_ts);
                     self.upper_capability.downgrade(&next_ts);
-                    NextMessage::Ready(SourceMessageType::Message(Err(err), cap, ()))
+                    NextMessage::Ready(SourceMessageType::Message(Err(err), cap, 1))
                 }
             },
             None => NextMessage::Pending,

--- a/src/storage/src/source/testscript.rs
+++ b/src/storage/src/source/testscript.rs
@@ -93,7 +93,7 @@ impl SourceReader for TestScriptSourceReader {
     type Key = Option<Vec<u8>>;
     type Value = Option<Vec<u8>>;
     type Time = MzOffset;
-    type Diff = ();
+    type Diff = u32;
 
     async fn next(
         &mut self,
@@ -119,7 +119,7 @@ impl SourceReader for TestScriptSourceReader {
                     let next_ts = ts + 1;
                     self.data_capability.downgrade(&next_ts);
                     self.upper_capability.downgrade(&next_ts);
-                    return Some(SourceMessageType::Message(msg, cap, ()));
+                    return Some(SourceMessageType::Message(msg, cap, 1));
                 }
             }
         } else {


### PR DESCRIPTION
### Motivation

Many of the transformations in the ingestion pipeline should be expressed as transformations on collections without peeking into the underlying timely stream. This forces us to think about our transformations purely on the data of the collection, acting as a guardrail to stay in the IVM mode.

This PR is mostly mechanical and only changes signatures to work with `Collection` and only converts transformation steps when they were truly trivial.

In a subsequent PR we should attempt to translate more of our operators (decode looks like an easy start) to use `Collection::map` or `Collection::flat_map`.

During this translation I also realized that we have been using the wrong diff for append-only sources (`()`) which does not do the correct thing in the presence of compaction and consolidation. Fortunately we didn't have any code that consolidated batches with those timestamps but I fixed it anyway by switching to `u32` as the `Diff` of append only sources.

Side note: Threading the generic parameter for `Diff` when it is only ever `i64` or `u32` might not be worth it and we should consider forcing all sources to produce an `i64` and just assert that it's positive for append-only cases.

### Tips for reviewer

The changes are pretty much only mechanical. Some indentation changes were triggered so maybe no whitespace will help.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
