### PR TITLE
storage: make storage-usage test less flaky

### DIFF
--- a/test/storage-usage/mzcompose.py
+++ b/test/storage-usage/mzcompose.py
@@ -247,7 +247,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 $ set-regex match=\d+ replacement=<SIZE>
 
                 # Select the raw size as well, so if this errors in testdrive, its easier to debug.
-                > SELECT size_bytes, size_bytes BETWEEN {database_object.expected_size} AND {database_object.expected_size*2}
+                > SELECT size_bytes, size_bytes BETWEEN {database_object.expected_size//2} AND {database_object.expected_size*3}
                   FROM mz_storage_usage
                   WHERE collection_timestamp = ( SELECT MAX(collection_timestamp) FROM mz_storage_usage )
                   AND object_id = ( SELECT id FROM mz_objects WHERE name = 'obj' );


### PR DESCRIPTION
@philip-stoev and I have seen it:
- smaller: https://buildkite.com/materialize/tests/builds/51838#0186fdce-b879-497d-90e6-cb051acbd81d
- larger: https://buildkite.com/materialize/tests/builds/51978#01870546-919d-4ea5-b3ca-47f01b88be80

But still within a reasonable bound. This pr simply expands the acceptable range, to remove some flakiness

### Motivation
de-flake a test


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
