### PR TITLE
ci: Move the "Checks + restart CRDB" job to Nightly

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -39,6 +39,7 @@ steps:
           - { value: zippy-cluster-replicas }
           - { value: zippy-crdb-latest }
           - { value: secrets }
+          - { value: checks-restart-cockroach }
           - { value: checks-parallel-drop-create-default-replica }
           - { value: checks-parallel-restart-clusterd-compute }
           - { value: checks-parallel-restart-entire-mz }
@@ -337,6 +338,18 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: secrets
+
+  - id: checks-restart-cockroach
+    label: "Checks + restart Cockroach"
+    depends_on: build-x86_64
+    timeout_in_minutes: 60
+    artifact_paths: junit_*.xml
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartCockroach, "--seed=$BUILDKITE_JOB_ID"]
 
   - id: checks-parallel-drop-create-default-replica
     label: "Checks parallel + DROP/CREATE replica"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -521,19 +521,6 @@ steps:
           composition: platform-checks
           args: [--scenario=KillClusterdStorage, "--seed=$BUILDKITE_JOB_ID"]
 
-  - id: checks-restart-cockroach
-    label: "Checks + restart Cockroach"
-    depends_on: build-x86_64
-    inputs: [misc/python/materialize/checks]
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartCockroach, "--seed=$BUILDKITE_JOB_ID"]
-
   - id: checks-restart-source-postgres
     label: "Checks + restart source Postgres"
     depends_on: build-x86_64


### PR DESCRIPTION
The job was taking too much time in the per-push CI compared to its utility. It was also timing out.

Move to Nightly and increase the timeout.

Relates to #18110
Fixes #17856

### Motivation
  * This PR fixes a recognized bug.