### PR TITLE
adapter: Add indexes for common internal tables for faster UI

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2940,14 +2940,6 @@ IN CLUSTER mz_introspection
 ON mz_catalog.mz_columns (id)",
 };
 
-pub const MZ_SHOW_CLUSTERS_IND: BuiltinIndex = BuiltinIndex {
-    name: "mz_show_clusters_ind",
-    schema: MZ_INTERNAL_SCHEMA,
-    sql: "CREATE INDEX mz_show_clusters_ind
-IN CLUSTER mz_introspection
-ON mz_catalog.mz_clusters (name)",
-};
-
 pub const MZ_SHOW_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
     name: "mz_show_cluster_replicas_ind",
     schema: MZ_INTERNAL_SCHEMA,
@@ -2962,6 +2954,47 @@ pub const MZ_SHOW_SECRETS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_secrets_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_secrets (schema_id)",
+};
+
+pub const MZ_CLUSTERS_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_clusters_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_clusters_ind
+IN CLUSTER mz_introspection
+ON mz_catalog.mz_clusters (id, name)",
+};
+
+pub const MZ_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_cluster_replicas_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_cluster_replicas_ind
+IN CLUSTER mz_introspection
+ON mz_catalog.mz_cluster_replicas (id, cluster_id, name, size, availability_zone)",
+};
+
+pub const MZ_CLUSTER_REPLICA_UTILIZATION_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_cluster_replica_utilization_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql:
+        "CREATE INDEX mz_cluster_replica_utilization_ind
+IN CLUSTER mz_introspection
+ON mz_internal.mz_cluster_replica_utilization (replica_id, process_id, cpu_percent, memory_percent)",
+};
+
+pub const MZ_SOURCE_STATUSES_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_source_statuses_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_source_statuses_ind
+IN CLUSTER mz_introspection
+ON mz_internal.mz_source_statuses (id, name, type, last_status_change_at, status, error, details)",
+};
+
+pub const MZ_SOURCE_STATUS_HISTORY_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_source_status_history_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_source_status_history_ind
+IN CLUSTER mz_introspection
+ON mz_internal.mz_source_status_history (occurred_at, source_id, status, error, details)",
 };
 
 pub static MZ_SYSTEM_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {
@@ -3229,9 +3262,13 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Index(&MZ_SHOW_ALL_OBJECTS_IND),
         Builtin::Index(&MZ_SHOW_INDEXES_IND),
         Builtin::Index(&MZ_SHOW_COLUMNS_IND),
-        Builtin::Index(&MZ_SHOW_CLUSTERS_IND),
         Builtin::Index(&MZ_SHOW_CLUSTER_REPLICAS_IND),
         Builtin::Index(&MZ_SHOW_SECRETS_IND),
+        Builtin::Index(&MZ_CLUSTERS_IND),
+        Builtin::Index(&MZ_CLUSTER_REPLICAS_IND),
+        Builtin::Index(&MZ_CLUSTER_REPLICA_UTILIZATION_IND),
+        Builtin::Index(&MZ_SOURCE_STATUSES_IND),
+        Builtin::Index(&MZ_SOURCE_STATUS_HISTORY_IND),
     ]);
 
     builtins

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2940,6 +2940,14 @@ IN CLUSTER mz_introspection
 ON mz_catalog.mz_columns (id)",
 };
 
+pub const MZ_SHOW_CLUSTERS_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_show_clusters_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_show_clusters_ind
+IN CLUSTER mz_introspection
+ON mz_catalog.mz_clusters (name)",
+};
+
 pub const MZ_SHOW_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
     name: "mz_show_cluster_replicas_ind",
     schema: MZ_INTERNAL_SCHEMA,
@@ -2961,7 +2969,7 @@ pub const MZ_CLUSTERS_IND: BuiltinIndex = BuiltinIndex {
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE INDEX mz_clusters_ind
 IN CLUSTER mz_introspection
-ON mz_catalog.mz_clusters (id, name)",
+ON mz_catalog.mz_clusters (id)",
 };
 
 pub const MZ_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
@@ -2969,7 +2977,7 @@ pub const MZ_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE INDEX mz_cluster_replicas_ind
 IN CLUSTER mz_introspection
