### PR TITLE
coord: Remove objects from Timelines transactionally

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4245,6 +4245,9 @@ impl Catalog {
         F: FnOnce(&CatalogState) -> Result<R, AdapterError>,
     {
         trace!("transact: {:?}", ops);
+        fail::fail_point!("catalog_transact", |arg| {
+            Err(AdapterError::Unstructured(anyhow::anyhow!("failpoint: {arg:?}")))
+        });
 
         let drop_ids: BTreeSet<_> = ops
             .iter()

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4246,7 +4246,9 @@ impl Catalog {
     {
         trace!("transact: {:?}", ops);
         fail::fail_point!("catalog_transact", |arg| {
-            Err(AdapterError::Unstructured(anyhow::anyhow!("failpoint: {arg:?}")))
+            Err(AdapterError::Unstructured(anyhow::anyhow!(
+                "failpoint: {arg:?}"
+            )))
         });
 
         let drop_ids: BTreeSet<_> = ops

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -320,6 +320,9 @@ impl Coordinator {
         // No error returns are allowed after this point. Enforce this at compile time
         // by using this odd structure so we don't accidentally add a stray `?`.
         let _: () = async {
+            self.send_builtin_table_updates(builtin_table_updates, BuiltinTableUpdateSource::DDL)
+                .await;
+
             let mut empty_timelines = Vec::new();
             if !storage_ids_to_drop.is_empty() {
                 let timelines = self.remove_storage_ids_from_timeline(storage_ids_to_drop);
@@ -347,9 +350,6 @@ impl Coordinator {
                     self.global_timelines.remove(&timeline);
                 }
             }
-
-            self.send_builtin_table_updates(builtin_table_updates, BuiltinTableUpdateSource::DDL)
-                .await;
 
             if !sources_to_drop.is_empty() {
                 self.drop_sources(sources_to_drop);

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -43,6 +43,8 @@ use crate::telemetry::SegmentClientExt;
 use crate::util::{ComputeSinkId, ResultExt};
 use crate::{catalog, AdapterError, AdapterNotice};
 
+use super::timeline::{TimelineContext, TimelineState};
+
 /// State provided to a catalog transaction closure.
 pub struct CatalogTxn<'a, T> {
     pub(crate) dataflow_client: &'a mz_controller::Controller<T>,
@@ -267,15 +269,32 @@ impl Coordinator {
             .chain(materialized_views_to_drop.iter())
             .chain(log_sources_to_drop.iter())
             .cloned();
+
         // Check if any Timelines would become empty, if we dropped the specified storage or
         // compute resources.
         //
         // Note: only after a Transaction succeeds do we actually drop the timeline
-        let timeline_associations = self.associate_with_timelines(
+        let collection_id_bundle = self.build_collection_id_bundle(
             storage_ids_to_drop,
             compute_ids_to_drop,
             clusters_to_drop.clone(),
         );
+        let timeline_associations: BTreeMap<_, _> = self
+            .partition_ids_by_timeline_context(&collection_id_bundle)
+            .filter_map(|(context, bundle)| {
+                let TimelineContext::TimelineDependent(timeline) = context else {
+                    return None;
+                };
+                let TimelineState { read_holds, .. } = self
+                    .global_timelines
+                    .get(&timeline)
+                    .expect("all timeslines have a timestamp oracle");
+
+                let empty = read_holds.id_bundle().difference(&bundle).is_empty();
+
+                Some((timeline, (empty, bundle)))
+            })
+            .collect();
         timelines_to_drop.extend(
             timeline_associations
                 .iter()
@@ -327,7 +346,11 @@ impl Coordinator {
                 .await;
 
             if !timeline_associations.is_empty() {
-                self.remove_resources_associate_with_timeline(timeline_associations);
+                for (timeline, (should_be_empty, id_bundle)) in timeline_associations {
+                    let became_empty =
+                        self.remove_resources_associated_with_timeline(timeline, id_bundle);
+                    assert_eq!(should_be_empty, became_empty, "emptiness did not match!");
+                }
             }
             if !sources_to_drop.is_empty() {
                 self.drop_sources(sources_to_drop);

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -22,6 +22,7 @@
 
 use differential_dataflow::lattice::Lattice;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
 use std::hash::Hash;
 
 use timely::progress::frontier::MutableAntichain;
@@ -179,6 +180,14 @@ impl<T: Eq + Hash + Ord> ReadHolds<T> {
             id_bundle.compute_ids.remove(compute_instance);
         }
         self.holds.retain(|_, id_bundle| !id_bundle.is_empty());
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for ReadHolds<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReadHolds")
+            .field("holds", &self.holds)
+            .finish()
     }
 }
 

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -22,7 +22,6 @@
 
 use differential_dataflow::lattice::Lattice;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::fmt;
 use std::hash::Hash;
 
 use timely::progress::frontier::MutableAntichain;
@@ -72,7 +71,7 @@ impl<T: timely::progress::Timestamp> ReadCapability<T> {
 }
 
 /// Relevant information for acquiring or releasing a bundle of read holds.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct ReadHolds<T> {
     holds: HashMap<Antichain<T>, CollectionIdBundle>,
 }
@@ -171,23 +170,6 @@ impl<T: Eq + Hash + Ord> ReadHolds<T> {
             }
         }
         self.holds.retain(|_, id_bundle| !id_bundle.is_empty());
-    }
-
-    /// If the read hold contains a compute instance equal `compute_instance`, removes it from
-    /// the read hold and drops it.
-    pub fn remove_compute_instance(&mut self, compute_instance: &ComputeInstanceId) {
-        for (_, id_bundle) in &mut self.holds {
-            id_bundle.compute_ids.remove(compute_instance);
-        }
-        self.holds.retain(|_, id_bundle| !id_bundle.is_empty());
-    }
-}
-
-impl<T: fmt::Debug> fmt::Debug for ReadHolds<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ReadHolds")
-            .field("holds", &self.holds)
-            .finish()
     }
 }
 

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -522,6 +522,8 @@ impl Coordinator {
         }
     }
 
+    /// Given a [`Timeline`] and a [`CollectionIdBundle`], removes all of the "storage ids"
+    /// and "compute ids" in the bundle, from the timeline.
     pub(crate) fn remove_resources_associated_with_timeline(
         &mut self,
         timeline: Timeline,

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -511,7 +511,7 @@ impl Coordinator {
                 .filter(|(instance_id, _id)| cluster_set.contains(instance_id));
             for (instance_id, ids) in holds {
                 let ids = ids.map(|(_antichain, id)| id);
-                if let Some(set) = compute.get_mut(&instance_id) {
+                if let Some(set) = compute.get_mut(instance_id) {
                     set.extend(ids);
                 } else {
                     compute.insert(*instance_id, ids.copied().collect());

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2536,7 +2536,7 @@ fn test_timelines_persist_after_failed_transaction() {
     let server = util::start_server(config).unwrap();
 
     let mut client = server.connect(postgres::NoTls).unwrap();
-    
+
     client.batch_execute(
         "CREATE SOURCE counter FROM LOAD GENERATOR COUNTER (TICK INTERVAL '10ms') WITH (TIMELINE 'my_timline')"
     )

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2529,3 +2529,42 @@ fn test_concurrent_role_drop() {
         "unexpected error: {err:?}",
     );
 }
+
+#[test]
+fn test_timelines_persist_after_failed_transaction() {
+    let config = util::Config::default().unsafe_mode();
+    let server = util::start_server(config).unwrap();
+
+    let mut client = server.connect(postgres::NoTls).unwrap();
+    
+    client.batch_execute(
+        "CREATE SOURCE counter FROM LOAD GENERATOR COUNTER (TICK INTERVAL '10ms') WITH (TIMELINE 'my_timline')"
+    )
+    .unwrap();
+
+    // Should be able to query the source.
+    client
+        .query("SELECT * FROM counter", &[])
+        .expect("failed to select from LOAD GENERATOR");
+
+    fail::cfg("catalog_transact", "return(1)").expect("failed to set the fail_point");
+
+    // Should fail to drop the source, because of the fail_point.
+    let result = client.batch_execute("DROP SOURCE counter");
+
+    // Assert the error we get back is from our fail_point
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("failpoint: Some(\"1\")"));
+
+    fail::remove("catalog_transact");
+
+    // Should still be able to query the source, since we shouldn't have cleaned up the
+    // timeline or source because of the failed transaction.
+    client
+        .query("SELECT * FROM counter", &[])
+        .expect("failed to select from LOAD GENERATOR");
+
+    // Dropping the source should also work now.
+    client.batch_execute("DROP SOURCE counter").unwrap();
+}


### PR DESCRIPTION
### Motivation

Fixes a known bug:
  * Fixes #14194 

This PR introduces a change to how we handle `Timeline`s when running catalog transactions. Previously we would drop empty timelines before actually running the transaction, which is an issue because if the transaction failed we'd then be in a bad state. Now before running a transaction we check if any `Timeline`s would become empty from the changes being run in the transaction, if so we track those, and only drop the `Timeline`s if the transaction succeeds.

I also added a test to exercise this scenario using `fail_point!`s. We make it such that the catalog transaction will fail, then assert afterwards we can still query a `SOURCE` that depends on the `Timeline` that would have been dropped. When patched on top of `main` this test fails.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
