### PR TITLE
Updating docs to mention `hint` could be present

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -573,7 +573,7 @@ Field         | Type                          | Meaning
 `source_id`   | [`text`]                      | The ID of the source. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources).
 `status`      | [`text`]                      | The status of the source: one of `created`, `starting`, `running`, `stalled`, `failed`, or `dropped`.
 `error`       | [`text`]                      | If the source is in an error state, the error message.
-`details`     | [`jsonb`]                     | Additional metadata provided by the source.
+`details`     | [`jsonb`]                     | Additional metadata provided by the source. In case of error, may contain a `hint` field with helpful suggestions.
 
 ### `mz_sink_statuses`
 
@@ -603,7 +603,7 @@ Field         | Type                          | Meaning
 `sink_id`     | [`text`]                      | The ID of the sink. Corresponds to [`mz_catalog.mz_sinks.id`](../mz_catalog#mz_sinks).
 `status`      | [`text`]                      | The status of the sink: one of `created`, `starting`, `running`, `stalled`, `failed`, or `dropped`.
 `error`       | [`text`]                      | If the sink is in an error state, the error message.
-`details`     | [`jsonb`]                     | Additional metadata provided by the sink.
+`details`     | [`jsonb`]                     | Additional metadata provided by the sink. In case of error, may contain a `hint` field with helpful suggestions.
 
 
 [`bigint`]: /sql/types/bigint

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -609,6 +609,7 @@ Field         | Type                          | Meaning
 [`bigint`]: /sql/types/bigint
 [`bigint list`]: /sql/types/list
 [`boolean`]: /sql/types/boolean
+[`jsonb`]: /sql/types/jsonb
 [`mz_timestamp`]: /sql/types/mz_timestamp
 [`numeric`]: /sql/types/numeric
 [`text`]: /sql/types/text

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -559,7 +559,7 @@ Field                   | Type                          | Meaning
 `last_status_change_at` | [`timestamp with time zone`]  | Wall-clock timestamp of the source status change.
 `status`                | [`text`]                      | The status of the source: one of `created`, `starting`, `running`, `stalled`, `failed`, or `dropped`.
 `error`                 | [`text`]                      | If the source is in an error state, the error message.
-`details`               | [`jsonb`]                     | Additional metadata provided by the source.
+`details`               | [`jsonb`]                     | Additional metadata provided by the source. In case of error, may contain a `hint` field with helpful suggestions.
 
 ### `mz_source_status_history`
 
@@ -589,7 +589,7 @@ Field                   | Type                          | Meaning
 `last_status_change_at` | [`timestamp with time zone`]  | Wall-clock timestamp of the sink status change.
 `status`                | [`text`]                      | The status of the sink: one of `created`, `starting`, `running`, `stalled`, `failed`, or `dropped`.
 `error`                 | [`text`]                      | If the sink is in an error state, the error message.
-`details`               | [`jsonb`]                     | Additional metadata provided by the sink.
+`details`               | [`jsonb`]                     | Additional metadata provided by the sink. In case of error, may contain a `hint` field with helpful suggestions.
 
 ### `mz_sink_status_history`
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Updating the docs to mention that `hint` could be populated in certain error scenarios. 
(Currently it's only populated for one scenario though https://github.com/MaterializeInc/materialize/pull/18009)

### Motivation
A follow up from https://github.com/MaterializeInc/materialize/pull/18009#discussion_r1136001186

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer
Happy to update the wording!

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
