### PR TITLE
persist: initial skeleton of part stats collection and filtering

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -34,6 +34,7 @@ use mz_persist_types::{Codec, Codec64};
 
 use crate::async_runtime::CpuHeavyRuntime;
 use crate::error::InvalidUsage;
+use crate::internal::encoding::Schemas;
 use crate::internal::machine::retry_external;
 use crate::internal::metrics::{BatchWriteMetrics, Metrics};
 use crate::internal::paths::{PartId, PartialBatchKey};
@@ -211,12 +212,63 @@ where
     V: Codec,
     T: Timestamp + Lattice + Codec64,
 {
+    pub(crate) stats_schemas: Schemas<K, V>,
+    pub(crate) builder: BatchBuilderInternal<K, V, T, D>,
+}
+
+impl<K, V, T, D> BatchBuilder<K, V, T, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Semigroup + Codec64,
+{
+    /// Finish writing this batch and return a handle to the written batch.
+    ///
+    /// This fails if any of the updates in this batch are beyond the given
+    /// `upper`.
+    pub async fn finish(
+        self,
+        registered_upper: Antichain<T>,
+    ) -> Result<Batch<K, V, T, D>, InvalidUsage<T>> {
+        self.builder
+            .finish(&self.stats_schemas, registered_upper)
+            .await
+    }
+
+    /// Adds the given update to the batch.
+    ///
+    /// The update timestamp must be greater or equal to `lower` that was given
+    /// when creating this [BatchBuilder].
+    pub async fn add(
+        &mut self,
+        key: &K,
+        val: &V,
+        ts: &T,
+        diff: &D,
+    ) -> Result<Added, InvalidUsage<T>> {
+        self.builder
+            .add(&self.stats_schemas, key, val, ts, diff)
+            .await
+    }
+}
+
+// TODO: Merge this back into BatchBuilder once we no longer need this separate
+// schemas nonsense for compaction.
+#[derive(Debug)]
+pub(crate) struct BatchBuilderInternal<K, V, T, D>
+where
+    K: Codec,
+    V: Codec,
+    T: Timestamp + Lattice + Codec64,
+{
     lower: Antichain<T>,
     max_ts: T,
 
     shard_id: ShardId,
     blob: Arc<dyn Blob + Send + Sync>,
     metrics: Arc<Metrics>,
+    _schemas: Schemas<K, V>,
     consolidate: bool,
 
     buffer: BatchBuffer<D>,
@@ -236,7 +288,7 @@ where
     _phantom: PhantomData<(K, V, T, D)>,
 }
 
-impl<K, V, T, D> BatchBuilder<K, V, T, D>
+impl<K, V, T, D> BatchBuilderInternal<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
@@ -246,6 +298,7 @@ where
     pub(crate) fn new(
         cfg: BatchBuilderConfig,
         metrics: Arc<Metrics>,
+        schemas: Schemas<K, V>,
         batch_write_metrics: BatchWriteMetrics,
         lower: Antichain<T>,
         blob: Arc<dyn Blob + Send + Sync>,
@@ -277,6 +330,7 @@ where
                 consolidate,
             ),
             metrics,
+            _schemas: schemas,
             consolidate,
             max_kvt_in_run: None,
             parts_written: 0,
@@ -301,8 +355,9 @@ where
     /// This fails if any of the updates in this batch are beyond the given
     /// `upper`.
     #[instrument(level = "debug", name = "batch::finish", skip_all, fields(shard = %self.shard_id))]
