### PR TITLE
testdrive: enrich errors with unprocessed rows

### DIFF
--- a/test/storage-usage/mzcompose.py
+++ b/test/storage-usage/mzcompose.py
@@ -244,11 +244,14 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         c.testdrive(
             dedent(
                 f"""
-                > SELECT size_bytes BETWEEN {database_object.expected_size} AND {database_object.expected_size*2}
+                $ set-regex match=\d+ replacement=<SIZE>
+
+                # Select the raw size as well, so if this errors in testdrive, its easier to debug.
+                > SELECT size_bytes, size_bytes BETWEEN {database_object.expected_size} AND {database_object.expected_size*2}
                   FROM mz_storage_usage
                   WHERE collection_timestamp = ( SELECT MAX(collection_timestamp) FROM mz_storage_usage )
                   AND object_id = ( SELECT id FROM mz_objects WHERE name = 'obj' );
-                true
+                <SIZE> true
                 """
             )
         )


### PR DESCRIPTION
The storage usage test is flaky, but I can't repro it. Next time it comes up, I want to see the actual value that is not in the `BETWEEN` clause. This pr adjusts testdrive to print the raw, non-regex-replaced rows from an output when the non-matching rows error is thrown. It comes with a little bit more cloning, but felt easier than letting users run sql statements on error to add additional information.

The pr also enriches the offending flaky test to help debug it in the future. When there are regex replacements, the error now looks like:
```
5:1: error: non-matching rows: expected:
[["<SIZE>", "true"]]
got:
[["<SIZE>", "false"]]
got raw rows:
[Some(["1532", "false"])]
Poor diff:
+ <SIZE> false
- <SIZE> true
```

### Motivation

  * This PR adds a feature that has not yet been specified.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
