### PR TITLE
persist: introduce mfp pushdown API boundary between persist+compute

### DIFF
--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -101,7 +101,7 @@ pub use id::{Id, LocalId, PartitionId, SourceInstanceId};
 pub use id::{ProtoId, ProtoLocalId};
 pub use linear::{
     memoize_expr,
-    plan::{MfpPlan, SafeMfpPlan},
+    plan::{MfpPlan, MfpPushdown, SafeMfpPlan},
     util::{join_permutations, permutation_for_arrangement},
     MapFilterProject, ProtoMapFilterProject, ProtoMfpPlan, ProtoSafeMfpPlan,
 };

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1431,7 +1431,8 @@ pub mod plan {
     use serde::{Deserialize, Serialize};
 
     use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
-    use mz_repr::{Datum, Diff, Row, RowArena};
+    use mz_repr::stats::PersistSourceDataStats;
+    use mz_repr::{Datum, Diff, RelationDesc, Row, RowArena};
 
     use crate::{
         func, BinaryFunc, EvalError, MapFilterProject, MirScalarExpr, ProtoMfpPlan,
@@ -1879,6 +1880,144 @@ pub mod plan {
             self.mfp.could_error()
                 || self.lower_bounds.iter().any(|e| e.could_error())
                 || self.upper_bounds.iter().any(|e| e.could_error())
+        }
+    }
+
+    /// Logic for turning an [MfpPlan] into filters that can confidently skip
+    /// fetching an entire persist part based on aggregate statistics (e.g.
+    /// min/max) about the data contained in it.
+    #[derive(Debug)]
+    pub struct MfpPushdown {
+        relation_desc: RelationDesc,
+        // TODO(mfp): Probably some preprocessing we could do to make
+        // `should_fetch` calls more efficient.
+        mfp: MfpPlan,
+    }
+
+    impl MfpPushdown {
+        /// Returns a new [MfpPushdown] for the given [MfpPlan] and support
+        /// info.
+        pub fn new(
+            relation_desc: RelationDesc,
+            mfp: &MfpPlan,
+            // TODO: timestamp/as_of and until.
+        ) -> Self {
+            MfpPushdown {
+                relation_desc,
+                mfp: mfp.clone(),
+            }
+        }
+
+        /// Returns `false` if a chunk of data with the given statistics would
+        /// entirely be filtered out by this MFP once fetched.
+        ///
+        /// Returns `true` if we don't know.
+        pub fn should_fetch<S: PersistSourceDataStats>(&self, stats: &S) -> bool {
+            for (support, predicate) in self.mfp.mfp.predicates.iter() {
+                if self.mfp.mfp.input_arity < *support {
+                    // We'd need the result of map to evaluate this predicate.
+                    continue;
+                }
+                match self.provably_not_in_part(stats, predicate) {
+                    // The predicates are ANDed, so if any of them are provably
+                    // not in the part, we can confidently skip fetching it.
+                    Some(true) => return false,
+                    // TODO: There's probably some useful distinctions we could
+                    // pass back to persist for tracking: e.g. part definitely
+                    // is not needed vs part definitely might be needed vs we
+                    // don't know because some stats were missing vs we don't
+                    // know because the code doesn't yet handle some expression.
+                    Some(false) | None => continue,
+                }
+            }
+            // TODO: Do the same for self.map.{lower,upper}_bounds.
+            true
+        }
+
+        fn provably_not_in_part<S: PersistSourceDataStats>(
+            &self,
+            stats: &S,
+            expr: &MirScalarExpr,
+        ) -> Option<bool> {
+            let arena = RowArena::default();
+            // TODO: This is entirely just a placeholder impl so that we can get
+            // at least one query to work end-to-end. The real structure would
+            // certainly look different than this.
+            //
+            // It works by sniffing out expressions that (at a high level) look
+            // like `some_col {<,<=,>=,>} constant`. For `<`, if we substitute
+            // the minimal value in the part and if `some_col_min < constant` is
+            // _false_, then we know nothing else in the part would be true and
+            // we can skip fetching it. Analogous logic holds for the other
+            // comparisons, but with the max substituted for `{>=,>}`. It's
+            // possible that `any_expr_eq_literal` would be a useful building
+            // block here.
+            //
+            // The full generalization probably requires being able to reason
+            // about the range of outputs of functions given a restricted input
+            // domain, but... that seems hard? There's probably some nice middle
+            // ground.
+            if let MirScalarExpr::CallBinary { func, expr1, expr2 } = expr {
+                let col_idx = Self::one_column_reference(expr1)?;
+                // Should the `col_min` and `col_max` methods instead take
+                // indexes? That would allow us to remove the RelationDesc from
+                // MfpPushdown.
+                let col_name = self.relation_desc.get_name(col_idx);
+                let min_or_max = match func {
+                    BinaryFunc::Lt | BinaryFunc::Lte => stats.col_min(col_name.as_str(), &arena)?,
+                    BinaryFunc::Gt | BinaryFunc::Gte => stats.col_max(col_name.as_str(), &arena)?,
+                    _ => return None,
+                };
+                if !Self::zero_column_references(expr2)? {
+                    return None;
+                }
+                let mut datums = Vec::with_capacity(self.relation_desc.arity());
+                while datums.len() < col_idx {
+                    datums.push(Datum::Null);
+                }
+                datums.push(min_or_max);
+                while datums.len() < self.relation_desc.arity() {
+                    datums.push(Datum::Null);
+                }
+                match expr.eval(datums.as_slice(), &arena) {
+                    Ok(Datum::False) => return Some(true),
+                    _ => return Some(false),
+                }
+            }
+            None
+        }
+
+        fn zero_column_references(expr: &MirScalarExpr) -> Option<bool> {
+            match expr {
+                MirScalarExpr::Literal(..) => Some(true),
+                _ => None,
+            }
+        }
+
+        fn one_column_reference(expr: &MirScalarExpr) -> Option<usize> {
+            match expr {
+                MirScalarExpr::Column(idx) => Some(*idx),
+                MirScalarExpr::CallUnary {
+                    // `invert_casts_on_expr_eq_literal_inner` has a similar
+                    // logic for equalities instead of inequalities. It relies
+                    // on the inverse and preserves_uniqueness function
+                    // annotations, so it works for all those sneaky implicit
+                    // casts, and even for some other unary functions.
+                    //
+                    // Unfortunately, it can't be applied here out of the box,
+                    // because some inverse functions might flip the > to <. For
+                    // example, we have an inverse for integer negation
+                    // (itself), and a flip would happen if we apply this
+                    // inverse. But maybe we could adapt the code: we could
+                    // introduce an additional function annotation besides
+                    // preserves_uniqueness to mark an inverse function safe for
+                    // applying on both sides of an inequality.
+                    func:
+                        UnaryFunc::CastUint64ToNumeric(..) | UnaryFunc::CastUint64ToMzTimestamp(..),
+                    expr,
+                } => Self::one_column_reference(expr),
+                _ => None,
+            }
         }
     }
 }

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -18,23 +18,6 @@ use mz_persist_types::Codec;
 
 use crate::internal::encoding::Schemas;
 
