### PR TITLE
cloudtest: Increase paralellism to 3

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -537,7 +537,7 @@ steps:
   - id: cloudtest
     label: Cloudtest
     depends_on: build-x86_64
-    parallelism: 2
+    parallelism: 3
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     inputs: [test/cloudtest, misc/python/materialize/cloudtest]


### PR DESCRIPTION
Relates to: #18110

### Motivation

  * This PR adds a known-desirable feature.

Now that it has been proven that cloudtest can run with paralellism=2 , increase this to 3 to get the total execution time down a bit more.