### PR TITLE
Allow some load generators to be monotonic sources

### DIFF
--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -1737,9 +1737,9 @@ impl SourceDesc<GenericSourceConnection> {
             } => false,
             // Loadgen can produce retractions (deletes)
             SourceDesc {
-                connection: GenericSourceConnection::LoadGenerator(_),
+                connection: GenericSourceConnection::LoadGenerator(g),
                 ..
-            } => false,
+            } => g.load_generator.is_monotonic(),
             // Other sources the `None` envelope are append-only.
             SourceDesc {
                 envelope: SourceEnvelope::None(_),
@@ -2419,6 +2419,18 @@ impl LoadGenerator {
                     ),
                 ]
             }
+        }
+    }
+
+    pub fn is_monotonic(&self) -> bool {
+        match self {
+            LoadGenerator::Auction => true,
+            LoadGenerator::Counter {
+                max_cardinality: None,
+            } => true,
+            LoadGenerator::Counter { .. } => false,
+            LoadGenerator::Datums => true,
+            LoadGenerator::Tpch { .. } => false,
         }
     }
 }

--- a/src/storage/src/source/generator/auction.rs
+++ b/src/storage/src/source/generator/auction.rs
@@ -66,6 +66,9 @@ const ACCOUNTS_OUTPUT: usize = 3;
 const AUCTIONS_OUTPUT: usize = 4;
 const BIDS_OUTPUT: usize = 5;
 
+// Note that this generator never issues retractions; if you change this,
+// `mz_storage_client::types::sources::LoadGenerator::is_monotonic`
+// must be updated.
 impl Generator for Auction {
     fn by_seed(
         &self,

--- a/src/storage/src/source/generator/counter.rs
+++ b/src/storage/src/source/generator/counter.rs
@@ -14,9 +14,11 @@ use mz_repr::{Datum, Row};
 use mz_storage_client::types::sources::{Generator, GeneratorMessageType};
 
 pub struct Counter {
-    /// How many values will be emitted
-    /// before old ones are retracted, or `None` for
-    /// an append-only collection.
+    /// How many values will be emitted before old ones are retracted,
+    /// or `None` for an append-only collection.  (If this retraction
+    /// behavior is changed,
+    /// `mz_storage_client::types::sources::LoadGenerator::is_monotonic`
+    /// must be updated.
     ///
     /// This is verified by the planner to be nonnegative. We encode it as
     /// an `i64` to make the code in `Counter::by_seed` simpler.

--- a/src/storage/src/source/generator/datums.rs
+++ b/src/storage/src/source/generator/datums.rs
@@ -15,6 +15,9 @@ use mz_storage_client::types::sources::{Generator, GeneratorMessageType};
 
 pub struct Datums {}
 
+// Note that this generator never issues retractions; if you change this,
+// `mz_storage_client::types::sources::LoadGenerator::is_monotonic`
+// must be updated.
 impl Generator for Datums {
     fn by_seed(
         &self,


### PR DESCRIPTION
I was hoping to be able to trigger some monotonic plans just from load generators; `Counter` documents that `max_cardinality = None` produces an append-only collection, so my hope was to expose that with this change.  I'm not sure if there would be unexpected consequences from this, so I'd appreciate feedback on that.

~~Also, it looks like `Auction` and `Datum` never issue retractions, either; I don't know if it would be safe or desirable to also mark them as monotone.~~ (I've decided to mark these as monotone, but omit TPC-H for now, despite being append-only in the case where no tick interval is defined, since this seems like enough options for testing, and I don't want to interfere with existing benchmarks we have that use the TPC-H load generator.)  Ideally, load generators would have an option to indicate whether we want them to be append-only or not, but this seems fine for now.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

 * This PR adds a feature that has not yet been specified: It would be convenient for testing to be able to trigger monotonic plans without having to setup an external source.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - I believe this shouldn't change anything a user would be depending on. <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
