### PR TITLE
persist: batch construction with partially order time

### DIFF
--- a/src/persist-client/src/error.rs
+++ b/src/persist-client/src/error.rs
@@ -88,16 +88,16 @@ pub enum InvalidUsage<T> {
     },
     /// An update in the batch was beyond the expected upper
     UpdateBeyondUpper {
-        /// The maximum timestamp of updates added to the batch.
-        max_ts: T,
+        /// The timestamp of the update
+        ts: T,
         /// The expected upper of the batch
         expected_upper: Antichain<T>,
     },
     /// An update in the batch was beyond the expected since
     /// This is an error when `upper.less_than(since)`
     UpdateBeyondSince {
-        /// The maximum timestamp of updates added to the batch.
-        max_ts: T,
+        /// The timestamp of the update
+        ts: T,
         /// The expected since of the batch
         expected_since: Antichain<T>,
     },
@@ -143,21 +143,15 @@ impl<T: Debug> std::fmt::Display for InvalidUsage<T> {
             InvalidUsage::UpdateNotBeyondLower { ts, lower } => {
                 write!(f, "timestamp {:?} not beyond batch lower {:?}", ts, lower)
             }
-            InvalidUsage::UpdateBeyondUpper {
-                max_ts,
-                expected_upper,
-            } => write!(
+            InvalidUsage::UpdateBeyondUpper { ts, expected_upper } => write!(
                 f,
-                "maximum timestamp {:?} is beyond the expected batch upper: {:?}",
-                max_ts, expected_upper
+                "timestamp {:?} is beyond the expected batch upper: {:?}",
+                ts, expected_upper
             ),
-            InvalidUsage::UpdateBeyondSince {
-                max_ts,
-                expected_since,
-            } => write!(
+            InvalidUsage::UpdateBeyondSince { ts, expected_since } => write!(
                 f,
-                "maximum timestamp {:?} is beyond the expected batch since: {:?}",
-                max_ts, expected_since
+                "timestamp {:?} is beyond the expected batch since: {:?}",
+                ts, expected_since
             ),
             InvalidUsage::BatchNotFromThisShard {
                 batch_shard,

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -924,7 +924,9 @@ mod tests {
     use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
     use timely::progress::Antichain;
 
-    use crate::tests::{all_ok, expect_fetch_part, new_test_client, new_test_client_cache};
+    use crate::tests::{
+        all_ok, expect_fetch_part, new_test_client, new_test_client_cache, CodecProduct,
+    };
 
     use super::*;
 
@@ -998,6 +1000,93 @@ mod tests {
         .await;
         assert_eq!(part.desc, res.output.desc);
         assert_eq!(updates, all_ok(&data, 10));
+    }
+
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
+    async fn compaction_partial_order() {
+        mz_ore::test::init_logging();
+
+        let data = vec![
+            (
+                ("0".to_owned(), "zero".to_owned()),
+                CodecProduct::new(0, 10),
+                1,
+            ),
+            (
+                ("1".to_owned(), "one".to_owned()),
+                CodecProduct::new(10, 0),
+                1,
+            ),
+        ];
+
+        let cache = new_test_client_cache();
+        cache.cfg.dynamic.set_blob_target_size(100);
+        let (mut write, _) = cache
+            .open(PersistLocation {
+                blob_uri: "mem://".to_owned(),
+                consensus_uri: "mem://".to_owned(),
+            })
+            .await
+            .expect("client construction failed")
+            .expect_open::<String, String, CodecProduct, i64>(ShardId::new())
+            .await;
+        let b0 = write
+            .batch(
+                &data[..1],
+                Antichain::from_elem(CodecProduct::new(0, 0)),
+                Antichain::from_iter([CodecProduct::new(0, 11), CodecProduct::new(10, 0)]),
+            )
+            .await
+            .expect("invalid usage")
+            .into_hollow_batch();
+
+        let b1 = write
+            .batch(
+                &data[1..],
+                Antichain::from_iter([CodecProduct::new(0, 11), CodecProduct::new(10, 0)]),
+                Antichain::from_elem(CodecProduct::new(10, 1)),
+            )
+            .await
+            .expect("invalid usage")
+            .into_hollow_batch();
+
+        let req = CompactReq {
+            shard_id: write.machine.shard_id(),
+            desc: Description::new(
+                b0.desc.lower().clone(),
+                b1.desc.upper().clone(),
+                Antichain::from_elem(CodecProduct::new(10, 0)),
+            ),
+            inputs: vec![b0, b1],
+        };
+        let schemas = Schemas {
+            key: Arc::new(StringSchema),
+            val: Arc::new(UnitSchema),
+        };
+        let res = Compactor::<String, (), CodecProduct, i64>::compact(
+            CompactConfig::from(&write.cfg),
+            Arc::clone(&write.blob),
+            Arc::clone(&write.metrics),
+            Arc::new(CpuHeavyRuntime::new()),
+            req.clone(),
+            write.writer_id.clone(),
+            schemas,
+        )
+        .await
+        .expect("compaction failed");
+
+        assert_eq!(res.output.desc, req.desc);
+        assert_eq!(res.output.len, 2);
+        assert_eq!(res.output.parts.len(), 1);
+        let part = &res.output.parts[0];
+        let (part, updates) = expect_fetch_part(
+            write.blob.as_ref(),
+            &part.key.complete(&write.machine.shard_id()),
+        )
+        .await;
+        assert_eq!(part.desc, res.output.desc);
+        assert_eq!(updates, all_ok(&data, CodecProduct::new(10, 0)));
     }
 
     #[tokio::test]

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -648,6 +648,7 @@ mod tests {
     use std::time::Duration;
 
     use differential_dataflow::consolidation::consolidate_updates;
+    use differential_dataflow::lattice::Lattice;
     use futures_task::noop_waker;
     use mz_ore::future::OreFutureExt;
     use mz_ore::now::NowFn;
@@ -656,9 +657,11 @@ mod tests {
     use mz_persist_types::codec_impls::{StringSchema, VecU8Schema};
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
+    use serde::{Deserialize, Serialize};
     use serde_json::json;
+    use timely::order::{PartialOrder, Product};
+    use timely::progress::timestamp::PathSummary;
     use timely::progress::Antichain;
-    use timely::PartialOrder;
     use tokio::task::JoinHandle;
 
     use crate::cache::PersistClientCache;
@@ -667,6 +670,68 @@ mod tests {
     use crate::read::ListenEvent;
 
     use super::*;
+
+    /// A product type that fits in Codec64. Used to test persist on partial orders
+    #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+    pub(crate) struct CodecProduct(Product<u32, u32>);
+
+    impl CodecProduct {
+        pub(crate) fn new(outer: u32, inner: u32) -> Self {
+            Self(Product::new(outer, inner))
+        }
+    }
+
+    impl Timestamp for CodecProduct {
+        type Summary = <Product<u32, u32> as Timestamp>::Summary;
+
+        fn minimum() -> Self {
+            Self(Product::minimum())
+        }
+    }
+
+    impl PathSummary<CodecProduct> for <Product<u32, u32> as Timestamp>::Summary {
+        fn results_in(&self, src: &CodecProduct) -> Option<CodecProduct> {
+            self.results_in(&src.0).map(CodecProduct)
+        }
+
+        fn followed_by(&self, other: &Self) -> Option<Self> {
+            PathSummary::<Product<u32, u32>>::followed_by(self, other)
+        }
+    }
+
+    impl PartialOrder for CodecProduct {
+        fn less_equal(&self, other: &Self) -> bool {
+            self.0.less_equal(&other.0)
+        }
+    }
+
+    impl Codec64 for CodecProduct {
+        fn codec_name() -> String {
+            "CodecProduct".to_owned()
+        }
+
+        fn encode(&self) -> [u8; 8] {
+            let [a, b, c, d] = u32::to_le_bytes(self.0.outer);
+            let [e, f, g, h] = u32::to_le_bytes(self.0.inner);
+            [a, b, c, d, e, f, g, h]
+        }
+
+        fn decode([a, b, c, d, e, f, g, h]: [u8; 8]) -> Self {
+            let outer = u32::from_le_bytes([a, b, c, d]);
+            let inner = u32::from_le_bytes([e, f, g, h]);
+            Self(Product::new(outer, inner))
+        }
+    }
+
+    impl Lattice for CodecProduct {
+        fn join(&self, other: &Self) -> Self {
+            Self(self.0.join(&other.0))
+        }
+
+        fn meet(&self, other: &Self) -> Self {
+            Self(self.0.meet(&other.0))
+        }
+    }
 
     pub fn new_test_client_cache() -> PersistClientCache {
         // Configure an aggressively small blob_target_size so we get some

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -1095,7 +1095,7 @@ mod tests {
                     .await
                     .unwrap_err(),
                 InvalidUsage::UpdateBeyondUpper {
-                    max_ts: 3,
+                    ts: 3,
                     expected_upper: Antichain::from_elem(3),
                 },
             );

--- a/src/persist-client/tests/machine/batch
+++ b/src/persist-client/tests/machine/batch
@@ -231,7 +231,7 @@ fetch-batch input=b0
 write-batch output=b0 lower=0 upper=2
 a 3 1
 ----
-error: maximum timestamp 3 is beyond the expected batch upper: Antichain { elements: [2] }
+error: timestamp 3 is beyond the expected batch upper: Antichain { elements: [2] }
 
 # but batches with since > upper are allowed to have updates with timestamps beyond upper
 write-batch output=b0 lower=0 upper=2 since=10
@@ -243,7 +243,7 @@ parts=1 len=1
 write-batch output=b0 lower=0 upper=2 since=10
 a 100 1
 ----
-error: maximum timestamp 100 is beyond the expected batch since: Antichain { elements: [10] }
+error: timestamp 100 is beyond the expected batch since: Antichain { elements: [10] }
 
 # batches can be written unsorted
 write-batch output=b0 lower=0 upper=2 consolidate=false

--- a/src/persist-client/tests/machine/batch
+++ b/src/persist-client/tests/machine/batch
@@ -239,12 +239,6 @@ a 10 1
 ----
 parts=1 len=1
 
-# however when since is an advance of upper, our update cannot be in advance of since
-write-batch output=b0 lower=0 upper=2 since=10
-a 100 1
-----
-error: timestamp 100 is beyond the expected batch since: Antichain { elements: [10] }
-
 # batches can be written unsorted
 write-batch output=b0 lower=0 upper=2 consolidate=false
 d 0 1

--- a/src/timely-util/src/order.rs
+++ b/src/timely-util/src/order.rs
@@ -348,6 +348,30 @@ impl<P> Partition for P where
 {
 }
 
+/// A helper struct for reverse partial ordering.
+///
+/// This struct is a helper that can be used with `Antichain` when the maximum inclusive frontier
+/// needs to be maintained as opposed to the mininimum inclusive.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Reverse<T>(pub T);
+
+impl<T: PartialOrder> PartialOrder for Reverse<T> {
+    fn less_equal(&self, other: &Self) -> bool {
+        PartialOrder::less_equal(&other.0, &self.0)
+    }
+}
+impl<T: PartialOrd> PartialOrd for Reverse<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        other.0.partial_cmp(&self.0)
+    }
+}
+
+impl<T: Ord> Ord for Reverse<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.0.cmp(&self.0)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use timely::progress::Antichain;


### PR DESCRIPTION
### Motivation

Bug 1:

The batch builder behaves incorrectly in the presence of partially ordered timestamps by assuming that the updates included in the batch can be tightly bound by the `Lattice::join` of all of their timestamps.

This is true for totally ordered times but mostly false for partially ordered ones. I added a testcase that tries to append a batch to a shard but produces an error even though none of the contained updates are beyond the batch upper.

The fix is to maintain an `Antichain` of all the observed timestamps under the reverse partial order so that the antichain retains the maximum observed timestamps inclusive. Essentially this is the `max_ts` idea but extended to partial orders.


Bug 2:

Persist assumes that a compacted batch will satisfy one of the following:
* If since < upper, then all the updates are bounded by upper
* If upper < since, then all the updates will be exactly at the since

None of these are true however (added a testcase with a counter example).

The fix for those is to only perform bound checking when `lower == since`, i.e only when the batch has not been compacted.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
