### PR TITLE
persist: single path to update state after CaS mismatches

### DIFF
--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -24,7 +24,9 @@ use uuid::Uuid;
 
 use mz_ore::task::RuntimeExt;
 use mz_persist::indexed::encoding::BlobTraceBatchPart;
-use mz_persist::location::{Atomicity, Blob, Consensus, ExternalError, SeqNo, VersionedData};
+use mz_persist::location::{
+    Atomicity, Blob, CaSResult, Consensus, ExternalError, SeqNo, VersionedData,
+};
 use mz_persist::workload::{self, DataGenerator};
 use mz_persist_client::ShardId;
 
@@ -110,9 +112,7 @@ fn bench_consensus_compare_and_set_all_iters(
                         let results = futs.collect::<Vec<_>>().await;
 
                         for result in results {
-                            result
-                                .expect("gave invalid inputs")
-                                .expect("failed to compare_and_set");
+                            assert_eq!(result.expect("gave invalid inputs"), CaSResult::Committed);
                         }
                     }
                 },

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -21,7 +21,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist::cfg::{BlobConfig, ConsensusConfig};
 use mz_persist::location::{
-    Atomicity, Blob, BlobMetadata, Consensus, ExternalError, SeqNo, VersionedData,
+    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, ExternalError, SeqNo, VersionedData,
 };
 use prometheus::proto::{MetricFamily, MetricType};
 use tracing::{info, warn};
