### PR TITLE
Use Materialized instead of StandaloneMaterialized

### DIFF
--- a/misc/rqg/mzcompose.py
+++ b/misc/rqg/mzcompose.py
@@ -7,34 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from typing import List, Optional
-
-from materialize.mzcompose import (
-    Composition,
-    Service,
-    ServiceConfig,
-    WorkflowArgumentParser,
-)
-
-
-class StandaloneMaterialized(Service):
-    def __init__(
-        self,
-        name: str,
-        image: Optional[str] = None,
-        ports: List[str] = [],
-    ) -> None:
-        config: ServiceConfig = {
-            "allow_host_ports": True,
-            "ports": ports,
-        }
-
-        if image:
-            config["image"] = image
-        else:
-            config["mzbuild"] = "materialized"
-
-        super().__init__(name=name, config=config)
+from materialize.mzcompose import Composition, Service, WorkflowArgumentParser
+from materialize.mzcompose.services import Materialized
 
 
 def workflow_start_two_mzs(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -51,14 +25,14 @@ def workflow_start_two_mzs(c: Composition, parser: WorkflowArgumentParser) -> No
     args = parser.parse_args()
 
     with c.override(
-        StandaloneMaterialized(
+        Materialized(
             name="mz_this",
             image=f"materialize/materialized:{args.this_tag}"
             if args.this_tag
             else None,
             ports=["6875:6875"],
         ),
-        StandaloneMaterialized(
+        Materialized(
             name="mz_other",
             image=f"materialize/materialized:{args.other_tag}"
             if args.other_tag


### PR DESCRIPTION
Ported all features into Materialized instead

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
