### PR TITLE
sql: fix @> range params

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -677,8 +677,12 @@ pub enum ParamType {
     /// An pseudotype permitting any range type, requiring other "Any"-type
     /// parameters to be of the same type.
     RangeAny,
-    /// A pseudotype permitting any range type, permitting other "Compatibility"-type
-    /// parameters to find the best common type.
+    /// A pseudotype permitting any range type, permitting other
+    /// "Compatibility"-type parameters to find the best common type.
+    ///
+    /// Prefer using [`ParamType::RangeAny`] over this type; it is easy to fool
+    /// this type into generating non-existent range types (e.g. ranges of
+    /// floats) that will panic.
     RangeAnyCompatible,
 }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3446,7 +3446,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
                       .call_binary(rhs, JsonbContainsJsonb))
             }) => Bool, oid::OP_CONTAINS_STRING_JSONB_OID;
             params!(MapAnyCompatible, MapAnyCompatible) => MapContainsMap => Bool, oid::OP_CONTAINS_MAP_MAP_OID;
-            params!(RangeAnyCompatible, AnyCompatible) => Operation::binary(|ecx, lhs, rhs| {
+            params!(RangeAny, AnyElement) => Operation::binary(|ecx, lhs, rhs| {
                 let elem_type = ecx.scalar_type(&lhs).unwrap_range_element_type().clone();
                 Ok(lhs.call_binary(rhs, BinaryFunc::RangeContainsElem { elem_type, rev: false }))
             }) => Bool, 3889;
@@ -3474,7 +3474,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(MapAnyCompatible, MapAnyCompatible) => Operation::binary(|_ecx, lhs, rhs| {
                 Ok(rhs.call_binary(lhs, MapContainsMap))
             }) => Bool, oid::OP_CONTAINED_MAP_MAP_OID;
-            params!(AnyCompatible, RangeAnyCompatible) => Operation::binary(|ecx, lhs, rhs| {
+            params!(AnyElement, RangeAny) => Operation::binary(|ecx, lhs, rhs| {
                 let elem_type = ecx.scalar_type(&rhs).unwrap_range_element_type().clone();
                 Ok(rhs.call_binary(lhs, BinaryFunc::RangeContainsElem { elem_type, rev: true }))
             }) => Bool, 3891;

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -536,6 +536,12 @@ SELECT a AS t FROM int4range_values EXCEPT SELECT column1 FROM (VALUES
 ----
 NULL
 
+query error operator does not exist: int4range @> numeric
+SELECT int4range(-1,1) @> 0.1;
+
+query error operator does not exist: int4range @> double precision
+SELECT int4range(-1,1) @> 0.1::float;
+
 query error range constructor flags argument must not be null
 SELECT int4range(1,2,null);
 
@@ -1708,6 +1714,12 @@ SELECT a AS t FROM int8range_values EXCEPT SELECT column1 FROM (VALUES
 ) t;
 ----
 NULL
+
+query error operator does not exist: int8range @> numeric
+SELECT int8range(-1,1) @> 0.1;
+
+query error operator does not exist: int8range @> double precision
+SELECT int8range(-1,1) @> 0.1::float;
 
 query error range constructor flags argument must not be null
 SELECT int8range(1,2,null);
@@ -3937,6 +3949,9 @@ SELECT a AS t FROM numrange_values EXCEPT SELECT column1 FROM (VALUES
 ) t;
 ----
 NULL
+
+query error operator does not exist: numrange @> double precision
+SELECT numrange(-1.0,1.0) @> 0.1::float;
 
 query error range constructor flags argument must not be null
 SELECT numrange(1,2,null);


### PR DESCRIPTION
I got `Any` and `AnyElement` confused––this turned out to be more straightforward.

### Motivation

This PR fixes a recognized bug. Fixes #18017

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
