### PR TITLE
adapter: generate_series returns set

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2756,7 +2756,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["key".into(), "value".into()],
                 })
-            }) => ReturnType::set_of(RecordAny.into()), 3208;
+            }) => ReturnType::set_of(RecordAny), 3208;
         },
         "jsonb_each_text" => Table {
             params!(Jsonb) => Operation::unary(move |_ecx, jsonb| {
@@ -2767,7 +2767,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["key".into(), "value".into()],
                 })
-            }) => ReturnType::set_of(RecordAny.into()), 3932;
+            }) => ReturnType::set_of(RecordAny), 3932;
         },
         "jsonb_object_keys" => Table {
             params!(Jsonb) => Operation::unary(move |_ecx, jsonb| {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2734,7 +2734,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["value".into()],
                 })
-            }) => Jsonb, 3219;
+            }) => ReturnType::set_of(Jsonb.into()), 3219;
         },
         "jsonb_array_elements_text" => Table {
             params!(Jsonb) => Operation::unary(move |_ecx, jsonb| {
@@ -2745,7 +2745,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["value".into()],
                 })
-            }) => String, 3465;
+            }) => ReturnType::set_of(String.into()), 3465;
         },
         "jsonb_each" => Table {
             params!(Jsonb) => Operation::unary(move |_ecx, jsonb| {
@@ -2756,7 +2756,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["key".into(), "value".into()],
                 })
-            }) => RecordAny, 3208;
+            }) => ReturnType::set_of(RecordAny.into()), 3208;
         },
         "jsonb_each_text" => Table {
             params!(Jsonb) => Operation::unary(move |_ecx, jsonb| {
@@ -2767,7 +2767,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["key".into(), "value".into()],
                 })
-            }) => RecordAny, 3932;
+            }) => ReturnType::set_of(RecordAny.into()), 3932;
         },
         "jsonb_object_keys" => Table {
             params!(Jsonb) => Operation::unary(move |_ecx, jsonb| {
@@ -2778,7 +2778,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["jsonb_object_keys".into()],
                 })
-            }) => String, 3931;
+            }) => ReturnType::set_of(String.into()), 3931;
         },
         // Note that these implementations' input to `generate_series` is
         // contrived to match Flink's expected values. There are other,

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2663,7 +2663,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["generate_series".into()],
                 })
-            }) => Int32, 1066;
+            }) => ReturnType::set_of(Int32.into()), 1066;
             params!(Int32, Int32) => Operation::binary(move |_ecx, start, stop| {
                 Ok(TableFuncPlan {
                     expr: HirRelationExpr::CallTable {
@@ -2672,7 +2672,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["generate_series".into()],
                 })
-            }) => Int32, 1067;
+            }) => ReturnType::set_of(Int32.into()), 1067;
             params!(Int64, Int64, Int64) => Operation::variadic(move |_ecx, exprs| {
                 Ok(TableFuncPlan {
                     expr: HirRelationExpr::CallTable {
@@ -2681,7 +2681,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["generate_series".into()],
                 })
-            }) => Int64, 1068;
+            }) => ReturnType::set_of(Int64.into()), 1068;
             params!(Int64, Int64) => Operation::binary(move |_ecx, start, stop| {
                 let row = Row::pack([Datum::Int64(1)]);
                 let column_type = ColumnType { scalar_type: ScalarType::Int64, nullable: false };
@@ -2692,7 +2692,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["generate_series".into()],
                 })