-ON mz_catalog.mz_cluster_replicas (id, cluster_id, name, size, availability_zone)",
+ON mz_catalog.mz_cluster_replicas (id)",
 };
 
 pub const MZ_CLUSTER_REPLICA_UTILIZATION_IND: BuiltinIndex = BuiltinIndex {
@@ -2978,7 +2986,7 @@ pub const MZ_CLUSTER_REPLICA_UTILIZATION_IND: BuiltinIndex = BuiltinIndex {
     sql:
         "CREATE INDEX mz_cluster_replica_utilization_ind
 IN CLUSTER mz_introspection
-ON mz_internal.mz_cluster_replica_utilization (replica_id, process_id, cpu_percent, memory_percent)",
+ON mz_internal.mz_cluster_replica_utilization (replica_id)",
 };
 
 pub const MZ_SOURCE_STATUSES_IND: BuiltinIndex = BuiltinIndex {
@@ -2986,7 +2994,7 @@ pub const MZ_SOURCE_STATUSES_IND: BuiltinIndex = BuiltinIndex {
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE INDEX mz_source_statuses_ind
 IN CLUSTER mz_introspection
-ON mz_internal.mz_source_statuses (id, name, type, last_status_change_at, status, error, details)",
+ON mz_internal.mz_source_statuses (id)",
 };
 
 pub const MZ_SOURCE_STATUS_HISTORY_IND: BuiltinIndex = BuiltinIndex {
@@ -2994,7 +3002,7 @@ pub const MZ_SOURCE_STATUS_HISTORY_IND: BuiltinIndex = BuiltinIndex {
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE INDEX mz_source_status_history_ind
 IN CLUSTER mz_introspection
-ON mz_internal.mz_source_status_history (occurred_at, source_id, status, error, details)",
+ON mz_internal.mz_source_status_history (source_id)",
 };
 
 pub static MZ_SYSTEM_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {
@@ -3262,6 +3270,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Index(&MZ_SHOW_ALL_OBJECTS_IND),
         Builtin::Index(&MZ_SHOW_INDEXES_IND),
         Builtin::Index(&MZ_SHOW_COLUMNS_IND),
+        Builtin::Index(&MZ_SHOW_CLUSTERS_IND),
         Builtin::Index(&MZ_SHOW_CLUSTER_REPLICAS_IND),
         Builtin::Index(&MZ_SHOW_SECRETS_IND),
         Builtin::Index(&MZ_CLUSTERS_IND),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2983,8 +2983,7 @@ ON mz_catalog.mz_cluster_replicas (id)",
 pub const MZ_CLUSTER_REPLICA_UTILIZATION_IND: BuiltinIndex = BuiltinIndex {
     name: "mz_cluster_replica_utilization_ind",
     schema: MZ_INTERNAL_SCHEMA,
-    sql:
-        "CREATE INDEX mz_cluster_replica_utilization_ind
+    sql: "CREATE INDEX mz_cluster_replica_utilization_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_cluster_replica_utilization (replica_id)",
 };

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -366,7 +366,7 @@ CREATE CLUSTER test REPLICAS (foo (SIZE '1'));
 query I
 SELECT COUNT(name) FROM mz_indexes;
 ----
-95
+96
 
 statement ok
 DROP CLUSTER test CASCADE
@@ -374,7 +374,7 @@ DROP CLUSTER test CASCADE
 query T
 SELECT COUNT(name) FROM mz_indexes;
 ----
-76
+77
 
 statement error nvalid SIZE: must provide a string value
 CREATE CLUSTER REPLICA default.size_1 SIZE;

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -366,7 +366,7 @@ CREATE CLUSTER test REPLICAS (foo (SIZE '1'));
 query I
 SELECT COUNT(name) FROM mz_indexes;
 ----
-91
+95
 
 statement ok
 DROP CLUSTER test CASCADE
@@ -374,7 +374,7 @@ DROP CLUSTER test CASCADE
 query T
 SELECT COUNT(name) FROM mz_indexes;
 ----
-72
+76
 
 statement error nvalid SIZE: must provide a string value
 CREATE CLUSTER REPLICA default.size_1 SIZE;

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -176,11 +176,11 @@ query T multiline
 EXPLAIN SHOW CLUSTERS
 ----
 Explained Query (fast path):
-  Project (#1)
-    ReadExistingIndex mz_internal.mz_clusters_ind
+  Project (#0)
+    ReadExistingIndex mz_internal.mz_show_clusters_ind
 
 Used Indexes:
-  - mz_internal.mz_clusters_ind
+  - mz_internal.mz_show_clusters_ind
 
 EOF
 
@@ -224,16 +224,14 @@ ORDER BY r.id;
 ----
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#5]
-    Project (#0..=#3, #5, #7)
-      Join on=(#0 = #6 AND #2 = #4) type=differential
-        ArrangeBy keys=[[#2]]
-          Project (#0..=#3)
-            Get mz_catalog.mz_cluster_replicas
+    Project (#0..=#3, #6, #10)
+      Join on=(#0 = #7 AND #2 = #5) type=differential
+        ArrangeBy keys=[[#0]]
+          Get mz_catalog.mz_cluster_replicas
         ArrangeBy keys=[[#0]]
           Get mz_catalog.mz_clusters
         ArrangeBy keys=[[#0]]
-          Project (#0, #3)
-            Get mz_internal.mz_cluster_replica_utilization
+          Get mz_internal.mz_cluster_replica_utilization
 
 Used Indexes:
   - mz_internal.mz_clusters_ind
@@ -266,13 +264,12 @@ Explained Query:
       Get l2
   With
     cte l2 =
-      Project (#0..=#4, #6, #7)
-        Join on=(#0 = #5) type=differential
-          Get l1
-          ArrangeBy keys=[[#0]]
-            Project (#0, #4, #5)
-              Filter "u%" ~~(#0)
-                Get mz_internal.mz_source_statuses
+      Project (#0..=#4, #9, #10)
+        Filter "u%" ~~(#0)
+          Join on=(#0 = #5) type=differential
+            Get l1
+            ArrangeBy keys=[[#0]]
+              Get mz_internal.mz_source_statuses
     cte l1 =
       ArrangeBy keys=[[#0]]
         Get l0
@@ -302,9 +299,9 @@ Explained Query:
     Project (#1, #0, #2)
       Reduce group_by=[#1] aggregates=[max((extract_epoch_tstz(#0) * 1000)), count(*)]
         Project (#0, #3)
-          Filter (#1 = "u6") AND (#5 <= 100) AND (#5 >= 0) AND (#3) IS NOT NULL
+          Filter (#6 <= 100) AND (#6 >= 0) AND (#3) IS NOT NULL
             Map (timestamp_tz_to_mz_timestamp(#0))
-              Get mz_internal.mz_source_status_history
+              ReadExistingIndex mz_internal.mz_source_status_history lookup_value=("u6")
 
 Used Indexes:
   - mz_internal.mz_source_status_history_ind

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -176,11 +176,11 @@ query T multiline
 EXPLAIN SHOW CLUSTERS
 ----
 Explained Query (fast path):
-  Project (#0)
-    ReadExistingIndex mz_internal.mz_show_clusters_ind
+  Project (#1)
+    ReadExistingIndex mz_internal.mz_clusters_ind
 
 Used Indexes:
-  - mz_internal.mz_show_clusters_ind
+  - mz_internal.mz_clusters_ind
 
 EOF
 
@@ -205,5 +205,108 @@ Explained Query (fast path):
 
 Used Indexes:
   - mz_internal.mz_show_secrets_ind
+
+EOF
+
+# Following are used in the UI
+
+query T multiline
+EXPLAIN SELECT r.id,
+  r.name as replica_name,
+  r.cluster_id,
+  r.size,
+  c.name as cluster_name,
+  u.memory_percent
+FROM mz_cluster_replicas r
+JOIN mz_clusters c ON c.id = r.cluster_id
+JOIN mz_internal.mz_cluster_replica_utilization u ON u.replica_id = r.id
+ORDER BY r.id;
+----
+Explained Query:
+  Finish order_by=[#0 asc nulls_last] output=[#0..=#5]
+    Project (#0..=#3, #5, #7)
+      Join on=(#0 = #6 AND #2 = #4) type=differential
+        ArrangeBy keys=[[#2]]
+          Project (#0..=#3)
+            Get mz_catalog.mz_cluster_replicas
+        ArrangeBy keys=[[#0]]
+          Get mz_catalog.mz_clusters
+        ArrangeBy keys=[[#0]]
+          Project (#0, #3)
+            Get mz_internal.mz_cluster_replica_utilization
+
+Used Indexes:
+  - mz_internal.mz_clusters_ind
+  - mz_internal.mz_cluster_replicas_ind
+  - mz_internal.mz_cluster_replica_utilization_ind
+
+EOF
+
+query T multiline
+EXPLAIN SELECT s.id, s.oid, s.name, s.type, s.size, st.status, st.error
+FROM mz_sources s
+LEFT OUTER JOIN mz_internal.mz_source_statuses st
+ON st.id = s.id
+WHERE s.id LIKE 'u%';
+----
+Explained Query:
+  Return
+    Union
+      Map (null, null)
+        Union
+          Negate
+            Project (#0..=#4)
+              Join on=(#0 = #5) type=differential
+                Get l1
+                ArrangeBy keys=[[#0]]
+                  Distinct group_by=[#0]
+                    Project (#0)
+                      Get l2
+          Get l0
+      Get l2
+  With
+    cte l2 =
+      Project (#0..=#4, #6, #7)
+        Join on=(#0 = #5) type=differential
+          Get l1
+          ArrangeBy keys=[[#0]]
+            Project (#0, #4, #5)
+              Filter "u%" ~~(#0)
+                Get mz_internal.mz_source_statuses
+    cte l1 =
+      ArrangeBy keys=[[#0]]
+        Get l0
+    cte l0 =
+      Project (#0, #1, #3, #4, #6)
+        Filter "u%" ~~(#0)
+          Get mz_catalog.mz_sources
+
+Used Indexes:
+  - mz_internal.mz_show_sources_ind
+  - mz_internal.mz_source_statuses_ind
+
+EOF
+
+query T multiline
+EXPLAIN SELECT MAX(extract(epoch from h.occurred_at) * 1000) as last_occurred, h.error, COUNT(h.occurred_at)
+FROM mz_internal.mz_source_status_history h
+WHERE source_id = 'u6'
+AND error IS NOT NULL
+AND h.occurred_at BETWEEN 0 AND 100
+GROUP BY h.error
+ORDER BY last_occurred DESC
+LIMIT 10;
+----
+Explained Query:
+  Finish order_by=[#0 desc nulls_first] limit=10 output=[#0..=#2]
+    Project (#1, #0, #2)
+      Reduce group_by=[#1] aggregates=[max((extract_epoch_tstz(#0) * 1000)), count(*)]
+        Project (#0, #3)
+          Filter (#1 = "u6") AND (#5 <= 100) AND (#5 >= 0) AND (#3) IS NOT NULL
+            Map (timestamp_tz_to_mz_timestamp(#0))
+              Get mz_internal.mz_source_status_history
+
+Used Indexes:
+  - mz_internal.mz_source_status_history_ind
 
 EOF

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -589,7 +589,7 @@ test_table
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'
-72
+77
 
 # Create a second schema with the same table name as above
 > CREATE SCHEMA tester2

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -279,6 +279,9 @@ mz_active_peeks_s2_primary_idx                              mz_active_peeks     
 mz_arrangement_batches_internal_s2_primary_idx              mz_arrangement_batches_internal             mz_introspection    {operator_id,worker_id}
 mz_arrangement_records_internal_s2_primary_idx              mz_arrangement_records_internal             mz_introspection    {operator_id,worker_id}
 mz_arrangement_sharing_internal_s2_primary_idx              mz_arrangement_sharing_internal             mz_introspection    {operator_id,worker_id}
+mz_cluster_replica_utilization_ind                          mz_cluster_replica_utilization              mz_introspection    {replica_id}
+mz_cluster_replicas_ind                                     mz_cluster_replicas                         mz_introspection    {id}
+mz_clusters_ind                                             mz_clusters                                 mz_introspection    {id}
 mz_compute_exports_s2_primary_idx                           mz_compute_exports                          mz_introspection    {export_id,worker_id}
 mz_dataflow_addresses_s2_primary_idx                        mz_dataflow_addresses                       mz_introspection    {id,worker_id}
 mz_dataflow_channels_s2_primary_idx                         mz_dataflow_channels                        mz_introspection    {id,worker_id}
@@ -306,6 +309,8 @@ mz_show_sources_ind                                         mz_sources          
 mz_show_tables_ind                                          mz_tables                                   mz_introspection    {schema_id}
 mz_show_types_ind                                           mz_types                                    mz_introspection    {schema_id}
 mz_show_views_ind                                           mz_views                                    mz_introspection    {schema_id}
+mz_source_status_history_ind                                mz_source_status_history                    mz_introspection    {source_id}
+mz_source_statuses_ind                                      mz_source_statuses                          mz_introspection    {id}
 mz_worker_compute_dependencies_s2_primary_idx               mz_worker_compute_dependencies              mz_introspection    {export_id,import_id,worker_id}
 mz_worker_compute_frontiers_s2_primary_idx                  mz_worker_compute_frontiers                 mz_introspection    {export_id,worker_id,time}
 mz_worker_compute_import_frontiers_s2_primary_idx           mz_worker_compute_import_frontiers          mz_introspection    {export_id,import_id,worker_id,time}


### PR DESCRIPTION
Fixes #17328

We're only making indexes for the tables (and internal views) that are used by the queries instead of creating new views (and corresponding indexes) for these queries. This should be fast enough for the future and gives us greater freedom in changing the queries in the future.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Faster web UI
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer
I think the output of system-cluster.slt is enough to convince us that these queries will be faster but I haven't tested them by hand. I did some experiments locally that indicate to me that this should be good enough.
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
