### PR TITLE
adapter: Prevent statements with dropped roles

### DIFF
--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -151,10 +151,6 @@ pub fn check_plan(
     session: &Session,
     plan: &Plan,
 ) -> Result<(), AdapterError> {
-    if !catalog.system_vars().enable_rbac_checks() {
-        return Ok(());
-    }
-
     let role_id = session.role_id();
     if catalog.try_get_role(role_id).is_none() {
         // PostgreSQL allows users that have their role dropped to perform some actions,
@@ -163,6 +159,10 @@ pub fn check_plan(
         // role is dropped.
         return Err(AdapterError::ConcurrentRoleDrop(role_id.clone()));
     };
+
+    if !catalog.system_vars().enable_rbac_checks() {
+        return Ok(());
+    }
 
     if session.is_superuser() {
         return Ok(());

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2504,9 +2504,6 @@ fn test_concurrent_role_drop() {
         .user(&SYSTEM_USER.name)
         .connect(postgres::NoTls)
         .unwrap();
-    sys_client
-        .execute("ALTER SYSTEM SET enable_rbac_checks TO true", &[])
-        .unwrap();
     assert_eq!(
         1,
         foo_client

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2490,44 +2490,6 @@ fn test_dont_drop_sinks_twice() {
 }
 
 #[test]
-fn test_concurrent_role_drop() {
-    const ROLE_NAME: &str = "foo";
-    let config = util::Config::default().with_now(NOW_ZERO.clone());
-    let server = util::start_server(config).unwrap();
-    let mut foo_client = server
-        .pg_config()
-        .user(ROLE_NAME)
-        .connect(postgres::NoTls)
-        .unwrap();
-    let mut sys_client = server
-        .pg_config_internal()
-        .user(&SYSTEM_USER.name)
-        .connect(postgres::NoTls)
-        .unwrap();
-    assert_eq!(
-        1,
-        foo_client
-            .query_one("SELECT 1;", &[])
-            .unwrap()
-            .get::<_, i32>(0)
-    );
-
-    sys_client
-        .execute(&format!("DROP ROLE {ROLE_NAME}"), &[])
-        .unwrap();
-    let err = foo_client
-        .query_one("SELECT 1;", &[])
-        .unwrap_err()
-        .unwrap_db_error();
-
-    assert_eq!(&SqlState::UNDEFINED_OBJECT, err.code());
-    assert!(
-        err.message().contains("was concurrently dropped"),
-        "unexpected error: {err:?}",
-    );
-}
-
-#[test]
 fn test_timelines_persist_after_failed_transaction() {
     let config = util::Config::default().unsafe_mode();
     let server = util::start_server(config).unwrap();

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -9,6 +9,8 @@
 
 mode cockroach
 
+reset-server
+
 # Verify initial roles.
 query TTBBBB
 SELECT id, name, inherit, create_role, create_db, create_cluster FROM mz_roles WHERE id LIKE 's%'
@@ -224,3 +226,20 @@ query T
 SELECT pg_get_userbyid(4294967295);
 ----
  unknown (OID=4294967295)
+
+# Test concurrently dropped role
+
+simple conn=foo,user=foo
+SELECT current_user();
+----
+foo
+COMPLETE 1
+
+statement ok
+DROP ROLE foo
+
+simple conn=foo,user=foo
+SELECT current_user();
+----
+db error: ERROR: role u4 was concurrently dropped
+DETAIL: Please disconnect and re-connect with a valid role.


### PR DESCRIPTION
Previously, if a user's role was dropped while they were connected, then we'd prevent them from executing a statement only if RBAC checks were turned on. This commit modifies the logic, so we always prevent dropped roles from executing a statement even if RBAC checks are turned off.

We will need this check for object ownership. If a user's role was dropped, and then they try and create an object, we will have no role to assign as the object's owner.

Part of #11579

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
