### PR TITLE
adapter: Prevent connecting as public role

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4775,7 +4775,7 @@ impl Catalog {
                     oid,
                     attributes,
                 } => {
-                    if is_reserved_name(&name) || is_public_role(name.as_str()) {
+                    if is_reserved_role_name(&name) {
                         return Err(AdapterError::Catalog(Error::new(
                             ErrorKind::ReservedRoleName(name),
                         )));
@@ -6035,6 +6035,10 @@ pub fn is_reserved_name(name: &str) -> bool {
     BUILTIN_PREFIXES
         .iter()
         .any(|prefix| name.starts_with(prefix))
+}
+
+pub fn is_reserved_role_name(name: &str) -> bool {
+    is_reserved_name(name) || is_public_role(name)
 }
 
 pub fn is_public_role(name: &str) -> bool {

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -496,7 +496,7 @@ async fn auth(
         }
     };
 
-    if mz_adapter::catalog::is_reserved_name(user.name.as_str()) {
+    if mz_adapter::catalog::is_reserved_role_name(user.name.as_str()) {
         return Err(AuthError::InvalidLogin(user.name));
     }
     Ok(AuthedUser(user))

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -130,7 +130,7 @@ where
         }
     } else {
         // The external server cannot be used to connect to any system users.
-        if mz_adapter::catalog::is_reserved_name(user.as_str()) {
+        if mz_adapter::catalog::is_reserved_role_name(user.as_str()) {
             let msg = format!("unauthorized login to user '{user}'");
             return conn
                 .send(ErrorResponse::fatal(SqlState::INSUFFICIENT_PRIVILEGE, msg))


### PR DESCRIPTION
Part of MaterializeInc/database-issues#3380


### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
