### PR TITLE
ci: SQLsmith execution time at 55 min

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -548,7 +548,7 @@ steps:
   - id: sqlsmith-2-joins
     label: "SQLsmith 2 joins"
     artifact_paths: junit_*.xml
-    timeout_in_minutes: 70
+    timeout_in_minutes: 58
     agents:
       # A larger instance is needed since SQLsmith likes creating
       # large queries and going out of memory
@@ -556,18 +556,18 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
-          args: [--max-joins=2, --runtime=3600]
+          args: [--max-joins=2, --runtime=3300]
 
   - id: sqlsmith-explain
     label: "SQLsmith explain"
     artifact_paths: junit_*.xml
-    timeout_in_minutes: 70
+    timeout_in_minutes: 58
     agents:
       queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
-          args: [--max-joins=15, --explain-only, --runtime=3600]
+          args: [--max-joins=15, --explain-only, --runtime=3300]
 
   - id: crdb-restarts
     label: "CRDB rolling restarts"


### PR DESCRIPTION
Similar to #18266

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
