### PR TITLE
Allow unstable dependencies in temporary views

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -308,7 +308,10 @@ impl CatalogState {
             .map(|id| self.get_entry(id).name().item.clone())
             .collect();
 
-        if unstable_dependencies.is_empty() {
+        // It's okay to create a temporary object with unstable
+        // dependencies, since we will never need to reboot a catalog
+        // that contains it.
+        if unstable_dependencies.is_empty() || !item.is_temporary() {
             Ok(())
         } else {
             let object_type = item.typ().to_string();
@@ -316,7 +319,7 @@ impl CatalogState {
                 object_type,
                 unstable_dependencies,
             })
-        }
+        }}
     }
 
     pub fn resolve_full_name(

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -319,7 +319,7 @@ impl CatalogState {
                 object_type,
                 unstable_dependencies,
             })
-        }}
+        }
     }
 
     pub fn resolve_full_name(

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -311,7 +311,7 @@ impl CatalogState {
         // It's okay to create a temporary object with unstable
         // dependencies, since we will never need to reboot a catalog
         // that contains it.
-        if unstable_dependencies.is_empty() || !item.is_temporary() {
+        if unstable_dependencies.is_empty() || item.is_temporary() {
             Ok(())
         } else {
             let object_type = item.typ().to_string();

--- a/test/sqllogictest/introspection/unstable.slt
+++ b/test/sqllogictest/introspection/unstable.slt
@@ -30,6 +30,11 @@ CREATE DEFAULT INDEX ON mz_internal.mz_active_peeks_1
 statement error cannot create view with unstable dependencies
 CREATE VIEW v AS SELECT * FROM mz_internal.mz_scheduling_elapsed
 
+# Unstable temporary views are allowed
+
+statement ok
+CREATE TEMPORARY VIEW v AS SELECT * FROM mz_internal.mz_scheduling_elapsed
+
 statement error cannot create index with unstable dependencies
 CREATE DEFAULT INDEX ON mz_internal.mz_scheduling_elapsed_1
 


### PR DESCRIPTION
Allow unstable dependencies in temporary views.

### Motivation

  * This PR adds a feature that has not yet been specified.

This will make it possible to do local prototyping of introspection queries using views, without risking startup crashes due to the underlying schema of the dependencies changing. 
 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  Small enough not to require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
None 
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Internal objects can now be depended on in `CREATE TEMPORARY VIEW` statements.