### PR TITLE
ci: don't publish tags for mz

### DIFF
--- a/ci/deploy/docker.py
+++ b/ci/deploy/docker.py
@@ -23,9 +23,15 @@ def main() -> None:
     ]
     buildkite_tag = os.environ["BUILDKITE_TAG"]
 
+    def include_image(image: mzbuild.Image) -> bool:
+        # Images must always be publishable to be tagged. Only mainline images
+        # get tagged for releases, but even non-mainline images get `unstable`
+        # tags.
+        return image.publish and (not buildkite_tag or image.mainline)
+
     print(f"--- Tagging Docker images")
     deps = [
-        repo.resolve_dependencies(image for image in repo if image.publish)
+        repo.resolve_dependencies(image for image in repo if include_image(image))
         for repo in repos
     ]
 

--- a/doc/developer/mzbuild.md
+++ b/doc/developer/mzbuild.md
@@ -438,6 +438,11 @@ publish: true
 * `description` (str) is a short description for the image. If `publish` is
   true, CI will automatically sync the description to Docker Hub.
 
+* `mainline` (bool) indicates whether the image participates in the main
+  Materialize versioning scheme. CI will automatically push version tags for
+  mainline images for unprefixed tag builds (e.g., `v0.27.0`). Non-mainline
+  images must handle their own release scheme. The default is `true`.
+
 * `build-args` (map[str, str]) a list of parameters to pass as [`--build-arg`][buildarg]
   to Docker. For example:
 

--- a/misc/images/mz/mzbuild.yml
+++ b/misc/images/mz/mzbuild.yml
@@ -9,6 +9,7 @@
 
 name: mz
 description: The CLI for Materialize.
+mainline: false
 pre-image:
   - type: cargo-build
     bin: [mz]

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -369,6 +369,7 @@ class Image:
             self.name: str = data.pop("name")
             self.publish: bool = data.pop("publish", True)
             self.description: Optional[str] = data.pop("description", None)
+            self.mainline: bool = data.pop("mainline", True)
             for pre_image in data.pop("pre-image", []):
                 typ = pre_image.pop("type", None)
                 if typ == "cargo-build":


### PR DESCRIPTION
mz will use a separate tagging scheme from the main Materialize releases. This commit introduces the necessary mzbuild machinery to allow this.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
