### PR TITLE
sql: Fix min(int16)

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2489,7 +2489,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         },
         "min" => Aggregate {
             params!(Bool) => AggregateFunc::MinBool => Bool, oid::FUNC_MIN_BOOL_OID;
-            params!(Int16) => AggregateFunc::MinInt32 => Int16, 2133;
+            params!(Int16) => AggregateFunc::MinInt16 => Int16, 2133;
             params!(Int32) => AggregateFunc::MinInt32 => Int32, 2132;
             params!(Int64) => AggregateFunc::MinInt64 => Int64, 2131;
             params!(UInt16) => AggregateFunc::MinUInt16 => UInt16, oid::FUNC_MIN_UINT16_OID;

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -606,3 +606,14 @@ query TI
 SELECT a.*, ROW_NUMBER() OVER() from (SELECT TRUE::text as x FROM(SELECT AVG(0) FROM qs)) a
 ----
 true 1
+
+statement ok
+CREATE TABLE t_16 (i16 smallint)
+
+statement ok
+INSERT INTO t_16 VALUES (0), (-1), (1)
+
+query TT
+SELECT MIN(i16), MAX(i16) from t_16
+----
+-1 1

--- a/test/sqllogictest/pg_catalog_class.slt
+++ b/test/sqllogictest/pg_catalog_class.slt
@@ -60,3 +60,8 @@ SELECT relname FROM pg_catalog.pg_class WHERE relname IN ('a', 'foo', 'bar', 'pg
 bar
 foo
 pg_class
+
+query TT
+SELECT min(relchecks), max(relchecks) FROM pg_catalog.pg_class
+----
+0 0


### PR DESCRIPTION
Fixes #17978.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
