### PR TITLE
adapter: Always clone catalogstate

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1294,7 +1294,7 @@ pub struct ConnCatalog<'a> {
     pub(crate) database: Option<DatabaseId>,
     pub(crate) search_path: Vec<(ResolvedDatabaseSpecifier, SchemaSpecifier)>,
     pub(crate) role_id: RoleId,
-    pub(crate) prepared_statements: Option<Cow<'a, BTreeMap<String, PreparedStatement>>>,
+    pub(crate) prepared_statements: Option<&'a BTreeMap<String, PreparedStatement>>,
 }
 
 impl ConnCatalog<'_> {
@@ -3580,7 +3580,7 @@ impl Catalog {
             database,
             search_path,
             role_id: session.role_id().clone(),
-            prepared_statements: Some(Cow::Borrowed(session.prepared_statements())),
+            prepared_statements: Some(session.prepared_statements()),
         }
     }
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1303,7 +1303,7 @@ impl ConnCatalog<'_> {
     }
 
     pub fn state(&self) -> &CatalogState {
-        &self.state
+        self.state
     }
 
     /// Returns the schemas:
@@ -3574,7 +3574,7 @@ impl Catalog {
             .map(|schema| (schema.name().database.clone(), schema.id().clone()))
             .collect();
         ConnCatalog {
-            state: &state,
+            state,
             conn_id: session.conn_id(),
             cluster: session.vars().cluster().into(),
             database,

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -510,7 +510,9 @@ impl CatalogState {
         // Existing catalog items might have been created while a
         // specific feature flag turned on, so we need to ensure that this is also the
         // case during catalog rehydration in order to avoid panics.
-        state.system_configuration.set_enable_with_mutually_recursive(true);
+        state
+            .system_configuration
+            .set_enable_with_mutually_recursive(true);
         let session_catalog = ConnCatalog {
             state: &state,
             conn_id: SYSTEM_CONN_ID,
@@ -5544,7 +5546,9 @@ impl Catalog {
         // Existing catalog items might have been created while a
         // specific feature flag turned on, so we need to ensure that this is also the
         // case during catalog rehydration in order to avoid panics.
-        state.system_configuration.set_enable_with_mutually_recursive(true);
+        state
+            .system_configuration
+            .set_enable_with_mutually_recursive(true);
         session_catalog.state = &state;
 
         let stmt = mz_sql::parse::parse(&create_sql)?.into_element();

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -10,7 +10,6 @@
 //! Logic for  processing client [`Command`]s. Each [`Command`] is initiated by a
 //! client via some external Materialize API (ex: HTTP and psql).
 
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -482,10 +481,8 @@ impl Coordinator {
                     let database = catalog.database;
                     let search_path = catalog.search_path;
                     let role_id = catalog.role_id;
-                    let prepared_statements = catalog
-                        .prepared_statements
-                        .clone()
-                        .map(|s| Cow::Owned(s.into_owned()));
+
+                    let raw_prepared_statements = catalog.prepared_statements.map(|s| s.clone());
 
                     async move {
                         let catalog = ConnCatalog {
@@ -495,7 +492,7 @@ impl Coordinator {
                             database,
                             search_path,
                             role_id,
-                            prepared_statements,
+                            prepared_statements: raw_prepared_statements.as_ref(),
                         };
                         let purify_fut = mz_sql::pure::purify_create_source(
                             &catalog,

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -481,8 +481,7 @@ impl Coordinator {
                     let database = catalog.database;
                     let search_path = catalog.search_path;
                     let role_id = catalog.role_id;
-
-                    let raw_prepared_statements = catalog.prepared_statements.map(|s| s.clone());
+                    let prepared_statements = catalog.prepared_statements.cloned();
 
                     async move {
                         let catalog = ConnCatalog {
@@ -492,7 +491,7 @@ impl Coordinator {
                             database,
                             search_path,
                             role_id,
-                            prepared_statements: raw_prepared_statements.as_ref(),
+                            prepared_statements: prepared_statements.as_ref(),
                         };
                         let purify_fut = mz_sql::pure::purify_create_source(
                             &catalog,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -216,14 +216,6 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
 
     /// Returns system vars
     fn system_vars(&self) -> &SystemVars;
-
-    /// Returns mutable system vars
-    ///
-    /// Clients should use this this method carefully, as changes to the backing
-    /// state here are not guarateed to be persisted. The motivating use case
-    /// for this method was ensuring that features are temporary turned on so
-    /// catalog rehydration does not break due to unsupported SQL syntax.
-    fn system_vars_mut(&mut self) -> &mut SystemVars;
 }
 
 /// Configuration associated with a catalog.

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -93,7 +93,7 @@ fn subsource_gen<'a, T>(
 /// See the section on [purification](crate#purification) in the crate
 /// documentation for details.
 pub async fn purify_create_source(
-    catalog: Box<dyn SessionCatalog>,
+    catalog: &dyn SessionCatalog,
     now: u64,
     mut stmt: CreateSourceStatement<Aug>,
     connection_context: ConnectionContext,
@@ -186,7 +186,7 @@ pub async fn purify_create_source(
                 },
             ..
         }) => {
-            let scx = StatementContext::new(None, &*catalog);
+            let scx = StatementContext::new(None, catalog);
             let mut connection = {
                 let item = scx.get_item_by_resolved_name(connection)?;
                 // Get Kafka connection
@@ -254,7 +254,7 @@ pub async fn purify_create_source(
             // TODO: verify valid json and valid schema
         }
         CreateSourceConnection::S3 { connection, .. } => {
-            let scx = StatementContext::new(None, &*catalog);
+            let scx = StatementContext::new(None, catalog);
             let aws = {
                 let item = scx.get_item_by_resolved_name(connection)?;
                 match item.connection()? {
@@ -270,7 +270,7 @@ pub async fn purify_create_source(
             .await?;
         }
         CreateSourceConnection::Kinesis { connection, .. } => {
-            let scx = StatementContext::new(None, &*catalog);
+            let scx = StatementContext::new(None, catalog);
             let aws = {
                 let item = scx.get_item_by_resolved_name(connection)?;
                 match item.connection()? {
@@ -289,7 +289,7 @@ pub async fn purify_create_source(
             connection,
             options,
         } => {
-            let scx = StatementContext::new(None, &*catalog);
+            let scx = StatementContext::new(None, catalog);
             let connection = {
                 let item = scx.get_item_by_resolved_name(connection)?;
                 match item.connection()? {
@@ -537,7 +537,7 @@ pub async fn purify_create_source(
             })
         }
         CreateSourceConnection::LoadGenerator { generator, options } => {
-            let scx = StatementContext::new(None, &*catalog);
+            let scx = StatementContext::new(None, catalog);
 
             let (_load_generator, available_subsources) =
                 load_generator_ast_to_generator(generator, options)?;
@@ -641,7 +641,7 @@ pub async fn purify_create_source(
     // Create the targeted AST node for the original CREATE SOURCE statement
     let transient_id = GlobalId::Transient(subsource_id_counter);
 
-    let scx = StatementContext::new(None, &*catalog);
+    let scx = StatementContext::new(None, catalog);
 
     // Take name from input or generate name
     let (name, subsource) = match progress_subsource {
@@ -691,7 +691,7 @@ pub async fn purify_create_source(
     };
     subsources.push((transient_id, subsource));
 
-    purify_source_format(&*catalog, format, connection, envelope, &connection_context).await?;
+    purify_source_format(catalog, format, connection, envelope, &connection_context).await?;
 
     Ok((subsources, stmt))
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Fixes #18006. In practice today we're using the Owned version of Cow<CatalogState> anytime we do CatalogState::{parse_item, parse_view_item} because we want to set enable_with_mutually_recursive to true (by default it's false). I assume these functions are pretty common so always cloning CatalogState won't be a big change. I tried using some interior mutability for CatalogState (like RefCell<CatalogState> so that we could swap out a dummy/changed catalogstate without requiring a mut CatalogState) but since we use references to Catalog in futures, that requires the interior mutable things to be sync, which basically forces Arc<Mutex<CatalogState>> which seems like overkill

### Motivation

Cow behavior was confusing

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
