### PR TITLE
Mark `UnionBranchCancellation` WMR-safe

### DIFF
--- a/test/sqllogictest/transform/union_cancel.slt
+++ b/test/sqllogictest/transform/union_cancel.slt
@@ -227,3 +227,55 @@ NULL NULL
 4 5
 5 5
 5 5
+
+statement ok
+CREATE TABLE init(n int, m int, s string);
+
+# Union branch cancellation should happen inside WMR.
+query T multiline
+EXPLAIN
+WITH MUTUALLY RECURSIVE
+  c0(n int) AS (
+    (SELECT n FROM init)
+    UNION ALL
+    (SELECT * FROM c2)
+  ),
+  c1(n int) AS (
+    (SELECT n+n FROM c0)
+    UNION ALL
+    ((SELECT n+3 FROM c0) EXCEPT ALL (SELECT n+3 FROM c0))
+  ),
+  c2(n int) AS (
+    (SELECT * FROM c0)
+    UNION ALL
+    (SELECT * FROM c1)
+    UNION ALL
+    (SELECT * FROM c1)
+  )
+SELECT * FROM c2;
+----
+Explained Query:
+  Return
+    Get l2
+  With Mutually Recursive
+    cte l2 =
+      Union
+        Get l0
+        Get l1
+        Get l1
+    cte l1 =
+      Union
+        Project (#1)
+          Map ((#0 + #0))
+            Get l0
+        Threshold
+          Union
+            Constant <empty>
+            Constant <empty>
+    cte l0 =
+      Union
+        Project (#0)
+          Get materialize.public.init
+        Get l2
+
+EOF

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -263,7 +263,7 @@ EXPLAIN WITH MUTUALLY RECURSIVE
             bar (b int8) AS (
                 SELECT * FROM foo
             )
-        SELECT * FROM (SELECT * FROM foo EXCEPT ALL SELECT * FROM bar)
+        SELECT * FROM (SELECT * FROM foo UNION ALL SELECT * FROM bar)
     )
 SELECT * FROM foo;
 ----
@@ -272,11 +272,9 @@ Explained Query:
     Get l0
   With Mutually Recursive
     cte l0 =
-      Threshold
-        Union
-          Get l0
-          Negate
-            Get l0
+      Union
+        Get l0
+        Get l0
 
 EOF
 


### PR DESCRIPTION
This simply marks `UnionBranchCancellation` to be `recursion_safe`, and adds a test where it happens inside WMR, and slightly adjusts a test in `with_mutually_recursive.slt` (see below).

I made no actual changes to `UnionBranchCancellation`, because it's already recursion-safe. However, this fact is not obvious at all, so I added a comment there to explain this.

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/18176.

### Tips for reviewer

Note that the plan in the added test will simplify even further when we make `FoldConstants` recursion-safe.

I slightly changed a test in `with_mutually_recursive.slt`, because it was being simplified too much by `UnionBranchCancellation`. That test intends to show a situation where two apparently nested WMRs can actually be normalized to one WMR. With the original query, having `UnionBranchCancellation` would get both WMRs eliminated.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
