### PR TITLE
sql: allow filtering subsources by upstream schema

### DIFF
--- a/doc/user/content/integrations/cdc-postgres.md
+++ b/doc/user/content/integrations/cdc-postgres.md
@@ -174,6 +174,15 @@ CREATE SOURCE mz_source
     WITH (SIZE = '3xsmall');
 ```
 
+_Create subsources for all tables in specific schemas included in the Postgres publication_
+
+```sql
+CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
+  FOR SCHEMAS (public, project)
+  WITH (SIZE = '3xsmall');
+```
+
 _Create subsources for specific tables included in the Postgres publication_
 
 ```sql

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -31,6 +31,7 @@ _src_name_  | The name for the source.
 **IN CLUSTER** _cluster_name_ | The [cluster](/sql/create-cluster) to maintain this source. If not specified, the `SIZE` option must be specified.
 **CONNECTION** _connection_name_ | The name of the PostgreSQL connection to use in the source. For details on creating connections, check the [`CREATE CONNECTION`](/sql/create-connection/#postgresql) documentation page.
 **FOR ALL TABLES** | Create subsources for all tables in the publication.
+**FOR SCHEMAS (** _schema_list_ **)** | Create subsources for specific schemas in the publication.
 **FOR TABLES (** _table_list_ **)** | Create subsources for specific tables in the publication.
 **EXPOSE PROGRESS AS** _progress_subsource_name_ | The name of the progress collection for the source. If this is not specified, the progress collection will be named `<src_name>_progress`. For more information, see [Monitoring source progress](#monitoring-source-progress).
 
@@ -57,7 +58,9 @@ For this reason, you must configure the upstream PostgreSQL database to support 
 
 #### Creating a source
 
-To avoid creating multiple replication slots in the upstream PostgreSQL database and minimize the required bandwidth, Materialize ingests the raw replication stream data for either all tables (`FOR ALL TABLES`) or a specified subset of tables (`FOR TABLES`) included in a specific publication.
+To avoid creating multiple replication slots in the upstream PostgreSQL database
+and minimize the required bandwidth, Materialize ingests the raw replication
+stream data for some specific set of tables in your publication.
 
 ```sql
 CREATE SOURCE mz_source
@@ -253,6 +256,15 @@ CREATE SOURCE mz_source
     FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
     FOR ALL TABLES
     WITH (SIZE = '3xsmall');
+```
+
+_Create subsources for all tables from specific schemas included in the PostgreSQL publication_
+
+```sql
+CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
+  FOR SCHEMAS (public, project)
+  WITH (SIZE = '3xsmall');
 ```
 
 _Create subsources for specific tables included in the PostgreSQL publication_

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -112,7 +112,9 @@ create_source_load_generator ::=
   ('IN CLUSTER' cluster_name)?
   'FROM LOAD GENERATOR' ('AUCTION' | 'COUNTER' | 'TPCH')
   ('(' (load_generator_option) ( ( ',' load_generator_option ) )* ')')?
-  ('FOR ALL TABLES' | 'FOR TABLES' '(' table_name ('AS' subsrc_name)?  (',' table_name ('AS' subsrc_name)? )* ')')
+  (
+    'FOR ALL TABLES' |
+    'FOR TABLES' '(' table_name ('AS' subsrc_name)?  (',' table_name ('AS' subsrc_name)? )* ')')
   ('EXPOSE' 'PROGRESS' 'AS' progress_subsource_name)?
   ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
 load_generator_option ::=
@@ -124,7 +126,10 @@ create_source_postgres ::=
   ('IN CLUSTER' cluster_name)?
   'FROM' 'POSTGRES' 'CONNECTION' connection_name
   '(' 'PUBLICATION' publication_name ( ( ',' 'TEXT COLUMNS' ('(' (column_name) ( ( ',' column_name ) )* ')')? )? ) ')'
-  ('FOR ALL TABLES' | 'FOR TABLES' '(' table_name ('AS' subsrc_name)?  (',' table_name ('AS' subsrc_name)? )* ')')
+  ('FOR ALL TABLES'
+    | 'FOR TABLES' '(' table_name ('AS' subsrc_name)?  (',' table_name ('AS' subsrc_name)? )* ')'
+    | 'FOR SCHEMAS' '(' schema_name (',' schema_name )* ')'
+  )
   ('EXPOSE' 'PROGRESS' 'AS' progress_subsource_name)?
   ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
 create_type ::=

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -22,6 +22,19 @@ use mz_proto::{RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_postgres_util.desc.rs"));
 
+/// Describes a schema in a PostgreSQL database.
+///
+/// <https://www.postgresql.org/docs/current/catalog-pg-namespace.html>
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PostgresSchemaDesc {
+    /// The OID of the schema.
+    pub oid: Oid,
+    /// The name of the schema.
+    pub name: String,
+    /// Owner of the namespace
+    pub owner: Oid,
+}
+
 /// Describes a table in a PostgreSQL database.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PostgresTableDesc {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -638,7 +638,9 @@ impl_display_t!(CreateSourceSubsource);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ReferencedSubsources<T: AstInfo> {
     /// A subset defined with FOR TABLES (...)
-    Subset(Vec<CreateSourceSubsource<T>>),
+    SubsetTables(Vec<CreateSourceSubsource<T>>),
+    /// A subset defined with FOR SCHEMAS (...)
+    SubsetSchemas(Vec<Ident>),
     /// FOR ALL TABLES
     All,
 }
@@ -646,9 +648,14 @@ pub enum ReferencedSubsources<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for ReferencedSubsources<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            Self::Subset(subsources) => {
+            Self::SubsetTables(subsources) => {
                 f.write_str("FOR TABLES (");
                 f.write_node(&display::comma_separated(subsources));
+                f.write_str(")");
+            }
+            Self::SubsetSchemas(schemas) => {
+                f.write_str("FOR SCHEMAS (");
+                f.write_node(&display::comma_separated(schemas));
                 f.write_str(")");
             }
             Self::All => f.write_str("FOR ALL TABLES"),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2471,7 +2471,12 @@ impl<'a> Parser<'a> {
             self.expect_token(&Token::LParen)?;
             let subsources = self.parse_comma_separated(Parser::parse_subsource_references)?;
             self.expect_token(&Token::RParen)?;
-            Some(ReferencedSubsources::Subset(subsources))
+            Some(ReferencedSubsources::SubsetTables(subsources))
+        } else if self.parse_keywords(&[FOR, SCHEMAS]) {
+            self.expect_token(&Token::LParen)?;
+            let schemas = self.parse_comma_separated(Parser::parse_identifier)?;
+            self.expect_token(&Token::RParen)?;
+            Some(ReferencedSubsources::SubsetSchemas(schemas))
         } else if self.parse_keywords(&[FOR, ALL, TABLES]) {
             Some(ReferencedSubsources::All)
         } else {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1591,6 +1591,13 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') 
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
 
 parse-statement
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR SCHEMAS (one, two);
+----
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR SCHEMAS (one, two)
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(SubsetSchemas([Ident("one"), Ident("two")])), progress_subsource: None })
+
+parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR ALL TABLES WITH (SIZE = 'small');
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR ALL TABLES WITH (SIZE = 'small')
@@ -1609,7 +1616,7 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FO
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR TABLES (foo, bar AS qux, baz AS zop) WITH (SIZE = 'small')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(Subset([CreateSourceSubsource { reference: UnresolvedItemName([Ident("foo")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("bar")]), subsource: Some(Deferred(UnresolvedItemName([Ident("qux")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(Deferred(UnresolvedItemName([Ident("zop")]))) }])), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(SubsetTables([CreateSourceSubsource { reference: UnresolvedItemName([Ident("foo")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("bar")]), subsource: Some(Deferred(UnresolvedItemName([Ident("qux")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(Deferred(UnresolvedItemName([Ident("zop")]))) }])), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES ([s1 AS foo.bar]) WITH (SIZE = 'small');
@@ -1623,7 +1630,7 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FO
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR TABLES (baz AS [s1 AS foo.bar]) WITH (SIZE = 'small')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(Subset([CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(Named(Id("s1", UnresolvedItemName([Ident("foo"), Ident("bar")])))) }])), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(SubsetTables([CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(Named(Id("s1", UnresolvedItemName([Ident("foo"), Ident("bar")])))) }])), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES ([s1 AS foo.bar] AS baz) WITH (SIZE = 'small');

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -810,7 +810,7 @@ pub fn plan_create_source(
         available_subsources,
         referenced_subsources,
     ) {
-        (Some(available_subsources), Some(ReferencedSubsources::Subset(subsources))) => {
+        (Some(available_subsources), Some(ReferencedSubsources::SubsetTables(subsources))) => {
             let mut requested_subsources = vec![];
             for subsource in subsources {
                 let name = subsource.reference.clone();
@@ -830,7 +830,8 @@ pub fn plan_create_source(
             // Multi-output sources must have a table selection clause
             sql_bail!("This is a multi-output source. Use `FOR TABLE (..)` or `FOR ALL TABLES` to select which ones to ingest");
         }
-        (None, Some(_)) | (Some(_), Some(ReferencedSubsources::All)) => {
+        (None, Some(_))
+        | (Some(_), Some(ReferencedSubsources::All | ReferencedSubsources::SubsetSchemas(_))) => {
             sql_bail!("[internal error] subsources should be resolved during purification")
         }
         (None, None) => (BTreeMap::new(), vec![]),

--- a/test/pg-cdc/empty-publication.td
+++ b/test/pg-cdc/empty-publication.td
@@ -40,4 +40,4 @@ exact: FOR TABLES (..) is only valid for non-empty publications
 
 ! CREATE SOURCE "mz_source_empty"
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source_empty');
-exact: multi-output sources require a FOR TABLES (..) or FOR ALL TABLES statement
+exact: multi-output sources require a FOR TABLES (..), FOR SCHEMAS (..), or FOR ALL TABLES clause

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -115,6 +115,16 @@ DROP PUBLICATION IF EXISTS mz_source_narrow;
 
 CREATE PUBLICATION mz_source_narrow FOR TABLE enum_table, public.another_enum_table, pk_table;
 
+DROP SCHEMA IF EXISTS another_schema CASCADE;
+CREATE SCHEMA another_schema;
+CREATE TABLE another_schema.another_table (f1 TEXT);
+ALTER TABLE another_schema.another_table REPLICA IDENTITY FULL;
+INSERT INTO another_schema.another_table VALUES ('123');
+
+DROP PUBLICATION IF EXISTS another_publication;
+
+CREATE PUBLICATION another_publication FOR TABLE another_schema.another_table;
+
 #
 # Test that slots created for replication sources are deleted on DROP
 #
@@ -210,6 +220,11 @@ regex: the following columns contain unsupported types:\npostgres.public.enum_ta
     public.another_enum_table
   );
 regex: the following columns contain unsupported types:\npostgres\.public\.another_enum_table\."колона" \(OID \d+\)\npostgres\.public\.enum_table\.a \(OID \d+\)
+
+! CREATE SOURCE "mz_source"
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR SCHEMAS (dne);
+regex: Postgres source must ingest at least one table, but FOR SCHEMAS \(dne\) matched none
 
 #
 # Establish direct replication
@@ -642,6 +657,29 @@ INSERT INTO pk_table VALUES (99999);
 # should be "materialize.public.pk_table"
 ! SELECT COUNT(*) = 0 FROM pk_table;
 regex:Source error: .*: db error: ERROR: publication "mz_source" does not exist
+
+> DROP SOURCE enum_source CASCADE;
+> DROP SOURCE "mz_source" CASCADE;
+
+#
+# Check schema scoped tables
+
+> CREATE SOURCE another_source
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'another_publication'
+  )
+  FOR SCHEMAS (
+    another_schema
+  );
+
+$ set-regex match=\d+ replacement=<NUMBER>
+
+> SHOW SOURCES
+another_source          postgres  <NUMBER>
+another_source_progress subsource <null>
+another_table           subsource <null>
+
+> DROP SOURCE another_source
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP SCHEMA conflict_schema CASCADE;

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -153,7 +153,7 @@ $ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=mat
 ! CREATE SOURCE "no_such_host"
   FROM POSTGRES CONNECTION no_such_host (PUBLICATION 'mz_source');
 # TODO: assert on `detail` here.
-exact:failed to fetch publication information from PostgreSQL database
+exact:failed to connect to PostgreSQL database
 
 > CREATE CONNECTION no_such_port TO POSTGRES (
     HOST postgres,
@@ -165,7 +165,7 @@ exact:failed to fetch publication information from PostgreSQL database
 ! CREATE SOURCE "no_such_port"
   FROM POSTGRES CONNECTION no_such_port (PUBLICATION 'mz_source');
 # TODO: assert on `detail` here.
-exact:failed to fetch publication information from PostgreSQL database
+exact:failed to connect to PostgreSQL database
 
 > CREATE CONNECTION no_such_user TO POSTGRES (
     HOST postgres,
@@ -176,7 +176,7 @@ exact:failed to fetch publication information from PostgreSQL database
 ! CREATE SOURCE "no_such_user"
   FROM POSTGRES CONNECTION no_such_user (PUBLICATION 'mz_source');
 # TODO: assert on `detail` here.
-exact:failed to fetch publication information from PostgreSQL database
+exact:failed to connect to PostgreSQL database
 
 > CREATE SECRET badpass AS 'badpass'
 > CREATE CONNECTION no_such_password TO POSTGRES (
@@ -188,7 +188,7 @@ exact:failed to fetch publication information from PostgreSQL database
 ! CREATE SOURCE "no_such_password"
   FROM POSTGRES CONNECTION no_such_password (PUBLICATION 'mz_source');
 # TODO: assert on `detail` here.
-exact:failed to fetch publication information from PostgreSQL database
+exact:failed to connect to PostgreSQL database
 
 > CREATE CONNECTION no_such_dbname TO POSTGRES (
     HOST postgres,
@@ -199,12 +199,12 @@ exact:failed to fetch publication information from PostgreSQL database
 ! CREATE SOURCE "no_such_dbname"
   FROM POSTGRES CONNECTION no_such_dbname (PUBLICATION 'mz_source');
 # TODO: assert on `detail` here.
-exact:failed to fetch publication information from PostgreSQL database
+exact:failed to connect to PostgreSQL database
 
 ! CREATE SOURCE "no_such_publication"
   FROM POSTGRES CONNECTION pg (PUBLICATION 'no_such_publication');
 # TODO: assert on `detail` here.
-exact:failed to fetch publication information from PostgreSQL database
+exact:failed to connect to PostgreSQL database
 
 ! CREATE SOURCE "mz_source"
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
@@ -220,11 +220,6 @@ regex: the following columns contain unsupported types:\npostgres.public.enum_ta
     public.another_enum_table
   );
 regex: the following columns contain unsupported types:\npostgres\.public\.another_enum_table\."колона" \(OID \d+\)\npostgres\.public\.enum_table\.a \(OID \d+\)
-
-! CREATE SOURCE "mz_source"
-  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
-  FOR SCHEMAS (dne);
-regex: Postgres source must ingest at least one table, but FOR SCHEMAS \(dne\) matched none
 
 #
 # Establish direct replication
@@ -573,7 +568,10 @@ contains: invalid TEXT COLUMNS option value: table table_dne not found in source
     PUBLICATION 'mz_source',
     TEXT COLUMNS [another_enum_table."колона"]
   )
-  FOR ALL TABLES;
+  FOR TABLES(
+    conflict_schema.another_enum_table AS conflict_enum,
+    public.another_enum_table AS public_enum
+  );
 contains: invalid TEXT COLUMNS option value: table another_enum_table is ambiguous, consider specifying the schema
 
 ! CREATE SOURCE enum_source
@@ -581,7 +579,7 @@ contains: invalid TEXT COLUMNS option value: table another_enum_table is ambiguo
     PUBLICATION 'mz_source',
     TEXT COLUMNS [foo]
   )
-  FOR ALL TABLES;
+  FOR SCHEMAS (public);
 contains: invalid TEXT COLUMNS option value: column name 'foo' must have at least a table qualification
 
 ! CREATE SOURCE enum_source
@@ -589,7 +587,7 @@ contains: invalid TEXT COLUMNS option value: column name 'foo' must have at leas
     PUBLICATION 'mz_source',
     TEXT COLUMNS [foo.bar.qux.qax.foo]
   )
-  FOR ALL TABLES;
+  FOR SCHEMAS (public);
 contains: invalid TEXT COLUMNS option value: qualified name did not have between 1 and 3 components: foo.bar.qux.qax
 
 ! CREATE SOURCE enum_source
@@ -597,7 +595,7 @@ contains: invalid TEXT COLUMNS option value: qualified name did not have between
     PUBLICATION 'mz_source',
     TEXT COLUMNS [enum_table.a, enum_table.a]
   )
-  FOR ALL TABLES;
+  FOR SCHEMAS (public);
 contains: invalid TEXT COLUMNS option value: unexpected multiple references to postgres.public.enum_table.a
 
 # utf8_table is not part of mz_source_narrow publication
@@ -606,7 +604,7 @@ contains: invalid TEXT COLUMNS option value: unexpected multiple references to p
     PUBLICATION 'mz_source_narrow',
     TEXT COLUMNS [enum_table.a, utf8_table.f1]
   )
-  FOR ALL TABLES;
+  FOR SCHEMAS (public);
 contains: invalid TEXT COLUMNS option value: table utf8_table not found in source
 
 # n.b includes a reference to pk_table, which is not a table that's part of the

--- a/test/pg-cdc/subsource-resolution-duplicates.td
+++ b/test/pg-cdc/subsource-resolution-duplicates.td
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# IMPORTANT: The Postgres server has a custom pg_hba.conf that only
+# accepts connections from specific users. You will have to update
+# pg_hba.conf if you modify the existing user names or add new ones.
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+DROP SCHEMA IF EXISTS other CASCADE;
+CREATE SCHEMA other;
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+CREATE TABLE t (f1 INT);
+INSERT INTO t VALUES (1);
+ALTER TABLE t REPLICA IDENTITY FULL;
+
+CREATE TABLE other.t (f1 INT);
+INSERT INTO other.t VALUES (1);
+ALTER TABLE other.t REPLICA IDENTITY FULL;
+
+! CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+contains:multiple tables with name "t": "postgres"."other"."t", "postgres"."public"."t"
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR SCHEMAS (other);
+
+> SHOW sources
+ mz_source          postgres  4
+ mz_source_progress subsource <null>
+ t                  subsource <null>
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP SCHEMA other CASCADE;

--- a/test/pg-cdc/subsource-resolution-empty.td
+++ b/test/pg-cdc/subsource-resolution-empty.td
@@ -24,20 +24,33 @@ ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
 DROP PUBLICATION IF EXISTS mz_source;
 CREATE SCHEMA public;
+DROP SCHEMA IF EXISTS other CASCADE;
+CREATE SCHEMA other;
 
 DROP PUBLICATION IF EXISTS mz_source_empty;
 CREATE PUBLICATION mz_source_empty;
 
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+CREATE TABLE t (f1 int);
+ALTER TABLE t REPLICA IDENTITY FULL;
+
 ! CREATE SOURCE "mz_source_empty"
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source_empty')
   FOR ALL TABLES;
-exact: FOR ALL TABLES is only valid for non-empty publications
+exact: PostgreSQL PUBLICATION mz_source_empty is empty
 
 ! CREATE SOURCE "mz_source_empty"
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source_empty')
   FOR TABLES (t1);
-exact: FOR TABLES (..) is only valid for non-empty publications
+exact: PostgreSQL PUBLICATION mz_source_empty is empty
 
 ! CREATE SOURCE "mz_source_empty"
-  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source_empty');
+  FROM POSTGRES CONNECTION pg (PUBLICATION mz_source);
 exact: multi-output sources require a FOR TABLES (..), FOR SCHEMAS (..), or FOR ALL TABLES clause
+
+! CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION mz_source)
+  FOR SCHEMAS (dne);
+exact: FOR SCHEMAS (..) included dne, but PostgreSQL database has no schema with that name

--- a/test/pg-cdc/two-source-schemas.td
+++ b/test/pg-cdc/two-source-schemas.td
@@ -47,7 +47,7 @@ INSERT INTO schema2.t1 SELECT * FROM schema2.t1;
 ! CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR ALL TABLES;
-contains:item 't1' already exists
+contains:multiple tables with name "t1"
 
 ! CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')

--- a/test/testdrive/kafka-source-errors.td
+++ b/test/testdrive/kafka-source-errors.td
@@ -52,5 +52,5 @@ contains: FOR ALL TABLES is only valid for multi-output sources
 # Check that for tables() clause is rejected
 ! CREATE SOURCE bad_definition2
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'any_topic')
-  FORMAT BYTES FOR TABLES(t1);
-contains: FOR TABLES (..) is only valid for multi-output sources
+  FORMAT BYTES FOR TABLES (t1);
+contains: FOR TABLES (t1) is only valid for multi-output sources

--- a/test/testdrive/structured-errors.td
+++ b/test/testdrive/structured-errors.td
@@ -22,7 +22,7 @@
 ! CREATE SOURCE "test_error"
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR ALL TABLES
-exact:failed to fetch publication information from PostgreSQL database
+exact:failed to connect to PostgreSQL database
 detail:error connecting to server:
 
 > CREATE MATERIALIZED VIEW mv as SELECT 1;


### PR DESCRIPTION
To make PG sources more ergonomic, I suggest letting users scope the tables they ingest by schema, not just "all" or a "specific list," e.g. I imagine a lot of people want to scope this to `public` and not ingest every table they've ever created. This also takes a step toward handling some of the complexity of helping users map their upstream namespaces to their subsources.

### Motivation

This PR adds a feature that has not yet been specified. [design doc](https://github.com/MaterializeInc/materialize/pull/18338)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Let users include only tables from particular schemas when creating PostgreSQL sources using the new `FOR SCHEMAS(...)` clause in `CREATE SOURCE`.
