### PR TITLE
adapter: move some send diffs work off coord thread

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -497,7 +497,7 @@ impl ExecuteResponse {
             Explain | Peek | SendRows | ShowAllVariables | ShowVariable => {
                 vec![CopyTo, SendingRows]
             }
-            Execute | ReadThenWrite | SendDiffs => vec![Deleted, Inserted, SendingRows, Updated],
+            Execute | ReadThenWrite => vec![Deleted, Inserted, SendingRows, Updated],
             PlanKind::Fetch => vec![ExecuteResponseKind::Fetch],
             Insert => vec![Inserted, SendingRows],
             PlanKind::Prepare => vec![ExecuteResponseKind::Prepare],

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -68,7 +68,6 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::net::Ipv4Addr;
-use std::num::NonZeroUsize;
 use std::ops::Neg;
 use std::sync::Arc;
 use std::thread;
@@ -101,12 +100,12 @@ use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{stack, task};
 use mz_persist_client::usage::{ShardsUsage, StorageUsageClient};
 use mz_repr::explain::ExplainFormat;
-use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
+use mz_repr::{Datum, GlobalId, Row, Timestamp};
 use mz_secrets::SecretsController;
 use mz_sql::ast::{CreateSourceStatement, CreateSubsourceStatement, Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
 use mz_sql::names::Aug;
-use mz_sql::plan::{CopyFormat, MutationKind, Params, QueryWhen};
+use mz_sql::plan::{CopyFormat, Params, QueryWhen};
 use mz_storage_client::controller::{
     CollectionDescription, CreateExportToken, DataSource, StorageError,
 };
@@ -181,7 +180,6 @@ pub enum Message<T = mz_repr::Timestamp> {
     ControllerReady,
     CreateSourceStatementReady(CreateSourceStatementReady),
     SinkConnectionReady(SinkConnectionReady),
-    SendDiffs(SendDiffs),
     WriteLockGrant(tokio::sync::OwnedMutexGuard<()>),
     /// Initiates a group commit.
     GroupCommitInitiate,
@@ -207,18 +205,6 @@ pub enum Message<T = mz_repr::Timestamp> {
         transient_revision: u64,
         real_time_recency_ts: Timestamp,
     },
-}
-
-#[derive(Derivative)]
-#[derivative(Debug)]
-pub struct SendDiffs {
-    session: Session,
-    #[derivative(Debug = "ignore")]
-    tx: ClientTransmitter<ExecuteResponse>,
-    pub id: GlobalId,
-    pub diffs: Result<Vec<(Row, Diff)>, AdapterError>,
-    pub kind: MutationKind,
-    pub returning: Vec<(Row, NonZeroUsize)>,
 }
 
 #[derive(Derivative)]

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -85,7 +85,7 @@ use crate::coord::peek::FastPathPlan;
 use crate::coord::timeline::TimelineContext;
 use crate::coord::timestamp_selection::TimestampContext;
 use crate::coord::{
-    peek, Coordinator, Message, PendingReadTxn, PendingTxn, RealTimeRecencyContext, SendDiffs,
+    peek, Coordinator, Message, PendingReadTxn, PendingTxn, RealTimeRecencyContext,
     SinkConnectionReady, DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
 };
 use crate::error::AdapterError;
@@ -322,9 +322,6 @@ impl Coordinator {
             }
             Plan::Explain(plan) => {
                 self.sequence_explain(tx, session, plan);
-            }
-            Plan::SendDiffs(plan) => {
-                tx.send(self.sequence_send_diffs(&mut session, plan), session);
             }
             Plan::Insert(plan) => {
                 self.sequence_insert(tx, session, plan).await;
@@ -3160,7 +3157,6 @@ impl Coordinator {
 
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn sequence_send_diffs(
-        &mut self,
         session: &mut Session,
         mut plan: SendDiffsPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
@@ -3216,10 +3212,7 @@ impl Coordinator {
                 offset: 0,
                 project: (0..plan.returning[0].0.iter().count()).collect(),
             };
-            return match finishing.finish(
-                plan.returning,
-                self.catalog.system_config().max_result_size(),
-            ) {
+            return match finishing.finish(plan.returning, plan.max_result_size) {
                 Ok(rows) => Ok(send_immediate_rows(rows)),
                 Err(e) => Err(AdapterError::ResultSize(e)),
             };
@@ -3337,8 +3330,9 @@ impl Coordinator {
                     updates: rows,
                     kind: MutationKind::Insert,
                     returning: Vec::new(),
+                    max_result_size: self.catalog.system_config().max_result_size(),
                 };
-                self.sequence_send_diffs(session, diffs_plan)
+                Self::sequence_send_diffs(session, diffs_plan)
             }
             None => panic!(
                 "tried using sequence_insert_constant on non-constant MirRelationExpr {:?}",
@@ -3461,6 +3455,7 @@ impl Coordinator {
 
         let internal_cmd_tx = self.internal_cmd_tx.clone();
         let strict_serializable_reads_tx = self.strict_serializable_reads_tx.clone();
+        let max_result_size = self.catalog.system_config().max_result_size();
         task::spawn(|| format!("sequence_read_then_write:{id}"), async move {
             let (peek_response, mut session) = match peek_rx.await {
                 Ok(Response {
@@ -3646,17 +3641,25 @@ impl Coordinator {
                 }
             }
 
-            // It is not an error for these results to be ready after `internal_cmd_rx` has been dropped.
-            let result = internal_cmd_tx.send(Message::SendDiffs(SendDiffs {
-                session,
-                tx,
-                id,
-                diffs,
-                kind,
-                returning: returning_rows,
-            }));
-            if let Err(e) = result {
-                warn!("internal_cmd_rx dropped before we could send: {:?}", e);
+            match diffs {
+                Ok(diffs) => {
+                    tx.send(
+                        Self::sequence_send_diffs(
+                            &mut session,
+                            SendDiffsPlan {
+                                id,
+                                updates: diffs,
+                                kind,
+                                returning: returning_rows,
+                                max_result_size,
+                            },
+                        ),
+                        session,
+                    );
+                }
+                Err(e) => {
+                    tx.send(Err(e), session);
+                }
             }
         });
     }
@@ -4016,7 +4019,6 @@ impl Coordinator {
             | Plan::DropClusters(_)
             | Plan::DropClusterReplicas(_)
             | Plan::DropItems(_)
-            | Plan::SendDiffs(_)
             | Plan::Insert(_)
             | Plan::AlterNoop(_)
             | Plan::AlterIndexSetOptions(_)

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -220,7 +220,6 @@ fn generate_plan_attribute(plan: &Plan) -> Option<Attribute> {
         | Plan::SendRows(_)
         | Plan::CopyFrom(_)
         | Plan::Explain(_)
-        | Plan::SendDiffs(_)
         | Plan::Insert(_)
         | Plan::AlterNoop(_)
         | Plan::AlterIndexSetOptions(_)

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -121,7 +121,6 @@ pub enum Plan {
     SendRows(SendRowsPlan),
     CopyFrom(CopyFromPlan),
     Explain(ExplainPlan),
-    SendDiffs(SendDiffsPlan),
     Insert(InsertPlan),
     AlterNoop(AlterNoopPlan),
     AlterIndexSetOptions(AlterIndexSetOptionsPlan),
@@ -172,12 +171,7 @@ impl Plan {
             StatementKind::AlterSystemSet => vec![PlanKind::AlterNoop, PlanKind::AlterSystemSet],
             StatementKind::Close => vec![PlanKind::Close],
             StatementKind::Commit => vec![PlanKind::CommitTransaction],
-            StatementKind::Copy => vec![
-                PlanKind::CopyFrom,
-                PlanKind::Peek,
-                PlanKind::SendDiffs,
-                PlanKind::Subscribe,
-            ],
+            StatementKind::Copy => vec![PlanKind::CopyFrom, PlanKind::Peek, PlanKind::Subscribe],
             StatementKind::CreateCluster => vec![PlanKind::CreateCluster],
             StatementKind::CreateClusterReplica => vec![PlanKind::CreateClusterReplica],
             StatementKind::CreateConnection => vec![PlanKind::CreateConnection],
@@ -279,11 +273,6 @@ impl Plan {
             Plan::SendRows(_) => "send rows",
             Plan::CopyFrom(_) => "copy from",
             Plan::Explain(_) => "explain",
-            Plan::SendDiffs(plan) => match plan.kind {
-                MutationKind::Insert => "insert",
-                MutationKind::Update => "update",
-                MutationKind::Delete => "delete",
-            },
             Plan::Insert(_) => "insert",
             Plan::AlterNoop(plan) => match plan.object_type {
                 ObjectType::Table => "alter table",
@@ -610,6 +599,7 @@ pub struct SendDiffsPlan {
     pub updates: Vec<(Row, Diff)>,
     pub kind: MutationKind,
     pub returning: Vec<(Row, NonZeroUsize)>,
+    pub max_result_size: u32,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The only reason we needed the coordinator struct to send diff results to a session after a read-then-write was to get the max result size. Do that early, then send the diffs immediately instead of through the coordinator.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a