### PR TITLE
adapter: Restrict the queries that can run on mz_introspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,6 +3422,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "smallvec",
  "thiserror",
  "timely",
  "tokio",

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,14 @@
 # dbt-materialize Changelog
 
+## Unreleased
+
+* **Breaking change.** Automatically run introspection queries in the
+    `mz_introspection` cluster via the new `auto_route_introspection_queries`
+    session variable, instead of hardcoding the cluster on connection.
+
+  This change requires [Materialize >=0.49.0](https://materialize.com/docs/releases/v0.49/).
+  **Users of older versions should pin `dbt-materialize` to `v1.4.0`.**
+
 ## 1.4.0 - 2023-02-03
 
 * Upgrade to `dbt-postgres` v1.4.0.
@@ -55,8 +64,8 @@
 
 ## 1.2.0 - 2022-08-31
 
-* Enable additional configuration for indexes created on view,
-  materializedview, or source materializations. Fix to use Materialize's
+* Enable additional configuration for indexes created on `view`,
+  `materializedview`, or `source` materializations. Fix to use Materialize's
   internal naming convention when creating indexes without providing
   explicit names.
 
@@ -92,7 +101,7 @@
   ```
 
   * A new `cluster` option for indexes on view, materializedview, or source
-    materializations. If 'cluster' is not supplied, indexes will be created
+    materializations. If `cluster` is not supplied, indexes will be created
     in the cluster used to create the materialization.
 
   ```sql

--- a/misc/dbt-materialize/README.md
+++ b/misc/dbt-materialize/README.md
@@ -18,7 +18,7 @@ pip install dbt-materialize      # install the adapter
 ## Requirements
 
 <!-- If you update this, bump the constraint in connections.py too. -->
-`dbt-materialize` requires Materialize v0.28.0+.
+`dbt-materialize` requires Materialize v0.49.0+.
 
 ## Configuring your profile
 

--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -53,6 +53,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument(
         "filter", nargs="?", default="", help="limit to test cases matching filter"
     )
+    parser.add_argument(
+        "-k", nargs="?", default=None, help="limit tests by keyword expressions"
+    )
     args = parser.parse_args()
 
     for test_case in test_cases:
@@ -63,6 +66,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 image=test_case.materialized_image,
                 volumes_extra=["secrets:/secrets"],
             )
+            test_args = ["dbt-materialize/tests"]
+            if args.k:
+                test_args.append(f"-k {args.k}")
 
             with c.test_case(test_case.name):
                 with c.override(materialized):
