### PR TITLE
SQLsmith: Run multiple instances against same server

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -553,7 +553,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
-          args: [--num-sqlsmith=2, --create-cluster, --max-joins=2, --runtime=3600]
+          args: [--max-joins=2, --runtime=3600]
 
   - id: sqlsmith-explain
     label: "SQLsmith explain"
@@ -564,7 +564,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
-          args: [--num-sqlsmith=1, --max-joins=15, --explain-only, --runtime=3600]
+          args: [--max-joins=15, --explain-only, --runtime=3600]
 
   - wait: ~
     continue_on_failure: true

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -555,7 +555,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
-          args: [--max-joins=2, --runtime=3600]
+          args: [--num-sqlsmith=8, --max-joins=2, --runtime=3600]
 
   - id: sqlsmith-explain
     label: "SQLsmith explain"
@@ -566,7 +566,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
-          args: [--max-joins=15, --explain-only, --runtime=3600]
+          args: [--num-sqlsmith=4, --max-joins=15, --explain-only, --runtime=3600]
 
   - wait: ~
     continue_on_failure: true

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -549,13 +549,11 @@ steps:
     artifact_paths: junit_*.xml
     timeout_in_minutes: 70
     agents:
-      # A larger instance is needed since SQLsmith likes creating
-      # large queries and going out of memory
-      queue: builder-linux-x86_64
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
-          args: [--num-sqlsmith=8, --max-joins=2, --runtime=3600]
+          args: [--num-sqlsmith=2, --create-cluster, --max-joins=2, --runtime=3600]
 
   - id: sqlsmith-explain
     label: "SQLsmith explain"
@@ -566,7 +564,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
-          args: [--num-sqlsmith=4, --max-joins=15, --explain-only, --runtime=3600]
+          args: [--num-sqlsmith=1, --max-joins=15, --explain-only, --runtime=3600]
 
   - wait: ~
     continue_on_failure: true

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -35,6 +35,7 @@ SERVICES = [
 known_errors = [
     "no connection to the server",  # Expected AFTER a crash, the query before this is interesting, not the ones after
     "failed: Connection refused",  # Expected AFTER a crash, the query before this is interesting, not the ones after
+    "canceling statement due to statement timeout",
     "value too long for type",
     "list_agg on char not yet supported",
     "does not allow subqueries",
@@ -125,6 +126,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     # https://github.com/MaterializeInc/materialize/issues/2392
     parser.add_argument("--max-joins", default=2, type=int)
     parser.add_argument("--explain-only", action="store_true")
+    parser.add_argument("--create-cluster", action="store_true")
     parser.add_argument("--exclude-catalog", default=False, type=bool)
     parser.add_argument("--seed", default=None, type=int)
     args = parser.parse_args()
@@ -156,6 +158,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         """
     )
 
+    c.sql("ALTER SYSTEM SET max_clusters to 100;", user="mz_system", port=6877)
+
     seed = args.seed or random.randint(0, 2**31 - args.num_sqlsmith)
 
     def kill_sqlsmith_with_delay() -> None:
@@ -180,6 +184,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             cmd.append("--exclude-catalog")
         if args.explain_only:
             cmd.append("--explain-only")
+        if args.create_cluster:
+            cmd.append("--create-cluster")
 
         threads.append(Thread(target=run_sqlsmith, args=[c, cmd, aggregate]))
         threads[-1].start()


### PR DESCRIPTION
I think this way we can have our cake and have it too. By running multiple SQLsmith instances we should get more coverage without using more resources, just utilizing the existing ones better. It's not yet clear to me if there should be a cluster per SQLsmith instance, let's try without first.

I have to see if this actually runs more queries on CI, mark to beat:
179484 queries for SQLsmith 2 joins
280091 queries for SQLsmith explain

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
