### PR TITLE
ci: Enable miri for further cargo tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,9 @@
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 2 }
 
+[profile.default-miri]
+slow-timeout = { period = "600s", terminate-after = 2 }
+
 # For a given configuration parameter, the first override to match wins. Keep
 # these sorted in order from most specific to least specific.
 

--- a/ci/test/cargo-test-miri.sh
+++ b/ci/test/cargo-test-miri.sh
@@ -16,14 +16,7 @@ set -euo pipefail
 
 # miri artifacts are thoroughly incompatible with normal build artifacts,
 # so keep them away from the `target` directory.
-export CARGO_TARGET_DIR=miri-target
-
-# At the moment only ore and repr have tests meant to be run under miri.
-pkgs=(
-    repr
-    ore
-)
-
-for pkg in "${pkgs[@]}"; do
-    (cd src/"$pkg" && cargo miri test miri --all-features)
-done
+export CARGO_TARGET_DIR="$PWD/miri-target"
+export MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-strict-provenance"
+# exclude netwrok based tests, they mostly fail on epoll_wait
+cargo miri nextest run -j"$(nproc)" --no-fail-fast --workspace --exclude 'mz-adapter*' --exclude 'mz-environmentd*' --exclude 'mz-expr*' --exclude 'mz-compute-client*' --exclude 'mz-persist-client*' --exclude 'mz-ssh-util*'

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -133,7 +133,7 @@ steps:
   - id: miri-test
     label: Miri test
     command: bin/ci-builder run nightly ci/test/cargo-test-miri.sh
