### PR TITLE
platform checks: Choose identifiers randomly

### DIFF
--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -51,9 +51,7 @@ class Sleep(Action):
 
 class Initialize(Action):
     def __init__(self, scenario: "Scenario") -> None:
-        self.checks = [
-            check_class(scenario.base_version()) for check_class in scenario.checks()
-        ]
+        self.checks = scenario.check_objects
 
     def execute(self, e: Executor) -> None:
         for check in self.checks:
@@ -73,9 +71,7 @@ class Manipulate(Action):
         assert phase is not None
         self.phase = phase - 1
 
-        self.checks = [
-            check_class(scenario.base_version()) for check_class in scenario.checks()
-        ]
+        self.checks = scenario.check_objects
         assert len(self.checks) >= self.phase
 
     def execute(self, e: Executor) -> None:
@@ -90,9 +86,7 @@ class Manipulate(Action):
 
 class Validate(Action):
     def __init__(self, scenario: "Scenario") -> None:
-        self.checks = [
-            check_class(scenario.base_version()) for check_class in scenario.checks()
-        ]
+        self.checks = scenario.check_objects
 
     def execute(self, e: Executor) -> None:
         for check in self.checks:

--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -7,7 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from typing import List
+from random import Random
+from typing import List, Optional
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.executors import Executor
@@ -15,8 +16,9 @@ from materialize.util import MzVersion
 
 
 class Check:
-    def __init__(self, base_version: MzVersion) -> None:
+    def __init__(self, base_version: MzVersion, rng: Optional[Random]) -> None:
         self.base_version = base_version
+        self.rng = rng
         self._initialize = self.initialize()
         self._manipulate = self.manipulate()
         self._validate = self.validate()

--- a/misc/python/materialize/checks/identifiers.py
+++ b/misc/python/materialize/checks/identifiers.py
@@ -6,8 +6,9 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+from random import Random
 from textwrap import dedent
-from typing import Any, List
+from typing import Any, List, Optional
 
 from pg8000.converters import literal  # type: ignore
 
@@ -84,30 +85,29 @@ class Identifiers(Check):
             "alias": "18",
             "role": "19",
         },
-        # Disabled because of timeouts, revisit if we want to accept longer runtime
-        # {
-        #     "db": "-1.0",
-        #     "schema": "0.0",
-        #     "type": "1.0",
-        #     "table": "2.0",
-        #     "column": "3.0",
-        #     "value1": "4.0",
-        #     "value2": "5.0",
-        #     "source": "6.0",
-        #     "source_view": "7.0",
-        #     "kafka_conn": "8.0",
-        #     "csr_conn": "9.0",
-        #     "secret": "10.0",
-        #     "secret_value": "11.0",
-        #     "mv0": "12.0",
-        #     "mv1": "13.0",
-        #     "mv2": "14.0",
-        #     "sink0": "15.0",
-        #     "sink1": "16.0",
-        #     "sink2": "17.0",
-        #     "alias": "18.0",
-        #     "role": "19.0",
-        # },
+        {
+            "db": "-1.0",
+            "schema": "0.0",
+            "type": "1.0",
+            "table": "2.0",
+            "column": "3.0",
+            "value1": "4.0",
+            "value2": "5.0",
+            "source": "6.0",
+            "source_view": "7.0",
+            "kafka_conn": "8.0",
+            "csr_conn": "9.0",
+            "secret": "10.0",
+            "secret_value": "11.0",
+            "mv0": "12.0",
+            "mv1": "13.0",
+            "mv2": "14.0",
+            "sink0": "15.0",
+            "sink1": "16.0",
+            "sink2": "17.0",
+            "alias": "18.0",
+            "role": "19.0",
+        },
         {
             "db": "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f^?",
             "schema": ",./;'[]\\-=",
@@ -154,167 +154,160 @@ class Identifiers(Check):
             "alias": "⅛⅜⅝⅞",
             "role": "ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя",
         },