@@ -313,9 +313,9 @@ impl Consensus for ReadOnly<Arc<dyn Consensus + Sync + Send>> {
         key: &str,
         _expected: Option<SeqNo>,
         _new: VersionedData,
-    ) -> Result<Result<(), Vec<VersionedData>>, ExternalError> {
+    ) -> Result<CaSResult, ExternalError> {
         warn!("ignoring cas({key}) in read-only mode");
-        Ok(Ok(()))
+        Ok(CaSResult::Committed)
     }
 
     async fn scan(

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -307,6 +307,15 @@ pub const SCAN_ALL: usize = u64_to_usize(i64::MAX as u64);
 /// A key usable for liveness checks via [Consensus::head].
 pub const CONSENSUS_HEAD_LIVENESS_KEY: &str = "LIVENESS";
 
+/// Return type to indicate whether [Consensus::compare_and_set] succeeded or failed.
+#[derive(Debug, PartialEq)]
+pub enum CaSResult {
+    /// The compare-and-set succeeded and committed new state.
+    Committed,
+    /// The compare-and-set failed due to expectation mismatch.
+    ExpectationMismatch,
+}
+
 /// An abstraction for [VersionedData] held in a location in persistent storage
 /// where the data are conditionally updated by version.
 ///
@@ -325,11 +334,9 @@ pub trait Consensus: std::fmt::Debug {
     /// current sequence number is exactly `expected` and `new`'s sequence
     /// number > the current sequence number.
     ///
-    /// If the current seqno does not equal `expected`, returns all versions >
-    /// `expected` and <= current. It is invalid to call this function with a
-    /// `new` and `expected` such that `new`'s sequence number is <= `expected`.
-    /// It is invalid to call this function with a sequence number outside of
-    /// the range `[0, i64::MAX]`.
+    /// It is invalid to call this function with a `new` and `expected` such
+    /// that `new`'s sequence number is <= `expected`. It is invalid to call
+    /// this function with a sequence number outside of the range `[0, i64::MAX]`.
     ///
     /// This data is initialized to None, and the first call to compare_and_set
     /// needs to happen with None as the expected value to set the state.
@@ -338,7 +345,7 @@ pub trait Consensus: std::fmt::Debug {
         key: &str,
         expected: Option<SeqNo>,
         new: VersionedData,
-    ) -> Result<Result<(), Vec<VersionedData>>, ExternalError>;
+    ) -> Result<CaSResult, ExternalError>;
 
     /// Return `limit` versions of data stored for this `key` at sequence numbers
     /// >= `from`, in ascending order of sequence number.
@@ -618,13 +625,13 @@ pub mod tests {
             consensus
                 .compare_and_set(&key, Some(SeqNo(0)), state.clone())
                 .await,
-            Ok(Err(vec![]))
+            Ok(CaSResult::ExpectationMismatch),
         );
 
         // Correctly updating the state with the correct expected value should succeed.
         assert_eq!(
             consensus.compare_and_set(&key, None, state.clone()).await,
-            Ok(Ok(()))
+            Ok(CaSResult::Committed),
         );
 
         // We can observe the a recent value on successful update.
@@ -664,7 +671,7 @@ pub mod tests {
             consensus
                 .compare_and_set(&key, Some(SeqNo(7)), new_state.clone())
                 .await,
-            Ok(Err(vec![]))
+            Ok(CaSResult::ExpectationMismatch),
         );
 
         // Trying to update without the correct expected seqno fails, (even if expected < current)
@@ -672,7 +679,7 @@ pub mod tests {
             consensus
                 .compare_and_set(&key, Some(SeqNo(3)), new_state.clone())
                 .await,
-            Ok(Err(vec![state.clone()]))
+            Ok(CaSResult::ExpectationMismatch),
         );
 
         let invalid_constant_seqno = VersionedData {
@@ -708,41 +715,11 @@ pub mod tests {
             consensus
                 .compare_and_set(&key, Some(state.seqno), new_state.clone())
                 .await,
-            Ok(Ok(()))
+            Ok(CaSResult::Committed),
         );
 
         // We can observe the a recent value on successful update.
         assert_eq!(consensus.head(&key).await, Ok(Some(new_state.clone())));
-
-        // We get both versions back if our expected is < both of them
-        assert_eq!(
-            consensus
-                .compare_and_set(
-                    &key,
-                    Some(SeqNo(0)),
-                    VersionedData {
-                        seqno: SeqNo(3),
-                        data: Bytes::from(""),
-                    }
-                )
-                .await,
-            Ok(Err(vec![state.clone(), new_state.clone()]))
-        );
-
-        // We only get the greater back if our expected == the lesser one
-        assert_eq!(
-            consensus
-                .compare_and_set(
-                    &key,
-                    Some(state.seqno),
-                    VersionedData {
-                        seqno: SeqNo(20),
-                        data: Bytes::from(""),
-                    }
-                )
-                .await,
-            Ok(Err(vec![new_state.clone()]))
-        );
 
         // We can observe both states in the correct order with scan if pass
         // in a suitable lower bound.
@@ -817,7 +794,7 @@ pub mod tests {
             consensus
                 .compare_and_set(&other_key, None, state.clone())
                 .await,
-            Ok(Ok(()))
+            Ok(CaSResult::Committed),
         );
 
         assert_eq!(consensus.head(&other_key).await, Ok(Some(state.clone())));
@@ -834,7 +811,7 @@ pub mod tests {
             consensus
                 .compare_and_set(&key, Some(state.seqno), invalid_jump_forward)
                 .await,
-            Ok(Err(vec![new_state.clone()]))
+            Ok(CaSResult::ExpectationMismatch),
         );
 
         // Writing a large (~10 KiB) amount of data works fine.
@@ -846,7 +823,7 @@ pub mod tests {
             consensus
                 .compare_and_set(&key, Some(new_state.seqno), large_state)
                 .await,
-            Ok(Ok(()))
+            Ok(CaSResult::Committed),
         );
 
         // Truncate can delete more than one version at a time.
@@ -856,7 +833,7 @@ pub mod tests {
         };
         assert_eq!(
             consensus.compare_and_set(&key, Some(SeqNo(11)), v12).await,
-            Ok(Ok(()))
+            Ok(CaSResult::Committed),
         );
         assert_eq!(consensus.truncate(&key, SeqNo(12)).await, Ok(2));
 
@@ -873,7 +850,7 @@ pub mod tests {
                     }
                 )
                 .await,
-            Ok(Ok(()))
+            Ok(CaSResult::Committed),
         );
         assert_eq!(
             consensus
@@ -886,7 +863,7 @@ pub mod tests {
                     }
                 )
                 .await,
