### PR TITLE
adapter: correct alteration of source/sink size

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -3783,11 +3783,11 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, AdapterError> {
         let cluster_config = alter_storage_cluster_config(size);
         if let Some(cluster_config) = cluster_config {
-            let mut ops = vec![catalog::Op::AlterSink {
+            let mut ops = self.alter_linked_cluster_ops(id, &cluster_config).await?;
+            ops.push(catalog::Op::AlterSink {
                 id,
                 cluster_config: cluster_config.clone(),
-            }];
-            ops.extend(self.alter_linked_cluster_ops(id, &cluster_config).await?);
+            });
             self.catalog_transact(Some(session), ops).await?;
 
             self.maybe_alter_linked_cluster(id).await;
@@ -3816,11 +3816,11 @@ impl Coordinator {
         }
         let cluster_config = alter_storage_cluster_config(size);
         if let Some(cluster_config) = cluster_config {
-            let mut ops = vec![catalog::Op::AlterSource {
+            let mut ops = self.alter_linked_cluster_ops(id, &cluster_config).await?;
+            ops.push(catalog::Op::AlterSource {
                 id,
                 cluster_config: cluster_config.clone(),
-            }];
-            ops.extend(self.alter_linked_cluster_ops(id, &cluster_config).await?);
+            });
             self.catalog_transact(Some(session), ops).await?;
 
             self.maybe_alter_linked_cluster(id).await;

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -88,7 +88,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 3  create  cluster  {"id":"u1","name":"default"}  NULL
 4  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","logical_size":"1","replica_id":"1","replica_name":"r1"}  NULL
 5  create  role  {"id":"u1","name":"materialize"}  materialize
-6 create  database  {"id":"2","name":"test"}  materialize
+6  create  database  {"id":"2","name":"test"}  materialize
 7  create  schema  {"database_name":"test","id":"6","name":"public"}  materialize
 8  create  schema  {"database_name":"test","id":"7","name":"sc1"}  materialize
 9  create  schema  {"database_name":"test","id":"8","name":"sc2"}  materialize
@@ -114,9 +114,9 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 29  create  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
 30  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","logical_size":"1","replica_id":"5","replica_name":"linked"}  materialize
 31  create  source  {"database":"materialize","id":"u8","item":"s","schema":"public","size":"1","type":"load-generator"}  materialize
-32  alter  source  {"database":"materialize","id":"u8","item":"s","new_size":"2","old_size":"1","schema":"public"}  materialize
-33  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"5","replica_name":"linked"}  materialize
-34  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","logical_size":"2","replica_id":"6","replica_name":"linked"}  materialize
+32  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"5","replica_name":"linked"}  materialize
+33  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","logical_size":"2","replica_id":"6","replica_name":"linked"}  materialize
+34  alter  source  {"database":"materialize","id":"u8","item":"s","new_size":"2","old_size":"1","schema":"public"}  materialize
 35  drop  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public"}  materialize
 36  drop  source  {"database":"materialize","id":"u8","item":"s","schema":"public"}  materialize
 37  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"6","replica_name":"linked"}  materialize

--- a/test/testdrive/linked-clusters.td
+++ b/test/testdrive/linked-clusters.td
@@ -73,17 +73,15 @@ mz_system               r1      1
 materialize_public_lg1  linked  1
 materialize_public_lg2  linked  2
 
-# Test that changing a source size results in the cluster being dropped and
-# recreated.
-> ALTER SOURCE lg2 SET (SIZE = '4')
-> SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) WHERE cluster = 'materialize_public_lg2'
-materialize_public_lg2  linked  4
-
 # Test altering the size of a source.
 > ALTER SOURCE lg2 SET (SIZE = '4')
+> SELECT size FROM (SHOW SOURCES) WHERE name = 'lg2'
+4
 > SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) WHERE cluster = 'materialize_public_lg2'
 materialize_public_lg2  linked  4
 > ALTER SOURCE lg2 RESET (SIZE)
+> SELECT size FROM (SHOW SOURCES) WHERE name = 'lg2'
+\${arg.default-storage-size}
 > SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) WHERE cluster = 'materialize_public_lg2'
 materialize_public_lg2  linked  ${arg.default-storage-size}
 
@@ -178,17 +176,15 @@ mz_system                r1      1
 materialize_public_snk1  linked  1
 materialize_public_snk2  linked  2
 
-# Test that changing a sink size results in the cluster being dropped and
-# recreated.
-> ALTER SINK snk2 SET (SIZE = '4')
-> SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) WHERE cluster = 'materialize_public_snk2'
-materialize_public_snk2  linked  4
-
 # Test altering the size of a sink.
 > ALTER SINK snk2 SET (SIZE = '4')
+> SELECT size FROM (SHOW SINKS) WHERE name = 'snk2'
+4
 > SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) WHERE cluster = 'materialize_public_snk2'
 materialize_public_snk2  linked  4
 > ALTER SINK snk2 RESET (SIZE)
+> SELECT size FROM (SHOW SINKS) WHERE name = 'snk2'
+\${arg.default-storage-size}
 > SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) WHERE cluster = 'materialize_public_snk2'
 materialize_public_snk2  linked  ${arg.default-storage-size}
 


### PR DESCRIPTION
We were previously failing to update `mz_sources` and `mz_sinks` with the new size of the source or sink. If the source or sink was later dropped, we'd then generate an invalid retraction in `mz_sources` or `mz_sinks`.

See the comment within the patch for details on the bug and the fix.

Fix #18061.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix a bug that would cause `mz_sources` and `mz_sinks` to report the wrong size for a source after an `ALTER {SOURCE|SINK} ... SET (SIZE = ...)` command.