-        # Disabled because of timeouts, revisit if we want to accept longer runtime
-        # {
-        #     "db": "❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙",
-        #     "schema": "😍",
-        #     "type": "👩🏽",
-        #     "table": "👨‍🦰 👨🏿‍🦰 👨‍🦱 👨🏿‍🦱 🦹🏿‍♂️",
-        #     "column": "👾 🙇 💁 🙅 🙆 🙋 🙎 🙍",
-        #     "value1": "🐵 🙈 🙉 🙊",
-        #     "value2": "✋🏿 💪🏿   👐🏿   🙌🏿   👏🏿   🙏🏿",
-        #     "source": "🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧",
-        #     "source_view": "🇺 🇸 🇷 🇺 🇸  🇦 🇫 🇦 🇲 🇸",
-        #     "kafka_conn": "🇺 🇸 🇷 🇺 🇸 🇦 🇫 🇦 🇲",
-        #     "csr_conn": "🇺 🇸 🇷 🇺 🇸 🇦",
-        #     "secret": "１２３",
-        #     "secret_value": "١٢٣",
-        #     "mv0": "🇺s🇸r🇷p🇺>🇸l🇦r",
-        #     "mv1": "Ⱦ",
-        #     "mv2": "👨‍👩‍👦 👨‍👩‍👧‍👦 👨‍👨‍👦 👩‍👩‍👧 👨‍👦 👨‍👧‍👦 👩‍👦 👩‍👧‍👦",
-        #     "sink0": "0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟",
-        #     "sink1": " test ",
-        #     "sink2": "‫test‫",
-        #     "alias": "1#INF",
-        # },
-        # {
-        #     "db": "ﺚﻣ ﻦﻔﺳ ﺲﻘﻄﺗ ﻮﺑﺎﻠﺘﺣﺪﻳﺩ،, ﺝﺰﻳﺮﺘﻳ ﺏﺎﺴﺘﺧﺩﺎﻣ ﺄﻧ ﺪﻧﻭ. ﺇﺫ ﻪﻧﺍ؟ ﺎﻠﺴﺗﺍﺭ ﻮﺘﻨﺼﻴﺑ ﻙﺎﻧ. ﺄﻬّﻟ ﺎﻴﻃﺎﻠﻳﺍ، ﺏﺮﻴﻃﺎﻨﻳﺍ-ﻑﺮﻨﺳﺍ ﻕﺩ ﺄﺧﺫ. ﺲﻠﻴﻣﺎﻧ، ﺈﺘﻓﺎﻘﻳﺓ ﺐﻴﻧ ﻡﺍ, ﻱﺬﻛﺭ ﺎﻠﺣﺩﻭﺩ ﺄﻳ ﺐﻋﺩ, ﻢﻋﺎﻤﻟﺓ ﺏﻮﻠﻧﺩﺍ، ﺍﻺﻃﻼﻗ ﻊﻟ ﺈﻳﻭ.",
-        #     "schema": "בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּמַיִם, וְאֵת הָאָרֶץ",
-        #     "type": "הָיְתָהtestﺎﻠﺼﻔﺣﺎﺗ ﺎﻠﺘّﺣﻮﻟ",
-        #     "table": "﷽",
-        #     "column": "undefined",
-        #     "value1": "undef",
-        #     "value2": "NULL",
-        #     "source": "(null)",
-        #     "source_view": "NIL",
-        #     "kafka_conn": "true",
-        #     "csr_conn": "FALSE",
-        #     "secret": "None",
-        #     "secret_value": "'",
-        #     "mv0": "\\",
-        #     "mv1": "\\\\",
-        #     "mv2": '"',
-        #     "sink0": "nil",
-        #     "sink1": "⁦test⁧",
-        #     "sink2": "‪‪᚛                 ᚜‪",
-        #     "alias": "0xabad1dea",
-        #     "role": "0xffffffffffffffff",
-        # },
+        {
+            "db": "❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙",
+            "schema": "😍",
+            "type": "👩🏽",
+            "table": "👨‍🦰 👨🏿‍🦰 👨‍🦱 👨🏿‍🦱 🦹🏿‍♂️",
+            "column": "👾 🙇 💁 🙅 🙆 🙋 🙎 🙍",
+            "value1": "🐵 🙈 🙉 🙊",
+            "value2": "✋🏿 💪🏿   👐🏿   🙌🏿   👏🏿   🙏🏿",
+            "source": "🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧",
+            "source_view": "🇺 🇸 🇷 🇺 🇸  🇦 🇫 🇦 🇲 🇸",
+            "kafka_conn": "🇺 🇸 🇷 🇺 🇸 🇦 🇫 🇦 🇲",
+            "csr_conn": "🇺 🇸 🇷 🇺 🇸 🇦",
+            "secret": "１２３",
+            "secret_value": "١٢٣",
+            "mv0": "🇺s🇸r🇷p🇺>🇸l🇦r",
+            "mv1": "Ⱦ",
+            "mv2": "👨‍👩‍👦 👨‍👩‍👧‍👦 👨‍👨‍👦 👩‍👩‍👧 👨‍👦 👨‍👧‍👦 👩‍👦 👩‍👧‍👦",
+            "sink0": "0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟",
+            "sink1": " test ",
+            "sink2": "‫test‫",
+            "alias": "1#INF",
+            "role": "0xffffffffffffffff",
+        },
+        {
+            "db": "ﺚﻣ ﻦﻔﺳ ﺲﻘﻄﺗ ﻮﺑﺎﻠﺘﺣﺪﻳﺩ،, ﺝﺰﻳﺮﺘﻳ ﺏﺎﺴﺘﺧﺩﺎﻣ ﺄﻧ ﺪﻧﻭ. ﺇﺫ ﻪﻧﺍ؟ ﺎﻠﺴﺗﺍﺭ ﻮﺘﻨﺼﻴﺑ ﻙﺎﻧ. ﺄﻬّﻟ ﺎﻴﻃﺎﻠﻳﺍ، ﺏﺮﻴﻃﺎﻨﻳﺍ-ﻑﺮﻨﺳﺍ ﻕﺩ ﺄﺧﺫ. ﺲﻠﻴﻣﺎﻧ، ﺈﺘﻓﺎﻘﻳﺓ ﺐﻴﻧ ﻡﺍ, ﻱﺬﻛﺭ ﺎﻠﺣﺩﻭﺩ ﺄﻳ ﺐﻋﺩ, ﻢﻋﺎﻤﻟﺓ ﺏﻮﻠﻧﺩﺍ، ﺍﻺﻃﻼﻗ ﻊﻟ ﺈﻳﻭ.",
+            "schema": "בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּמַיִם, וְאֵת הָאָרֶץ",
+            "type": "הָיְתָהtestﺎﻠﺼﻔﺣﺎﺗ ﺎﻠﺘّﺣﻮﻟ",
+            "table": "﷽",
+            "column": "undefined",
+            "value1": "undef",
+            "value2": "NULL",
+            "source": "(null)",
+            "source_view": "NIL",
+            "kafka_conn": "true",
+            "csr_conn": "FALSE",
+            "secret": "None",
+            "secret_value": "'",
+            "mv0": "\\",
+            "mv1": "\\\\",
+            "mv2": '"',
+            "sink0": "nil",
+            "sink1": "⁦test⁧",
+            "sink2": "‪‪᚛                 ᚜‪",
+            "alias": "0xabad1dea",
+            "role": "0xffffffffffffffff",
+        },
     ]
 
