### PR TITLE
Introduce `mz_dataflow_operator_parents` view.

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -143,6 +143,17 @@ Field       | Type            | Meaning
 `worker_id` | [`bigint`]      | The ID of the worker thread hosting the channel or operator.
 `address`   | [`bigint list`] | A list of scope-local indexes indicating the path from the root to this channel or operator.
 
+### `mz_dataflow_operator_parents`
+
+The `mz_dataflow_operator_parents` view describes how operators are
+nested into scopes, by relating operators to their parent operators.
+
+| Field       | Type       | Meaning                                                                                     |
+|-------------|------------|---------------------------------------------------------------------------------------------|
+| `id`        | [`bigint`] | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators) |
+| `parent_id` | [`bigint`] | The ID of the operator's parent operator.                                                   |
+| `worker_id` | [`bigint`] | The ID of the worker thread hosting the operators.                                          |
+
 ### `mz_dataflow_channels`
 
 The `mz_dataflow_channels` source describes the communication channels between

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2563,7 +2563,7 @@ WITH parent_addrs AS (
         INNER JOIN mz_internal.mz_dataflow_operators
             USING (id, worker_id)
 )
-SELECT pa.id, mda.id AS parent_id
+SELECT pa.id, mda.id AS parent_id, pa.worker_id
 FROM parent_addrs AS pa
     JOIN mz_internal.mz_dataflow_addresses AS mda
         ON pa.parent_address = mda.address

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2550,6 +2550,32 @@ FROM
         JOIN mz_internal.mz_cluster_replica_metrics AS m ON m.replica_id = r.id",
 };
 
+pub const MZ_DATAFLOW_OPERATOR_PARENTS: BuiltinView = BuiltinView {
+    name: "mz_dataflow_operator_parents",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_operator_parents AS
+WITH
+	parent_addrs
+		AS (
+			SELECT
+				id,
+				address[1:list_length(address) - 1]
+					AS parent_address,
+				worker_id
+			FROM
+				mz_internal.mz_dataflow_addresses AS mda
+				INNER JOIN mz_internal.mz_dataflow_operators
+						AS mdo USING (id, worker_id)
+		)
+SELECT
+	pa.id, mda.id AS parent_id
+FROM
+	parent_addrs AS pa
+	JOIN mz_internal.mz_dataflow_addresses AS mda ON
+			pa.parent_address = mda.address
+			AND pa.worker_id = mda.worker_id",
+};
+
 // NOTE: If you add real data to this implementation, then please update
 // the related `pg_` function implementations (like `pg_get_constraintdef`)
 pub const PG_CONSTRAINT: BuiltinView = BuiltinView {
@@ -3208,6 +3234,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&MZ_DATAFLOW_OPERATOR_DATAFLOWS),
         Builtin::View(&MZ_DATAFLOW_OPERATOR_REACHABILITY),
         Builtin::View(&MZ_CLUSTER_REPLICA_UTILIZATION),
+        Builtin::View(&MZ_DATAFLOW_OPERATOR_PARENTS),
         Builtin::View(&MZ_COMPUTE_FRONTIERS),
         Builtin::View(&MZ_DATAFLOW_CHANNEL_OPERATORS),
         Builtin::View(&MZ_COMPUTE_IMPORT_FRONTIERS),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2554,26 +2554,20 @@ pub const MZ_DATAFLOW_OPERATOR_PARENTS: BuiltinView = BuiltinView {
     name: "mz_dataflow_operator_parents",
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE VIEW mz_internal.mz_operator_parents AS
-WITH
-	parent_addrs
-		AS (
-			SELECT
-				id,
-				address[1:list_length(address) - 1]
-					AS parent_address,
-				worker_id
-			FROM
-				mz_internal.mz_dataflow_addresses AS mda
-				INNER JOIN mz_internal.mz_dataflow_operators
-						AS mdo USING (id, worker_id)
-		)
-SELECT
-	pa.id, mda.id AS parent_id
-FROM
-	parent_addrs AS pa
-	JOIN mz_internal.mz_dataflow_addresses AS mda ON
-			pa.parent_address = mda.address
-			AND pa.worker_id = mda.worker_id",
+WITH parent_addrs AS (
+    SELECT
+        id,
+        address[1:list_length(address) - 1] AS parent_address,
+        worker_id
+    FROM mz_internal.mz_dataflow_addresses
+        INNER JOIN mz_internal.mz_dataflow_operators
+            USING (id, worker_id)
+)
+SELECT pa.id, mda.id AS parent_id
+FROM parent_addrs AS pa
+    JOIN mz_internal.mz_dataflow_addresses AS mda
+        ON pa.parent_address = mda.address
+        AND pa.worker_id = mda.worker_id",
 };
 
 // NOTE: If you add real data to this implementation, then please update

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -442,7 +442,7 @@ impl LogView {
                         INNER JOIN mz_internal.mz_dataflow_operators_{}
                             USING (id, worker_id)
                 )
