### PR TITLE
sql: compile and test checks for set returning fns

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -3648,7 +3648,7 @@ mod tests {
                             }
 
                             if imp.return_is_set != pg_fn.ret_set {
-                                println!(
+                                panic!(
                                 "funcs with oid {} ({}) don't match set-returning value: {:?} in mz, {:?} in pg",
                                 imp.oid, func.name, imp.return_is_set, pg_fn.ret_set
                             );

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1574,7 +1574,12 @@ macro_rules! builtins {
         let mut builtins = BTreeMap::new();
         $(
             let impls = vec![$(impl_def!($params, $op, $return_type, $oid)),+];
-            let old = builtins.insert($name, Func::$ty(impls));
+            let func = Func::$ty(impls);
+            let expect_set_return = matches!(&func, Func::Table(_));
+            for imp in func.func_impls() {
+                assert_eq!(imp.return_is_set, expect_set_return, "wrong set return value for func with oid {}", imp.oid);
+            }
+            let old = builtins.insert($name, func);
             assert!(old.is_none(), "duplicate entry in builtins list {:?}", old);
         )+
         builtins


### PR DESCRIPTION
The linked issue describes some confusion as to why we were even allowed to have incorrectly-typed functions. test_compare_builtins_postgres was printing these problems before #18021, but no one looks at the printlns.

Enforce that set-returning functions correctly set their type at compile time. Enforce (instead of print) set-returningness with postgres.

 Fixes #18097

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a