+    def __init__(self, base_version: MzVersion, rng: Optional[Random]) -> None:
+        self.ident = rng.choice(self.IDENTS) if rng else self.IDENTS[0]
+        super().__init__(base_version, rng)
+
     def initialize(self) -> Testdrive:
-        cmds = "\n".join(
-            [
-                f"""
+        cmds = f"""
             > SET cluster=identifiers;
-            > CREATE ROLE {dq(ident["role"])};
-            > CREATE DATABASE {dq(ident["db"])};
-            > SET DATABASE={dq(ident["db"])};
-            > CREATE SCHEMA {dq(ident["schema"])};
-            > CREATE TYPE {dq(ident["type"])} AS LIST (ELEMENT TYPE = text);
-            > CREATE TABLE {dq(ident["schema"])}.{dq(ident["table"])} ({dq(ident["column"])} TEXT, c2 {dq(ident["type"])});
-            > INSERT INTO {dq(ident["schema"])}.{dq(ident["table"])} VALUES ({sq(ident["value1"])}, LIST[{sq(ident["value2"])}]::{dq(ident["type"])});
-            > CREATE MATERIALIZED VIEW {dq(ident["schema"])}.{dq(ident["mv0"])} IN CLUSTER default AS
-              SELECT COUNT({dq(ident["column"])}) FROM {dq(ident["schema"])}.{dq(ident["table"])};
+            > CREATE ROLE {dq(self.ident["role"])};
+            > CREATE DATABASE {dq(self.ident["db"])};
+            > SET DATABASE={dq(self.ident["db"])};
+            > CREATE SCHEMA {dq(self.ident["schema"])};
+            > CREATE TYPE {dq(self.ident["type"])} AS LIST (ELEMENT TYPE = text);
+            > CREATE TABLE {dq(self.ident["schema"])}.{dq(self.ident["table"])} ({dq(self.ident["column"])} TEXT, c2 {dq(self.ident["type"])});
+            > INSERT INTO {dq(self.ident["schema"])}.{dq(self.ident["table"])} VALUES ({sq(self.ident["value1"])}, LIST[{sq(self.ident["value2"])}]::{dq(self.ident["type"])});
+            > CREATE MATERIALIZED VIEW {dq(self.ident["schema"])}.{dq(self.ident["mv0"])} IN CLUSTER default AS
+              SELECT COUNT({dq(self.ident["column"])}) FROM {dq(self.ident["schema"])}.{dq(self.ident["table"])};
 
-            $ kafka-create-topic topic=sink-source-ident{i}
+            $ kafka-create-topic topic=sink-source-ident
 
-            $ kafka-ingest format=avro key-format=avro topic=sink-source-ident{i} key-schema=${{keyschema}} schema=${{schema}} repeat=1000
+            $ kafka-ingest format=avro key-format=avro topic=sink-source-ident key-schema=${{keyschema}} schema=${{schema}} repeat=1000
             {{"key1": "U2${{kafka-ingest.iteration}}"}} {{"f1": "A${{kafka-ingest.iteration}}"}}
 
-            > CREATE CONNECTION IF NOT EXISTS {dq(ident["kafka_conn"])} FOR KAFKA BROKER '${{testdrive.kafka-addr}}';
-            > CREATE CONNECTION IF NOT EXISTS {dq(ident["csr_conn"])} FOR CONFLUENT SCHEMA REGISTRY URL '${{testdrive.schema-registry-url}}';
-            > CREATE SOURCE {dq(ident["source"])}
+            > CREATE CONNECTION IF NOT EXISTS {dq(self.ident["kafka_conn"])} FOR KAFKA BROKER '${{testdrive.kafka-addr}}';
+            > CREATE CONNECTION IF NOT EXISTS {dq(self.ident["csr_conn"])} FOR CONFLUENT SCHEMA REGISTRY URL '${{testdrive.schema-registry-url}}';
+            > CREATE SOURCE {dq(self.ident["source"])}
               IN CLUSTER identifiers
-              FROM KAFKA CONNECTION {dq(ident["kafka_conn"])} (TOPIC 'testdrive-sink-source-ident{i}-${{testdrive.seed}}')
-              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {dq(ident["csr_conn"])}
+              FROM KAFKA CONNECTION {dq(self.ident["kafka_conn"])} (TOPIC 'testdrive-sink-source-ident-${{testdrive.seed}}')
+              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {dq(self.ident["csr_conn"])}
               ENVELOPE UPSERT;
-            > CREATE MATERIALIZED VIEW {dq(ident["source_view"])} IN CLUSTER default AS
-              SELECT LEFT(key1, 2) as l_k, LEFT(f1, 1) AS l_v, COUNT(*) AS c FROM {dq(ident["source"])} GROUP BY LEFT(key1, 2), LEFT(f1, 1);
-            > CREATE SINK {dq(ident["schema"])}.{dq(ident["sink0"])} FROM {dq(ident["source_view"])}
-              INTO KAFKA CONNECTION {dq(ident["kafka_conn"])} (TOPIC 'sink-sink-ident0')
-              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {dq(ident["csr_conn"])}
+            > CREATE MATERIALIZED VIEW {dq(self.ident["source_view"])} IN CLUSTER default AS
+              SELECT LEFT(key1, 2) as l_k, LEFT(f1, 1) AS l_v, COUNT(*) AS c FROM {dq(self.ident["source"])} GROUP BY LEFT(key1, 2), LEFT(f1, 1);
+            > CREATE SINK {dq(self.ident["schema"])}.{dq(self.ident["sink0"])} FROM {dq(self.ident["source_view"])}
+              INTO KAFKA CONNECTION {dq(self.ident["kafka_conn"])} (TOPIC 'sink-sink-ident0')
+              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {dq(self.ident["csr_conn"])}
               ENVELOPE DEBEZIUM;
             """
-                + (
-                    f"""
-            > CREATE SECRET {dq(ident["secret"])} as {sq(ident["secret_value"])};
+        if self.base_version >= MzVersion(0, 44, 0):
+            cmds += f"""
+            > CREATE SECRET {dq(self.ident["secret"])} as {sq(self.ident["secret_value"])};
             """
-                    if self.base_version >= MzVersion(0, 44, 0)
-                    else ""
-                )
-                for i, ident in enumerate(self.IDENTS)
-            ]
-        )
+
         return Testdrive(schemas() + cluster() + dedent(cmds))
 
     def manipulate(self) -> List[Testdrive]:
         cmds = [
-            "\n".join(
-                [
-                    f"""
+            f"""
             > SET CLUSTER=identifiers;
-            > SET DATABASE={dq(ident["db"])};
-            > CREATE MATERIALIZED VIEW {dq(ident["schema"])}.{dq(ident["mv" + i])} IN CLUSTER default AS
-              SELECT {dq(ident["column"])}, c2 as {dq(ident["alias"])} FROM {dq(ident["schema"])}.{dq(ident["table"])};
-            > INSERT INTO {dq(ident["schema"])}.{dq(ident["table"])} VALUES ({sq(ident["value1"])}, LIST[{sq(ident["value2"])}]::{dq(ident["type"])});
-            > CREATE SINK {dq(ident["schema"])}.{dq(ident["sink" + i])} FROM {dq(ident["source_view"])}
-              INTO KAFKA CONNECTION {dq(ident["kafka_conn"])} (TOPIC 'sink-sink-ident{i}')
-              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {dq(ident["csr_conn"])}
+            > SET DATABASE={dq(self.ident["db"])};
+            > CREATE MATERIALIZED VIEW {dq(self.ident["schema"])}.{dq(self.ident["mv" + i])} IN CLUSTER default AS
+              SELECT {dq(self.ident["column"])}, c2 as {dq(self.ident["alias"])} FROM {dq(self.ident["schema"])}.{dq(self.ident["table"])};
+            > INSERT INTO {dq(self.ident["schema"])}.{dq(self.ident["table"])} VALUES ({sq(self.ident["value1"])}, LIST[{sq(self.ident["value2"])}]::{dq(self.ident["type"])});
+            > CREATE SINK {dq(self.ident["schema"])}.{dq(self.ident["sink" + i])} FROM {dq(self.ident["source_view"])}
+              INTO KAFKA CONNECTION {dq(self.ident["kafka_conn"])} (TOPIC 'sink-sink-ident')
+              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {dq(self.ident["csr_conn"])}
               ENVELOPE DEBEZIUM;
             """
-                    for ident in self.IDENTS
-                ]
-            )
             for i in ["1", "2"]
         ]
         return [Testdrive(dedent(s)) for s in cmds]
 
     def validate(self) -> Testdrive:
-        cmds = "> SHOW DATABASES WHERE name NOT LIKE 'to_be_created%';\nmaterialize\n"
-        cmds += "\n".join([dq(ident["db"]) for ident in self.IDENTS])
-        for ident in self.IDENTS:
-            cmds += f"""
-> SET DATABASE={dq(ident["db"])};
+        cmds = f"""
+        > SHOW DATABASES WHERE name NOT LIKE 'to_be_created%';
+        materialize
+        {dq(self.ident["db"])}
 
-> SELECT name FROM mz_roles WHERE name LIKE {sq(ident["role"])}
-{dq_print(ident["role"])}
+        > SET DATABASE={dq(self.ident["db"])};
 
-> SHOW TYPES;
-{dq_print(ident["type"])}
+        > SELECT name FROM mz_roles WHERE name LIKE {sq(self.ident["role"])}
+        {dq_print(self.ident["role"])}
 
-> SHOW SCHEMAS FROM {dq(ident["db"])};
-public
-information_schema
-mz_catalog
-mz_internal
-pg_catalog
-{dq_print(ident["schema"])}
+        > SHOW TYPES;
+        {dq_print(self.ident["type"])}
 
-> SHOW SINKS FROM {dq(ident["schema"])};
-{dq_print(ident["sink0"])} kafka ${{arg.default-storage-size}}
-{dq_print(ident["sink1"])} kafka ${{arg.default-storage-size}}
-{dq_print(ident["sink2"])} kafka ${{arg.default-storage-size}}
+        > SHOW SCHEMAS FROM {dq(self.ident["db"])};
+        public
+        information_schema
+        mz_catalog
+        mz_internal
+        pg_catalog
+        {dq_print(self.ident["schema"])}
 
-> SELECT * FROM {dq(ident["schema"])}.{dq(ident["mv0"])};
-3
+        > SHOW SINKS FROM {dq(self.ident["schema"])};
+        {dq_print(self.ident["sink0"])} kafka ${{arg.default-storage-size}}
+        {dq_print(self.ident["sink1"])} kafka ${{arg.default-storage-size}}
+        {dq_print(self.ident["sink2"])} kafka ${{arg.default-storage-size}}
 
-> SELECT {dq(ident["column"])}, {dq(ident["alias"])}[1] FROM {dq(ident["schema"])}.{dq(ident["mv1"])};
-{dq_print(ident["value1"])} {dq_print(ident["value2"])}
-{dq_print(ident["value1"])} {dq_print(ident["value2"])}
-{dq_print(ident["value1"])} {dq_print(ident["value2"])}
+        > SELECT * FROM {dq(self.ident["schema"])}.{dq(self.ident["mv0"])};
+        3
 
-> SELECT {dq(ident["column"])}, {dq(ident["alias"])}[1] FROM {dq(ident["schema"])}.{dq(ident["mv2"])};
-{dq_print(ident["value1"])} {dq_print(ident["value2"])}
-{dq_print(ident["value1"])} {dq_print(ident["value2"])}
-{dq_print(ident["value1"])} {dq_print(ident["value2"])}
+        > SELECT {dq(self.ident["column"])}, {dq(self.ident["alias"])}[1] FROM {dq(self.ident["schema"])}.{dq(self.ident["mv1"])};
+        {dq_print(self.ident["value1"])} {dq_print(self.ident["value2"])}
+        {dq_print(self.ident["value1"])} {dq_print(self.ident["value2"])}
+        {dq_print(self.ident["value1"])} {dq_print(self.ident["value2"])}
 
-> SELECT * FROM {dq(ident["source_view"])};
-U2 A 1000
-"""
+        > SELECT {dq(self.ident["column"])}, {dq(self.ident["alias"])}[1] FROM {dq(self.ident["schema"])}.{dq(self.ident["mv2"])};
+        {dq_print(self.ident["value1"])} {dq_print(self.ident["value2"])}
+        {dq_print(self.ident["value1"])} {dq_print(self.ident["value2"])}
+        {dq_print(self.ident["value1"])} {dq_print(self.ident["value2"])}
+
+        > SELECT * FROM {dq(self.ident["source_view"])};
+        U2 A 1000
+        """
         if self.base_version >= MzVersion(0, 44, 0):
             cmds += f"""
-> SHOW SECRETS;
-{dq_print(ident["secret"])}
-"""
+        > SHOW SECRETS;
+        {dq_print(self.ident["secret"])}
+        """
         return Testdrive(dedent(cmds))

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -46,6 +46,9 @@ class Scenario:
         self.executor = executor
         self.rng = None if seed is None else Random(seed)
         self._base_version = MzVersion.parse_cargo()
+        self.check_objects = [
+            check_class(self._base_version, self.rng) for check_class in self.checks()
+        ]
 
     def checks(self) -> List[Type[Check]]:
         if self.rng:


### PR DESCRIPTION
Using seed passed in in platform-checks. This should speed up identifier tests more, while making sure we still notice regressions quickly.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
