### PR TITLE
pgwire: commit session vars on startup

### DIFF
--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -237,6 +237,9 @@ where
             }
         }
     }
+    session
+        .vars_mut()
+        .end_transaction(EndTransactionAction::Commit);
 
     let mut buf = vec![BackendMessage::AuthenticationOk];
     for var in session.vars().notify_set() {

--- a/test/pgtest-mz/startup.pt
+++ b/test/pgtest-mz/startup.pt
@@ -1,0 +1,23 @@
+# Test that a first query error doesn't ignore startup options.
+
+send conn=c cluster=mz_introspection
+Query {"query": "SELECT wat"}
+----
+
+until conn=c
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"column \"wat\" does not exist"}]}
+ReadyForQuery {"status":"I"}
+
+send conn=c
+Query {"query": "SHOW cluster"}
+----
+
+until conn=c
+ReadyForQuery
+----
+RowDescription {"fields":[{"name":"cluster"}]}
+DataRow {"fields":["mz_introspection"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
The session vars API requires commiting them, which usually happens at the end of a regular transaction. After startup if the first statement was an error we would incorrectly forget these settings.

Teach pgtest to run this test because some drivers choose to execute some of their own statements on startup.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Correctly respect session settings even if the first executed statement errored.