### PR TITLE
doc/user: polish v0.46 release notes

### DIFF
--- a/doc/user/content/releases/v0.45.md
+++ b/doc/user/content/releases/v0.45.md
@@ -63,7 +63,7 @@ now specify the cluster to connect to in the `psql` connection string:
 
 * Remove the `CREATE USER` command, as well as the `LOGIN` and `SUPERUSER`
   attributes from the [`CREATE ROLE`](/sql/create-role/) command. This is part
-  of the work to enable **Role-Based Access Control** (RBAC) in a future release
+  of the work to enable **Role-based access control** (RBAC) in a future release
   {{% gh 11579 %}}.
 
 #### Bug fixes and other improvements

--- a/doc/user/content/releases/v0.45.md
+++ b/doc/user/content/releases/v0.45.md
@@ -58,7 +58,6 @@ now specify the cluster to connect to in the `psql` connection string:
   | Function                                        | Description                                                             |
   | ----------------------------------------------- | ----------------------------------------------------------------------- |
   | [`ceiling`](/sql/functions/#numbers-func)       | Works as an alias of the `ceil` function.                               |
-  | [`uuid_generate_v5`](/sql/functions/#uuid-func) | Generates a UUID in the given namespace using the specified input name. |
 
 <br>
 

--- a/doc/user/content/releases/v0.46.md
+++ b/doc/user/content/releases/v0.46.md
@@ -1,13 +1,46 @@
 ---
 title: "Materialize v0.46"
 date: 2023-03-15
-released: false
+released: true
+patch: 1
 ---
-
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
 
 ## v0.46.0
 
-* No documented changes yet.
+#### SQL
+
+* Add [`mz_internal.mz_subscriptions`](/sql/system-catalog/mz_internal/#mz_subscriptions)
+  to the system catalog. This table describes all active `SUBSCRIBE` operations
+  in the system.
+
+* Add support for new SQL functions:
+
+  | Function                                        | Description                                                             |
+  | ----------------------------------------------- | ----------------------------------------------------------------------- |
+  | [`uuid_generate_v5`](/sql/functions/#uuid-func) | Generates a UUID in the given namespace using the specified input name. |
+
+* Add the `is_superuser` configuration parameter, which reports whether the
+  current session is a _superuser_ with admin privileges. This is part of the
+  work to enable **Role-Based Access Control** (RBAC) in a future release {{% gh
+  11579 %}}.
+
+* Add the [`ALTER ROLE`](/sql/alter-role) command, as well as role attributes to
+  the [`CREATE ROLE`](/sql/create-role/) command. This is part of the work to
+  enable **Role-Based Access Control** (RBAC){{% gh 11579 %}}.
+
+  It's important to note that no role attributes or privileges will be
+  considered when executing `CREATE ROLE` statements. These attributes will be
+  saved and considered in a future release.
+
+#### Bug fixes and other improvements
+
+* Fix a bug that would cause the `mz_sources` and `mz_sinks` system tables to
+  report the wrong size for a source after an `ALTER {SOURCE|SINK} ... SET
+  (SIZE = ...)` command.
+
+## Patch releases
+
+### v0.46.1
+
+* Stabilizate resource utilization in the [`mz_introspection`](/sql/show-clusters/#mz_introspection-system-cluster)
+  system cluster.

--- a/doc/user/content/releases/v0.46.md
+++ b/doc/user/content/releases/v0.46.md
@@ -21,12 +21,12 @@ patch: 1
 
 * Add the `is_superuser` configuration parameter, which reports whether the
   current session is a _superuser_ with admin privileges. This is part of the
-  work to enable **Role-Based Access Control** (RBAC) in a future release {{% gh
+  work to enable **Role-based access control** (RBAC) in a future release {{% gh
   11579 %}}.
 
 * Add the [`ALTER ROLE`](/sql/alter-role) command, as well as role attributes to
   the [`CREATE ROLE`](/sql/create-role/) command. This is part of the work to
-  enable **Role-Based Access Control** (RBAC){{% gh 11579 %}}.
+  enable **Role-based access control** (RBAC){{% gh 11579 %}}.
 
   It's important to note that no role attributes or privileges will be
   considered when executing `CREATE ROLE` statements. These attributes will be

--- a/doc/user/content/releases/v0.47.md
+++ b/doc/user/content/releases/v0.47.md
@@ -1,0 +1,13 @@
+---
+title: "Materialize v0.47"
+date: 2023-03-22
+released: false
+---
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}
+
+## v0.47.0
+
+* No documented changes yet.

--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -9,15 +9,10 @@ menu:
 `ALTER ROLE` alters the attributes of an existing role.
 
 {{< warning >}}
-Roles in Materialize are currently limited in functionality. In the future they
-will be used for role-based access control. See GitHub issue {{% gh 677 %}}
-for details.
-{{< /warning >}}
-
-{{< warning >}}
-RBAC is under development: currently no role attributes or privileges will be
-considered when executing statements, although these attributes are saved and
-will be considered in a later release.
+Role-Based Access Control is under development {{% gh 11579 %}}. Currently, no
+role attributes or privileges are considered when executing `CREATE ROLE`
+statements, but these attributes are saved and will be considered in a future
+release.
 {{< /warning >}}
 
 ## Syntax
@@ -26,6 +21,7 @@ will be considered in a later release.
 
 Field               | Use
 --------------------|-------------------------------------------------------------------------
+_role_name_         | A name for the role.
 **INHERIT**         | Grants the role the ability to inheritance of privileges of other roles.
 **CREATEROLE**      | Grants the role the ability to create, alter, and delete roles.
 **NOCREATEROLE**    | Denies the role the ability to create, alter, and delete roles.
@@ -33,7 +29,6 @@ Field               | Use
 **NOCREATEDB**      | Denies the role the ability to create databases.
 **CREATECLUSTER**   | Grants the role the ability to create clusters.
 **NOCREATECLUSTER** | Denies the role the ability to create clusters.
-_role_name_         | A name for the role.
 
 ## Details
 

--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -9,10 +9,10 @@ menu:
 `ALTER ROLE` alters the attributes of an existing role.
 
 {{< warning >}}
-Role-Based Access Control is under development {{% gh 11579 %}}. Currently, no
-role attributes or privileges are considered when executing `CREATE ROLE`
-statements, but these attributes are saved and will be considered in a future
-release.
+Role-based access control (RBAC) is under development {{% gh 11579 %}}.
+Currently, no role attributes or privileges are considered when executing
+`CREATE ROLE` statements, but these attributes are saved and will be considered
+in a future release.
 {{< /warning >}}
 
 ## Syntax

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -6,14 +6,10 @@ menu:
     parent: commands
 ---
 
-`CREATE ROLE` creates a new role.
+`CREATE ROLE` creates a new role, which is a user account in Materialize.
 
-## Conceptual framework
-
-A role is a user account in a Materialize instance.
-
-When you [connect to a Materialize instance](/integrations/psql), you must specify
-the name of a valid role in the system.
+When you connect to Materialize, you must specify the name of a valid role in
+the system.
 
 {{< warning >}}
 Role-Based Access Control is under development {{% gh 11579 %}}. Currently, no
@@ -28,6 +24,7 @@ release.
 
 Field               | Use
 --------------------|-------------------------------------------------------------------------
+_role_name_         | A name for the role.
 **INHERIT**         | Grants the role the ability to inheritance of privileges of other roles.
 **CREATEROLE**      | Grants the role the ability to create, alter, and delete roles.
 **NOCREATEROLE**    | Denies the role the ability to create, alter, and delete roles.
@@ -35,7 +32,6 @@ Field               | Use
 **NOCREATEDB**      | Denies the role the ability to create databases.
 **CREATECLUSTER**   | Grants the role the ability to create clusters.
 **NOCREATECLUSTER** | Denies the role the ability to create clusters.
-_role_name_         | A name for the role.
 
 ## Details
 

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -12,10 +12,10 @@ When you connect to Materialize, you must specify the name of a valid role in
 the system.
 
 {{< warning >}}
-Role-Based Access Control is under development {{% gh 11579 %}}. Currently, no
-role attributes or privileges are considered when executing `CREATE ROLE`
-statements, but these attributes are saved and will be considered in a future
-release.
+Role-based access control (RBAC) is under development {{% gh 11579 %}}.
+Currently, no role attributes or privileges are considered when executing
+`CREATE ROLE` statements, but these attributes are saved and will be considered
+in a future release.
 {{< /warning >}}
 
 ## Syntax

--- a/doc/user/layouts/shortcodes/session-variables.html
+++ b/doc/user/layouts/shortcodes/session-variables.html
@@ -23,7 +23,7 @@ failpoints                                  |                           | Allows
 idle_in_transaction_session_timeout         | `120 seconds`             | The maximum allowed duration that a session can sit idle in a transaction before being terminated. If this value is specified without units, it is taken as milliseconds. A value of zero disables the timeout.
 integer_datetimes                           | `true`                    | **Read-only.** Reports whether the server uses 64-bit-integer dates and times.
 intervalstyle                               | `postgres`                | The display format for interval values. The only supported value is `postgres`.
-is_superuser                                |                           | **Read-only.** Reports whether the current session is a superuser.
+is_superuser                                |                           | **Read-only.** Reports whether the current session is a _superuser_ with admin privileges.
 mz_version                                  | Version-dependent         | **Read-only.** Shows the Materialize server version.
 server_version                              | Version-dependent         | **Read-only.** The PostgreSQL compatible server version.
 server_version_num                          | Version-dependent         | **Read-only.** The PostgreSQL compatible server version as an integer.


### PR DESCRIPTION
Release notes for v0.46.

## Tips for reviewer

* Outside the changes that improve resource utilization in `mz_introspection` (also on the cloud side/Web UI), I couldn't piece together the storage improvement commits in #18128.

* The change in #18026 partially voids the warning in the [`mz_internal` documentation page](https://materialize.com/docs/sql/system-catalog/mz_internal/). Keeping the warning as is because this is only valid for temporary objects, which seem mostly useful for internal debugging.