### PR TITLE
storage: resumption frontier is empty for closed collections

### DIFF
--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -321,7 +321,7 @@ impl PersistClient {
         ))
     }
 
-    /// [Self::open], but returning only a [/eadHandle].
+    /// [Self::open], but returning only a [ReadHandle].
     ///
     /// Use this to save latency and a bit of persist traffic if you're just
     /// going to immediately drop or expire the [WriteHandle].


### PR DESCRIPTION
tl;dr empty sinces need to stop dataflows from starting

### Motivation

This PR fixes a previously unreported bug.

We currently only downgrade the read handle to the empty antichain to signal that a collection has been dropped (see https://github.com/MaterializeInc/materialize/issues/17320#issuecomment-1441885572). However, if we are in a state where we drop a source and `clusterd` crashes and gets quickly rescheduled, we might try to create a source whose read handle is closed, though its write handle will still be < [].

This can cause a panic for the remap operator:
- [Its `as_of` is calculated to be `upper - 1`](https://github.com/MaterializeInc/materialize/blob/main/src/storage/src/source/source_reader_pipeline.rs#L708)
- [Its `since` can be empty](https://github.com/MaterializeInc/materialize/blob/main/src/storage-client/src/controller.rs#L1732-L1742), even when the upper is some value
- [On creation, it fails the assertion that its since is less than its as of when the since is empty](https://github.com/MaterializeInc/materialize/blob/main/src/storage/src/source/reclock/compat.rs#L114-L120)

To prevent this from occurring, I suggest we calculate the resumption frontier not only as the write handles upper, but as the join of the write and read handle, ensuring that if the read handle is closed, the resumption frontier will be empty, which will [stop the dataflow from being spawned on the rescheduled clusterd](https://github.com/MaterializeInc/materialize/blob/main/src/storage/src/storage_state.rs#L699).

This seems challenging to manufacture, but we have [observed it in production](https://materializeinc.sentry.io/issues/3993118310/events/a0815bc36b7147d29def78a2908a56b0/?project=6780145).

Note that implementing #17320 does not solve this condition absolutely because downgrading the write handle is not necessarily done before clusterd can be rescheduled.

I have a few open questions:
- Should this read handle be critical? It seems like the idea is that this is state one could hold onto, but it doesn't seem like it's used in that way.
- Is `join` the right semantics for this? Could also check if the read handle's since empty and continue; not sure what the aesthetic preference there is.

### Tips for reviewer

This is just a WIP for resolving this issue; this shouldn't be alarming and I'm putting something up only because it's Friday night and I didn't want to lose the fix's context.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
