### PR TITLE
Add index to `mz_cluster_replica_utilization`

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2964,6 +2964,14 @@ IN CLUSTER mz_introspection
 ON mz_catalog.mz_secrets (schema_id)",
 };
 
+pub const MZ_CLUSTER_REPLICA_UTILIZATION_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_cluster_replica_utilization_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_cluster_replica_utilization_ind
+IN CLUSTER mz_introspection
+ON mz_internal.mz_cluster_replica_utilization (replica_id)"
+};
+
 pub static MZ_SYSTEM_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {
     name: &*SYSTEM_USER.name,
     attributes: RoleAttributes::new().with_all(),
@@ -3232,6 +3240,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Index(&MZ_SHOW_CLUSTERS_IND),
         Builtin::Index(&MZ_SHOW_CLUSTER_REPLICAS_IND),
         Builtin::Index(&MZ_SHOW_SECRETS_IND),
+        Builtin::Index(&MZ_CLUSTER_REPLICA_UTILIZATION_IND),
     ]);
 
     builtins

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2969,7 +2969,7 @@ pub const MZ_CLUSTER_REPLICA_UTILIZATION_IND: BuiltinIndex = BuiltinIndex {
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE INDEX mz_cluster_replica_utilization_ind
 IN CLUSTER mz_introspection
-ON mz_internal.mz_cluster_replica_utilization (replica_id)"
+ON mz_internal.mz_cluster_replica_utilization (replica_id)",
 };
 
 pub static MZ_SYSTEM_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -279,6 +279,7 @@ mz_active_peeks_s2_primary_idx                              mz_active_peeks     
 mz_arrangement_batches_internal_s2_primary_idx              mz_arrangement_batches_internal             mz_introspection    {operator_id,worker_id}
 mz_arrangement_records_internal_s2_primary_idx              mz_arrangement_records_internal             mz_introspection    {operator_id,worker_id}
 mz_arrangement_sharing_internal_s2_primary_idx              mz_arrangement_sharing_internal             mz_introspection    {operator_id,worker_id}
+mz_cluster_replica_utilization_ind                          mz_cluster_replica_utilization              mz_introspection    {replica_id}
 mz_compute_exports_s2_primary_idx                           mz_compute_exports                          mz_introspection    {export_id,worker_id}
 mz_dataflow_addresses_s2_primary_idx                        mz_dataflow_addresses                       mz_introspection    {id,worker_id}
 mz_dataflow_channels_s2_primary_idx                         mz_dataflow_channels                        mz_introspection    {id,worker_id}


### PR DESCRIPTION
We query `mz_cluster_replica_utilization` from the cloud console, so we should have an index on it.

Anecdotally, this speeds up queries from >500ms to 20-150ms.

### Motivation

  * This PR fixes a previously unreported bug.

cloud console makes unindexed queries for replica metrics

### Tips for reviewer

I considered making the index on `mz_cluster_replica_metrics` instead (the underlying table), but I decided to make it on the view we actually query. Either will work; doing it on the underlying query would make latency slightly worse for the cloud console queries (they will have to do a join on demand), but would be more general. I can reconsider this if someone feels strongly. 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improved performance when querying `mz_cluster_replica_utilization` on the `mz_introspection` cluster.