### PR TITLE
ci: Better SQLancer block detection

### DIFF
--- a/test/sqlancer/mzcompose.py
+++ b/test/sqlancer/mzcompose.py
@@ -86,9 +86,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     in_assertion = False
     for line in result.stderr.splitlines():
-        if line.startswith("Caused by: "):
+        if line.startswith("--java.lang.AssertionError: "):
             in_assertion = True
-            print(f"--- [SQLancer] {line.removeprefix('Caused by: ')}")
+            print(f"--- [SQLancer] {line.removeprefix('--java.lang.AssertionError: ')}")
         elif line == "":
             in_assertion = False
         elif in_assertion:


### PR DESCRIPTION
Just had a wrong result locally:
```
--java.lang.AssertionError: the size of the result sets mismatch (2 and 0)! ---- SELECT 0.97668456902761058291417839427595026791095733642578125 FROM t1 FULL OUTER JOIN t3 ON NOT (((t1.c2) IN (t1.c0)) IS TRUE) GROUP BY t3.c1; ---- cardinality: 2
---- SELECT ALL 0.97668456902761058291417839427595026791095733642578125 FROM t1 FULL OUTER JOIN t3 ON NOT (((t1.c2) IN (t1.c0)) IS TRUE) GROUP BY t3.c1 HAVING MIN((((((t1.c2)::VARCHAR)||(0.6691758566527444)))||((((TRUE) IS TRUE)AND(((FALSE)OR(TRUE))))))!~*'[.');SELECT 0.97668456902761058291417839427595026791095733642578125 FROM t1 FULL OUTER JOIN t3 ON NOT (((t1.c2) IN (t1.c0)) IS TRUE) GROUP BY t3.c1 HAVING NOT (MIN((((((t1.c2)::VARCHAR)||(0.6691758566527444)))||((((TRUE) IS TRUE)AND(((FALSE)OR(TRUE))))))!~*'[.'));SELECT ALL 0.97668456902761058291417839427595026791095733642578125 FROM t1 FULL OUTER JOIN t3 ON NOT (((t1.c2) IN (t1.c0)) IS TRUE) GROUP BY t3.c1 HAVING (MIN(((((CAST(t1.c2 AS VARCHAR))||(0.6691758566527444)))||((((TRUE) IS TRUE)AND(((FALSE)OR(TRUE))))))!~*'[.')) IS NULL; ---- cardinality: 0
```

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
