### PR TITLE
sql: Create subsources using schema of source when applicable

### DIFF
--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -153,6 +153,20 @@ impl From<String> for PartialObjectName {
     }
 }
 
+impl From<PartialObjectName> for UnresolvedObjectName {
+    fn from(partial_name: PartialObjectName) -> UnresolvedObjectName {
+        let mut name_parts = Vec::new();
+        if let Some(database) = partial_name.database {
+            name_parts.push(Ident::new(database));
+        }
+        if let Some(schema) = partial_name.schema {
+            name_parts.push(Ident::new(schema));
+        }
+        name_parts.push(Ident::new(partial_name.item));
+        UnresolvedObjectName(name_parts)
+    }
+}
+
 /// A fully-qualified human readable name of a schema in the catalog.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct FullSchemaName {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -72,9 +72,9 @@ fn subsource_gen<'a, T>(
                         Some(_) => name.clone(),
                         // In cases when a prefix is not provided for the deferred name
                         // fallback to using the schema of the source with the given name
-                        None => subsource_name_gen(source_name, &partial.item)
+                        None => subsource_name_gen(source_name, &partial.item),
                     }
-                },
+                }
                 DeferredObjectName::Named(..) => {
                     unreachable!("already errored on this condition")
                 }

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -59,7 +59,7 @@ use crate::plan::StatementContext;
 fn subsource_gen<'a, T>(
     selected_subsources: &mut Vec<CreateSourceSubsource<Aug>>,
     catalog: &ErsatzCatalog<'a, T>,
-    name: &mut UnresolvedObjectName,
+    source_name: &mut UnresolvedObjectName,
 ) -> Result<Vec<(UnresolvedObjectName, UnresolvedObjectName, &'a T)>, PlanError> {
     let mut validated_requested_subsources = vec![];
 
@@ -76,12 +76,10 @@ fn subsource_gen<'a, T>(
                 // the item as the subsource name to ensure it's created in the
                 // current schema or the source's schema if provided, not mirroring
                 // the schema of the reference.
-                let (_, source_prefix) = name.0.split_last().unwrap();
-                let mut suggested_name = source_prefix.to_vec();
-                suggested_name.push(Ident::from(
-                    normalize::unresolved_object_name(subsource.reference.clone())?.item,
-                ));
-                UnresolvedObjectName(suggested_name)
+                subsource_name_gen(
+                    source_name,
+                    &normalize::unresolved_object_name(subsource.reference.clone())?.item,
+                )
             }
         };
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -100,7 +100,7 @@ fn subsource_gen<'a, T>(
 }
 
 /// Generates a subsource name by prepending source schema name if present
