### PR TITLE
mz: revert enable psql query timing by default

### DIFF
--- a/src/mz/src/bin/mz/shell.rs
+++ b/src/mz/src/bin/mz/shell.rs
@@ -24,8 +24,6 @@ use mz::configuration::ValidProfile;
 fn run_psql_shell(valid_profile: ValidProfile<'_>, environment: &Environment) -> Result<()> {
     let error = Command::new("psql")
         .arg(environment.sql_url(&valid_profile).to_string())
-        // Enable query timing output by default.
-        .args(["-c", "\\timing", "-f", "-"])
         .env("PGPASSWORD", valid_profile.app_password)
         .exec();
 


### PR DESCRIPTION
This reverts commit 9477ff3ac9f56611c6b4e9f567b3deaf2b6a5dd0.

For some reason this change caused broken control character behavior. I don't understand the issue, but it's very broken, so let's revert this for now.

### Motivation

  * This PR fixes a recognized bug: #18040 
