### PR TITLE
coord: restrict queries run on `mz_introspection`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,6 +3408,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "smallvec",
  "thiserror",
  "timely",
  "tokio",

--- a/misc/dbt-materialize/dbt/adapters/materialize/connections.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/connections.py
@@ -68,9 +68,11 @@ class MaterializeConnectionManager(PostgresConnectionManager):
         # the mz_introspection cluster for optimal performance. Each materialization
         # should then handle falling back to the default connection cluster if no
         # cluster configuration is specified at the model level.
-        mz_introspection_cluster = "mz_introspection"
-        logger.debug("Switching to cluster '{}'".format(mz_introspection_cluster))
-        cursor.execute("SET cluster = %s" % mz_introspection_cluster)
+
+        # TODO(parkertimmerman): Delete this code instead of just commenting it out.
+        # mz_introspection_cluster = "mz_introspection"
+        # logger.debug("Switching to cluster '{}'".format(mz_introspection_cluster))
+        # cursor.execute("SET cluster = %s" % mz_introspection_cluster)
 
         cursor.execute("SELECT mz_version()")
         mz_version = cursor.fetchone()[0].split()[0].strip("v")

--- a/misc/dbt-materialize/tests/adapter/test_clusters.py
+++ b/misc/dbt-materialize/tests/adapter/test_clusters.py
@@ -112,13 +112,13 @@ class TestModelCluster:
     # not error if a user-provided cluster is specified as a connection or
     # model config, but will error otherwise.
     # See #17197: https://github.com/MaterializeInc/materialize/pull/17197
-    def test_materialize_drop_default(self, project):
-        project.run_sql("DROP CLUSTER default CASCADE")
+    # def test_materialize_drop_default(self, project):
+    #     project.run_sql("DROP CLUSTER default CASCADE")
 
-        run_dbt(["run", "--models", "override_cluster"], expect_pass=True)
-        run_dbt(["run", "--models", "default_cluster"], expect_pass=False)
+    #     run_dbt(["run", "--models", "override_cluster"], expect_pass=True)
+    #     run_dbt(["run", "--models", "default_cluster"], expect_pass=False)
 
-        project.run_sql("CREATE CLUSTER default REPLICAS (r1 (SIZE '1'))")
+    #     project.run_sql("CREATE CLUSTER default REPLICAS (r1 (SIZE '1'))")
 
 
 class TestProjectConfigCluster:

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -57,6 +57,7 @@ reqwest = "0.11.13"
 semver = "1.0.16"
 serde = "1.0.152"
 serde_json = "1.0.89"