-/// Logic for filtering parts in a read as uninteresting purely from stats about
-/// the data held in them.
-pub trait PartFilter<K, V>: 'static {
-    /// True if the part should be fetched, false if it should be skipped.
-    fn should_fetch(&mut self, stats: &PartStats) -> bool;
-}
-
-/// An implementation of [PartFilter] that always returns true.
-#[derive(Debug)]
-pub struct FetchAllPartFilter;
-
-impl<K, V> PartFilter<K, V> for FetchAllPartFilter {
-    fn should_fetch(&mut self, _stats: &PartStats) -> bool {
-        true
-    }
-}
-
 /// Aggregate statistics about data contained in a [Part].
 ///
 /// TODO(mfp): PartialEq, Eq, PartialOrd, Ord are sus.

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -103,6 +103,7 @@ pub mod antichain;
 pub mod chrono;
 pub mod explain;
 pub mod global_id;
+pub mod stats;
 pub mod strconv;
 pub mod url;
 

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -1,0 +1,53 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::{Datum, Row, RowArena};
+
+/// Provides access to statistics about SourceData stored in a Persist part (S3
+/// data blob).
+///
+/// Statistics are best-effort, and individual stats may be omitted at any time,
+/// e.g. if persist cannot determine them accurately, if the values are too
+/// large to store in Consensus, if the statistics data is larger than the part,
+/// if we wrote the data before we started collecting statistics, etc.
+pub trait PersistSourceDataStats: std::fmt::Debug {
+    /// The number of updates (Rows + errors) in the part.
+    fn len(&self) -> Option<usize>;
+
+    /// The number of errors in the part.
+    fn err_count(&self) -> Option<usize>;
+
+    /// The part's minimum value for the named column, if available.
+    /// A return value of `None` indicates that Persist did not / was
+    /// not able to calculate a minimum for this column.
+    fn col_min<'a>(&'a self, name: &str, arena: &'a RowArena) -> Option<Datum<'a>>;
+
+    /// (ditto above, but for the maximum column value)
+    fn col_max<'a>(&'a self, name: &str, arena: &'a RowArena) -> Option<Datum<'a>>;
+
+    /// The part's null count for the named column, if available. A
+    /// return value of `None` indicates that Persist did not / was
+    /// not able to calculate the null count for this column.
+    fn col_null_count(&self, name: &str) -> Option<usize>;
+
+    /// A prefix of column values for the minimum Row in the part. A
+    /// return of `None` indicates that Persist did not / was not able
+    /// to calculate the minimum row. A `Some(usize)` indicates how many
+    /// columns are in the prefix. The prefix may be less than the full
+    /// row if persist cannot determine/store an individual column, for
+    /// the same reasons that `col_min`/`col_max` may omit values.
+    ///
+    /// TODO: If persist adds more "indexes" than the "primary" one (the order
+    /// of columns returned by Schema), we'll want to generalize this to support
+    /// other subsets of columns.
+    fn row_min(&self, row: &mut Row) -> Option<usize>;
+
+    /// (ditto above, but for the maximum row)
+    fn row_max(&self, row: &mut Row) -> Option<usize>;
+}


