### PR TITLE
sql: Fix \d meta command

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2134,9 +2134,11 @@ pub const PG_INDEX: BuiltinView = BuiltinView {
     sql: "CREATE VIEW pg_catalog.pg_index AS SELECT
     mz_indexes.oid AS indexrelid,
     mz_relations.oid AS indrelid,
-    false::pg_catalog.bool AS indisprimary,
     -- MZ doesn't support creating unique indexes so indisunique is filled with false
     false::pg_catalog.bool AS indisunique,
+    false::pg_catalog.bool AS indisprimary,
+    -- MZ doesn't support unique indexes so indimmediate is filled with false
+    false::pg_catalog.bool AS indimmediate,
     -- MZ doesn't support CLUSTER so indisclustered is filled with false
     false::pg_catalog.bool AS indisclustered,
     -- MZ never creates invalid indexes so indisvalid is filled with true

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -55,8 +55,9 @@ name         nullable  type
 --------------------------
 indexrelid      false       oid
 indrelid        false       oid
-indisprimary    false       boolean
 indisunique     false       boolean
+indisprimary    false       boolean
+indimmediate    false       boolean
 indisclustered  false       boolean
 indisvalid      false       boolean
 indisreplident  false       boolean


### PR DESCRIPTION
The \d meta command occasionally relies on the "indimmediate" column from the pg_index catalog relation. This commit adds that column so \d can work properly.

Fixes #18218

### Motivation
This PR fixes a recognized bug.


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
