### PR TITLE
persist: require K: Codec and V: Codec on BatchBuilder struct

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -207,6 +207,8 @@ impl From<&PersistConfig> for BatchBuilderConfig {
 #[derive(Debug)]
 pub struct BatchBuilder<K, V, T, D>
 where
+    K: Codec,
+    V: Codec,
     T: Timestamp + Lattice + Codec64,
 {
     lower: Antichain<T>,

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use differential_dataflow::{Collection, Hashable};
 use mz_persist_types::codec_impls::UnitSchema;
+use mz_persist_types::Codec;
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::Scope;
 use timely::progress::frontier::Antichain;
@@ -32,6 +33,8 @@ use crate::storage_state::StorageState;
 
 struct BatchBuilderAndCounts<K, V, T, D>
 where
+    K: Codec,
+    V: Codec,
     T: timely::progress::Timestamp
         + differential_dataflow::lattice::Lattice
         + mz_persist_types::Codec64,
@@ -45,6 +48,8 @@ where
 
 impl<K, V, T, D> BatchBuilderAndCounts<K, V, T, D>
 where
+    K: Codec,
+    V: Codec,
     T: timely::progress::Timestamp
         + differential_dataflow::lattice::Lattice
         + mz_persist_types::Codec64,


### PR DESCRIPTION
Pulled out of some larger upcoming work.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
