### PR TITLE
frontegg-auth: refactor for reusability

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -287,10 +287,6 @@ pub struct Args {
     /// The name of the admin role in Frontegg.
     #[clap(long, env = "FRONTEGG_ADMIN_ROLE", requires = "frontegg-tenant")]
     frontegg_admin_role: Option<String>,
-    /// A common string prefix that is expected to be present at the beginning
-    /// of all Frontegg passwords.
-    #[clap(long, env = "FRONTEGG_PASSWORD_PREFIX", requires = "frontegg-tenant")]
-    frontegg_password_prefix: Option<String>,
 
     // === Orchestrator options. ===
     /// The service orchestrator implementation to use.
@@ -625,7 +621,6 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 tenant_id,
                 now: mz_ore::now::SYSTEM_TIME.clone(),
                 refresh_before_secs: 60,
-                password_prefix: args.frontegg_password_prefix.unwrap_or_default(),
                 admin_role,
             }))
         }

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -819,7 +819,6 @@ fn test_auth_expiry() {
         tenant_id,
         now: SYSTEM_TIME.clone(),
         refresh_before_secs: i64::try_from(REFRESH_BEFORE_SECS).unwrap(),
-        password_prefix: "mzauth_".to_string(),
         admin_role: "mzadmin".to_string(),
     });
     let frontegg_user = "user@_.com";
@@ -960,7 +959,6 @@ fn test_auth_base() {
         tenant_id,
         now,
         refresh_before_secs: 0,
-        password_prefix: "mzauth_".to_string(),
         admin_role: "mzadmin".to_string(),
     });
     let frontegg_user = "user@_.com";
@@ -1558,7 +1556,6 @@ fn test_auth_admin() {
         tenant_id,
         now,
         refresh_before_secs: i64::try_from(REFRESH_BEFORE_SECS).unwrap(),
-        password_prefix: password_prefix.to_string(),
         admin_role: admin_role.to_string(),
     });
 

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -822,7 +822,7 @@ fn test_auth_expiry() {
         admin_role: "mzadmin".to_string(),
     });
     let frontegg_user = "user@_.com";
-    let frontegg_password = &format!("mzauth_{client_id}{secret}");
+    let frontegg_password = &format!("mzp_{client_id}{secret}");
 
     let config = util::Config::default()
         .with_tls(TlsMode::Require, server_cert, server_key)
@@ -962,11 +962,11 @@ fn test_auth_base() {
         admin_role: "mzadmin".to_string(),
     });
     let frontegg_user = "user@_.com";
-    let frontegg_password = &format!("mzauth_{client_id}{secret}");
+    let frontegg_password = &format!("mzp_{client_id}{secret}");
     let frontegg_basic = Authorization::basic(frontegg_user, frontegg_password);
     let frontegg_header_basic = make_header(frontegg_basic);
 
-    let frontegg_system_password = &format!("mzauth_{system_client_id}{system_secret}");
+    let frontegg_system_password = &format!("mzp_{system_client_id}{system_secret}");
     let frontegg_system_basic = Authorization::basic(&SYSTEM_USER.name, frontegg_system_password);
     let frontegg_system_header_basic = make_header(frontegg_system_basic);
 
@@ -1031,7 +1031,7 @@ fn test_auth_base() {
                     buf.extend(client_id.as_bytes());
                     buf.extend(secret.as_bytes());
                     Some(&format!(
-                        "mzauth_{}",
+                        "mzp_{}",
                         base64::encode_config(buf, base64::URL_SAFE)
                     ))
                 },
@@ -1047,7 +1047,7 @@ fn test_auth_base() {
                     buf.extend(client_id.as_bytes());
                     buf.extend(secret.as_bytes());
                     Some(&format!(
-                        "mzauth_{}",
+                        "mzp_{}",
                         base64::encode_config(buf, base64::URL_SAFE_NO_PAD)
                     ))
                 },
@@ -1549,7 +1549,7 @@ fn test_auth_admin() {
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
     )
     .unwrap();
