### PR TITLE
storage: drop log level of offset commit failures

### DIFF
--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -314,6 +314,7 @@ where
         let data_cap = capabilities.pop().unwrap();
 
         let mut source_metrics = SourceReaderMetrics::new(&base_metrics, id);
+        let offset_commit_metrics = source_metrics.offset_commit_metrics();
 
         let source_upper = Antichain::from_iter(source_resume_upper.iter().map(R::Time::decode_row));
         info!(
@@ -375,7 +376,7 @@ where
                     frontier.pretty()
                 );
                 if let Err(e) = offset_committer.commit_offsets(frontier.clone()).await {
-                    // TODO(guswynn): stats for this error
+                    offset_commit_metrics.offset_commit_failures.inc();
                     tracing::warn!(
                         %e,
                         "timely-{worker_id} source({id}) failed to commit offsets: resume_upper={}",

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -376,7 +376,7 @@ where
                 );
                 if let Err(e) = offset_committer.commit_offsets(frontier.clone()).await {
                     // TODO(guswynn): stats for this error
-                    tracing::error!(
+                    tracing::warn!(
                         %e,
                         "timely-{worker_id} source({id}) failed to commit offsets: resume_upper={}",
                         frontier.pretty()

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -571,8 +571,7 @@ impl SourceReaderPartitionMetrics {
 /// Metrics about committing offsets
 pub struct OffsetCommitMetrics {
     /// The offset-domain resume_upper for a source.
-    //TODO(petrosagg): produce these metrics
-    pub(crate) _offset_commit_failures: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) offset_commit_failures: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
 }
 
 impl OffsetCommitMetrics {
@@ -580,7 +579,7 @@ impl OffsetCommitMetrics {
     pub fn new(base_metrics: &SourceBaseMetrics, source_id: GlobalId) -> OffsetCommitMetrics {
         let base = &base_metrics.source_specific;
         OffsetCommitMetrics {
-            _offset_commit_failures: base
+            offset_commit_failures: base
                 .offset_commit_failures
                 .get_delete_on_drop_counter(vec![source_id.to_string()]),
         }


### PR DESCRIPTION
### Motivation
This had already been done before in https://github.com/MaterializeInc/materialize/commit/29fd216508aff6524c2184ecd4a01f101e3411e6 but was lost accidentally during a rebase of a big refactor of mine in
https://github.com/MaterializeInc/materialize/commit/c91e381fbd0c9f83cb2d7ec99c7f2d1d91d8a8fb.

Fixes https://github.com/MaterializeInc/materialize/issues/17763

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
