### PR TITLE
compute,adapter: remove dedicated sink `as_of`

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -930,14 +930,10 @@ impl Coordinator {
                         .insert(entry.id());
 
                     // Re-create the sink on the compute instance.
-                    let id_bundle = self
-                        .index_oracle(mview.cluster_id)
-                        .sufficient_collections(&mview.depends_on);
-                    let as_of = self.least_valid_read(&id_bundle);
                     let internal_view_id = self.allocate_transient_id()?;
                     let df = self
                         .dataflow_builder(mview.cluster_id)
-                        .build_materialized_view_dataflow(entry.id(), as_of, internal_view_id)?;
+                        .build_materialized_view_dataflow(entry.id(), internal_view_id)?;
                     self.must_ship_dataflow(df, mview.cluster_id).await;
                 }
                 CatalogItem::Sink(sink) => {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -23,7 +23,7 @@ use mz_cloud_resources::VpcEndpointConfig;
 use mz_compute_client::controller::ComputeReplicaConfig;
 use mz_compute_client::types::dataflows::{BuildDesc, DataflowDesc, IndexDesc};
 use mz_compute_client::types::sinks::{
-    ComputeSinkConnection, ComputeSinkDesc, SinkAsOf, SubscribeSinkConnection,
+    ComputeSinkConnection, ComputeSinkDesc, SubscribeSinkConnection,
 };
 use mz_controller::clusters::{
     ClusterConfig, ClusterId, ReplicaAllocation, ReplicaConfig, ReplicaId, ReplicaLogging,
@@ -1265,12 +1265,12 @@ impl Coordinator {
                 // it to storage.
                 let df = txn
                     .dataflow_builder(cluster_id)
-                    .build_materialized_view_dataflow(id, as_of.clone(), internal_view_id)?;
+                    .build_materialized_view_dataflow(id, internal_view_id)?;
                 Ok(df)
             })
             .await
         {
-            Ok(df) => {
+            Ok(mut df) => {
                 // Announce the creation of the materialized view source.
                 self.controller
                     .storage
@@ -1279,7 +1279,7 @@ impl Coordinator {
                         CollectionDescription {
                             desc,
                             data_source: DataSource::Other,
-                            since: Some(as_of),
+                            since: Some(as_of.clone()),
                             status_collection_id: None,
                         },
                     )])
@@ -1292,6 +1292,7 @@ impl Coordinator {
                 )
                 .await;
 
+                df.set_as_of(as_of);
                 self.must_ship_dataflow(df, cluster_id).await;
 
                 Ok(ExecuteResponse::CreatedMaterializedView)
@@ -2227,49 +2228,41 @@ impl Coordinator {
             session.add_transaction_ops(TransactionOps::Subscribe)?;
         }
 
-        let make_sink_desc = |coord: &mut Coordinator,
-                              session: &mut Session,
-                              from,
-                              from_desc,
-                              uses| {
-            // Determine the frontier of updates to subscribe *from*.
-            // Updates greater or equal to this frontier will be produced.
-            let id_bundle = coord.index_oracle(cluster_id).sufficient_collections(uses);
-            let timeline = coord.validate_timeline_context(id_bundle.iter())?;
-            // If a timestamp was explicitly requested, use that.
-            let frontier = coord
-                .determine_timestamp(session, &id_bundle, &when, cluster_id, timeline, None)?
-                .timestamp_context;
-            let frontier_ts = frontier.timestamp_or_default();
+        // Determine the frontier of updates to subscribe *from*.
+        // Updates greater or equal to this frontier will be produced.
+        let uses = match from {
+            SubscribeFrom::Id(id) => vec![id],
+            SubscribeFrom::Query { .. } => depends_on,
+        };
+        let id_bundle = self.index_oracle(cluster_id).sufficient_collections(&uses);
+        let timeline = self.validate_timeline_context(id_bundle.iter())?;
+        let as_of = self
+            .determine_timestamp(session, &id_bundle, &when, cluster_id, timeline, None)?
+            .timestamp_context
+            .timestamp_or_default();
 
+        let make_sink_desc = |coord: &mut Coordinator, session: &mut Session, from, from_desc| {
             let up_to = up_to
                 .map(|expr| coord.evaluate_when(expr, session))
                 .transpose()?;
             if let Some(up_to) = up_to {
-                if frontier_ts == up_to {
+                if as_of == up_to {
                     session.add_notice(AdapterNotice::EqualSubscribeBounds { bound: up_to });
-                } else if frontier_ts > up_to {
-                    return Err(AdapterError::AbsurdSubscribeBounds {
-                        as_of: frontier_ts,
-                        up_to,
-                    });
+                } else if as_of > up_to {
+                    return Err(AdapterError::AbsurdSubscribeBounds { as_of, up_to });
                 }
             }
-            let frontier = frontier.antichain();
             let up_to = up_to.map(Antichain::from_elem).unwrap_or_default();
             Ok::<_, AdapterError>(ComputeSinkDesc {
                 from,
                 from_desc,
                 connection: ComputeSinkConnection::Subscribe(SubscribeSinkConnection::default()),
-                as_of: SinkAsOf {
-                    frontier,
-                    strict: !with_snapshot,
-                },
+                with_snapshot,
                 up_to,
             })
         };
 
-        let dataflow = match from {
+        let mut dataflow = match from {
             SubscribeFrom::Id(from_id) => {
                 check_no_invalid_log_reads(
                     &self.catalog,
@@ -2287,7 +2280,7 @@ impl Coordinator {
                     .expect("subscribes can only be run on items with descs")
                     .into_owned();
                 let sink_id = self.allocate_transient_id()?;
-                let sink_desc = make_sink_desc(self, session, from_id, from_desc, &[from_id][..])?;
+                let sink_desc = make_sink_desc(self, session, from_id, from_desc)?;
                 let sink_name = format!("subscribe-{}", sink_id);
                 self.dataflow_builder(cluster_id)
                     .build_sink_dataflow(sink_name, sink_id, sink_desc)?
@@ -2302,7 +2295,7 @@ impl Coordinator {
                 let id = self.allocate_transient_id()?;
                 let expr = self.view_optimizer.optimize(expr)?;
                 let desc = RelationDesc::new(expr.typ(), desc.iter_names());
-                let sink_desc = make_sink_desc(self, session, id, desc, &depends_on)?;
+                let sink_desc = make_sink_desc(self, session, id, desc)?;
                 let mut dataflow = DataflowDesc::new(format!("subscribe-{}", id));
                 let mut dataflow_builder = self.dataflow_builder(cluster_id);
                 dataflow_builder.import_view_into_dataflow(&id, &expr, &mut dataflow)?;
@@ -2310,6 +2303,8 @@ impl Coordinator {
                 dataflow
             }
         };
+
+        dataflow.set_as_of(Antichain::from_elem(as_of));
 
         let (&sink_id, sink_desc) = dataflow
             .sink_exports
@@ -2324,7 +2319,7 @@ impl Coordinator {
             emit_progress,
             arity: sink_desc.from_desc.arity(),
             cluster_id,
-            depends_on: depends_on.into_iter().collect(),
+            depends_on: uses.into_iter().collect(),
             start_time: SYSTEM_TIME(),
             dropping: false,
         };

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -657,7 +657,7 @@ where
                     from: se.from,
                     from_desc: se.from_desc,
                     connection,
-                    as_of: se.as_of,
+                    with_snapshot: se.with_snapshot,
                     up_to: se.up_to,
                 };
                 sink_exports.insert(id, desc);

--- a/src/compute-client/src/types/sinks.proto
+++ b/src/compute-client/src/types/sinks.proto
@@ -21,7 +21,7 @@ message ProtoComputeSinkDesc {
     mz_repr.global_id.ProtoGlobalId from = 1;
     mz_repr.relation_and_scalar.ProtoRelationDesc from_desc = 2;
     ProtoComputeSinkConnection connection = 3;
-    ProtoSinkAsOf as_of = 4;
+    bool with_snapshot = 4;
     mz_repr.antichain.ProtoU64Antichain up_to = 5;
 }
 
@@ -30,11 +30,6 @@ message ProtoComputeSinkConnection {
         google.protobuf.Empty subscribe = 1;
         ProtoPersistSinkConnection persist = 2;
     }
-}
-
-message ProtoSinkAsOf {
-    mz_repr.antichain.ProtoU64Antichain frontier = 1;
-    bool strict = 2;
 }
 
 message ProtoPersistSinkConnection {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -743,10 +743,17 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
 
                 match reported_frontier {
                     ReportedFrontier::Reported(old_frontier) => {
-                        assert!(PartialOrder::less_than(old_frontier, &new_frontier))
+                        assert!(
+                            PartialOrder::less_than(old_frontier, &new_frontier),
+                            "new frontier {new_frontier:?} is not beyond \
+                             old frontier {old_frontier:?}"
+                        );
                     }
                     ReportedFrontier::NotReported { lower } => {
-                        assert!(PartialOrder::less_equal(lower, &new_frontier))
+                        assert!(
+                            PartialOrder::less_equal(lower, &new_frontier),
+                            "new frontier {new_frontier:?} is before lower bound {lower:?}"
+                        );
                     }
                 }
 

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -78,10 +78,10 @@ where
     pub debug_name: String,
     /// The Timely ID of the dataflow associated with this context.
     pub dataflow_id: usize,
-    /// Indicates a frontier that can be used to compact input timestamps
-    /// without affecting the results. We *should* apply it, to sources and
-    /// imported traces, both because it improves performance, and because
-    /// potentially incorrect results are visible in sinks.
+    /// Frontier before which updates should not be emitted.
+    ///
+    /// We *must* apply it to sinks, to ensure correct outputs.
+    /// We *should* apply it to sources and imported traces, because it improves performance.
     pub as_of_frontier: Antichain<T>,
     /// Frontier after which updates should not be emitted.
     /// Used to limit the amount of work done when appropriate.

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -15,6 +15,7 @@ use std::rc::Rc;
 
 use differential_dataflow::Collection;
 use timely::dataflow::{scopes::Child, Scope};
+use timely::progress::Antichain;
 
 use mz_compute_client::types::sinks::{ComputeSinkConnection, ComputeSinkDesc};
 use mz_expr::{permutation_for_arrangement, MapFilterProject};
@@ -84,6 +85,7 @@ where
                     compute_state,
                     sink,
                     sink_id,
+                    self.as_of_frontier.clone(),
                     ok_collection.enter_region(inner),
                     err_collection.enter_region(inner),
                     probes,
@@ -117,6 +119,7 @@ where
         compute_state: &mut crate::compute_state::ComputeState,
         sink: &ComputeSinkDesc<CollectionMetadata>,
         sink_id: GlobalId,
+        as_of: Antichain<mz_repr::Timestamp>,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
         probes: Vec<probe::Handle<mz_repr::Timestamp>>,

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -53,6 +53,7 @@ where
         compute_state: &mut ComputeState,
         sink: &ComputeSinkDesc<CollectionMetadata>,
         sink_id: GlobalId,
+        as_of: Antichain<Timestamp>,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
         probes: Vec<probe::Handle<Timestamp>>,
@@ -71,7 +72,7 @@ where
             sink_id,
             &self.storage_metadata,
             desired_collection,
-            sink.as_of.frontier.clone(),
+            as_of,
             compute_state,
             probes,
         )


### PR DESCRIPTION
This PR removes the dedicated `as_of` frontier that is part of compute sink descriptions (it does not touch storage sinks). Our code sometimes makes the assumption that the sink `as_of` is greater than or equal to the dataflow `as_of` but does not thoroughly check that assumption. The assumption is sometimes violated, which caused at least one known bug (#18042) and perhaps a few unknown ones as well. The approach taken here is to remove the sink `as_of` and rely on the dataflow `as_of` in its stead, thereby also removing the need to worry about the stated assumption.

The advantage of this approach is that we don't need to introduce logic for checking and maintaining the above invariance.

The (AFAICT only) drawback of this approach is that it might make it harder to support dataflows that export multiple sinks in the future. If we want to do that at some point, and if we then need the feature that different sinks can have different `as_of`s, we will need to re-introduce the per-sink `as_of` again.

### Motivation

  * This PR fixes a recognized bug.

Fixes #18042.

### Tips for reviewer

There is a bit of a Chesterton's fence situation here in that I don't know with certainty why the per-sink `as_of` was originally introduced. Maybe it was to prepare for a future where we support multi-sink dataflows, or perhaps the storage sinks require dedicated `as_of`s.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
