### PR TITLE
Inline obvious candidates

### DIFF
--- a/src/compute/src/arrangement/manager.rs
+++ b/src/compute/src/arrangement/manager.rs
@@ -118,6 +118,7 @@ impl TraceManager {
     /// will not be physically merged until the method is called again. This is mostly due to limitations
     /// of differential dataflow, which requires users to perform this explicitly; if that changes we may
     /// be able to remove this code.
+    #[inline]
     pub fn maintenance(&mut self) {
         let mut antichain = Antichain::new();
         for (arrangement_id, bundle) in self.traces.iter_mut() {

--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -39,6 +39,7 @@ macro_rules! cast_from {
         paste::paste! {
             impl crate::cast::CastFrom<$from> for $to {
                 #[allow(clippy::as_conversions)]
+                #[inline(always)]
                 fn cast_from(from: $from) -> $to {
                     from as $to
                 }
@@ -49,6 +50,7 @@ macro_rules! cast_from {
             /// This is equivalent to the [`crate::cast::CastFrom`] implementation but is
             /// available as a `const fn`.
             #[allow(clippy::as_conversions)]
+            #[inline(always)]
             pub const fn [< $from _to_ $to >](from: $from) -> $to {
                 from as $to
             }

--- a/src/ore/src/vec.rs
+++ b/src/ore/src/vec.rs
@@ -48,10 +48,12 @@ pub trait Vector<T> {
 }
 
 impl<T> Vector<T> for Vec<T> {
+    #[inline]
     fn push(&mut self, value: T) {
         Vec::push(self, value)
     }
 
+    #[inline]
     fn extend_from_slice(&mut self, other: &[T])
     where
         T: Copy,
@@ -65,10 +67,12 @@ impl<A> Vector<A::Item> for SmallVec<A>
 where
     A: smallvec::Array,
 {
+    #[inline]
     fn push(&mut self, value: A::Item) {
         SmallVec::push(self, value)
     }
 
+    #[inline]
     fn extend_from_slice(&mut self, other: &[A::Item])
     where
         A::Item: Copy,

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -954,6 +954,7 @@ pub struct ProtoStateFieldDiffsIter<'a> {
 impl<'a> Iterator for ProtoStateFieldDiffsIter<'a> {
     type Item = Result<(ProtoStateField, ProtoStateFieldDiff<'a>), TryFromProtoError>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.diff_idx >= self.len {
             return None;

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -236,10 +236,12 @@ impl Codec64 for i64 {
         "i64".to_owned()
     }
 
+    #[inline(always)]
     fn encode(&self) -> [u8; 8] {
         self.to_le_bytes()
     }
 
+    #[inline(always)]
     fn decode(buf: [u8; 8]) -> Self {
         i64::from_le_bytes(buf)
     }
@@ -250,10 +252,12 @@ impl Codec64 for u64 {
         "u64".to_owned()
     }
 
+    #[inline(always)]
     fn encode(&self) -> [u8; 8] {
         self.to_le_bytes()
     }
 
+    #[inline(always)]
     fn decode(buf: [u8; 8]) -> Self {
         u64::from_le_bytes(buf)
     }

--- a/src/repr/src/datum_vec.rs
+++ b/src/repr/src/datum_vec.rs
@@ -32,6 +32,7 @@ impl DatumVec {
     /// Borrow an instance with a specific lifetime.
     ///
     /// When the result is dropped, its allocation will be returned to `self`.
+    #[inline]
     pub fn borrow<'a>(&'a mut self) -> DatumVecBorrow<'a> {
         let inner = std::mem::take(&mut self.outer);
         DatumVecBorrow {
@@ -40,6 +41,7 @@ impl DatumVec {
         }
     }
     /// Borrow an instance with a specific lifetime, and pre-populate with a `Row`.
+    #[inline]
     pub fn borrow_with<'a>(&'a mut self, row: &'a Row) -> DatumVecBorrow<'a> {
         let mut borrow = self.borrow();
         borrow.extend(row.iter());
@@ -48,6 +50,7 @@ impl DatumVec {
 
     /// Borrow an instance with a specific lifetime, and pre-populate with `Row`s, for example
     /// first adding a key followed by its values.
+    #[inline]
     pub fn borrow_with_many<'a, 'b, D: ::std::borrow::Borrow<Row> + 'a>(
         &'a mut self,
         rows: &'b [&'a D],
@@ -71,6 +74,7 @@ pub struct DatumVecBorrow<'outer> {
 }
 
 impl<'outer> Drop for DatumVecBorrow<'outer> {
+    #[inline]
     fn drop(&mut self) {
         *self.outer = mz_ore::vec::repurpose_allocation(std::mem::take(&mut self.inner));
     }

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -151,18 +151,21 @@ impl Timestamp {
 }
 
 impl From<u64> for Timestamp {
+    #[inline(always)]
     fn from(internal: u64) -> Self {
         Self { internal }
     }
 }
 
 impl From<Timestamp> for u64 {
+    #[inline(always)]
     fn from(ts: Timestamp) -> Self {
         ts.internal
     }
 }
 
 impl From<Timestamp> for u128 {
+    #[inline(always)]
     fn from(ts: Timestamp) -> Self {
         u128::from(ts.internal)
     }
@@ -171,18 +174,21 @@ impl From<Timestamp> for u128 {
 impl TryFrom<Timestamp> for i64 {
     type Error = TryFromIntError;
 
+    #[inline]
     fn try_from(value: Timestamp) -> Result<Self, Self::Error> {
         value.internal.try_into()
     }
 }
 
 impl From<&Timestamp> for u64 {
+    #[inline(always)]
     fn from(ts: &Timestamp) -> Self {
         ts.internal
     }
 }
 
 impl From<Timestamp> for Numeric {
+    #[inline(always)]
     fn from(ts: Timestamp) -> Self {
         ts.internal.into()
     }
@@ -191,6 +197,7 @@ impl From<Timestamp> for Numeric {
 impl std::ops::Rem<Timestamp> for Timestamp {
     type Output = Timestamp;
 
+    #[inline]
     fn rem(self, rhs: Timestamp) -> Self::Output {
         Self {
             internal: self.internal % rhs.internal,
@@ -199,6 +206,7 @@ impl std::ops::Rem<Timestamp> for Timestamp {
 }
 
 impl Serialize for Timestamp {
+    #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -208,6 +216,7 @@ impl Serialize for Timestamp {
 }
 
 impl<'de> Deserialize<'de> for Timestamp {
+    #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -219,6 +228,7 @@ impl<'de> Deserialize<'de> for Timestamp {
 }
 
 impl timely::order::PartialOrder for Timestamp {
+    #[inline(always)]
     fn less_equal(&self, other: &Self) -> bool {
         self.internal.less_equal(&other.internal)
     }
@@ -277,10 +287,12 @@ impl mz_persist_types::Codec64 for Timestamp {
         u64::codec_name()
     }
 
+    #[inline(always)]
     fn encode(&self) -> [u8; 8] {
         self.internal.encode()
     }
 
+    #[inline(always)]
     fn decode(buf: [u8; 8]) -> Self {
         Self {
             internal: u64::decode(buf),


### PR DESCRIPTION
This has been gathered from callgrind and are obvious candidates where Rust currently has a hard time to inline simple functions due to crate boundaries.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