-    let password_prefix = "mzauth_";
+    let password_prefix = "mzp_";
     let frontegg_auth = FronteggAuthentication::new(FronteggConfig {
         admin_api_token_url: frontegg_server.url.clone(),
         decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),

--- a/src/frontegg-auth/src/app_password.rs
+++ b/src/frontegg-auth/src/app_password.rs
@@ -1,0 +1,11 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// The prefix that identifies an app password as a Materialize password.
+pub const PREFIX: &str = "mzp_";

--- a/src/frontegg-auth/src/app_password.rs
+++ b/src/frontegg-auth/src/app_password.rs
@@ -55,18 +55,14 @@ impl FromStr for AppPassword {
     type Err = AppPasswordParseError;
 
     fn from_str(password: &str) -> Result<AppPassword, AppPasswordParseError> {
-        let password = password
-            .strip_prefix(PREFIX)
-            .ok_or(AppPasswordParseError)?;
+        let password = password.strip_prefix(PREFIX).ok_or(AppPasswordParseError)?;
         if password.len() == 43 || password.len() == 44 {
             // If it's exactly 43 or 44 bytes, assume we have base64-encoded
             // UUID bytes without or with padding, respectively.
             let buf = base64::decode_config(password, base64::URL_SAFE)
                 .map_err(|_| AppPasswordParseError)?;
-            let client_id =
-                Uuid::from_slice(&buf[..16]).map_err(|_| AppPasswordParseError)?;
-            let secret_key =
-                Uuid::from_slice(&buf[16..]).map_err(|_| AppPasswordParseError)?;
+            let client_id = Uuid::from_slice(&buf[..16]).map_err(|_| AppPasswordParseError)?;
+            let secret_key = Uuid::from_slice(&buf[16..]).map_err(|_| AppPasswordParseError)?;
             Ok(AppPassword {
                 client_id,
                 secret_key,
@@ -132,7 +128,8 @@ mod tests {
                 expected_secret_key: "1947fdce-f540-4adb-84a4-7347e5d30c9f".parse().unwrap(),
             },
             TestCase {
-                input: "mzp_0445db36-5826-41af-84f6-e09402fc6171:a0c11434-07ba-426a-b83d-cc4f192325a3",
+                input:
+                    "mzp_0445db36-5826-41af-84f6-e09402fc6171:a0c11434-07ba-426a-b83d-cc4f192325a3",
                 expected_output: "mzp_BEXbNlgmQa-E9uCUAvxhcaDBFDQHukJquD3MTxkjJaM",
                 expected_client_id: "0445db36-5826-41af-84f6-e09402fc6171".parse().unwrap(),
                 expected_secret_key: "a0c11434-07ba-426a-b83d-cc4f192325a3".parse().unwrap(),

--- a/src/frontegg-auth/src/app_password.rs
+++ b/src/frontegg-auth/src/app_password.rs
@@ -7,5 +7,141 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::error::Error;
+use std::fmt;
+use std::str::FromStr;
+
+use uuid::Uuid;
+
 /// The prefix that identifies an app password as a Materialize password.
 pub const PREFIX: &str = "mzp_";
+
+/// A Materialize app password.
+///
+/// Somewhat unusually, the app password encodes both the client ID and secret
+/// for the API key in use. Both the client ID and secret are UUIDs. The
+/// password can have one of two formats:
+///
+///   * The URL-safe base64 encoding of the concatenated bytes of the UUIDs.
+///
+///     This format is a very compact representation (only 43 or 44 bytes)
+///     that is safe to use in a connection string without escaping.
+///
+///   * The concatenated hex-encoding of the UUIDs, with any number of
+///     special characters that are ignored.
+///
+///     This format allows for the UUIDs to be formatted with hyphens, or
+///     not.
+///
+pub struct AppPassword {
+    /// The client ID embedded in the app password.
+    pub client_id: Uuid,
+    /// The secret key embedded in the app password.
+    pub secret_key: Uuid,
+}
+
+impl fmt::Display for AppPassword {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut buf = vec![];
+        buf.extend(self.client_id.as_bytes());
+        buf.extend(self.secret_key.as_bytes());
+        let encoded = base64::encode_config(buf, base64::URL_SAFE_NO_PAD);
+        f.write_str(PREFIX)?;
+        f.write_str(&encoded)
+    }
+}
+
+impl FromStr for AppPassword {
+    type Err = AppPasswordParseError;
+
+    fn from_str(password: &str) -> Result<AppPassword, AppPasswordParseError> {
+        let password = password
+            .strip_prefix(PREFIX)
+            .ok_or(AppPasswordParseError)?;
+        if password.len() == 43 || password.len() == 44 {
+            // If it's exactly 43 or 44 bytes, assume we have base64-encoded
+            // UUID bytes without or with padding, respectively.
+            let buf = base64::decode_config(password, base64::URL_SAFE)
+                .map_err(|_| AppPasswordParseError)?;
+            let client_id =
+                Uuid::from_slice(&buf[..16]).map_err(|_| AppPasswordParseError)?;
+            let secret_key =
+                Uuid::from_slice(&buf[16..]).map_err(|_| AppPasswordParseError)?;
+            Ok(AppPassword {
+                client_id,
+                secret_key,
+            })
+        } else if password.len() >= 64 {
+            // If it's more than 64 bytes, assume we have concatenated
+            // hex-encoded UUIDs, possibly with some special characters mixed
+            // in.
+            let mut chars = password.chars().filter(|c| c.is_alphanumeric());
+            let client_id = Uuid::parse_str(&chars.by_ref().take(32).collect::<String>())
+                .map_err(|_| AppPasswordParseError)?;
+            let secret_key = Uuid::parse_str(&chars.take(32).collect::<String>())
+                .map_err(|_| AppPasswordParseError)?;
+            Ok(AppPassword {
+                client_id,
+                secret_key,
+            })
+        } else {
+            // Otherwise it's definitely not a password format we understand.
+            Err(AppPasswordParseError)
+        }
+    }
+}
+
+/// An error while parsing an [`AppPassword`].
+#[derive(Debug)]
+pub struct AppPasswordParseError;
+
+impl Error for AppPasswordParseError {}
+
+impl fmt::Display for AppPasswordParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("invalid app password format")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::AppPassword;
+
+    #[test]
+    fn test_app_password() {
+        struct TestCase {
+            input: &'static str,
+            expected_output: &'static str,
+            expected_client_id: Uuid,
+            expected_secret_key: Uuid,
+        }
+
+        for tc in [
+            TestCase {
+                input: "mzp_7ce3c1e8ea854594ad5d785f17d1736f1947fdcef5404adb84a47347e5d30c9f",
+                expected_output: "mzp_fOPB6OqFRZStXXhfF9FzbxlH_c71QErbhKRzR-XTDJ8",
+                expected_client_id: "7ce3c1e8-ea85-4594-ad5d-785f17d1736f".parse().unwrap(),
+                expected_secret_key: "1947fdce-f540-4adb-84a4-7347e5d30c9f".parse().unwrap(),
+            },
+            TestCase {
+                input: "mzp_fOPB6OqFRZStXXhfF9FzbxlH_c71QErbhKRzR-XTDJ8",
+                expected_output: "mzp_fOPB6OqFRZStXXhfF9FzbxlH_c71QErbhKRzR-XTDJ8",
+                expected_client_id: "7ce3c1e8-ea85-4594-ad5d-785f17d1736f".parse().unwrap(),
+                expected_secret_key: "1947fdce-f540-4adb-84a4-7347e5d30c9f".parse().unwrap(),
+            },
+            TestCase {
+                input: "mzp_0445db36-5826-41af-84f6-e09402fc6171:a0c11434-07ba-426a-b83d-cc4f192325a3",
+                expected_output: "mzp_BEXbNlgmQa-E9uCUAvxhcaDBFDQHukJquD3MTxkjJaM",
+                expected_client_id: "0445db36-5826-41af-84f6-e09402fc6171".parse().unwrap(),
+                expected_secret_key: "a0c11434-07ba-426a-b83d-cc4f192325a3".parse().unwrap(),
+            },
+        ] {
+            let app_password: AppPassword = tc.input.parse().unwrap();
+            assert_eq!(app_password.to_string(), tc.expected_output);
+            assert_eq!(app_password.client_id, tc.expected_client_id);
+            assert_eq!(app_password.secret_key, tc.expected_secret_key);
+        }
+    }
+}

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -87,7 +87,7 @@ use uuid::Uuid;
 
 use mz_ore::{now::NowFn, retry::Retry};
 
-use crate::app_password::{AppPasswordParseError, AppPassword};
+use crate::app_password::{AppPassword, AppPasswordParseError};
 
 pub mod app_password;
 

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -87,7 +87,7 @@ use uuid::Uuid;
 
 use mz_ore::{now::NowFn, retry::Retry};
 
-use crate::app_password::PREFIX;
+use crate::app_password::{AppPasswordParseError, AppPassword};
 
 pub mod app_password;
 
@@ -169,53 +169,12 @@ impl FronteggAuthentication {
     }
 
     /// Exchanges a password for a JWT token.
-    ///
-    /// Somewhat unusually, the password encodes both the client ID and secret
-    /// for the API key in use. Both the client ID and secret are UUIDs. The
-    /// password can have one of two formats:
-    ///
-    ///   * The URL-safe base64 encoding of the concatenated bytes of the UUIDs.
-    ///
-    ///     This format is a very compact representation (only 43 or 44 bytes)
-    ///     that is safe to use in a connection string without escaping.
-    ///
-    ///   * The concatenated hex-encoding of the UUIDs, with any number of
-    ///     special characters that are ignored.
-    ///
-    ///     This format allows for the UUIDs to be formatted with hyphens, or
-    ///     not, and for the two
     pub async fn exchange_password_for_token(
         &self,
         password: &str,
     ) -> Result<ApiTokenResponse, FronteggError> {
-        let password = password
-            .strip_prefix(PREFIX)
-            .ok_or(FronteggError::InvalidPasswordFormat)?;
-        let (client_id, secret) = if password.len() == 43 || password.len() == 44 {
-            // If it's exactly 43 or 44 bytes, assume we have base64-encoded
-            // UUID bytes without or with padding, respectively.
-            let buf = base64::decode_config(password, base64::URL_SAFE)
-                .map_err(|_| FronteggError::InvalidPasswordFormat)?;
-            let client_id =
-                Uuid::from_slice(&buf[..16]).map_err(|_| FronteggError::InvalidPasswordFormat)?;
-            let secret =
-                Uuid::from_slice(&buf[16..]).map_err(|_| FronteggError::InvalidPasswordFormat)?;
-            (client_id, secret)
-        } else if password.len() >= 64 {
-            // If it's more than 64 bytes, assume we have concatenated
-            // hex-encoded UUIDs, possibly with some special characters mixed
-            // in.
-            let mut chars = password.chars().filter(|c| c.is_alphanumeric());
-            let client_id = Uuid::parse_str(&chars.by_ref().take(32).collect::<String>())
-                .map_err(|_| FronteggError::InvalidPasswordFormat)?;
-            let secret = Uuid::parse_str(&chars.take(32).collect::<String>())
-                .map_err(|_| FronteggError::InvalidPasswordFormat)?;
-            (client_id, secret)
-        } else {
-            // Otherwise it's definitely not a password format we understand.
-            return Err(FronteggError::InvalidPasswordFormat);
-        };
-        self.exchange_client_secret_for_token(client_id, secret)
+        let password: AppPassword = password.parse()?;
+        self.exchange_client_secret_for_token(password.client_id, password.secret_key)
             .await
     }
 
@@ -396,8 +355,8 @@ impl Claims {
 
 #[derive(Error, Debug)]
 pub enum FronteggError {
-    #[error("invalid password format")]
-    InvalidPasswordFormat,
+    #[error(transparent)]
+    InvalidPasswordFormat(#[from] AppPasswordParseError),
     #[error("invalid token format: {0}")]
     InvalidTokenFormat(#[from] jsonwebtoken::errors::Error),
     #[error("authentication token exchange failed: {0}")]


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