-    pub async fn finish(
+    pub async fn finish<StatsK: Codec, StatsV: Codec>(
         mut self,
+        stats_schemas: &Schemas<StatsK, StatsV>,
         registered_upper: Antichain<T>,
     ) -> Result<Batch<K, V, T, D>, InvalidUsage<T>> {
         if PartialOrder::less_than(&registered_upper, &self.lower) {
@@ -332,7 +387,7 @@ where
         }
 
         let remainder = self.buffer.drain();
-        self.flush_part(remainder).await;
+        self.flush_part(stats_schemas, remainder).await;
 
         let parts = self.parts.finish().await;
 
@@ -355,8 +410,9 @@ where
     ///
     /// The update timestamp must be greater or equal to `lower` that was given
     /// when creating this [BatchBuilder].
-    pub async fn add(
+    pub async fn add<StatsK: Codec, StatsV: Codec>(
         &mut self,
+        stats_schemas: &Schemas<StatsK, StatsV>,
         key: &K,
         val: &V,
         ts: &T,
@@ -373,7 +429,7 @@ where
 
         match self.buffer.push(key, val, ts, diff.clone()) {
             Some(part_to_flush) => {
-                self.flush_part(part_to_flush).await;
+                self.flush_part(stats_schemas, part_to_flush).await;
                 Ok(Added::RecordAndParts)
             }
             None => Ok(Added::Record),
@@ -385,7 +441,11 @@ where
     /// chunk `current_part` to be no greater than
     /// [BatchBuilderConfig::blob_target_size], and must absolutely be less than
     /// [mz_persist::indexed::columnar::KEY_VAL_DATA_MAX_LEN]
-    async fn flush_part(&mut self, columnar: ColumnarRecords) {
+    async fn flush_part<StatsK: Codec, StatsV: Codec>(
+        &mut self,
+        stats_schemas: &Schemas<StatsK, StatsV>,
+        columnar: ColumnarRecords,
+    ) {
         let num_updates = columnar.len();
         if num_updates == 0 {
             return;
@@ -434,7 +494,12 @@ where
 
         let start = Instant::now();
         self.parts
-            .write(columnar, self.inline_upper.clone(), self.since.clone())
+            .write(
+                stats_schemas,
+                columnar,
+                self.inline_upper.clone(),
+                self.since.clone(),
+            )
             .await;
         self.metrics
             .compaction
@@ -612,8 +677,9 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         }
     }
 
-    pub(crate) async fn write(
+    pub(crate) async fn write<K: Codec, V: Codec>(
         &mut self,
+        _schemas: &Schemas<K, V>,
         updates: ColumnarRecords,
         upper: Antichain<T>,
         since: Antichain<T>,
@@ -769,14 +835,16 @@ mod tests {
             .await;
 
         // A new builder has no writing or finished parts.
-        let mut builder = write.builder(Antichain::from_elem(0));
+        let builder = write.builder(Antichain::from_elem(0));
+        let x = builder.stats_schemas;
+        let mut builder = builder.builder;
         assert_eq!(builder.parts.writing_parts.len(), 0);
         assert_eq!(builder.parts.finished_parts.len(), 0);
 
         // We set blob_target_size to 0, so the first update gets forced out
         // into a batch.
         builder
-            .add(&data[0].0 .0, &data[0].0 .1, &data[0].1, &data[0].2)
+            .add(&x, &data[0].0 .0, &data[0].0 .1, &data[0].1, &data[0].2)
             .await
             .expect("invalid usage");
         assert_eq!(builder.parts.writing_parts.len(), 1);
@@ -785,7 +853,7 @@ mod tests {
         // We set batch_builder_max_outstanding_parts to 2, so we are allowed to
         // pipeline a second part.
         builder
-            .add(&data[1].0 .0, &data[1].0 .1, &data[1].1, &data[1].2)
+            .add(&x, &data[1].0 .0, &data[1].0 .1, &data[1].1, &data[1].2)
             .await
             .expect("invalid usage");
         assert_eq!(builder.parts.writing_parts.len(), 2);
@@ -794,7 +862,7 @@ mod tests {
         // But now that we have 3 parts, the add call back-pressures until the
         // first one finishes.
         builder
-            .add(&data[2].0 .0, &data[2].0 .1, &data[2].1, &data[2].2)
+            .add(&x, &data[2].0 .0, &data[2].0 .1, &data[2].1, &data[2].2)
             .await
             .expect("invalid usage");
         assert_eq!(builder.parts.writing_parts.len(), 2);
@@ -803,7 +871,7 @@ mod tests {
         // Finish off the batch and verify that the keys and such get plumbed
         // correctly by reading the data back.
         let batch = builder
-            .finish(Antichain::from_elem(4))
+            .finish(&x, Antichain::from_elem(4))
             .await
             .expect("invalid usage");
         assert_eq!(batch.batch.parts.len(), 3);

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -23,12 +23,14 @@ use mz_persist::cfg::{BlobConfig, ConsensusConfig};
 use mz_persist::location::{
     Atomicity, Blob, BlobMetadata, CaSResult, Consensus, ExternalError, SeqNo, VersionedData,
 };
+use mz_persist_types::codec_impls::TodoSchema;
 use prometheus::proto::{MetricFamily, MetricType};
 use tracing::{info, warn};
 
 use crate::async_runtime::CpuHeavyRuntime;
 use crate::cli::inspect::StateArgs;
 use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
+use crate::internal::encoding::Schemas;
 use crate::internal::gc::{GarbageCollector, GcReq};
 use crate::internal::machine::Machine;
 use crate::internal::metrics::{MetricsBlob, MetricsConsensus};
@@ -219,6 +221,10 @@ pub async fn force_compaction(
                 info!("skipping compaction because --commit is not set");
                 continue;
             }
+            let schemas = Schemas {
+                key: Arc::new(TodoSchema::default()),
+                val: Arc::new(TodoSchema::default()),
+            };
             let res =
                 Compactor::<crate::cli::inspect::K, crate::cli::inspect::V, u64, i64>::compact(
                     CompactConfig::from(&cfg),
@@ -227,6 +233,7 @@ pub async fn force_compaction(
                     Arc::new(CpuHeavyRuntime::new()),
                     req,
                     writer_id.clone(),
+                    schemas,
                 )
                 .await?;
             info!(

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -34,6 +34,7 @@ use crate::internal::machine::retry_external;
 use crate::internal::metrics::{Metrics, ReadMetrics};
 use crate::internal::paths::PartialBatchKey;
 use crate::read::{LeasedReaderId, ReadHandle};
+use crate::stats::PartStats;
 use crate::ShardId;
 
 /// Capable of fetching [`LeasedBatchPart`] while not holding any capabilities.
@@ -341,6 +342,7 @@ where
     pub(crate) metadata: SerdeLeasedBatchPartMetadata,
     pub(crate) desc: Description<T>,
     pub(crate) key: PartialBatchKey,
+    pub(crate) stats: Option<Arc<PartStats>>,
     pub(crate) encoded_size_bytes: usize,
     /// The `SeqNo` from which this part originated; we track this value as
     /// long as necessary to ensure the `SeqNo` isn't garbage collected while a
@@ -619,6 +621,10 @@ impl<T: Timestamp + Codec64> LeasedBatchPart<T> {
             ),
             key: x.key,
             encoded_size_bytes: x.encoded_size_bytes,
+            // TODO(mfp): We don't need stats after the batch is Exchanged into
+            // the fetch operator. This is unfortunately non-obvious, so perhaps
+            // better would be to lift stats off LeasedBatchPart.
+            stats: None,
             leased_seqno: x.leased_seqno,
             reader_id: x.reader_id,
         }

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -22,6 +22,7 @@ use futures_util::TryFutureExt;
 use mz_ore::cast::CastFrom;
 use mz_ore::task::spawn;
 use mz_persist::location::Blob;
+use mz_persist_types::codec_impls::VecU8Schema;
 use mz_persist_types::{Codec, Codec64};
 use timely::progress::Timestamp;
 use timely::PartialOrder;
@@ -32,9 +33,10 @@ use tracing::log::warn;
 use tracing::{debug, debug_span, trace, Instrument, Span};
 
 use crate::async_runtime::CpuHeavyRuntime;
-use crate::batch::{BatchBuilder, BatchBuilderConfig};
+use crate::batch::{BatchBuilderConfig, BatchBuilderInternal};
 use crate::cfg::MB;
 use crate::fetch::{fetch_batch_part, EncodedPart};
+use crate::internal::encoding::Schemas;
 use crate::internal::gc::GarbageCollector;
 use crate::internal::machine::{retry_external, Machine};
 use crate::internal::state::{HollowBatch, HollowBatchPart};
@@ -122,6 +124,7 @@ where
         metrics: Arc<Metrics>,
         cpu_heavy_runtime: Arc<CpuHeavyRuntime>,
         writer_id: WriterId,
+        schemas: Schemas<K, V>,
         gc: GarbageCollector<K, V, T, D>,
     ) -> Self {
         let (compact_req_sender, mut compact_req_receiver) = mpsc::channel::<(
@@ -173,6 +176,7 @@ where
                 let blob = Arc::clone(&machine.applier.state_versions.blob);
                 let cpu_heavy_runtime = Arc::clone(&cpu_heavy_runtime);
                 let writer_id = writer_id.clone();
+                let schemas = schemas.clone();
 
                 let compact_span =
                     debug_span!(parent: None, "compact::apply", shard_id=%machine.shard_id());
@@ -186,6 +190,7 @@ where
                         cpu_heavy_runtime,
                         req,
                         writer_id,
+                        schemas,
                         &mut machine,
                         &gc,
                     )
@@ -264,6 +269,7 @@ where
         cpu_heavy_runtime: Arc<CpuHeavyRuntime>,
         req: CompactReq<T>,
         writer_id: WriterId,
+        schemas: Schemas<K, V>,
         machine: &mut Machine<K, V, T, D>,
         gc: &GarbageCollector<K, V, T, D>,
     ) -> Result<ApplyMergeResult, anyhow::Error> {
@@ -306,6 +312,7 @@ where
                         Arc::clone(&cpu_heavy_runtime),
                         req,
                         writer_id,
+                        schemas.clone(),
                     )
                     .instrument(compact_span),
                 )
@@ -401,6 +408,7 @@ where
         cpu_heavy_runtime: Arc<CpuHeavyRuntime>,
         req: CompactReq<T>,
         writer_id: WriterId,
+        schemas: Schemas<K, V>,
     ) -> Result<CompactRes<T>, anyhow::Error> {
         let () = Self::validate_req(&req)?;
         // compaction needs memory enough for at least 2 runs and 2 in-progress parts
@@ -441,6 +449,7 @@ where
                 Arc::clone(&metrics),
                 Arc::clone(&cpu_heavy_runtime),
                 writer_id.clone(),
+                schemas.clone(),
             )
             .await?;
             let (parts, runs, updates) = (batch.parts, batch.runs, batch.len);
@@ -603,6 +612,7 @@ where
         metrics: Arc<Metrics>,
         cpu_heavy_runtime: Arc<CpuHeavyRuntime>,
         writer_id: WriterId,
+        real_schemas: Schemas<K, V>,
     ) -> Result<HollowBatch<T>, anyhow::Error> {
         // TODO: Figure out a more principled way to allocate our memory budget.
         // Currently, we give any excess budget to write parallelism. If we had
@@ -631,9 +641,18 @@ where
 
         let mut timings = Timings::default();
 
-        let mut batch = BatchBuilder::new(
+        // Old style compaction operates on the encoded bytes and doesn't need
+        // the real schema, so we synthesize one. We use the real schema for
+        // stats though (see below).
+        let fake_compaction_schema = Schemas {
+            key: Arc::new(VecU8Schema),
+            val: Arc::new(VecU8Schema),
+        };
+
+        let mut batch = BatchBuilderInternal::<Vec<u8>, Vec<u8>, T, D>::new(
             cfg.batch.clone(),
             Arc::clone(&metrics),
+            fake_compaction_schema,
             metrics.compaction.batch.clone(),
             desc.lower().clone(),
             Arc::clone(&blob),
@@ -716,10 +735,10 @@ where
                 }
             }
 
-            batch.add(&k, &v, &t, &d).await?;
+            batch.add(&real_schemas, &k, &v, &t, &d).await?;
         }
 
-        let batch = batch.finish(desc.upper().clone()).await?;
+        let batch = batch.finish(&real_schemas, desc.upper().clone()).await?;
         let hollow_batch = batch.into_hollow_batch();
 
         timings.record(&metrics);
@@ -903,6 +922,7 @@ fn start_prefetches<T: Timestamp + Lattice + Codec64>(
 mod tests {
     use crate::internal::paths::PartialBatchKey;
     use crate::PersistLocation;
+    use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
     use timely::progress::Antichain;
 
     use crate::tests::{all_ok, expect_fetch_part, new_test_client, new_test_client_cache};
@@ -952,6 +972,10 @@ mod tests {
             ),
             inputs: vec![b0, b1],
         };
+        let schemas = Schemas {
+            key: Arc::new(StringSchema),
+            val: Arc::new(UnitSchema),
+        };
         let res = Compactor::<String, (), u64, i64>::compact(
             CompactConfig::from(&write.cfg),
             Arc::clone(&write.blob),
@@ -959,6 +983,7 @@ mod tests {
             Arc::new(CpuHeavyRuntime::new()),
             req.clone(),
             write.writer_id.clone(),
+            schemas,
         )
         .await
         .expect("compaction failed");

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -1013,6 +1013,7 @@ mod tests {
             .map(|encoded_size_bytes| HollowBatchPart {
                 key: PartialBatchKey("".into()),
                 encoded_size_bytes,
+                stats: None,
             })
             .collect::<Vec<_>>();
         let parse = |x: &str| {

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -106,6 +106,7 @@ impl<'a> DirectiveArgs<'a> {
                 .map(|x| HollowBatchPart {
                     key: PartialBatchKey((*x).to_owned()),
                     encoded_size_bytes: 0,
+                    stats: None,
                 })
                 .collect(),
             runs: vec![],

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -9,6 +9,7 @@
 
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
@@ -44,6 +45,21 @@ use crate::internal::trace::Trace;
 use crate::read::LeasedReaderId;
 use crate::write::WriterEnrichedHollowBatch;
 use crate::{PersistConfig, ShardId, WriterId};
+
+#[derive(Debug)]
+pub struct Schemas<K: Codec, V: Codec> {
+    pub key: Arc<K::Schema>,
+    pub val: Arc<V::Schema>,
+}
+
+impl<K: Codec, V: Codec> Clone for Schemas<K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            key: Arc::clone(&self.key),
+            val: Arc::clone(&self.val),
+        }
+    }
+}
 
 pub(crate) fn parse_id(id_prefix: char, id_type: &str, encoded: &str) -> Result<[u8; 16], String> {
     let uuid_encoded = match encoded.strip_prefix(id_prefix) {

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -35,14 +35,15 @@ use crate::internal::state::{
     IdempotencyToken, LeasedReaderState, OpaqueState, ProtoCriticalReaderState,
     ProtoHandleDebugState, ProtoHollowBatch, ProtoHollowBatchPart, ProtoHollowRollup,
     ProtoLeasedReaderState, ProtoStateDiff, ProtoStateField, ProtoStateFieldDiffType,
-    ProtoStateFieldDiffs, ProtoStateRollup, ProtoTrace, ProtoU64Antichain, ProtoU64Description,
-    ProtoWriterState, State, StateCollections, TypedState, WriterState,
+    ProtoStateFieldDiffs, ProtoStateRollup, ProtoTrace, ProtoU64Antichain, ProtoU64ColStats,
+    ProtoU64Description, ProtoWriterState, State, StateCollections, TypedState, WriterState,
 };
 use crate::internal::state_diff::{
     ProtoStateFieldDiff, StateDiff, StateFieldDiff, StateFieldValDiff,
 };
 use crate::internal::trace::Trace;
 use crate::read::LeasedReaderId;
+use crate::stats::PartStats;
 use crate::write::WriterEnrichedHollowBatch;
 use crate::{PersistConfig, ShardId, WriterId};
 
@@ -896,6 +897,7 @@ impl<T: Timestamp + Codec64> RustType<ProtoHollowBatch> for HollowBatch<T> {
                 .map(|key| HollowBatchPart {
                     key: PartialBatchKey(key),
                     encoded_size_bytes: 0,
+                    stats: None,
                 }),
         );
         Ok(HollowBatch {
@@ -909,16 +911,46 @@ impl<T: Timestamp + Codec64> RustType<ProtoHollowBatch> for HollowBatch<T> {
 
 impl RustType<ProtoHollowBatchPart> for HollowBatchPart {
     fn into_proto(&self) -> ProtoHollowBatchPart {
+        let key_col_stats = match self.stats.as_ref() {
+            Some(x) => x
+                .key_col_min_max_nulls
+                .iter()
+                .map(|(name, (min, max, nulls))| ProtoU64ColStats {
+                    name: name.into_proto(),
+                    min: min.into_proto(),
+                    max: max.into_proto(),
+                    nulls: nulls.into_proto(),
+                })
+                .collect(),
+            None => Vec::new(),
+        };
         ProtoHollowBatchPart {
             key: self.key.into_proto(),
             encoded_size_bytes: self.encoded_size_bytes.into_proto(),
+            key_col_stats,
         }
     }
 
     fn from_proto(proto: ProtoHollowBatchPart) -> Result<Self, TryFromProtoError> {
+        let stats = if proto.key_col_stats.is_empty() {
+            None
+        } else {
+            let mut key_col_min_max_nulls = BTreeMap::new();
+            for x in proto.key_col_stats {
+                key_col_min_max_nulls.insert(
+                    x.name.into_rust()?,
+                    (x.min.into_rust()?, x.max.into_rust()?, x.nulls.into_rust()?),
+                );
+            }
+            let stats = Arc::new(PartStats {
+                key_col_min_max_nulls,
+            });
+            Some(stats)
+        };
         Ok(HollowBatchPart {
             key: proto.key.into_rust()?,
             encoded_size_bytes: proto.encoded_size_bytes.into_rust()?,
+            stats,
         })
     }
 }
@@ -1097,6 +1129,7 @@ mod tests {
             parts: vec![HollowBatchPart {
                 key: PartialBatchKey("a".into()),
                 encoded_size_bytes: 5,
+                stats: None,
             }],
             runs: vec![],
         };
@@ -1114,6 +1147,7 @@ mod tests {
         expected.parts.push(HollowBatchPart {
             key: PartialBatchKey("b".into()),
             encoded_size_bytes: 0,
+            stats: None,
         });
         assert_eq!(<HollowBatch<u64>>::from_proto(old).unwrap(), expected);
     }

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -24,6 +24,16 @@ message ProtoU64Description {
 message ProtoHollowBatchPart {
     string key = 1;
     uint64 encoded_size_bytes = 2;
+
+    // TODO(mfp): This is definitely not the final way for us to store this.
+    repeated ProtoU64ColStats key_col_stats = 536870911;
+}
+
+message ProtoU64ColStats {
+    string name = 1;
+    uint64 min = 2;
+    uint64 max = 3;
+    uint64 nulls = 4;
 }
 
 message ProtoHollowBatch {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -125,17 +125,18 @@ pub mod cli {
 pub mod critical;
 pub mod error;
 pub mod fetch;
-pub mod operators {
-    //! [timely] operators for reading and writing persist Shards.
-    pub mod shard_source;
-}
+pub mod internals_bench;
 pub mod metrics {
     //! Utilities related to metrics.
     pub use crate::internal::metrics::encode_ts_metric;
     pub use crate::internal::metrics::Metrics;
 }
-pub mod internals_bench;
+pub mod operators {
+    //! [timely] operators for reading and writing persist Shards.
+    pub mod shard_source;
+}
 pub mod read;
+pub mod stats;
 pub mod usage;
 pub mod write;
 

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -715,6 +715,7 @@ where
             metadata: metadata.clone(),
             desc: batch.desc.clone(),
             key: part.key,
+            stats: part.stats,
             encoded_size_bytes: part.encoded_size_bytes,
             leased_seqno: Some(self.lease_seqno()),
         })

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -1,0 +1,129 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Aggregate statistics about data stored in persist.
+
+use std::collections::BTreeMap;
+
+use mz_persist::indexed::columnar::ColumnarRecords;
+use mz_persist_types::columnar::{ColumnFormat, PartEncoder, Schema};
+use mz_persist_types::part::{Part, PartBuilder};
+use mz_persist_types::Codec;
+
+use crate::internal::encoding::Schemas;
+
+/// Logic for filtering parts in a read as uninteresting purely from stats about
+/// the data held in them.
+pub trait PartFilter<K, V>: 'static {
+    /// True if the part should be fetched, false if it should be skipped.
+    fn should_fetch(&mut self, stats: &PartStats) -> bool;
+}
+
+/// An implementation of [PartFilter] that always returns true.
+#[derive(Debug)]
+pub struct FetchAllPartFilter;
+
+impl<K, V> PartFilter<K, V> for FetchAllPartFilter {
+    fn should_fetch(&mut self, _stats: &PartStats) -> bool {
+        true
+    }
+}
+
+/// Aggregate statistics about data contained in a [Part].
+///
+/// TODO(mfp): PartialEq, Eq, PartialOrd, Ord are sus.
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PartStats {
+    // TODO(mfp): Only contains Option<u64> columns in this initial skeleton.
+    pub(crate) key_col_min_max_nulls: BTreeMap<String, (u64, u64, usize)>,
+}
+
+impl PartStats {
+    pub(crate) fn new<K: Codec, V: Codec>(
+        schemas: &Schemas<K, V>,
+        part: &Part,
+    ) -> Result<Self, String> {
+        // TODO(mfp): This impl is all entirely just a placeholder. Zero chance
+        // it works like this by the time it ships.
+        let mut key_cols = part.key_ref();
+        let mut key_col_min_max_nulls = BTreeMap::new();
+        // TODO(mfp): We only need to plumb the schemas here if we end up
+        // allowing them to specify arbitrary min/max logic for complex types.
+        // If we don't end up doing that, consider pulling the schemas out of
+        // here.
+        for (name, typ) in schemas.key.columns() {
+            let col = match (typ.optional, typ.format) {
+                (true, ColumnFormat::U64) => key_cols.col::<Option<u64>>(name.as_str())?,
+                // TODO(mfp): Support stats on other column types.
+                _ => continue,
+            };
+            let (mut min, mut max, mut nulls) = (u64::MAX, u64::MIN, 0usize);
+            for x in col.iter() {
+                if let Some(x) = x {
+                    min = std::cmp::min(*x, min);
+                    max = std::cmp::max(*x, max);
+                } else {
+                    nulls += 1;
+                }
+            }
+            // Skip adding nonsensical min=u64::MAX max=u64::MIN. This might
+            // lose null count for an all null batch, but we keep sparse metrics
+            // so fine for placeholder impl.
+            if min <= max {
+                key_col_min_max_nulls.insert(name, (min, max, nulls));
+            }
+        }
+        drop(key_cols);
+        Ok(PartStats {
+            key_col_min_max_nulls,
+        })
+    }
+
+    pub(crate) fn legacy_part_format<K: Codec, V: Codec>(
+        schemas: &Schemas<K, V>,
+        part: &[ColumnarRecords],
+    ) -> Result<Self, String> {
+        // This is a laughably inefficient placeholder implementation of stats
+        // on the old part format. We don't intend to make this fast, rather we
+        // intend to compute stats on the new part format.
+        let mut new_format = PartBuilder::new(schemas.key.as_ref(), schemas.val.as_ref());
+        let builder = new_format.get_mut();
+        let mut key = schemas.key.encoder(builder.key)?;
+        let mut val = schemas.val.encoder(builder.val)?;
+        for x in part {
+            for ((k, v), t, d) in x.iter() {
+                let k = K::decode(k)?;
+                let v = V::decode(v)?;
+                key.encode(&k);
+                val.encode(&v);
+                builder.ts.push(i64::from_le_bytes(t));
+                builder.diff.push(i64::from_le_bytes(d));
+            }
+        }
+        drop(key);
+        drop(val);
+        let new_format = new_format.finish()?;
+        Self::new(schemas, &new_format)
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self == &Self::default()
+    }
+
+    /// The min and max values as well as null count for an `Option<u64>` column
+    /// in this part.
+    ///
+    /// Returns `None` if persist doesn't have stats about this column, or if
+    /// the column is not `Option<u64>`.
+    ///
+    /// TODO(mfp): This is decidedly not the final public interface.
+    pub fn opt_u64_key_col_min_max_nulls(&self, name: &str) -> Option<(u64, u64, usize)> {
+        self.key_col_min_max_nulls.get(name).copied()
+    }
+}

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -642,7 +642,7 @@ impl<T> PartDecoder<'_, T> for TodoSchema<T> {
     }
 }
 
-impl<T: Debug> Schema<T> for TodoSchema<T> {
+impl<T: Debug + Send + Sync> Schema<T> for TodoSchema<T> {
     type Encoder<'a> = Self;
     type Decoder<'a> = Self;
 

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -203,7 +203,7 @@ pub trait PartDecoder<'a, T> {
 }
 
 /// A description of the structure of a [crate::Codec] implementor.
-pub trait Schema<T>: Debug {
+pub trait Schema<T>: Debug + Send + Sync {
     /// The associated [PartEncoder] implementor.
     type Encoder<'a>: PartEncoder<'a, T>;
     /// The associated [PartDecoder] implementor.

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -232,8 +232,12 @@ pub fn validate_roundtrip<T: Codec + Default + PartialEq + Debug>(
     val: &T,
 ) -> Result<(), String> {
     let mut part = PartBuilder::new(schema, &UnitSchema);
-    schema.encoder(part.key_mut())?.encode(val);
-    part.push_ts_diff(1, 1);
+    {
+        let part_mut = part.get_mut();
+        schema.encoder(part_mut.key)?.encode(val);
+        part_mut.ts.push(1);
+        part_mut.diff.push(1);
+    }
     let part = part.finish()?;
 
     let mut actual = T::default();

--- a/src/persist-types/src/parquet.rs
+++ b/src/persist-types/src/parquet.rs
@@ -101,8 +101,12 @@ pub fn validate_roundtrip<T: Default + PartialEq + Debug, S: Schema<T>>(
     val: &T,
 ) -> Result<(), String> {
     let mut part = PartBuilder::new(schema, &UnitSchema);
-    schema.encoder(part.key_mut())?.encode(val);
-    part.push_ts_diff(1, 1);
+    {
+        let part_mut = part.get_mut();
+        schema.encoder(part_mut.key)?.encode(val);
+        part_mut.ts.push(1);
+        part_mut.diff.push(1);
+    }
     let part = part.finish()?;
 
     let mut encoded = Vec::new();


### PR DESCRIPTION
This is controlled by two independent DynamicConfigs. When set,
`stats_collection_enabled` will compute and durably record PartStats for
each user and compaction part. When set, `stats_filter_enabled` will use
any PartStats that are available to skip fetching parts at read time.
PartStats are never required, so either config may be set without the
other.

This is intentionally a minimal skeleton of collectings stats on parts
and using them to skip fetching parts entirely in persist_source. This
will allow productionized versions of the various pieces to be worked on
with far less coordination. It includes a number of limitations:

- This commit/PR only introduces changes in src/persist*, changes to
  persist users for the skeleton will be done in followup PRs to enable
  tighter code review audiences. As a result:
  - The configs are not yet hooked up to LaunchDarkly.
  - The impl of `Schema<SourceData> for RelationDesc` remains a TODO for
    now.
  - The filter is not hooked up to MFPs.
- Many `TODO(mfp)` comments are left. These are things that certainly
  will be fixed before turning this on in prod and have the additional
  suffix to allow for easy grepping.
- Stats are only collected for `Option<u64>` columns.
- Stats are stored in metadata in an extremely inefficient way (one per
  ProtoHollowBatchPart).
- Stats are computed for parts in the old format by wastefully
  re-encoding them to the new (schema'd) part format, computing stats on
  that, and then throwing it away.
- No metrics are kept.
- No tests are included.

A slight performance hit is expected due to additional Arc::clones from
plumbing the Schemas around. We'll let Feature Benchmarks decide if this
is significant.

Touches #12684

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
