### PR TITLE
adapter: move some catalog work off coord thread

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3225,7 +3225,7 @@ impl Catalog {
     /// Objects need to be dropped starting from the leafs of the DAG going up towards the roots,
     /// and they need to be recreated starting at the roots of the DAG and going towards the leafs.
     pub async fn generate_builtin_migration_metadata(
-        &mut self,
+        &self,
         migrated_ids: Vec<GlobalId>,
         id_fingerprint_map: BTreeMap<GlobalId, String>,
     ) -> Result<BuiltinMigrationMetadata, Error> {
@@ -3416,7 +3416,7 @@ impl Catalog {
 
     #[tracing::instrument(level = "info", skip_all)]
     pub async fn apply_persisted_builtin_migration(
-        &mut self,
+        &self,
         migration_metadata: &mut BuiltinMigrationMetadata,
     ) -> Result<(), Error> {
         let mut storage = self.storage().await;
@@ -3710,7 +3710,7 @@ impl Catalog {
     /// Allocate new system ids for any new builtin objects and looks up existing system ids for
     /// existing builtin objects
     async fn allocate_system_ids<T, F>(
-        &mut self,
+        &self,
         builtins: Vec<T>,
         builtin_lookup: F,
     ) -> Result<AllocatedBuiltinSystemIds<T>, Error>
@@ -3761,12 +3761,12 @@ impl Catalog {
         })
     }
 
-    pub async fn allocate_user_id(&mut self) -> Result<GlobalId, Error> {
+    pub async fn allocate_user_id(&self) -> Result<GlobalId, Error> {
         self.storage().await.allocate_user_id().await
     }
 
     #[cfg(test)]
-    pub async fn allocate_system_id(&mut self) -> Result<GlobalId, Error> {
+    pub async fn allocate_system_id(&self) -> Result<GlobalId, Error> {
         self.storage()
             .await
             .allocate_system_ids(1)
@@ -3774,11 +3774,11 @@ impl Catalog {
             .map(|ids| ids.into_element())
     }
 
-    pub async fn allocate_user_cluster_id(&mut self) -> Result<ClusterId, Error> {
+    pub async fn allocate_user_cluster_id(&self) -> Result<ClusterId, Error> {
         self.storage().await.allocate_user_cluster_id().await
     }
 
-    pub async fn allocate_replica_id(&mut self) -> Result<ReplicaId, Error> {
+    pub async fn allocate_replica_id(&self) -> Result<ReplicaId, Error> {
         self.storage().await.allocate_replica_id().await
     }
 
@@ -3788,24 +3788,24 @@ impl Catalog {
 
     /// Get all global timestamps that has been persisted to disk.
     pub async fn get_all_persisted_timestamps(
-        &mut self,
+        &self,
     ) -> Result<BTreeMap<Timeline, mz_repr::Timestamp>, Error> {
         self.storage().await.get_all_persisted_timestamps().await
     }
 
     /// Get the next user ID without allocating it.
-    pub async fn get_next_user_global_id(&mut self) -> Result<GlobalId, Error> {
+    pub async fn get_next_user_global_id(&self) -> Result<GlobalId, Error> {
         self.storage().await.get_next_user_global_id().await
     }
 
     /// Get the next replica id without allocating it.
-    pub async fn get_next_replica_id(&mut self) -> Result<ReplicaId, Error> {
+    pub async fn get_next_replica_id(&self) -> Result<ReplicaId, Error> {
         self.storage().await.get_next_replica_id().await
     }
 
     /// Persist new global timestamp for a timeline to disk.
     pub async fn persist_timestamp(
-        &mut self,
+        &self,
         timeline: &Timeline,
         timestamp: mz_repr::Timestamp,
     ) -> Result<(), Error> {
@@ -4030,7 +4030,7 @@ impl Catalog {
         Ok(())
     }
 
-    pub fn drop_database_ops(&mut self, id: Option<DatabaseId>) -> Vec<Op> {
+    pub fn drop_database_ops(&self, id: Option<DatabaseId>) -> Vec<Op> {
         let mut ops = vec![];
         let mut seen = BTreeSet::new();
         if let Some(id) = id {
@@ -4047,7 +4047,7 @@ impl Catalog {
         ops
     }
 
-    pub fn drop_schema_ops(&mut self, id: Option<(DatabaseId, SchemaId)>) -> Vec<Op> {
+    pub fn drop_schema_ops(&self, id: Option<(DatabaseId, SchemaId)>) -> Vec<Op> {
         let mut ops = vec![];
         let mut seen = BTreeSet::new();
         if let Some((database_id, schema_id)) = id {
@@ -4190,7 +4190,7 @@ impl Catalog {
     /// Gets GlobalIds of temporary items to be created, checks for name collisions
     /// within a connection id.
     fn temporary_ids(
-        &mut self,
+        &self,
         ops: &[Op],
         temporary_drops: BTreeSet<(ConnectionId, String)>,
     ) -> Result<Vec<GlobalId>, Error> {
@@ -5634,11 +5634,11 @@ impl Catalog {
         Ok(())
     }
 
-    pub async fn consolidate(&mut self, collections: &[mz_stash::Id]) -> Result<(), AdapterError> {
+    pub async fn consolidate(&self, collections: &[mz_stash::Id]) -> Result<(), AdapterError> {
         Ok(self.storage().await.consolidate(collections).await?)
     }
 
-    pub async fn confirm_leadership(&mut self) -> Result<(), AdapterError> {
+    pub async fn confirm_leadership(&self) -> Result<(), AdapterError> {
         Ok(self.storage().await.confirm_leadership().await?)
     }
 
@@ -5916,7 +5916,7 @@ impl Catalog {
 
     /// Allocate ids for legacy, active logs. Called once per cluster creation.
     pub async fn allocate_arranged_introspection_sources(
-        &mut self,
+        &self,
     ) -> Vec<(&'static BuiltinLog, GlobalId)> {
         let log_amount = BUILTINS::logs().count();
         let system_ids = self
@@ -5933,7 +5933,7 @@ impl Catalog {
     }
 
     /// Allocate ids for persisted introspection views. Called once per cluster replica creation
-    pub async fn allocate_persisted_introspection_views(&mut self) -> Vec<(LogView, GlobalId)> {
+    pub async fn allocate_persisted_introspection_views(&self) -> Vec<(LogView, GlobalId)> {
         if !self.state.config.persisted_introspection {
             return Vec::new();
         }
@@ -5958,9 +5958,7 @@ impl Catalog {
 
     /// Allocate ids for persisted introspection sources.
     /// Called once per cluster replica creation.
-    pub async fn allocate_persisted_introspection_sources(
-        &mut self,
-    ) -> Vec<(LogVariant, GlobalId)> {
+    pub async fn allocate_persisted_introspection_sources(&self) -> Vec<(LogVariant, GlobalId)> {
         if !self.state.config.persisted_introspection {
             return Vec::new();
         }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -340,6 +340,7 @@ impl SessionClient {
             tx,
         })
         .await
+        .map(|_| ())
     }
 
     /// Executes a previously-bound portal.

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -48,7 +48,7 @@ pub enum Command {
         stmt: Statement<Raw>,
         param_types: Vec<Option<ScalarType>>,
         session: Session,
-        tx: oneshot::Sender<Response<()>>,
+        tx: oneshot::Sender<Response<ExecuteResponse>>,
     },
 
     Describe {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1293,13 +1293,11 @@ impl Coordinator {
         &self.catalog
     }
 
-    /*
     /// Obtain a read-only Catalog snapshot, suitable for giving out to
     /// non-Coordinator thread tasks.
     fn owned_catalog(&self) -> Arc<Catalog> {
         Arc::clone(&self.catalog)
     }
-    */
 
     /// Obtain a writeable Catalog reference.
     fn catalog_mut(&mut self) -> &mut Catalog {

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -138,7 +138,7 @@ impl Coordinator {
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn try_group_commit(&mut self) {
         let timestamp = self.peek_local_write_ts();
-        let now = Timestamp::from((self.catalog.config().now)());
+        let now = Timestamp::from((self.catalog().config().now)());
         if timestamp > now {
             // Cap retry time to 1s. In cases where the system clock has retreated by
             // some large amount of time, this prevents against then waiting for that
@@ -252,7 +252,7 @@ impl Coordinator {
                         // client that the write was successful. This is only possible if the write
                         // and the delete were concurrent. Therefore, we are free to order the
                         // write before the delete without violating any consistency guarantees.
-                        if self.catalog.try_get_entry(&id).is_some() {
+                        if self.catalog().try_get_entry(&id).is_some() {
                             appends.entry(id).or_default().extend(rows);
                         }
                     }
@@ -278,7 +278,7 @@ impl Coordinator {
             differential_dataflow::consolidation::consolidate(updates);
         }
         // Add table advancements for all tables.
-        for table in self.catalog.entries().filter(|entry| entry.is_table()) {
+        for table in self.catalog().entries().filter(|entry| entry.is_table()) {
             appends.entry(table.id()).or_default();
         }
         let appends = appends

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -79,11 +79,11 @@ impl Coordinator {
                 name,
                 stmt,
                 param_types,
-                mut session,
+                session,
                 tx,
             } => {
-                let result = self.declare(&mut session, name, stmt, param_types);
-                let _ = tx.send(Response { result, session });
+                let tx = ClientTransmitter::new(tx, self.internal_cmd_tx.clone());
+                self.declare(tx, session, name, stmt, param_types);
             }
 
             Command::Describe {

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -48,7 +48,7 @@ impl Coordinator {
         if let Some(session) = cmd.session() {
             session.apply_external_metadata_updates();
         }
-        if let Err(e) = rbac::check_command(&self.catalog, &cmd) {
+        if let Err(e) = rbac::check_command(self.catalog(), &cmd) {
             cmd.send_error(e.into());
             return;
         }
@@ -109,7 +109,7 @@ impl Coordinator {
                 // require superuser permissions.
 
                 let _ = tx.send(Response {
-                    result: Ok(self.catalog.dump()),
+                    result: Ok(self.catalog().dump()),
                     session,
                 });
             }
@@ -132,7 +132,7 @@ impl Coordinator {
 
             Command::GetSystemVars { session, tx } => {
                 let mut vars = BTreeMap::new();
-                for var in self.catalog.system_config().iter() {
+                for var in self.catalog().system_config().iter() {
                     vars.insert(var.name().to_string(), var.value());
                 }
                 let _ = tx.send(Response {
@@ -202,7 +202,7 @@ impl Coordinator {
         tx: oneshot::Sender<Response<StartupResponse>>,
     ) {
         if self
-            .catalog
+            .catalog()
             .try_get_role_by_name(&session.user().name)
             .is_none()
         {
@@ -225,13 +225,16 @@ impl Coordinator {
         }
 
         let role_id = self
-            .catalog
+            .catalog()
             .try_get_role_by_name(&session.user().name)
             .expect("created above")
             .id;
         session.set_role_id(role_id);
 
-        if let Err(e) = self.catalog.create_temporary_schema(session.conn_id()) {
+        if let Err(e) = self
+            .catalog_mut()
+            .create_temporary_schema(session.conn_id())
+        {
             let _ = tx.send(Response {
                 result: Err(e.into()),
                 session,
@@ -240,7 +243,8 @@ impl Coordinator {
         }
 
         let mut messages = vec![];
-        let catalog = self.catalog.for_session(&session);
+        let catalog = self.catalog();
+        let catalog = catalog.for_session(&session);
         if catalog.active_database().is_none() {
             messages.push(StartupMessage::UnknownSessionDatabase(
                 session.vars().database().into(),
@@ -455,7 +459,8 @@ impl Coordinator {
             }
         }
 
-        let catalog = self.catalog.for_session(&session);
+        let catalog = self.catalog();
+        let catalog = catalog.for_session(&session);
         let original_stmt = stmt.clone();
         let (stmt, depends_on) = match mz_sql::names::resolve(&catalog, stmt) {
             Ok(resolved) => resolved,
@@ -526,7 +531,7 @@ impl Coordinator {
         let desc = self.describe(session, stmt.clone(), param_types)?;
         session.set_prepared_statement(
             name,
-            PreparedStatement::new(stmt, desc, self.catalog.transient_revision()),
+            PreparedStatement::new(stmt, desc, self.catalog().transient_revision()),
         );
         Ok(())
     }
@@ -608,7 +613,7 @@ impl Coordinator {
         self.clear_transaction(session);
 
         self.drop_temp_items(session).await;
-        self.catalog
+        self.catalog_mut()
             .drop_temporary_schema(&session.conn_id())
             .unwrap_or_terminate("unable to drop temporary schema");
         let session_type = metrics::session_type_label_value(session.user());

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -87,7 +87,7 @@ impl Coordinator {
             .instance_ref(instance)
             .expect("compute instance does not exist");
         DataflowBuilder {
-            catalog: self.catalog.state(),
+            catalog: self.catalog().state(),
             compute,
             recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
         }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -104,7 +104,7 @@ impl Coordinator {
         for op in &ops {
             match op {
                 catalog::Op::DropItem(id) => {
-                    match self.catalog.get_entry(id).item() {
+                    match self.catalog().get_entry(id).item() {
                         CatalogItem::Table(_) => {
                             tables_to_drop.push(*id);
                         }
@@ -165,7 +165,7 @@ impl Coordinator {
                     }
                 }
                 catalog::Op::DropCluster { id } => {
-                    let cluster = self.catalog.get_cluster(*id);
+                    let cluster = self.catalog().get_cluster(*id);
 
                     // Drop the introspection sources
                     let replica_logs = cluster
@@ -182,7 +182,7 @@ impl Coordinator {
                     cluster_id,
                     replica_id,
                 } => {
-                    let cluster = self.catalog.get_cluster(*cluster_id);
+                    let cluster = self.catalog().get_cluster(*cluster_id);
                     let replica = &cluster.replicas_by_id[replica_id];
 
                     // Drop the introspection sources
@@ -229,8 +229,10 @@ impl Coordinator {
             })
             .map(|(dependent_id, sink_id, active_subscribe)| {
                 let conn_id = active_subscribe.conn_id;
-                let entry = self.catalog.get_entry(dependent_id);
-                let name = self.catalog.resolve_full_name(entry.name(), Some(conn_id));
+                let entry = self.catalog().get_entry(dependent_id);
+                let name = self
+                    .catalog()
+                    .resolve_full_name(entry.name(), Some(conn_id));
 
                 (
                     (conn_id, name.to_string()),
@@ -249,9 +251,9 @@ impl Coordinator {
                 .iter()
                 .find(|id| relations_to_drop.contains(id))
             {
-                let entry = self.catalog.get_entry(id);
+                let entry = self.catalog().get_entry(id);
                 let name = self
-                    .catalog
+                    .catalog()
                     .resolve_full_name(entry.name(), Some(pending_peek.conn_id));
                 peeks_to_drop.push((name.to_string(), uuid.clone()));
             }
@@ -325,15 +327,15 @@ impl Coordinator {
         // regress or pause for 10s.
         let oracle_write_ts = self.get_local_write_ts().await.timestamp;
 
+        let (catalog, controller) = self.catalog_and_controller_mut();
         let TransactionResult {
             builtin_table_updates,
             audit_events,
             result,
-        } = self
-            .catalog
+        } = catalog
             .transact(oracle_write_ts, session, ops, |catalog| {
                 f(CatalogTxn {
-                    dataflow_client: &self.controller,
+                    dataflow_client: controller,
                     catalog,
                 })
             })
@@ -465,7 +467,7 @@ impl Coordinator {
                     event.event_type.as_title_case()
                 );
                 segment_client.environment_track(
-                    &self.catalog.config().environment_id,
+                    &self.catalog().config().environment_id,
                     user_metadata.user_id,
                     event_type,
                     json!({ "details": event.details.as_json() }),
@@ -485,7 +487,7 @@ impl Coordinator {
         {
             let mut updates = vec![];
             if let Some(last_heartbeat) = last_heartbeat {
-                let retraction = self.catalog.state().pack_replica_heartbeat_update(
+                let retraction = self.catalog().state().pack_replica_heartbeat_update(
                     replica_id,
                     last_heartbeat,
                     -1,
@@ -494,12 +496,12 @@ impl Coordinator {
             }
             if let Some(metrics) = metrics {
                 let retraction = self
-                    .catalog
+                    .catalog()
                     .state()
                     .pack_replica_metric_updates(replica_id, &metrics, -1);
                 updates.extend(retraction.into_iter());
             }
-            let retraction = self.catalog.state().pack_replica_write_frontiers_updates(
+            let retraction = self.catalog().state().pack_replica_write_frontiers_updates(
                 replica_id,
                 &write_frontiers,
                 -1,
@@ -652,7 +654,7 @@ impl Coordinator {
     /// Removes all temporary items created by the specified connection, though
     /// not the temporary schema itself.
     pub(crate) async fn drop_temp_items(&mut self, session: &Session) {
-        let ops = self.catalog.drop_temp_item_ops(&session.conn_id());
+        let ops = self.catalog_mut().drop_temp_item_ops(&session.conn_id());
         if ops.is_empty() {
             return;
         }
@@ -662,17 +664,17 @@ impl Coordinator {
     }
 
     fn update_compute_config(&mut self) {
-        let config_params = self.catalog.compute_config();
+        let config_params = self.catalog().compute_config();
         self.controller.compute.update_configuration(config_params);
     }
 
     fn update_storage_config(&mut self) {
-        let config_params = self.catalog.storage_config();
+        let config_params = self.catalog().storage_config();
         self.controller.storage.update_configuration(config_params);
     }
 
     fn update_metrics_retention(&mut self) {
-        let duration = self.catalog.system_config().metrics_retention();
+        let duration = self.catalog().system_config().metrics_retention();
         let policy = ReadPolicy::lag_writes_by(Timestamp::new(
             u64::try_from(duration.as_millis()).unwrap_or_else(|_e| {
                 tracing::error!("Absurd metrics retention duration: {duration:?}.");
@@ -680,7 +682,7 @@ impl Coordinator {
             }),
         ));
         let policies = self
-            .catalog
+            .catalog()
             .entries()
             .filter(|entry| entry.item().is_retained_metrics_relation())
             .map(|entry| (entry.id(), policy.clone()))
@@ -698,7 +700,7 @@ impl Coordinator {
         self.controller.storage.collection(sink.from)?;
 
         let status_id =
-            Some(self.catalog.resolve_builtin_storage_collection(
+            Some(self.catalog().resolve_builtin_storage_collection(
                 &crate::catalog::builtin::MZ_SINK_STATUS_HISTORY,
             ));
 
@@ -717,11 +719,11 @@ impl Coordinator {
             strict: !sink.with_snapshot,
         };
 
-        let storage_sink_from_entry = self.catalog.get_entry(&sink.from);
+        let storage_sink_from_entry = self.catalog().get_entry(&sink.from);
         let storage_sink_desc = mz_storage_client::types::sinks::StorageSinkDesc {
             from: sink.from,
             from_desc: storage_sink_from_entry
-                .desc(&self.catalog.resolve_full_name(
+                .desc(&self.catalog().resolve_full_name(
                     storage_sink_from_entry.name(),
                     storage_sink_from_entry.conn_id(),
                 ))
@@ -756,7 +758,7 @@ impl Coordinator {
         session: Option<&Session>,
     ) -> Result<(), AdapterError> {
         // Update catalog entry with sink connection.
-        let entry = self.catalog.get_entry(&id);
+        let entry = self.catalog().get_entry(&id);
         let name = entry.name().clone();
         let sink = match entry.item() {
             CatalogItem::Sink(sink) => sink,
@@ -907,7 +909,7 @@ impl Coordinator {
                     *new_replicas_per_cluster.entry(*cluster_id).or_insert(0) -= 1;
                 }
                 Op::DropItem(id) => {
-                    let entry = self.catalog.get_entry(id);
+                    let entry = self.catalog().get_entry(id);
                     *new_objects_per_schema
                         .entry((
                             entry.name().qualifiers.database_spec.clone(),
@@ -965,7 +967,7 @@ impl Coordinator {
         }
 
         self.validate_resource_limit(
-            self.catalog
+            self.catalog()
                 .user_connections()
                 .filter(|c| {
                     matches!(
@@ -981,7 +983,7 @@ impl Coordinator {
             "AWS PrivateLink Connection",
         )?;
         self.validate_resource_limit(
-            self.catalog.user_tables().count(),
+            self.catalog().user_tables().count(),
             new_tables,
             SystemVars::max_tables,
             "Table",
@@ -989,7 +991,7 @@ impl Coordinator {
         // Only sources that ingest data from an external system count
         // towards resource limits.
         let current_sources = self
-            .catalog
+            .catalog()
             .user_sources()
             .filter_map(|source| source.source())
             .filter(|source| source.is_external())
@@ -1001,13 +1003,13 @@ impl Coordinator {
             "Source",
         )?;
         self.validate_resource_limit(
-            self.catalog.user_sinks().count(),
+            self.catalog().user_sinks().count(),
             new_sinks,
             SystemVars::max_sinks,
             "Sink",
         )?;
         self.validate_resource_limit(
-            self.catalog.user_materialized_views().count(),
+            self.catalog().user_materialized_views().count(),
             new_materialized_views,
             SystemVars::max_materialized_views,
             "Materialized view",
@@ -1018,7 +1020,7 @@ impl Coordinator {
             //
             // TODO(benesch): remove the `max_sources` and `max_sinks` limit,
             // and set a higher max cluster limit?
-            self.catalog
+            self.catalog()
                 .user_clusters()
                 .filter(|c| c.linked_object_id.is_none())
                 .count(),
@@ -1029,7 +1031,7 @@ impl Coordinator {
         for (cluster_id, new_replicas) in new_replicas_per_cluster {
             // It's possible that the cluster hasn't been created yet.
             let current_amount = self
-                .catalog
+                .catalog()
                 .try_get_cluster(cluster_id)
                 .map(|instance| instance.replicas_by_id.len())
                 .unwrap_or(0);
@@ -1041,14 +1043,14 @@ impl Coordinator {
             )?;
         }
         self.validate_resource_limit(
-            self.catalog.databases().count(),
+            self.catalog().databases().count(),
             new_databases,
             SystemVars::max_databases,
             "Database",
         )?;
         for (database_id, new_schemas) in new_schemas_per_database {
             self.validate_resource_limit(
-                self.catalog.get_database(database_id).schemas_by_id.len(),
+                self.catalog().get_database(database_id).schemas_by_id.len(),
                 new_schemas,
                 SystemVars::max_schemas_per_database,
                 "Schemas per database",
@@ -1056,7 +1058,7 @@ impl Coordinator {
         }
         for ((database_spec, schema_spec), new_objects) in new_objects_per_schema {
             self.validate_resource_limit(
-                self.catalog
+                self.catalog()
                     .get_schema(&database_spec, &schema_spec, conn_id)
                     .items
                     .len(),
@@ -1066,13 +1068,13 @@ impl Coordinator {
             )?;
         }
         self.validate_resource_limit(
-            self.catalog.user_secrets().count(),
+            self.catalog().user_secrets().count(),
             new_secrets,
             SystemVars::max_secrets,
             "Secret",
         )?;
         self.validate_resource_limit(
-            self.catalog.user_roles().count(),
+            self.catalog().user_roles().count(),
             new_roles,
             SystemVars::max_roles,
             "Role",
@@ -1091,7 +1093,7 @@ impl Coordinator {
     where
         F: Fn(&SystemVars) -> u32,
     {
-        let limit = resource_limit(self.catalog.system_config());
+        let limit = resource_limit(self.catalog().system_config());
         let exceeds_limit = match (u32::try_from(current_amount), u32::try_from(new_instances)) {
             // 0 new instances are always ok.
             (_, Ok(new_instances)) if new_instances == 0 => false,

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -33,7 +33,7 @@ impl Coordinator {
         instance: ComputeInstanceId,
     ) -> ComputeInstanceIndexOracle<mz_repr::Timestamp> {
         ComputeInstanceIndexOracle {
-            catalog: self.catalog.state(),
+            catalog: self.catalog().state(),
             compute: self
                 .controller
                 .compute

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -338,7 +338,8 @@ impl crate::coord::Coordinator {
                     ));
                 }
             }
-            let results = finishing.finish(results, self.catalog.system_config().max_result_size());
+            let results =
+                finishing.finish(results, self.catalog().system_config().max_result_size());
             return match results {
                 Ok(rows) => Ok(send_immediate_rows(rows)),
                 Err(e) => Err(AdapterError::ResultSize(e)),
@@ -458,7 +459,7 @@ impl crate::coord::Coordinator {
             .unwrap_or_terminate("cannot fail to peek");
 
         // Prepare the receiver to return as a response.
-        let max_result_size = self.catalog.system_config().max_result_size();
+        let max_result_size = self.catalog().system_config().max_result_size();
         let rows_rx = rows_rx.map_ok_or_else(
             |e| PeekResponseUnary::Error(e.to_string()),
             move |resp| match resp {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -368,10 +368,7 @@ impl Coordinator {
             }
             Plan::Declare(plan) => {
                 let param_types = vec![];
-                let res = self
-                    .declare(&mut session, plan.name, plan.stmt, param_types)
-                    .map(|()| ExecuteResponse::DeclaredCursor);
-                tx.send(res, session);
+                self.declare(tx, session, plan.name, plan.stmt, param_types);
             }
             Plan::Fetch(FetchPlan {
                 name,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -278,10 +278,7 @@ impl Coordinator {
                 );
             }
             Plan::CopyRows(CopyRowsPlan { id, columns, rows }) => {
-                tx.send(
-                    self.sequence_copy_rows(&mut session, id, columns, rows),
-                    session,
-                );
+                self.sequence_copy_rows(tx, session, id, columns, rows);
             }
             Plan::Explain(plan) => {
                 self.sequence_explain(tx, session, plan);

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -126,7 +126,7 @@ impl Coordinator {
             .collect::<BTreeMap<_, _>>();
 
         for (source_id, plan, depends_on) in plans {
-            let source_oid = self.catalog.allocate_oid()?;
+            let source_oid = self.catalog_mut().allocate_oid()?;
             let source = catalog::Source {
                 create_sql: plan.source.create_sql,
                 data_source: match plan.source.data_source {
@@ -187,7 +187,7 @@ impl Coordinator {
                 let mut source_ids = Vec::with_capacity(sources.len());
                 for (source_id, source) in sources {
                     let source_status_collection_id =
-                        Some(self.catalog.resolve_builtin_storage_collection(
+                        Some(self.catalog().resolve_builtin_storage_collection(
                             &crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
                         ));
 
@@ -281,8 +281,8 @@ impl Coordinator {
         plan: CreateConnectionPlan,
         depends_on: Vec<GlobalId>,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let connection_oid = self.catalog.allocate_oid()?;
-        let connection_gid = self.catalog.allocate_user_id().await?;
+        let connection_oid = self.catalog_mut().allocate_oid()?;
+        let connection_gid = self.catalog_mut().allocate_user_id().await?;
         let mut connection = plan.connection.connection;
 
         match connection {
@@ -365,8 +365,8 @@ impl Coordinator {
         session: &mut Session,
         plan: CreateDatabasePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let db_oid = self.catalog.allocate_oid()?;
-        let schema_oid = self.catalog.allocate_oid()?;
+        let db_oid = self.catalog_mut().allocate_oid()?;
+        let schema_oid = self.catalog_mut().allocate_oid()?;
         let ops = vec![catalog::Op::CreateDatabase {
             name: plan.name.clone(),
             oid: db_oid,
@@ -391,7 +391,7 @@ impl Coordinator {
         session: &mut Session,
         plan: CreateSchemaPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let oid = self.catalog.allocate_oid()?;
+        let oid = self.catalog_mut().allocate_oid()?;
         let op = catalog::Op::CreateSchema {
             database_id: plan.database_spec,
             schema_name: plan.schema_name.clone(),
@@ -418,7 +418,7 @@ impl Coordinator {
         session: &Session,
         CreateRolePlan { name, attributes }: CreateRolePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let oid = self.catalog.allocate_oid()?;
+        let oid = self.catalog_mut().allocate_oid()?;
         let op = catalog::Op::CreateRole {
             name,
             oid,
@@ -457,13 +457,15 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, AdapterError> {
         tracing::debug!("sequence_create_cluster");
 
-        let id = self.catalog.allocate_user_cluster_id().await?;
+        let id = self.catalog_mut().allocate_user_cluster_id().await?;
         // The catalog items for the arranged introspection sources are shared between all replicas
         // of a compute instance, so we create them unconditionally during instance creation.
         // Whether a replica actually maintains introspection arrangements is determined by the
         // per-replica introspection configuration.
-        let arranged_introspection_sources =
-            self.catalog.allocate_arranged_introspection_sources().await;
+        let arranged_introspection_sources = self
+            .catalog_mut()
+            .allocate_arranged_introspection_sources()
+            .await;
         let mut ops = vec![catalog::Op::CreateCluster {
             id,
             name: name.clone(),
@@ -471,7 +473,7 @@ impl Coordinator {
             arranged_introspection_sources,
         }];
 
-        let azs = self.catalog.state().availability_zones();
+        let azs = self.catalog().state().availability_zones();
         let mut n_replicas_per_az = azs
             .iter()
             .map(|s| (s.clone(), 0))
@@ -537,10 +539,13 @@ impl Coordinator {
 
             let logging = if let Some(config) = compute.introspection {
                 let sources = self
-                    .catalog
+                    .catalog_mut()
                     .allocate_persisted_introspection_sources()
                     .await;
-                let views = self.catalog.allocate_persisted_introspection_views().await;
+                let views = self
+                    .catalog_mut()
+                    .allocate_persisted_introspection_views()
+                    .await;
                 ReplicaLogging {
                     log_logging: config.debugging,
                     interval: Some(config.interval),
@@ -552,9 +557,12 @@ impl Coordinator {
             };
 
             let config = ReplicaConfig {
-                location: self.catalog.concretize_replica_location(
+                location: self.catalog().concretize_replica_location(
                     location,
-                    &self.catalog.system_config().allowed_cluster_replica_sizes(),
+                    &self
+                        .catalog()
+                        .system_config()
+                        .allowed_cluster_replica_sizes(),
                 )?,
                 compute: ComputeReplicaConfig {
                     logging,
@@ -564,7 +572,7 @@ impl Coordinator {
 
             ops.push(catalog::Op::CreateClusterReplica {
                 cluster_id: id,
-                id: self.catalog.allocate_replica_id().await?,
+                id: self.catalog_mut().allocate_replica_id().await?,
                 name: replica_name.clone(),
                 config,
             });
@@ -578,12 +586,13 @@ impl Coordinator {
     }
 
     async fn create_cluster(&mut self, cluster_id: ClusterId) {
-        let cluster = self.catalog.get_cluster(cluster_id);
+        let (catalog, controller) = self.catalog_and_controller_mut();
+        let cluster = catalog.get_cluster(cluster_id);
         let cluster_id = cluster.id;
         let arranged_introspection_source_ids: Vec<_> =
             cluster.log_indexes.iter().map(|(_, id)| *id).collect();
 
-        self.controller
+        controller
             .create_cluster(
                 cluster_id,
                 ClusterConfig {
@@ -648,7 +657,7 @@ impl Coordinator {
             } => {
                 let (availability_zone, user_specified) = match availability_zone {
                     Some(az) => {
-                        let azs = self.catalog.state().availability_zones();
+                        let azs = self.catalog().state().availability_zones();
                         if !azs.contains(&az) {
                             return Err(AdapterError::InvalidClusterReplicaAz {
                                 az,
@@ -662,8 +671,8 @@ impl Coordinator {
                         // if none was specified. If there is a tie for "least popular", pick the first one.
                         // That is globally unbiased (for Materialize, not necessarily for this customer)
                         // because we shuffle the AZs on boot in `crate::serve`.
-                        let cluster = self.catalog.get_cluster(cluster_id);
-                        let azs = self.catalog.state().availability_zones();
+                        let cluster = self.catalog().get_cluster(cluster_id);
+                        let azs = self.catalog().state().availability_zones();
                         let mut n_replicas_per_az = azs
                             .iter()
                             .map(|s| (s.clone(), 0))
@@ -688,10 +697,13 @@ impl Coordinator {
 
         let logging = if let Some(config) = compute.introspection {
             let sources = self
-                .catalog
+                .catalog_mut()
                 .allocate_persisted_introspection_sources()
                 .await;
-            let views = self.catalog.allocate_persisted_introspection_views().await;
+            let views = self
+                .catalog_mut()
+                .allocate_persisted_introspection_views()
+                .await;
             ReplicaLogging {
                 log_logging: config.debugging,
                 interval: Some(config.interval),
@@ -703,9 +715,12 @@ impl Coordinator {
         };
 
         let config = ReplicaConfig {
-            location: self.catalog.concretize_replica_location(
+            location: self.catalog().concretize_replica_location(
                 location,
-                &self.catalog.system_config().allowed_cluster_replica_sizes(),
+                &self
+                    .catalog()
+                    .system_config()
+                    .allowed_cluster_replica_sizes(),
             )?,
             compute: ComputeReplicaConfig {
                 logging,
@@ -713,7 +728,7 @@ impl Coordinator {
             },
         };
 
-        let id = self.catalog.allocate_replica_id().await?;
+        let id = self.catalog_mut().allocate_replica_id().await?;
         let op = catalog::Op::CreateClusterReplica {
             cluster_id,
             id,
@@ -734,7 +749,7 @@ impl Coordinator {
         let mut replicas_to_start = Vec::new();
 
         for (cluster_id, replica_id) in replicas.iter().copied() {
-            let cluster = self.catalog.get_cluster(cluster_id);
+            let cluster = self.catalog().get_cluster(cluster_id);
             let role = cluster.role();
             let replica_config = cluster.replicas_by_id[&replica_id].config.clone();
 
@@ -803,7 +818,7 @@ impl Coordinator {
         } else {
             None
         };
-        let table_id = self.catalog.allocate_user_id().await?;
+        let table_id = self.catalog_mut().allocate_user_id().await?;
         let table = catalog::Table {
             create_sql: table.create_sql,
             desc: table.desc,
@@ -813,7 +828,7 @@ impl Coordinator {
             custom_logical_compaction_window: None,
             is_retained_metrics_relation: false,
         };
-        let table_oid = self.catalog.allocate_oid()?;
+        let table_oid = self.catalog_mut().allocate_oid()?;
         let ops = vec![catalog::Op::CreateItem {
             id: table_id,
             oid: table_oid,
@@ -884,8 +899,8 @@ impl Coordinator {
 
         let payload = self.extract_secret(session, &mut secret.secret_as)?;
 
-        let id = self.catalog.allocate_user_id().await?;
-        let oid = self.catalog.allocate_oid()?;
+        let id = self.catalog_mut().allocate_user_id().await?;
+        let oid = self.catalog_mut().allocate_oid()?;
         let secret = catalog::Secret {
             create_sql: secret.create_sql,
         };
@@ -940,8 +955,8 @@ impl Coordinator {
         } = plan;
 
         // First try to allocate an ID and an OID. If either fails, we're done.
-        let id = return_if_err!(self.catalog.allocate_user_id().await, tx, session);
-        let oid = return_if_err!(self.catalog.allocate_oid(), tx, session);
+        let id = return_if_err!(self.catalog_mut().allocate_user_id().await, tx, session);
+        let oid = return_if_err!(self.catalog_mut().allocate_oid(), tx, session);
 
         let mut ops = vec![];
         let cluster_id = return_if_err!(
@@ -981,7 +996,7 @@ impl Coordinator {
             item: CatalogItem::Sink(catalog_sink.clone()),
         });
 
-        let from = self.catalog.get_entry(&catalog_sink.from);
+        let from = self.catalog().get_entry(&catalog_sink.from);
         let from_name = from.name().item.clone();
         let from_type = from.item().typ().to_string();
         let result = self
@@ -1088,7 +1103,7 @@ impl Coordinator {
         if uses_ambiguous_columns
             && depends_on
                 .iter()
-                .any(|id| id.is_system() && self.catalog.get_entry(id).is_relation())
+                .any(|id| id.is_system() && self.catalog().get_entry(id).is_relation())
         {
             Err(AdapterError::AmbiguousSystemColumnReference)
         } else {
@@ -1144,10 +1159,10 @@ impl Coordinator {
         let mut ops = vec![];
 
         if let Some(id) = replace {
-            ops.extend(self.catalog.drop_items_ops(&[id]));
+            ops.extend(self.catalog().drop_items_ops(&[id]));
         }
-        let view_id = self.catalog.allocate_user_id().await?;
-        let view_oid = self.catalog.allocate_oid()?;
+        let view_id = self.catalog_mut().allocate_user_id().await?;
+        let view_oid = self.catalog_mut().allocate_oid()?;
         let optimized_expr = self.view_optimizer.optimize(view.expr)?;
         let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
         let view = catalog::View {
@@ -1193,13 +1208,13 @@ impl Coordinator {
         } = plan;
 
         if !self
-            .catalog
+            .catalog()
             .state()
             .is_system_schema_specifier(&name.qualifiers.schema_spec)
         {
             self.ensure_cluster_is_not_linked(cluster_id)?;
             if !self.is_compute_cluster(cluster_id) {
-                let cluster_name = self.catalog.get_cluster(cluster_id).name.clone();
+                let cluster_name = self.catalog().get_cluster(cluster_id).name.clone();
                 return Err(AdapterError::BadItemInStorageCluster { cluster_name });
             }
         }
@@ -1214,8 +1229,8 @@ impl Coordinator {
         // are replaced with persist-based ones.
         let log_names = depends_on
             .iter()
-            .flat_map(|id| self.catalog.arranged_introspection_dependencies(*id))
-            .map(|id| self.catalog.get_entry(&id).name().item.clone())
+            .flat_map(|id| self.catalog().arranged_introspection_dependencies(*id))
+            .map(|id| self.catalog().get_entry(&id).name().item.clone())
             .collect::<Vec<_>>();
         if !log_names.is_empty() {
             return Err(AdapterError::InvalidLogDependency {
@@ -1225,8 +1240,8 @@ impl Coordinator {
         }
 
         // Allocate IDs for the materialized view in the catalog.
-        let id = self.catalog.allocate_user_id().await?;
-        let oid = self.catalog.allocate_oid()?;
+        let id = self.catalog_mut().allocate_user_id().await?;
+        let oid = self.catalog_mut().allocate_oid()?;
         // Allocate a unique ID that can be used by the dataflow builder to
         // connect the view dataflow to the storage sink.
         let internal_view_id = self.allocate_transient_id()?;
@@ -1244,7 +1259,7 @@ impl Coordinator {
 
         let mut ops = Vec::new();
         if let Some(drop_id) = replace {
-            ops.extend(self.catalog.drop_items_ops(&[drop_id]));
+            ops.extend(self.catalog().drop_items_ops(&[drop_id]));
         }
         ops.push(catalog::Op::CreateItem {
             id,
@@ -1329,18 +1344,18 @@ impl Coordinator {
         let cluster_id = index.cluster_id;
 
         if !self
-            .catalog
+            .catalog()
             .state()
             .is_system_schema_specifier(&name.qualifiers.schema_spec)
         {
             self.ensure_cluster_is_not_linked(cluster_id)?;
             if !self.is_compute_cluster(cluster_id) {
-                let cluster_name = self.catalog.get_cluster(cluster_id).name.clone();
+                let cluster_name = self.catalog().get_cluster(cluster_id).name.clone();
                 return Err(AdapterError::BadItemInStorageCluster { cluster_name });
             }
         }
 
-        let id = self.catalog.allocate_user_id().await?;
+        let id = self.catalog_mut().allocate_user_id().await?;
         let index = catalog::Index {
             create_sql: index.create_sql,
             keys: index.keys,
@@ -1349,7 +1364,7 @@ impl Coordinator {
             depends_on,
             cluster_id,
         };
-        let oid = self.catalog.allocate_oid()?;
+        let oid = self.catalog_mut().allocate_oid()?;
         let op = catalog::Op::CreateItem {
             id,
             oid,
@@ -1398,8 +1413,8 @@ impl Coordinator {
             },
             depends_on,
         };
-        let id = self.catalog.allocate_user_id().await?;
-        let oid = self.catalog.allocate_oid()?;
+        let id = self.catalog_mut().allocate_user_id().await?;
+        let oid = self.catalog_mut().allocate_oid()?;
         let op = catalog::Op::CreateItem {
             id,
             oid,
@@ -1419,10 +1434,10 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, AdapterError> {
         let database_name = plan
             .id
-            .map(|id| self.catalog.get_database(&id))
+            .map(|id| self.catalog().get_database(&id))
             .map(|db| db.name.clone());
 
-        let ops = self.catalog.drop_database_ops(plan.id);
+        let ops = self.catalog().drop_database_ops(plan.id);
         self.catalog_transact(Some(session), ops).await?;
 
         if let Some(name) = database_name {
@@ -1439,7 +1454,7 @@ impl Coordinator {
         session: &Session,
         plan: DropSchemaPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let ops = self.catalog.drop_schema_ops(plan.id);
+        let ops = self.catalog().drop_schema_ops(plan.id);
         self.catalog_transact(Some(session), ops).await?;
         Ok(ExecuteResponse::DroppedSchema)
     }
@@ -1453,7 +1468,7 @@ impl Coordinator {
         let mut ops = Vec::new();
 
         // If any role is a member of a dropped role, then we must revoke that membership.
-        for role in self.catalog.user_roles() {
+        for role in self.catalog().user_roles() {
             for dropped_role_id in dropped_ids.intersection(&role.membership.map.keys().collect()) {
                 ops.push(catalog::Op::RevokeRole {
                     role_id: **dropped_role_id,
@@ -1463,7 +1478,7 @@ impl Coordinator {
         }
         // We must also revoke all role memberships that the dropped roles belongs to.
         for dropped_id in dropped_ids {
-            let role = self.catalog.get_role(dropped_id);
+            let role = self.catalog().get_role(dropped_id);
             for group_id in role.membership.map.keys() {
                 ops.push(catalog::Op::RevokeRole {
                     role_id: *group_id,
@@ -1487,7 +1502,7 @@ impl Coordinator {
         DropClustersPlan { ids }: DropClustersPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let active_cluster_id = self
-            .catalog
+            .catalog()
             .active_cluster(session)
             .ok()
             .map(|cluster| cluster.id);
@@ -1495,7 +1510,7 @@ impl Coordinator {
             self.ensure_cluster_is_not_linked(*id)?;
         }
 
-        let ops = self.catalog.drop_cluster_ops(&ids, &mut BTreeSet::new());
+        let ops = self.catalog().drop_cluster_ops(&ids, &mut BTreeSet::new());
 
         self.catalog_transact(Some(session), ops).await?;
 
@@ -1519,7 +1534,7 @@ impl Coordinator {
             self.ensure_cluster_is_not_linked(*id)?;
         }
         let ops = self
-            .catalog
+            .catalog()
             .drop_cluster_replica_ops(&ids, &mut BTreeSet::new());
 
         self.catalog_transact(Some(session), ops).await?;
@@ -1533,7 +1548,7 @@ impl Coordinator {
         session: &Session,
         plan: DropItemsPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let ops = self.catalog.drop_items_ops(&plan.items);
+        let ops = self.catalog().drop_items_ops(&plan.items);
         self.catalog_transact(Some(session), ops).await?;
         Ok(match plan.ty {
             ObjectType::Source => ExecuteResponse::DroppedSource,
@@ -1557,7 +1572,7 @@ impl Coordinator {
         session: &Session,
     ) -> Result<ExecuteResponse, AdapterError> {
         Ok(send_immediate_rows(
-            viewable_variables(self.catalog.state(), session)
+            viewable_variables(self.catalog().state(), session)
                 .map(|v| {
                     Row::pack_slice(&[
                         Datum::String(v.name()),
@@ -1577,9 +1592,9 @@ impl Coordinator {
         let variable = session
             .vars()
             .get(&plan.name)
-            .or_else(|_| self.catalog.system_config().get(&plan.name))?;
+            .or_else(|_| self.catalog().system_config().get(&plan.name))?;
 
-        if variable.visible(session.user()) && (variable.safe() || self.catalog.unsafe_mode()) {
+        if variable.visible(session.user()) && (variable.safe() || self.catalog().unsafe_mode()) {
             let row = Row::pack_slice(&[Datum::String(&variable.value())]);
             Ok(send_immediate_rows(vec![row]))
         } else {
@@ -1603,7 +1618,7 @@ impl Coordinator {
 
         let var = vars.get(&name)?;
         if !var.safe() {
-            self.catalog.require_unsafe_mode(var.name())?;
+            self.catalog().require_unsafe_mode(var.name())?;
         }
 
         match values {
@@ -1613,7 +1628,7 @@ impl Coordinator {
                 // Database or cluster value does not correspond to a catalog item.
                 if name.as_str() == DATABASE_VAR_NAME
                     && matches!(
-                        self.catalog.resolve_database(vars.database()),
+                        self.catalog().resolve_database(vars.database()),
                         Err(CatalogError::UnknownDatabase(_))
                     )
                 {
@@ -1621,7 +1636,7 @@ impl Coordinator {
                     session.add_notice(AdapterNotice::DatabaseDoesNotExist { name });
                 } else if name.as_str() == CLUSTER_VAR_NAME
                     && matches!(
-                        self.catalog.resolve_cluster(vars.cluster()),
+                        self.catalog().resolve_cluster(vars.cluster()),
                         Err(CatalogError::UnknownCluster(_))
                     )
                 {
@@ -1654,7 +1669,7 @@ impl Coordinator {
         let name = plan.name;
         let var = vars.get(&name)?;
         if !var.safe() {
-            self.catalog.require_unsafe_mode(var.name())?;
+            self.catalog().require_unsafe_mode(var.name())?;
         }
         session.vars_mut().reset(&name, false)?;
         Ok(ExecuteResponse::SetVariable { name, reset: true })
@@ -1738,7 +1753,7 @@ impl Coordinator {
                 if let TransactionOps::Writes(writes) = &mut ops {
                     for WriteOp { id, .. } in &mut writes.iter() {
                         // Re-verify this id exists.
-                        let _ = self.catalog.try_get_entry(id).ok_or_else(|| {
+                        let _ = self.catalog().try_get_entry(id).ok_or_else(|| {
                             AdapterError::SqlCatalog(CatalogError::UnknownItem(id.to_string()))
                         })?;
                     }
@@ -1783,7 +1798,7 @@ impl Coordinator {
 
         match self.recent_timestamp(&session, source_ids.iter().cloned()) {
             Some(fut) => {
-                let transient_revision = self.catalog.transient_revision();
+                let transient_revision = self.catalog().transient_revision();
                 let internal_cmd_tx = self.internal_cmd_tx.clone();
                 let conn_id = session.conn_id();
                 self.pending_real_time_recency_timestamp.insert(
@@ -1878,7 +1893,7 @@ impl Coordinator {
         let view_id = self.allocate_transient_id()?;
         let index_id = self.allocate_transient_id()?;
 
-        let cluster = self.catalog.active_cluster(session)?;
+        let cluster = self.catalog().active_cluster(session)?;
         let target_replica_name = session.vars().cluster_replica();
         let mut target_replica = target_replica_name
             .map(|name| {
@@ -1910,7 +1925,7 @@ impl Coordinator {
         let in_immediate_multi_stmt_txn = session.transaction().is_in_multi_statement_transaction()
             && when == QueryWhen::Immediately;
 
-        check_no_invalid_log_reads(&self.catalog, cluster, &source_ids, &mut target_replica)?;
+        check_no_invalid_log_reads(self.catalog(), cluster, &source_ids, &mut target_replica)?;
 
         let id_bundle = self
             .index_oracle(cluster.id)
@@ -2081,20 +2096,20 @@ impl Coordinator {
                         let mut names: Vec<_> = allowed_id_bundle
                             .iter()
                             // This could filter out a view that has been replaced in another transaction.
-                            .filter_map(|id| self.catalog.try_get_entry(&id))
+                            .filter_map(|id| self.catalog().try_get_entry(&id))
                             .map(|item| item.name())
                             .map(|name| {
-                                self.catalog
+                                self.catalog()
                                     .resolve_full_name(name, Some(session.conn_id()))
                                     .to_string()
                             })
                             .collect();
                         let mut outside: Vec<_> = outside
                             .iter()
-                            .filter_map(|id| self.catalog.try_get_entry(&id))
+                            .filter_map(|id| self.catalog().try_get_entry(&id))
                             .map(|item| item.name())
                             .map(|name| {
-                                self.catalog
+                                self.catalog()
                                     .resolve_full_name(name, Some(session.conn_id()))
                                     .to_string()
                             })
@@ -2136,7 +2151,7 @@ impl Coordinator {
         builder.import_view_into_dataflow(&view_id, &source, &mut dataflow)?;
         for BuildDesc { plan, .. } in &mut dataflow.objects_to_build {
             prep_relation_expr(
-                self.catalog.state(),
+                self.catalog().state(),
                 plan,
                 ExprPrepStyle::OneShot {
                     logical_time: Some(timestamp_context.timestamp_or_default()),
@@ -2215,7 +2230,7 @@ impl Coordinator {
             up_to,
         } = plan;
 
-        let cluster = self.catalog.active_cluster(session)?;
+        let cluster = self.catalog().active_cluster(session)?;
         let cluster_id = cluster.id;
 
         let target_replica_name = session.vars().cluster_replica();
@@ -2275,16 +2290,16 @@ impl Coordinator {
         let mut dataflow = match from {
             SubscribeFrom::Id(from_id) => {
                 check_no_invalid_log_reads(
-                    &self.catalog,
+                    self.catalog(),
                     cluster,
                     &btreeset!(from_id),
                     &mut target_replica,
                 )?;
-                let from = self.catalog.get_entry(&from_id);
+                let from = self.catalog().get_entry(&from_id);
                 let from_desc = from
                     .desc(
                         &self
-                            .catalog
+                            .catalog()
                             .resolve_full_name(from.name(), Some(session.conn_id())),
                     )
                     .expect("subscribes can only be run on items with descs")
@@ -2297,7 +2312,7 @@ impl Coordinator {
             }
             SubscribeFrom::Query { expr, desc } => {
                 check_no_invalid_log_reads(
-                    &self.catalog,
+                    self.catalog(),
                     cluster,
                     &expr.depends_on(),
                     &mut target_replica,
@@ -2389,7 +2404,7 @@ impl Coordinator {
         use mz_repr::explain::trace_plan;
         use ExplainStage::*;
 
-        let cluster = self.catalog.active_cluster(session)?.id;
+        let cluster = self.catalog().active_cluster(session)?.id;
 
         let ExplainPlan {
             raw_plan,
@@ -2521,7 +2536,7 @@ impl Coordinator {
         let trace = optimizer_trace.drain_all(
             format,
             config,
-            self.catalog.for_session(session),
+            self.catalog().for_session(session),
             row_set_finishing,
             used_indexes,
             fast_path_plan,
@@ -2579,7 +2594,7 @@ impl Coordinator {
         );
         match self.recent_timestamp(&session, source_ids.iter().cloned()) {
             Some(fut) => {
-                let transient_revision = self.catalog.transient_revision();
+                let transient_revision = self.catalog().transient_revision();
                 let internal_cmd_tx = self.internal_cmd_tx.clone();
                 let conn_id = session.conn_id();
                 self.pending_real_time_recency_timestamp.insert(
@@ -2641,7 +2656,7 @@ impl Coordinator {
         let decorrelated_plan = raw_plan.optimize_and_lower(&OptimizerConfig {})?;
         let optimized_plan = self.view_optimizer.optimize(decorrelated_plan)?;
         let source_ids = optimized_plan.depends_on();
-        let cluster = self.catalog.active_cluster(session)?;
+        let cluster = self.catalog().active_cluster(session)?;
         let id_bundle = self
             .index_oracle(cluster.id)
             .sufficient_collections(&source_ids);
@@ -2682,11 +2697,11 @@ impl Coordinator {
                     .collection(*id)
                     .expect("id does not exist");
                 let name = self
-                    .catalog
+                    .catalog()
                     .try_get_entry(id)
                     .map(|item| item.name())
                     .map(|name| {
-                        self.catalog
+                        self.catalog()
                             .resolve_full_name(name, Some(session.conn_id()))
                             .to_string()
                     })
@@ -2700,18 +2715,18 @@ impl Coordinator {
         }
         {
             if let Some(compute_ids) = id_bundle.compute_ids.get(&cluster_id) {
+                let catalog = self.catalog();
                 for id in compute_ids {
                     let state = self
                         .controller
                         .compute
                         .collection(cluster_id, *id)
                         .expect("id does not exist");
-                    let name = self
-                        .catalog
+                    let name = catalog
                         .try_get_entry(id)
                         .map(|item| item.name())
                         .map(|name| {
-                            self.catalog
+                            catalog
                                 .resolve_full_name(name, Some(session.conn_id()))
                                 .to_string()
                         })
@@ -2827,11 +2842,11 @@ impl Coordinator {
             ),
             // All non-constant values must be planned as read-then-writes.
             selection => {
-                let desc_arity = match self.catalog.try_get_entry(&plan.id) {
+                let desc_arity = match self.catalog().try_get_entry(&plan.id) {
                     Some(table) => table
                         .desc(
                             &self
-                                .catalog
+                                .catalog()
                                 .resolve_full_name(table.name(), Some(session.conn_id())),
                         )
                         .expect("desc called on table")
@@ -2886,10 +2901,10 @@ impl Coordinator {
         constants: MirRelationExpr,
     ) -> Result<ExecuteResponse, AdapterError> {
         // Insert can be queued, so we need to re-verify the id exists.
-        let desc = match self.catalog.try_get_entry(&id) {
+        let desc = match self.catalog().try_get_entry(&id) {
             Some(table) => table.desc(
                 &self
-                    .catalog
+                    .catalog()
                     .resolve_full_name(table.name(), Some(session.conn_id())),
             )?,
             None => {
@@ -2912,7 +2927,7 @@ impl Coordinator {
                     updates: rows,
                     kind: MutationKind::Insert,
                     returning: Vec::new(),
-                    max_result_size: self.catalog.system_config().max_result_size(),
+                    max_result_size: self.catalog().system_config().max_result_size(),
                 };
                 Self::sequence_send_diffs(session, diffs_plan)
             }
@@ -2930,7 +2945,7 @@ impl Coordinator {
         columns: Vec<usize>,
         rows: Vec<Row>,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let catalog = self.catalog.for_session(session);
+        let catalog = self.catalog().for_session(session);
         let values = mz_sql::plan::plan_copy_from(session.pcx(), &catalog, id, columns, rows)?;
         let values = self.view_optimizer.optimize(values.lower()?)?;
         // Copied rows must always be constants.
@@ -2959,11 +2974,11 @@ impl Coordinator {
         } = plan;
 
         // Read then writes can be queued, so re-verify the id exists.
-        let desc = match self.catalog.try_get_entry(&id) {
+        let desc = match self.catalog().try_get_entry(&id) {
             Some(table) => table
                 .desc(
                     &self
-                        .catalog
+                        .catalog()
                         .resolve_full_name(table.name(), Some(session.conn_id())),
                 )
                 .expect("desc called on table")
@@ -3015,7 +3030,7 @@ impl Coordinator {
         }
 
         for id in selection.depends_on() {
-            if !validate_read_dependencies(&self.catalog, &id) {
+            if !validate_read_dependencies(self.catalog(), &id) {
                 tx.send(Err(AdapterError::InvalidTableMutationSelection), session);
                 return;
             }
@@ -3037,7 +3052,7 @@ impl Coordinator {
 
         let internal_cmd_tx = self.internal_cmd_tx.clone();
         let strict_serializable_reads_tx = self.strict_serializable_reads_tx.clone();
-        let max_result_size = self.catalog.system_config().max_result_size();
+        let max_result_size = self.catalog().system_config().max_result_size();
         task::spawn(|| format!("sequence_read_then_write:{id}"), async move {
             let (peek_response, mut session) = match peek_rx.await {
                 Ok(Response {
@@ -3300,7 +3315,7 @@ impl Coordinator {
                 IndexOption::LogicalCompactionWindow(window) => {
                     // The index is on a specific cluster.
                     let cluster = self
-                        .catalog
+                        .catalog()
                         .get_entry(&id)
                         .index()
                         .expect("setting options on index")
@@ -3375,7 +3390,7 @@ impl Coordinator {
         AlterSourcePlan { id, size }: AlterSourcePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let source = self
-            .catalog
+            .catalog()
             .get_entry(&id)
             .source()
             .expect("known to be source");
@@ -3409,7 +3424,7 @@ impl Coordinator {
     ) -> Result<Vec<u8>, AdapterError> {
         let temp_storage = RowArena::new();
         prep_scalar_expr(
-            self.catalog.state(),
+            self.catalog().state(),
             secret_as,
             ExprPrepStyle::OneShot {
                 logical_time: None,
@@ -3544,15 +3559,16 @@ impl Coordinator {
             grantor_id,
         }: GrantRolePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
+        let catalog = self.catalog();
         let mut ops = Vec::new();
         for member_id in member_ids {
-            let member_membership: BTreeSet<_> = self.catalog.get_role(&member_id).membership();
+            let member_membership: BTreeSet<_> = catalog.get_role(&member_id).membership();
             if member_membership.contains(&role_id) {
-                let role_name = self.catalog.get_role(&role_id).name().to_string();
-                let member_name = self.catalog.get_role(&member_id).name().to_string();
+                let role_name = catalog.get_role(&role_id).name().to_string();
+                let member_name = catalog.get_role(&member_id).name().to_string();
                 // We need this check so we don't accidentally return a success on a reserved role.
-                self.catalog.ensure_not_reserved_role(&member_id)?;
-                self.catalog.ensure_not_reserved_role(&role_id)?;
+                catalog.ensure_not_reserved_role(&member_id)?;
+                catalog.ensure_not_reserved_role(&role_id)?;
                 session.add_notice(AdapterNotice::RoleMembershipAlreadyExists {
                     role_name,
                     member_name,
@@ -3583,15 +3599,16 @@ impl Coordinator {
             member_ids,
         }: RevokeRolePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
+        let catalog = self.catalog();
         let mut ops = Vec::new();
         for member_id in member_ids {
-            let member_membership: BTreeSet<_> = self.catalog.get_role(&member_id).membership();
+            let member_membership: BTreeSet<_> = catalog.get_role(&member_id).membership();
             if !member_membership.contains(&role_id) {
-                let role_name = self.catalog.get_role(&role_id).name().to_string();
-                let member_name = self.catalog.get_role(&member_id).name().to_string();
+                let role_name = catalog.get_role(&role_id).name().to_string();
+                let member_name = catalog.get_role(&member_id).name().to_string();
                 // We need this check so we don't accidentally return a success on a reserved role.
-                self.catalog.ensure_not_reserved_role(&member_id)?;
-                self.catalog.ensure_not_reserved_role(&role_id)?;
+                catalog.ensure_not_reserved_role(&member_id)?;
+                catalog.ensure_not_reserved_role(&role_id)?;
                 session.add_notice(AdapterNotice::RoleMembershipDoesNotExists {
                     role_name,
                     member_name,
@@ -3627,12 +3644,14 @@ impl Coordinator {
             SourceSinkClusterConfig::Undefined => self.default_linked_cluster_size()?,
             SourceSinkClusterConfig::Existing { id } => return Ok(*id),
         };
-        let id = self.catalog.allocate_user_cluster_id().await?;
-        let name = self.catalog.resolve_full_name(name, None);
+        let id = self.catalog().allocate_user_cluster_id().await?;
+        let name = self.catalog().resolve_full_name(name, None);
         let name = format!("{}_{}_{}", name.database, name.schema, name.item);
-        let name = self.catalog.find_available_cluster_name(&name);
-        let arranged_introspection_sources =
-            self.catalog.allocate_arranged_introspection_sources().await;
+        let name = self.catalog().find_available_cluster_name(&name);
+        let arranged_introspection_sources = self
+            .catalog()
+            .allocate_arranged_introspection_sources()
+            .await;
         ops.push(catalog::Op::CreateCluster {
             id,
             name: name.clone(),
@@ -3652,7 +3671,7 @@ impl Coordinator {
         ops: &mut Vec<catalog::Op>,
     ) -> Result<(), AdapterError> {
         let availability_zone = {
-            let azs = self.catalog.state().availability_zones();
+            let azs = self.catalog().state().availability_zones();
             let n_replicas_per_az = azs
                 .iter()
                 .map(|az| (az.clone(), 0))
@@ -3664,9 +3683,12 @@ impl Coordinator {
             availability_zone,
             az_user_specified: false,
         };
-        let location = self.catalog.concretize_replica_location(
+        let location = self.catalog().concretize_replica_location(
             location,
-            &self.catalog.system_config().allowed_cluster_replica_sizes(),
+            &self
+                .catalog()
+                .system_config()
+                .allowed_cluster_replica_sizes(),
         )?;
         let logging = {
             ReplicaLogging {
@@ -3680,7 +3702,7 @@ impl Coordinator {
         };
         ops.push(catalog::Op::CreateClusterReplica {
             cluster_id,
-            id: self.catalog.allocate_replica_id().await?,
+            id: self.catalog().allocate_replica_id().await?,
             name: LINKED_CLUSTER_REPLICA_NAME.into(),
             config: ReplicaConfig {
                 location,
@@ -3701,13 +3723,13 @@ impl Coordinator {
         config: &SourceSinkClusterConfig,
     ) -> Result<Vec<catalog::Op>, AdapterError> {
         let mut ops = vec![];
-        match self.catalog.get_linked_cluster(linked_object_id) {
+        match self.catalog().get_linked_cluster(linked_object_id) {
             None => {
                 coord_bail!("cannot change the size of a source or sink created with IN CLUSTER");
             }
             Some(linked_cluster) => {
                 for id in linked_cluster.replicas_by_id.keys() {
-                    let drop_ops = self.catalog.drop_cluster_replica_ops(
+                    let drop_ops = self.catalog().drop_cluster_replica_ops(
                         &[(linked_cluster.id, *id)],
                         &mut BTreeSet::new(),
                     );
@@ -3728,9 +3750,9 @@ impl Coordinator {
     }
 
     fn default_linked_cluster_size(&self) -> Result<String, AdapterError> {
-        if !self.catalog.config().unsafe_mode {
+        if !self.catalog().config().unsafe_mode {
             let mut entries = self
-                .catalog
+                .catalog()
                 .cluster_replica_sizes()
                 .0
                 .iter()
@@ -3749,13 +3771,13 @@ impl Coordinator {
             let expected = entries.into_iter().map(|(name, _)| name.clone()).collect();
             return Err(AdapterError::SourceOrSinkSizeRequired { expected });
         }
-        Ok(self.catalog.default_linked_cluster_size())
+        Ok(self.catalog().default_linked_cluster_size())
     }
 
     /// Creates the cluster linked to the specified object after a create
     /// operation, if such a linked cluster exists.
     async fn maybe_create_linked_cluster(&mut self, linked_object_id: GlobalId) {
-        if let Some(cluster) = self.catalog.get_linked_cluster(linked_object_id) {
+        if let Some(cluster) = self.catalog().get_linked_cluster(linked_object_id) {
             self.create_cluster(cluster.id).await;
         }
     }
@@ -3763,7 +3785,7 @@ impl Coordinator {
     /// Updates the replicas of the cluster linked to the specified object after
     /// an alter operation, if such a linked cluster exists.
     async fn maybe_alter_linked_cluster(&mut self, linked_object_id: GlobalId) {
-        if let Some(cluster) = self.catalog.get_linked_cluster(linked_object_id) {
+        if let Some(cluster) = self.catalog().get_linked_cluster(linked_object_id) {
             // The old replicas of the linked cluster will have been dropped by
             // `catalog_transact`, both from the catalog state and from the
             // controller. The new replicas will be in the catalog state, and
@@ -3780,10 +3802,10 @@ impl Coordinator {
     }
     /// Returns an error if the given cluster is a linked cluster
     fn ensure_cluster_is_not_linked(&self, cluster_id: ClusterId) -> Result<(), AdapterError> {
-        let cluster = self.catalog.get_cluster(cluster_id);
+        let cluster = self.catalog().get_cluster(cluster_id);
         if let Some(linked_id) = cluster.linked_object_id {
-            let cluster_name = self.catalog.get_cluster(cluster_id).name.clone();
-            let linked_object_name = self.catalog.get_entry(&linked_id).name().to_string();
+            let cluster_name = self.catalog().get_cluster(cluster_id).name.clone();
+            let linked_object_name = self.catalog().get_entry(&linked_id).name().to_string();
             Err(AdapterError::ModifyLinkedCluster {
                 cluster_name,
                 linked_object_name,
@@ -3796,10 +3818,10 @@ impl Coordinator {
     /// Returns whether the given cluster exclusively maintains items
     /// that were formerly maintained on `computed`.
     fn is_compute_cluster(&self, id: ClusterId) -> bool {
-        let cluster = self.catalog.get_cluster(id);
+        let cluster = self.catalog().get_cluster(id);
         cluster.bound_objects().iter().all(|id| {
             matches!(
-                self.catalog.get_entry(id).item_type(),
+                self.catalog().get_entry(id).item_type(),
                 CatalogItemType::Index | CatalogItemType::MaterializedView
             )
         })

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3540,7 +3540,7 @@ impl Coordinator {
         plan: ExecutePlan,
     ) -> Result<String, AdapterError> {
         // Verify the stmt is still valid.
-        self.verify_prepared_statement(session, &plan.name)?;
+        Self::verify_prepared_statement(self.catalog(), session, &plan.name)?;
         let ps = session
             .get_prepared_statement_unverified(&plan.name)
             .expect("known to exist");

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -78,13 +78,13 @@ impl Coordinator {
     }
 
     pub(crate) fn describe(
-        &self,
+        catalog: &Catalog,
         session: &Session,
         stmt: Option<Statement<Raw>>,
         param_types: Vec<Option<ScalarType>>,
     ) -> Result<StatementDesc, AdapterError> {
         if let Some(stmt) = stmt {
-            describe(self.catalog(), stmt, &param_types, session)
+            describe(catalog, stmt, &param_types, session)
         } else {
             Ok(StatementDesc::new(None))
         }
@@ -143,9 +143,11 @@ impl Coordinator {
         desc: &StatementDesc,
         catalog_revision: u64,
     ) -> Result<Option<u64>, AdapterError> {
-        let current_revision = self.catalog().transient_revision();
+        let catalog = self.catalog();
+        let current_revision = catalog.transient_revision();
         if catalog_revision != current_revision {
-            let current_desc = self.describe(
+            let current_desc = Self::describe(
+                catalog,
                 session,
                 stmt.cloned(),
                 desc.param_types.iter().map(|ty| Some(ty.clone())).collect(),

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -345,7 +345,7 @@ impl Coordinator {
     ) -> Result<mz_repr::Timestamp, AdapterError> {
         let temp_storage = RowArena::new();
         prep_scalar_expr(
-            self.catalog.state(),
+            self.catalog().state(),
             &mut timestamp,
             ExprPrepStyle::AsOfUpTo,
         )?;
@@ -370,7 +370,9 @@ impl Coordinator {
             ScalarType::Timestamp => evaled.unwrap_timestamp().timestamp_millis().try_into()?,
             _ => coord_bail!(
                 "can't use {} as a mz_timestamp for AS OF or UP TO",
-                self.catalog.for_session(session).humanize_column_type(&ty)
+                self.catalog()
+                    .for_session(session)
+                    .humanize_column_type(&ty)
             ),
         })
     }

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -124,6 +124,14 @@ pub trait Transmittable {
     fn to_allowed(&self) -> Self::Allowed;
 }
 
+impl Transmittable for () {
+    type Allowed = bool;
+
+    fn to_allowed(&self) -> Self::Allowed {
+        true
+    }
+}
+
 /// `ClientTransmitter` with a response to send.
 #[derive(Debug)]
 pub struct CompletedClientTransmitter<T: Transmittable> {


### PR DESCRIPTION
Change the coordinator catalog to be able to hand out readonly copies of itself for use in other tokio tasks. This allows for lots of work to be moved off the coordinator thread. Achieve this by using an Arc that will only clone the underlying catalog struct if there's an outstanding read reference while a mutation is being performed.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a