### PR TITLE
ci slt: Speed up execution of long-running sqllogictest

### DIFF
--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -30,7 +30,7 @@ sqllogictest \
     test/sqllogictest/transform/*.slt \
     | tee -a target/slt.log
 
-sqllogictest --auto-index-tables \
+sqllogictest --auto-index-tables --auto-transactions \
     -v "$@" \
     test/sqllogictest/sqlite/test \
     | tee -a target/slt.log

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -436,6 +436,7 @@ class Cockroach(Service):
         name: str = "cockroach",
         image: Optional[str] = None,
         setup_materialize: bool = True,
+        in_memory: bool = False,
     ):
         volumes = []
 
@@ -448,12 +449,18 @@ class Cockroach(Service):
                 loader.composition_path,
             )
             volumes += [f"{path}:/docker-entrypoint-initdb.d/setup_materialize.sql"]
+
+        command = ["start-single-node", "--insecure"]
+
+        if in_memory:
+            command.append("--store=type=mem,size=2G")
+
         super().__init__(
             name=name,
             config={
                 "image": image,
                 "ports": [26257],
-                "command": ["start-single-node", "--insecure"],
+                "command": command,
                 "volumes": volumes,
                 "init": True,
                 "healthcheck": {

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -125,6 +125,9 @@ struct Args {
     /// Inject `CREATE INDEX` after all `CREATE TABLE` statements.
     #[clap(long)]
     auto_index_tables: bool,
+    /// Inject `BEGIN` and `COMMIT` to create longer running transactions for faster testing.
+    #[clap(long)]
+    auto_transactions: bool,
     /// Run Materialize with persisted introspection sources enabled.
     #[clap(long)]
     persisted_introspection: bool,
@@ -145,6 +148,7 @@ async fn main() -> ExitCode {
         no_fail: args.no_fail,
         fail_fast: args.fail_fast,
         auto_index_tables: args.auto_index_tables,
+        auto_transactions: args.auto_transactions,
         persisted_introspection: args.persisted_introspection,
     };
 

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -11,7 +11,7 @@ from materialize import ROOT, ci_util
 from materialize.mzcompose import Composition
 from materialize.mzcompose.services import Cockroach, SqlLogicTest
 
-SERVICES = [Cockroach(), SqlLogicTest()]
+SERVICES = [Cockroach(in_memory=True), SqlLogicTest()]
 
 
 def workflow_default(c: Composition) -> None:


### PR DESCRIPTION
Not a real fix for the performance problems, but an attempt to work around them and get the runs to not time out anymore.

I also took a `strace`. Slowest calls contain a lot of `getrandom`: https://gist.github.com/def-/ae565f411824962bb70b11c93d713316 via `std::sys::unix::rand::hashmap_random_keys`.

A bisect showed me the slowdown mostly comes from
```
c5293806585087a81be4c0c0b6f3b0c4dbf4310a is the first bad commit
commit c5293806585087a81be4c0c0b6f3b0c4dbf4310a
Author: Nikhil Benesch <nikhil.benesch@gmail.com>
Date:   Sun Apr 10 17:21:40 2022 -0400

    materialized: stop hosting a local storage/compute instance

    Remove the options to run local storage and compute instances in
    `materialized` directly. Instead, commit to `materialized` being a
    controller that interacts with remote storage and compute instances.
```
Which I guess was kind of expected.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
