### PR TITLE
SQLsmith: Ignore new errors that happen when more functions are used

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -35,10 +35,17 @@ SERVICES = [
 known_errors = [
     "no connection to the server",  # Expected AFTER a crash, the query before this is interesting, not the ones after
     "failed: Connection refused",  # Expected AFTER a crash, the query before this is interesting, not the ones after
+    "function pg_catalog.array_remove(",
+    "function pg_catalog.array_cat(",
+    "function mz_catalog.list_append(",
+    "function mz_catalog.list_prepend(",
+    "does not support implicitly casting from",
+    "aggregate functions that refer exclusively to outer columns not yet supported",  # https://github.com/MaterializeInc/materialize/issues/3720
+    "range lower bound must be less than or equal to range upper bound",
     "violates not-null constraint",
     "division by zero",
     "operator does not exist",  # For list types
-    "function sin is only defined for finite arguments",
+    "is only defined for finite arguments",
     "more than one record produced in subquery",
     "invalid range bound flags",
     "invalid input syntax for type jsonb",


### PR DESCRIPTION
Following https://github.com/def-/sqlsmith/commit/147ce5314997899e33aaba0725edb07ba61a65da, more functions are now enabled and thus more errors are occurring.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
