### PR TITLE
SQLsmith: Also test beta features

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -28,12 +28,15 @@ class StandaloneMaterialized(Service):
         name: str,
         ports: List[str] = [],
         propagate_crashes: bool = True,
-        restart: Optional[str] = None,
         memory: Optional[str] = None,
+        unsafe_mode: bool = True,
+        restart: Optional[str] = None,
     ) -> None:
         command = []
         if propagate_crashes:
             command += ["--orchestrator-process-propagate-crashes"]
+        if unsafe_mode:
+            command += ["--unsafe-mode"]
 
         config: ServiceConfig = {
             "mzbuild": "materialized",


### PR DESCRIPTION
I missed previously that Materialized() set that automatically. Makes sense to find issues as early as possible, even if feature is in beta.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