### PR DESCRIPTION
Persist is introducing the ability to skip fetching a chunk of data ("part") at read time if we can tell from statistics about it (e.g. min/max) that it would entirely be filtered out by an MFP once fetched.

This is a performance optimization, but it is believed it will be enough to unlock acceptable rehydration times for temporal filters on columns of data that are roughly correlated with realtime. It may also help with one-off exploratory queries. See #18007 for more context.

The primary purpose of this PR is to introduce an initial guess at the API boundary between persist/storage (which contains the stats and fetching) and compute (which contains MFP and expression evaluation) for these filters. In particular, if persist_source is given an MFP, then persist asks the MFP a series of queries about whether it can prove that no data in a part is relevant, given some stats.

For crate dependency and code ownership reasons, the pieces are broken up as follows:
- In mz_repr, a `PersistSourceDataStats` trait which can answer questions about which `SourceData` (`Result<Row, DataflowError>`) may be present in a part. This is a trait for dependency reasons, but it should also make it easier to write unit tests.
- In mz_expr next to MapFilterProject/MfpPlan, an `MfpPushdown` implementation of the query logic mentioned above.
- In mz_storage_client next to persist_source, an implementation of the `PersistSourceDataStats` trait that wraps persist's internal stats format and maps it back to Datums, etc.

This PR is the last piece necessary to getting everything working end-to-end (for a _very_ limited subset of queries) behind feature flags. As a result, it also includes a placeholder impl of the MfpPushdown logic. This is not meant to be representative of what the final logic will look like, but rather will allow us to start getting this in front of devex (customers?) ASAP so that we can derisk the feature itself as well as the initial scope.

Touches #12684

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

@frankmcsherry This is an attempt at, as best as I can remember, the persist/compute API boundary for mfp pushdown that we discussed way back when.

Besides a few crate dependency concerns, I'm mostly indifferent to the details of the API here and happy to do whatever is best for compute. This is meant to be a starting place for discussion.

However, as much as possible, I would like to avoid bikesheds on the placeholder impl of the logic in here (though any correctness feedback is of course quite welcome).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
