### PR TITLE
adapter: remove start transaction coord message

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -72,12 +72,6 @@ pub enum Command {
         span: tracing::Span,
     },
 
-    StartTransaction {
-        implicit: Option<usize>,
-        session: Session,
-        tx: oneshot::Sender<Response<()>>,
-    },
-
     Commit {
         action: EndTransactionAction,
         session: Session,
@@ -127,7 +121,6 @@ impl Command {
             | Command::Describe { session, .. }
             | Command::VerifyPreparedStatement { session, .. }
             | Command::Execute { session, .. }
-            | Command::StartTransaction { session, .. }
             | Command::Commit { session, .. }
             | Command::DumpCatalog { session, .. }
             | Command::CopyRows { session, .. }
@@ -151,7 +144,6 @@ impl Command {
             Command::Describe { tx, session, .. } => send(tx, session, e),
             Command::VerifyPreparedStatement { tx, session, .. } => send(tx, session, e),
             Command::Execute { tx, session, .. } => send(tx, session, e),
-            Command::StartTransaction { tx, session, .. } => send(tx, session, e),
             Command::Commit { tx, session, .. } => send(tx, session, e),
             Command::CancelRequest { .. } => {}
             Command::DumpCatalog { tx, session, .. } => send(tx, session, e),

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1397,6 +1397,7 @@ pub async fn serve(
     let metrics = Metrics::register_into(&metrics_registry);
     let metrics_clone = metrics.clone();
     let span = tracing::Span::current();
+    let coord_now = now.clone();
     let thread = thread::Builder::new()
         // The Coordinator thread tends to keep a lot of data on its stack. To
         // prevent a stack overflow we allocate a stack twice as big as the default
@@ -1409,7 +1410,7 @@ pub async fn serve(
                 handle.block_on(Coordinator::ensure_timeline_state_with_initial_time(
                     &timeline,
                     initial_timestamp,
-                    now.clone(),
+                    coord_now.clone(),
                     |ts| catalog.persist_timestamp(&timeline, ts),
                     &mut timestamp_oracles,
                 ));
@@ -1475,7 +1476,7 @@ pub async fn serve(
                 start_instant,
                 _thread: thread.join_on_drop(),
             };
-            let client = Client::new(build_info, cmd_tx.clone(), metrics_clone);
+            let client = Client::new(build_info, cmd_tx.clone(), metrics_clone, now);
             Ok((handle, client))
         }
         Err(e) => Err(e),

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -163,19 +163,6 @@ impl Coordinator {
                 }
             }
 
-            Command::StartTransaction {
-                implicit,
-                session,
-                tx,
-            } => {
-                let now = self.now_datetime();
-                let (session, result) = match implicit {
-                    None => session.start_transaction(now, None, None),
-                    Some(stmts) => (session.start_transaction_implicit(now, stmts), Ok(())),
-                };
-                let _ = tx.send(Response { result, session });
-            }
-
             Command::Commit {
                 action,
                 session,

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -136,7 +136,6 @@ pub fn check_command(catalog: &Catalog, cmd: &Command) -> Result<(), Unauthorize
         | Command::Describe { .. }
         | Command::VerifyPreparedStatement { .. }
         | Command::Execute { .. }
-        | Command::StartTransaction { .. }
         | Command::Commit { .. }
         | Command::CancelRequest { .. }
         | Command::CopyRows { .. }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -481,7 +481,7 @@ async fn execute_stmt_group<S: ResultSender>(
 
         // Mirror the behavior of the PostgreSQL simple query protocol.
         // See the pgwire::protocol::StateMachine::query method for details.
-        if let Err(e) = client.start_transaction(Some(num_stmts)).await {
+        if let Err(e) = client.start_transaction(Some(num_stmts)) {
             let _ = sender.add_result(SqlResult::err(client, e).into()).await?;
             return Ok(Err(()));
         }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -600,10 +600,10 @@ where
         result
     }
 
-    async fn start_transaction(&mut self, stmts: Option<usize>) {
+    fn start_transaction(&mut self, stmts: Option<usize>) {
         // start_transaction can't error (but assert that just in case it changes in
         // the future.
-        let res = self.adapter_client.start_transaction(stmts).await;
+        let res = self.adapter_client.start_transaction(stmts);
         assert!(res.is_ok());
     }
 
@@ -637,7 +637,7 @@ where
             // This needs to be done in the loop instead of once at the top because
             // a COMMIT/ROLLBACK statement needs to start a new transaction on next
             // statement.
-            self.start_transaction(Some(num_stmts)).await;
+            self.start_transaction(Some(num_stmts));
 
             match self.one_query(stmt).await? {
                 State::Ready => (),
@@ -667,7 +667,7 @@ where
         param_oids: Vec<u32>,
     ) -> Result<State, io::Error> {
         // Start a transaction if we aren't in one.
-        self.start_transaction(Some(1)).await;
+        self.start_transaction(Some(1));
 
         let mut param_types = vec![];
         for oid in param_oids {
@@ -760,7 +760,7 @@ where
         result_formats: Vec<mz_pgrepr::Format>,
     ) -> Result<State, io::Error> {
         // Start a transaction if we aren't in one.
-        self.start_transaction(Some(1)).await;
+        self.start_transaction(Some(1));
 
         let aborted_txn = self.is_aborted_txn();
         let stmt = match self
@@ -921,7 +921,7 @@ where
                     // in bind. We don't do it in bind because I'm not sure what purpose it would
                     // serve us (i.e., I'm not aware of a pgtest that would differ between us and
                     // Postgres).
-                    self.start_transaction(Some(1)).await;
+                    self.start_transaction(Some(1));
 
                     match self.adapter_client.execute(portal_name.clone()).await {
                         Ok(response) => {
@@ -985,7 +985,7 @@ where
 
     async fn describe_statement(&mut self, name: &str) -> Result<State, io::Error> {
         // Start a transaction if we aren't in one.
-        self.start_transaction(Some(1)).await;
+        self.start_transaction(Some(1));
 
         let stmt = match self.adapter_client.get_prepared_statement(name).await {
             Ok(stmt) => stmt,
@@ -1014,7 +1014,7 @@ where
 
     async fn describe_portal(&mut self, name: &str) -> Result<State, io::Error> {
         // Start a transaction if we aren't in one.
-        self.start_transaction(Some(1)).await;
+        self.start_transaction(Some(1));
 
         let session = self.adapter_client.session();
         let row_desc = session


### PR DESCRIPTION
This was only using the now fn from coord, which we can plumb into the conn client instead.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a