### PR TITLE
docs: improve description of progress sources

### DIFF
--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -273,8 +273,8 @@ The following metadata is available for each source as a progress subsource:
 
 Field          | Type                                     | Meaning
 ---------------|------------------------------------------|--------
-`partition`    | `numrange`                               | The upstream Kafka partition.
-`offset`       | [`uint8`](/sql/types/uint/#uint8-info)   | The greatest offset consumed from each upstream Kafka partition.
+`partition`    | `numrange`                               | The upstream Kafka partitions.
+`offset`       | [`uint8`](/sql/types/uint/#uint8-info)   | The next possible offset to consume from the identified partitions, e.g. `offset - 1` shows the greatest offset we've consumed.
 
 And can be queried using:
 
@@ -298,6 +298,18 @@ WHERE
 As long as any offset continues increasing, Materialize is consuming data from
 the upstream Kafka broker. For more details on monitoring source ingestion
 progress and debugging related issues, see [Troubleshooting](/ops/troubleshooting/).
+
+#### Progress details
+
+The progress collection describes which Kafka messages are available in the
+source itself at a given time. Namely, all records in each reported partition
+with offsets up to but not including (i.e. `<`) the reported offset will be
+considered.
+
+This means that any queries that assess the source's progress collection will
+include all messages from the source whose offsets are described. You could, for
+instance, join a query of the source and a query of the progress collection to
+understand which `(partition, offset)` pairs have been included.
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/kinesis.md
+++ b/doc/user/content/sql/create-source/kinesis.md
@@ -78,7 +78,7 @@ The following metadata is available for each source as a progress subsource:
 
 Field          | Type                                     | Meaning
 ---------------|------------------------------------------|--------
-`offset`       | [`uint8`](/sql/types/uint/#uint8-info)   | The greatest offset consumed from the upstream Kinesis broker.
+`offset`       | [`uint8`](/sql/types/uint/#uint8-info)   | The next possible offset offset consumed from the upstream Kinesis broker, e.g. `offset - 1` shows the greatest record we've consumed.
 
 And can be queried using:
 
@@ -90,6 +90,17 @@ FROM <src_name>_progress;
 As long as any offset continues increasing, Materialize is consuming data from
 the upstream Kinesis broker. For more details on monitoring source ingestion
 progress and debugging related issues, see [Troubleshooting](/ops/troubleshooting/).
+
+#### Progress details
+
+The progress collection describes which Kinsesis messages are available in the
+source itself at a given time. Namely, all records with offsets up to but not
+including (i.e. `<`) the reported offset will be considered.
+
+This means that any queries that assess the source's progress collection will
+include all messages from the source whose offsets are described. You could, for
+instance, join a query of the source and a query of the progress collection to
+understand which offset's messages have been included.
 
 ## Authentication
 

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -135,7 +135,7 @@ The following metadata is available for each source as a progress subsource:
 
 Field          | Type                                     | Meaning
 ---------------|------------------------------------------|--------
-`lsn`          | [`uint8`](/sql/types/uint/#uint8-info)   | The last Log Sequence Number (LSN) consumed from the upstream PostgreSQL replication stream.
+`lsn`          | [`uint8`](/sql/types/uint/#uint8-info)   | The next Log Sequence Number (LSN) that can be consumed from the upstream PostgreSQL replication stream.
 
 And can be queried using:
 
@@ -146,7 +146,19 @@ FROM <src_name>_progress;
 
 The reported LSN should increase as Materialize consumes **new** WAL records
 from the upstream PostgreSQL database. For more details on monitoring source
-ingestion progress and debugging related issues, see [Troubleshooting](/ops/troubleshooting/).
+ingestion progress and debugging related issues, see
+[Troubleshooting](/ops/troubleshooting/).
+
+#### Progress details
+
+The progress collection describes which PostgreSQL messages are available in the
+source itself at a given time. Namely, all records from the WAL with LSN's up to
+but not including (i.e. `<`) the reported LSN will be considered.
+
+This means that any queries that assess the source's progress collection will
+include all data from the source whose LSNs are described. You could, for
+instance, join a query of the source and a query of the progress collection to
+understand which LSNs have been included.
 
 ## Known limitations
 


### PR DESCRIPTION
### Motivation

 This PR refactors existing code. From [Slack](https://materializeinc.slack.com/archives/CM7ATT65S/p1679072154197029)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
