### PR TITLE
adapter: Automatically run some queries on mz_introspection

### DIFF
--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -160,6 +160,6 @@ mod tests {
         let sync = SynchronizedParameters::new(vars);
 
         // A smoke test to ensure the variables we want to get synced, are getting synced
-        assert!(sync.is_synchronized("enable_force_introspection_cluster"));
+        assert!(sync.is_synchronized("enable_auto_route_introspection_queries"));
     }
 }

--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -138,3 +138,28 @@ pub struct ModifiedParameter {
     pub value: String,
     pub is_default: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SynchronizedParameters;
+    use mz_sql::session::vars::SystemVars;
+
+    #[test]
+    fn test_github_18189() {
+        let vars = SystemVars::default();
+        let mut sync = SynchronizedParameters::new(vars);
+        assert!(sync.modify("allowed_cluster_replica_sizes", "1,2"));
+        assert_eq!(sync.get("allowed_cluster_replica_sizes"), r#""1", "2""#);
+        assert!(sync.modify("allowed_cluster_replica_sizes", ""));
+        assert_eq!(sync.get("allowed_cluster_replica_sizes"), "");
+    }
+
+    #[test]
+    fn test_vars_are_synced() {
+        let vars = SystemVars::default();
+        let sync = SynchronizedParameters::new(vars);
+
+        // A smoke test to ensure the variables we want to get synced, are getting synced
+        assert!(sync.is_synchronized("enable_force_introspection_cluster"));
+    }
+}

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -145,6 +145,7 @@ mod command_handler;
 mod dataflows;
 mod ddl;
 mod indexes;
+mod introspection;
 mod message_handler;
 mod read_policy;
 mod sequencer;

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -23,7 +23,6 @@ use mz_repr::GlobalId;
 use mz_sql::catalog::SessionCatalog;
 use mz_sql::plan::Plan;
 use once_cell::sync::Lazy;
-use smallvec::SmallVec;
 
 use crate::catalog::{Catalog, Cluster};
 use crate::notice::AdapterNotice;

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -54,8 +54,11 @@ pub fn auto_run_on_introspection<'a, 's>(
     session: &'s mut Session,
     depends_on: impl IntoIterator<Item = GlobalId>,
 ) -> Option<&'a Cluster> {
-    // Allow users to opt out of this behavior.
-    if !session.vars().force_introspection_cluster() {
+    // If this feature is disabled via LaunchDarkly, or the user has disabled it for
+    // this session.
+    if !catalog.system_config().enable_force_introspection_cluster()
+        || !session.vars().force_introspection_cluster()
+    {
         return None;
     }
 

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -73,7 +73,7 @@ pub fn auto_run_on_introspection<'a, 's>(
 
         match (intros_cluster, active_cluster) {
             (Ok(intros), active) => {
-                tracing::info!("Running on mz_introspection cluster");
+                tracing::debug!("Running on mz_introspection cluster");
                 // If we're running on a different cluster than the active
                 // one, notify the user.
                 if active.map(|c| c.id != intros.id).unwrap_or(true) {

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -63,7 +63,7 @@ pub fn auto_run_on_introspection<'a, 's>(
         let schema = &entry.name().qualifiers.schema_spec;
 
         let system_only = catalog.state().is_system_schema_specifier(schema);
-        let non_replica = catalog.arranged_introspection_dependencies(id).is_empty();
+        let non_replica = catalog.introspection_dependencies(id).is_empty();
 
         system_only && non_replica
     });

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -41,8 +41,8 @@ pub fn auto_run_on_introspection<'a, 's>(
 ) -> Option<&'a Cluster> {
     // If this feature is disabled via LaunchDarkly, or the user has disabled it for
     // this session.
-    if !catalog.system_config().enable_force_introspection_cluster()
-        || !session.vars().force_introspection_cluster()
+    if !catalog.system_config().enable_auto_route_introspection_queries()
+        || !session.vars().auto_route_introspection_queries()
     {
         return None;
     }
@@ -59,7 +59,6 @@ pub fn auto_run_on_introspection<'a, 's>(
         catalog.state().is_system_schema_specifier(schema)
     });
 
-    // If we're allowed to run on the mz_introspection cluster, make sure we can resolve it.
     if non_empty && system_only {
         let intros_cluster = catalog.resolve_builtin_cluster(&MZ_INTROSPECTION_CLUSTER);
         tracing::debug!("Running on '{}' cluster", MZ_INTROSPECTION_CLUSTER.name);

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -1,0 +1,192 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Special cases related to the "introspection" of Materialize
+//!
+//! Every Materialize deployment has a pre-installed [`mz_introspection`] cluster, which
+//! has several indexes to speed up common introspection queries. We also have a special
+//! `mz_introspection` role, which can be used by support teams to diagnose a deployment.
+//! For each of these use cases, we have some special restrictions we want to apply. The
+//! logic around these restrictions is defined here.
+//!
+//!
+//! [`mz_introspection`]: https://materialize.com/docs/sql/show-clusters/#mz_introspection-system-cluster
+
+use mz_ore::collections::HashSet;
+use mz_repr::GlobalId;
+use mz_sql::catalog::SessionCatalog;
+use mz_sql::plan::Plan;
+use once_cell::sync::Lazy;
+use smallvec::SmallVec;
+
+use crate::catalog::{Catalog, Cluster};
+use crate::notice::AdapterNotice;
+use crate::rbac;
+use crate::session::Session;
+
+use crate::{
+    catalog::builtin::{
+        INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_INTROSPECTION_CLUSTER,
+        MZ_INTROSPECTION_ROLE, PG_CATALOG_SCHEMA,
+    },
+    AdapterError,
+};
+
+/// The schema's a user is allowed to query from the `mz_introspection` cluster
+static ALLOWED_SCHEMAS: Lazy<HashSet<&str>> = Lazy::new(|| {
+    HashSet::from([
+        MZ_CATALOG_SCHEMA,
+        PG_CATALOG_SCHEMA,
+        MZ_INTERNAL_SCHEMA,
+        INFORMATION_SCHEMA,
+    ])
+});
+
+/// Checks whether or not we should automatically run a query on the `mz_introspection`
+/// cluster, as opposed to whatever the current default cluster is.
+pub fn auto_run_on_introspection<'a, 's>(
+    catalog: &'a Catalog,
+    session: &'s mut Session,
+    depends_on: impl IntoIterator<Item = GlobalId>,
+) -> Option<&'a Cluster> {
+    // Allow users to opt out of this behavior.
+    if !session.vars().force_introspection_cluster() {
+        return None;
+    }
+
+    // Make sure we only depend on the system catalog.
+    let allowed = depends_on.into_iter().all(|id| {
+        let entry = catalog.get_entry(&id);
+        let full_name = catalog.resolve_full_name(entry.name(), Some(session.conn_id()));
+        ALLOWED_SCHEMAS.contains(full_name.schema.as_str())
+    });
+
+    // If we're allowed to run on the mz_introspection cluster, make sure we can resolve it.
+    if allowed {
+        let intros_cluster = catalog.resolve_cluster(MZ_INTROSPECTION_CLUSTER.name);
+        let active_cluster = catalog.active_cluster(session);
+
+        match (intros_cluster, active_cluster) {
+            (Ok(intros), active) => {
+                tracing::info!("Running on mz_introspection cluster");
+                // If we're running on a different cluster than the active
+                // one, notify the user.
+                if active.map(|c| c.id != intros.id).unwrap_or(true) {
+                    session.add_notice(AdapterNotice::AutoRunOnIntrospectionCluster);
+                }
+                Some(intros)
+            }
+            (Err(e), _) => {
+                // Uh oh, failed to resolve the mz_introspection cluster, nothing we can do.
+                tracing::error!("Failed to resolve mz_introspection cluster, fall {:?}", e);
+                None
+            }
+        }
+    } else {
+        None
+    }
+}
+
+/// TODO(jkosh44) This function will verify the privileges for the mz_introspection user.
+///  All of the privileges are hard coded into this function. In the future if we ever add
+///  a more robust privileges framework, then this function should be replaced with that
+///  framework.
+pub fn user_privilege_hack(
+    catalog: &impl SessionCatalog,
+    session: &Session,
+    plan: &Plan,
+    depends_on: &Vec<GlobalId>,
+) -> Result<(), AdapterError> {
+    if session.user().name != MZ_INTROSPECTION_ROLE.name {
+        return Ok(());
+    }
+
+    match plan {
+        Plan::Subscribe(_)
+        | Plan::Peek(_)
+        | Plan::CopyFrom(_)
+        | Plan::SendRows(_)
+        | Plan::Explain(_)
+        | Plan::ShowAllVariables
+        | Plan::ShowVariable(_)
+        | Plan::SetVariable(_)
+        | Plan::ResetVariable(_)
+        | Plan::StartTransaction(_)
+        | Plan::CommitTransaction(_)
+        | Plan::AbortTransaction(_)
+        | Plan::EmptyQuery
+        | Plan::Declare(_)
+        | Plan::Fetch(_)
+        | Plan::Close(_)
+        | Plan::Prepare(_)
+        | Plan::Execute(_)
+        | Plan::Deallocate(_) => {}
+
+        Plan::CreateConnection(_)
+        | Plan::CreateDatabase(_)
+        | Plan::CreateSchema(_)
+        | Plan::CreateRole(_)
+        | Plan::CreateCluster(_)
+        | Plan::CreateClusterReplica(_)
+        | Plan::CreateSource(_)
+        | Plan::CreateSources(_)
+        | Plan::CreateSecret(_)
+        | Plan::CreateSink(_)
+        | Plan::CreateTable(_)
+        | Plan::CreateView(_)
+        | Plan::CreateMaterializedView(_)
+        | Plan::CreateIndex(_)
+        | Plan::CreateType(_)
+        | Plan::DiscardTemp
+        | Plan::DiscardAll
+        | Plan::DropDatabase(_)
+        | Plan::DropSchema(_)
+        | Plan::DropRoles(_)
+        | Plan::DropClusters(_)
+        | Plan::DropClusterReplicas(_)
+        | Plan::DropItems(_)
+        | Plan::Insert(_)
+        | Plan::AlterNoop(_)
+        | Plan::AlterIndexSetOptions(_)
+        | Plan::AlterIndexResetOptions(_)
+        | Plan::AlterRole(_)
+        | Plan::AlterSink(_)
+        | Plan::AlterSource(_)
+        | Plan::AlterItemRename(_)
+        | Plan::AlterSecret(_)
+        | Plan::AlterSystemSet(_)
+        | Plan::AlterSystemReset(_)
+        | Plan::AlterSystemResetAll(_)
+        | Plan::ReadThenWrite(_)
+        | Plan::Raise(_)
+        | Plan::RotateKeys(_)
+        | Plan::GrantRole(_)
+        | Plan::RevokeRole(_)
+        | Plan::CopyRows(_) => {
+            return Err(AdapterError::Unauthorized(
+                rbac::UnauthorizedError::privilege(plan.name().to_string(), None),
+            ))
+        }
+    }
+
+    for id in depends_on {
+        let item = catalog.get_item(id);
+        let full_name = catalog.resolve_full_name(item.name());
+        if !ALLOWED_SCHEMAS.contains(full_name.schema.as_str()) {
+            return Err(AdapterError::Unauthorized(
+                rbac::UnauthorizedError::privilege(
+                    format!("interact with object {full_name}"),
+                    None,
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -51,6 +51,11 @@ pub fn auto_run_on_introspection<'a, 's>(
         return None;
     }
 
+    // We can't switch what cluster we're using, if the user has specified a replica.
+    if session.vars().cluster_replica().is_some() {
+        return None;
+    }
+
     // Check to make sure our iterator contains atleast one element, this prevents us
     // from always running empty queries on the mz_introspection cluster.
     let mut depends_on = depends_on.into_iter().peekable();

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1920,11 +1920,8 @@ impl Coordinator {
         let view_id = self.allocate_transient_id()?;
         let index_id = self.allocate_transient_id()?;
 
-<<<<<<< HEAD
-        let cluster = self.catalog().active_cluster(session)?;
-=======
-        // If our query only depends on system tables, then we optionally run it on the
-        // introspection cluster.
+        // If our query only depends on system tables, a LaunchDarkly flag is enabled, and a
+        // session var is set, then we automatically run the query on the mz_introspection cluster
         let cluster = match introspection::auto_run_on_introspection(
             &self.catalog,
             session,
@@ -2271,20 +2268,16 @@ impl Coordinator {
             up_to,
         } = plan;
 
-<<<<<<< HEAD
-        let cluster = self.catalog().active_cluster(session)?;
-=======
         // If our query only depends on system tables, then we optionally run it on the
         // introspection cluster.
         let cluster = match introspection::auto_run_on_introspection(
-            &self.catalog,
+            self.catalog(),
             session,
             depends_on.iter().copied(),
         ) {
             Some(cluster) => cluster,
-            None => self.catalog.active_cluster(session)?,
+            None => self.catalog().active_cluster(session)?,
         };
->>>>>>> 344f2cfa2 (branch start)
         let cluster_id = cluster.id;
 
         let target_replica_name = session.vars().cluster_replica();

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1923,15 +1923,14 @@ impl Coordinator {
         // If our query only depends on system tables, a LaunchDarkly flag is enabled, and a
         // session var is set, then we automatically run the query on the mz_introspection cluster
         let cluster = match introspection::auto_run_on_introspection(
-            &self.catalog,
+            self.catalog(),
             session,
             source.depends_on(),
         ) {
             Some(cluster) => cluster,
-            None => self.catalog.active_cluster(session)?,
+            None => self.catalog().active_cluster(session)?,
         };
 
->>>>>>> 344f2cfa2 (branch start)
         let target_replica_name = session.vars().cluster_replica();
         let mut target_replica = target_replica_name
             .map(|name| {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -84,7 +84,7 @@ use crate::coord::read_policy::SINCE_GRANULARITY;
 use crate::coord::timeline::TimelineContext;
 use crate::coord::timestamp_selection::{TimestampContext, TimestampSource};
 use crate::coord::{
-    peek, Coordinator, Message, PendingReadTxn, PendingTxn, RealTimeRecencyContext,
+    introspection, peek, Coordinator, Message, PendingReadTxn, PendingTxn, RealTimeRecencyContext,
     SinkConnectionReady, DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
 };
 use crate::error::AdapterError;
@@ -1817,7 +1817,11 @@ impl Coordinator {
             target_replica,
             timeline_context,
             in_immediate_multi_stmt_txn,
-        ) = return_if_err!(self.sequence_peek_begin_inner(&session, plan), tx, session);
+        ) = return_if_err!(
+            self.sequence_peek_begin_inner(&mut session, plan),
+            tx,
+            session
+        );
 
         match self.recent_timestamp(&session, source_ids.iter().cloned()) {
             Some(fut) => {
@@ -1883,7 +1887,7 @@ impl Coordinator {
 
     fn sequence_peek_begin_inner(
         &mut self,
-        session: &Session,
+        session: &mut Session,
         plan: PeekPlan,
     ) -> Result<
         (
@@ -1916,7 +1920,21 @@ impl Coordinator {
         let view_id = self.allocate_transient_id()?;
         let index_id = self.allocate_transient_id()?;
 
+<<<<<<< HEAD
         let cluster = self.catalog().active_cluster(session)?;
+=======
+        // If our query only depends on system tables, then we optionally run it on the
+        // introspection cluster.
+        let cluster = match introspection::auto_run_on_introspection(
+            &self.catalog,
+            session,
+            source.depends_on(),
+        ) {
+            Some(cluster) => cluster,
+            None => self.catalog.active_cluster(session)?,
+        };
+
+>>>>>>> 344f2cfa2 (branch start)
         let target_replica_name = session.vars().cluster_replica();
         let mut target_replica = target_replica_name
             .map(|name| {
@@ -2253,7 +2271,20 @@ impl Coordinator {
             up_to,
         } = plan;
 
+<<<<<<< HEAD
         let cluster = self.catalog().active_cluster(session)?;
+=======
+        // If our query only depends on system tables, then we optionally run it on the
+        // introspection cluster.
+        let cluster = match introspection::auto_run_on_introspection(
+            &self.catalog,
+            session,
+            depends_on.iter().copied(),
+        ) {
+            Some(cluster) => cluster,
+            None => self.catalog.active_cluster(session)?,
+        };
+>>>>>>> 344f2cfa2 (branch start)
         let cluster_id = cluster.id;
 
         let target_replica_name = session.vars().cluster_replica();

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -87,6 +87,7 @@ pub enum AdapterNotice {
         role_name: String,
         member_name: String,
     },
+    AutoRunOnIntrospectionCluster,
 }
 
 impl AdapterNotice {
@@ -207,6 +208,10 @@ impl fmt::Display for AdapterNotice {
             } => write!(
                 f,
                 "role \"{member_name}\" is not a member of role \"{role_name}\""
+            ),
+            AdapterNotice::AutoRunOnIntrospectionCluster => write!(
+                f,
+                "query was automatically run on the \"mz_introspection\" cluster"
             ),
         }
     }

--- a/src/adapter/tests/parameters.rs
+++ b/src/adapter/tests/parameters.rs
@@ -76,31 +76,10 @@
 // END LINT CONFIG
 
 use mz_adapter::catalog::Catalog;
-use mz_adapter::config::SynchronizedParameters;
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::NOW_ZERO;
 use mz_repr::ScalarType;
 use mz_sql::plan::PlanContext;
-use mz_sql::session::vars::SystemVars;
-
-#[test]
-fn test_github_18189() {
-    let vars = SystemVars::default();
-    let mut sync = SynchronizedParameters::new(vars);
-    assert!(sync.modify("allowed_cluster_replica_sizes", "1,2"));
-    assert_eq!(sync.get("allowed_cluster_replica_sizes"), r#""1", "2""#);
-    assert!(sync.modify("allowed_cluster_replica_sizes", ""));
-    assert_eq!(sync.get("allowed_cluster_replica_sizes"), "");
-}
-
-#[test]
-fn test_vars_are_synced() {
-    let vars = SystemVars::default();
-    let sync = SynchronizedParameters::new(vars);
-
-    // A smoke test to ensure the variables we want to get synced, are getting synced
-    assert!(sync.is_synchronized("enable_force_introspection_cluster"));
-}
 
 #[tokio::test]
 async fn test_parameter_type_inference() {

--- a/src/adapter/tests/parameters.rs
+++ b/src/adapter/tests/parameters.rs
@@ -93,6 +93,15 @@ fn test_github_18189() {
     assert_eq!(sync.get("allowed_cluster_replica_sizes"), "");
 }
 
+#[test]
+fn test_vars_are_synced() {
+    let vars = SystemVars::default();
+    let sync = SynchronizedParameters::new(vars);
+
+    // A smoke test to ensure the variables we want to get synced, are getting synced
+    assert!(sync.is_synchronized("enable_force_introspection_cluster"));
+}
+
 #[tokio::test]
 async fn test_parameter_type_inference() {
     let test_cases = vec![

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2653,3 +2653,126 @@ fn test_mz_sessions() {
         foo_conn_id,
     );
 }
+
+#[test]
+fn test_auto_run_on_introspection() {
+    let config = util::Config::default();
+    let server = util::start_server(config).unwrap();
+
+    let (tx, mut rx) = futures::channel::mpsc::unbounded();
+    let mut client = server
+        .pg_config()
+        .notice_callback(move |notice| {
+            tx.unbounded_send(notice).unwrap();
+        })
+        .connect(postgres::NoTls)
+        .unwrap();
+
+    let mut assert_introspection_notice = |expected| {
+        match (rx.try_next(), expected) {
+            (Ok(Some(notice)), true) => {
+                let msg = notice.message();
+                let expected = "query was automatically run on the \"mz_introspection\" cluster";
+                assert_eq!(msg, expected);
+            }
+            (Err(_), false) => (),
+            (_, true) => panic!("Didn't get the expected notice!"),
+            (res, false) => panic!("Got a notice, but it wasn't expected! {:?}", res),
+        }
+        // Drain the channel of any other notices
+        while let Ok(Some(_)) = rx.try_next() {}
+    };
+
+    // The notice we assert on only gets emitted at the DEBUG level
+    client
+        .execute("SET client_min_messages = debug", &[])
+        .unwrap();
+
+    // By default force_introspection_cluster should be OFF
+    let _row = client
+        .query_one("SELECT * FROM mz_functions LIMIT 1", &[])
+        .unwrap();
+    assert_introspection_notice(false);
+
+    let _row = client
+        .query_one("SELECT * FROM pg_attribute LIMIT 1", &[])
+        .unwrap();
+    assert_introspection_notice(false);
+
+    let _rows = client
+        .query("SELECT * FROM mz_internal.mz_active_peeks", &[])
+        .unwrap();
+    assert_introspection_notice(false);
+
+    // Start our subscribe.
+    client
+        .batch_execute("BEGIN; DECLARE c CURSOR FOR SUBSCRIBE (SELECT * FROM mz_functions);")
+        .unwrap();
+    assert_introspection_notice(false);
+
+    // Fetch all of the rows.
+    client.batch_execute("FETCH ALL c").unwrap();
+    assert_introspection_notice(false);
+
+    // End the subscribe.
+    client.batch_execute("COMMIT").unwrap();
+    assert_introspection_notice(false);
+
+    client
+        .execute("SET force_introspection_cluster = true", &[])
+        .unwrap();
+
+    // Queries with no dependencies should not get run on the introspection cluster
+    let _row = client.query_one("SELECT 1;", &[]).unwrap();
+    assert_introspection_notice(false);
+
+    // Queries that only depend on system tables, __should__ get run on the introspection cluster
+    let _row = client
+        .query_one("SELECT * FROM mz_functions LIMIT 1", &[])
+        .unwrap();
+    assert_introspection_notice(true);
+
+    let _row = client
+        .query_one("SELECT * FROM pg_attribute LIMIT 1", &[])
+        .unwrap();
+    assert_introspection_notice(true);
+
+    let _rows = client
+        .query("SELECT * FROM mz_internal.mz_active_peeks", &[])
+        .unwrap();
+    assert_introspection_notice(true);
+
+    // Start our subscribe.
+    client
+        .batch_execute("BEGIN; DECLARE c CURSOR FOR SUBSCRIBE (SELECT * FROM mz_functions);")
+        .unwrap();
+    assert_introspection_notice(false);
+
+    // Fetch all of the rows.
+    client.batch_execute("FETCH ALL c").unwrap();
+    assert_introspection_notice(true);
+
+    // End the subscribe.
+    client.batch_execute("COMMIT").unwrap();
+    assert_introspection_notice(false);
+
+    // ... even more complex queries that depend on multiple system tables
+    let _rows = client
+        .query("SELECT mz_types.name, mz_types.id FROM mz_types JOIN mz_base_types ON mz_types.id = mz_base_types.id", &[])
+        .unwrap();
+    assert_introspection_notice(true);
+
+    client
+        .execute(
+            "CREATE VIEW user_made AS SELECT name FROM mz_functions;",
+            &[],
+        )
+        .unwrap();
+    assert_introspection_notice(false);
+
+    // But querying user made objects should not result in queries being run on mz_introspection.
+    let _row = client
+        .query_one("SELECT * FROM user_made LIMIT 1", &[])
+        .unwrap();
+    assert_introspection_notice(false);
+}

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2688,7 +2688,7 @@ fn test_auto_run_on_introspection() {
         .execute("SET client_min_messages = debug", &[])
         .unwrap();
 
-    // By default force_introspection_cluster should be OFF
+    // By default auto_route_introspection_queries should be OFF
     let _row = client
         .query_one("SELECT * FROM mz_functions LIMIT 1", &[])
         .unwrap();
@@ -2727,7 +2727,7 @@ fn test_auto_run_on_introspection() {
         .unwrap();
     sys_client
         .execute(
-            "ALTER SYSTEM SET enable_force_introspection_cluster TO true",
+            "ALTER SYSTEM SET enable_auto_route_introspection_queries TO true",
             &[],
         )
         .unwrap();
@@ -2789,7 +2789,7 @@ fn test_auto_run_on_introspection() {
     // If the feature is enabled, but the behavior is disabled, we shouldn't run on the
     // introspection cluster
     client
-        .execute("SET force_introspection_cluster = false", &[])
+        .execute("SET auto_route_introspection_queries = false", &[])
         .unwrap();
     let _row = client
         .query_one("SELECT * FROM mz_functions LIMIT 1", &[])

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2804,7 +2804,7 @@ fn test_auto_run_on_introspection_feature_disabled() {
             &[],
         )
         .unwrap();
-    assert_introspection_notice(true);
+    assert_introspection_notice(false);
 
     let _rows = client
         .query("SELECT * FROM mz_internal.mz_active_peeks", &[])

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -591,7 +591,7 @@ impl Severity {
             AdapterNotice::RbacDisabled => Severity::Notice,
             AdapterNotice::RoleMembershipAlreadyExists { .. } => Severity::Notice,
             AdapterNotice::RoleMembershipDoesNotExists { .. } => Severity::Warning,
-            AdapterNotice::AutoRunOnIntrospectionCluster => Severity::Log,
+            AdapterNotice::AutoRunOnIntrospectionCluster => Severity::Debug,
         }
     }
 }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -430,6 +430,7 @@ impl ErrorResponse {
             AdapterNotice::RbacDisabled => SqlState::WARNING,
             AdapterNotice::RoleMembershipAlreadyExists { .. } => SqlState::WARNING,
             AdapterNotice::RoleMembershipDoesNotExists { .. } => SqlState::WARNING,
+            AdapterNotice::AutoRunOnIntrospectionCluster => SqlState::WARNING,
         };
         ErrorResponse {
             severity: Severity::for_adapter_notice(&notice),
@@ -590,6 +591,7 @@ impl Severity {
             AdapterNotice::RbacDisabled => Severity::Notice,
             AdapterNotice::RoleMembershipAlreadyExists { .. } => Severity::Notice,
             AdapterNotice::RoleMembershipDoesNotExists { .. } => Severity::Warning,
+            AdapterNotice::AutoRunOnIntrospectionCluster => Severity::Log,
         }
     }
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -624,11 +624,11 @@ pub const ENABLE_RBAC_CHECKS: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
-/// This is separate from the [`FORCE_INTROSPECTION_CLUSTER`] `ServerVar` so we can
+/// This is separate from the [`AUTO_ROUTE_INTROSPECTION_QUERIES`] `ServerVar` so we can
 /// independently roll out this feature via LaunchDarkly without effecting user's ability
 /// to disable the behavior for there sessions.
-pub const ENABLE_FORCE_INTROSPECTION_CLUSTER: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_force_introspection_cluster"),
+pub const ENABLE_AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_auto_route_introspection_queries"),
     value: &false,
     description:
         "Whether the feature to force queries that depends only on system tables to run on the mz_introspection cluster, is enabled (Materialize).",
@@ -636,11 +636,11 @@ pub const ENABLE_FORCE_INTROSPECTION_CLUSTER: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
-/// This is separate from the [`ENABLE_FORCE_INTROSPECTION_CLUSTER`] `ServerVar` so we
+/// This is separate from the [`ENABLE_AUTO_ROUTE_INTROSPECTION_QUERIES`] `ServerVar` so we
 /// can independently roll out this feature via LaunchDarkly. Users can set this var as
 /// a session variable, while we can control the feature overall with the former.
-pub const FORCE_INTROSPECTION_CLUSTER: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("force_introspection_cluster"),
+pub const AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("auto_route_introspection_queries"),
     value: &true,
     description:
         "Whether to force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize).",
@@ -745,7 +745,7 @@ pub struct SessionVars {
     real_time_recency: SessionVar<bool>,
     emit_timestamp_notice: SessionVar<bool>,
     emit_trace_id_notice: SessionVar<bool>,
-    force_introspection_cluster: SessionVar<bool>,
+    auto_route_introspection_queries: SessionVar<bool>,
     // Inputs to computed variables.
     build_info: &'static BuildInfo,
     user: User,
@@ -780,7 +780,7 @@ impl SessionVars {
             real_time_recency: SessionVar::new(&REAL_TIME_RECENCY),
             emit_timestamp_notice: SessionVar::new(&EMIT_TIMESTAMP_NOTICE),
             emit_trace_id_notice: SessionVar::new(&EMIT_TRACE_ID_NOTICE),
-            force_introspection_cluster: SessionVar::new(&FORCE_INTROSPECTION_CLUSTER),
+            auto_route_introspection_queries: SessionVar::new(&AUTO_ROUTE_INTROSPECTION_QUERIES),
             build_info,
             user,
         }
@@ -815,7 +815,7 @@ impl SessionVars {
             &self.real_time_recency,
             &self.emit_timestamp_notice,
             &self.emit_trace_id_notice,
-            &self.force_introspection_cluster,
+            &self.auto_route_introspection_queries,
             self.build_info,
             &self.user,
         ];
@@ -905,8 +905,8 @@ impl SessionVars {
             Ok(&self.emit_timestamp_notice)
         } else if name == EMIT_TRACE_ID_NOTICE.name {
             Ok(&self.emit_trace_id_notice)
-        } else if name == FORCE_INTROSPECTION_CLUSTER.name {
-            Ok(&self.force_introspection_cluster)
+        } else if name == AUTO_ROUTE_INTROSPECTION_QUERIES.name {
+            Ok(&self.auto_route_introspection_queries)
         } else if name == IS_SUPERUSER_NAME {
             Ok(&self.user)
         } else {
@@ -1043,8 +1043,8 @@ impl SessionVars {
             self.emit_timestamp_notice.set(input, local)
         } else if name == EMIT_TRACE_ID_NOTICE.name {
             self.emit_trace_id_notice.set(input, local)
-        } else if name == FORCE_INTROSPECTION_CLUSTER.name {
-            self.force_introspection_cluster.set(input, local)
+        } else if name == AUTO_ROUTE_INTROSPECTION_QUERIES.name {
+            self.auto_route_introspection_queries.set(input, local)
         } else if name == IS_SUPERUSER_NAME {
             Err(VarError::ReadOnlyParameter(self.user.name()))
         } else {
@@ -1093,8 +1093,8 @@ impl SessionVars {
             self.emit_timestamp_notice.reset(local);
         } else if name == EMIT_TRACE_ID_NOTICE.name {
             self.emit_trace_id_notice.reset(local);
-        } else if name == FORCE_INTROSPECTION_CLUSTER.name {
-            self.force_introspection_cluster.reset(local);
+        } else if name == AUTO_ROUTE_INTROSPECTION_QUERIES.name {
+            self.auto_route_introspection_queries.reset(local);
         } else if name == CLIENT_ENCODING.name
             || name == DATE_STYLE.name
             || name == FAILPOINTS.name
@@ -1141,7 +1141,7 @@ impl SessionVars {
             real_time_recency,
             emit_timestamp_notice,
             emit_trace_id_notice,
-            force_introspection_cluster,
+            auto_route_introspection_queries,
             build_info: _,
             user: _,
         } = self;
@@ -1160,7 +1160,7 @@ impl SessionVars {
         real_time_recency.end_transaction(action);
         emit_timestamp_notice.end_transaction(action);
         emit_trace_id_notice.end_transaction(action);
-        force_introspection_cluster.end_transaction(action);
+        auto_route_introspection_queries.end_transaction(action);
     }
 
     /// Returns the value of the `application_name` configuration parameter.
@@ -1285,9 +1285,9 @@ impl SessionVars {
         *self.emit_trace_id_notice.value()
     }
 
-    /// Returns the value of `force_introspection_cluster` configuration parameter.
-    pub fn force_introspection_cluster(&self) -> bool {
-        *self.force_introspection_cluster.value()
+    /// Returns the value of `auto_route_introspection_queries` configuration parameter.
+    pub fn auto_route_introspection_queries(&self) -> bool {
+        *self.auto_route_introspection_queries.value()
     }
 
     /// Returns the value of `is_superuser` configuration parameter.
@@ -1359,7 +1359,7 @@ impl Default for SystemVars {
             .with_var(&MOCK_AUDIT_EVENT_TIMESTAMP)
             .with_var(&ENABLE_WITH_MUTUALLY_RECURSIVE)
             .with_var(&ENABLE_RBAC_CHECKS)
-            .with_var(&ENABLE_FORCE_INTROSPECTION_CLUSTER)
+            .with_var(&ENABLE_AUTO_ROUTE_INTROSPECTION_QUERIES)
     }
 }
 
@@ -1653,11 +1653,11 @@ impl SystemVars {
         *self.expect_value(&ENABLE_RBAC_CHECKS)
     }
 
-    /// Returns the `enable_force_introspection_cluster` configuration parameter.
+    /// Returns the `enable_auto_route_introspection_queries` configuration parameter.
     ///
     /// Note: this is generally intended to be set via LaunchDarkly
-    pub fn enable_force_introspection_cluster(&self) -> bool {
-        *self.expect_value(&ENABLE_FORCE_INTROSPECTION_CLUSTER)
+    pub fn enable_auto_route_introspection_queries(&self) -> bool {
+        *self.expect_value(&ENABLE_AUTO_ROUTE_INTROSPECTION_QUERIES)
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -628,7 +628,7 @@ pub const FORCE_INTROSPECTION_CLUSTER: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("force_introspection_cluster"),
     value: &false,
     description:
-        "Boolean flag indicating whether we should force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize).",
+        "Whether to force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize).",
     internal: true,
     safe: true,
 };

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -624,6 +624,15 @@ pub const ENABLE_RBAC_CHECKS: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
+pub const FORCE_INTROSPECTION_CLUSTER: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("force_introspection_cluster"),
+    value: &true,
+    description:
+        "Boolean flag indicating whether we should force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize).",
+    internal: true,
+    safe: true,
+};
+
 /// Represents the input to a variable.
 ///
 /// Each variable has different rules for how it handles each style of input.
@@ -721,6 +730,7 @@ pub struct SessionVars {
     real_time_recency: SessionVar<bool>,
     emit_timestamp_notice: SessionVar<bool>,
     emit_trace_id_notice: SessionVar<bool>,
+    force_introspection_cluster: SessionVar<bool>,
     // Inputs to computed variables.
     build_info: &'static BuildInfo,
     user: User,
@@ -755,6 +765,7 @@ impl SessionVars {
             real_time_recency: SessionVar::new(&REAL_TIME_RECENCY),
             emit_timestamp_notice: SessionVar::new(&EMIT_TIMESTAMP_NOTICE),
             emit_trace_id_notice: SessionVar::new(&EMIT_TRACE_ID_NOTICE),
+            force_introspection_cluster: SessionVar::new(&FORCE_INTROSPECTION_CLUSTER),
             build_info,
             user,
         }
@@ -763,8 +774,10 @@ impl SessionVars {
     /// Returns an iterator over the configuration parameters and their current
     /// values for this session.
     pub fn iter(&self) -> impl Iterator<Item = &dyn Var> {
-        let vars: [&dyn Var; 25] = [
-            &self.application_name,
+        // `as` is ok to use to cast to a trait object.
+        #[allow(clippy::as_conversions)]
+        let vars = [
+            &self.application_name as &dyn Var,
             &self.client_encoding,
             &self.client_min_messages,
             &self.cluster,
@@ -787,6 +800,7 @@ impl SessionVars {
             &self.real_time_recency,
             &self.emit_timestamp_notice,
             &self.emit_trace_id_notice,
+            &self.force_introspection_cluster,
             self.build_info,
             &self.user,
         ];
@@ -876,6 +890,8 @@ impl SessionVars {
             Ok(&self.emit_timestamp_notice)
         } else if name == EMIT_TRACE_ID_NOTICE.name {
             Ok(&self.emit_trace_id_notice)
+        } else if name == FORCE_INTROSPECTION_CLUSTER.name {
+            Ok(&self.force_introspection_cluster)
         } else if name == IS_SUPERUSER_NAME {
             Ok(&self.user)
         } else {
@@ -1012,6 +1028,8 @@ impl SessionVars {
             self.emit_timestamp_notice.set(input, local)
         } else if name == EMIT_TRACE_ID_NOTICE.name {
             self.emit_trace_id_notice.set(input, local)
+        } else if name == FORCE_INTROSPECTION_CLUSTER.name {
+            self.force_introspection_cluster.set(input, local)
         } else if name == IS_SUPERUSER_NAME {
             Err(VarError::ReadOnlyParameter(self.user.name()))
         } else {
@@ -1060,6 +1078,8 @@ impl SessionVars {
             self.emit_timestamp_notice.reset(local);
         } else if name == EMIT_TRACE_ID_NOTICE.name {
             self.emit_trace_id_notice.reset(local);
+        } else if name == FORCE_INTROSPECTION_CLUSTER.name {
+            self.force_introspection_cluster.reset(local);
         } else if name == CLIENT_ENCODING.name
             || name == DATE_STYLE.name
             || name == FAILPOINTS.name
@@ -1106,6 +1126,7 @@ impl SessionVars {
             real_time_recency,
             emit_timestamp_notice,
             emit_trace_id_notice,
+            force_introspection_cluster,
             build_info: _,
             user: _,
         } = self;
@@ -1124,6 +1145,7 @@ impl SessionVars {
         real_time_recency.end_transaction(action);
         emit_timestamp_notice.end_transaction(action);
         emit_trace_id_notice.end_transaction(action);
+        force_introspection_cluster.end_transaction(action);
     }
 
     /// Returns the value of the `application_name` configuration parameter.
@@ -1246,6 +1268,11 @@ impl SessionVars {
     /// Returns the value of `emit_trace_id_notice` configuration parameter.
     pub fn emit_trace_id_notice(&self) -> bool {
         *self.emit_trace_id_notice.value()
+    }
+
+    /// Returns the value of `force_introspection_cluster` configuration parameter.
+    pub fn force_introspection_cluster(&self) -> bool {
+        *self.force_introspection_cluster.value()
     }
 
     /// Returns the value of `is_superuser` configuration parameter.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -624,9 +624,24 @@ pub const ENABLE_RBAC_CHECKS: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
+/// This is separate from the [`FORCE_INTROSPECTION_CLUSTER`] `ServerVar` so we can
+/// independently roll out this feature via LaunchDarkly without effecting user's ability
+/// to disable the behavior for there sessions.
+pub const ENABLE_FORCE_INTROSPECTION_CLUSTER: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_force_introspection_cluster"),
+    value: &false,
+    description:
+        "Whether the feature to force queries that depends only on system tables to run on the mz_introspection cluster, is enabled (Materialize).",
+    internal: true,
+    safe: true,
+};
+
+/// This is separate from the [`ENABLE_FORCE_INTROSPECTION_CLUSTER`] `ServerVar` so we
+/// can independently roll out this feature via LaunchDarkly. Users can set this var as
+/// a session variable, while we can control the feature overall with the former.
 pub const FORCE_INTROSPECTION_CLUSTER: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("force_introspection_cluster"),
-    value: &false,
+    value: &true,
     description:
         "Whether to force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize).",
     internal: true,
@@ -1344,6 +1359,7 @@ impl Default for SystemVars {
             .with_var(&MOCK_AUDIT_EVENT_TIMESTAMP)
             .with_var(&ENABLE_WITH_MUTUALLY_RECURSIVE)
             .with_var(&ENABLE_RBAC_CHECKS)
+            .with_var(&ENABLE_FORCE_INTROSPECTION_CLUSTER)
     }
 }
 
@@ -1635,6 +1651,13 @@ impl SystemVars {
     /// Returns the `enable_rbac_checks` configuration parameter.
     pub fn enable_rbac_checks(&self) -> bool {
         *self.expect_value(&ENABLE_RBAC_CHECKS)
+    }
+
+    /// Returns the `enable_force_introspection_cluster` configuration parameter.
+    ///
+    /// Note: this is generally intended to be set via LaunchDarkly
+    pub fn enable_force_introspection_cluster(&self) -> bool {
+        *self.expect_value(&ENABLE_FORCE_INTROSPECTION_CLUSTER)
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -644,7 +644,7 @@ pub const FORCE_INTROSPECTION_CLUSTER: ServerVar<bool> = ServerVar {
     value: &true,
     description:
         "Whether to force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize).",
-    internal: true,
+    internal: false,
     safe: true,
 };
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -626,7 +626,7 @@ pub const ENABLE_RBAC_CHECKS: ServerVar<bool> = ServerVar {
 
 pub const FORCE_INTROSPECTION_CLUSTER: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("force_introspection_cluster"),
-    value: &true,
+    value: &false,
     description:
         "Boolean flag indicating whether we should force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize).",
     internal: true,

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -22,6 +22,7 @@ emit_timestamp_notice                   off                    "Boolean flag ind
 emit_trace_id_notice                    off                    "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize)."
 extra_float_digits                      3                      "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."
 failpoints                              ""                     "Allows failpoints to be dynamically activated."
+force_introspection_cluster             on                     "Whether to force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize)."
 idle_in_transaction_session_timeout     "2 min"                "Sets the maximum allowed duration that a session can sit idle in a transaction before being terminated. If this value is specified without units, it is taken as milliseconds. A value of zero disables the timeout (PostgreSQL)."
 integer_datetimes                       on                     "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL)."
 IntervalStyle                           postgres               "Sets the display format for interval values (PostgreSQL)."

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -22,7 +22,7 @@ emit_timestamp_notice                   off                    "Boolean flag ind
 emit_trace_id_notice                    off                    "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize)."
 extra_float_digits                      3                      "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."
 failpoints                              ""                     "Allows failpoints to be dynamically activated."
-force_introspection_cluster             on                     "Whether to force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize)."
+auto_route_introspection_queries             on                     "Whether to force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize)."
 idle_in_transaction_session_timeout     "2 min"                "Sets the maximum allowed duration that a session can sit idle in a transaction before being terminated. If this value is specified without units, it is taken as milliseconds. A value of zero disables the timeout (PostgreSQL)."
 integer_datetimes                       on                     "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL)."
 IntervalStyle                           postgres               "Sets the display format for interval values (PostgreSQL)."

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -44,8 +44,9 @@ contains:system cluster 'mz_introspection' cannot be modified
 
 > SET CLUSTER TO mz_system
 
-! SHOW MATERIALIZED VIEWS
-contains:system cluster 'mz_system' cannot execute user queries
+# Query gets automatically run on mz_introspection, despite mz_system being set
+> SHOW MATERIALIZED VIEWS
+mv default
 
 ! CREATE MATERIALIZED VIEW mv1 AS SELECT MIN(1)
 contains:system cluster 'mz_system' cannot be modified


### PR DESCRIPTION
### Motivation

* This PR adds a known-desirable feature.
  * Fixes #17609 

This PR makes a change to sequencing Peeks and Subscribes, such that if the plan only depends on system tables, i.e. objects in the `mz_catalog`, `pg_catalog`, `mz_internal`, or `information_schema`, then we automatically run the query on the `mz_introspection` cluster. The reasoning here is the `mz_introspection` cluster has indexes for these tables, so all queries are about to be faster.

We also introduce a new Adapter Notice, `AutoRunOnIntrospectionCluster`, which is emitted at the log level. If the user's current cluster isn't `mz_introspection`, but we're about to run their query on that cluster, we emit a notice so there is some indication of this swap.

### Testing
I added a Rust test to `sql.rs` that asserts when the feature is enabled we actually run against `mz_introspection` by asserting a notice is emitted, and that when the feature is off we don't.

### Gating
There are two things that must be true for this feature to be enabled:
1. `enable_force_introspection_cluster`, a `SystemVar` that is synced with LaunchDarkly and enables us to turn the feature on an off or `unsafe_mode` is enabled. **default false**
2. `force_introspection_cluster`, a `SessionVar` that allows a user to disable this behavior on a per-session basis, **default true**

Using the `SystemVar` and LaunchDarkly, we should be able to gradually roll this feature out, while enabling the feature when `unsafe_mode` is enabled, allows us to test it in CI.

### Tips for reviewer

* What I was mostly unsure about is where we override the current cluster, and make the choice to use `mz_introspection`, feedback on that would be great.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - When the feature is enabled, queries that depend only on system tables will automatically get run against the `mz_introspection` cluster.
