### PR TITLE
sql: check signed division for overflow

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -950,7 +950,10 @@ fn div_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     if b == 0 {
         Err(EvalError::DivisionByZero)
     } else {
-        Ok(Datum::from(a.unwrap_int16() / b))
+        a.unwrap_int16()
+            .checked_div(b)
+            .map(Datum::from)
+            .ok_or(EvalError::Int16OutOfRange)
     }
 }
 
@@ -959,7 +962,10 @@ fn div_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     if b == 0 {
         Err(EvalError::DivisionByZero)
     } else {
-        Ok(Datum::from(a.unwrap_int32() / b))
+        a.unwrap_int32()
+            .checked_div(b)
+            .map(Datum::from)
+            .ok_or(EvalError::Int32OutOfRange)
     }
 }
 
@@ -968,7 +974,10 @@ fn div_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     if b == 0 {
         Err(EvalError::DivisionByZero)
     } else {
-        Ok(Datum::from(a.unwrap_int64() / b))
+        a.unwrap_int64()
+            .checked_div(b)
+            .map(Datum::from)
+            .ok_or(EvalError::Int64OutOfRange)
     }
 }
 
@@ -1072,7 +1081,7 @@ fn mod_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     if b == 0 {
         Err(EvalError::DivisionByZero)
     } else {
-        Ok(Datum::from(a.unwrap_int16() % b))
+        Ok(Datum::from(a.unwrap_int16().checked_rem(b).unwrap_or(0)))
     }
 }
 
@@ -1081,7 +1090,7 @@ fn mod_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     if b == 0 {
         Err(EvalError::DivisionByZero)
     } else {
-        Ok(Datum::from(a.unwrap_int32() % b))
+        Ok(Datum::from(a.unwrap_int32().checked_rem(b).unwrap_or(0)))
     }
 }
 
@@ -1090,7 +1099,7 @@ fn mod_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     if b == 0 {
         Err(EvalError::DivisionByZero)
     } else {
-        Ok(Datum::from(a.unwrap_int64() % b))
+        Ok(Datum::from(a.unwrap_int64().checked_rem(b).unwrap_or(0)))
     }
 }
 

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -1130,3 +1130,27 @@ SELECT - '-9223372036854775808'::int8
 
 query error bigint out of range
 SELECT  ABS('-9223372036854775808'::int8)
+
+query error smallint out of range
+SELECT '-32768'::int2 / '-1'::int2
+
+query error integer out of range
+SELECT '-2147483648'::int4 / '-1'::int4
+
+query error bigint out of range
+SELECT '-9223372036854775808'::int8 / '-1'::int8
+
+query I
+SELECT '-32768'::int2 % '-1'::int2
+----
+0
+
+query I
+SELECT '-2147483648'::int4 % '-1'::int4
+----
+0
+
+query I
+SELECT '-9223372036854775808'::int8 % '-1'::int8
+----
+0


### PR DESCRIPTION
The case INT_MIN / -1 is equivalent to (-INT_MIN) which is one larger than INT_MAX.  There was some concern that maybe the constant folding code that chokes on this also wouldn't handle errors from these functions but it seems fine, at least for the cases reported.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes #18181.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