@@ -72,7 +78,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     c.run(
                         "dbt-test",
                         "pytest",
-                        "dbt-materialize/tests",
+                        *test_args,
                         env_extra={
                             "DBT_HOST": "materialized",
                             "KAFKA_ADDR": "redpanda:9092",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -58,6 +58,7 @@ reqwest = "0.11.13"
 semver = "1.0.16"
 serde = "1.0.152"
 serde_json = "1.0.89"
+smallvec = { version = "1.10.0", features = ["union"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["rt", "time"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -21,6 +21,7 @@
 use mz_repr::GlobalId;
 use mz_sql::catalog::SessionCatalog;
 use mz_sql::plan::Plan;
+use smallvec::SmallVec;
 
 use crate::catalog::{Catalog, Cluster};
 use crate::notice::AdapterNotice;
@@ -77,6 +78,50 @@ pub fn auto_run_on_introspection<'a, 's>(
         Some(intros_cluster)
     } else {
         None
+    }
+}
+
+/// Checks if we're currently running on the [`MZ_INTROSPECTION_CLUSTER`], and if so, do
+/// we depend on any objects that we're not allowed to query from the cluster.
+pub fn check_cluster_restrictions(
+    catalog: &impl SessionCatalog,
+    plan: &Plan,
+    depends_on: &Vec<GlobalId>,
+) -> Result<(), AdapterError> {
+    // We only impose restrictions if the current cluster is the introspection cluster.
+    let cluster = catalog.active_cluster();
+    if cluster != MZ_INTROSPECTION_CLUSTER.name {
+        return Ok(());
+    }
+
+    // Allows explain queries.
+    if let Plan::Explain(_) = plan {
+        return Ok(());
+    }
+
+    // Collect any items that are not allowed to be run on the introspection cluster.
+    let unallowed_dependents: SmallVec<[String; 2]> = depends_on
+        .iter()
+        .filter_map(|id| {
+            let item = catalog.get_item(id);
+            let full_name = catalog.resolve_full_name(item.name());
+
+            if !catalog.is_system_schema(&full_name.schema) {
+                Some(full_name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // If the query depends on unallowed items, error out.
+    if !unallowed_dependents.is_empty() {
+        Err(AdapterError::UnallowedOnCluster {
+            depends_on: unallowed_dependents,
+            cluster: MZ_INTROSPECTION_CLUSTER.name.to_string(),
+        })
+    } else {
+        Ok(())
     }
 }
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -72,6 +72,11 @@ impl Coordinator {
         {
             return tx.send(Err(e), session);
         }
+        if let Err(e) =
+            introspection::check_cluster_restrictions(&session_catalog, &plan, &depends_on)
+        {
+            return tx.send(Err(e), session);
+        }
 
         match plan {
             Plan::CreateSource(plan) => {

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -15,6 +15,7 @@ use std::num::TryFromIntError;
 use dec::TryFromDecimalError;
 use itertools::Itertools;
 use mz_repr::adt::timestamp::TimestampError;
+use smallvec::SmallVec;
 use tokio::sync::oneshot;
 
 use mz_compute_client::controller::error as compute_error;
@@ -145,6 +146,11 @@ pub enum AdapterError {
     SubscribeOnlyTransaction,
     /// An error occurred in the MIR stage of the optimizer.
     Transform(TransformError),
+    /// A query depends on items which are not allowed to be referenced from the current cluster.
+    UnallowedOnCluster {
+        depends_on: SmallVec<[String; 2]>,
+        cluster: String,
+    },
     /// A user tried to perform an action that they were unauthorized to do.
     Unauthorized(rbac::UnauthorizedError),
     /// The specified function cannot be called
@@ -442,6 +448,18 @@ impl fmt::Display for AdapterError {
             AdapterError::Transform(e) => e.fmt(f),
             AdapterError::UncallableFunction { func, context } => {
                 write!(f, "cannot call {} in {}", func, context)
+            }
+            AdapterError::UnallowedOnCluster {
+                depends_on,
+                cluster,
+            } => {
+                let items = depends_on.into_iter().map(|item| item.quoted()).join(", ");
+                write!(
+                    f,
+                    "querying the following items {items} is not allowed from the {} cluster. \
+                    Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query.",
+                    cluster.quoted()
+                )
             }
             AdapterError::Unauthorized(unauthorized) => {
                 write!(f, "{unauthorized}")

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -324,6 +324,10 @@ impl AdapterError {
             ),
             AdapterError::PlanError(e) => e.hint(),
             AdapterError::VarError(e) => e.hint(),
+            AdapterError::UnallowedOnCluster { .. } => Some(
+                "Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query."
+                    .into(),
+            ),
             _ => None,
         }
     }
@@ -456,8 +460,7 @@ impl fmt::Display for AdapterError {
                 let items = depends_on.into_iter().map(|item| item.quoted()).join(", ");
                 write!(
                     f,
-                    "querying the following items {items} is not allowed from the {} cluster. \
-                    Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query.",
+                    "querying the following items {items} is not allowed from the {} cluster",
                     cluster.quoted()
                 )
             }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -362,6 +362,7 @@ impl ErrorResponse {
             AdapterError::SqlCatalog(_) => SqlState::INTERNAL_ERROR,
             AdapterError::SubscribeOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::Transform(_) => SqlState::INTERNAL_ERROR,
+            AdapterError::UnallowedOnCluster { .. } => SqlState::INTERNAL_ERROR,
             AdapterError::Unauthorized(_) => SqlState::INSUFFICIENT_PRIVILEGE,
             AdapterError::UncallableFunction { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::UnknownCursor(_) => SqlState::INVALID_CURSOR_NAME,

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -362,7 +362,9 @@ impl ErrorResponse {
             AdapterError::SqlCatalog(_) => SqlState::INTERNAL_ERROR,
             AdapterError::SubscribeOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::Transform(_) => SqlState::INTERNAL_ERROR,
-            AdapterError::UnallowedOnCluster { .. } => SqlState::INTERNAL_ERROR,
+            AdapterError::UnallowedOnCluster { .. } => {
+                SqlState::S_R_E_PROHIBITED_SQL_STATEMENT_ATTEMPTED
+            }
             AdapterError::Unauthorized(_) => SqlState::INSUFFICIENT_PRIVILEGE,
             AdapterError::UncallableFunction { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::UnknownCursor(_) => SqlState::INVALID_CURSOR_NAME,

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -258,11 +258,15 @@ materialize.public.mv CREATE␠MATERIALIZED␠VIEW␠"materialize"."public"."mv"
 
 # Test: SHOW CREATE MATERIALIZED VIEW as mz_introspection
 
-simple conn=mz_introspection,user=mz_introspection
+
+statement ok
+SET cluster = mz_introspection
+
+statement error querying the following items "materialize\.public\.mv" is not allowed from the "mz_introspection" cluster\nHINT: Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query.
 SHOW CREATE MATERIALIZED VIEW mv
-----
-materialize.public.mv,CREATE MATERIALIZED VIEW "materialize"."public"."mv" IN CLUSTER "default" AS SELECT 1
-COMPLETE 1
+
+statement ok
+RESET cluster
 
 # Test: SHOW MATERIALIZED VIEWS
 

--- a/test/sqllogictest/operator.slt
+++ b/test/sqllogictest/operator.slt
@@ -129,11 +129,17 @@ SHOW CREATE VIEW ADDER
 materialize.public.adder
 CREATE VIEW "materialize"."public"."adder" AS SELECT 2 + 2
 
-simple conn=mz_introspection,user=mz_introspection
+
+# Test: Show user view on mz_introspection
+
+statement ok
+SET cluster = mz_introspection
+
+statement error querying the following items "materialize\.public\.adder" is not allowed from the "mz_introspection" cluster\nHINT: Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query.
 SHOW CREATE VIEW ADDER
-----
-materialize.public.adder,CREATE VIEW "materialize"."public"."adder" AS SELECT 2 + 2
-COMPLETE 1
+
+statement ok
+RESET cluster
 
 statement ok
 CREATE VIEW MULTIPLIER AS SELECT 2 OPERATOR(*) 2;

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -30,7 +30,14 @@ $ kafka-ingest topic=data format=avro schema=${writer-schema}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${writer-schema}'
 
+# Not allowed to query user objects from mz_introspection.
 > SET CLUSTER TO mz_introspection
+! SHOW INDEXES ON data
+contains: querying the following items "materialize.public.data" is not allowed from the "mz_introspection" cluster. Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query
+
+> CREATE CLUSTER my_cluster REPLICAS (r1 (size '1'))
+> SET CLUSTER TO my_cluster
+
 > SHOW INDEXES ON data
 name    on  cluster key
 --------------------------------------------------------------------------
@@ -39,7 +46,7 @@ name    on  cluster key
 # Sources can have default indexes added
 > CREATE DEFAULT INDEX ON data
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON data
 name                on      cluster             key
 -------------------------------------------------------------------------------------------
@@ -63,7 +70,7 @@ position         name
 # Views do not have indexes automatically created
 > CREATE VIEW data_view as SELECT * from data
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON data_view
 name    on  cluster key
 --------------------------------------------------------------------------
@@ -72,7 +79,7 @@ name    on  cluster key
 # Views can have default indexes added
 > CREATE DEFAULT INDEX ON data_view
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 ---------------------------------------------------------------------------------------------------
@@ -83,7 +90,7 @@ data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
 > CREATE MATERIALIZED VIEW matv AS
   SELECT b, sum(a) FROM data GROUP BY b
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON matv
 name    on  cluster key
 --------------------------------------------------------------------------
@@ -92,7 +99,7 @@ name    on  cluster key
 # Materialized views can have default indexes added
 > CREATE DEFAULT INDEX ON matv
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON matv
 name                on      cluster             key
 --------------------------------------------------------------------------------------------
@@ -102,7 +109,7 @@ matv_primary_idx    matv    <VARIABLE_OUTPUT>   {b}
 # IF NOT EXISTS prevents adding multiple default indexes
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 -------------------------------------------------------------------------------------------------
@@ -112,7 +119,7 @@ data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
 # Additional default indexes have the same structure as the first
 > CREATE DEFAULT INDEX ON matv
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON matv
 name                on      cluster             key
 ------------------------------------------------------------------------------------------------
@@ -123,7 +130,7 @@ matv_primary_idx1   matv    <VARIABLE_OUTPUT>   {b}
 # Default indexes can be named
 > CREATE DEFAULT INDEX named_idx ON data_view
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 -----------------------------------------------------------------------------------------------
@@ -137,7 +144,7 @@ named_idx               data_view   <VARIABLE_OUTPUT>   {a,b}
 # Indexes with specified columns can be automatically named
 > CREATE INDEX ON data_view(a)
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON data_view
 name            on          cluster             key
 -------------------------------------------------------------------------------------------
@@ -150,7 +157,7 @@ data_view_a_idx data_view   <VARIABLE_OUTPUT>   {a}
 > CREATE INDEX ON data_view(b, a)
 > CREATE INDEX ON data_view(b - a, a)
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 -----------------------------------------------------------------------------------------------
@@ -164,7 +171,7 @@ data_view_expr_a_idx    data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 # Indexes can be both explicitly named and explicitly structured
 > CREATE INDEX named_idx ON data_view (b - a, a)
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON data_view
 name        on          cluster             key
 ---------------------------------------------------------------------------------------------
@@ -177,7 +184,7 @@ named_idx   data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 > CREATE INDEX data_view_primary_idx ON data_view (b - a, a)
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 ------------------------------------------------------------------------------------------------------
@@ -197,7 +204,7 @@ materialize.public.data_view_primary_idx "CREATE INDEX \"data_view_primary_idx\"
 > CREATE DEFAULT INDEX ON foo
 > CREATE INDEX ON foo (a + b)
 > CREATE INDEX ON foo (substr(z, 3))
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON foo
 foo_primary_idx foo <VARIABLE_OUTPUT>   {a,b,z}
 foo_expr_idx    foo <VARIABLE_OUTPUT>   "{a + b}"
@@ -219,7 +226,7 @@ contains:cannot show indexes on materialize.public.foo_primary_idx because it is
 
 > CREATE CLUSTER clstr REPLICAS (r1 (SIZE '1'))
 > CREATE DEFAULT INDEX IN CLUSTER clstr ON foo;
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES IN CLUSTER clstr WHERE on = 'foo'
 foo_primary_idx1    foo clstr   {a,b,z}
 
@@ -230,7 +237,7 @@ foo_primary_idx1    foo clstr   {a,b,z}
 > DROP TABLE foo CASCADE
 > DROP SOURCE data CASCADE
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 
 ! SHOW INDEXES FROM public ON foo
 contains:Cannot specify both FROM and ON
@@ -243,7 +250,7 @@ contains:unknown schema 'nonexistent'
 > CREATE TABLE bar ();
 > CREATE INDEX bar_ind ON bar ();
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES
 bar_ind bar <VARIABLE_OUTPUT> {}
 > SET CLUSTER TO default
@@ -253,7 +260,7 @@ bar_ind bar <VARIABLE_OUTPUT> {}
 > CREATE TABLE foo.bar (a INT)
 > CREATE INDEX bar_ind ON foo.bar (a)
 
-> SET CLUSTER TO mz_introspection
+> SET CLUSTER TO my_cluster
 > SHOW INDEXES ON foo.bar
 bar_ind bar <VARIABLE_OUTPUT> {a}
 > SET CLUSTER TO default

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -33,7 +33,7 @@ $ kafka-ingest topic=data format=avro schema=${writer-schema}
 # Not allowed to query user objects from mz_introspection.
 > SET CLUSTER TO mz_introspection
 ! SHOW INDEXES ON data
-contains: querying the following items "materialize.public.data" is not allowed from the "mz_introspection" cluster. Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query
+contains: querying the following items "materialize.public.data" is not allowed from the "mz_introspection" cluster
 
 > CREATE CLUSTER my_cluster REPLICAS (r1 (size '1'))
 > SET CLUSTER TO my_cluster


### PR DESCRIPTION
### Motivation
 * This PR adds a known-desirable feature.
   * Fixes #18075 

This PR restricts what queries can get run on the `mz_introspection` cluster. Specifically only queries that depend on system tables can get run. As part of this change, we also update the dbt-adapter to set the `auto_route_introspection_queries` session var to make sure all of its introspection queries automatically get run on the mz_introspection cluster, regardless of what cluster is currently set.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
