### PR TITLE
slt: Fix error message when run fails

### DIFF
--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -205,7 +205,12 @@ async fn main() -> ExitCode {
                             outcomes += o;
                         }
                         Err(err) => {
-                            writeln!(config.stderr, "error: parsing file: {}", err);
+                            writeln!(
+                                config.stderr,
+                                "error: running file {}: {}",
+                                entry.file_name().to_string_lossy(),
+                                err
+                            );
                             bad_file = true;
                         }
                     }


### PR DESCRIPTION
When SQL Logic Test failed to run a file it printed an error of the following format: "error: parsing file: {inner-error}". This is confusing for two reasons:
  - The name of the file is not included so it's impossible to tell which file failed from the error message.
  - A parsing error is just one of multiple reasons an .slt file can fail to run. The previous error was not only misleading, but could cause someone to waste a lot of time on a wild goose chase looking for a syntax error that doesn't exist.

This commit adds the file name to the error message and makes it more generic.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
