### PR TITLE
sql: disallow null in range flag of create_range

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -5928,8 +5928,16 @@ fn create_range<'a>(
     datums: &[Datum<'a>],
     temp_storage: &'a RowArena,
 ) -> Result<Datum<'a>, EvalError> {
-    let (lower_inclusive, upper_inclusive) =
-        range::parse_range_bound_flags(datums[2].unwrap_str())?;
+    let flags = match datums[2] {
+        Datum::Null => {
+            return Err(EvalError::InvalidRange(
+                range::InvalidRangeError::NullRangeBoundFlags,
+            ));
+        }
+        o => o.unwrap_str(),
+    };
+
+    let (lower_inclusive, upper_inclusive) = range::parse_range_bound_flags(flags)?;
 
     let mut range = Range::new(Some((
         RangeBound::new(datums[0], lower_inclusive),

--- a/src/repr/src/adt/range.proto
+++ b/src/repr/src/adt/range.proto
@@ -20,5 +20,6 @@ message ProtoInvalidRangeError {
         google.protobuf.Empty invalid_range_bound_flags = 3;
         google.protobuf.Empty discontiguous_union = 4;
         google.protobuf.Empty discontiguous_difference = 5;
+        google.protobuf.Empty null_range_bound_flags = 6;
     }
 }

--- a/src/repr/src/adt/range.rs
+++ b/src/repr/src/adt/range.rs
@@ -750,6 +750,7 @@ pub enum InvalidRangeError {
     InvalidRangeBoundFlags,
     DiscontiguousUnion,
     DiscontiguousDifference,
+    NullRangeBoundFlags,
 }
 
 impl Display for InvalidRangeError {
@@ -767,6 +768,9 @@ impl Display for InvalidRangeError {
             }
             InvalidRangeError::DiscontiguousDifference => {
                 f.write_str("result of range difference would not be contiguous")
+            }
+            InvalidRangeError::NullRangeBoundFlags => {
+                f.write_str("range constructor flags argument must not be null")
             }
         }
     }
@@ -795,6 +799,7 @@ impl RustType<ProtoInvalidRangeError> for InvalidRangeError {
             InvalidRangeError::InvalidRangeBoundFlags => InvalidRangeBoundFlags(()),
             InvalidRangeError::DiscontiguousUnion => DiscontiguousUnion(()),
             InvalidRangeError::DiscontiguousDifference => DiscontiguousDifference(()),
+            InvalidRangeError::NullRangeBoundFlags => NullRangeBoundFlags(()),
         };
         ProtoInvalidRangeError { kind: Some(kind) }
     }
@@ -808,6 +813,7 @@ impl RustType<ProtoInvalidRangeError> for InvalidRangeError {
                 InvalidRangeBoundFlags(()) => InvalidRangeError::InvalidRangeBoundFlags,
                 DiscontiguousUnion(()) => InvalidRangeError::DiscontiguousUnion,
                 DiscontiguousDifference(()) => InvalidRangeError::DiscontiguousDifference,
+                NullRangeBoundFlags(()) => InvalidRangeError::NullRangeBoundFlags,
             }),
             None => Err(TryFromProtoError::missing_field(
                 "`ProtoInvalidRangeError::kind`",

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -536,6 +536,12 @@ SELECT a AS t FROM int4range_values EXCEPT SELECT column1 FROM (VALUES
 ----
 NULL
 
+query error range constructor flags argument must not be null
+SELECT int4range(1,2,null);
+
+query error range constructor flags argument must not be null
+SELECT int4range(null,null,null);
+
 #
 # int4range upper, lower
 query TT
@@ -1703,6 +1709,12 @@ SELECT a AS t FROM int8range_values EXCEPT SELECT column1 FROM (VALUES
 ----
 NULL
 
+query error range constructor flags argument must not be null
+SELECT int8range(1,2,null);
+
+query error range constructor flags argument must not be null
+SELECT int8range(null,null,null);
+
 #
 # int8range upper, lower
 query TT
@@ -2836,6 +2848,12 @@ SELECT a AS t FROM daterange_values EXCEPT SELECT column1 FROM (VALUES
 ----
 NULL
 
+query error range constructor flags argument must not be null
+SELECT daterange('1970-01-01','1970-01-01',null);
+
+query error range constructor flags argument must not be null
+SELECT daterange(null,null,null);
+
 
 # Test range in list
 query T
@@ -3919,6 +3937,12 @@ SELECT a AS t FROM numrange_values EXCEPT SELECT column1 FROM (VALUES
 ) t;
 ----
 NULL
+
+query error range constructor flags argument must not be null
+SELECT numrange(1,2,null);
+
+query error range constructor flags argument must not be null
+SELECT numrange(null,null,null);
 
 #
 # numrange upper, lower
@@ -5652,6 +5676,13 @@ SELECT a AS t FROM tsrange_values EXCEPT SELECT column1 FROM (VALUES
 ----
 NULL
 
+query error range constructor flags argument must not be null
+SELECT tsrange('1970-01-01 00:00:01','1970-01-01 00:00:01',null);
+
+query error range constructor flags argument must not be null
+SELECT tsrange(null,null,null);
+
+
 #
 # tsrange upper, lower
 query TT
@@ -7371,6 +7402,12 @@ SELECT a AS t FROM tstzrange_values EXCEPT SELECT column1 FROM (VALUES
 ) t;
 ----
 NULL
+
+query error range constructor flags argument must not be null
+SELECT tstzrange('1970-01-01 00:00:01','1970-01-01 00:00:01',null);
+
+query error range constructor flags argument must not be null
+SELECT tstzrange(null,null,null);
 
 #
 # tstzrange upper, lower


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug. fixes #18036

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
