### PR TITLE
sql: Allow multiple roles in grant/revoke

### DIFF
--- a/doc/user/content/sql/grant-role.md
+++ b/doc/user/content/sql/grant-role.md
@@ -35,6 +35,10 @@ _member_name_ | The role name to add to _role_name_ as a member.
 GRANT data_scientist TO joe;
 ```
 
+```sql
+GRANT data_scientist TO joe, mike;
+```
+
 ## Related pages
 
 - [CREATE ROLE](../create-role)

--- a/doc/user/content/sql/revoke-role.md
+++ b/doc/user/content/sql/revoke-role.md
@@ -39,6 +39,10 @@ You may not set up circular membership loops.
 REVOKE data_scientist FROM joe;
 ```
 
+```sql
+REVOKE data_scientist FROM joe, mike;
+```
+
 ## Related pages
 
 - [CREATE ROLE](../create-role)

--- a/doc/user/layouts/partials/sql-grammar/grant-role.svg
+++ b/doc/user/layouts/partials/sql-grammar/grant-role.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="563" height="69">
+<svg xmlns="http://www.w3.org/2000/svg" width="421" height="179">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="70" height="32" rx="10"/>
@@ -28,11 +28,19 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="317" y="53">GROUP</text>
-   <rect x="419" y="3" width="116" height="32"/>
-   <rect x="417" y="1" width="116" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="427" y="21">member_name</text>
+   <rect x="257" y="145" width="116" height="32"/>
+   <rect x="255" y="143" width="116" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="265" y="163">member_name</text>
+   <rect x="257" y="101" width="24" height="32" rx="10"/>
+   <rect x="255"
+         y="99"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="119">,</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m20 -32 h10 m116 0 h10 m3 0 h-3"/>
-   <polygon points="553 17 561 13 561 21"/>
-   <polygon points="553 17 545 13 545 21"/>
+         d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-206 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m23 44 h-3"/>
+   <polygon points="411 159 419 155 419 163"/>
+   <polygon points="411 159 403 155 403 163"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/revoke-role.svg
+++ b/doc/user/layouts/partials/sql-grammar/revoke-role.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="591" height="69">
+<svg xmlns="http://www.w3.org/2000/svg" width="449" height="179">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="78" height="32" rx="10"/>
@@ -28,11 +28,19 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="345" y="53">GROUP</text>
-   <rect x="447" y="3" width="116" height="32"/>
-   <rect x="445" y="1" width="116" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="455" y="21">member_name</text>
+   <rect x="285" y="145" width="116" height="32"/>
+   <rect x="283" y="143" width="116" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="293" y="163">member_name</text>
+   <rect x="285" y="101" width="24" height="32" rx="10"/>
+   <rect x="283"
+         y="99"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="293" y="119">,</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m78 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m60 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m20 -32 h10 m116 0 h10 m3 0 h-3"/>
-   <polygon points="581 17 589 13 589 21"/>
-   <polygon points="581 17 573 13 573 21"/>
+         d="m17 17 h2 m0 0 h10 m78 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m60 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-206 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m23 44 h-3"/>
+   <polygon points="439 159 447 155 447 163"/>
+   <polygon points="439 159 431 155 431 163"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -234,7 +234,7 @@ format_spec ::=
   'TEXT' |
   'BYTES'
 grant_role ::=
-  'GRANT' role_name 'TO' 'GROUP'? member_name
+  'GRANT' role_name 'TO' 'GROUP'? member_name ( ',' member_name )*
 key_strat ::=
   'KEY STRATEGY' strat
 val_strat ::=
@@ -315,7 +315,7 @@ prepare ::=
 reset_session_variable ::=
   'RESET' variable_name
 revoke_role ::=
-  'REVOKE' role_name 'FROM' 'GROUP'? member_name
+  'REVOKE' role_name 'FROM' 'GROUP'? member_name ( ',' member_name )*
 rollback ::=
   'ROLLBACK'
 select_stmt ::=

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2906,8 +2906,8 @@ impl_display_t!(ShowStatement);
 pub struct GrantRoleStatement<T: AstInfo> {
     /// The role that is gaining a member.
     pub role_name: T::RoleName,
-    /// The role that will be added to `role_name`.
-    pub member_name: T::RoleName,
+    /// The roles that will be added to `role_name`.
+    pub member_names: Vec<T::RoleName>,
 }
 
 impl<T: AstInfo> AstDisplay for GrantRoleStatement<T> {
@@ -2915,7 +2915,7 @@ impl<T: AstInfo> AstDisplay for GrantRoleStatement<T> {
         f.write_str("GRANT ");
         f.write_node(&self.role_name);
         f.write_str(" TO ");
-        f.write_node(&self.member_name);
+        f.write_node(&display::comma_separated(&self.member_names));
     }
 }
 impl_display_t!(GrantRoleStatement);
