### PR TITLE
Fix bug in mz_dataflow_operator_parents

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2572,10 +2572,7 @@ SELECT pa.id, oa.id AS parent_id, pa.worker_id
 FROM parent_addrs AS pa
     INNER JOIN operator_addrs AS oa
         ON pa.parent_address = oa.address
-        AND pa.worker_id = oa.worker_id
-    INNER JOIN mz_internal.mz_dataflow_operators AS mdo
-        ON mda.id = mdo.id
-        AND mda.worker_id = mdo.worker_id",
+        AND pa.worker_id = oa.worker_id",
 };
 
 // NOTE: If you add real data to this implementation, then please update

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -433,20 +433,25 @@ impl LogView {
             ),
 
             LogView::MzDataflowOperatorParents => (
-                "WITH parent_addrs AS (
+                "WITH operator_addrs AS (
+                    SELECT
+                        id, address, worker_id
+                    FROM mz_internal.mz_dataflow_addresses_{}
+                        INNER JOIN mz_internal.mz_dataflow_operators_{}
+                            USING (id, worker_id)
+                ),
+                parent_addrs AS (
                     SELECT
                         id,
                         address[1:list_length(address) - 1] AS parent_address,
                         worker_id
-                    FROM mz_internal.mz_dataflow_addresses_{}
-                        INNER JOIN mz_internal.mz_dataflow_operators_{}
-                            USING (id, worker_id)
+                    FROM operator_addrs
                 )
-                SELECT pa.id, mda.id AS parent_id, pa.worker_id
+                SELECT pa.id, oa.id AS parent_id, pa.worker_id
                 FROM parent_addrs AS pa
-                    JOIN mz_internal.mz_dataflow_addresses_{} AS mda
-                        ON pa.parent_address = mda.address
-                        AND pa.worker_id = mda.worker_id",
+                    INNER JOIN operator_addrs AS oa
+                        ON pa.parent_address = oa.address
+                        AND pa.worker_id = oa.worker_id",
                 "mz_dataflow_operator_parents_{}",
             ),
 

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -212,3 +212,11 @@ mv1_primary_idx mv1
     df.worker_id = 0 AND
     df.name LIKE '%my_unique_mv_name%';
 1
+
+# Test that each operator has at most one parent
+
+> SELECT max(count) FROM (
+    SELECT count(*)
+    FROM mz_internal.mz_dataflow_operator_parents mdop
+    GROUP BY mdop.id) counts
+1

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -217,6 +217,6 @@ mv1_primary_idx mv1
 
 > SELECT max(count) FROM (
     SELECT count(*)
-    FROM mz_internal.mz_dataflow_operator_parents mdop
-    GROUP BY mdop.id) counts
+    FROM mz_internal.mz_dataflow_operator_parents
+    GROUP BY id, worker_id) counts
 1


### PR DESCRIPTION
We were joining against _all_ addresses in the last step of the query, so we would pick up all items whose address is the same as the parent address of the operator. But this also includes all the channels in the scope.
   
We refactor the query to restrict only to operators in a CTE (`operator_addrs`) and then compute everything else in terms of that, so we can't accidentally forget to filter out channels at any step.