+smallvec = { version = "1.10.0", features = ["union"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["rt", "time"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -145,6 +145,7 @@ mod command_handler;
 mod dataflows;
 mod ddl;
 mod indexes;
+mod introspection;
 mod message_handler;
 mod read_policy;
 mod sequencer;

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -50,11 +50,17 @@ static ALLOWED_SCHEMAS: Lazy<HashSet<&str>> = Lazy::new(|| {
 /// we depend on any objects that we're not allowed to query from the cluster.
 pub fn check_cluster_restrictions(
     catalog: &impl SessionCatalog,
+    plan: &Plan,
     depends_on: &Vec<GlobalId>,
 ) -> Result<(), AdapterError> {
     // We only impose restrictions if the current cluster is the introspection cluster.
     let cluster = catalog.active_cluster();
     if cluster != MZ_INTROSPECTION_CLUSTER.name {
+        return Ok(());
+    }
+
+    // Allows explain queries.
+    if let Plan::Explain(_) = plan {
         return Ok(());
     }
 

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -1,3 +1,12 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
 //! Special cases related to the "introspection" of Materialize
 //!
 //! Every Materialize deployment has a pre-installed [`mz_introspection`] cluster, which

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -1,0 +1,72 @@
+//! Special cases related to the "introspection" of Materialize
+//!
+//! Every Materialize deployment has a pre-installed [`mz_introspection`] cluster, which
+//! has several indexes to speed up common introspection queries. We also have a special
+//! `mz_introspection` role, which can be used by support teams to diagnose a deployment.
+//! For each of these use cases, we have some special restrictions we want to apply. The
+//! logic around these restrictions is defined here.
+//!
+//!
+//! [`mz_introspection`]: https://materialize.com/docs/sql/show-clusters/#mz_introspection-system-cluster
+
+use mz_ore::collections::HashSet;
+use mz_repr::GlobalId;
+use mz_sql::catalog::SessionCatalog;
+use once_cell::sync::Lazy;
+use smallvec::SmallVec;
+
+use crate::{
+    catalog::builtin::{
+        INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_INTROSPECTION_CLUSTER,
+        PG_CATALOG_SCHEMA,
+    },
+    AdapterError,
+};
+
+/// The schema's a user is allowed to query from the `mz_introspection` cluster
+static ALLOWED_SCHEMAS: Lazy<HashSet<&str>> = Lazy::new(|| {
+    HashSet::from([
+        MZ_CATALOG_SCHEMA,
+        PG_CATALOG_SCHEMA,
+        MZ_INTERNAL_SCHEMA,
+        INFORMATION_SCHEMA,
+    ])
+});
+
+/// Checks if we're currently running on the [`MZ_INTROSPECTION_CLUSTER`], and if so, do
+/// we depend on any objects that we're not allowed to query from the cluster.
+pub fn check_cluster_restrictions(
+    catalog: &impl SessionCatalog,
+    depends_on: &Vec<GlobalId>,
+) -> Result<(), AdapterError> {
+    // We only impose restrictions if the current cluster is the introspection cluster.
+    let cluster = catalog.active_cluster();
+    if cluster != MZ_INTROSPECTION_CLUSTER.name {
+        return Ok(());
+    }
+
+    // Collect any items that are not allowed to be run on the introspection cluster.
+    let unallowed_dependents: SmallVec<[String; 2]> = depends_on
+        .iter()
+        .filter_map(|id| {
+            let item = catalog.get_item(id);
+            let full_name = catalog.resolve_full_name(item.name());
+
+            if !ALLOWED_SCHEMAS.contains(full_name.schema.as_str()) {
+                Some(full_name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // If the query depends on unallowed items, error out.
+    if !unallowed_dependents.is_empty() {
+        Err(AdapterError::UnallowedOnCluster {
+            depends_on: unallowed_dependents,
+            cluster: MZ_INTROSPECTION_CLUSTER.name.to_string(),
+        })
+    } else {
+        Ok(())
+    }
+}

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -75,7 +75,9 @@ impl Coordinator {
         {
             return tx.send(Err(e), session);
         }
-        if let Err(e) = introspection::check_cluster_restrictions(&session_catalog, &depends_on) {
+        if let Err(e) =
+            introspection::check_cluster_restrictions(&session_catalog, &plan, &depends_on)
+        {
             return tx.send(Err(e), session);
         }
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -26,10 +26,6 @@ use mz_sql::plan::{
     FetchPlan, Plan, PlanKind, QueryWhen, RaisePlan, RotateKeysPlan,
 };
 
-use crate::catalog::builtin::{
-    INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_INTROSPECTION_ROLE,
-    PG_CATALOG_SCHEMA,
-};
 use crate::command::{Command, ExecuteResponse};
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::timeline::TimelineContext;
@@ -74,15 +70,13 @@ impl Coordinator {
             return tx.send(Err(e), session);
         }
 
-        if let Err(e) = introspection::check_cluster_restrictions(&session_catalog, &depends_on) {
+        if let Err(e) =
+            introspection::user_privilege_hack(&session_catalog, &session, &plan, &depends_on)
+        {
             return tx.send(Err(e), session);
         }
-
-        if session.user().name == MZ_INTROSPECTION_ROLE.name {
-            if let Err(e) = self.mz_introspection_user_privilege_hack(&session, &plan, &depends_on)
-            {
-                return tx.send(Err(e), session);
-            }
+        if let Err(e) = introspection::check_cluster_restrictions(&session_catalog, &depends_on) {
+            return tx.send(Err(e), session);
         }
 
         match plan {
@@ -539,110 +533,5 @@ impl Coordinator {
         }
         self.transient_id_counter += 1;
         Ok(GlobalId::Transient(id))
-    }
-
-    /// TODO(jkosh44) This function will verify the privileges for the mz_introspection user.
-    ///  All of the privileges are hard coded into this function. In the future if we ever add
-    ///  a more robust privileges framework, then this function should be replaced with that
-    ///  framework.
-    fn mz_introspection_user_privilege_hack(
-        &self,
-        session: &Session,
-        plan: &Plan,
-        depends_on: &Vec<GlobalId>,
-    ) -> Result<(), AdapterError> {
-        if session.user().name != MZ_INTROSPECTION_ROLE.name {
-            return Ok(());
-        }
-
-        match plan {
-            Plan::Subscribe(_)
-            | Plan::Peek(_)
-            | Plan::CopyFrom(_)
-            | Plan::SendRows(_)
-            | Plan::Explain(_)
-            | Plan::ShowAllVariables
-            | Plan::ShowVariable(_)
-            | Plan::SetVariable(_)
-            | Plan::ResetVariable(_)
-            | Plan::StartTransaction(_)
-            | Plan::CommitTransaction(_)
-            | Plan::AbortTransaction(_)
-            | Plan::EmptyQuery
-            | Plan::Declare(_)
-            | Plan::Fetch(_)
-            | Plan::Close(_)
-            | Plan::Prepare(_)
-            | Plan::Execute(_)
-            | Plan::Deallocate(_) => {}
-
-            Plan::CreateConnection(_)
-            | Plan::CreateDatabase(_)
-            | Plan::CreateSchema(_)
-            | Plan::CreateRole(_)
-            | Plan::CreateCluster(_)
-            | Plan::CreateClusterReplica(_)
-            | Plan::CreateSource(_)
-            | Plan::CreateSources(_)
-            | Plan::CreateSecret(_)
-            | Plan::CreateSink(_)
-            | Plan::CreateTable(_)
-            | Plan::CreateView(_)
-            | Plan::CreateMaterializedView(_)
-            | Plan::CreateIndex(_)
-            | Plan::CreateType(_)
-            | Plan::DiscardTemp
-            | Plan::DiscardAll
-            | Plan::DropDatabase(_)
-            | Plan::DropSchema(_)
-            | Plan::DropRoles(_)
-            | Plan::DropClusters(_)
-            | Plan::DropClusterReplicas(_)
-            | Plan::DropItems(_)
-            | Plan::Insert(_)
-            | Plan::AlterNoop(_)
-            | Plan::AlterIndexSetOptions(_)
-            | Plan::AlterIndexResetOptions(_)
-            | Plan::AlterRole(_)
-            | Plan::AlterSink(_)
-            | Plan::AlterSource(_)
-            | Plan::AlterItemRename(_)
-            | Plan::AlterSecret(_)
-            | Plan::AlterSystemSet(_)
-            | Plan::AlterSystemReset(_)
-            | Plan::AlterSystemResetAll(_)
-            | Plan::ReadThenWrite(_)
-            | Plan::Raise(_)
-            | Plan::RotateKeys(_)
-            | Plan::GrantRole(_)
-            | Plan::RevokeRole(_)
-            | Plan::CopyRows(_) => {
-                return Err(AdapterError::Unauthorized(
-                    rbac::UnauthorizedError::privilege(plan.name().to_string(), None),
-                ))
-            }
-        }
-
-        for id in depends_on {
-            let entry = self.catalog.get_entry(id);
-            let full_name = self
-                .catalog
-                .resolve_full_name(entry.name(), Some(session.conn_id()));
-            let schema = &full_name.schema;
-            if schema != MZ_CATALOG_SCHEMA
-                && schema != PG_CATALOG_SCHEMA
-                && schema != MZ_INTERNAL_SCHEMA
-                && schema != INFORMATION_SCHEMA
-            {
-                return Err(AdapterError::Unauthorized(
-                    rbac::UnauthorizedError::privilege(
-                        format!("interact with object {full_name}"),
-                        None,
-                    ),
-                ));
-            }
-        }
-
-        Ok(())
     }
 }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1878,13 +1878,11 @@ impl Coordinator {
         let view_id = self.allocate_transient_id()?;
         let index_id = self.allocate_transient_id()?;
 
-        // If our query only depends on system tables, then we optionally run it on the 
+        // If our query only depends on system tables, then we optionally run it on the
         // introspection cluster.
-        let cluster = if let Some(cluster) = introspection::auto_run_on_introspection(
-            &self.catalog,
-            &session,
-            source.depends_on()
-        ) {
+        let cluster = if let Some(cluster) =
+            introspection::auto_run_on_introspection(&self.catalog, session, source.depends_on())
+        {
             let cluster = self.catalog.resolve_cluster(cluster.name)?;
             tracing::info!("Running Peek on the mz_introspection cluster");
             cluster
@@ -2227,11 +2225,11 @@ impl Coordinator {
             up_to,
         } = plan;
 
-        // If our query only depends on system tables, then we optionally run it on the 
+        // If our query only depends on system tables, then we optionally run it on the
         // introspection cluster.
         let cluster = if let Some(cluster) = introspection::auto_run_on_introspection(
             &self.catalog,
-            &session,
+            session,
             depends_on.iter().copied(),
         ) {
             let cluster = self.catalog.resolve_cluster(cluster.name)?;

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1779,7 +1779,11 @@ impl Coordinator {
             target_replica,
             timeline_context,
             in_immediate_multi_stmt_txn,
-        ) = return_if_err!(self.sequence_peek_begin_inner(&mut session, plan), tx, session);
+        ) = return_if_err!(
+            self.sequence_peek_begin_inner(&mut session, plan),
+            tx,
+            session
+        );
 
         match self.recent_timestamp(&session, source_ids.iter().cloned()) {
             Some(fut) => {

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -445,7 +445,7 @@ impl fmt::Display for AdapterError {
             } => {
                 let items = depends_on.into_iter().map(|item| item.quoted()).join(", ");
                 write!(
-                    f, 
+                    f,
                     "querying the following items {items} is not allowed from the {} cluster. \
                     Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query.",
                     cluster.quoted()

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -444,7 +444,12 @@ impl fmt::Display for AdapterError {
                 cluster,
             } => {
                 let items = depends_on.into_iter().map(|item| item.quoted()).join(", ");
-                write!(f, "referencing the following items {items} is not allowed from the {} cluster", cluster.quoted())
+                write!(
+                    f, 
+                    "querying the following items {items} is not allowed from the {} cluster. \
+                    Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query.",
+                    cluster.quoted()
+                )
             }
             AdapterError::Unauthorized(unauthorized) => {
                 write!(f, "{unauthorized}")

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -12,6 +12,7 @@ use std::fmt;
 use std::num::TryFromIntError;
 
 use dec::TryFromDecimalError;
+use itertools::Itertools;
 use mz_repr::adt::timestamp::TimestampError;
 use smallvec::SmallVec;
 use tokio::sync::oneshot;
@@ -442,8 +443,8 @@ impl fmt::Display for AdapterError {
                 depends_on,
                 cluster,
             } => {
-                let items = depends_on.join(", ");
-                write!(f, "referencing the following items [{items}] is not allowed from the {cluster} cluster")
+                let items = depends_on.into_iter().map(|item| item.quoted()).join(", ");
+                write!(f, "referencing the following items {items} is not allowed from the {} cluster", cluster.quoted())
             }
             AdapterError::Unauthorized(unauthorized) => {
                 write!(f, "{unauthorized}")

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -87,6 +87,7 @@ pub enum AdapterNotice {
         role_name: String,
         member_name: String,
     },
+    AutoRunOnIntrospectionCluster,
 }
 
 impl AdapterNotice {
@@ -207,6 +208,10 @@ impl fmt::Display for AdapterNotice {
             } => write!(
                 f,
                 "role \"{member_name}\" is not a member of role \"{role_name}\""
+            ),
+            AdapterNotice::AutoRunOnIntrospectionCluster => write!(
+                f,
+                "query was automatically run on the \"mz_introspection\" cluster"
             ),
         }
     }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -591,7 +591,7 @@ impl Severity {
             AdapterNotice::RbacDisabled => Severity::Notice,
             AdapterNotice::RoleMembershipAlreadyExists { .. } => Severity::Notice,
             AdapterNotice::RoleMembershipDoesNotExists { .. } => Severity::Warning,
-            AdapterNotice::AutoRunOnIntrospectionCluster => Severity::Info,
+            AdapterNotice::AutoRunOnIntrospectionCluster => Severity::Log,
         }
     }
 }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -430,6 +430,7 @@ impl ErrorResponse {
             AdapterNotice::RbacDisabled => SqlState::WARNING,
             AdapterNotice::RoleMembershipAlreadyExists { .. } => SqlState::WARNING,
             AdapterNotice::RoleMembershipDoesNotExists { .. } => SqlState::WARNING,
+            AdapterNotice::AutoRunOnIntrospectionCluster => SqlState::WARNING,
         };
         ErrorResponse {
             severity: Severity::for_adapter_notice(&notice),
@@ -590,6 +591,7 @@ impl Severity {
             AdapterNotice::RbacDisabled => Severity::Notice,
             AdapterNotice::RoleMembershipAlreadyExists { .. } => Severity::Notice,
             AdapterNotice::RoleMembershipDoesNotExists { .. } => Severity::Warning,
+            AdapterNotice::AutoRunOnIntrospectionCluster => Severity::Info,
         }
     }
 }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -363,6 +363,7 @@ impl ErrorResponse {
             AdapterError::SqlCatalog(_) => SqlState::INTERNAL_ERROR,
             AdapterError::SubscribeOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::Transform(_) => SqlState::INTERNAL_ERROR,
+            AdapterError::UnallowedOnCluster { .. } => SqlState::INTERNAL_ERROR,
             AdapterError::Unauthorized(_) => SqlState::INSUFFICIENT_PRIVILEGE,
             AdapterError::UncallableFunction { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::UnknownCursor(_) => SqlState::INVALID_CURSOR_NAME,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -624,7 +624,7 @@ pub const ENABLE_RBAC_CHECKS: ServerVar<bool> = ServerVar {
 pub const FORCE_INTROSPECTION_CLUSTER: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("force_introspection_cluster"),
     value: &false,
-    description: 
+    description:
         "Boolean flag indicating whether we should force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize).",
     internal: true,
     safe: true,

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -30,7 +30,14 @@ $ kafka-ingest topic=data format=avro schema=${writer-schema}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${writer-schema}'
 
+# Not allowed to query user objects from mz_introspection.
 > SET CLUSTER TO mz_introspection
+! SHOW INDEXES ON data
+contains: querying the following items "materialize.public.data" is not allowed from the "mz_introspection" cluster. Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query
+
+> CREATE CLUSTER other REPLICAS (r1 (size '1'))
+> SET CLUSTER TO other
+
 > SHOW INDEXES ON data
 name    on  cluster key
 --------------------------------------------------------------------------
@@ -39,7 +46,7 @@ name    on  cluster key
 # Sources can have default indexes added
 > CREATE DEFAULT INDEX ON data
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON data
 name                on      cluster             key
 -------------------------------------------------------------------------------------------
@@ -63,7 +70,7 @@ position         name
 # Views do not have indexes automatically created
 > CREATE VIEW data_view as SELECT * from data
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON data_view
 name    on  cluster key
 --------------------------------------------------------------------------
@@ -72,7 +79,7 @@ name    on  cluster key
 # Views can have default indexes added
 > CREATE DEFAULT INDEX ON data_view
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 ---------------------------------------------------------------------------------------------------
@@ -83,7 +90,7 @@ data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
 > CREATE MATERIALIZED VIEW matv AS
   SELECT b, sum(a) FROM data GROUP BY b
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON matv
 name    on  cluster key
 --------------------------------------------------------------------------
@@ -92,7 +99,7 @@ name    on  cluster key
 # Materialized views can have default indexes added
 > CREATE DEFAULT INDEX ON matv
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON matv
 name                on      cluster             key
 --------------------------------------------------------------------------------------------
@@ -102,7 +109,7 @@ matv_primary_idx    matv    <VARIABLE_OUTPUT>   {b}
 # IF NOT EXISTS prevents adding multiple default indexes
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 -------------------------------------------------------------------------------------------------
@@ -112,7 +119,7 @@ data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
 # Additional default indexes have the same structure as the first
 > CREATE DEFAULT INDEX ON matv
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON matv
 name                on      cluster             key
 ------------------------------------------------------------------------------------------------
@@ -123,7 +130,7 @@ matv_primary_idx1   matv    <VARIABLE_OUTPUT>   {b}
 # Default indexes can be named
 > CREATE DEFAULT INDEX named_idx ON data_view
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 -----------------------------------------------------------------------------------------------
@@ -137,7 +144,7 @@ named_idx               data_view   <VARIABLE_OUTPUT>   {a,b}
 # Indexes with specified columns can be automatically named
 > CREATE INDEX ON data_view(a)
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON data_view
 name            on          cluster             key
 -------------------------------------------------------------------------------------------
@@ -150,7 +157,7 @@ data_view_a_idx data_view   <VARIABLE_OUTPUT>   {a}
 > CREATE INDEX ON data_view(b, a)
 > CREATE INDEX ON data_view(b - a, a)
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 -----------------------------------------------------------------------------------------------
@@ -164,7 +171,7 @@ data_view_expr_a_idx    data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 # Indexes can be both explicitly named and explicitly structured
 > CREATE INDEX named_idx ON data_view (b - a, a)
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON data_view
 name        on          cluster             key
 ---------------------------------------------------------------------------------------------
@@ -177,7 +184,7 @@ named_idx   data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 > CREATE INDEX data_view_primary_idx ON data_view (b - a, a)
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 ------------------------------------------------------------------------------------------------------
@@ -197,7 +204,7 @@ materialize.public.data_view_primary_idx "CREATE INDEX \"data_view_primary_idx\"
 > CREATE DEFAULT INDEX ON foo
 > CREATE INDEX ON foo (a + b)
 > CREATE INDEX ON foo (substr(z, 3))
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON foo
 foo_primary_idx foo <VARIABLE_OUTPUT>   {a,b,z}
 foo_expr_idx    foo <VARIABLE_OUTPUT>   "{a + b}"
@@ -219,7 +226,7 @@ contains:cannot show indexes on materialize.public.foo_primary_idx because it is
 
 > CREATE CLUSTER clstr REPLICAS (r1 (SIZE '1'))
 > CREATE DEFAULT INDEX IN CLUSTER clstr ON foo;
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES IN CLUSTER clstr WHERE on = 'foo'
 foo_primary_idx1    foo clstr   {a,b,z}
 
@@ -230,7 +237,7 @@ foo_primary_idx1    foo clstr   {a,b,z}
 > DROP TABLE foo CASCADE
 > DROP SOURCE data CASCADE
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 
 ! SHOW INDEXES FROM public ON foo
 contains:Cannot specify both FROM and ON
@@ -243,7 +250,7 @@ contains:unknown schema 'nonexistent'
 > CREATE TABLE bar ();
 > CREATE INDEX bar_ind ON bar ();
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES
 bar_ind bar <VARIABLE_OUTPUT> {}
 > SET CLUSTER TO default
@@ -253,7 +260,7 @@ bar_ind bar <VARIABLE_OUTPUT> {}
 > CREATE TABLE foo.bar (a INT)
 > CREATE INDEX bar_ind ON foo.bar (a)
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO other
 > SHOW INDEXES ON foo.bar
 bar_ind bar <VARIABLE_OUTPUT> {a}
 > SET CLUSTER TO default
@@ -312,3 +319,5 @@ mz_worker_compute_delays_histogram_internal_s2_primary_idx       mz_worker_compu
 mz_worker_compute_dependencies_s2_primary_idx                    mz_worker_compute_dependencies                    mz_introspection    {export_id,import_id,worker_id}
 mz_worker_compute_frontiers_s2_primary_idx                       mz_worker_compute_frontiers                       mz_introspection    {export_id,worker_id,time}
 mz_worker_compute_import_frontiers_s2_primary_idx                mz_worker_compute_import_frontiers                mz_introspection    {export_id,import_id,worker_id,time}
+
+> DROP CLUSTER other CASCADE;


### PR DESCRIPTION
**_Work in Progress_**

### Motivation

- add new adapter::coord::introspection module
- check when sequencing, if we're on the mz_introspection cluster, we're only referencing system items

* This PR fixes a recognized bug.
  * Fixes #18075 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