-                SELECT pa.id, mda.id AS parent_id
+                SELECT pa.id, mda.id AS parent_id, pa.worker_id
                 FROM parent_addrs AS pa
                     JOIN mz_internal.mz_dataflow_addresses_{} AS mda
                         ON pa.parent_address = mda.address

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -335,6 +335,7 @@ pub enum LogView {
     MzComputeOperatorDurations,
     MzDataflowNames,
     MzDataflowOperatorDataflows,
+    MzDataflowOperatorParents,
     MzDataflowOperatorReachability,
     MzComputeFrontiers,
     MzComputeImportFrontiers,
@@ -356,6 +357,7 @@ pub static DEFAULT_LOG_VIEWS: Lazy<Vec<LogView>> = Lazy::new(|| {
         LogView::MzArrangementSizes,
         LogView::MzDataflowNames,
         LogView::MzDataflowOperatorDataflows,
+        LogView::MzDataflowOperatorParents,
         LogView::MzDataflowOperatorReachability,
         LogView::MzComputeFrontiers,
         LogView::MzComputeImportFrontiers,
@@ -428,6 +430,24 @@ impl LogView {
                         mz_dataflow_addresses_{}.worker_id = mz_dataflow_operators_{}.worker_id AND
                         mz_catalog.list_length(mz_dataflow_addresses_{}.address) = 1",
                 "mz_dataflows_{}",
+            ),
+
+            LogView::MzDataflowOperatorParents => (
+                "WITH parent_addrs AS (
+                    SELECT
+                        id,
+                        address[1:list_length(address) - 1] AS parent_address,
+                        worker_id
+                    FROM mz_internal.mz_dataflow_addresses_{}
+                        INNER JOIN mz_internal.mz_dataflow_operators_{}
+                            USING (id, worker_id)
+                )
+                SELECT pa.id, mda.id AS parent_id
+                FROM parent_addrs AS pa
+                    JOIN mz_internal.mz_dataflow_addresses_{} AS mda
+                        ON pa.parent_address = mda.address
+                        AND pa.worker_id = mda.worker_id",
+                "mz_dataflow_operator_parents_{}",
             ),
 
             LogView::MzDataflowOperatorDataflows => (

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -260,6 +260,10 @@ mz_dataflow_operator_dataflows
 VIEW
 materialize
 mz_internal
+mz_dataflow_operator_parents
+VIEW
+materialize
+mz_internal
 mz_dataflow_operator_reachability
 VIEW
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -552,6 +552,7 @@ mz_arrangement_sizes
 mz_dataflows
 mz_dataflow_channel_operators
 mz_dataflow_operator_dataflows
+mz_dataflow_operator_parents
 mz_dataflow_operator_reachability
 mz_cluster_replica_utilization
 mz_compute_frontiers


### PR DESCRIPTION
This view relates operators to their parents, allowing users to explore the scope structure

### Motivation

  * This PR adds a feature that has not yet been specified.

We need scope information in order to render a hierarchical dataflow graph.

### Tips for reviewer

The alternative is to download `mz_dataflow_addresses` and do this logic in JavaScript on the client side (which is how the internal hierarchical visualizer works). I rejected that approach as this view might be more broadly useful to others.

The query is a bit complicated (involving manual list munging...). It would be nice if someday we could expose this directly from introspection. 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Introduce `mz_internal.mz_dataflow_operator_parents` view.