### PR TITLE
persist: placeholder impl of `Schema<SourceData>` for RelationDesc

### DIFF
--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -570,7 +570,6 @@ impl ColumnPush<Vec<u8>> for MutableBinaryArray<i32> {
 
 impl ColumnPush<Option<Vec<u8>>> for MutableBinaryArray<i32> {
     fn push<'a>(&mut self, val: Option<&'a [u8]>) {
-        assert!(self.validity().is_none());
         <MutableBinaryArray<i32>>::push(self, val)
     }
 }

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -113,6 +113,7 @@ pub use crate::relation::{
     ColumnName, ColumnType, NotNullViolation, ProtoColumnName, ProtoColumnType, ProtoRelationDesc,
     ProtoRelationType, RelationDesc, RelationType,
 };
+pub use crate::row::encoding::{RowDecoder, RowEncoder};
 pub use crate::row::{
     datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, ProtoRow, Row,
     RowArena, RowPacker, RowRef,

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -44,7 +44,7 @@ use crate::scalar::arb_datum;
 use crate::scalar::DatumKind;
 use crate::{Datum, Timestamp};
 
-mod encoding;
+pub(crate) mod encoding;
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.row.rs"));
 

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -82,21 +82,52 @@ impl From<&ScalarType> for ColumnFormat {
             ScalarType::Float64 => ColumnFormat::F64,
             ScalarType::Bytes => ColumnFormat::Bytes,
             ScalarType::String => ColumnFormat::String,
-            _ => panic!("TODO: finish implementing all the ScalarType variants"),
+            _ => {
+                #[cfg(feature = "tracing_")]
+                tracing::trace!(
+                    "TODO: finish implementing all the ScalarType variants: {:?}",
+                    value
+                );
+                ColumnFormat::Bytes
+            }
         }
     }
 }
 
+/// A helper for adapting mz's [Datum] to persist's columnar [Data].
 #[derive(Debug)]
