### PR TITLE
persist-client: Reduce copies in proto serialization

### DIFF
--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1233,8 +1233,6 @@ mod tests {
                 val: StateFieldValDiff::Insert(r1_rollup.key.clone()),
             }],
             diff_proto.field_diffs.as_mut().unwrap(),
-            |k| k.into_proto().encode_to_vec(),
-            |v| v.into_proto().encode_to_vec(),
         );
 
         let diff = StateDiff::<u64>::from_proto(diff_proto.clone()).unwrap();

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -869,12 +869,8 @@ impl ProtoStateFieldDiffs {
         let encoded_length = msg.encoded_len();
         self.data_lens.push(u64::cast_from(encoded_length));
         self.data_bytes.reserve(encoded_length);
-        msg.encode(&mut self.data_bytes).expect("reserved enough space");
-    }
-
-    pub fn push_data(&mut self, mut data: Vec<u8>) {
-        self.data_lens.push(u64::cast_from(data.len()));
-        self.data_bytes.append(&mut data);
+        msg.encode(&mut self.data_bytes)
+            .expect("reserved enough space");
     }
 
     pub fn iter<'a>(&'a self) -> ProtoStateFieldDiffsIter<'a> {

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -866,11 +866,14 @@ fn apply_compaction_lenient<'a, T: Timestamp + Lattice>(
 
 impl ProtoStateFieldDiffs {
     pub fn encode_proto<M: prost::Message>(&mut self, msg: &M) {
-        let encoded_length = msg.encoded_len();
-        self.data_lens.push(u64::cast_from(encoded_length));
-        self.data_bytes.reserve(encoded_length);
+        self.data_bytes.reserve(msg.encoded_len());
+        let len_before = self.data_bytes.len();
         msg.encode(&mut self.data_bytes)
             .expect("reserved enough space");
+
+        // Record exactly how many bytes were written.
+        let written_len = self.data_bytes.len() - len_before;
+        self.data_lens.push(u64::cast_from(written_len));
     }
 
     pub fn iter<'a>(&'a self) -> ProtoStateFieldDiffsIter<'a> {

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -865,6 +865,13 @@ fn apply_compaction_lenient<'a, T: Timestamp + Lattice>(
 }
 
 impl ProtoStateFieldDiffs {
+    pub fn encode_proto<M: prost::Message>(&mut self, msg: &M) {
+        let encoded_length = msg.encoded_len();
+        self.data_lens.push(u64::cast_from(encoded_length));
+        self.data_bytes.reserve(encoded_length);
+        msg.encode(&mut self.data_bytes).expect("reserved enough space");
+    }
+
     pub fn push_data(&mut self, mut data: Vec<u8>) {
         self.data_lens.push(u64::cast_from(data.len()));
         self.data_bytes.append(&mut data);


### PR DESCRIPTION
### Motivation
This reduces the amount of copies and allocations we make in the `persist-client` when serializing `StateDiff`s to protobuf. Profiling locally this reduces the number of allocations by ~12% and improved runtime performance by ~6%.

When serializing we took three steps:
1. Convert "Rust Types" into protobuf, **allocation occurs**
2. Consume these "protobuf types" and encode into a `Vec<u8>`, **allocation occurs**
3. Copy the serialized buffer into a `ProtoStateFieldDiffs` message

This PR gets rid of step 2, instead of serializing into a buffer which we then immediately copy into a `ProtoStateFieldDiffs`, we just write our serialized bytes directly into the `ProtoStateFieldDiffs` message.

For testing I have a work-in-progress branch that derives `proptest::Abitrary` for `StateDiff` ([proto/impl-arbitrary](https://github.com/parker-timmerman/materialize/tree/proto/impl-abritrary)) which we then use to make sure `StateDiff` roundtrips through serialization. I also have a work-in-progress branch that implements some light benchmarking ([proto/benchmark](https://github.com/parker-timmerman/materialize/tree/proto/benchmark)). If folks would like to merge either or both branches before this one, that's totally fine, it'll probably just take another Skunkworks Friday to get them in shape to merge.

Note: theoretically we don't even need to do step 1, which is creating _owned_ "proto types" from our borrowed "Rust types". But that change is outside the scope of this PR.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
