### PR TITLE
*: clean up clippy warnings newly present in rust 1.68.0

### DIFF
--- a/src/cluster-client/src/client.rs
+++ b/src/cluster-client/src/client.rs
@@ -165,7 +165,6 @@ impl RustType<ProtoTimelyConfig> for TimelyConfig {
 impl TimelyConfig {
     pub fn split_command(&self, parts: usize) -> Vec<Self> {
         (0..parts)
-            .into_iter()
             .map(|part| TimelyConfig {
                 process: part,
                 ..self.clone()

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1191,13 +1191,9 @@ impl<T: timely::progress::Timestamp> Plan<T> {
                         // later.
                         let source_arrangement = (
                             (0..key.len())
-                                .into_iter()
                                 .map(MirScalarExpr::Column)
                                 .collect::<Vec<_>>(),
-                            (0..key.len())
-                                .into_iter()
-                                .map(|i| (i, i))
-                                .collect::<BTreeMap<_, _>>(),
+                            (0..key.len()).map(|i| (i, i)).collect::<BTreeMap<_, _>>(),
                             Vec::<usize>::new(),
                         );
                         let (ljp, missing) = LinearJoinPlan::create_from(

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1376,7 +1376,6 @@ pub mod util {
             .enumerate()
             .collect();
         let thinning = (0..unthinned_arity)
-            .into_iter()
             .filter(|c| !columns_in_key.contains_key(c))
             .collect();
         (permutation, thinning)

--- a/src/repr/src/explain/text.rs
+++ b/src/repr/src/explain/text.rs
@@ -217,10 +217,7 @@ where
             first_rows.push((row, diff));
         }
     }
-    let rest_of_row_count = rows
-        .into_iter()
-        .map(|(_, diff)| diff.abs())
-        .sum::<crate::Diff>();
+    let rest_of_row_count = rows.map(|(_, diff)| diff.abs()).sum::<crate::Diff>();
     if rest_of_row_count != 0 {
         writeln!(
             f,

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -1059,11 +1059,9 @@ where
     K: Data,
     V: Data,
 {
-    consolidate_updates(rows)
-        .into_iter()
-        .map(|((key, value), ts, diff)| {
-            let key: K = serde_json::from_value(key).expect("must deserialize");
-            let value: V = serde_json::from_value(value).expect("must deserialize");
-            ((key, value), ts, diff)
-        })
+    consolidate_updates(rows).map(|((key, value), ts, diff)| {
+        let key: K = serde_json::from_value(key).expect("must deserialize");
+        let value: V = serde_json::from_value(value).expect("must deserialize");
+        ((key, value), ts, diff)
+    })
 }

--- a/src/storage-client/src/types/sources/encoding.rs
+++ b/src/storage-client/src/types/sources/encoding.rs
@@ -255,11 +255,9 @@ impl DataEncoding {
                     desc.with_column(name, ty)
                 }),
             DataEncodingInner::Csv(CsvEncoding { columns, .. }) => match columns {
-                ColumnSpec::Count(n) => {
-                    (1..=*n).into_iter().fold(RelationDesc::empty(), |desc, i| {
-                        desc.with_column(format!("column{}", i), ScalarType::String.nullable(false))
-                    })
-                }
+                ColumnSpec::Count(n) => (1..=*n).fold(RelationDesc::empty(), |desc, i| {
+                    desc.with_column(format!("column{}", i), ScalarType::String.nullable(false))
+                }),
                 ColumnSpec::Header { names } => names
                     .iter()
                     .map(|s| &**s)


### PR DESCRIPTION
All of them are `clippy::useless_conversion`.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
