### PR TITLE
CODEOWNERS: change ownership of `doc/user` and `src/mz`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 /.github                            @benesch
 /bin
 /ci                                 @MaterializeInc/qa
-/doc/user                           @MaterializeInc/devex
+/doc/user                           @MaterializeInc/docs
 /doc/developer/reference/compute    @MaterializeInc/compute
 /doc/developer/reference/storage    @MaterializeInc/storage
 /misc/dbt-materialize               @MaterializeInc/devex
@@ -44,7 +44,7 @@
 /src/lowertest                      @MaterializeInc/compute
 /src/lowertest-derive               @MaterializeInc/compute
 /src/metabase                       @benesch
-/src/mz                             @MaterializeInc/surfaces
+/src/mz                             @MaterializeInc/surfaces @MaterializeInc/devex
 /src/npm                            @benesch
 /src/orchestrator                   @benesch
 /src/orchestrator-kubernetes        @benesch


### PR DESCRIPTION
Make the `docs` team the owner of `doc/user` and add `devex` as a co-owner of `src/mz`.

@benesch, could you remove @tr0njavolta from `devex`? No need for them to get flooded with dbt and mz notifications, now that there is a dedicated `docs` team.