### PR TITLE
Replace special-purpose monotonic explode operators with `explode_one`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5049,6 +5049,7 @@ dependencies = [
  "differential-dataflow",
  "futures-util",
  "mz-ore",
+ "num-traits",
  "polonius-the-crab",
  "proptest",
  "serde",

--- a/src/compute-client/src/plan/reduce.rs
+++ b/src/compute-client/src/plan/reduce.rs
@@ -71,7 +71,7 @@ use mz_expr::permutation_for_arrangement;
 use mz_expr::AggregateExpr;
 use mz_expr::AggregateFunc;
 use mz_expr::MirScalarExpr;
-use mz_ore::soft_assert_or_log;
+use mz_ore::{cast::CastFrom, soft_assert_or_log};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 
 use super::AvailableCollections;
@@ -678,10 +678,8 @@ impl ReducePlan {
                     // a balance between how many inputs each layer gets from
                     // the preceding layer, while also limiting the number of
                     // layers.
-                    while current < limit {
-                        // TODO(benesch): fix this dangerous use of `as`.
-                        #[allow(clippy::as_conversions)]
-                        buckets.push(current as u64);
+                    while current < u64::cast_from(limit) {
+                        buckets.push(current);
                         current = current.saturating_mul(16);
                     }
                     // We need to store the bucket numbers in decreasing order.

--- a/src/compute-client/src/plan/reduce.rs
+++ b/src/compute-client/src/plan/reduce.rs
@@ -800,7 +800,13 @@ impl KeyValPlan {
 ///
 /// This function requires that all of the elements in `indexes` are strictly
 /// increasing.
-/// E.g. [3, 6, 10, 15] turns into [3, 3, 4, 5]
+///
+/// # Examples
+///
+/// ```
+/// use mz_compute_client::plan::reduce::convert_indexes_to_skips;
+/// assert_eq!(convert_indexes_to_skips(vec![3, 6, 10, 15]), [3, 2, 3, 4])
+/// ```
 pub fn convert_indexes_to_skips(mut indexes: Vec<usize>) -> Vec<usize> {
     for i in 1..indexes.len() {
         soft_assert_or_log!(

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -16,6 +16,7 @@ mz-ore = { path = "../ore", features = ["tracing_"] }
 polonius-the-crab = "0.3.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread", "time"] }
+num-traits = "0.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]


### PR DESCRIPTION
We separate two ad-hoc operators into a monotonicity check and a call to `explode_one`, per #17606.  There are also two small cleanup commits included that didn't feel large enough to go in their own PRs.  This is closely related to, and modeled on, the work on #17178 and its design doc in #17597.

I'd like to have tests of the error paths but it's not clear how to easily provoke them.  I'm experimenting with this presently, and if I get time, will expand some the associated testdrive tests, but opening this for review now so as to avoid rabbitholing on that.

From a performance POV, it would be nice to demonstrate whether the benefits of `explode_one` outweigh the extra machinery for error handling.  This is also something I'm working on, but don't want to necessarily block this on.

Justification for `num_traits` dependency:
 - we already depend on this crate in other crates;
 - these traits only describe existing aspects of the standard library;
 - Signed feels like the least-specific specialization that allows the monotonicity check to be useful.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug: #17606.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No user-facing behavior changes, at least in the absence of erroneous sources or bugs. <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