-/// 
+///
 /// For eg. if source is `a.b`, then `a` will be prepended to the subsource name
 /// so that it's generated in the same schema as source
 fn subsource_name_gen(

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -50,7 +50,7 @@ use crate::ast::{
 use crate::catalog::{ErsatzCatalog, SessionCatalog};
 use crate::kafka_util;
 use crate::kafka_util::KafkaConfigOptionExtracted;
-use crate::names::{Aug, PartialObjectName, RawDatabaseSpecifier};
+use crate::names::{Aug, RawDatabaseSpecifier};
 use crate::normalize;
 use crate::plan::error::PlanError;
 use crate::plan::statement::ddl::load_generator_ast_to_generator;
@@ -107,23 +107,9 @@ fn subsource_name_gen(
     source_name: &UnresolvedObjectName,
     subsource_name: &String,
 ) -> Result<UnresolvedObjectName, PlanError> {
-    let PartialObjectName {
-        database,
-        schema,
-        item: _,
-    } = normalize::unresolved_object_name(source_name.clone())?;
-    let mut suggested_name = Vec::new();
-
-    if let Some(db_name) = database {
-        suggested_name.push(Ident::new(db_name));
-    }
-
-    if let Some(schema_name) = schema {
-        suggested_name.push(Ident::new(schema_name));
-    }
-
-    suggested_name.push(Ident::new(subsource_name));
-    Ok(UnresolvedObjectName(suggested_name))
+    let mut partial = normalize::unresolved_object_name(source_name.clone())?;
+    partial.item = subsource_name.to_string();
+    Ok(UnresolvedObjectName::from(partial))
 }
 
 /// Purifies a statement, removing any dependencies on external state.

--- a/test/pg-cdc/publication-for-table.td
+++ b/test/pg-cdc/publication-for-table.td
@@ -49,3 +49,19 @@ CREATE PUBLICATION mz_source FOR TABLE t1;
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES (t2);
 contains:table t2 not found
+
+> CREATE SCHEMA a;
+> CREATE SOURCE a.mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES (t1);
+
+> SELECT * FROM a.t1;
+1
+
+> CREATE SCHEMA another;
+> CREATE SOURCE another.mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * FROM another.t1;
+1

--- a/test/pg-cdc/subsource-names.td
+++ b/test/pg-cdc/subsource-names.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 #
-# Test that a publication that does not cover all tables is handled correctly
+# Test that subsources are created in the source schema if provided
 #
 
 > CREATE SECRET pgpass AS 'postgres'
@@ -34,18 +34,43 @@ CREATE TABLE t2 (f1 INTEGER);
 ALTER TABLE t2 REPLICA IDENTITY FULL;
 INSERT INTO t2 VALUES (5);
 
-CREATE PUBLICATION mz_source FOR TABLE t1;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
 
-> CREATE SOURCE mz_source
+> CREATE SCHEMA a;
+> CREATE SOURCE a.mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES (t1);
 
-> SELECT * FROM t1;
+> SELECT * FROM a.t1;
 1
 
-> DROP SOURCE mz_source;
-
-! CREATE SOURCE mz_source
+> CREATE SCHEMA another;
+> CREATE SOURCE another.mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
-  FOR TABLES (t2);
-contains:table t2 not found
+  FOR ALL TABLES;
+
+> SELECT * FROM another.t1;
+1
+
+> SELECT * FROM another.t2;
+5
+
+> CREATE SCHEMA foo;
+> CREATE SCHEMA bar;
+> CREATE SOURCE foo.mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES (t1 as table1, t2 as bar.table2);
+
+! SELECT * FROM table1;
+contains: unknown
+
+# table1 gets created in source schema foo because it doesn't have any prefix
+> SELECT * FROM foo.table1;
+1
+
+! SELECT * FROM foo.table2;
+contains: unknown
+
+# table2 gets created in mentioned bar because it does have a prefix
+> SELECT * FROM bar.table2;
+5

--- a/test/sqllogictest/source_with_schema.slt
+++ b/test/sqllogictest/source_with_schema.slt
@@ -1,0 +1,68 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+# Start from a pristine server
+reset-server
+
+statement ok
+CREATE SCHEMA foo
+----
+
+statement ok
+CREATE SOURCE foo.auction FROM LOAD GENERATOR AUCTION FOR ALL TABLES WITH (SIZE '1');
+
+query TTT
+SHOW SOURCES FROM foo;
+----
+accounts         subsource      NULL
+auction          load-generator 1
+auction_progress subsource      NULL
+auctions         subsource      NULL
+bids             subsource      NULL
+organizations    subsource      NULL
+users            subsource      NULL
+
+statement ok
+CREATE SCHEMA bar
+----
+
+statement ok
+CREATE SOURCE bar.auction FROM LOAD GENERATOR AUCTION FOR TABLES (bids) WITH (SIZE '1');
+
+query TTT
+SHOW SOURCES FROM bar;
+----
+auction          load-generator 1
+auction_progress subsource      NULL
+bids             subsource      NULL
+
+statement ok
+CREATE SCHEMA baz;
+----
+
+statement ok
+CREATE SCHEMA qux;
+----
+
+statement ok
+CREATE SOURCE baz.auction FROM LOAD GENERATOR AUCTION FOR TABLES (bids AS baz_bids, users AS qux.users) WITH (SIZE '1');
+
+query TTT
+SHOW SOURCES FROM baz;
+----
+auction          load-generator 1
+auction_progress subsource      NULL
+baz_bids         subsource      NULL
+
+query TTT
+SHOW SOURCES FROM qux;
+----
+users         subsource      NULL

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -20,12 +20,25 @@ users                   subsource      <null>
 
 # Adding test to check for tables() work
 > CREATE SCHEMA a;
-> CREATE SOURCE a.auction_bids FROM LOAD GENERATOR AUCTION FOR TABLES (bids as a.bids);
+> CREATE SOURCE a.auction_bids FROM LOAD GENERATOR AUCTION FOR TABLES (bids);
 
 > SHOW SOURCES FROM a;
 auction_bids            load-generator ${arg.default-storage-size}
 auction_bids_progress   subsource      <null>
 bids                    subsource      <null>
+
+# For Tables with mentioned schema should work
+> CREATE SCHEMA another;
+> CREATE SOURCE another.auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
+
+> SHOW SOURCES FROM another;
+accounts                subsource      <null>
+auction_house           load-generator ${arg.default-storage-size}
+auction_house_progress  subsource <null>
+auctions                subsource      <null>
+bids                    subsource      <null>
+organizations           subsource      <null>
+users                   subsource      <null>
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}');
 

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -43,8 +43,8 @@ users                   subsource      <null>
 # Subsources should be created in source schema if no schema is provided
 > CREATE SCHEMA foo;
 > CREATE SCHEMA bar;
-> CREATE SOURCE foo.auction_subset 
-  FROM LOAD GENERATOR AUCTION 
+> CREATE SOURCE foo.auction_subset
+  FROM LOAD GENERATOR AUCTION
   FOR TABLES (bids as foo_bids, users as bar.bar_users);
 
 > SHOW SOURCES FROM foo;

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -40,6 +40,21 @@ bids                    subsource      <null>
 organizations           subsource      <null>
 users                   subsource      <null>
 
+# Subsources should be created in source schema if no schema is provided
+> CREATE SCHEMA foo;
+> CREATE SCHEMA bar;
+> CREATE SOURCE foo.auction_subset 
+  FROM LOAD GENERATOR AUCTION 
+  FOR TABLES (bids as foo_bids, users as bar.bar_users);
+
+> SHOW SOURCES FROM foo;
+auction_subset            load-generator ${arg.default-storage-size}
+auction_subset_progress   subsource      <null>
+foo_bids                  subsource      <null>
+
+> SHOW SOURCES FROM bar;
+bar_users                 subsource      <null>
+
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}');
 
 # Validate that the ID column of the load generator data is usable as a key.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

