### PR TITLE
Add a test for introspection view consistency

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -9,6 +9,7 @@
 
 import re
 import time
+from collections import defaultdict
 from textwrap import dedent
 from threading import Thread
 from typing import Tuple
@@ -74,6 +75,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-replica-targeted-subscribe-abort",
         "test-compute-reconciliation-reuse",
         "test-mz-subscriptions",
+        "test-logview-consistency",
     ]:
         with c.test_case(name):
             c.workflow(name)
@@ -1356,3 +1358,75 @@ def workflow_test_mz_subscriptions(c: Composition) -> None:
 
     stop_subscribe(subscribe2)
     check_mz_subscriptions(())
+
+
+def workflow_test_logview_consistency(c: Composition) -> None:
+    """
+    Test that views over persisted introspection sources have the same
+    definitions as views over arranged introspection sources (modulo
+    name suffixes and GlobalIds).
+
+    This is necessary because the former are not derived from the
+    latter but are instead manually redefined. We want to make sure
+    that changes to one are always also applied to the other.
+    """
+
+    def clean_name(s: str) -> str:
+        """Clean a log view name by stripping the per-replica suffix."""
+        return re.sub(r"(?P<name>mz_\w+)_\d+", r"\g<name>", s)
+
+    def clean_definition(s: str) -> str:
+        """
+        Clean a log view definition by stripping per-replica suffixes
+        and GlobalIds of referenced collections.
+        """
+        s = clean_name(s)
+        return re.sub(
+            r'\[s\d+ AS (?P<relation>[\w"\.]+)\]',
+            r"\g<relation>",
+            s,
+        )
+
+    with c.override(
+        Materialized(options=["--persisted-introspection"]),
+    ):
+        c.down(destroy_volumes=True)
+        c.up("materialized")
+
+        # Collect the number of replicas.
+        output = c.sql_query("SELECT count(*) FROM mz_cluster_replicas")
+        replica_count = int(output[0][0])
+
+        # Collect all log views and their definitions.
+        output = c.sql_query(
+            f"""
+            WITH MUTUALLY RECURSIVE
+                log_ids (id text) AS (
+                    SELECT id FROM mz_sources WHERE type = 'log'
+                    UNION DISTINCT
+                    (
+                        SELECT object_id AS id
+                        FROM mz_internal.mz_object_dependencies
+                        WHERE referenced_object_id IN (SELECT * FROM log_ids)
+                    )
+                )
+            SELECT name, definition
+            FROM mz_views
+            WHERE id IN (SELECT * FROM log_ids)
+            """
+        )
+        definitions = defaultdict(list)
+        for (name, definition) in output:
+            name = clean_name(name)
+            definitions[name].append(definition)
+
+        for (name, defs) in definitions.items():
+            # Ensure no log views are missing.
+            assert len(defs) == replica_count + 1, (
+                f"unexpected number instances of log view {name}:"
+                f" expected {replica_count + 1}, got {len(defs)}"
+            )
+
+            # Ensure log views with the same name have the same definition.
+            cleaned = {clean_definition(d) for d in defs}
+            assert len(cleaned) == 1, f"inconsistent definitions for log view {name}"


### PR DESCRIPTION
This PR adds a cluster test to ensure that views over persisted introspection sources always have the same definitions as the corresponding views over arranged introspection sources.

### Motivation

  * This PR adds a test.

Making a larger change to the introspection view definitions, I noticed how easy it is to either forget to also update the per-replica introspection views, or make mistakes while updating them that lead to inconsistent view definitions. Ideally we would generate the per-replica view definitions from the `BuiltinView`s but that seems like it requires a large refactor. This test is a compromise to at least catch issues early.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
