### PR TITLE
Refactor the `limits` Nightly test

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -329,7 +329,6 @@ steps:
 
   - id: checks-restart-cockroach
     label: "Checks + restart Cockroach"
-    depends_on: build-x86_64
     timeout_in_minutes: 60
     artifact_paths: junit_*.xml
     agents:

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -23,7 +23,6 @@ steps:
           - { value: redpanda-testdrive }
 #         - { value: redpanda-testdrive-aarch64 }
           - { value: limits }
-          - { value: cluster-limits }
           - { value: limits-instance-size }
           - { value: testdrive-partitions-5 }
           - { value: testdrive-replicas-4}
@@ -152,17 +151,6 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: limits
-    timeout_in_minutes: 50
-
-  - id: cluster-limits
-    label: "Cluster Product limits"
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: limits
-          run: cluster
     timeout_in_minutes: 50
 
   - id: limits-instance-size

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-import argparse
 import contextlib
 import os
 import sys
@@ -1227,36 +1226,7 @@ SERVICES = [
 ]
 
 
-def run_test(c: Composition, args: argparse.Namespace) -> None:
-    c.up("testdrive", persistent=True)
-
-    scenarios = (
-        [globals()[args.scenario]] if args.scenario else Generator.__subclasses__()
-    )
-
-    for scenario in scenarios:
-        with tempfile.NamedTemporaryFile(mode="w", dir=c.path) as tmp:
-            with contextlib.redirect_stdout(tmp):
-                scenario.generate()
-                sys.stdout.flush()
-                c.exec("testdrive", os.path.basename(tmp.name))
-
-
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    parser.add_argument(
-        "--scenario", metavar="SCENARIO", type=str, help="Scenario to run."
-    )
-
-    args = parser.parse_args()
-
-    c.up("zookeeper", "kafka", "schema-registry")
-
-    c.up("materialized")
-
-    run_test(c, args)
-
-
-def workflow_cluster(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Run all the limits tests against a multi-node, multi-replica cluster"""
 
     parser.add_argument(
@@ -1287,7 +1257,8 @@ def workflow_cluster(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         c.sql(
             f"""
-            CREATE CLUSTER cluster1 REPLICAS (
+            DROP CLUSTER DEFAULT cascade;
+            CREATE CLUSTER default REPLICAS (
                 replica1 (
                     STORAGECTL ADDRESSES ['clusterd_1_1:2100', 'clusterd_1_2:2100'],
                     STORAGE ADDRESSES ['clusterd_1_1:2103', 'clusterd_1_2:2103'],
@@ -1306,7 +1277,18 @@ def workflow_cluster(c: Composition, parser: WorkflowArgumentParser) -> None:
         """
         )
 
-        run_test(c, args)
+        c.up("testdrive", persistent=True)
+
+        scenarios = (
+            [globals()[args.scenario]] if args.scenario else Generator.__subclasses__()
+        )
+
+        for scenario in scenarios:
+            with tempfile.NamedTemporaryFile(mode="w", dir=c.path) as tmp:
+                with contextlib.redirect_stdout(tmp):
+                    scenario.generate()
+                    sys.stdout.flush()
+                    c.exec("testdrive", os.path.basename(tmp.name))
 
 
 def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> None:

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -73,8 +73,6 @@ class Generator:
 
 
 class Connections(Generator):
-    COUNT = 25  # https://github.com/MaterializeInc/materialize/issues/12775
-
     @classmethod
     def body(cls) -> None:
         for i in cls.all():


### PR DESCRIPTION
```
commit 595c54fbe939c4155b63808270d7bb1b54ca9311 (HEAD -> limits-remove-nightly, origin/limits-remove-nightly)
Author: Philip Stoev <pstoev@materialize.com>
Date:   Tue Mar 14 15:39:36 2023 +0200

    limits test: Test with 1K concurrent SQL connections
    
    Due to a product bug that has since been fixed, the scenario was
    using only a very small number of concurrent SQL connections.
    
    Relates to: #12775

commit 3713e8f49b5acf44b740fc498a2e57b5887059fd
Author: Philip Stoev <pstoev@materialize.com>
Date:   Tue Mar 14 15:38:13 2023 +0200

    limits test: Unify the two variants of the limits test
    
    Previously, the limits test was running both against the `default`
    cluster and (supposedly, but not really due to a test bug), against
    a multi-node cluster as well.
    
    Unify the two workflows into a single one that simply uses a multi-node
    replacement of the `default` cluster.
    
    Relates to: #18110

```