If schema of the source is provided, the subsources are also created there. 
In case a name is explicitly provided for the subsources in FOR TABLES but it does not have any schema prefix, it will be created in the source schema as well.

For `CREATE SOURCE a.mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES (t1);`
```
materialize=> SHOW CREATE SOURCE a.mz_source;
             name        |      create_sql

-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.a.mz_source | CREATE SOURCE "materialize"."a"."mz_source" FROM POSTGRES CONNECTION "materialize"."public"."pg" (PUBLICATION = 'mz_source', DETAILS = '0a250a02743112067075626c69631881800122130a026631101718ffffffffffffffffff012001122c6d6174657269616c697a65f3265376239346361376238653437376362383532636432326535303939376665') FOR TABLES ("postgres"."public"."t1" AS "materialize"."a"."t1") EXPOSE PROGRESS AS "materialize"."a"."mz_source_progress"
(1 row)
```

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/17868

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer
The main logic of generating subsource name is in [`subsource_name_gen`](https://github.com/MaterializeInc/materialize/pull/18204/files#diff-c881dcaf0f6e4834831d07a5ca1d1dcfea538c718d5bf155d66ee04a2740230eR106). I am not entirely sure if that's the correct way to generate an `UnresolvedObjectName`. So any feedback would be great!

Also, do I have to do anything to run the new sqllogictest file in ci? (Update: looks like it's already included via slt-fast.sh and [ran in ci](https://buildkite.com/materialize/tests/builds/51813#0186f1de-d88e-4fbd-8cb9-8788962fd4b4/205-2054))

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
