### PR TITLE
sqllogictest: Same length timestamps

### DIFF
--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -320,11 +320,12 @@ where
             // We need to prefix every line in `s` with the current timestamp.
 
             let timestamp = Utc::now();
+            let timestamp_str = timestamp.format("%Y-%m-%d %H:%M:%S.%f %Z");
 
             // If the last character we outputted was a newline, then output a
             // timestamp prefix at the start of this line.
             if self.need_timestamp.replace(false) {
-                self.emit_str(&format!("[{}] ", timestamp));
+                self.emit_str(&format!("[{}] ", timestamp_str));
             }
 
             // Emit `s`, installing a timestamp at the start of every line
@@ -333,7 +334,7 @@ where
                 None => (&*s, false),
                 Some(s) => (s, true),
             };
-            self.emit_str(&s.replace('\n', &format!("\n[{}] ", timestamp)));
+            self.emit_str(&s.replace('\n', &format!("\n[{}] ", timestamp_str)));
 
             // If the line ended with a newline, output the newline but *not*
             // the timestamp prefix. We want the timestamp to reflect the moment


### PR DESCRIPTION
when using `--timestamps`. Example from before this change, when the last 3 digits are 0 they were left out:
```
[2023-03-15 14:12:12.386208359 UTC]     CREATE MATERIALIZED VIEW v41 AS SELECT * FROM v40
[2023-03-15 14:12:12.433885108 UTC]     CREATE MATERIALIZED VIEW v42 AS SELECT * FROM v41
[2023-03-15 14:12:12.495630322 UTC]     CREATE MATERIALIZED VIEW v43 AS SELECT * FROM v42
[2023-03-15 14:12:12.550625 UTC]     CREATE MATERIALIZED VIEW v44 AS SELECT * FROM v43
[2023-03-15 14:12:12.600878297 UTC]     CREATE MATERIALIZED VIEW v45 AS SELECT * FROM v44
[2023-03-15 14:12:12.653241707 UTC]     CREATE MATERIALIZED VIEW v46 AS SELECT * FROM v45
[2023-03-15 14:12:12.706028770 UTC]     CREATE MATERIALIZED VIEW v47 AS SELECT * FROM v46
```
Example with this change:
```
[2023-03-15 14:29:42.819929312 UTC]     SELECT a+b*2+c*3+d*4
[2023-03-15 14:29:42.819929312 UTC]       FROM t1
[2023-03-15 14:29:42.819929312 UTC]      WHERE d NOT BETWEEN 110 AND 150
[2023-03-15 14:29:42.819929312 UTC]        AND b>c
[2023-03-15 14:29:42.819929312 UTC]        AND c>d
[2023-03-15 14:29:42.819929312 UTC]      ORDER BY 1
[2023-03-15 14:29:42.821042000 UTC]     SELECT a+b*2+c*3+d*4
[2023-03-15 14:29:42.821042000 UTC]       FROM t1
[2023-03-15 14:29:42.821042000 UTC]      WHERE c>d
[2023-03-15 14:29:42.821042000 UTC]        AND b>c
[2023-03-15 14:29:42.821042000 UTC]        AND d NOT BETWEEN 110 AND 150
[2023-03-15 14:29:42.822140947 UTC]     SELECT a+b*2+c*3+d*4
[2023-03-15 14:29:42.822140947 UTC]       FROM t1
[2023-03-15 14:29:42.822140947 UTC]      WHERE c>d
[2023-03-15 14:29:42.822140947 UTC]        AND b>c
[2023-03-15 14:29:42.822140947 UTC]        AND d NOT BETWEEN 110 AND 150
[2023-03-15 14:29:42.822140947 UTC]      ORDER BY 1
```

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
