### PR TITLE
pg sources: make schema change detection harder to fool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3318,6 +3318,7 @@ dependencies = [
  "enum-kinds",
  "fail",
  "futures",
+ "hex",
  "itertools",
  "launchdarkly-server-sdk",
  "maplit",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -18,6 +18,7 @@ differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-
 enum-kinds = "0.5.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
+hex = "0.4.3"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 launchdarkly-server-sdk = { git = "https://github.com/MaterializeInc/rust-server-sdk", default_features = false, features = ["hypertls"] }

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2767,13 +2767,15 @@ impl Catalog {
             .unwrap_or_else(|| "new".to_string());
 
         if !config.skip_migrations {
-            migrate::migrate(&mut catalog).await.map_err(|e| {
-                Error::new(ErrorKind::FailedMigration {
-                    last_seen_version: last_seen_version.clone(),
-                    this_version: catalog.config().build_info.version,
-                    cause: e.to_string(),
-                })
-            })?;
+            migrate::migrate(&mut catalog, config.connection_context)
+                .await
+                .map_err(|e| {
+                    Error::new(ErrorKind::FailedMigration {
+                        last_seen_version: last_seen_version.clone(),
+                        this_version: catalog.config().build_info.version,
+                        cause: e.to_string(),
+                    })
+                })?;
             catalog
                 .storage()
                 .await
@@ -3646,6 +3648,7 @@ impl Catalog {
             system_parameter_frontend: None,
             // when debugging, no reaping
             storage_usage_retention_period: None,
+            connection_context: None,
         })
         .await?;
         Ok(catalog)

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -67,6 +67,13 @@ pub struct Config<'a> {
     pub system_parameter_frontend: Option<Arc<SystemParameterFrontend>>,
     /// How long to retain storage usage records
     pub storage_usage_retention_period: Option<Duration>,
+    /// Needed only for migrating PG source column metadata. If `None`, will
+    /// skip any migrations that require it, which will likely cause tests to
+    /// fail.
+    ///
+    /// TODO(migration): delete in version v.50 (released in v0.48 + 1
+    /// additional release)
+    pub connection_context: Option<mz_storage_client::types::connections::ConnectionContext>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -220,7 +220,7 @@ async fn pg_source_table_metadata_rewrite(
 
         // Get the current publication tables from the upstream PG source.
         let current_publication_tables =
-            match mz_postgres_util::publication_info(&config, publication).await {
+            match mz_postgres_util::publication_info(&config, publication, None).await {
                 Ok(v) => v,
                 Err(_) => {
                     warn!(

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -7,28 +7,39 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use futures::future::BoxFuture;
 use semver::Version;
 use std::collections::BTreeMap;
 use tracing::info;
 
 use mz_ore::collections::CollectionExt;
 use mz_sql::ast::display::AstDisplay;
-use mz_sql::ast::Raw;
+use mz_sql::ast::{Raw, Statement, Value};
+use mz_storage_client::types::connections::ConnectionContext;
 
 use crate::catalog::{Catalog, SerializedCatalogItem};
 
 use super::storage::Transaction;
+use super::ConnCatalog;
 
-fn rewrite_items<F>(tx: &mut Transaction, mut f: F) -> Result<(), anyhow::Error>
+async fn rewrite_items<F>(
+    tx: &mut Transaction<'_>,
+    cat: Option<&ConnCatalog<'_>>,
+    mut f: F,
+) -> Result<(), anyhow::Error>
 where
-    F: FnMut(&mut Transaction, &mut mz_sql::ast::Statement<Raw>) -> Result<(), anyhow::Error>,
+    F: for<'a> FnMut(
+        &'a mut Transaction<'_>,
+        &'a Option<&ConnCatalog<'_>>,
+        &'a mut mz_sql::ast::Statement<Raw>,
+    ) -> BoxFuture<'a, Result<(), anyhow::Error>>,
 {
     let mut updated_items = BTreeMap::new();
     let items = tx.loaded_items();
     for (id, name, SerializedCatalogItem::V1 { create_sql }) in items {
         let mut stmt = mz_sql::parse::parse(&create_sql)?.into_element();
 
-        f(tx, &mut stmt)?;
+        f(tx, &cat, &mut stmt).await?;
 
         let serialized_item = SerializedCatalogItem::V1 {
             create_sql: stmt.to_ast_string_stable(),
@@ -40,7 +51,10 @@ where
     Ok(())
 }
 
-pub(crate) async fn migrate(catalog: &mut Catalog) -> Result<(), anyhow::Error> {
+pub(crate) async fn migrate(
+    catalog: &mut Catalog,
+    connection_context: Option<ConnectionContext>,
+) -> Result<(), anyhow::Error> {
     let mut storage = catalog.storage().await;
     let catalog_version = storage.get_catalog_content_version().await?;
     let catalog_version = match catalog_version {
@@ -52,7 +66,7 @@ pub(crate) async fn migrate(catalog: &mut Catalog) -> Result<(), anyhow::Error> 
 
     let mut tx = storage.transaction().await?;
     // First, do basic AST -> AST transformations.
-    rewrite_items(&mut tx, |_tx, _stmt| Ok(()))?;
+    // rewrite_items(&mut tx, None, |_tx, _cat, _stmt| Box::pin(async { Ok(()) })).await?;
 
     // Then, load up a temporary catalog with the rewritten items, and perform
     // some transformations that require introspecting the catalog. These
@@ -60,8 +74,18 @@ pub(crate) async fn migrate(catalog: &mut Catalog) -> Result<(), anyhow::Error> 
     // it. You probably should be adding a basic AST migration above, unless
     // you are really certain you want one of these crazy migrations.
     let cat = Catalog::load_catalog_items(&mut tx, catalog)?;
-    let _conn_cat = cat.for_system_session();
-    rewrite_items(&mut tx, |_tx, _item| Ok(()))?;
+    let conn_cat = cat.for_system_session();
+    rewrite_items(&mut tx, Some(&conn_cat), |_tx, cat, item| {
+        let connection_context = connection_context.clone();
+        Box::pin(async move {
+            let conn_cat = cat.expect("must provide access to conn catalog");
+            if let Some(conn_cx) = connection_context {
+                pg_source_table_metadata_rewrite(conn_cat, &conn_cx, item).await;
+            }
+            Ok(())
+        })
+    })
+    .await?;
     tx.commit().await?;
     info!(
         "migration from catalog version {:?} complete",
@@ -94,3 +118,174 @@ pub(crate) async fn migrate(catalog: &mut Catalog) -> Result<(), anyhow::Error> 
 // ****************************************************************************
 // Semantic migrations -- Weird migrations that require access to the catalog
 // ****************************************************************************
+
+// Add the `col_num` to all PG column descriptions.
+//
+// TODO(migration): delete in version v.50 (released in v0.48 + 1 additional
+// release)
+async fn pg_source_table_metadata_rewrite(
+    catalog: &ConnCatalog<'_>,
+    connection_context: &ConnectionContext,
+    stmt: &mut mz_sql::ast::Statement<Raw>,
+) {
+    use prost::Message;
+    use tracing::warn;
+
+    use mz_proto::RustType;
+    use mz_sql::ast::{CreateSourceConnection, PgConfigOption, PgConfigOptionName};
+    use mz_sql::plan::StatementContext;
+    use mz_storage_client::types::sources::{
+        PostgresSourcePublicationDetails, ProtoPostgresSourcePublicationDetails,
+    };
+
+    if let Statement::CreateSource(mz_sql::ast::CreateSourceStatement {
+        name,
+        connection:
+            CreateSourceConnection::Postgres {
+                connection,
+                options,
+            },
+        ..
+    }) = stmt
+    {
+        // Find the option containing the serialized details.
+        let details_idx = options
+            .iter()
+            .position(|PgConfigOption { name, .. }| name == &PgConfigOptionName::Details)
+            .expect("corrupt catalog");
+
+        // Examine the current details
+        let details = match &options[details_idx].value {
+            Some(mz_sql::ast::WithOptionValue::Value(mz_sql::ast::Value::String(details))) => {
+                details
+            }
+            _ => unreachable!("corrupt catalog"),
+        };
+
+        let details = hex::decode(details).expect("valid catalog");
+        let details =
+            ProtoPostgresSourcePublicationDetails::decode(&*details).expect("valid catalog");
+        let mut publication_details =
+            PostgresSourcePublicationDetails::from_proto(details).expect("valid catalog");
+
+        if publication_details
+            .tables
+            .iter()
+            .all(|t| t.columns.iter().all(|c| c.col_num.is_some()))
+        {
+            mz_ore::soft_assert!(
+                publication_details
+                    .tables
+                    .iter()
+                    .all(|t| t.columns.iter().all(|c| c.col_num != Some(0))),
+                "PG does not use attnum 0"
+            );
+            // If every column is present, then no need for this migration.
+            return;
+        }
+
+        // Get details to connect to the upstream PG instance, which we need to
+        // get the schema details.
+        let scx = StatementContext::new(None, &*catalog);
+        let connection = {
+            let item = scx.resolve_item(connection.clone()).expect("valid catalog");
+            match item.connection().expect("valid catalog") {
+                mz_storage_client::types::connections::Connection::Postgres(connection) => {
+                    connection
+                }
+                _ => unreachable!("corrupt catalog"),
+            }
+        };
+
+        let publication = options
+            .iter()
+            .find(|o| matches!(o.name, PgConfigOptionName::Publication))
+            .expect("valid catalog")
+            .value
+            .as_ref()
+            .expect("valid catalog");
+
+        let publication = match publication {
+            mz_sql::ast::WithOptionValue::Value(mz_sql::ast::Value::String(publication)) => {
+                publication
+            }
+            _ => unreachable!("corrupt catalog"),
+        };
+
+        // verify that we can connect upstream and snapshot publication metadata
+        let config = connection
+            .config(&*connection_context.secrets_reader)
+            .await
+            .expect("valid config");
+
+        // Get the current publication tables from the upstream PG source.
+        let current_publication_tables =
+            match mz_postgres_util::publication_info(&config, publication).await {
+                Ok(v) => v,
+                Err(_) => {
+                    warn!(
+                        "could not perform migration of PG source {name} due \
+                    to external dependency; this will render the source useless, \
+                    but might be fixable by restarting Materialize"
+                    );
+                    return;
+                }
+            };
+
+        // Convert current tables into map because we only care that the tables
+        // we know about about are the same.
+        let cur_tables: BTreeMap<_, _> = current_publication_tables
+            .iter()
+            .map(|t| (t.oid, t))
+            .collect();
+
+        for prev_table in publication_details.tables.into_iter() {
+            match cur_tables.get(&prev_table.oid) {
+                Some(cur_table) => {
+                    // We must undergo this torturous equality check because we
+                    // want to check equality for all fields except for the new
+                    // col_num field.
+                    if prev_table.namespace != cur_table.namespace
+                        || prev_table.name != cur_table.name
+                        // Error if current table has fewer columns
+                        || cur_table.columns.len() != prev_table.columns.len()
+                        // Only match columns that are joined prefix of LHS
+                        || prev_table.columns.iter().zip(&cur_table.columns).any(
+                            |(prev_col, cur_col)| {
+                                prev_col.name != cur_col.name
+                                    || prev_col.type_oid != cur_col.type_oid
+                                    || prev_col.type_mod != cur_col.type_mod
+                            },
+                        )
+                    {
+                        warn!(
+                            "could not perform migration of PG source {name} due \
+                        to schema change; this source must be recreated, but the \
+                        schema in the warning where this occurs will have the wrong col_num."
+                        );
+                        return;
+                    }
+                }
+                None => {
+                    warn!(
+                        "could not perform migration of PG source {name} due \
+                    to schema change; this source must be recreated, but the \
+                    schema in the warning where this occurs will have the wrong col_num."
+                    );
+                    return;
+                }
+            }
+        }
+
+        let _ = options.remove(details_idx).value.expect("valid catalog");
+
+        publication_details.tables = current_publication_tables;
+
+        options.push(PgConfigOption {
+            name: PgConfigOptionName::Details,
+            value: Some(mz_sql::ast::WithOptionValue::Value(Value::String(
+                hex::encode(publication_details.into_proto().encode_to_vec()),
+            ))),
+        });
+    }
+}

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1378,6 +1378,7 @@ pub async fn serve(
             aws_privatelink_availability_zones,
             system_parameter_frontend,
             storage_usage_retention_period,
+            connection_context: Some(connection_context.clone()),
         })
         .await?;
     let session_id = catalog.config().session_id;

--- a/src/postgres-util/src/desc.proto
+++ b/src/postgres-util/src/desc.proto
@@ -24,4 +24,6 @@ message ProtoPostgresColumnDesc {
     int32 type_mod = 3;
     bool nullable = 4;
     bool primary_key = 5;
+    // TODO(migration): remove optional in v0.48
+    optional uint32 col_num = 6;
 }

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -82,7 +82,8 @@ pub struct PostgresColumnDesc {
     pub name: String,
     /// The column's monotonic position in its table, i.e. "this was the _i_th
     /// column created" irrespective of the current number of columns.
-    // TODO(migration): remove this Option in v0.48
+    // TODO(migration): remove option in version v.50 (released in v0.48 + 1
+    // additional release)
     pub col_num: Option<u16>,
     /// The OID of the column's type.
     pub type_oid: u32,

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -26,7 +26,7 @@ pub struct PostgresTableDesc {
     pub namespace: String,
     /// The name of the table.
     pub name: String,
-    /// The description of each column, in order.
+    /// The description of each column, in order of their position in the table.
     pub columns: Vec<PostgresColumnDesc>,
 }
 
@@ -80,6 +80,10 @@ impl Arbitrary for PostgresTableDesc {
 pub struct PostgresColumnDesc {
     /// The name of the column.
     pub name: String,
+    /// The column's monotonic position in its table, i.e. "this was the _i_th
+    /// column created" irrespective of the current number of columns.
+    // TODO(migration): remove this Option in v0.48
+    pub col_num: Option<u16>,
     /// The OID of the column's type.
     pub type_oid: u32,
     /// The modifier for the column's type.
@@ -97,6 +101,7 @@ impl RustType<ProtoPostgresColumnDesc> for PostgresColumnDesc {
     fn into_proto(&self) -> ProtoPostgresColumnDesc {
         ProtoPostgresColumnDesc {
             name: self.name.clone(),
+            col_num: self.col_num.map(|c| c.into()),
             type_oid: self.type_oid,
             type_mod: self.type_mod,
             nullable: self.nullable,
@@ -107,6 +112,9 @@ impl RustType<ProtoPostgresColumnDesc> for PostgresColumnDesc {
     fn from_proto(proto: ProtoPostgresColumnDesc) -> Result<Self, TryFromProtoError> {
         Ok(PostgresColumnDesc {
             name: proto.name,
+            col_num: proto
+                .col_num
+                .map(|c| c.try_into().expect("values roundtrip")),
             type_oid: proto.type_oid,
             type_mod: proto.type_mod,
             nullable: proto.nullable,
@@ -122,14 +130,16 @@ impl Arbitrary for PostgresColumnDesc {
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         (
             any::<String>(),
+            any::<u16>(),
             any::<u32>(),
             any::<i32>(),
             any::<bool>(),
             any::<bool>(),
         )
             .prop_map(
-                |(name, type_oid, type_mod, nullable, primary_key)| PostgresColumnDesc {
+                |(name, col_num, type_oid, type_mod, nullable, primary_key)| PostgresColumnDesc {
                     name,
+                    col_num: Some(col_num),
                     type_oid,
                     type_mod,
                     nullable,

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -235,6 +235,7 @@ pub async fn publication_info(
                 "SELECT
                         a.attname AS name,
                         a.atttypid AS typoid,
+                        a.attnum AS colnum,
                         a.atttypmod AS typmod,
                         a.attnotnull AS not_null,
                         b.oid IS NOT NULL AS primary_key
@@ -254,11 +255,17 @@ pub async fn publication_info(
             .map(|row| {
                 let name: String = row.get("name");
                 let type_oid = row.get("typoid");
+                let col_num = Some(
+                    row.get::<_, i16>("colnum")
+                        .try_into()
+                        .expect("non-negative values"),
+                );
                 let type_mod: i32 = row.get("typmod");
                 let not_null: bool = row.get("not_null");
                 let primary_key = row.get("primary_key");
                 Ok(PostgresColumnDesc {
                     name,
+                    col_num,
                     type_oid,
                     type_mod,
                     nullable: !not_null,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -269,11 +269,12 @@ pub async fn purify_create_source(
             let config = connection
                 .config(&*connection_context.secrets_reader)
                 .await?;
-            let publication_tables = mz_postgres_util::publication_info(&config, &publication)
-                .await
-                .map_err(|cause| PlanError::FetchingPostgresPublicationInfoFailed {
-                    cause: Arc::new(cause),
-                })?;
+            let publication_tables =
+                mz_postgres_util::publication_info(&config, &publication, None)
+                    .await
+                    .map_err(|cause| PlanError::FetchingPostgresPublicationInfoFailed {
+                        cause: Arc::new(cause),
+                    })?;
 
             // An index from table name -> schema name -> database name -> PostgresTableDesc
             let mut tables_by_name = BTreeMap::new();

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -404,6 +404,7 @@ impl Usage {
             aws_privatelink_availability_zones: None,
             system_parameter_frontend: None,
             storage_usage_retention_period: None,
+            connection_context: None,
         })
         .await?;
 

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -806,7 +806,11 @@ fn validate_tables(
                         "Error validating table in publication. Expected: {:?} Actual: {:?}",
                         &info.desc, pub_schema
                     );
-                    bail!("Schema for table {} differs, recreate Materialize source to use new schema", info.desc.name)
+                    bail!(
+                        "source table {} with oid {} has been altered",
+                        info.desc.name,
+                        info.desc.oid
+                    )
                 }
             }
             None => {
@@ -815,9 +819,9 @@ fn validate_tables(
                     info.desc.name, id
                 );
                 bail!(
-                    "Publication missing expected table {} with oid {}",
+                    "source table {} with oid {} has been dropped",
                     info.desc.name,
-                    id
+                    info.desc.oid
                 )
             }
         }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -512,6 +512,7 @@ async fn postgres_replication_loop_inner(
         let publication_tables = mz_postgres_util::publication_info(
             &task_info.connection_config,
             &task_info.publication,
+            None,
         )
         .await
         .err_indefinite()?;
@@ -801,6 +802,8 @@ fn validate_tables(
     for (id, info) in source_tables.iter() {
         match pub_tables.get(id) {
             Some(pub_schema) => {
+                // Keep this method in sync with the check in response to
+                // Relation messages in the replication stream.
                 if pub_schema != &info.desc {
                     warn!(
                         "Error validating table in publication. Expected: {:?} Actual: {:?}",
@@ -1118,6 +1121,7 @@ async fn produce_replication<'a>(
                         Relation(relation) => {
                             last_data_message = Instant::now();
                             let rel_id = relation.rel_id();
+                            let mut valid_schema_change = true;
                             if let Some(info) = source_tables.get(&rel_id) {
                                 // Start with the cheapest check first, this will catch the majority of alters
                                 if info.desc.columns.len() != relation.columns().len() {
@@ -1125,11 +1129,7 @@ async fn produce_replication<'a>(
                                         "alter table detected on {} with id {}",
                                         info.desc.name, info.desc.oid
                                     );
-                                    return Err(Definite(anyhow!(
-                                        "source table {} with oid {} has been altered",
-                                        info.desc.name,
-                                        info.desc.oid
-                                    )))?;
+                                    valid_schema_change = false;
                                 }
                                 let same_name = info.desc.name == relation.name().unwrap();
                                 let same_namespace =
@@ -1143,12 +1143,9 @@ async fn produce_replication<'a>(
                                         relation.namespace().unwrap(),
                                         relation.name().unwrap()
                                     );
-                                    return Err(Definite(anyhow!(
-                                        "source table {} with oid {} has been altered",
-                                        info.desc.name,
-                                        info.desc.oid
-                                    )))?;
+                                    valid_schema_change = false;
                                 }
+
                                 // Relation messages do not include nullability/primary_key data so we
                                 // check the name, type_oid, and type_mod explicitly and error if any
                                 // of them differ
@@ -1166,12 +1163,55 @@ async fn produce_replication<'a>(
                                             info.desc.columns,
                                             relation.columns()
                                         );
-                                        return Err(Definite(anyhow!(
-                                            "source table {} with oid {} has been altered",
-                                            info.desc.name,
-                                            info.desc.oid
-                                        )))?;
+
+                                        valid_schema_change = false;
                                     }
+                                }
+
+                                if valid_schema_change {
+                                    // Because the replication stream doesn't
+                                    // include columns' attnums, we need to check
+                                    // the current local schema against the current
+                                    // remote schema to ensure e.g. we haven't
+                                    // received a schema update with the same
+                                    // terminal column name which is actually a
+                                    // different column.
+                                    let current_publication_info =
+                                        mz_postgres_util::publication_info(
+                                            &client_config,
+                                            publication,
+                                            Some(rel_id),
+                                        )
+                                        .await
+                                        .err_indefinite()?;
+
+                                    let remote_schema_eq =
+                                        Some(&info.desc) == current_publication_info.get(0);
+                                    if !remote_schema_eq {
+                                        warn!(
+                                        "alter table error: name {}, oid {}, current local schema {:?}, current remote schema {:?}",
+                                        info.desc.name,
+                                        info.desc.oid,
+                                        info.desc.columns,
+                                        current_publication_info.get(0)
+                                    );
+
+                                        valid_schema_change = false;
+                                    }
+                                }
+
+                                if !valid_schema_change {
+                                    return Err(Definite(anyhow!(
+                                        "source table {} with oid {} has been altered",
+                                        info.desc.name,
+                                        info.desc.oid
+                                    )))?;
+                                } else {
+                                    warn!(
+                                        "source table {} with oid {} has been altered, but we could not determine how",
+                                        info.desc.name,
+                                        info.desc.oid
+                                    )
                                 }
                             }
                         }

--- a/test/pg-cdc/alter-table-after-source.td
+++ b/test/pg-cdc/alter-table-after-source.td
@@ -103,6 +103,7 @@ INSERT INTO alter_column VALUES (3, 'bc');
 
 ! SELECT * from alter_column;
 contains:altered
+
 > DROP SOURCE mz_source;
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
@@ -129,11 +130,11 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE alter_nullability ALTER COLUMN f1 DROP NOT NULL;
 INSERT INTO alter_nullability VALUES (NULL);
 
-> SELECT * FROM alter_nullability WHERE f1 IS NOT NULL;
-1
+! SELECT * FROM alter_nullability WHERE f1 IS NOT NULL;
+contains:altered
 
-> SELECT * FROM alter_nullability WHERE f1 IS NULL;
-<null>
+! SELECT * FROM alter_nullability WHERE f1 IS NULL;
+contains:altered
 
 > DROP SOURCE mz_source;
 
@@ -397,17 +398,13 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 > SELECT * from alter_table_change_attnum;
 f1_orig f2_orig
 
+# Ensure simpl name swap doesn't fool schema detection
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE alter_table_change_attnum DROP COLUMN f2;
 ALTER TABLE alter_table_change_attnum ADD COLUMN f2 VARCHAR(10);
 INSERT INTO alter_table_change_attnum (f1, f2) VALUES ('f1_changed', 'f2_changed');
 
-# We have fooled the system into accepting this schema change
-# Results should be:
-# f1_orig <null>
-# f1_changed f2_changed
-> SELECT * FROM alter_table_change_attnum;
-f1_orig f2_orig
-f1_changed f2_changed
+! SELECT * FROM alter_table_change_attnum;
+contains:altered
 
 > DROP SOURCE mz_source;

--- a/test/pg-cdc/alter-table-after-source.td
+++ b/test/pg-cdc/alter-table-after-source.td
@@ -270,7 +270,6 @@ INSERT INTO alter_set_with_oids VALUES (2);
 
 
 
-
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
@@ -373,5 +372,42 @@ INSERT INTO alter_table_rename_column (f1, f2) VALUES ('f1_renamed', 'f2_renamed
 
 ! SELECT * FROM alter_table_rename_column;
 contains:altered
+
+> DROP SOURCE mz_source;
+
+
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_table_change_attnum (f1 VARCHAR(10), f2 VARCHAR(10));
+ALTER TABLE alter_table_change_attnum REPLICA IDENTITY FULL;
+INSERT INTO alter_table_change_attnum (f1, f2) VALUES ('f1_orig','f2_orig');
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES ("alter_table_change_attnum") WITH (size = '1');
+
+> SELECT * from alter_table_change_attnum;
+f1_orig f2_orig
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_table_change_attnum DROP COLUMN f2;
+ALTER TABLE alter_table_change_attnum ADD COLUMN f2 VARCHAR(10);
+INSERT INTO alter_table_change_attnum (f1, f2) VALUES ('f1_changed', 'f2_changed');
+
+# We have fooled the system into accepting this schema change
+# Results should be:
+# f1_orig <null>
+# f1_changed f2_changed
+> SELECT * FROM alter_table_change_attnum;
+f1_orig f2_orig
+f1_changed f2_changed
 
 > DROP SOURCE mz_source;


### PR DESCRIPTION
Breaking this off from #17987; this code has all been reviewed and just need to merge it so as to make #17987 more manageable.

### Motivation

This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/materialize/issues/17927

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
