### PR TITLE
slt: Fix default cluster clean up

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -760,7 +760,7 @@ impl<'a> Runner<'a> {
                 (name, _) => {
                     inner
                         .client
-                        .batch_execute(&format!("DROP CLUSTER REPLICA {name}"))
+                        .batch_execute(&format!("DROP CLUSTER REPLICA default.{name}"))
                         .await?
                 }
             }


### PR DESCRIPTION
The syntax of deleting cluster replicas requires specifying the cluster name and the replica name. For example, `DELETE CLUSTER REPLICA default.r`. However, when SQL Logic Tests was deleting cluster replicas in the default cluster, it was failing to specify the cluster name, causing the cleanup process to fail.

This commit fixes the described issue.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