@@ -2926,8 +2926,7 @@ pub struct RevokeRoleStatement<T: AstInfo> {
     /// The role that is losing a member.
     pub role_name: T::RoleName,
     /// The role that will be removed from `role_name`.
-    pub member_name: T::RoleName,
-    // TODO(jkosh44) Add cascade/restrict.
+    pub member_names: Vec<T::RoleName>,
 }
 
 impl<T: AstInfo> AstDisplay for RevokeRoleStatement<T> {
@@ -2935,7 +2934,7 @@ impl<T: AstInfo> AstDisplay for RevokeRoleStatement<T> {
         f.write_str("REVOKE ");
         f.write_node(&self.role_name);
         f.write_str(" FROM ");
-        f.write_node(&self.member_name);
+        f.write_node(&display::comma_separated(&self.member_names));
     }
 }
 impl_display_t!(RevokeRoleStatement);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5836,10 +5836,10 @@ impl<'a> Parser<'a> {
         let role_name = self.parse_identifier()?;
         self.expect_keyword(TO)?;
         let _ = self.parse_keyword(GROUP);
-        let member_name = self.parse_identifier()?;
+        let member_names = self.parse_comma_separated(Parser::parse_identifier)?;
         Ok(Statement::GrantRole(GrantRoleStatement {
             role_name,
-            member_name,
+            member_names,
         }))
     }
 
