### PR TITLE
ci: automatically sync READMEs to Docker Hub

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -113,7 +113,9 @@ RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.3.0/au
     && rm shellcheck.tar.xz \
     && mkdir -p /usr/local/lib/docker/cli-plugins \
     && curl -fsSL https://github.com/docker/compose/releases/download/v2.15.1/docker-compose-linux-$ARCH_GCC > /usr/local/lib/docker/cli-plugins/docker-compose \
-    && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+    && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose \
+    && curl -fsSL https://github.com/christian-korneck/docker-pushrm/releases/download/v1.9.0/docker-pushrm_linux_$ARCH_GO > /usr/local/lib/docker/cli-plugins/docker-pushrm \
+    && chmod +x /usr/local/lib/docker/cli-plugins/docker-pushrm
 
 ENTRYPOINT ["autouseradd", "--user", "materialize"]
 

--- a/ci/deploy/docker.py
+++ b/ci/deploy/docker.py
@@ -42,6 +42,12 @@ def main() -> None:
         mzbuild.publish_multiarch_images("unstable", deps)
         mzbuild.publish_multiarch_images(f'unstable-{git.rev_parse("HEAD")}', deps)
 
+        # Sync image descriptions to Docker Hub. The image descriptions are the
+        # same across architectures, so we arbitrarily choose the first
+        # repository.
+        for image in repos[0]:
+            image.sync_description()
+
 
 if __name__ == "__main__":
     main()

--- a/doc/developer/mzbuild.md
+++ b/doc/developer/mzbuild.md
@@ -34,6 +34,7 @@ also have a convenience script alongside it, which you can invoke as
     * [`mzbuild.yml`](#mzbuildyml)
     * [`mzcompose.py`](#mzcomposepy)
     * [mzbuild `Dockerfile`](#mzbuild-Dockerfile)
+    * [`README.md`](#readmemd)
   * [Motivation](#motivation)
     * [Why a new build system?](#why-a-new-build-system)
     * [Why Docker?](#why-docker)
@@ -368,6 +369,7 @@ The directory containing a `mzbuild.yml` file is called the "mzbuild context."
 
 ```yml
 name: environmentd
+description: "A Docker image containing just environmentd."
 pre-image:
   - type: cargo-build
     bin: environmentd
@@ -433,6 +435,9 @@ publish: true
   CI, but they must always be built from source. Use sparingly. The default is
   `true`.
 
+* `description` (str) is a short description for the image. If `publish` is
+  true, CI will automatically sync the description to Docker Hub.
+
 * `build-args` (map[str, str]) a list of parameters to pass as [`--build-arg`][buildarg]
   to Docker. For example:
 
@@ -478,6 +483,12 @@ COPY --from=0 ...
   specified mzbuild image. It is like the vanilla Dockerfile [FROM
   command][dockerfile-from], except that the image named must be a valid mzbuild
   image in the repository, not a vanilla Docker image.
+
+### README.md
+
+If an mzbuild.yml file contains a file named README.md and `publish` is true, CI
+will automatically sync that file to Docker Hub as the repository's "full
+description."
 
 ## Motivation
 

--- a/misc/images/materialized/README.md
+++ b/misc/images/materialized/README.md
@@ -1,7 +1,6 @@
-# `materialized` Docker image
-
-This directory builds an all-in-one Docker image of Materialize for our internal
-development and testing.
+This is an all-in-one Docker image of Materialize, a fast, distributed SQL
+database built on streaming internals. This image is used for **internal**
+development and testing of Materialize.
 
 > **Warning**
 >

--- a/misc/images/materialized/mzbuild.yml
+++ b/misc/images/materialized/mzbuild.yml
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 name: materialized
+description: Materialize is a fast, distributed SQL database built on streaming internals.
 pre-image:
   - type: cargo-build
     bin: [clusterd, environmentd]

--- a/misc/images/mz/README.md
+++ b/misc/images/mz/README.md
@@ -1,0 +1,5 @@
+`mz` is the Materialize CLI.
+
+> **Warning**
+>
+> `mz` is under heavy development and is not yet fit for use.

--- a/misc/images/mz/mzbuild.yml
+++ b/misc/images/mz/mzbuild.yml
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 name: mz
+description: The CLI for Materialize.
 pre-image:
   - type: cargo-build
     bin: [mz]

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -368,6 +368,7 @@ class Image:
             data = yaml.safe_load(f)
             self.name: str = data.pop("name")
             self.publish: bool = data.pop("publish", True)
+            self.description: Optional[str] = data.pop("description", None)
             for pre_image in data.pop("pre-image", []):
                 typ = pre_image.pop("type", None)
                 if typ == "cargo-build":
@@ -391,6 +392,30 @@ class Image:
                 match = self._DOCKERFILE_MZFROM_RE.match(line)
                 if match:
                     self.depends_on.append(match.group(1).decode())
+
+    def sync_description(self) -> None:
+        """Sync the description to Docker Hub if the image is publishable
+        and either a description or a README.md file exists."""
+
+        if not self.publish:
+            ui.say(f"{self.name} is not publishable")
+            return
+
+        readme_path = self.path / "README.md"
+        has_readme = readme_path.exists()
+        if not (self.description or has_readme):
+            ui.say(f"{self.name} has no README.md or description")
+            return
+
+        spawn.runv(
+            [
+                "docker",
+                "pushrm",
+                f"--file={readme_path}",
+                *([f"--short={self.description}"] if self.description else []),
+                f"materialize/{self.name}",
+            ]
+        )
 
     def docker_name(self, tag: str) -> str:
         """Return the name of the image on Docker Hub at the given tag."""


### PR DESCRIPTION
Fix #9890.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
