### PR TITLE
upgrade: Add a scenario that upgrades through the previous two Mz rel…

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -47,6 +47,7 @@ steps:
           - { value: checks-parallel-restart-redpanda }
           - { value: checks-upgrade-entire-mz }
           - { value: checks-upgrade-entire-mz-previous-version }
+          - { value: checks-upgrade-entire-mz-two-versions }
           - { value: checks-upgrade-clusterd-compute-first }
           - { value: checks-upgrade-clusterd-compute-last }
           - { value: cloudtest-upgrade }
@@ -426,6 +427,17 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=UpgradeEntireMzPreviousVersion]
+
+  - id: checks-upgrade-entire-mz-two-versions
+    label: "Checks upgrade across two versions"
+    timeout_in_minutes: 60
+    agents:
+      queue: linux-x86_64
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=UpgradeEntireMzTwoVersions]
 
   - id: checks-upgrade-clusterd-compute-first
     label: "Platform checks upgrade, restarting compute clusterd first"

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -59,6 +59,37 @@ class UpgradeEntireMzPreviousVersion(UpgradeEntireMz):
         return previous_version
 
 
+class UpgradeEntireMzTwoVersions(UpgradeEntireMz):
+    """Upgrade the entire Mz instance starting from the previous
+    released version and passing through the last released version."""
+
+    def base_version(self) -> MzVersion:
+        return previous_version
+
+    def actions(self) -> List[Action]:
+        print(
+            f"Upgrading starting from tag {self.base_version()} going through {last_version}"
+        )
+        return [
+            # Start with previous_version
+            StartMz(tag=self.base_version()),
+            Initialize(self),
+            # Upgrade to last_version
+            KillMz(),
+            StartMz(tag=last_version),
+            Manipulate(self, phase=1),
+            # Upgrade to current source
+            KillMz(),
+            StartMz(tag=None),
+            Manipulate(self, phase=2),
+            Validate(self),
+            # A second restart while already on the current source
+            KillMz(),
+            StartMz(tag=None),
+            Validate(self),
+        ]
+
+
 #
 # We are limited with respect to the different orders in which stuff can be upgraded:
 # - some sequences of events are invalid


### PR DESCRIPTION
…eases

All existing upgrade scenarious would only upgrade from release X-1 or X-2 straight to release X, never passing through any intermediate release.

Therefore, no object in the database was ever subject to consequtive migrations, and there were indications that a recent bug happened because of the interaction between migrations in different releases.

Given how aggressively we both add and remove migrations, it is important for release X to be able to read objects that were not only freshly created in version X-1 but arrived via a migration from X-2 to X-1

### Motivation

  * This PR fixes a previously unreported bug.

This PR fixes a hole in our upgrade testing.

### Tips for reviewer

@def- with your recent changes around versioning it was very easy to express this test and it passed right off the bat.