@@ -5849,10 +5849,10 @@ impl<'a> Parser<'a> {
         let role_name = self.parse_identifier()?;
         self.expect_keyword(FROM)?;
         let _ = self.parse_keyword(GROUP);
-        let member_name = self.parse_identifier()?;
+        let member_names = self.parse_comma_separated(Parser::parse_identifier)?;
         Ok(Statement::RevokeRole(RevokeRoleStatement {
             role_name,
-            member_name,
+            member_names,
         }))
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1644,25 +1644,53 @@ GRANT admin TO joe
 ----
 GRANT admin TO joe
 =>
-GrantRole(GrantRoleStatement { role_name: Ident("admin"), member_name: Ident("joe") })
+GrantRole(GrantRoleStatement { role_name: Ident("admin"), member_names: [Ident("joe")] })
 
 parse-statement
 GRANT scientist TO GROUP joseph
 ----
 GRANT scientist TO joseph
 =>
-GrantRole(GrantRoleStatement { role_name: Ident("scientist"), member_name: Ident("joseph") })
+GrantRole(GrantRoleStatement { role_name: Ident("scientist"), member_names: [Ident("joseph")] })
+
+parse-statement
+GRANT admin TO joe, mike
+----
+GRANT admin TO joe, mike
+=>
+GrantRole(GrantRoleStatement { role_name: Ident("admin"), member_names: [Ident("joe"), Ident("mike")] })
+
+parse-statement
+GRANT scientist TO GROUP joseph, michael
+----
+GRANT scientist TO joseph, michael
+=>
+GrantRole(GrantRoleStatement { role_name: Ident("scientist"), member_names: [Ident("joseph"), Ident("michael")] })
 
 parse-statement
 REVOKE doctor FROM joe
 ----
 REVOKE doctor FROM joe
 =>
-RevokeRole(RevokeRoleStatement { role_name: Ident("doctor"), member_name: Ident("joe") })
+RevokeRole(RevokeRoleStatement { role_name: Ident("doctor"), member_names: [Ident("joe")] })
 
 parse-statement
 REVOKE ability_to_practice_law_in_arkansas FROM GROUP joseph
 ----
 REVOKE ability_to_practice_law_in_arkansas FROM joseph
 =>
-RevokeRole(RevokeRoleStatement { role_name: Ident("ability_to_practice_law_in_arkansas"), member_name: Ident("joseph") })
+RevokeRole(RevokeRoleStatement { role_name: Ident("ability_to_practice_law_in_arkansas"), member_names: [Ident("joseph")] })
+
+parse-statement
+REVOKE doctor FROM joe, mike
+----
+REVOKE doctor FROM joe, mike
+=>
+RevokeRole(RevokeRoleStatement { role_name: Ident("doctor"), member_names: [Ident("joe"), Ident("mike")] })
+
+parse-statement
+REVOKE ability_to_practice_law_in_arkansas FROM GROUP joseph, michael
+----
+REVOKE ability_to_practice_law_in_arkansas FROM joseph, michael
+=>
+RevokeRole(RevokeRoleStatement { role_name: Ident("ability_to_practice_law_in_arkansas"), member_names: [Ident("joseph"), Ident("michael")] })

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -802,8 +802,8 @@ pub struct RaisePlan {
 pub struct GrantRolePlan {
     /// The role that is gaining a member.
     pub role_id: RoleId,
-    /// The role that will be added to `role_id`.
-    pub member_id: RoleId,
+    /// The roles that will be added to `role_id`.
+    pub member_ids: Vec<RoleId>,
     /// The role who executed the plan.
     pub grantor_id: RoleId,
 }
@@ -812,8 +812,8 @@ pub struct GrantRolePlan {
 pub struct RevokeRolePlan {
     /// The role that is losing a member.
     pub role_id: RoleId,
-    /// The role that will be removed from `role_id`.
-    pub member_id: RoleId,
+    /// The roles that will be removed from `role_id`.
+    pub member_ids: Vec<RoleId>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4137,13 +4137,16 @@ pub fn plan_grant_role(
     scx: &StatementContext,
     GrantRoleStatement {
         role_name,
-        member_name,
+        member_names,
     }: GrantRoleStatement<Aug>,
 ) -> Result<Plan, PlanError> {
     let grantor_id = scx.catalog.active_role_id().clone();
     Ok(Plan::GrantRole(GrantRolePlan {
         role_id: role_name.id,
-        member_id: member_name.id,
+        member_ids: member_names
+            .into_iter()
+            .map(|member_name| member_name.id)
+            .collect(),
         grantor_id,
     }))
 }
@@ -4159,11 +4162,14 @@ pub fn plan_revoke_role(
     _: &StatementContext,
     RevokeRoleStatement {
         role_name,
-        member_name,
+        member_names,
     }: RevokeRoleStatement<Aug>,
 ) -> Result<Plan, PlanError> {
     Ok(Plan::RevokeRole(RevokeRolePlan {
         role_id: role_name.id,
-        member_id: member_name.id,
+        member_ids: member_names
+            .into_iter()
+            .map(|member_name| member_name.id)
+            .collect(),
     }))
 }

--- a/test/sqllogictest/role_membership.slt
+++ b/test/sqllogictest/role_membership.slt
@@ -202,12 +202,109 @@ REVOKE group1 FROM public
 statement error role name "public" is reserved
 REVOKE public FROM group1
 
+statement ok
+DROP ROLE group1
+
+statement ok
+DROP ROLE joe
+
 # SHOW ROLES/USERS is not yet implemented
 statement error SHOW ROLES not yet supported
 show roles
 
 statement error SHOW ROLES not yet supported
 show users
+
+# Test grant/revoke multiple roles
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+CREATE ROLE group1
+
+statement ok
+CREATE ROLE group2
+
+statement ok
+CREATE ROLE group3
+
+statement error unknown role 'bob'
+GRANT group3 TO joe, group1, bob
+
+query TTT
+SELECT * FROM role_members
+----
+
+statement error role name "mz_system" is reserved
+GRANT group3 TO joe, group1, mz_system
+
+query TTT
+SELECT * FROM role_members
+----
+
+statement ok
+GRANT group3 TO joe, group1
+
+query TTT
+SELECT * FROM role_members
+----
+group3  joe     materialize
+group3  group1  materialize
+
+statement error role "joe" is a member of role "group3"
+GRANT joe TO group1, group3
+
+query TTT
+SELECT * FROM role_members
+----
+group3  joe     materialize
+group3  group1  materialize
+
+statement ok
+GRANT group3 TO group1, group2
+
+query TTT
+SELECT * FROM role_members
+----
+group3  joe     materialize
+group3  group1  materialize
+group3  group2  materialize
+
+statement error unknown role 'bob'
+REVOKE group3 FROM joe, group1, bob
+
+query TTT
+SELECT * FROM role_members
+----
+group3  joe     materialize
+group3  group1  materialize
+group3  group2  materialize
+
+statement error role name "mz_system" is reserved
+REVOKE group3 FROM joe, group1, mz_system
+
+query TTT
+SELECT * FROM role_members
+----
+group3  joe     materialize
+group3  group1  materialize
+group3  group2  materialize
+
+statement ok
+REVOKE group3 FROM joe, group1
+
+query TTT
+SELECT * FROM role_members
+----
+group3  group2  materialize
+
+statement ok
+REVOKE group3 FROM joe, group2
+
+query TTT
+SELECT * FROM role_members
+----
 
 # Disable RBAC checks
 


### PR DESCRIPTION
This commit adds the ability to specify multiple roles when running GRANT or REVOKE.

Part of #11579



### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release will add the ability to specify multiple roles in `GRANT` and `REVOKE`.
