### PR TITLE
adapter: resolve startup roles directly from the catalog

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -429,6 +429,12 @@ impl CatalogState {
         self.roles_by_id.get(id).expect("catalog out of sync")
     }
 
+    fn try_get_role_by_name(&self, role_name: &str) -> Option<&Role> {
+        self.roles_by_name
+            .get(role_name)
+            .map(|id| &self.roles_by_id[id])
+    }
+
     fn get_role_mut(&mut self, id: &RoleId) -> &mut Role {
         self.roles_by_id.get_mut(id).expect("catalog out of sync")
     }
@@ -3959,6 +3965,10 @@ impl Catalog {
         self.state.get_role(id)
     }
 
+    pub fn try_get_role_by_name(&self, role_name: &str) -> Option<&Role> {
+        self.state.try_get_role_by_name(role_name)
+    }
+
     /// Creates a new schema in the `Catalog` for temporary items
     /// indicated by the TEMPORARY or TEMP keywords.
     pub fn create_temporary_schema(&mut self, conn_id: ConnectionId) -> Result<(), Error> {
@@ -6513,8 +6523,8 @@ impl SessionCatalog for ConnCatalog<'_> {
         &self,
         role_name: &str,
     ) -> Result<&dyn mz_sql::catalog::CatalogRole, SqlCatalogError> {
-        match self.state.roles_by_name.get(role_name) {
-            Some(id) => Ok(&self.state.roles_by_id[id]),
+        match self.state.try_get_role_by_name(role_name) {
+            Some(role) => Ok(role),
             None => Err(SqlCatalogError::UnknownRole(role_name.into())),
         }
     }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -214,12 +214,10 @@ impl Coordinator {
         cancel_tx: Arc<watch::Sender<Canceled>>,
         tx: oneshot::Sender<Response<StartupResponse>>,
     ) {
-        // Lookup is done with the system session because the current session has no role set.
         if self
             .catalog
-            .for_system_session()
-            .resolve_role(&session.user().name)
-            .is_err()
+            .try_get_role_by_name(&session.user().name)
+            .is_none()
         {
             // If the user has made it to this point, that means they have been fully authenticated.
             // This includes preventing any user, except a pre-defined set of system users, from
@@ -239,13 +237,11 @@ impl Coordinator {
             }
         }
 
-        // Lookup is done with the system session because the current session has no role set.
         let role_id = self
             .catalog
-            .for_system_session()
-            .resolve_role(&session.user().name)
+            .try_get_role_by_name(&session.user().name)
             .expect("created above")
-            .id();
+            .id;
         session.set_role_id(role_id);
 
         if let Err(e) = self.catalog.create_temporary_schema(session.conn_id()) {


### PR DESCRIPTION
This removes the need to create sessionless conn catalogs.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a