### PR TITLE
miri: Add separate initializer for SOFT_ASSERTIONS

### DIFF
--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -51,11 +51,21 @@ use crate::env;
 // The rules about what you can do in a `ctor` function are somewhat fuzzy,
 // because Rust does not explicitly support constructors. But a scan of the
 // stdlib suggests that reading environment variables is safe enough.
+#[cfg(not(miri))]
 #[ctor::ctor]
 pub static SOFT_ASSERTIONS: AtomicBool = {
     let default = cfg!(debug_assertions) || env::is_var_truthy("MZ_SOFT_ASSERTIONS");
     AtomicBool::new(default)
 };
+
+/// Always enable soft assertions when running [Miri].
+/// 
+/// Note: Miri also doesn't seem to support a [`ctor`], if it ever does we could
+/// get rid of this second definition.
+/// 
+/// [Miri]: https://github.com/rust-lang/miri
+#[cfg(miri)]
+pub static SOFT_ASSERTIONS: AtomicBool = AtomicBool::new(true);
 
 /// Asserts that a condition is true if soft assertions are enabled.
 ///

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -59,11 +59,11 @@ pub static SOFT_ASSERTIONS: AtomicBool = {
 };
 
 /// Always enable soft assertions when running [Miri].
-/// 
+///
 /// Note: Miri also doesn't support global constructors, aka [`ctor`], if it ever does we could
-/// get rid of this second definition. See <https://github.com/rust-lang/miri/issues/450> for 
+/// get rid of this second definition. See <https://github.com/rust-lang/miri/issues/450> for
 /// more details.
-/// 
+///
 /// [Miri]: https://github.com/rust-lang/miri
 #[cfg(miri)]
 pub static SOFT_ASSERTIONS: AtomicBool = AtomicBool::new(true);

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -60,8 +60,9 @@ pub static SOFT_ASSERTIONS: AtomicBool = {
 
 /// Always enable soft assertions when running [Miri].
 /// 
-/// Note: Miri also doesn't seem to support a [`ctor`], if it ever does we could
-/// get rid of this second definition.
+/// Note: Miri also doesn't support global constructors, aka [`ctor`], if it ever does we could
+/// get rid of this second definition. See <https://github.com/rust-lang/miri/issues/450> for 
+/// more details.
 /// 
 /// [Miri]: https://github.com/rust-lang/miri
 #[cfg(miri)]

--- a/src/stash/tests/stash.rs
+++ b/src/stash/tests/stash.rs
@@ -925,7 +925,6 @@ async fn test_stash_table(stash: &mut Stash) {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // Broken, see #18122
 fn test_table() {
     fn uniqueness_violation(a: &String, b: &String) -> bool {
         a == b


### PR DESCRIPTION
### Motivation
This PR fixes a recognized bug.
  * Fixes #18122 

Recently we began running [Miri](https://github.com/rust-lang/miri) in CI, which allows us to catch some tricky bugs. Unfortunately Miri doesn't support global constructors (see https://github.com/rust-lang/miri/issues/450) which we use when initializing the global `SOFT_ASSERTIONS` flag. This causes any test that uses soft assertions to fail.

This PR adds a new Miri specific initializer for `SOFT_ASSERTIONS` which is always `true`. A second approach we could take would be to use `once_cell::Lazy` instead of `ctor` to initialize `SOFT_ASSERTIONS`, but AFAIK that would introduce a small performance regression, as it would result in `SOFT_ASSERTIONS` getting initialized on first use, as opposed to when the program is loaded.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
