### PR TITLE
Fix some regressions introduced by #17658

### DIFF
--- a/src/adapter/tests/parameters.rs
+++ b/src/adapter/tests/parameters.rs
@@ -76,10 +76,22 @@
 // END LINT CONFIG
 
 use mz_adapter::catalog::Catalog;
+use mz_adapter::config::SynchronizedParameters;
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::NOW_ZERO;
 use mz_repr::ScalarType;
 use mz_sql::plan::PlanContext;
+use mz_sql::session::vars::SystemVars;
+
+#[test]
+fn test_github_18189() {
+    let vars = SystemVars::default();
+    let mut sync = SynchronizedParameters::new(vars);
+    assert!(sync.modify("allowed_cluster_replica_sizes", "1,2"));
+    assert_eq!(sync.get("allowed_cluster_replica_sizes"), r#""1", "2""#);
+    assert!(sync.modify("allowed_cluster_replica_sizes", ""));
+    assert_eq!(sync.get("allowed_cluster_replica_sizes"), "");
+}
 
 #[tokio::test]
 async fn test_parameter_type_inference() {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -119,13 +119,19 @@ pub fn parse_data_type(sql: &str) -> Result<RawDataType, ParserError> {
 ///
 /// This is analogous to the `SplitIdentifierString` function in PostgreSQL.
 pub fn split_identifier_string(s: &str) -> Result<Vec<String>, ParserError> {
-    let tokens = lexer::lex(s)?;
-    let mut parser = Parser::new(s, tokens);
-    let values = parser.parse_comma_separated(Parser::parse_set_variable_value)?;
-    Ok(values
-        .into_iter()
-        .map(|v| v.into_unquoted_value())
-        .collect())
+    // SplitIdentifierString ignores leading and trailing whitespace, and
+    // accepts empty input as a 0-length result.
+    if s.trim().is_empty() {
+        Ok(vec![])
+    } else {
+        let tokens = lexer::lex(s)?;
+        let mut parser = Parser::new(s, tokens);
+        let values = parser.parse_comma_separated(Parser::parse_set_variable_value)?;
+        Ok(values
+            .into_iter()
+            .map(|v| v.into_unquoted_value())
+            .collect())
+    }
 }
 
 macro_rules! maybe {


### PR DESCRIPTION
This is fixing some regressions that were introduced by the refactoring of session variable handling introduced in #17658.
This was recently seen [in Sentry](https://materializeinc.sentry.io/issues/3963619537/?project=6780145&referrer=slack) (see also [the associated Slack discussion](https://materializeinc.slack.com/archives/CL68GT3AT/p1678971202122549)).

### Motivation

  * This PR fixes a previously unreported bug.

    Fixes some backward incompatibilities introduced by #17658. See commit messages for details.

### Tips for reviewer

* See commit messages for details.
* I've not worked on adding regression tests for the fixes. If this is adding 1-2 lines I'm happy to do that, otherwise I suggest to let @MaterializeInc/surfaces take over the PR.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
