### PR TITLE
compute: fix update_type in reachability logging

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -431,9 +431,10 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                                 let massaged: Vec<_> = update
                                     .updates
                                     .iter()
-                                    .map(|u| {
-                                        let ts = u.2.as_any().downcast_ref::<Timestamp>().copied();
-                                        (*u.0, *u.1, true, ts, *u.3)
+                                    .map(|(node, port, time, diff)| {
+                                        let ts = time.as_any().downcast_ref::<Timestamp>().copied();
+                                        let is_source = true;
+                                        (*node, *port, is_source, ts, *diff)
                                     })
                                     .collect();
 
@@ -447,9 +448,10 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                                 let massaged: Vec<_> = update
                                     .updates
                                     .iter()
-                                    .map(|u| {
-                                        let ts = u.2.as_any().downcast_ref::<Timestamp>().copied();
-                                        (*u.0, *u.1, true, ts, *u.3)
+                                    .map(|(node, port, time, diff)| {
+                                        let ts = time.as_any().downcast_ref::<Timestamp>().copied();
+                                        let is_source = false;
+                                        (*node, *port, is_source, ts, *diff)
                                     })
                                     .collect();
 


### PR DESCRIPTION
[fef21c](https://github.com/MaterializeInc/materialize/commit/fef21c6046c05f5de26a2bfba1f516906c2e8cd8#diff-a71a34f67adb8f7bf99fde4b17530565a7fa8508a146bd1fd7a5e31434474549R454), which refactored the reachability logging, included a copy-paste-o that resulted in the `is_source`/`update_type` field of each row to always be set to `true`. As a consequence, entries in `mz_dataflow_operators_reachability` would always specify "source" as their update type, even if they were in fact target updates.

This PR fixes the bug and also makes the surrounding code slighly more readable by destructuring the tuples and using descriptive field names rather than index access.

### Motivation

  * This PR fixes a previously unreported bug.

Entries in `mz_dataflow_operators_reachability` always specify "source" as their update type, even if they are in fact target updates.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
