### PR TITLE
sql: Add date-integer subtraction and addition

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -604,6 +604,8 @@ message ProtoBinaryFunc {
         google.protobuf.Empty range_intersection = 181;
         google.protobuf.Empty range_difference = 182;
         google.protobuf.Empty uuid_generate_v5 = 183;
+        google.protobuf.Empty sub_date_int32 = 184;
+        google.protobuf.Empty add_date_int32 = 185;
     }
 }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3161,6 +3161,10 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(Time, Date) => {
                 Operation::binary(|_ecx, lhs, rhs| Ok(rhs.call_binary(lhs, AddDateTime)))
             } => Timestamp, 1363;
+            params!(Date, Int32) => AddDateInt32 => Date, 2555;
+            params!(Int32, Date) => {
+                Operation::binary(|_ecx, lhs, rhs| Ok(rhs.call_binary(lhs, AddDateInt32)))
+            } => Date, 1100;
             params!(Time, Interval) => AddTimeInterval => Time, 1800;
             params!(Interval, Time) => {
                 Operation::binary(|_ecx, lhs, rhs| Ok(rhs.call_binary(lhs, AddTimeInterval)))
@@ -3191,6 +3195,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(TimestampTz, Interval) => SubTimestampTzInterval => TimestampTz, 1329;
             params!(Date, Date) => SubDate => Int32, 1099;
             params!(Date, Interval) => SubDateInterval => Timestamp, 1077;
+            params!(Date, Int32) => SubDateInt32 => Date, 1101;
             params!(Time, Time) => SubTime => Interval, 1399;
             params!(Time, Interval) => SubTimeInterval => Time, 1801;
             params!(Jsonb, Int64) => JsonbDeleteInt64 => Jsonb, 3286;

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -217,6 +217,28 @@ SELECT DATE '2019-02-03' - DATE '2019-01-01';
 ----
 33
 
+# Date arithmetic with integer
+
+query T
+SELECT DATE '1995-08-06' - 2
+----
+1995-08-04
+
+query T
+SELECT DATE '1995-08-06' - -4
+----
+1995-08-10
+
+query T
+SELECT DATE '1995-08-06' + 3
+----
+1995-08-09
+
+query T
+SELECT DATE '1995-08-06' + -5
+----
+1995-08-01
+
 # Time arithmetic with intervals.
 
 query T


### PR DESCRIPTION
Resolves #18190

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release will add the ability to add and subtract dates with integers.
