### PR TITLE
deps: get back onto some mainlines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ source = "git+https://github.com/jorgecarleitao/arrow2.git#0ba4f8e21547ed08b4468
 dependencies = [
  "ahash",
  "arrow-format",
- "base64",
+ "base64 0.13.1",
  "bytemuck",
  "chrono",
  "dyn-clone",
@@ -701,12 +701,13 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.1"
-source = "git+https://github.com/tokio-rs/axum.git#978ae6335862b264b4368e01a52177d98c42b2d9"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64",
+ "base64 0.21.0",
  "bitflags",
  "bytes",
  "futures-util",
@@ -737,8 +738,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.0"
-source = "git+https://github.com/tokio-rs/axum.git#978ae6335862b264b4368e01a52177d98c42b2d9"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -788,6 +790,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64-simd"
@@ -1034,8 +1042,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
-source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#a1591e91f3a6af50e3d642039bbed1042f300d5b"
+version = "0.4.24"
+source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#daa86a77d36d74f474913fd3b560a40f1424bd77"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -2397,7 +2405,7 @@ version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6490be71f07a5f62b564bc58e36953f675833df11c7e4a0647bee7a07ca1ec5e"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "flate2",
  "nom",
@@ -2410,7 +2418,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -2478,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -2524,9 +2532,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2697,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
@@ -2748,7 +2756,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "pem",
  "ring",
  "serde",
@@ -2775,7 +2783,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "chrono",
  "http",
@@ -2805,7 +2813,7 @@ version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e80db3ca107e89da5f7eae37ea5274e06cefdcf9689d0ebd5ec3575a6f983e4e"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "chrono",
  "dirs-next",
@@ -3286,7 +3294,7 @@ version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9006c95034ccf7b903d955f210469119f6c3477fc9c9e7a7845ce38a3e665c2a"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bigdecimal",
  "bindgen",
  "bitflags",
@@ -3758,7 +3766,7 @@ dependencies = [
  "assert_cmd",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "bytesize",
  "cc",
@@ -3920,7 +3928,7 @@ name = "mz-frontegg-auth"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "derivative",
  "jsonwebtoken",
  "mz-ore",
@@ -4250,7 +4258,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
  "aws-types",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "deadpool-postgres",
  "differential-dataflow",
@@ -5581,7 +5589,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -5764,7 +5772,7 @@ name = "postgres-protocol"
 version = "0.6.4"
 source = "git+https://github.com/MaterializeInc/rust-postgres#9c9086235344fe794361a9985d97a64b42e61929"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -6049,7 +6057,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d378290cd658b119ce87621931ef448017ef1a0044d7b681159d779e7e07b8f6"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "prost",
  "prost-types",
  "serde",
@@ -6286,7 +6294,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -6761,7 +6769,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "chrono",
  "hex",
  "indexmap",
@@ -7555,7 +7563,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -7617,7 +7625,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "futures-core",
@@ -7776,7 +7784,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
@@ -7888,7 +7896,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "chunked_transfer",
  "log",
  "native-tls",
@@ -8144,45 +8152,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"
@@ -8204,7 +8212,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-http",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bstr",
  "byteorder",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,9 +2672,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "ipnet"
@@ -3075,9 +3079,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.46"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -5941,9 +5945,9 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfb6451c91904606a1abe93e83a8ec851f45827fa84273f256ade45dc095818"
+checksum = "b1de8dacb0873f77e6aefc6d71e044761fcc68060290f5b1089fcdf84626bb69"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -6277,15 +6281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6407,9 +6402,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.13"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
  "bitflags",
  "errno",
@@ -7164,16 +7159,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -8276,6 +8270,7 @@ dependencies = [
  "regex-syntax",
  "reqwest",
  "ring",
+ "rustix",
  "schemars",
  "scopeguard",
  "security-framework",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde",
 ]
 
 [[package]]
@@ -1473,10 +1472,10 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.6"
-source = "git+https://github.com/BurntSushi/rust-csv.git#41c71ed353a71526c52633d854466c1619dacae4"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
 dependencies = [
- "bstr",
  "csv-core",
  "itoa",
  "ryu",
@@ -1486,7 +1485,8 @@ dependencies = [
 [[package]]
 name = "csv-core"
 version = "0.1.10"
-source = "git+https://github.com/BurntSushi/rust-csv.git#41c71ed353a71526c52633d854466c1619dacae4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5353,9 +5353,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.22.0+1.1.1q"
+version = "111.25.0+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5811,8 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "pprof"
-version = "0.11.0"
-source = "git+https://github.com/MaterializeInc/pprof-rs.git#d0c984a4d7181078dcd45bc8fe441d8d5a9efa46"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196ded5d4be535690899a4631cc9f18cdc41b7ebf24a79400f46f48e49a11059"
 dependencies = [
  "backtrace",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,8 +113,6 @@ debug = 1
 [patch.crates-io]
 axum = { git = "https://github.com/tokio-rs/axum.git" }
 chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x" }
-csv = { git = "https://github.com/BurntSushi/rust-csv.git" }
-csv-core = { git = "https://github.com/BurntSushi/rust-csv.git" }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,6 @@ debug = 1
 #
 # The reasons for each of these overrides are listed in deny.toml.
 [patch.crates-io]
-axum = { git = "https://github.com/tokio-rs/axum.git" }
 chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x" }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/deny.toml
+++ b/deny.toml
@@ -167,10 +167,6 @@ allow-git = [
     # v0.18 of opentelemetry.
     "https://github.com/MaterializeInc/tracing.git",
 
-    # Waiting on https://github.com/tikv/pprof-rs/pull/181 to make it into a
-    # release.
-    "https://github.com/MaterializeInc/pprof-rs.git",
-
     # Waiting on https://github.com/AltSysrq/proptest/pull/264.
     "https://github.com/MaterializeInc/proptest.git",
 

--- a/deny.toml
+++ b/deny.toml
@@ -154,10 +154,6 @@ allow-git = [
     # dependency on arrayvec v0.5.2 via a dependency on vte v0.10.1.
     "https://github.com/alacritty/vte",
 
-    # Waiting for a new release that bumps to itoa v1.0.
-    # See: https://github.com/BurntSushi/rust-csv/issues/271
-    "https://github.com/BurntSushi/rust-csv.git",
-
     # Waiting for https://github.com/chronotope/chrono/pull/906
     # to be released in the v0.4.x series.
     "https://github.com/chronotope/chrono.git",

--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,11 @@ multiple-versions = "deny"
 # transitive dependencies. If necessary, use patch directives in the root
 # Cargo.toml to point at a Materialize-maintained fork that avoids the
 # duplicated transitive dependencies.
+skip = [
+    # One-time exception for base64 due to its prevalence in the crate graph.
+    # Do NOT add other exceptions to this list.
+    { name = "base64", version = "0.13.1" }
+]
 
 # Use `tracing` instead.
 [[bans.deny]]
@@ -146,10 +151,6 @@ license-files = [
 unknown-git = "deny"
 unknown-registry = "deny"
 allow-git = [
-    # Waiting on https://github.com/tokio-rs/axum/pull/1598 to make it into a
-    # release.
-    "https://github.com/tokio-rs/axum.git",
-
     # Waiting for a new release of strip-ansi-escapes that avoids the indirect
     # dependency on arrayvec v0.5.2 via a dependency on vte v0.10.1.
     "https://github.com/alacritty/vte",

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.66"
-axum = "0.6.1"
+axum = "0.6.7"
 clap = { version = "3.2.20", features = ["derive", "env"] }
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 anyhow = "1.0.66"
 askama = { version = "0.11.1", default-features = false, features = ["config", "serde-json"] }
 async-trait = "0.1.59"
-axum = { version = "0.6.1", features = ["headers", "ws"] }
+axum = { version = "0.6.7", features = ["headers", "ws"] }
 base64 = "0.13.1"
 bytes = "1.3.0"
 bytesize = "1.1.0"

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 askama = { version = "0.11.1", default-features = false, features = ["config", "serde-json"] }
-axum = { version = "0.6.1", features = ["headers"] }
+axum = { version = "0.6.7", features = ["headers"] }
 headers = "0.3.8"
 http = "0.2.8"
 hyper = { version = "0.14.23", features = ["http1", "server"] }

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
-axum = { version = "0.6.1" }
+axum = { version = "0.6.7" }
 clap = { version = "3.2.20", features = [ "derive" ] }
 dirs = "4.0.0"
 indicatif = "0.17.2"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -62,7 +62,7 @@ tokio-console = ["mz-ore/tokio-console"]
 
 [dev-dependencies]
 async-trait = "0.1.59"
-axum = { version = "0.6.1" }
+axum = { version = "0.6.7" }
 clap = { version = "3.2.20", features = ["derive", "env"] }
 criterion = { version = "0.4.0", features = ["html_reports"] }
 datadriven = { version = "0.6.0", features = ["async"] }

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 askama = { version = "0.11.1", default-features = false, features = ["config", "serde-json"] }
 anyhow = "1.0.66"
-axum = { version = "0.6.1", features = ["headers"] }
+axum = { version = "0.6.7", features = ["headers"] }
 backtrace = "0.3.66"
 bytesize = "1.1.0"
 cfg-if = "1.0.0"

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -22,7 +22,7 @@ mime = "0.3.16"
 mz-build-info = { path = "../build-info" }
 mz-http-util = { path = "../http-util" }
 mz-ore = { path = "../ore" }
-pprof = { git = "https://github.com/MaterializeInc/pprof-rs.git" }
+pprof = "0.11.1"
 serde = { version = "1.0.152", features = ["derive"] }
 tempfile = "3.2.0"
 tikv-jemalloc-ctl = { version = "0.5.0", features = ["use_std"], optional = true }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -22,7 +22,7 @@ aws-sigv4 = { version = "0.53.0", features = ["sign-eventstream"] }
 aws-smithy-http = { version = "0.53.1", default-features = false, features = ["event-stream", "rt-tokio"] }
 axum = { git = "https://github.com/tokio-rs/axum.git", features = ["headers", "ws"] }
 base64 = { version = "0.13.1", features = ["alloc"] }
-bstr = { version = "0.2.14", features = ["serde1"] }
+bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
 bytes = { version = "1.3.0" }
 chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x", default-features = false, features = ["alloc", "clock", "serde"] }
@@ -119,7 +119,7 @@ aws-sigv4 = { version = "0.53.0", features = ["sign-eventstream"] }
 aws-smithy-http = { version = "0.53.1", default-features = false, features = ["event-stream", "rt-tokio"] }
 axum = { git = "https://github.com/tokio-rs/axum.git", features = ["headers", "ws"] }
 base64 = { version = "0.13.1", features = ["alloc"] }
-bstr = { version = "0.2.14", features = ["serde1"] }
+bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
 bytes = { version = "1.3.0" }
 cc = { version = "1.0.78", default-features = false, features = ["parallel"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -214,6 +214,7 @@ byteorder = { version = "1.4.3", default-features = false, features = ["i128"] }
 getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
+rustix = { version = "0.36.7", features = ["param", "process", "thread"] }
 tikv-jemalloc-sys = { version = "0.5.2", features = ["background_threads", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
@@ -221,6 +222,7 @@ byteorder = { version = "1.4.3", default-features = false, features = ["i128"] }
 getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
+rustix = { version = "0.36.7", features = ["param", "process", "thread"] }
 tikv-jemalloc-sys = { version = "0.5.2", features = ["background_threads", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.x86_64-apple-darwin.dependencies]

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -20,7 +20,7 @@ aws-sdk-sts = { version = "0.23.0", default-features = false, features = ["nativ
 aws-sig-auth = { version = "0.53.0", default-features = false, features = ["sign-eventstream"] }
 aws-sigv4 = { version = "0.53.0", features = ["sign-eventstream"] }
 aws-smithy-http = { version = "0.53.1", default-features = false, features = ["event-stream", "rt-tokio"] }
-axum = { git = "https://github.com/tokio-rs/axum.git", features = ["headers", "ws"] }
+axum = { version = "0.6.7", features = ["headers", "ws"] }
 base64 = { version = "0.13.1", features = ["alloc"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
@@ -48,7 +48,7 @@ futures-task = { version = "0.3.25" }
 futures-util = { version = "0.3.25", features = ["channel", "io", "sink"] }
 globset = { version = "0.4.9", features = ["serde1"] }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["raw"] }
-hyper = { version = "0.14.23", features = ["full"] }
+hyper = { version = "0.14.25", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }
@@ -117,7 +117,7 @@ aws-sdk-sts = { version = "0.23.0", default-features = false, features = ["nativ
 aws-sig-auth = { version = "0.53.0", default-features = false, features = ["sign-eventstream"] }
 aws-sigv4 = { version = "0.53.0", features = ["sign-eventstream"] }
 aws-smithy-http = { version = "0.53.1", default-features = false, features = ["event-stream", "rt-tokio"] }
-axum = { git = "https://github.com/tokio-rs/axum.git", features = ["headers", "ws"] }
+axum = { version = "0.6.7", features = ["headers", "ws"] }
 base64 = { version = "0.13.1", features = ["alloc"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
@@ -146,7 +146,7 @@ futures-task = { version = "0.3.25" }
 futures-util = { version = "0.3.25", features = ["channel", "io", "sink"] }
 globset = { version = "0.4.9", features = ["serde1"] }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["raw"] }
-hyper = { version = "0.14.23", features = ["full"] }
+hyper = { version = "0.14.25", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }


### PR DESCRIPTION
Switch a few dependencies from our forks back to mainlines, now that the PRs we were waiting on have made it into a release.

### Motivation

* Dependency bump.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
