### PR TITLE
load test: Extend cloud-canary/mzcompose.py for cloud load testing

### DIFF
--- a/test/cloud-canary/canary-load-generator.td
+++ b/test/cloud-canary/canary-load-generator.td
@@ -15,5 +15,3 @@
 
 > SELECT cnt > 0 FROM generator_view1;
 true
-
-> DROP SOURCE generator1 CASCADE;

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import argparse
 import os
 import ssl
 import time
@@ -14,12 +15,12 @@ import urllib.parse
 
 import pg8000
 
-from materialize.mzcompose import Composition, _wait_for_pg
+from materialize.mzcompose import Composition, WorkflowArgumentParser, _wait_for_pg
 from materialize.mzcompose.services import Cockroach, Materialized, Mz, Testdrive
 from materialize.ui import UIError
 
 REGION = "aws/us-east-1"
-ENVIRONMENT = "staging"
+ENVIRONMENT = os.getenv("ENVIRONMENT", "staging")
 USERNAME = os.getenv("NIGHTLY_CANARY_USERNAME", "infra+nightly-canary@materialize.com")
 APP_PASSWORD = os.environ["NIGHTLY_CANARY_APP_PASSWORD"]
 VERSION = "devel-" + os.environ["BUILDKITE_COMMIT"]
@@ -52,11 +53,33 @@ SERVICES = [
 ]
 
 
-def workflow_default(c: Composition) -> None:
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Deploy the current source to the cloud and run tests."""
 
-    print(f"Shutting down region {REGION} ...")
-    c.run("mz", "region", "disable", REGION)
+    parser.add_argument(
+        "--cleanup",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Destroy the region at the end of the workflow.",
+    )
+    parser.add_argument(
+        "--version-check",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Perform a version check.",
+    )
+
+    parser.add_argument(
+        "td_files",
+        nargs="*",
+        default=["*.td"],
+        help="run against the specified files",
+    )
+
+    args = parser.parse_args()
+
+    if args.cleanup:
+        workflow_disable_region(c)
 
     test_failed = True
     try:
@@ -72,16 +95,24 @@ def workflow_default(c: Composition) -> None:
         assert "materialize.cloud" in cloud_hostname(c)
         wait_for_cloud(c)
 
-        version_check(c)
+        if args.version_check:
+            version_check(c)
 
-        print("Running tests ...")
-        td(c, "*.td")
+        print("Running .td files ...")
+        td(c, *args.td_files)
         test_failed = False
     finally:
         # Clean up
-        workflow_disable_region(c)
+        if args.cleanup:
+            workflow_disable_region(c)
 
     assert not test_failed
+
+
+def workflow_disable_region(c: Composition) -> None:
+    print(f"Shutting down region {REGION} ...")
+
+    c.run("mz", "region", "disable", REGION)
 
 
 def cloud_hostname(c: Composition) -> str:
@@ -165,9 +196,3 @@ def td(c: Composition, *args: str) -> None:
             *args,
             rm=True,
         )
-
-
-def workflow_disable_region(c: Composition) -> None:
-    print(f"Shutting down region {REGION} ...")
-
-    c.run("mz", "region", "disable", REGION)


### PR DESCRIPTION
Fixes to cloud-canary/mzcompose.py so that it can be used in the cloud load test.

### Motivation

In Nightly, the cloud-canary mzcompose workflow was used to create 1 region and run stuff against it. We repurpose the same machinery in the cloud load test to enable and populate N=100 environments.
### Tips for reviewer

@def- 

The way this is supposed to work is described in

https://www.notion.so/materialize/Cloud-Load-Test-Runbook-91fe570ce7454f01b1da33cc11a44122?pvs=4#61a57fb5e252414fa35c3d46f2be998d

The cloud-repository-side script is at:

https://github.com/MaterializeInc/cloud/pull/5728