### PR TITLE
sql: simplify typeconv::can_cast

### DIFF
--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -970,15 +970,8 @@ pub fn plan_cast(
 pub fn can_cast(
     ecx: &ExprContext,
     ccx: CastContext,
-    mut cast_from: &ScalarType,
-    mut cast_to: &ScalarType,
+    cast_from: &ScalarType,
+    cast_to: &ScalarType,
 ) -> bool {
-    // All stringlike types are treated like `ScalarType::String` during casts.
-    if TypeCategory::from_type(cast_from) == TypeCategory::String {
-        cast_from = &ScalarType::String;
-    }
-    if TypeCategory::from_type(cast_to) == TypeCategory::String {
-        cast_to = &ScalarType::String;
-    }
     get_cast(ecx, ccx, cast_from, cast_to).is_some()
 }

--- a/test/sqllogictest/character.slt
+++ b/test/sqllogictest/character.slt
@@ -1,0 +1,27 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# This file is derived from the logic test suite in CockroachDB. The
+# original file was retrieved on June 10, 2019 from:
+#
+#     https://github.com/cockroachdb/cockroach/blob/d2f7fbf5dd1fc1a099bbad790a2e1f7c60a66cc3/pkg/sql/logictest/testdata/logic_test/json_builtins
+#
+# The original source code is subject to the terms of the Apache
+# 2.0 license, a copy of which can be found in the LICENSE file at the
+# root of this repository.
+
+# Fixes #17871
+
+query T
+SELECT 'a'::character = 'a'::"char";
+----
+true
+
+query error coalesce could not convert type character to "char"
+SELECT pg_typeof(coalesce('1'::"char", '1'::char));

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -284,6 +284,28 @@ Map (lower(char_to_text(text_to_char(text_to_char("a")))))
 
 EOF
 
+# Check that "char" vs varchar promotes to text
+query T multiline
+EXPLAIN RAW PLAN FOR
+    SELECT 'a'::"char" < 'a'::varchar;
+----
+Map (("char"_to_text(text_to_"char"("a")) < varchar_to_text(text_to_varchar("a"))))
+  Constant
+    - ()
+
+EOF
+
+# Check that "char" vs char promotes to text
+query T multiline
+EXPLAIN RAW PLAN FOR
+    SELECT 'a'::"char" < 'a'::char;
+----
+Map (("char"_to_text(text_to_"char"("a")) < char_to_text(text_to_char(text_to_char("a")))))
+  Constant
+    - ()
+
+EOF
+
 # Check that varchar promotes to char
 query T multiline
 EXPLAIN RAW PLAN FOR


### PR DESCRIPTION
### Motivation

This PR fixes a recognized bug. Fixes #17871

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