-            }) => Int64, 1069;
+            }) => ReturnType::set_of(Int64.into()), 1069;
             params!(Timestamp, Timestamp, Interval) => Operation::variadic(move |_ecx, exprs| {
                 Ok(TableFuncPlan {
                     expr: HirRelationExpr::CallTable {
@@ -2701,7 +2701,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["generate_series".into()],
                 })
-            }) => Timestamp, 938;
+            }) => ReturnType::set_of(Timestamp.into()), 938;
             params!(TimestampTz, TimestampTz, Interval) => Operation::variadic(move |_ecx, exprs| {
                 Ok(TableFuncPlan {
                     expr: HirRelationExpr::CallTable {
@@ -2710,7 +2710,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     },
                     column_names: vec!["generate_series".into()],
                 })
-            }) => TimestampTz, 939;
+            }) => ReturnType::set_of(TimestampTz.into()), 939;
         },
 
         "generate_subscripts" => Table {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -4330,10 +4330,18 @@ fn plan_function<'a>(
             )
         }
         Func::Aggregate(_) => {
-            sql_bail!("aggregate functions are not allowed in {}", ecx.name);
+            sql_bail!(
+                "aggregate functions are not allowed in {} (function {})",
+                ecx.name,
+                unresolved_name
+            );
         }
         Func::Table(_) => {
-            sql_bail!("table functions are not allowed in {}", ecx.name);
+            sql_bail!(
+                "table functions are not allowed in {} (function {})",
+                ecx.name,
+                unresolved_name
+            );
         }
         Func::Scalar(impls) => impls,
         Func::ScalarWindow(impls) => {
@@ -4625,7 +4633,11 @@ fn validate_window_function_plan<'a>(
     PlanError,
 > {
     if !ecx.allow_windows {
-        sql_bail!("window functions are not allowed in {}", ecx.name);
+        sql_bail!(
+            "window functions are not allowed in {} (function {})",
+            ecx.name,
+            name
+        );
     }
 
     // Various things are duplicated here and in `plan_function` to improve error messages.
@@ -5075,8 +5087,11 @@ impl<'a> VisitMut<'_, Aug> for AggregateTableFuncVisitor<'a> {
                 if let Ok(item) = self.scx.resolve_function(func.name.clone()) {
                     if let Ok(Func::Table { .. }) = item.func() {
                         if let Some(context) = self.table_disallowed_context.last() {
-                            self.err =
-                                Some(sql_err!("table functions are not allowed in {}", context));
+                            self.err = Some(sql_err!(
+                                "table functions are not allowed in {} (function {})",
+                                context,
+                                func.name
+                            ));
                             return;
                         }
                         table_func = Some(func.clone());

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -15,7 +15,7 @@ CREATE TABLE t (a int, b int)
 statement ok
 INSERT INTO t (a, b) VALUES (1, 1), (1, 2), (2, 3), (3, 1)
 
-query error aggregate functions are not allowed in WHERE clause
+query error aggregate functions are not allowed in WHERE clause \(function sum\)
 SELECT a FROM t WHERE sum(b) = 3 GROUP BY a
 
 query error column "t.b" must appear in the GROUP BY clause or be used in an aggregate function
@@ -283,7 +283,7 @@ SELECT abs(1) FILTER (WHERE false)
 query error Expected end of statement, found left parenthesis
 SELECT column1 FILTER (WHERE column1 = 1) FROM (VALUES (1))
 
-query error aggregate functions are not allowed in FILTER
+query error aggregate functions are not allowed in FILTER \(function count\)
 SELECT v, count(*) FILTER (WHERE count(1) > 5) FROM filter_test GROUP BY v
 
 # These filter tests are Materialize-specific.

--- a/test/sqllogictest/returning.slt
+++ b/test/sqllogictest/returning.slt
@@ -90,10 +90,10 @@ INSERT INTO t VALUES (7, 8) RETURNING 1/0
 statement error column "z" does not exist
 INSERT INTO t VALUES (7, 8) RETURNING z
 
-statement error aggregate functions are not allowed in RETURNING clause
+statement error aggregate functions are not allowed in RETURNING clause \(function count\)
 INSERT INTO t VALUES (7, 8) RETURNING count(*)
 
-statement error window functions are not allowed in RETURNING clause
+statement error window functions are not allowed in RETURNING clause \(function row_number\)
 INSERT INTO t VALUES (7, 8) RETURNING row_number()
 
 statement error RETURNING clause does not allow subqueries

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -1084,3 +1084,14 @@ SELECT 'table_with_id'::regclass
 # fully qualified names are not yet supported
 statement error object "test.table_with_id" does not exist
 SELECT 'test.table_with_id'::regclass
+
+# Regression for 18020
+query B
+SELECT returns_set FROM mz_functions WHERE name = 'generate_series';
+----
+true
+true
+true
+true
+true
+true

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -1087,8 +1087,15 @@ SELECT 'test.table_with_id'::regclass
 
 # Regression for 18020
 query B
-SELECT returns_set FROM mz_functions WHERE name = 'generate_series';
+SELECT returns_set FROM mz_functions WHERE name in ('generate_series', 'generate_subscripts', 'regexp_extract', 'jsonb_array_elements', 'jsonb_array_elements_text', 'jsonb_each', 'jsonb_each_text', 'jsonb_object_keys');
 ----
+true
+true
+true
+true
+true
+true
+true
 true
 true
 true


### PR DESCRIPTION
Fixes #18020

I found further issues, see individual commits.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