-            Ok(Ok(()))
+            Ok(CaSResult::Committed),
         );
         assert!(consensus
             .compare_and_set(

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -34,7 +34,7 @@ use std::time::{Duration, Instant};
 use tracing::debug;
 
 use crate::error::Error;
-use crate::location::{Consensus, ExternalError, SeqNo, VersionedData, SCAN_ALL};
+use crate::location::{CaSResult, Consensus, ExternalError, SeqNo, VersionedData};
 use crate::metrics::PostgresConsensusMetrics;
 
 const SCHEMA: &str = "
@@ -371,7 +371,7 @@ impl Consensus for PostgresConsensus {
         key: &str,
         expected: Option<SeqNo>,
         new: VersionedData,
-    ) -> Result<Result<(), Vec<VersionedData>>, ExternalError> {
+    ) -> Result<CaSResult, ExternalError> {
         if let Some(expected) = expected {
             if new.seqno <= expected {
                 return Err(Error::from(
@@ -417,17 +417,9 @@ impl Consensus for PostgresConsensus {
         };
 
         if result == 1 {
-            Ok(Ok(()))
+            Ok(CaSResult::Committed)
         } else {
-            // It's safe to call scan in a subsequent transaction rather than doing
-            // so directly in the same transaction because, once a given (seqno, data)
-            // pair exists for our shard, we enforce the invariants that
-            // 1. Our shard will always have _some_ data mapped to it.
-            // 2. All operations that modify the (seqno, data) can only increase
-            //    the sequence number.
-            let from = expected.map_or_else(SeqNo::minimum, |x| x.next());
-            let current = self.scan(key, from, SCAN_ALL).await?;
-            Ok(Err(current))
+            Ok(CaSResult::ExpectationMismatch)
         }
     }
 
@@ -533,7 +525,7 @@ mod tests {
 
         assert_eq!(
             consensus.compare_and_set(&key, None, state.clone()).await,
-            Ok(Ok(()))
+            Ok(CaSResult::Committed),
         );
 
         assert_eq!(consensus.head(&key).await, Ok(Some(state.clone())));

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -21,7 +21,8 @@ use rand::{Rng, SeedableRng};
 use tracing::trace;
 
 use crate::location::{
-    Atomicity, Blob, BlobMetadata, Consensus, Determinate, ExternalError, SeqNo, VersionedData,
+    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, Determinate, ExternalError, SeqNo,
+    VersionedData,
 };
 
 #[derive(Debug)]
@@ -193,7 +194,7 @@ impl Consensus for UnreliableConsensus {
         key: &str,
         expected: Option<SeqNo>,
         new: VersionedData,
-    ) -> Result<Result<(), Vec<VersionedData>>, ExternalError> {
+    ) -> Result<CaSResult, ExternalError> {
         self.handle
             .run_op("compare_and_set", || {
                 self.consensus.compare_and_set(key, expected, new)


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

My skunkworks instantly got derailed when I realized we have two near-identical code paths to update state -- the CaS mismatch blocks in `Applier::apply_unbatched_cmd_locked` and `StateVersions::fetch_and_update_to_current`. The latter did not always exist, and the former tries to take advantage of how `Consensus::compare_and_set` returns all the live diffs past the current seqno in its CaS mismatch case. 

The problem is that at this point, `compare_and_set` is no better at returning these diffs than `fetch_and_update_to_current`, and it actually misses some of the broader context in how we want to limit the size of our scans, account for retries, metric coverage etc.

The calculus to keep the two paths might be different if `compare_and_set` could in fact more efficiently fetch these diffs than `fetch_and_update_to_current`, but we tried very hard to write a single SQL query to compare-and-set-or-else-return-remaining-diffs in a single round-trip and couldn't make an improvement over what we have now.

### Motivation

   * This PR refactors existing code.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
