### PR TITLE
ci: Ignore 'forced panic' panics

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -42,6 +42,8 @@ ERROR_RE = re.compile(
     | expected\ .*,\ but\ found\ none
     | unsupported\ SQL\ type\ in\ testdrive:
     )
+    # Emitted by tests employing explicit mz_panic()
+    (?!.*forced\ panic)
     # Expected once compute cluster has panicked, brings no new information
     (?!.*timely\ communication\ error:\ reading\ data:)
     # Expected once compute cluster has panicked, only happens in CI


### PR DESCRIPTION
They come from tests that explicitly use mz_panic() and therefore should be ignored and not presented in the Buildkite UI.

### Motivation


  * This PR fixes a previously unreported bug.
The Buildkite UI was displaying expected panics as "new" errors.