### PR TITLE
platform checks: Reduce the number of clusters involved

### DIFF
--- a/misc/python/materialize/checks/kafka_formats.py
+++ b/misc/python/materialize/checks/kafka_formats.py
@@ -38,6 +38,10 @@ class KafkaFormats(Check):
             PROTOBUF
             + dedent(
                 """
+                > CREATE CLUSTER kafka_formats REPLICAS (kafka_formats_r1 (SIZE '4'))
+
+                > SET cluster=kafka_formats
+
                 $ kafka-create-topic topic=format-bytes
 
                 $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-bytes
@@ -53,30 +57,35 @@ class KafkaFormats(Check):
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
                 > CREATE SOURCE format_bytes1
+                  IN CLUSTER kafka_formats
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-bytes-${testdrive.seed}')
                   KEY FORMAT BYTES
                   VALUE FORMAT BYTES
                   ENVELOPE UPSERT
 
                 > CREATE SOURCE format_text1
+                  IN CLUSTER kafka_formats
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-bytes-${testdrive.seed}')
                   KEY FORMAT TEXT
                   VALUE FORMAT TEXT
                   ENVELOPE UPSERT
 
                 > CREATE SOURCE format_csv1 (key1, key2, value1, value2)
+                  IN CLUSTER kafka_formats
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-bytes-${testdrive.seed}')
                   KEY FORMAT CSV WITH 2 COLUMNS DELIMITED BY ','
                   VALUE FORMAT CSV WITH 2 COLUMNS DELIMITED BY ','
                   ENVELOPE UPSERT
 
                 > CREATE SOURCE format_regex1 (key1, key2, value1, value2)
+                  IN CLUSTER kafka_formats
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-bytes-${testdrive.seed}')
                   KEY FORMAT REGEX '(?P<key1>[^,]+),(?P<key2>\\w+)'
                   VALUE FORMAT REGEX '(?P<value1>[^,]+),(?P<value2>\\w+)'
                   ENVELOPE UPSERT
 
                 > CREATE SOURCE format_protobuf1
+                  IN CLUSTER kafka_formats
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-protobuf-${testdrive.seed}')
                   KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA '${test-schema}'
                   VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA '${test-schema}'
@@ -90,31 +99,38 @@ class KafkaFormats(Check):
             Testdrive(PROTOBUF + dedent(s))
             for s in [
                 """
+                > SET cluster=kafka_formats
+
                 > CREATE SOURCE format_bytes2
+                  IN CLUSTER kafka_formats
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-bytes-${testdrive.seed}')
                   KEY FORMAT BYTES
                   VALUE FORMAT BYTES
                   ENVELOPE UPSERT
 
                 > CREATE SOURCE format_text2
+                  IN CLUSTER kafka_formats
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-bytes-${testdrive.seed}')
                   KEY FORMAT TEXT
                   VALUE FORMAT TEXT
                   ENVELOPE UPSERT
 
                 > CREATE SOURCE format_csv2 (key1, key2, value1, value2)
+                  IN CLUSTER kafka_formats
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-bytes-${testdrive.seed}')
                   KEY FORMAT CSV WITH 2 COLUMNS DELIMITED BY ','
                   VALUE FORMAT CSV WITH 2 COLUMNS DELIMITED BY ','
                   ENVELOPE UPSERT
 
                 > CREATE SOURCE format_regex2 (key1, key2, value1, value2)
+                  IN CLUSTER kafka_formats
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-bytes-${testdrive.seed}')
                   KEY FORMAT REGEX '(?P<key1>[^,]+),(?P<key2>\\w+)'
                   VALUE FORMAT REGEX '(?P<value1>[^,]+),(?P<value2>\\w+)'
                   ENVELOPE UPSERT
 
                 > CREATE SOURCE format_protobuf2
+                  IN CLUSTER kafka_formats
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-protobuf-${testdrive.seed}')
                   KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA '${test-schema}'
                   VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA '${test-schema}'


### PR DESCRIPTION
CREATE SOURCE and CREATE SINK cause implicit clusters to be created which hog up the CPU as we have a lot of sources and sinks in the Platform checks test

- attempt to put all the objects created by the Identifiers and KafkaFormats checks in a single cluster
- use `SET CLUSTER` in each testdrive fragment
- use `IN CLUSTER` for all `CREATE` statements that support it

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
