### PR TITLE
sqllogictest: add timeout actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4726,6 +4726,7 @@ dependencies = [
  "clap",
  "fallible-iterator",
  "futures",
+ "humantime",
  "itertools",
  "junit-report",
  "md-5",

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.20", features = ["derive"] }
 fallible-iterator = "0.2.0"
 futures = "0.3.25"
+humantime = "2.1.0"
 itertools = "0.10.5"
 junit-report = "0.7.1"
 once_cell = "1.16.0"


### PR DESCRIPTION
Allow for logging or failing a timedout test.

Fixes #18098

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a