### PR TITLE
deps: upgrade to arrow v0.16/parquet v0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,8 +110,9 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.14.2"
-source = "git+https://github.com/jorgecarleitao/arrow2.git#0ba4f8e21547ed08b446828bd921787e8c00e3d3"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4c5b03335bc1cb0fd9f5297f8fd3bbfd6fb04f3cb0bc7d6c91b7128cb8336a"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -5545,9 +5546,9 @@ dependencies = [
 
 [[package]]
 name = "parquet2"
-version = "0.16.3"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7752b1a7d61b278f36820ba05557a2a8bfcb17f3559254577ef447beda0c4975"
+checksum = "aefc53bedbf9bbe0ff8912befafaafe30ced83851fb0aebe86696a9289ebb29e"
 dependencies = [
  "async-stream",
  "futures",

--- a/deny.toml
+++ b/deny.toml
@@ -180,10 +180,6 @@ allow-git = [
     # Waiting on https://github.com/edenhill/librdkafka/pull/4051.
     "https://github.com/MaterializeInc/rust-rdkafka.git",
 
-    # Waiting on https://github.com/jorgecarleitao/arrow2/pull/1297 to make it
-    # into a release.
-    "https://github.com/jorgecarleitao/arrow2.git",
-
     # Waiting for hashlink, indexmap, and lru to upgrade to hashbrown v0.13,
     # which depends on ahash v0.8 instead of v0.7. In the meantime we've
     # backported the ahash v0.8 bump into hashbrown v0.12.

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-arrow2 = { git = "https://github.com/jorgecarleitao/arrow2.git", features = ["io_ipc", "io_parquet"] }
+arrow2 = { version = "0.16.0", features = ["io_ipc", "io_parquet"] }
 bytes = "1.3.0"
-parquet2 = { version = "0.16.3", default-features = false }
+parquet2 = { version = "0.17.1", default-features = false }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/persist-types/src/parquet.rs
+++ b/src/persist-types/src/parquet.rs
@@ -43,6 +43,7 @@ pub fn encode_part<W: Write>(w: &mut W, part: &Part) -> Result<(), anyhow::Error
         write_statistics: false,
         compression: CompressionOptions::Uncompressed,
         version: Version::V2,
+        data_pagesize_limit: None, // use default limit
     };
     let created_by = None;
     let mut writer = FileWriter::new(

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -20,7 +20,7 @@ bench = false
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-arrow2 = { git = "https://github.com/jorgecarleitao/arrow2.git", features = ["io_ipc", "io_parquet"] }
+arrow2 = { version = "0.16.0", features = ["io_ipc", "io_parquet"] }
 async-trait = "0.1.59"
 aws-config = { version = "0.53.0", default-features = false, features = ["native-tls"] }
 aws-credential-types = { version = "0.53.0", features = ["hardcoded-credentials"] }

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -14,6 +14,7 @@ use std::mem::size_of;
 use std::{cmp, fmt};
 
 use arrow2::buffer::Buffer;
+use arrow2::offset::OffsetsBuffer;
 use arrow2::types::Index;
 
 pub mod arrow;
@@ -84,9 +85,9 @@ const BYTES_PER_KEY_VAL_OFFSET: usize = 4;
 pub struct ColumnarRecords {
     len: usize,
     key_data: Buffer<u8>,
-    key_offsets: Buffer<i32>,
+    key_offsets: OffsetsBuffer<i32>,
     val_data: Buffer<u8>,
-    val_offsets: Buffer<i32>,
+    val_offsets: OffsetsBuffer<i32>,
     timestamps: Buffer<i64>,
     diffs: Buffer<i64>,
 }
@@ -456,9 +457,11 @@ impl ColumnarRecordsBuilder {
         let ret = ColumnarRecords {
             len: self.len,
             key_data: Buffer::from(self.key_data),
-            key_offsets: Buffer::from(self.key_offsets),
+            key_offsets: OffsetsBuffer::try_from(self.key_offsets)
+                .expect("constructed valid offsets"),
             val_data: Buffer::from(self.val_data),
-            val_offsets: Buffer::from(self.val_offsets),
+            val_offsets: OffsetsBuffer::try_from(self.val_offsets)
+                .expect("constructed valid offsets"),
             timestamps: Buffer::from(self.timestamps),
             diffs: Buffer::from(self.diffs),
         };

--- a/src/persist/src/indexed/columnar/parquet.rs
+++ b/src/persist/src/indexed/columnar/parquet.rs
@@ -93,6 +93,7 @@ fn encode_parquet_kvtd<W: Write>(
         write_statistics: false,
         compression: CompressionOptions::Uncompressed,
         version: Version::V2,
+        data_pagesize_limit: None, // use default limit
     };
     let row_groups = RowGroupIterator::try_new(
         iter,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* Dependency bump PR.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
