### PR TITLE
sql-parser: allow compilation to wasm targets

### DIFF
--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -41,6 +41,7 @@ tokio-openssl = { version = "0.6.3", optional = true }
 # Note that this feature is distinct from `tracing`'s `log` feature, which has `tracing` macros emit `log` records if
 # there is no global `tracing` subscriber.
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt", "json", "tracing-log"], optional = true }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 
 # For the `tracing` feature
@@ -58,7 +59,6 @@ opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-ru
 console-subscriber = { git = "https://github.com/MaterializeInc/tokio-console.git", optional = true }
 sentry-tracing = { version = "0.29.1", optional = true }
 yansi = { version = "0.5.1", optional = true }
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 anyhow = { version = "1.0.66" }
@@ -66,6 +66,7 @@ scopeguard = "1.1.0"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 
 [features]
+default = ["workspace-hack"]
 async = ["async-trait", "futures", "openssl", "tokio-openssl", "tokio"]
 network = ["async", "bytes", "hyper", "smallvec", "tonic"]
 tracing_ = [

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -16,7 +16,7 @@ phf = { version = "0.11.1", features = ["uncased"] }
 serde = { version = "1.0.152", features = ["derive"] }
 tracing = "0.1.37"
 uncased = "0.9.7"
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
 datadriven = "0.6.0"
@@ -29,6 +29,9 @@ mz-walkabout = { path = "../walkabout" }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_codegen = "0.11.1"
 uncased = "0.9.7"
+
+[features]
+default = ["workspace-hack"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -345,7 +345,7 @@ pub enum Format<T: AstInfo> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CsvColumns {
     /// `WITH count COLUMNS`
-    Count(usize),
+    Count(u64),
     /// `WITH HEADER (ident, ...)?`: `names` is empty if there are no names specified
     Header { names: Vec<Ident> },
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -27,7 +27,6 @@ use bytesize::ByteSize;
 use itertools::Itertools;
 use tracing::warn;
 
-use mz_ore::cast::u64_to_usize;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::option::OptionExt;
@@ -44,8 +43,8 @@ use crate::lexer::{self, Token};
 // a healthy factor to be conservative.
 const RECURSION_LIMIT: usize = 128;
 
-/// Maximum allowed size for a batch of statements
-pub const MAX_STATEMENT_BATCH_SIZE: usize = u64_to_usize(bytesize::MB);
+/// Maximum allowed size for a batch of statements in bytes: 1MB.
+pub const MAX_STATEMENT_BATCH_SIZE: usize = 1_000_000;
 
 // Use `Parser::expected` instead, if possible
 macro_rules! parser_err {
@@ -1733,7 +1732,7 @@ impl<'a> Parser<'a> {
                     names: self.parse_parenthesized_column_list(Mandatory)?,
                 }
             } else {
-                let n_cols = usize::cast_from(self.parse_literal_uint()?);
+                let n_cols = self.parse_literal_uint()?;
                 self.expect_keyword(COLUMNS)?;
                 CsvColumns::Count(n_cols)
             };

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -25,7 +25,7 @@ use tracing::warn;
 use mz_controller::clusters::DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS;
 use mz_expr::CollectionPlan;
 use mz_interchange::avro::AvroSchemaGenerator;
-use mz_ore::cast::{self, TryCastFrom};
+use mz_ore::cast::{self, CastFrom, TryCastFrom};
 use mz_ore::collections::CollectionExt;
 use mz_ore::str::StrExt;
 use mz_proto::RustType;
@@ -1579,7 +1579,7 @@ fn get_encoding_inner(
                         names: names.iter().cloned().map(|n| n.into_string()).collect(),
                     }
                 }
-                CsvColumns::Count(n) => ColumnSpec::Count(*n),
+                CsvColumns::Count(n) => ColumnSpec::Count(usize::cast_from(*n)),
             };
             DataEncodingInner::Csv(CsvEncoding {
                 columns,


### PR DESCRIPTION
Remove some 64-bit assumptions and allow skipping workspace-hack on select crates so it doesn't pull in the whole world of dependencies.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a