-enum DatumEncoder<'a> {
+pub enum DatumEncoder<'a> {
     Bool(&'a mut <bool as Data>::Mut),
     BoolOpt(&'a mut <Option<bool> as Data>::Mut),
+    UInt16(&'a mut <u16 as Data>::Mut),
+    UInt16Opt(&'a mut <Option<u16> as Data>::Mut),
+    UInt32(&'a mut <u32 as Data>::Mut),
+    UInt32Opt(&'a mut <Option<u32> as Data>::Mut),
+    UInt64(&'a mut <u64 as Data>::Mut),
+    UInt64Opt(&'a mut <Option<u64> as Data>::Mut),
+    Int16(&'a mut <i16 as Data>::Mut),
+    Int16Opt(&'a mut <Option<i16> as Data>::Mut),
+    Int32(&'a mut <i32 as Data>::Mut),
+    Int32Opt(&'a mut <Option<i32> as Data>::Mut),
+    Int64(&'a mut <i64 as Data>::Mut),
+    Int64Opt(&'a mut <Option<i64> as Data>::Mut),
+    Float32(&'a mut <f32 as Data>::Mut),
+    Float32Opt(&'a mut <Option<f32> as Data>::Mut),
+    Float64(&'a mut <f64 as Data>::Mut),
+    Float64Opt(&'a mut <Option<f64> as Data>::Mut),
     String(&'a mut <String as Data>::Mut),
     StringOpt(&'a mut <Option<String> as Data>::Mut),
+    Bytes(&'a mut <Vec<u8> as Data>::Mut),
+    BytesOpt(&'a mut <Option<Vec<u8>> as Data>::Mut),
+    Todo(&'a mut <Vec<u8> as Data>::Mut),
 }
 
 impl<'a> DatumEncoder<'a> {
-    fn encode(&mut self, datum: Datum) {
+    /// Encodes and pushes the given Datum into the wrapped persist column.
+    ///
+    /// Panics if the Datum doesn't match the wrapped column type (which is
+    /// derived from the RelationDesc).
+    pub fn encode(&mut self, datum: Datum) {
         match self {
             DatumEncoder::Bool(col) => {
                 let x = match datum {
@@ -115,6 +146,126 @@ impl<'a> DatumEncoder<'a> {
                 };
                 col.push(x)
             }
+            DatumEncoder::UInt16(col) => {
+                let x = match datum {
+                    Datum::UInt16(x) => x,
+                    _ => panic!("Datum cannot be converted into u16: {}", datum),
+                };
+                col.push(x);
+            }
+            DatumEncoder::UInt16Opt(col) => {
+                let x = match datum {
+                    Datum::UInt16(x) => Some(x),
+                    Datum::Null => None,
+                    _ => panic!("Datum cannot be converted into Option<u16>: {}", datum),
+                };
+                col.push(x);
+            }
+            DatumEncoder::UInt32(col) => {
+                let x = match datum {
+                    Datum::UInt32(x) => x,
+                    _ => panic!("Datum cannot be converted into u32: {}", datum),
+                };
+                col.push(x);
+            }
+            DatumEncoder::UInt32Opt(col) => {
+                let x = match datum {
+                    Datum::UInt32(x) => Some(x),
+                    Datum::Null => None,
+                    _ => panic!("Datum cannot be converted into Option<u32>: {}", datum),
+                };
+                col.push(x);
+            }
+            DatumEncoder::UInt64(col) => {
+                let x = match datum {
+                    Datum::UInt64(x) => x,
+                    _ => panic!("Datum cannot be converted into u64: {}", datum),
+                };
+                col.push(x);
+            }
+            DatumEncoder::UInt64Opt(col) => {
+                let x = match datum {
+                    Datum::UInt64(x) => Some(x),
+                    Datum::Null => None,
+                    _ => panic!("Datum cannot be converted into Option<u64>: {}", datum),
+                };
+                col.push(x);
+            }
+            DatumEncoder::Int16(col) => {
+                let x = match datum {
+                    Datum::Int16(x) => x,
+                    _ => panic!("Datum cannot be converted into i16: {}", datum),
+                };
+                col.push(x);
+            }
+            DatumEncoder::Int16Opt(col) => {
+                let x = match datum {
+                    Datum::Int16(x) => Some(x),
+                    Datum::Null => None,
+                    _ => panic!("Datum cannot be converted into Option<i16>: {}", datum),
+                };
+                col.push(x);
+            }
+            DatumEncoder::Int32(col) => {
+                let x = match datum {
+                    Datum::Int32(x) => x,
+                    _ => panic!("Datum cannot be converted into i32: {}", datum),
+                };
+                col.push(x);
+            }
+            DatumEncoder::Int32Opt(col) => {
+                let x = match datum {
+                    Datum::Int32(x) => Some(x),
+                    Datum::Null => None,
+                    _ => panic!("Datum cannot be converted into Option<i32>: {}", datum),
+                };
+                col.push(x);
+            }
+            DatumEncoder::Int64(col) => {
+                let x = match datum {
+                    Datum::Int64(x) => x,
+                    _ => panic!("Datum cannot be converted into i64: {}", datum),
+                };
+                col.push(x);
+            }
+            DatumEncoder::Int64Opt(col) => {
+                let x = match datum {
+                    Datum::Int64(x) => Some(x),
+                    Datum::Null => None,
+                    _ => panic!("Datum cannot be converted into Option<i64>: {}", datum),
+                };
+                col.push(x);
+            }
+            DatumEncoder::Float32(col) => {
+                let x = match datum {
+                    Datum::Float32(x) => x,
+                    _ => panic!("Datum cannot be converted into f32: {}", datum),
+                };
+                col.push(x.into_inner());
+            }
+            DatumEncoder::Float32Opt(col) => {
+                let x = match datum {
+                    Datum::Float32(x) => Some(x),
+                    Datum::Null => None,
+                    _ => panic!("Datum cannot be converted into Option<f32>: {}", datum),
+                };
+                col.push(x.map(|x| x.into_inner()));
+            }
+            DatumEncoder::Float64(col) => {
+                let x = match datum {
+                    Datum::Float64(x) => x,
+                    _ => panic!("Datum cannot be converted into f64: {}", datum),
+                };
+                col.push(x.into_inner());
+            }
+            DatumEncoder::Float64Opt(col) => {
+                let x = match datum {
+                    Datum::Float64(x) => Some(x),
+                    Datum::Null => None,
+                    _ => panic!("Datum cannot be converted into Option<f64>: {}", datum),
+                };
+                col.push(x.map(|x| x.into_inner()));
+            }
             DatumEncoder::String(col) => {
                 let x = match datum {
                     Datum::String(x) => x,
@@ -130,38 +281,115 @@ impl<'a> DatumEncoder<'a> {
                 };
                 ColumnPush::<Option<String>>::push(*col, x);
             }
+            DatumEncoder::Bytes(col) => {
+                let x = match datum {
+                    Datum::Bytes(x) => x,
+                    _ => panic!("Datum cannot be converted into Vec<u8>: {}", datum),
+                };
+                ColumnPush::<Vec<u8>>::push(*col, x);
+            }
+            DatumEncoder::BytesOpt(col) => {
+                let x = match datum {
+                    Datum::Bytes(x) => Some(x),
+                    Datum::Null => None,
+                    _ => panic!("Datum cannot be converted into Option<Vec<u8>>: {}", datum),
+                };
+                ColumnPush::<Option<Vec<u8>>>::push(*col, x);
+            }
+            DatumEncoder::Todo(col) => {
+                let proto = ProtoDatum::from(datum);
+                let buf = proto.encode_to_vec();
+                ColumnPush::<Vec<u8>>::push(*col, &buf);
+            }
         }
     }
 }
 
 /// An implementation of [PartEncoder] for [Row].
 #[derive(Debug)]
-pub struct RowEncoder<'a>(Vec<DatumEncoder<'a>>);
+pub struct RowEncoder<'a> {
+    col_encoders: Vec<DatumEncoder<'a>>,
+}
+
+impl<'a> RowEncoder<'a> {
+    /// Returns the underlying DatumEncoders, one per column in the Row.
+    pub fn col_encoders(&mut self) -> &mut [DatumEncoder<'a>] {
+        &mut self.col_encoders
+    }
+}
 
 impl<'a> PartEncoder<'a, Row> for RowEncoder<'a> {
     fn encode(&mut self, val: &Row) {
-        for (encoder, datum) in self.0.iter_mut().zip(val.iter()) {
+        for (encoder, datum) in self.col_encoders.iter_mut().zip(val.iter()) {
             encoder.encode(datum);
         }
     }
 }
 
+/// A helper for adapting mz's [Datum] to persist's columnar [Data].
 #[derive(Debug)]
-enum DatumDecoder<'a> {
+pub enum DatumDecoder<'a> {
     Bool(&'a <bool as Data>::Col),
     BoolOpt(&'a <Option<bool> as Data>::Col),
+    UInt16(&'a <u16 as Data>::Col),
+    UInt16Opt(&'a <Option<u16> as Data>::Col),
+    UInt32(&'a <u32 as Data>::Col),
+    UInt32Opt(&'a <Option<u32> as Data>::Col),
+    UInt64(&'a <u64 as Data>::Col),
+    UInt64Opt(&'a <Option<u64> as Data>::Col),
+    Int16(&'a <i16 as Data>::Col),
+    Int16Opt(&'a <Option<i16> as Data>::Col),
+    Int32(&'a <i32 as Data>::Col),
+    Int32Opt(&'a <Option<i32> as Data>::Col),
+    Int64(&'a <i64 as Data>::Col),
+    Int64Opt(&'a <Option<i64> as Data>::Col),
+    Float32(&'a <f32 as Data>::Col),
+    Float32Opt(&'a <Option<f32> as Data>::Col),
+    Float64(&'a <f64 as Data>::Col),
+    Float64Opt(&'a <Option<f64> as Data>::Col),
     String(&'a <String as Data>::Col),
     StringOpt(&'a <Option<String> as Data>::Col),
+    Bytes(&'a <Vec<u8> as Data>::Col),
+    BytesOpt(&'a <Option<Vec<u8>> as Data>::Col),
+    Todo(&'a <Vec<u8> as Data>::Col),
 }
 
 impl<'a> DatumDecoder<'a> {
-    fn decode(&self, idx: usize) -> Datum<'a> {
+    /// Decodes the data in the persist column at the specific offset into a
+    /// Datum. This Datum is returned by pushing it in to the given RowPacker.
+    pub fn push(&self, idx: usize, row: &'a mut RowPacker) {
         match self {
-            DatumDecoder::Bool(col) => Datum::from(col.get(idx)),
-            DatumDecoder::BoolOpt(col) => Datum::from(col.get(idx)),
-            DatumDecoder::String(col) => Datum::from(ColumnGet::<String>::get(*col, idx)),
+            DatumDecoder::Bool(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::BoolOpt(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::UInt16(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::UInt16Opt(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::UInt32(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::UInt32Opt(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::UInt64(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::UInt64Opt(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::Int16(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::Int16Opt(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::Int32(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::Int32Opt(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::Int64(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::Int64Opt(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::Float32(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::Float32Opt(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::Float64(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::Float64Opt(col) => row.push(Datum::from(col.get(idx))),
+            DatumDecoder::String(col) => row.push(Datum::from(ColumnGet::<String>::get(*col, idx))),
             DatumDecoder::StringOpt(col) => {
-                Datum::from(ColumnGet::<Option<String>>::get(*col, idx))
+                row.push(Datum::from(ColumnGet::<Option<String>>::get(*col, idx)))
+            }
+            DatumDecoder::Bytes(col) => row.push(Datum::from(ColumnGet::<Vec<u8>>::get(*col, idx))),
+            DatumDecoder::BytesOpt(col) => {
+                row.push(Datum::from(ColumnGet::<Option<Vec<u8>>>::get(*col, idx)))
+            }
+            DatumDecoder::Todo(col) => {
+                let buf = ColumnGet::<Vec<u8>>::get(*col, idx);
+                let proto = ProtoDatum::decode(buf).expect("col should be valid ProtoDatum");
+                row.try_push_proto(&proto)
+                    .expect("ProtoDatum should be valid");
             }
         }
     }
@@ -169,13 +397,22 @@ impl<'a> DatumDecoder<'a> {
 
 /// An implementation of [PartDecoder] for [Row].
 #[derive(Debug)]
-pub struct RowDecoder<'a>(Vec<DatumDecoder<'a>>);
+pub struct RowDecoder<'a> {
+    col_decoders: Vec<DatumDecoder<'a>>,
+}
+
+impl<'a> RowDecoder<'a> {
+    /// Returns the underlying DatumDecoders, one per column in the Row.
+    pub fn col_decoders(&self) -> &[DatumDecoder<'a>] {
+        &self.col_decoders
+    }
+}
 
 impl<'a> PartDecoder<'a, Row> for RowDecoder<'a> {
     fn decode(&self, idx: usize, val: &mut Row) {
         let mut packer = val.packer();
-        for decoder in self.0.iter() {
-            packer.push(decoder.decode(idx));
+        for decoder in self.col_decoders.iter() {
+            decoder.push(idx, &mut packer);
         }
     }
 }
@@ -197,57 +434,209 @@ impl Schema<Row> for RelationDesc {
     }
 
     fn decoder<'a>(&self, mut part: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
-        let mut decoders = Vec::new();
+        let mut col_decoders = Vec::new();
         for (name, typ) in self.iter() {
             match (typ.nullable, &typ.scalar_type) {
                 (false, ScalarType::Bool) => {
-                    decoders.push(DatumDecoder::Bool(part.col::<bool>(name.as_str())?));
+                    col_decoders.push(DatumDecoder::Bool(part.col::<bool>(name.as_str())?));
                 }
                 (true, ScalarType::Bool) => {
-                    decoders.push(DatumDecoder::BoolOpt(
+                    col_decoders.push(DatumDecoder::BoolOpt(
                         part.col::<Option<bool>>(name.as_str())?,
                     ));
                 }
+                (false, ScalarType::UInt16) => {
+                    col_decoders.push(DatumDecoder::UInt16(part.col::<u16>(name.as_str())?));
+                }
+                (true, ScalarType::UInt16) => {
+                    col_decoders.push(DatumDecoder::UInt16Opt(
+                        part.col::<Option<u16>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::UInt32) => {
+                    col_decoders.push(DatumDecoder::UInt32(part.col::<u32>(name.as_str())?));
+                }
+                (true, ScalarType::UInt32) => {
+                    col_decoders.push(DatumDecoder::UInt32Opt(
+                        part.col::<Option<u32>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::UInt64) => {
+                    col_decoders.push(DatumDecoder::UInt64(part.col::<u64>(name.as_str())?));
+                }
+                (true, ScalarType::UInt64) => {
+                    col_decoders.push(DatumDecoder::UInt64Opt(
+                        part.col::<Option<u64>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::Int16) => {
+                    col_decoders.push(DatumDecoder::Int16(part.col::<i16>(name.as_str())?));
+                }
+                (true, ScalarType::Int16) => {
+                    col_decoders.push(DatumDecoder::Int16Opt(
+                        part.col::<Option<i16>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::Int32) => {
+                    col_decoders.push(DatumDecoder::Int32(part.col::<i32>(name.as_str())?));
+                }
+                (true, ScalarType::Int32) => {
+                    col_decoders.push(DatumDecoder::Int32Opt(
+                        part.col::<Option<i32>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::Int64) => {
+                    col_decoders.push(DatumDecoder::Int64(part.col::<i64>(name.as_str())?));
+                }
+                (true, ScalarType::Int64) => {
+                    col_decoders.push(DatumDecoder::Int64Opt(
+                        part.col::<Option<i64>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::Float32) => {
+                    col_decoders.push(DatumDecoder::Float32(part.col::<f32>(name.as_str())?));
+                }
+                (true, ScalarType::Float32) => {
+                    col_decoders.push(DatumDecoder::Float32Opt(
+                        part.col::<Option<f32>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::Float64) => {
+                    col_decoders.push(DatumDecoder::Float64(part.col::<f64>(name.as_str())?));
+                }
+                (true, ScalarType::Float64) => {
+                    col_decoders.push(DatumDecoder::Float64Opt(
+                        part.col::<Option<f64>>(name.as_str())?,
+                    ));
+                }
                 (false, ScalarType::String) => {
-                    decoders.push(DatumDecoder::String(part.col::<String>(name.as_str())?));
+                    col_decoders.push(DatumDecoder::String(part.col::<String>(name.as_str())?));
                 }
                 (true, ScalarType::String) => {
-                    decoders.push(DatumDecoder::StringOpt(
+                    col_decoders.push(DatumDecoder::StringOpt(
                         part.col::<Option<String>>(name.as_str())?,
                     ));
                 }
-                _ => panic!("TODO: finish implementing all the Datum variants"),
+                (false, ScalarType::Bytes) => {
+                    col_decoders.push(DatumDecoder::Bytes(part.col::<Vec<u8>>(name.as_str())?));
+                }
+                (true, ScalarType::Bytes) => {
+                    col_decoders.push(DatumDecoder::BytesOpt(
+                        part.col::<Option<Vec<u8>>>(name.as_str())?,
+                    ));
+                }
+                _ => {
+                    #[cfg(feature = "tracing_")]
+                    tracing::trace!("TODO: finish implementing all the Datum variants");
+                    col_decoders.push(DatumDecoder::Todo(part.col::<Vec<u8>>(name.as_str())?));
+                }
             };
         }
         let () = part.finish()?;
-        Ok(RowDecoder(decoders))
+        Ok(RowDecoder { col_decoders })
     }
 
     fn encoder<'a>(&self, mut part: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
-        let mut encoders = Vec::new();
+        let mut col_encoders = Vec::new();
         for (name, typ) in self.iter() {
             match (typ.nullable, &typ.scalar_type) {
                 (false, ScalarType::Bool) => {
-                    encoders.push(DatumEncoder::Bool(part.col::<bool>(name.as_str())?));
+                    col_encoders.push(DatumEncoder::Bool(part.col::<bool>(name.as_str())?));
                 }
                 (true, ScalarType::Bool) => {
-                    encoders.push(DatumEncoder::BoolOpt(
+                    col_encoders.push(DatumEncoder::BoolOpt(
                         part.col::<Option<bool>>(name.as_str())?,
                     ));
                 }
+                (false, ScalarType::UInt16) => {
+                    col_encoders.push(DatumEncoder::UInt16(part.col::<u16>(name.as_str())?));
+                }
+                (true, ScalarType::UInt16) => {
+                    col_encoders.push(DatumEncoder::UInt16Opt(
+                        part.col::<Option<u16>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::UInt32) => {
+                    col_encoders.push(DatumEncoder::UInt32(part.col::<u32>(name.as_str())?));
+                }
+                (true, ScalarType::UInt32) => {
+                    col_encoders.push(DatumEncoder::UInt32Opt(
+                        part.col::<Option<u32>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::UInt64) => {
+                    col_encoders.push(DatumEncoder::UInt64(part.col::<u64>(name.as_str())?));
+                }
+                (true, ScalarType::UInt64) => {
+                    col_encoders.push(DatumEncoder::UInt64Opt(
+                        part.col::<Option<u64>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::Int16) => {
+                    col_encoders.push(DatumEncoder::Int16(part.col::<i16>(name.as_str())?));
+                }
+                (true, ScalarType::Int16) => {
+                    col_encoders.push(DatumEncoder::Int16Opt(
+                        part.col::<Option<i16>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::Int32) => {
+                    col_encoders.push(DatumEncoder::Int32(part.col::<i32>(name.as_str())?));
+                }
+                (true, ScalarType::Int32) => {
+                    col_encoders.push(DatumEncoder::Int32Opt(
+                        part.col::<Option<i32>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::Int64) => {
+                    col_encoders.push(DatumEncoder::Int64(part.col::<i64>(name.as_str())?));
+                }
+                (true, ScalarType::Int64) => {
+                    col_encoders.push(DatumEncoder::Int64Opt(
+                        part.col::<Option<i64>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::Float32) => {
+                    col_encoders.push(DatumEncoder::Float32(part.col::<f32>(name.as_str())?));
+                }
+                (true, ScalarType::Float32) => {
+                    col_encoders.push(DatumEncoder::Float32Opt(
+                        part.col::<Option<f32>>(name.as_str())?,
+                    ));
+                }
+                (false, ScalarType::Float64) => {
+                    col_encoders.push(DatumEncoder::Float64(part.col::<f64>(name.as_str())?));
+                }
+                (true, ScalarType::Float64) => {
+                    col_encoders.push(DatumEncoder::Float64Opt(
+                        part.col::<Option<f64>>(name.as_str())?,
+                    ));
+                }
                 (false, ScalarType::String) => {
-                    encoders.push(DatumEncoder::String(part.col::<String>(name.as_str())?));
+                    col_encoders.push(DatumEncoder::String(part.col::<String>(name.as_str())?));
                 }
                 (true, ScalarType::String) => {
-                    encoders.push(DatumEncoder::StringOpt(
+                    col_encoders.push(DatumEncoder::StringOpt(
                         part.col::<Option<String>>(name.as_str())?,
                     ));
                 }
-                _ => panic!("TODO: finish implementing all the Datum variants"),
+                (false, ScalarType::Bytes) => {
+                    col_encoders.push(DatumEncoder::Bytes(part.col::<Vec<u8>>(name.as_str())?));
+                }
+                (true, ScalarType::Bytes) => {
+                    col_encoders.push(DatumEncoder::BytesOpt(
+                        part.col::<Option<Vec<u8>>>(name.as_str())?,
+                    ));
+                }
+                _ => {
+                    #[cfg(feature = "tracing_")]
+                    tracing::trace!("TODO: finish implementing all the Datum variants");
+                    col_encoders.push(DatumEncoder::Todo(part.col::<Vec<u8>>(name.as_str())?));
+                }
             }
         }
         let () = part.finish()?;
-        Ok(RowEncoder(encoders))
+        Ok(RowEncoder { col_encoders })
     }
 }
 


### PR DESCRIPTION
This implements Schema for SourceData by flatmap-ing the Ok Row's columns and the Err. This has the unfortunate effect of requiring us to make all Row columns nullable (even if they aren't in the RelationDesc) so we have something to store if the Err column is set. (Luckily, we can still check it at decode time.)

Better would be something like pushing the union structure of Result down to parquet, but that's much harder and left for followup work (if we do it at all).

Touches #12684

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Note that the decoders are still totally unused, even when the feature flag is on. I figured I may as well impl them, but I can pull that out if we think it's too confusing.

Also there's clearly a _ton_ of boilerplate here. I don't think it's fundamental, but nothing jumped out at me as obviously better.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
