### PR TITLE
zippy: Add observability via Prometheus and Grafana

### DIFF
--- a/misc/mzcompose/grafana/datasources/prometheus.yml
+++ b/misc/mzcompose/grafana/datasources/prometheus.yml
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090

--- a/misc/mzcompose/prometheus/prometheus.yml
+++ b/misc/mzcompose/prometheus/prometheus.yml
@@ -1,0 +1,60 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: environmentd
+    static_configs:
+    - targets: [materialized:6878]
+      labels:
+        namespace: local
+        pod: environmentd-0
+  - job_name: services
+    file_sd_configs:
+    - files:
+      - /mnt/mzdata/prometheus/*.json
+      refresh_interval: 30s
+    relabel_configs:
+      # Rewrite references to 127.0.0.1 or 0.0.0.0 to materialized,
+      # since the services are running in that container.
+      - source_labels: [__address__]
+        target_label: __address__
+        regex: (127\.0\.0\.1|0\.0\.0\.0)(.*)
+        replacement: materialized$2
+        action: replace
+      # The process orchestrator emits static configurations for all ports, but
+      # only the "internal-http" port serves metrics. Filter out other configs,
+      # to avoid scrape failures in the Prometheus UI.
+      - source_labels: [mz_orchestrator_port]
+        regex: internal-http
+        action: keep
+      # Construct namespace and pod labels that are similar to the label that
+      # Kubernetes installs, so that production dashboards work without changes
+      # when running locally.
+      - target_label: namespace
+        replacement: local
+      - source_labels: [mz_orchestrator_namespace, mz_orchestrator_service_id]
+        separator: "-"
+        target_label: pod
+        replacement: $1-0
+
+  - job_name: 'cockroachdb'
+    metrics_path: '/_status/vars'
+    # Insecure mode:
+    scheme: 'http'
+    # Secure mode:
+    # scheme: 'https'
+    tls_config:
+      insecure_skip_verify: true
+
+    static_configs:
+    - targets: ['cockroach:8080']
+      labels:
+        cluster: cockroach

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -17,10 +17,12 @@ from materialize.mzcompose.services import (
     Clusterd,
     Cockroach,
     Debezium,
+    Grafana,
     Kafka,
     Materialized,
     Minio,
     Postgres,
+    Prometheus,
     SchemaRegistry,
     Testdrive,
     Zookeeper,
@@ -40,6 +42,8 @@ SERVICES = [
     Materialized(),
     Clusterd(name="storaged"),
     Testdrive(),
+    Grafana(),
+    Prometheus(),
 ]
 
 
@@ -115,10 +119,19 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         help="Cockroach DockerHub tag to use.",
     )
 
+    parser.add_argument(
+        "--observability",
+        action="store_true",
+        help="Start Prometheus and Grafana",
+    )
+
     args = parser.parse_args()
     scenario_class = globals()[args.scenario]
 
     c.up("zookeeper", "kafka", "schema-registry")
+
+    if args.observability:
+        c.up("prometheus", "grafana")
 
     random.seed(args.seed)
 


### PR DESCRIPTION
Allos Zippy to start Prometheus and Grafana if the --observability workflow option is specified.

### Motivation

  * This PR adds a feature that has not yet been specified.

I am trying to debug chronic CRDB issues that affect the Release Qualification Tests