### PR TITLE
sql: Implement pg_get_userbyid function

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2152,7 +2152,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
             params!(String, Oid, Bool) => Operation::variadic(move |_ecx, mut args| Ok(args.remove(0))) => String, 2509;
         },
         "pg_get_userbyid" => Scalar {
-            params!(Oid) => sql_impl_func("'unknown (OID=' || $1 || ')'") => String, 1642;
+            params!(Oid) => sql_impl_func("(SELECT name FROM mz_catalog.mz_roles WHERE oid = $1)") => String, 1642;
         },
         "pg_postmaster_start_time" => Scalar {
             params!() => UnmaterializableFunc::PgPostmasterStartTime => TimestampTz, 2560;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2152,7 +2152,15 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
             params!(String, Oid, Bool) => Operation::variadic(move |_ecx, mut args| Ok(args.remove(0))) => String, 2509;
         },
         "pg_get_userbyid" => Scalar {
-            params!(Oid) => sql_impl_func("(SELECT name FROM mz_catalog.mz_roles WHERE oid = $1)") => String, 1642;
+            params!(Oid) => sql_impl_func(
+                "CASE \
+                   WHEN $1 IS NULL THEN NULL \
+                   ELSE COALESCE(\
+                     (SELECT name FROM mz_catalog.mz_roles WHERE oid = $1),\
+                     'unknown (OID=' || $1 || ')'\
+                   ) \
+                END"
+            ) => String, 1642;
         },
         "pg_postmaster_start_time" => Scalar {
             params!() => UnmaterializableFunc::PgPostmasterStartTime => TimestampTz, 2560;

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -204,3 +204,15 @@ DROP ROLE bad
 
 statement ok
 ROLLBACK
+
+query T
+SELECT pg_get_userbyid(SELECT oid FROM mz_roles WHERE name = 'materialize')
+----
+materialize
+
+statement ok
+CREATE ROLE joe
+
+SELECT pg_get_userbyid(SELECT oid FROM mz_roles WHERE name = 'joe')
+----
+joe

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -210,9 +210,7 @@ SELECT pg_get_userbyid(SELECT oid FROM mz_roles WHERE name = 'materialize')
 ----
 materialize
 
-statement ok
-CREATE ROLE joe
-
-SELECT pg_get_userbyid(SELECT oid FROM mz_roles WHERE name = 'joe')
+query T
+SELECT pg_get_userbyid(SELECT oid FROM mz_roles WHERE name = 'foo')
 ----
-joe
+foo

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -206,11 +206,21 @@ statement ok
 ROLLBACK
 
 query T
-SELECT pg_get_userbyid(SELECT oid FROM mz_roles WHERE name = 'materialize')
+SELECT pg_get_userbyid((SELECT oid FROM mz_roles WHERE name = 'materialize'))
 ----
 materialize
 
 query T
-SELECT pg_get_userbyid(SELECT oid FROM mz_roles WHERE name = 'foo')
+SELECT pg_get_userbyid((SELECT oid FROM mz_roles WHERE name = 'foo'))
 ----
 foo
+
+query T
+SELECT pg_get_userbyid(NULL)
+----
+NULL
+
+query T
+SELECT pg_get_userbyid(4294967295);
+----
+ unknown (OID=4294967295)


### PR DESCRIPTION
Part of #11579


### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release adds a working implementation of `pg_get_userbyid`
