### PR TITLE
persist: wire up `next_least_batch` retry params to be configurable

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -46,7 +46,7 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{to_datetime, EpochMillis, NowFn};
 use mz_ore::soft_assert;
-use mz_persist_client::cfg::PersistParameters;
+use mz_persist_client::cfg::{PersistParameters, RetryParameters};
 use mz_pgrepr::oid::FIRST_USER_OID;
 use mz_repr::{explain::ExprHumanizer, Diff, GlobalId, RelationDesc, ScalarType};
 use mz_secrets::InMemorySecretsController;
@@ -6011,6 +6011,11 @@ impl Catalog {
             compaction_minimum_timeout: Some(config.persist_compaction_minimum_timeout()),
             consensus_connect_timeout: Some(config.crdb_connect_timeout()),
             sink_minimum_batch_updates: Some(config.persist_sink_minimum_batch_updates()),
+            next_listen_batch_retryer: Some(RetryParameters {
+                initial_backoff: config.persist_next_listen_batch_retryer_initial_backoff(),
+                multiplier: config.persist_next_listen_batch_retryer_multiplier(),
+                clamp: config.persist_next_listen_batch_retryer_clamp(),
+            }),
         }
     }
 }

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -18,4 +18,11 @@ message ProtoPersistParameters {
     mz_proto.ProtoDuration compaction_minimum_timeout = 2;
     mz_proto.ProtoDuration consensus_connect_timeout = 3;
     optional uint64 sink_minimum_batch_updates = 4;
+    optional ProtoRetryParameters next_listen_batch_retryer = 5;
+}
+
+message ProtoRetryParameters {
+    mz_proto.ProtoDuration initial_backoff = 1;
+    uint32 multiplier = 2;
+    mz_proto.ProtoDuration clamp = 3;
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

After doing some digging, something like 80% of our CRDB reads are coming from our `Listen::next` / `ReadHandle::next_listen_batch` poll loop, which in turn consumes 30-40% of our CRDB CPU time in prod. The current backoff structure is very aggressive, given that we expect sources to progress at ~1 batch per second, meaning we could fruitlessly query CRDB up to 8 times per second per active listen.

Without anything more elaborate than tweaking this retry policy, my hunch is that we can shave off a very meaningful amount of CRDB traffic / cost without impacting the snappiness of subscribes to sources. Depending on what policy we use, listens over tables could see a drop in median response time to new inputs, but I think we can improve the worst case.

This PR makes the knobs for `next_listen_batch` dynamically configurable so we can dial in the listen latency vs CRDB traffic ratio we want. I've been playing with it locally, and not gonna lie, it's pretty cool. Note that there are more sophisticated ways to approach traffic reduction to CRDB, but they all involve significantly more work, so this is starting with the simplest approach to see how far we can get.

cc @benesch this might be of interest

### Motivation

  * This PR adds a feature that has not yet been specified.
 
Related to https://materializeinc.slack.com/archives/C04NJBBS42D/p1678466262813289

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
