### PR TITLE
SQLsmith+Logged Errors CI: detect further harmless errors

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -43,7 +43,7 @@ ERROR_RE = re.compile(
     | unsupported\ SQL\ type\ in\ testdrive:
     )
     # Expected once compute cluster has panicked, brings no new information
-    (?!.*timely\ communication\ error:\ reading\ data:\ socket\ closed)
+    (?!.*timely\ communication\ error:\ reading\ data:)
     # Expected once compute cluster has panicked, only happens in CI
     (?!.*aborting\ because\ propagate_crashes\ is\ enabled)
     """,

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -38,6 +38,7 @@ known_errors = [
     "violates not-null constraint",
     "division by zero",
     "operator does not exist",  # For list types
+    "function sin is only defined for finite arguments",
     "more than one record produced in subquery",
     "invalid range bound flags",
     "invalid input syntax for type jsonb",


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/1968 and in a local run respectively.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