-    inputs: [src/repr]
+    inputs: [src]
     timeout_in_minutes: 30
     agents:
       queue: builder-linux-x86_64

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -7555,6 +7555,7 @@ mod tests {
 
     // Test that if a large catalog item is somehow committed, then we can still load the catalog.
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // slow
     async fn test_large_catalog_item() {
         let view_def = "CREATE VIEW \"materialize\".\"public\".\"v\" AS SELECT 1 FROM (SELECT 1";
         let column = ", 1";

--- a/src/alloc/src/lib.rs
+++ b/src/alloc/src/lib.rs
@@ -77,7 +77,7 @@
 
 use mz_ore::metrics::MetricsRegistry;
 
-#[cfg(all(not(target_os = "macos"), feature = "jemalloc"))]
+#[cfg(all(not(target_os = "macos"), feature = "jemalloc", not(miri)))]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
@@ -85,7 +85,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 ///
 /// What metrics are registered varies by platform. Not all platforms use
 /// allocators that support metrics.
-#[cfg(any(target_os = "macos", not(feature = "jemalloc")))]
+#[cfg(any(target_os = "macos", not(feature = "jemalloc"), miri))]
 #[allow(clippy::unused_async)]
 pub async fn register_metrics_into(_: &MetricsRegistry) {
     // No-op on platforms that don't use jemalloc.
@@ -95,7 +95,7 @@ pub async fn register_metrics_into(_: &MetricsRegistry) {
 ///
 /// What metrics are registered varies by platform. Not all platforms use
 /// allocators that support metrics.
-#[cfg(all(not(target_os = "macos"), feature = "jemalloc"))]
+#[cfg(all(not(target_os = "macos"), feature = "jemalloc", not(miri)))]
 pub async fn register_metrics_into(registry: &MetricsRegistry) {
     mz_prof::jemalloc::JemallocMetrics::register_into(registry).await;
 }

--- a/src/avro/src/codec.rs
+++ b/src/avro/src/codec.rs
@@ -173,6 +173,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `deflateInit2_` on OS `linux`
     fn deflate_compress_and_decompress() {
         let codec = Codec::Deflate;
         let mut stream = INPUT.to_vec();

--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -435,6 +435,7 @@ mod tests {
 
     //TODO: move where it fits better
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
     fn test_enum_default() {
         let writer_raw_schema = r#"
             {
@@ -488,6 +489,7 @@ mod tests {
 
     //TODO: move where it fits better
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
     fn test_enum_string_value() {
         let raw_schema = r#"
             {
@@ -531,6 +533,7 @@ mod tests {
 
     //TODO: move where it fits better
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
     fn test_enum_resolution() {
         let writer_raw_schema = r#"
             {

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -999,6 +999,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
     fn test_reader_stream() {
         let schema: Schema = SCHEMA.parse().unwrap();
         let reader = Reader::with_schema(&schema, ENCODED).unwrap();
@@ -1026,6 +1027,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
     fn test_reader_invalid_block() {
         let schema: Schema = SCHEMA.parse().unwrap();
         let invalid = ENCODED

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -2934,6 +2934,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: inline assembly is not supported
     fn test_schema_fingerprint() {
         use sha2::Sha256;
 

--- a/src/avro/src/writer.rs
+++ b/src/avro/src/writer.rs
@@ -531,6 +531,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `deflateInit2_` on OS `linux`
     fn test_writer_with_codec() {
         let schema = Schema::from_str(SCHEMA).unwrap();
         let mut writer = Writer::with_codec(schema.clone(), Vec::new(), Codec::Deflate);

--- a/src/ccsr/tests/client.rs
+++ b/src/ccsr/tests/client.rs
@@ -94,6 +94,7 @@ pub static SCHEMA_REGISTRY_URL: Lazy<reqwest::Url> =
     });
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_method` on OS `linux`
 async fn test_client() -> Result<(), anyhow::Error> {
     let client = mz_ccsr::ClientConfig::new(SCHEMA_REGISTRY_URL.clone()).build()?;
 
@@ -200,6 +201,7 @@ async fn test_client() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_method` on OS `linux`
 async fn test_client_subject_and_references() -> Result<(), anyhow::Error> {
     let client = mz_ccsr::ClientConfig::new(SCHEMA_REGISTRY_URL.clone()).build()?;
 
@@ -305,6 +307,7 @@ async fn test_client_subject_and_references() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_method` on OS `linux`
 async fn test_client_errors() -> Result<(), anyhow::Error> {
     let invalid_schema_registry_url: reqwest::Url = "data::text/plain,Info".parse().unwrap();
     match mz_ccsr::ClientConfig::new(invalid_schema_registry_url).build() {
@@ -348,6 +351,7 @@ async fn test_client_errors() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_method` on OS `linux`
 async fn test_server_errors() -> Result<(), anyhow::Error> {
     // When the schema registry gracefully reports an error by including a
     // properly-formatted JSON document in the response, the specific error code

--- a/src/cluster-client/src/client.rs
+++ b/src/cluster-client/src/client.rs
@@ -202,6 +202,7 @@ mod tests {
         #![proptest_config(ProptestConfig::with_cases(32))]
 
         #[test]
+        #[cfg_attr(miri, ignore)] // slow
         fn timely_config_protobuf_roundtrip(expect in any::<TimelyConfig>() ) {
             let actual = protobuf_roundtrip::<_, ProtoTimelyConfig>(&expect);
             assert!(actual.is_ok());

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1951,6 +1951,7 @@ mod tests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(10))]
         #[test]
+        #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
         fn available_collections_protobuf_roundtrip(expect in any::<AvailableCollections>() ) {
             let actual = protobuf_roundtrip::<_, ProtoAvailableCollections>(&expect);
             assert!(actual.is_ok());

--- a/src/compute-client/src/plan/reduce.rs
+++ b/src/compute-client/src/plan/reduce.rs
@@ -901,6 +901,7 @@ mod tests {
     // ignore by default.
     proptest! {
         #[test]
+        #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
         fn reduce_plan_protobuf_roundtrip(expect in any::<ReducePlan>() ) {
             let actual = protobuf_roundtrip::<_, ProtoReducePlan>(&expect);
             assert!(actual.is_ok());

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -778,6 +778,7 @@ fn wait_for_refresh(frontegg_server: &MzCloudServer, expires_in_secs: u64) {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
 fn test_auth_expiry() {
     // This function verifies that the background expiry refresh task runs. This
     // is done by starting a web server that awaits the refresh request, which the
@@ -870,6 +871,7 @@ fn test_auth_expiry() {
 
 #[allow(clippy::unit_arg)]
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
 fn test_auth_base() {
     mz_ore::test::init_logging();
 
@@ -1408,6 +1410,7 @@ fn test_auth_base() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
 fn test_auth_intermediate_ca() {
     // Create a CA, an intermediate CA, and a server key pair signed by the
     // intermediate CA.
@@ -1494,6 +1497,7 @@ fn test_auth_intermediate_ca() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
 fn test_auth_admin() {
     mz_ore::test::init_logging();
 

--- a/src/environmentd/tests/cli.rs
+++ b/src/environmentd/tests/cli.rs
@@ -88,6 +88,7 @@ fn cmd() -> Command {
 /// This test seems a bit tautological, but it protects against Clap defaults
 /// changing and overwriting our custom version output.
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `pipe2` on OS `linux`
 fn test_version() {
     // We don't make assertions about the build SHA because caching in CI can
     // cause the test binary and `environmentd` to have different embedded SHAs.

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -174,6 +174,7 @@ fn test_bind_params() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_partial_read() {
     let server = util::start_server(util::Config::default()).unwrap();
     let mut client = server.connect(postgres::NoTls).unwrap();
@@ -200,6 +201,7 @@ fn test_partial_read() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_read_many_rows() {
     let server = util::start_server(util::Config::default()).unwrap();
     let mut client = server.connect(postgres::NoTls).unwrap();
@@ -214,6 +216,7 @@ fn test_read_many_rows() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_conn_startup() {
     let server = util::start_server(util::Config::default()).unwrap();
     let mut client = server.connect(postgres::NoTls).unwrap();
@@ -362,6 +365,7 @@ fn test_conn_startup() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_conn_user() {
     let server = util::start_server(util::Config::default()).unwrap();
 
@@ -396,6 +400,7 @@ fn test_conn_user() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_simple_query_no_hang() {
     let server = util::start_server(util::Config::default()).unwrap();
     let mut client = server.connect(postgres::NoTls).unwrap();
@@ -405,6 +410,7 @@ fn test_simple_query_no_hang() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_copy() {
     let server = util::start_server(util::Config::default()).unwrap();
     let mut client = server.connect(postgres::NoTls).unwrap();
@@ -454,6 +460,7 @@ fn test_copy() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_arrays() {
     let server = util::start_server(util::Config::default().unsafe_mode()).unwrap();
     let mut client = server.connect(postgres::NoTls).unwrap();
@@ -501,6 +508,7 @@ fn test_arrays() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_record_types() {
     let server = util::start_server(util::Config::default()).unwrap();
     let mut client = server.connect(postgres::NoTls).unwrap();
@@ -567,12 +575,15 @@ fn pg_test_inner(dir: PathBuf) {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_pgtest() {
     let dir: PathBuf = ["..", "..", "test", "pgtest"].iter().collect();
     pg_test_inner(dir);
 }
 
 #[test]
+// unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
+#[cfg_attr(miri, ignore)]
 // Materialize's differences from Postgres' responses.
 fn test_pgtest_mz() {
     let dir: PathBuf = ["..", "..", "test", "pgtest-mz"].iter().collect();

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -232,6 +232,7 @@ fn test_source_sink_size_required() {
 
 // Test the POST and WS server endpoints.
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_http_sql() {
     // Datadriven directives for WebSocket are "ws-text" and "ws-binary" to send
     // text or binary websocket messages that are the input. Output is
@@ -321,6 +322,7 @@ fn test_http_sql() {
 
 // Test that the server properly handles cancellation requests.
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_cancel_long_running_query() {
     let config = util::Config::default().unsafe_mode();
     let server = util::start_server(config).unwrap();
@@ -363,6 +365,7 @@ fn test_cancel_long_running_query() {
 
 // Test that dataflow uninstalls cancelled peeks.
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_cancel_dataflow_removal() {
     let config = util::Config::default().unsafe_mode();
     let server = util::start_server(config).unwrap();
@@ -745,6 +748,7 @@ fn test_old_storage_usage_records_are_reaped_on_restart() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_default_cluster_sizes() {
     let config = util::Config::default()
         .with_builtin_cluster_replica_size("1".to_string())
@@ -776,6 +780,7 @@ fn test_default_cluster_sizes() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_max_request_size() {
     let statement = "SELECT $1::text";
     let statement_size = statement.bytes().count();
@@ -833,6 +838,7 @@ fn test_max_request_size() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // too slow
 fn test_max_statement_batch_size() {
     let statement = "SELECT 1;";
     let statement_size = statement.bytes().count();
@@ -914,6 +920,7 @@ fn test_max_statement_batch_size() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_mz_system_user_admin() {
     let config = util::Config::default();
     let server = util::start_server(config).unwrap();

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -454,6 +454,7 @@ mod tests {
     use mz_repr::{Datum, ScalarType};
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
     fn try_map_to_input_with_bound_expr_test() {
         let input_mapper = JoinInputMapper {
             arities: vec![2, 3, 3],

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -76,6 +76,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     /// Test that primitive Avro Schema types are allow Datums to be correctly
     /// serialized into Avro Values.
     ///

--- a/src/ore/src/retry.rs
+++ b/src/ore/src/retry.rs
@@ -516,6 +516,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
     async fn test_retry_async_success() {
         let mut states = vec![];
         let res = Retry::default()
@@ -581,6 +582,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
     async fn test_retry_async_fatal() {
         let mut states = vec![];
         let res = Retry::default()
@@ -613,6 +615,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
     async fn test_retry_fail_max_tries() {
         let mut states = vec![];
         let res = Retry::default()
@@ -643,6 +646,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
     async fn test_retry_async_fail_max_tries() {
         let mut states = vec![];
         let res = Retry::default()
@@ -674,6 +678,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
     fn test_retry_fail_max_duration() {
         let mut states = vec![];
         let res = Retry::default()
@@ -713,6 +718,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
     async fn test_retry_async_fail_max_duration() {
         let mut states = vec![];
         let res = Retry::default()
@@ -756,6 +762,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
     fn test_retry_fail_clamp_backoff() {
         let mut states = vec![];
         let res = Retry::default()
@@ -791,6 +798,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
     async fn test_retry_async_fail_clamp_backoff() {
         let mut states = vec![];
         let res = Retry::default()
@@ -829,6 +837,7 @@ mod tests {
     /// Test that canceling retry operations surface the last error when the
     /// underlying future is not explicitly timed out.
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
     async fn test_retry_async_canceling_uncanceled_failure() {
         let res = Retry::default()
             .max_duration(Duration::from_millis(100))
@@ -840,6 +849,7 @@ mod tests {
     /// Test that canceling retry operations surface the last error when the
     /// underlying future *is* not explicitly timed out.
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
     async fn test_retry_async_canceling_canceled_failure() {
         let res = Retry::default()
             .max_duration(Duration::from_millis(100))
@@ -858,6 +868,7 @@ mod tests {
     /// Test that the "deadline has elapsed" error is surfaced when there is
     /// no other error to surface.
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
     async fn test_retry_async_canceling_canceled_first_failure() {
         let res = Retry::default()
             .max_duration(Duration::from_millis(100))
@@ -870,6 +881,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
     async fn test_retry_reader() {
         use tokio::io::AsyncReadExt;
 

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -742,6 +742,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn batch_builder_flushing() {
         mz_ore::test::init_logging();
         let data = vec![
@@ -815,6 +816,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn batch_builder_keys() {
         mz_ore::test::init_logging();
 

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -258,6 +258,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn client_cache() {
         let cache = PersistClientCache::new(
             PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone()),

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -346,6 +346,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn rate_limit() {
         let client = crate::tests::new_test_client().await;
 
@@ -373,6 +374,7 @@ mod tests {
 
     // Verifies that the handle updates its view of the opaque token correctly
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn handle_opaque_token() {
         let client = new_test_client().await;
         let shard_id = ShardId::new();

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -913,6 +913,7 @@ mod tests {
     // made it to main) where batches written by compaction would always have a
     // since of the minimum timestamp.
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn regression_minimum_since() {
         mz_ore::test::init_logging();
 
@@ -976,6 +977,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn prefetches() {
         let desc = Description::new(
             Antichain::from_elem(0u64),

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -173,6 +173,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn machine() {
         use crate::internal::machine::datadriven as machine_dd;
 

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1189,6 +1189,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     fn state_diff_migration_rollups() {
         let r1_rollup = HollowRollup {
             key: PartialRollupKey("foo".to_owned()),

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1687,6 +1687,7 @@ pub mod tests {
     use crate::ShardId;
 
     #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn apply_unbatched_cmd_truncate() {
         mz_ore::test::init_logging();
 
@@ -1740,6 +1741,7 @@ pub mod tests {
     // state invariant being violated which resulted in gc being permanently
     // wedged for the shard.
     #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn regression_gc_skipped_req_and_interrupted() {
         let mut client = new_test_client().await;
         let intercept = InterceptHandle::default();

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -1053,6 +1053,7 @@ mod tests {
     /// Regression test for (part of) #17752, where an interrupted
     /// `bin/environmentd --reset` resulted in panic in persist usage code.
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn fetch_all_live_states_regression_uninitialized() {
         let client = new_test_client().await;
         let state_versions = StateVersions::new(

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -728,6 +728,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn sanity_check() {
         mz_ore::test::init_logging();
 
@@ -1288,6 +1289,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn overlapping_append() {
         mz_ore::test::init_logging_default("info");
 
@@ -1682,6 +1684,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn concurrency() {
         mz_ore::test::init_logging();
 
@@ -1781,6 +1784,7 @@ mod tests {
     // immediately return the data currently available instead of waiting for
     // upper to advance past as_of.
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn regression_blocking_reads() {
         mz_ore::test::init_logging();
         let waker = noop_waker();
@@ -1853,6 +1857,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn heartbeat_task_shutdown() {
         // Verify that the ReadHandle and WriteHandle background heartbeat tasks
         // shut down cleanly after the handle is expired.

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1016,6 +1016,7 @@ mod tests {
 
     // Verifies `Subscribe` can be dropped while holding snapshot batches.
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn drop_unused_subscribe() {
         let data = vec![
             (("0".to_owned(), "zero".to_owned()), 0, 1),

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -245,6 +245,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn file_blob() -> Result<(), ExternalError> {
         let temp_dir = tempfile::tempdir().map_err(Error::from)?;
         blob_impl_test(move |path| {

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -509,6 +509,7 @@ mod tests {
     use super::*;
 
     #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn postgres_consensus() -> Result<(), ExternalError> {
         let config = match PostgresConsensusConfig::new_for_test()? {
             Some(config) => config,

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -951,6 +951,7 @@ mod tests {
     use super::*;
 
     #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn s3_blob() -> Result<(), ExternalError> {
         mz_ore::test::init_logging();
         let config = match S3BlobConfig::new_for_test().await? {

--- a/src/pgrepr/src/value/numeric.rs
+++ b/src/pgrepr/src/value/numeric.rs
@@ -237,6 +237,7 @@ impl<'a> FromSql<'a> for Numeric {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_to_from_sql_roundtrip() {
     fn inner(s: &str) {
         let mut cx = numeric::cx_datum();

--- a/src/pid-file/tests/pid_file.rs
+++ b/src/pid-file/tests/pid_file.rs
@@ -86,6 +86,7 @@ use std::error::Error;
 use mz_pid_file::PidFile;
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_pid_file_basics() -> Result<(), Box<dyn Error>> {
     let dir = tempfile::tempdir()?;
     let path = dir.path().join("pidfile");

--- a/src/prof/src/http/mod.rs
+++ b/src/prof/src/http/mod.rs
@@ -23,7 +23,7 @@ use once_cell::sync::Lazy;
 use crate::{ProfStartTime, StackProfile};
 
 cfg_if! {
-    if #[cfg(any(target_os = "macos", not(feature = "jemalloc")))] {
+    if #[cfg(any(target_os = "macos", not(feature = "jemalloc"), miri))] {
         use disabled::{handle_get, handle_post};
     } else {
         use enabled::{handle_get, handle_post};
@@ -95,7 +95,7 @@ async fn time_prof<'a>(
 ) -> impl IntoResponse {
     let ctl_lock;
     cfg_if! {
-        if #[cfg(any(target_os = "macos", not(feature = "jemalloc")))] {
+        if #[cfg(any(target_os = "macos", not(feature = "jemalloc"), miri))] {
             ctl_lock = ();
         } else {
             ctl_lock = if let Some(ctl) = crate::jemalloc::PROF_CTL.as_ref() {
@@ -151,7 +151,7 @@ fn flamegraph(
     })
 }
 
-#[cfg(any(target_os = "macos", not(feature = "jemalloc")))]
+#[cfg(any(target_os = "macos", not(feature = "jemalloc"), miri))]
 mod disabled {
     use axum::extract::{Form, Query};
     use axum::response::IntoResponse;
@@ -226,7 +226,7 @@ mod disabled {
     }
 }
 
-#[cfg(all(not(target_os = "macos"), feature = "jemalloc"))]
+#[cfg(all(not(target_os = "macos"), feature = "jemalloc", not(miri)))]
 mod enabled {
     use std::io::{BufReader, Read};
     use std::sync::Arc;

--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -588,6 +588,7 @@ mod tests {
         #![proptest_config(ProptestConfig::with_cases(4096))]
 
         #[test]
+        #[cfg_attr(miri, ignore)] // too slow
         fn duration_protobuf_roundtrip(expect in any_duration() ) {
             let actual = protobuf_roundtrip::<_, ProtoDuration>(&expect);
             assert!(actual.is_ok());

--- a/src/repr-test-util/tests/test_runner.rs
+++ b/src/repr-test-util/tests/test_runner.rs
@@ -146,6 +146,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
     fn run() {
         datadriven::walk("tests/testdata", |f| {
             f.run(move |s| -> String {

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -3880,6 +3880,7 @@ mod tests {
 
     proptest! {
         #[test]
+        #[cfg_attr(miri, ignore)] // slow, large amount of memory
         fn datetimeunits_serialization_roundtrip(expect in any::<DateTimeUnits>() ) {
             let actual = protobuf_roundtrip::<_, ProtoDateTimeUnits>(&expect);
             assert!(actual.is_ok());

--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -415,6 +415,7 @@ pub fn twos_complement_be_to_numeric_inner<D: Dec<N>, const N: usize>(
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
 fn test_twos_complement_roundtrip() {
     fn inner(s: &str) {
         let mut cx = cx_datum();
@@ -450,6 +451,7 @@ fn test_twos_complement_roundtrip() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
 fn test_twos_comp_numeric_primitive() {
     fn inner_inner<P>(i: P, i_be_bytes: &mut [u8])
     where
@@ -577,6 +579,7 @@ fn test_twos_comp_numeric_primitive() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
 fn test_twos_complement_to_numeric_fail() {
     fn inner(b: &mut [u8]) {
         let r = twos_complement_be_to_numeric(b, 0);
@@ -594,6 +597,7 @@ fn test_twos_complement_to_numeric_fail() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
 fn test_wide_twos_complement_roundtrip() {
     fn inner(s: &str) {
         let mut cx = cx_datum();

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -127,6 +127,7 @@ mod tests {
 
     proptest! {
         #[test]
+        #[cfg_attr(miri, ignore)] // too slow
         fn regex_protobuf_roundtrip( expect in any_regex() ) {
             let actual =  protobuf_roundtrip::<_, ProtoRegex>(&expect);
             assert!(actual.is_ok());

--- a/src/repr/src/chrono.rs
+++ b/src/repr/src/chrono.rs
@@ -165,6 +165,7 @@ mod tests {
         #![proptest_config(ProptestConfig::with_cases(4096))]
 
         #[test]
+        #[cfg_attr(miri, ignore)] // too slow
         fn naive_date_protobuf_roundtrip(expect in any_naive_date() ) {
             let actual = protobuf_roundtrip::<_, ProtoNaiveDate>(&expect);
             assert!(actual.is_ok());
@@ -172,6 +173,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)] // too slow
         fn naive_date_time_protobuf_roundtrip(expect in any_naive_datetime() ) {
             let actual = protobuf_roundtrip::<_, ProtoNaiveDateTime>(&expect);
             assert!(actual.is_ok());
@@ -179,6 +181,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)] // too slow
         fn date_time_protobuf_roundtrip(expect in any_datetime() ) {
             let actual = protobuf_roundtrip::<_, ProtoNaiveDateTime>(&expect);
             assert!(actual.is_ok());
@@ -186,6 +189,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)] // too slow
         fn fixed_offset_protobuf_roundtrip(expect in any_fixed_offset() ) {
             let actual = protobuf_roundtrip::<_, ProtoFixedOffset>(&expect);
             assert!(actual.is_ok());

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -2151,6 +2151,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     fn test_datum_sizes() {
         let arena = RowArena::new();
 

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -542,6 +542,7 @@ mod tests {
     // catch any changes in the encoding.
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     fn roundtrip() {
         let mut row = Row::default();
         let mut packer = row.packer();

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -3177,6 +3177,7 @@ mod tests {
 
     proptest! {
        #[test]
+       #[cfg_attr(miri, ignore)] // too slow
         fn scalar_type_protobuf_roundtrip(expect in any::<ScalarType>() ) {
             let actual = protobuf_roundtrip::<_, ProtoScalarType>(&expect);
             assert!(actual.is_ok());
@@ -3186,6 +3187,7 @@ mod tests {
 
     proptest! {
         #[test]
+        #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
         fn array_packing_unpacks_correctly(array in arb_array(arb_datum())) {
             let PropArray(row, elts) = array;
             let datums: Vec<Datum<'_>> = elts.iter().map(|e| e.into()).collect();
@@ -3194,6 +3196,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
         fn list_packing_unpacks_correctly(array in arb_list(arb_datum())) {
             let PropList(row, elts) = array;
             let datums: Vec<Datum<'_>> = elts.iter().map(|e| e.into()).collect();
@@ -3202,6 +3205,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)] // too slow
         fn dict_packing_unpacks_correctly(array in arb_dict(arb_datum())) {
             let PropDict(row, elts) = array;
             let datums: Vec<(&str, Datum<'_>)> = elts.iter().map(|(k, e)| (k.as_str(), e.into())).collect();
@@ -3210,6 +3214,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)] // too slow
         fn row_packing_roundtrips_single_valued(prop_datums in prop::collection::vec(arb_datum(), 1..100)) {
             let datums: Vec<Datum<'_>> = prop_datums.iter().map(|pd| pd.into()).collect();
             let row = Row::pack(&datums);
@@ -3218,6 +3223,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)] // too slow
         fn range_packing_unpacks_correctly(range in arb_range()) {
             let PropRange(row, prop_range) = range;
             let row = row.unpack_first();

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -1826,6 +1826,7 @@ mod tests {
 
     proptest! {
         #[test]
+        #[cfg_attr(miri, ignore)] // too slow
         fn parse_error_protobuf_roundtrip(expect in any::<ParseError>()) {
             let actual = protobuf_roundtrip::<_, ProtoParseError>(&expect);
             assert!(actual.is_ok());

--- a/src/repr/src/url.rs
+++ b/src/repr/src/url.rs
@@ -43,6 +43,7 @@ mod tests {
         #![proptest_config(ProptestConfig::with_cases(4096))]
 
         #[test]
+        #[cfg_attr(miri, ignore)] // too slow
         fn url_protobuf_roundtrip(expect in any_url() ) {
             let actual = protobuf_roundtrip::<_, ProtoUrl>(&expect);
             assert!(actual.is_ok());

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -103,6 +103,7 @@ use mz_sql_parser::parser::{
 };
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
 fn datadriven() {
     use datadriven::{walk, TestCase};
 
@@ -179,6 +180,7 @@ fn datadriven() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
 fn op_precedence() -> Result<(), Box<dyn Error>> {
     struct RemoveParens;
 
@@ -249,6 +251,7 @@ fn format_ident() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
 fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
     struct Visitor<'a> {
         seen_idents: Vec<&'a str>,
@@ -356,6 +359,7 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // too slow
 fn test_max_statement_batch_size() {
     let statement = "SELECT 1;";
     let size = statement.bytes().count();

--- a/src/stash/tests/stash.rs
+++ b/src/stash/tests/stash.rs
@@ -98,6 +98,7 @@ pub static C2: TypedCollection<i64, i64> = TypedCollection::new("c2");
 pub static C_SAVEPOINT: TypedCollection<i64, i64> = TypedCollection::new("c_savepoint");
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
 async fn test_stash_postgres() {
     mz_ore::test::init_logging();
 
@@ -924,6 +925,7 @@ async fn test_stash_table(stash: &mut Stash) {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // Broken, see #18122
 fn test_table() {
     fn uniqueness_violation(a: &String, b: &String) -> bool {
         a == b

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -736,6 +736,7 @@ mod tests {
         #![proptest_config(ProptestConfig::with_cases(32))]
 
         #[test]
+        #[cfg_attr(miri, ignore)] // too slow
         fn storage_command_protobuf_roundtrip(expect in any::<StorageCommand<mz_repr::Timestamp>>() ) {
             let actual = protobuf_roundtrip::<_, ProtoStorageCommand>(&expect);
             assert!(actual.is_ok());

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -180,6 +180,7 @@ mod tests {
 
     // Test suite
     #[tokio::test(start_paused = true)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn test_startup() {
         let persist_cache = persist_cache();
         let healthchecker = simple_healthchecker(ShardId::new(), 1, &persist_cache).await;
@@ -196,6 +197,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn test_bootstrap_different_sources() {
         let shard_id = ShardId::new();
         let persist_cache = persist_cache();
@@ -216,6 +218,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn test_repeated_update() {
         let shard_id = ShardId::new();
         let persist_cache = persist_cache();
@@ -255,6 +258,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn test_forbidden_transition() {
         let shard_id = ShardId::new();
         let persist_cache = persist_cache();

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -727,6 +727,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn test_basic_usage() {
         let (mut operator, mut follower) =
             make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
@@ -779,6 +780,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn test_reclock_frontier() {
         let persist_location = PersistLocation {
             blob_uri: "mem://".to_owned(),
@@ -948,6 +950,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn test_reclock() {
         let (mut operator, mut follower) =
             make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
@@ -1036,6 +1039,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn test_reclock_gh16318() {
         let (mut operator, mut follower) =
             make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
@@ -1064,6 +1068,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn test_compaction() {
         let persist_location = PersistLocation {
             blob_uri: "mem://".to_owned(),
@@ -1173,6 +1178,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn test_concurrency() {
         // Create two operators pointing to the same shard
         let shared_shard = ShardId::new();
@@ -1228,6 +1234,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn test_inversion() {
         let persist_location = PersistLocation {
             blob_uri: "mem://".to_owned(),
@@ -1390,6 +1397,7 @@ mod tests {
     // Regression test for
     // https://github.com/MaterializeInc/materialize/issues/14740.
     #[tokio::test(start_paused = true)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn test_since_hold() {
         let binding_shard = ShardId::new();
 

--- a/src/storage/tests/sources.rs
+++ b/src/storage/tests/sources.rs
@@ -85,6 +85,7 @@ use mz_storage_client::types::sources::{encoding::SourceDataEncoding, SourceEnve
 mod setup;
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
 fn test_datadriven() {
     datadriven::walk("tests/datadriven", |f| {
         let mut sources: BTreeMap<

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -542,6 +542,7 @@ mod test {
     use timely::dataflow::operators::{Capture, ToStream};
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn async_operator() {
         // Run timely in a separate thread
         #[allow(clippy::disallowed_methods)]

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -520,6 +520,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
     fn run() {
         datadriven::walk("tests/testdata", |f| {
             let mut catalog = TestCatalog::default();

--- a/src/walkabout/tests/walkabout.rs
+++ b/src/walkabout/tests/walkabout.rs
@@ -80,6 +80,7 @@ use std::io::Write;
 use tempfile::NamedTempFile;
 
 #[test]
+#[cfg_attr(miri, ignore)] // unsupported operation: non-default mode 0o600 is not supported
 fn datadriven() {
     datadriven::walk("tests/testdata", |f| {
         f.run(|test_case| {


### PR DESCRIPTION
This seems more fruitful than sanitizers which are not well supported with Rust yet. Most individual tests I disabled for miri in their specific location, when an entire directory seemed to fail I excluded it entirely in ci/test/cargo-test-miri.sh. This means that new tests outside of those directories will run in miri by default unless disabled.

What miri offers: https://github.com/rust-lang/miri

> An experimental interpreter for [Rust](https://www.rust-lang.org/)'s [mid-level intermediate representation](https://github.com/rust-lang/rfcs/blob/master/text/1211-mir.md) (MIR). It can run binaries and test suites of cargo projects and detect certain classes of [undefined behavior](https://doc.rust-lang.org/reference/behavior-considered-undefined.html), for example: [...]

Fixes: https://github.com/MaterializeInc/materialize/issues/17760

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
