### PR TITLE
storage: cleanup the upsert operator

### DIFF
--- a/src/storage-client/src/types/errors.rs
+++ b/src/storage-client/src/types/errors.rs
@@ -29,23 +29,23 @@ include!(concat!(
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct DecodeError {
     pub kind: DecodeErrorKind,
-    pub raw: Option<Vec<u8>>,
+    pub raw: Vec<u8>,
 }
 
 impl RustType<ProtoDecodeError> for DecodeError {
     fn into_proto(&self) -> ProtoDecodeError {
         ProtoDecodeError {
             kind: Some(RustType::into_proto(&self.kind)),
-            raw: self.raw.clone(),
+            raw: Some(self.raw.clone()),
         }
     }
 
     fn from_proto(proto: ProtoDecodeError) -> Result<Self, TryFromProtoError> {
-        let ProtoDecodeError { kind, raw } = proto;
-        let kind = match kind {
+        let kind = match proto.kind {
             Some(kind) => RustType::from_proto(kind)?,
             None => return Err(TryFromProtoError::missing_field("ProtoDecodeError::kind")),
         };
+        let raw = proto.raw.into_rust_if_some("raw")?;
         Ok(Self { kind, raw })
     }
 }
@@ -68,10 +68,7 @@ impl DecodeError {
 
 impl Display for DecodeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.raw {
-            None => write!(f, "{}", self.kind),
-            Some(raw) => write!(f, "{} (original bytes: {:x?})", self.kind, raw),
-        }
+        write!(f, "{} (original bytes: {:x?})", self.kind, self.raw)
     }
 }
 
@@ -478,7 +475,7 @@ mod tests {
     fn test_decode_error_codec_roundtrip() -> Result<(), String> {
         let original = DecodeError {
             kind: DecodeErrorKind::Text("ciao".to_string()),
-            raw: Some(b"oaic".to_vec()),
+            raw: b"oaic".to_vec(),
         };
         let mut encoded = Vec::new();
         original.encode(&mut encoded);

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -19,17 +19,20 @@ use differential_dataflow::{collection, AsCollection, Collection, Hashable};
 use serde::{Deserialize, Serialize};
 use timely::dataflow::operators::{self, Exchange, OkErr};
 use timely::dataflow::Scope;
-use timely::progress::Antichain;
+use timely::progress::{Antichain, Timestamp as _};
 use tokio::runtime::Handle as TokioHandle;
 
 use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::source::persist_source;
-use mz_storage_client::types::errors::{DataflowError, DecodeError, EnvelopeError};
+use mz_storage_client::types::errors::{
+    DataflowError, DecodeError, EnvelopeError, UpsertError, UpsertNullKeyError, UpsertValueError,
+};
 use mz_storage_client::types::sources::{encoding::*, *};
 use mz_timely_util::operator::CollectionExt;
 
 use crate::decode::{render_decode_cdcv2, render_decode_delimited};
+use crate::render::upsert::UpsertCommand;
 use crate::source::types::{DecodeResult, SourceOutput};
 use crate::source::{self, RawSourceCreationConfig};
 
@@ -336,44 +339,23 @@ where
                     (debezium_ok, Some(errors))
                 }
                 SourceEnvelope::Upsert(upsert_envelope) => {
-                    // TODO: use the key envelope to figure out when to add keys.
-                    // The operator currently does it unconditionally
-                    let transformed_results =
-                        transform_keys_from_key_envelope(upsert_envelope, results);
+                    let upsert_input = upsert_commands(results, upsert_envelope.clone());
 
                     let persist_clients = Arc::clone(&storage_state.persist_clients);
 
-                    // persit requires an `as_of`, and presents all data before that
-                    // `as_of` as if its at that `as_of`. We only care about if
-                    // the data is before the `resume_upper` or not, so we pick
-                    // the biggest `as_of` we can. We could always choose
-                    // 0, but that may have been compacted away.
-                    let previous_as_of = match resume_upper.as_option() {
-                        None => {
-                            // We are at the end of time, so our `as_of` is everything.
-                            Some(Timestamp::MAX)
-                        }
-                        Some(&Timestamp::MIN) => {
-                            // We are the beginning of time (no data persisted yet), so we can
-                            // skip reading out of persist.
-                            None
-                        }
-                        Some(&t) => Some(t.saturating_sub(1)),
-                    };
-                    let (previous, previous_token) = if let Some(previous_as_of) = previous_as_of {
+                    let upper_ts = resume_upper
+                        .as_option()
+                        .expect("resuming an already finished ingestion")
+                        .clone();
+                    let (previous, previous_token) = if Timestamp::minimum() < upper_ts {
+                        let as_of = Antichain::from_elem(upper_ts.saturating_sub(1));
+
                         let (stream, tok) = persist_source::persist_source_core(
                             scope,
                             id,
                             persist_clients,
-                            // TODO(petrosagg): upsert needs to read its output and here we
-                            // assume that all upsert ingestion will output their data to the
-                            // same collection as the one carrying the ingestion. This is the
-                            // case at the time of writing but we need a more robust
-                            // implementation. Consider having the upsert operator hold private
-                            // state (a copy), or encoding the fact that this operator's state
-                            // and the output collection state is the same in an explicit way
                             description.ingestion_metadata,
-                            Some(Antichain::from_elem(previous_as_of)),
+                            Some(as_of),
                             Antichain::new(),
                             None,
                             None,
@@ -387,35 +369,22 @@ where
                             None,
                         )
                     };
-                    let (upsert_ok, upsert_err) = super::upsert::upsert(
-                        &transformed_results,
+                    let upsert = crate::render::upsert::upsert(
+                        &upsert_input,
+                        upsert_envelope.key_indices.clone(),
                         resume_upper,
-                        upsert_envelope.clone(),
                         previous,
                         previous_token,
                     );
 
-                    (upsert_ok, Some(upsert_err))
+                    let (upsert_ok, upsert_err) = upsert.inner.ok_err(split_ok_err);
+
+                    (upsert_ok.as_collection(), Some(upsert_err.as_collection()))
                 }
                 SourceEnvelope::None(none_envelope) => {
                     let results = append_metadata_to_value(results);
 
                     let flattened_stream = flatten_results_prepend_keys(none_envelope, results);
-
-                    // TODO: Maybe we should finally move this to some central
-                    // place and re-use. There seem to be enough instances of this
-                    // by now.
-                    fn split_ok_err(
-                        x: (Result<Row, DataflowError>, mz_repr::Timestamp, Diff),
-                    ) -> Result<
-                        (Row, mz_repr::Timestamp, Diff),
-                        (DataflowError, mz_repr::Timestamp, Diff),
-                    > {
-                        match x {
-                            (Ok(row), ts, diff) => Ok((row, ts, diff)),
-                            (Err(err), ts, diff) => Err((err, ts, diff)),
-                        }
-                    }
 
                     let (stream, errors) = flattened_stream.inner.ok_err(split_ok_err);
 
@@ -447,6 +416,15 @@ where
     (collection, err_collection, needed_tokens)
 }
 
+// TODO: Maybe we should finally move this to some central place and re-use. There seem to be
+// enough instances of this by now.
+fn split_ok_err<O, E, T, D>(x: (Result<O, E>, T, D)) -> Result<(O, T, D), (E, T, D)> {
+    match x {
+        (Ok(ok), ts, diff) => Ok((ok, ts, diff)),
+        (Err(err), ts, diff) => Err((err, ts, diff)),
+    }
+}
+
 /// After handling metadata insertion, we split streams into key/value parts for convenience
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize)]
 struct KV {
@@ -471,44 +449,78 @@ fn append_metadata_to_value<G: Scope>(
     })
 }
 
-/// Convert from streams of [`DecodeResult`] to Rows, inserting the Key according to [`KeyEnvelope`]
-// TODO(guswynn): figure out how to merge this duplicated logic with `flatten_results_prepend_keys`
-fn transform_keys_from_key_envelope<G: Scope>(
-    upsert_envelope: &UpsertEnvelope,
-    results: Collection<G, DecodeResult, Diff>,
-) -> Collection<G, DecodeResult, Diff> {
-    match upsert_envelope {
-        UpsertEnvelope {
-            style: UpsertStyle::Default(KeyEnvelope::Flattened) | UpsertStyle::Debezium { .. },
-            ..
-        } => results,
-        UpsertEnvelope {
-            style: UpsertStyle::Default(KeyEnvelope::Named(_)),
-            ..
-        } => {
-            let mut row_buf = mz_repr::Row::default();
-            results.map(move |mut res| {
-                res.key = res.key.map(|k_result| {
-                    k_result.map(|k| {
-                        if k.iter().nth(1).is_none() {
-                            k
-                        } else {
-                            row_buf.packer().push_list(k.iter());
-                            row_buf.clone()
-                        }
-                    })
-                });
+/// Convert from streams of [`DecodeResult`] to UpsertCommands, inserting the Key according to [`KeyEnvelope`]
+fn upsert_commands<G: Scope>(
+    input: Collection<G, DecodeResult, Diff>,
+    upsert_envelope: UpsertEnvelope,
+) -> Collection<G, (UpsertCommand, MzOffset), Diff> {
+    let mut row_buf = Row::default();
+    input.map(move |result| {
+        let key = match result.key {
+            Some(Ok(key)) => Ok(key),
+            None => Err(UpsertError::NullKey(UpsertNullKeyError::with_partition_id(
+                result.partition,
+            ))),
+            Some(Err(err)) => Err(UpsertError::KeyDecode(err)),
+        };
 
-                res
-            })
-        }
-        UpsertEnvelope {
-            style: UpsertStyle::Default(KeyEnvelope::None),
-            ..
-        } => {
-            unreachable!("SourceEnvelope::Upsert should never have KeyEnvelope::None")
-        }
-    }
+        // If we have a well-formed key we can continue, otherwise we're upserting an error
+        let key = match key {
+            Ok(key) => key,
+            Err(err) => match result.value {
+                Some(_) => return (UpsertCommand::Insert(Err(err)), result.position),
+                None => return (UpsertCommand::Remove(Err(err)), result.position),
+            },
+        };
+
+        // We can now apply the key envelope
+        let key = match upsert_envelope.style {
+            UpsertStyle::Debezium { .. } | UpsertStyle::Default(KeyEnvelope::Flattened) => key,
+            UpsertStyle::Default(KeyEnvelope::Named(_)) => {
+                if key.iter().nth(1).is_none() {
+                    key
+                } else {
+                    row_buf.packer().push_list(key.iter());
+                    row_buf.clone()
+                }
+            }
+            UpsertStyle::Default(KeyEnvelope::None) => unreachable!(),
+        };
+
+        // If we have a well-formed value we can continue, otherwise we're upserting an error
+        let metadata = result.metadata;
+        let value = match result.value {
+            Some(Ok(ref row)) => match upsert_envelope.style {
+                UpsertStyle::Debezium { after_idx } => match row.iter().nth(after_idx).unwrap() {
+                    Datum::List(after) => {
+                        row_buf.packer().extend(after.iter().chain(metadata.iter()));
+                        Some(row_buf.clone())
+                    }
+                    Datum::Null => None,
+                    d => panic!("type error: expected record, found {:?}", d),
+                },
+                UpsertStyle::Default(_) => {
+                    let mut packer = row_buf.packer();
+                    packer.extend(key.iter().chain(row.iter()).chain(metadata.iter()));
+                    Some(row_buf.clone())
+                }
+            },
+            None => None,
+            Some(Err(err)) => {
+                let cmd = UpsertCommand::Insert(Err(UpsertError::Value(UpsertValueError {
+                    for_key: key,
+                    inner: Box::new(DataflowError::DecodeError(Box::new(err))),
+                })));
+                return (cmd, result.position);
+            }
+        };
+
+        let command = match value {
+            Some(value) => UpsertCommand::Insert(Ok(value)),
+            None => UpsertCommand::Remove(Ok(key)),
+        };
+        (command, result.position)
+    })
 }
 
 /// Convert from streams of [`DecodeResult`] to Rows, inserting the Key according to [`KeyEnvelope`]

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -8,1045 +8,278 @@
 // by the Apache License, Version 2.0.
 
 use std::any::Any;
-use std::collections::btree_map::Entry;
-use std::collections::BTreeMap;
+use std::borrow::Borrow;
+use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
+use differential_dataflow::consolidation;
 use differential_dataflow::hashable::Hashable;
-use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{AsCollection, Collection};
+use itertools::Either;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::Exchange;
-use timely::dataflow::operators::{Capability, Concat, InputCapability, OkErr, Operator};
-use timely::dataflow::{Scope, Stream};
-use timely::order::PartialOrder;
-use timely::progress::frontier::AntichainRef;
-use timely::progress::{Antichain, ChangeBatch};
-use tracing::info;
+use timely::dataflow::Scope;
+use timely::order::{PartialOrder, TotalOrder};
+use timely::progress::{Antichain, Timestamp};
 
-use mz_expr::{EvalError, MirScalarExpr};
-use mz_ore::permutations::inverse_argsort;
-use mz_repr::{Datum, DatumVec, DatumVecBorrow, Diff, Row, RowArena, Timestamp};
-use mz_storage_client::types::errors::{
-    DataflowError, EnvelopeError, UpsertError, UpsertValueError,
-};
-use mz_storage_client::types::sources::{MzOffset, UpsertEnvelope, UpsertStyle};
-use mz_timely_util::operator::StreamExt;
+use mz_ore::collections::{CollectionExt, HashSet};
+use mz_repr::{Datum, Diff, Row};
+use mz_storage_client::types::errors::{DataflowError, EnvelopeError, UpsertError};
+use mz_timely_util::builder_async::{Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder};
 
-use crate::source::types::DecodeResult;
-
-#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
-struct UpsertSourceData {
-    /// The actual value
-    value: Option<Result<Row, UpsertError>>,
-    /// The source's reported position for this record
-    position: MzOffset,
-    /// The time that the upstream source believes that the message was created
-    /// Currently only applies to Kafka
-    upstream_time_millis: Option<i64>,
-    /// Metadata for this row
-    metadata: Row,
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum UpsertCommand {
+    Insert(Result<Row, UpsertError>),
+    Remove(Result<Row, UpsertError>),
 }
 
-/// Entrypoint to the upsert-specific transformations involved
-/// in rendering a stream that came from an upsert source.
-/// Upsert-specific operators are different from the rest of
-/// the rendering pipeline in that their input is a stream
-/// with two components instead of one, and the second component
-/// can be null or empty.
-pub(crate) fn upsert<G>(
-    input: &Collection<G, DecodeResult, Diff>,
-    as_of_frontier: Antichain<Timestamp>,
-    upsert_envelope: UpsertEnvelope,
+impl UpsertCommand {
+    fn keyed<'a>(&'a self, key_indices: &'a [usize]) -> KeyedCommand<'a, &Self> {
+        KeyedCommand {
+            command: self,
+            key_indices,
+        }
+    }
+
+    fn into_keyed(self, key_indices: &[usize]) -> KeyedCommand<'_, Self> {
+        KeyedCommand {
+            command: self,
+            key_indices,
+        }
+    }
+}
+
+/// An UpsertCommand wrapper whose implementations of Hash,PartialEq, and Eq are such that any
+/// variant with the same key is considered the same.
+struct KeyedCommand<'a, C: Borrow<UpsertCommand>> {
+    command: C,
+    key_indices: &'a [usize],
+}
+
+impl<'a, C: Borrow<UpsertCommand>> KeyedCommand<'a, C> {
+    /// Produces the key of this upsert command. If the command has a well-formed key then an
+    /// `Ok(_)` variant is returned with an iterator over the datum keys. If the command is about a
+    /// key error then an `Err(_)` variant is returned.
+    fn key(&self) -> Result<impl Iterator<Item = Datum<'_>> + '_, Datum<'_>> {
+        match self.command.borrow() {
+            UpsertCommand::Insert(Ok(row)) => {
+                let mut key_indices = &*self.key_indices;
+                let iter = row.iter().enumerate().flat_map(move |(idx, datum)| {
+                    let key_idx = key_indices.get(0)?;
+                    if idx == *key_idx {
+                        key_indices = &key_indices[1..];
+                        Some(datum)
+                    } else {
+                        None
+                    }
+                });
+                Ok(Either::Left(Either::Left(iter)))
+            }
+            UpsertCommand::Remove(Ok(key)) => Ok(Either::Left(Either::Right(key.iter()))),
+            UpsertCommand::Insert(Err(err)) | UpsertCommand::Remove(Err(err)) => match err {
+                UpsertError::Value(err) => Ok(Either::Right(err.for_key.iter())),
+                UpsertError::KeyDecode(err) => Err(Datum::Bytes(&err.raw)),
+                UpsertError::NullKey(_) => Err(Datum::Null),
+            },
+        }
+    }
+}
+
+impl<C: Borrow<UpsertCommand>> Hash for KeyedCommand<'_, C> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self.key() {
+            Ok(iter) => {
+                for datum in iter {
+                    datum.hash(state);
+                }
+                state.write_u8(0x01);
+            }
+            Err(datum) => {
+                datum.hash(state);
+                state.write_u8(0x02);
+            }
+        }
+    }
+}
+
+impl<C: Borrow<UpsertCommand>> PartialEq for KeyedCommand<'_, C> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.key(), other.key()) {
+            (Ok(this), Ok(other)) => this.eq(other),
+            (Err(this), Err(other)) => this.eq(&other),
+            _ => false,
+        }
+    }
+}
+
+impl<C: Borrow<UpsertCommand>> Eq for KeyedCommand<'_, C> {}
+
+/// Resumes an upsert computation at `resume_upper` given as inputs a collection of upsert commands
+/// and the collection of the previous output of this operator.
+pub(crate) fn upsert<G: Scope, O: timely::ExchangeData + Ord>(
+    input: &Collection<G, (UpsertCommand, O), Diff>,
+    mut key_indices: Vec<usize>,
+    resume_upper: Antichain<G::Timestamp>,
     previous: Collection<G, Result<Row, DataflowError>, Diff>,
     previous_token: Option<Rc<dyn Any>>,
-) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
+) -> Collection<G, Result<Row, DataflowError>, Diff>
 where
-    G: Scope<Timestamp = Timestamp>,
+    G::Timestamp: TotalOrder,
 {
-    if as_of_frontier != Antichain::from_elem(timely::progress::Timestamp::minimum()) {
-        info!("upsert resuming from time {as_of_frontier:?}");
-    }
-    // Currently, the upsert-specific transformations run in the
-    // following order:
-    // 1. Applies `as_of` frontier compaction. The compaction is important as
-    // downstream upsert preparation can compact away updates for the same keys
-    // at the same times, and by advancing times we make more of them the same.
-    // 2. compact away updates for the same keys at the same times
-    // 3. decoding records
-    // 4. prepending the key to the value so that the stream becomes
-    //        of the format (key, <entire record>)
-    // We may want to consider switching the order of the transformations to
-    // optimize performance trade-offs. In the current order, by running
-    // deduplicating before decoding/linear operators, we're reducing compute at the
-    // cost of requiring more memory.
-    //
-    // In the future, we may want to have optimization hints that enable people
-    // to specify that they believe that they have a large number of unique
-    // keys, at which point materialize may be more performant if it runs
-    // decoding/linear operators before deduplicating.
-    //
-    // The method also takes in `operators` which describes predicates that can
-    // be applied and columns of the data that can be blanked out. We can apply
-    // these operations but must be careful: for example, we can apply predicates
-    // before staging the records, but we need to present filtered results as a
-    // `None` value to ensure that it prompts dropping any held values with the
-    // same key. If the predicates produce errors, we should notice these as well
-    // and retract them if non-erroring records overwrite them.
+    // Sort key indices to ensure we can construct the key by iterating over the datums of the row
+    key_indices.sort_unstable();
 
-    // TODO: We could move the decoding before the staging grounds, which would
-    // allow us to stage potentially less data. The motivation for the current
-    // design is to support bulk deduplication without decoding, but we expect
-    // this is most likely to happen in the loading of data; consequently, we
-    // could use this implementation until `as_of_frontier` is reached, and then
-    // switch over to eager decoding. A work-in-progress idea that needs thought.
+    let mut builder = AsyncOperatorBuilder::new("Upsert".to_string(), input.scope());
 
-    // Extract predicates, and "dummy column" information.
-    // Predicates are distinguished into temporal and non-temporal,
-    // as the non-temporal determine if a record is retained at all,
-    // and the temporal indicate how we should transform its timestamps
-    // when it is transmitted.
-    let temporal = Vec::new();
-    let predicates = Vec::new();
-    let position_or = (0..upsert_envelope.source_arity)
-        .map(Some)
-        .collect::<Vec<_>>();
-    let temporal_plan = if !temporal.is_empty() {
-        let temporal_mfp =
-            mz_expr::MapFilterProject::new(upsert_envelope.source_arity).filter(temporal);
-        Some(temporal_mfp.into_plan().unwrap_or_else(|e| panic!("{}", e)))
-    } else {
-        None
+    let mut input = {
+        let key_indices = key_indices.clone();
+        builder.new_input(
+            &input.inner,
+            Exchange::new(move |((cmd, _), _, _)| UpsertCommand::keyed(cmd, &key_indices).hashed()),
+        )
     };
 
-    // Break `previous` into:
-    //  - On the one hand, `Ok` and `Err(UpsertError)`, which we know how to
-    //   deal with, and,
-    //  - On the other hand, `Err(everything else)`, which we don't.
-    let (previous, mut errs) = previous.inner.ok_err(|(d, t, r)| match d {
-        Ok(row) => Ok((Ok(row), t, r)),
+    // We only care about UpsertValueError since this is the only error that we can retract
+    let previous = previous.flat_map(|result| match result {
+        Ok(ok) => Some(UpsertCommand::Insert(Ok(ok))),
         Err(DataflowError::EnvelopeError(err)) => match *err {
-            EnvelopeError::Upsert(e) => Ok((Err(e), t, r)),
-            err => Err((err.into(), t, r)),
+            EnvelopeError::Upsert(err) => Some(UpsertCommand::Insert(Err(err))),
+            _ => None,
         },
-        Err(err) => Err((err, t, r)),
+        Err(_) => None,
     });
+    let mut previous = {
+        let key_indices = key_indices.clone();
+        builder.new_input(
+            &previous.inner,
+            Exchange::new(move |(cmd, _, _)| UpsertCommand::keyed(cmd, &key_indices).hashed()),
+        )
+    };
+    let (mut output_handle, output) = builder.new_output();
 
-    let upsert_output = upsert_core(
-        input,
-        predicates,
-        position_or,
-        as_of_frontier,
-        upsert_envelope,
-        previous.as_collection(),
-        previous_token,
-    );
-    let (mut oks, errs2) = upsert_output.ok_err(|(data, time, diff)| match data {
-        Ok(data) => Ok((data, time, diff)),
-        Err(err) => Err((err, time, diff)),
-    });
-    errs = errs.concat(&errs2);
+    builder.build(move |caps| async move {
+        let mut output_cap = caps.into_element();
 
-    // If we have temporal predicates do the thing they have to do.
-    if let Some(plan) = temporal_plan {
-        let (oks2, errs2) = oks.flat_map_fallible("UpsertTemporalOperators", {
-            let mut datum_vec = mz_repr::DatumVec::new();
-            let mut row_builder = Row::default();
-            move |(row, time, diff)| {
-                let arena = mz_repr::RowArena::new();
-                let mut datums_local = datum_vec.borrow_with(&row);
-                plan.evaluate(
-                    &mut datums_local,
-                    &arena,
-                    time,
-                    diff,
-                    |_time| true,
-                    &mut row_builder,
-                )
-            }
-        });
+        let mut snapshot = vec![];
 
-        oks = oks2;
-        errs = errs.concat(&errs2);
-    }
-
-    (oks.as_collection(), errs.as_collection())
-}
-
-/// Evaluates predicates and dummy column information.
-///
-/// This method takes decoded datums and prepares as output
-/// a row which contains only those positions of `position_or`.
-/// If any predicate is failed, no row is produced, and if an
-/// error is encountered it is returned instead.
-fn evaluate(
-    datums: &[Datum],
-    predicates: &[MirScalarExpr],
-    position_or: &[Option<usize>],
-    row_buf: &mut Row,
-) -> Result<Option<Row>, EvalError> {
-    let arena = RowArena::new();
-    // Each predicate is tested in order.
-    for predicate in predicates.iter() {
-        if predicate.eval(datums, &arena)? != Datum::True {
-            return Ok(None);
-        }
-    }
-
-    // We pack dummy values in locations that do not reference
-    // specific columns.
-    let mut row_packer = row_buf.packer();
-    row_packer.extend(position_or.iter().map(|x| match x {
-        Some(column) => datums[*column],
-        None => Datum::Dummy,
-    }));
-    Ok(Some(row_buf.clone()))
-}
-
-/// Extracts the data that we need for UPSERT from the given collection of
-/// `DecodeResult`. While doing this, also lifts any errors into the appropriate
-/// `UpsertError`.
-fn extract_from_decode_results<G: Scope>(
-    input: &Collection<G, DecodeResult, Diff>,
-) -> Collection<
-    G,
-    (
-        (
-            Option<Result<Row, UpsertError>>,
-            Option<Result<Row, UpsertError>>,
-        ),
-        MzOffset,
-        Row,
-    ),
-    Diff,
-> {
-    input.map(|decode_result| {
-        let DecodeResult {
-            key,
-            value,
-            position,
-            upstream_time_millis: _,
-            partition,
-            metadata,
-        } = decode_result;
-
-        let (key, value) = match key {
-            Some(Err(decode_error)) => (
-                Some(Err(UpsertError::KeyDecode(decode_error.clone()))),
-                value.map(|decode_result| {
-                    // Match what we do in `extract_from_previous`, though
-                    // the value is not really important when we have a key
-                    // error. Plus, we can't map any value error to an
-                    // UpsertValueError because we don't have a real key that we
-                    // could give to it.
-                    decode_result.map_err(|_err| UpsertError::KeyDecode(decode_error.clone()))
-                }),
-            ),
-            Some(Ok(key)) => (
-                Some(Ok(key.clone())),
-                value.map(|decode_result| {
-                    decode_result.map_err(|err| {
-                        UpsertError::Value(UpsertValueError {
-                            for_key: key,
-                            inner: Box::new(DataflowError::DecodeError(Box::new(err))),
-                        })
-                    })
-                }),
-            ),
-            None => {
-                let key_error = UpsertError::NullKey(
-                    mz_storage_client::types::errors::UpsertNullKeyError::with_partition_id(
-                        partition,
-                    ),
-                );
-                (
-                    None,
-                    // Match what we do in `extract_from_previous`, though
-                    // the value is not really important when we have a key
-                    // error. Plus, we can't map any value error to an
-                    // UpsertValueError because we don't have a real key that we
-                    // could give to it.
-                    //
-                    // This makes sure that `None` stays `None`, meaning we
-                    // retract when we get a `None` value, and that a `Some`
-                    // value gets mapped to an error.
-                    value.map(|_value| Err(key_error)),
-                )
-            }
-        };
-
-        ((key, value), position, metadata)
-    })
-}
-
-/// Given a stream of rows and a description of the columns that form their key,
-/// produce a stream of keys and thinned values.
-///
-/// This is used to re-extract a key-value-style collection from the (persisted)
-/// output of an UPSERT source. It is the equivalent to
-/// [`extract_from_decode_results`], but for our already persisted data that we
-/// read on re-hydration.
-fn extract_from_previous<G: Scope>(
-    records: Collection<G, Result<Row, UpsertError>, Diff>,
-    key_indices_sorted: Vec<usize>,
-    key_indices: &[usize],
-) -> Collection<G, (Option<Result<Row, UpsertError>>, Result<Row, UpsertError>), Diff> {
-    debug_assert!({
-        let mut verified_sorted = key_indices.to_vec();
-        verified_sorted.sort_unstable();
-        key_indices_sorted == verified_sorted
-    });
-    let key_cols_are_sorted = &key_indices_sorted == key_indices;
-
-    let mut row_buf = Row::default();
-    // If the key columns are in order, we can pack them directly
-    // into `key_row_buf` while scanning the original row.
-    //
-    // Otherwise, we need to put them into `key_dv` and then invert the permutation
-    // before packing.
-    let mut key_row_buf = Row::default();
-    let mut key_dv = DatumVec::default();
-    let key_unsort_permutation = inverse_argsort(key_indices);
-    records.map(move |result| {
-        match result {
-            Ok(row) => {
-                let mut row_packer = row_buf.packer();
-                let mut key_row_packer = key_row_buf.packer();
-                let values = &mut row.iter();
-                let mut next_idx = 0;
-                let mut key_dv = key_dv.borrow();
-                for &key_idx in key_indices_sorted.iter() {
-                    // First, push the datums that are before `key_idx`
-                    row_packer.extend(values.take(key_idx - next_idx));
-                    // Then, add the key field to whichever buffer we're using for the key
-                    let key_datum = values.next().unwrap();
-                    if key_cols_are_sorted {
-                        key_row_packer.push(key_datum);
-                    } else {
-                        key_dv.push(key_datum);
-                    }
-                    next_idx = key_idx + 1;
+        // In the first phase we will collect all the updates from our output that are not beyond
+        // resume_upper. This will be the seed state for the command processing below.
+        while let Some(event) = previous.next_mut().await {
+            match event {
+                AsyncEvent::Data(_cap, data) => {
+                    snapshot.extend(
+                        data.drain(..)
+                            .filter(|(_row, ts, _diff)| !resume_upper.less_equal(ts))
+                            .map(|(row, _ts, diff)| (row, diff)),
+                    );
                 }
-                // Finally, push any columns after the last key index
-                row_packer.extend(values);
-
-                if !key_cols_are_sorted {
-                    for &i in key_unsort_permutation.iter() {
-                        key_row_packer.push(key_dv[i])
+                AsyncEvent::Progress(upper) => {
+                    if PartialOrder::less_equal(&resume_upper, &upper) {
+                        break;
                     }
                 }
-                (Some(Ok(key_row_buf.clone())), Ok(row_buf.clone()))
             }
-            Err(UpsertError::KeyDecode(err)) => (
-                Some(Err(UpsertError::KeyDecode(err.clone()))),
-                Err(UpsertError::KeyDecode(err)),
-            ),
-            Err(UpsertError::NullKey(null_key_err)) => {
-                (None, Err(UpsertError::NullKey(null_key_err)))
-            }
-            Err(UpsertError::Value(UpsertValueError { inner, for_key })) => (
-                Some(Ok(for_key.clone())),
-                Err(UpsertError::Value(UpsertValueError { inner, for_key })),
-            ),
         }
-    })
-}
+        drop(previous_token);
+        while let Some(_event) = previous.next().await {
+            // Exchaust the previous input. It is expected to immediately reach the empty
+            // antichain since we have dropped its token.
+        }
 
-/// Internal core upsert logic.
-fn upsert_core<G>(
-    input: &Collection<G, DecodeResult, Diff>,
-    predicates: Vec<MirScalarExpr>,
-    position_or: Vec<Option<usize>>,
-    as_of_frontier: Antichain<Timestamp>,
-    upsert_envelope: UpsertEnvelope,
-    previous: Collection<G, Result<Row, UpsertError>, Diff>,
-    mut previous_token: Option<Rc<dyn Any>>,
-) -> Stream<G, (Result<Row, DataflowError>, Timestamp, Diff)>
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    // Prepare sorted and structured `key_indices` required
-    // by the upsert operator, and a `DatumVec` used to avoid
-    // an allocation.
-    let mut key_indices_sorted = upsert_envelope.key_indices.clone();
-    key_indices_sorted.sort_unstable();
+        consolidation::consolidate(&mut snapshot);
 
-    let previous_ok = extract_from_previous(
-        previous,
-        key_indices_sorted.clone(),
-        &upsert_envelope.key_indices,
-    );
+        let mut state = HashSet::new();
 
-    let input = extract_from_decode_results(input);
+        for (cmd, diff) in snapshot {
+            assert_eq!(diff, 1, "invalid upsert state");
+            state.insert(cmd.into_keyed(&key_indices));
+        }
 
-    // It's very important to hash the right thing. We have nested `Option` and
-    // `Result` here. And, for example, `Some(key).hashed()` is not the same as
-    // `key.hashed()`.
-    //
-    // We make sure  to hash the same thing for both previous updates and new
-    // updates.
-    //
-    // Also: this problem was only showing up when trying to use upsert-style
-    // sources with multiple clusterd workers.
-    let result_stream = input.inner.binary_frontier(
-        &previous_ok.inner,
-        Exchange::new(move |(((key, _v), _pos, _meta), _t, _r)| {
-            // N.B. We make the expected type explicit here to make sure it
-            // cannot change by accident.
-            let key: &Option<Result<Row, UpsertError>> = key;
+        // Now can can resume consuming the collection
+        let mut pending_batches = vec![];
+        let mut output_updates = vec![];
+        let mut input_upper = Antichain::from_elem(Timestamp::minimum());
+        while let Some(event) = input.next_mut().await {
+            match event {
+                AsyncEvent::Data(_cap, data) => {
+                    if PartialOrder::less_equal(&input_upper, &resume_upper) {
+                        data.retain(|(_, ts, _)| resume_upper.less_equal(ts));
+                    }
 
-            // Another N.B. we use `as_ref()` here so that we're hashing a
-            // `Option<&Result<Row, UpsertError>`, like we do below. We don't
-            // stricly need it because the result is the same without but with
-            // this we are extra future safe.
-            key.as_ref().hashed()
-        }),
-        Exchange::new(|((key, _v), _t, _r)| {
-            // N.B.  We make the expected type explicit here to make sure it
-            // cannot change by accident.
-            let key: &Option<Result<Row, UpsertError>> = key;
-            key.as_ref().hashed()
-        }),
-        "Upsert",
-        move |_cap, _info| {
-            // This is a map of (time) -> (capability, ((key) -> (value with max offset)))
-            //
-            // This is a BTreeMap because we want to ensure that if we receive (key1, value1, time
-            // 5) and (key1, value2, time 7) that we send (key1, value1, time 5) before (key1,
-            // value2, time 7)
-            let mut pending_values =
-                BTreeMap::<Timestamp, (Capability<Timestamp>, BTreeMap<_, UpsertSourceData>)>::new(
-                );
-            // Intermediate structures re-used to limit allocations
-            let mut scratch_vector = Vec::new();
-            let mut repop_scratch_vector = Vec::new();
-            let mut row_packer = mz_repr::Row::default();
-            let mut dv = DatumVec::new();
-
-            let key_indices_map = upsert_envelope
-                .key_indices
-                .iter()
-                .enumerate()
-                .map(|(idx, value_idx)| (*value_idx, idx))
-                .collect();
-            let mut kdv = DatumVec::new();
-            // This is a map of (decoded key) -> (decoded_value). We store the
-            // latest value for a given key that way we know what to retract if
-            // a new value with the same key comes along.
-            //
-            // If `previous_token` is true, we need to rehydrate this from the last good input,
-            // so set it to `None` for now.
-            let mut current_values = if previous_token.is_some() {
-                None
-            } else {
-                Some(BTreeMap::default())
-            };
-
-            let mut initial_values_multiset = ChangeBatch::default();
-            move |data_input, previous_input, output| {
-                if previous_token.is_some() {
-                    assert!(current_values.is_none());
-                    // Hydrate the `current_values` map from the previous state of the collection.
-                    // We can't just insert things into the `current_values` map directly, since
-                    // we might in general have non-one multiplicities due to Persist being behind on compaction.
-                    // Thus, we use `initial_values_multiset` to keep track of how many of each record we've seen.
-                    //
-                    // At the end of reading the entire previous input, `initial_values_multiset` must have exactly one of each record,
-                    // and furthermore, each key must be unique. We validate this property for sanity's sake, and build `current_values`.
-                    //
-                    // TODO[btv] This algorithm has the potential to use unbounded space if we can't make any assumptions
-                    // about Persist's level of compaction or the order in which it returns updates.
-                    // See the detailed discussion [here](https://materializeinc.slack.com/archives/C01CFKM1QRF/p1659063332027139).
-                    // This is thought to be fine for our current purposes, but we will need to rethink it once the Persist team has
-                    // thought harder about what guarantees/APIs they want to offer relating to bounded-memory consolidation.
-                    // Tracked here: https://github.com/MaterializeInc/materialize/issues/14086
-                    previous_input.for_each(|_cap, data| {
-                        data.swap(&mut repop_scratch_vector);
-                        initial_values_multiset.extend(
-                            repop_scratch_vector
-                                .drain(..)
-                                // filter out records at or past when we are resuming this operator from
-                                .filter(|(_d, t, _r)| !as_of_frontier.less_equal(t))
-                                .map(|(d, _t, r)| (d, r)),
-                        );
+                    // This could be done with a BTree but since we don't need indexed access merge
+                    // sorting sorted batches is simpler.
+                    data.sort_unstable_by(|((_, a_order), a_ts, _), ((_, b_order), b_ts, _)| {
+                        a_ts.cmp(b_ts).then_with(|| a_order.cmp(b_order))
                     });
-                    if PartialOrder::less_equal(
-                        &AntichainRef::new(&as_of_frontier),
-                        &previous_input.frontier().frontier(),
-                    ) {
-                        // Prevent the persist source from continuing to operate.
-                        // Without this, we will re-download everything we upload, wasting tons of bandwidth.
-                        previous_token = None;
 
-                        let mut new_current_values = BTreeMap::new();
-                        for ((k, v), r) in initial_values_multiset.drain() {
-                            assert!(
-                                r == 1,
-                                "The upsert state should have exactly one value per key"
-                            );
+                    pending_batches.push(std::mem::take(data).into_iter().peekable());
+                }
+                AsyncEvent::Progress(upper) => {
+                    // From all the pending batches take the prefix that is not beyond upper and
+                    // produce the overall sorted iterator by merge sorting them.
+                    let mut commands = pending_batches
+                        .iter_mut()
+                        .map(|batch| batch.peeking_take_while(|(_, ts, _)| !upper.less_equal(ts)))
+                        .kmerge_by(|((_, a_order), a_ts, _), ((_, b_order), b_ts, _)| {
+                            a_ts.cmp(b_ts).then_with(|| a_order.cmp(b_order)).is_lt()
+                        })
+                        .peekable();
 
-                            // `current_values` will contain a `DataflowError`
-                            // for values, because those can result from
-                            // applying the MFP that we apply to values before
-                            // we store them. Technically, the MFP application
-                            // can result in an `EvalError`, and we already
-                            // potentially have `UpsertErrors`, and
-                            // `DataflowError` is the enum that wraps those two.
-                            let v = v.map_err(|err| EnvelopeError::Upsert(err).into());
+                    while let Some(((cmd, _order), ts, diff)) = commands.next() {
+                        assert!(diff > 0, "invalid upsert input");
 
-                            match new_current_values.entry(k) {
-                                Entry::Occupied(_oe) => {
-                                    panic!("The upsert state should have exactly one value per key")
+                        if let Some(((p, _), p_ts, _)) = commands.peek() {
+                            // Skip this command if the next one is for the same (time, key) pair.
+                            // This skips to the command with the latest offset, as sorted above.
+                            if p_ts == &ts && p.keyed(&key_indices) == cmd.keyed(&key_indices) {
+                                continue;
+                            }
+                        }
+
+                        match cmd {
+                            UpsertCommand::Insert(result) => {
+                                let new_cmd =
+                                    UpsertCommand::Insert(result.clone()).into_keyed(&key_indices);
+                                if let Some(old_cmd) = state.replace(new_cmd) {
+                                    let UpsertCommand::Insert(old_result) = old_cmd.command else {
+                                        // We only store insertions in the state set
+                                        unreachable!()
+                                    };
+                                    output_updates.push((old_result, ts.clone(), -1));
                                 }
-                                Entry::Vacant(ve) => {
-                                    ve.insert(v);
+                                output_updates.push((result, ts, 1));
+                            }
+                            UpsertCommand::Remove(result) => {
+                                let cmd = UpsertCommand::Remove(result).into_keyed(&key_indices);
+                                if let Some(old_cmd) = state.take(&cmd) {
+                                    let UpsertCommand::Insert(old_result) = old_cmd.command else {
+                                        // We only store insertions in the state set
+                                        unreachable!()
+                                    };
+                                    output_updates.push((old_result, ts, -1));
                                 }
                             }
                         }
-                        current_values = Some(new_current_values);
                     }
-                }
 
-                // Digest each input, reduce by presented timestamp.
-                data_input.for_each(|cap, data| {
-                    data.swap(&mut scratch_vector);
-                    process_new_data(
-                        &mut scratch_vector,
-                        &mut pending_values,
-                        &cap,
-                        &as_of_frontier,
-                    );
-                });
+                    // Retain batches that still have data
+                    pending_batches.retain_mut(|batch| batch.peek().is_some());
 
-                // Don't try to do anything if we aren't done building the `current_values` map.
-                // Any new data that comes in as we rehydrate `current_values` is just stored in
-                // memory in `pending_values` until we are ready to merge it into `current_values`.
-                let current_values = match &mut current_values {
-                    None => return,
-                    Some(x) => x,
-                };
-
-                let mut removed_times = Vec::new();
-                for (time, (cap, map)) in pending_values.iter_mut() {
-                    if data_input.frontier.less_equal(time) {
-                        // because this is a BTreeMap, the rest of the times in
-                        // the map will be greater than this time. So if the
-                        // input_frontier is less than or equal to this time,
-                        // it will be less than the times in the rest of the map
-                        break;
+                    output_handle
+                        .give_container(&output_cap, &mut output_updates)
+                        .await;
+                    if let Some(ts) = upper.as_option() {
+                        output_cap.downgrade(ts);
                     }
-                    process_pending_values_batch(
-                        time,
-                        cap,
-                        map,
-                        current_values,
-                        &mut row_packer,
-                        &mut dv,
-                        &upsert_envelope,
-                        &key_indices_sorted,
-                        &key_indices_map,
-                        &mut kdv,
-                        &predicates,
-                        &position_or,
-                        &mut removed_times,
-                        output,
-                    )
-                }
-                // Discard entries, capabilities for complete times.
-                for time in removed_times {
-                    pending_values.remove(&time);
-                }
-            }
-        },
-    );
-
-    result_stream
-}
-
-/// This function fills `pending_values` with new data
-/// from the timely operator input.
-///
-/// The given tuple contains key, value, a "position", and "metadata".
-// TODO(aljoscha): Turn this into a struct?
-fn process_new_data(
-    new_data: &mut Vec<(
-        (
-            (
-                Option<Result<Row, UpsertError>>,
-                Option<Result<Row, UpsertError>>,
-            ),
-            MzOffset,
-            Row,
-        ),
-        Timestamp,
-        Diff,
-    )>,
-    pending_values: &mut BTreeMap<
-        Timestamp,
-        (
-            Capability<Timestamp>,
-            BTreeMap<Option<Result<Row, UpsertError>>, UpsertSourceData>,
-        ),
-    >,
-    cap: &InputCapability<Timestamp>,
-    as_of_frontier: &Antichain<Timestamp>,
-) {
-    for (((key, new_value), new_position, metadata), mut time, diff) in new_data.drain(..) {
-        // TODO(petrosagg): any positive diff should be accepted
-        assert_eq!(
-            diff, 1,
-            "Upsert should only be used with append-only sources"
-        );
-
-        time.advance_by(as_of_frontier.borrow());
-
-        let entry = pending_values
-            .entry(time)
-            .or_insert_with(|| (cap.delayed(&time), BTreeMap::new()))
-            .1
-            .entry(key);
-
-        let new_entry = UpsertSourceData {
-            value: new_value.map(|res| res.map_err(Into::into)),
-            position: new_position,
-            // upsert sources don't have a column for this, so setting it to
-            // `None` is fine.
-            upstream_time_millis: None,
-            metadata,
-        };
-
-        match entry {
-            Entry::Occupied(mut e) => {
-                // If the time is equal, toss out the row with the
-                // lower offset
-                if e.get().position < new_position {
-                    e.insert(new_entry);
-                }
-            }
-            Entry::Vacant(e) => {
-                e.insert(new_entry);
-            }
-        }
-    }
-}
-
-/// This function processes a batch of ready (i.e. whose time is below the current
-/// input frontier) values and evaluate them against the intermediate upsert
-/// data (`current_values`) and output issues and retractions for the output timely
-/// stream. It is used exclusively by `upsert_core`
-fn process_pending_values_batch(
-    // The time, capability, and map of data at that time we
-    // are processing in this call.
-    time: &Timestamp,
-    cap: &mut Capability<Timestamp>,
-    map: &mut BTreeMap<Option<Result<Row, UpsertError>>, UpsertSourceData>,
-    // The current map of values we use to perform the upsert comparision
-    current_values: &mut BTreeMap<Option<Result<Row, UpsertError>>, Result<Row, DataflowError>>,
-    // A shared row used to pack new rows for evaluation and output
-    row_packer: &mut Row,
-    // A shared row used to build a Vec<Datum<'_>> for evaluation
-    dv: &mut DatumVec,
-    // Additional source properties used to correctly manage key-value pairs
-    upsert_envelope: &UpsertEnvelope,
-    // `key_indices` in `upsert_envelope`, but sorted
-    key_indices_sorted: &[usize],
-    // `key_indices` in `upsert_envelope`, but turned into a value index to
-    // key index map
-    key_indices_map: &BTreeMap<usize, usize>,
-    // A shared row used to build a Vec<Datum<'_>> for key thinning
-    kdv: &mut DatumVec,
-    // Additional information used to pre-evaluate predicates that reduces the output
-    // stream size
-    predicates: &[MirScalarExpr],
-    position_or: &[Option<usize>],
-    // An out parameter of times that must be removed from the `to_send` map
-    // as we are done processing them.
-    removed_times: &mut Vec<Timestamp>,
-    // The output handle to output processed values into the output timely stream.
-    output: &mut timely::dataflow::operators::generic::OutputHandle<
-        '_,
-        Timestamp,
-        (Result<Row, DataflowError>, Timestamp, Diff),
-        timely::dataflow::channels::pushers::tee::Tee<
-            Timestamp,
-            (Result<Row, DataflowError>, Timestamp, Diff),
-        >,
-    >,
-) {
-    let mut session = output.session(cap);
-    removed_times.push(time.clone());
-    for (key, data) in std::mem::take(map) {
-        // decode key and value, and apply predicates/projections to they combined key/value
-        if let Some(decoded_key) = key {
-            let (decoded_key, decoded_value): (_, Result<_, DataflowError>) =
-                match (decoded_key, data.value) {
-                    // Make sure that the value is also an Err if they key is an
-                    // Err. Otherwise, any decoding logic that would try and
-                    // work on this can get flustered.
-                    (Err(upsert_error), Some(_)) => (
-                        Err(upsert_error.clone()),
-                        Err(EnvelopeError::Upsert(upsert_error).into()),
-                    ),
-                    (Err(upsert_error), None) => (Err(upsert_error), Ok(None)),
-                    (Ok(decoded_key), None) => (Ok(decoded_key), Ok(None)),
-                    (Ok(decoded_key), Some(value)) => {
-                        let decoded_value = value
-                            .map_err(|err| EnvelopeError::Upsert(err).into())
-                            .and_then(|row| {
-                                build_datum_vec_for_evaluation(
-                                    dv,
-                                    &upsert_envelope.style,
-                                    &row,
-                                    &decoded_key,
-                                )
-                                .map_or(Ok(None), |mut datums| {
-                                    datums.extend(data.metadata.iter());
-                                    evaluate(&datums, predicates, position_or, row_packer)
-                                        .map_err(DataflowError::from)
-                                })
-                            });
-                        (Ok(decoded_key), decoded_value)
-                    }
-                };
-
-            // Turns Ok(None) into None, and others into Some(OK) and Some(Err).
-            // We store errors as well as non-None values, so that they can be
-            // retracted if new rows show up for the same key.
-            let new_value = decoded_value.transpose();
-
-            let old_value = if let Some(new_value) = &new_value {
-                // Thin out the row to not contain a copy of the
-                // key columns, cloning when need-be
-                let thinned_value = new_value
-                    .as_ref()
-                    .map(|full_row| thin(key_indices_sorted, full_row, row_packer))
-                    .map_err(|e| e.clone());
-                current_values
-                    .insert(Some(decoded_key.clone()), thinned_value)
-                    .map(|res| {
-                        res.map(|v| {
-                            rehydrate(
-                                key_indices_map,
-                                // The value is never `Ok`
-                                // unless the key is also
-                                decoded_key.as_ref().unwrap(),
-                                &v,
-                                row_packer,
-                                kdv,
-                            )
-                        })
-                    })
-            } else {
-                current_values
-                    // WIP: What to do about this?
-                    .remove(&Some(decoded_key.clone()))
-                    .map(|res| {
-                        res.map(|v| {
-                            rehydrate(
-                                key_indices_map,
-                                // The value is never `Ok`
-                                // unless the key is also
-                                decoded_key.as_ref().unwrap(),
-                                &v,
-                                row_packer,
-                                kdv,
-                            )
-                        })
-                    })
-            };
-
-            if let Some(old_value) = old_value {
-                // retract old value
-                session.give((old_value, cap.time().clone(), -1));
-            }
-            if let Some(new_value) = new_value {
-                // give new value
-                session.give((new_value, cap.time().clone(), 1));
-            }
-        } else {
-            // Special-case handling for NULL keys, which are encoded as `None`
-            // here. We expect to either have an error for the value, or `None`,
-            // which would retract a previous error.
-            //
-            // We don't encode a NULL-key error as an `Err` in the `key`, like
-            // we do for other errors, so that we can change the error when
-            // there are updates.
-            //
-            // When a newer NULL message comes in, say with a higher offset, it
-            // will replace the previous one. This way, we can also make
-            // NULL-key errors retractable without having to match the NULL-key
-            // error exactly, by making sure to emit a retraction for the last
-            // error we saw, when we see a NULL-value message (encoded as the
-            // value being `None`).
-            //
-            // NOTE: We could think about how we can fold this into the if
-            // branch.
-
-            let current_value = current_values.get(&None);
-
-            match data.value {
-                Some(Ok(_value)) => {
-                    panic!("got NULL key but some value that is not an error or NULL as well");
-                }
-                Some(Err(err)) => {
-                    if let Some(old_value) = current_value {
-                        // retract old value
-                        session.give((old_value.clone(), cap.time().clone(), -1));
-                    }
-                    let err = Err(EnvelopeError::Upsert(err).into());
-                    current_values.insert(None, err.clone());
-                    session.give((err, cap.time().clone(), 1));
-                }
-                None => {
-                    if let Some(old_value) = current_value {
-                        // retract old value
-                        session.give((old_value.clone(), cap.time().clone(), -1));
-
-                        current_values.remove(&None);
-                    }
+                    input_upper = upper;
                 }
             }
         }
-    }
-}
+    });
 
-fn build_datum_vec_for_evaluation<'row>(
-    dv: &'row mut DatumVec,
-    upsert_style: &UpsertStyle,
-    row: &'row Row,
-    key: &'row Row,
-) -> Option<DatumVecBorrow<'row>> {
-    let mut datums = dv.borrow();
-    match upsert_style {
-        UpsertStyle::Debezium { after_idx } => match row.iter().nth(*after_idx).unwrap() {
-            Datum::List(after) => {
-                datums.extend(after.iter());
-                Some(datums)
-            }
-            Datum::Null => None,
-            d => panic!("type error: expected record, found {:?}", d),
-        },
-        UpsertStyle::Default(_) => {
-            datums.extend(key.iter());
-            datums.extend(row.iter());
-            Some(datums)
-        }
-    }
-}
-
-/// `thin` uses information from the source description to find which indices in the row
-/// are keys and skip them. It requires that `key_indices` is sorted.
-fn thin(key_indices_sorted: &[usize], value: &Row, row_buf: &mut Row) -> Row {
-    let mut row_packer = row_buf.packer();
-    let values = &mut value.iter();
-    let mut next_idx = 0;
-    for &key_idx in key_indices_sorted {
-        // First, push the datums that are before `key_idx`
-        row_packer.extend(values.take(key_idx - next_idx));
-        // Then, skip this key datum
-        values.next().unwrap();
-        next_idx = key_idx + 1;
-    }
-    // Finally, push any columns after the last key index
-    row_packer.extend(values);
-
-    row_buf.clone()
-}
-
-/// `rehydrate` uses information from the source description to find which indices in the row
-/// are keys and add them back in in the right places. `key_indices` is a map
-/// from the each key-part's index in the value to its index in the key.
-fn rehydrate(
-    key_indices_map: &BTreeMap<usize, usize>,
-    key: &Row,
-    thinned_value: &Row,
-    row_buf: &mut Row,
-    kdv: &mut DatumVec,
-) -> Row {
-    let mut row_packer = row_buf.packer();
-    let values = &mut thinned_value.iter();
-
-    let mut key_datums = kdv.borrow();
-    key_datums.extend(key.iter());
-
-    let mut next_idx = 0;
-    let mut key_indices_iter = key_indices_map.iter().peekable();
-
-    while let Some((value_idx, key_idx)) = key_indices_iter.next() {
-        // First, push the datums that are before `key_idx`
-        row_packer.extend(values.take(*value_idx - next_idx));
-        // Then, push this key datum
-        row_packer.push(key_datums[*key_idx]);
-        next_idx = *value_idx + 1;
-    }
-    // Finally, push any columns after the last key index
-    row_packer.extend(values);
-    row_buf.clone()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_rehydrate_thin_first() {
-        let mut packer = Row::default();
-        let mut kdv = DatumVec::new();
-
-        let key_indices = vec![0];
-        let mut key_indices_sorted = key_indices.clone();
-        key_indices_sorted.sort_unstable();
-        let key_indices_map = key_indices
-            .iter()
-            .enumerate()
-            .map(|(idx, value_idx)| (*value_idx, idx))
-            .collect();
-        let key = Row::pack([Datum::String("key")]);
-
-        let thinned = Row::pack([Datum::String("two")]);
-
-        let rehydrated = rehydrate(&key_indices_map, &key, &thinned, &mut packer, &mut kdv);
-
-        assert_eq!(
-            rehydrated,
-            Row::pack([Datum::String("key"), Datum::String("two"),])
-        );
-
-        assert_eq!(thin(&key_indices_sorted, &rehydrated, &mut packer), thinned);
-    }
-
-    #[test]
-    fn test_rehydrate_thin_middle() {
-        let mut packer = Row::default();
-        let mut kdv = DatumVec::new();
-
-        let key_indices = vec![2];
-        let mut key_indices_sorted = key_indices.clone();
-        key_indices_sorted.sort_unstable();
-        let key_indices_map = key_indices
-            .iter()
-            .enumerate()
-            .map(|(idx, value_idx)| (*value_idx, idx))
-            .collect();
-        let key = Row::pack([Datum::String("key")]);
-
-        let thinned = Row::pack([
-            Datum::String("one"),
-            Datum::String("two"),
-            Datum::String("four"),
-        ]);
-
-        let rehydrated = rehydrate(&key_indices_map, &key, &thinned, &mut packer, &mut kdv);
-
-        assert_eq!(
-            rehydrated,
-            Row::pack([
-                Datum::String("one"),
-                Datum::String("two"),
-                Datum::String("key"),
-                Datum::String("four"),
-            ])
-        );
-
-        assert_eq!(thin(&key_indices_sorted, &rehydrated, &mut packer), thinned);
-    }
-
-    #[test]
-    fn test_rehydrate_thin_multiple() {
-        let mut packer = Row::default();
-        let mut kdv = DatumVec::new();
-
-        let key_indices = vec![2, 4];
-        let mut key_indices_sorted = key_indices.clone();
-        key_indices_sorted.sort_unstable();
-        let key_indices_map = key_indices
-            .iter()
-            .enumerate()
-            .map(|(idx, value_idx)| (*value_idx, idx))
-            .collect();
-        let key = Row::pack([Datum::String("key1"), Datum::String("key2")]);
-
-        let thinned = Row::pack([
-            Datum::String("one"),
-            Datum::String("two"),
-            Datum::String("four"),
-            Datum::String("six"),
-        ]);
-
-        let rehydrated = rehydrate(&key_indices_map, &key, &thinned, &mut packer, &mut kdv);
-
-        assert_eq!(
-            rehydrated,
-            Row::pack([
-                Datum::String("one"),
-                Datum::String("two"),
-                Datum::String("key1"),
-                Datum::String("four"),
-                Datum::String("key2"),
-                Datum::String("six"),
-            ])
-        );
-
-        assert_eq!(thin(&key_indices_sorted, &rehydrated, &mut packer), thinned);
-    }
-
-    #[test]
-    fn test_rehydrate_thin_unordered() {
-        let mut packer = Row::default();
-        let mut kdv = DatumVec::new();
-
-        // Note these are unordered
-        let key_indices = vec![4, 2];
-        let mut key_indices_sorted = key_indices.clone();
-        key_indices_sorted.sort_unstable();
-        let key_indices_map = key_indices
-            .iter()
-            .enumerate()
-            .map(|(idx, value_idx)| (*value_idx, idx))
-            .collect();
-
-        let key = Row::pack([Datum::String("key2"), Datum::String("key1")]);
-
-        let thinned = Row::pack([
-            Datum::String("one"),
-            Datum::String("two"),
-            Datum::String("four"),
-            Datum::String("six"),
-        ]);
-        let full = Row::pack([
-            Datum::String("one"),
-            Datum::String("two"),
-            Datum::String("key1"),
-            Datum::String("four"),
-            Datum::String("key2"),
-            Datum::String("six"),
-        ]);
-
-        assert_eq!(thin(&key_indices_sorted, &full, &mut packer), thinned);
-
-        assert_eq!(
-            rehydrate(&key_indices_map, &key, &thinned, &mut packer, &mut kdv),
-            full
-        );
-    }
-
-    #[test]
-    fn test_thin_end() {
-        let mut packer = Row::default();
-
-        let key_indices = vec![2];
-
-        assert_eq!(
-            thin(
-                &key_indices,
-                &Row::pack([
-                    Datum::String("one"),
-                    Datum::String("two"),
-                    Datum::String("key"),
-                ]),
-                &mut packer
-            ),
-            Row::pack([Datum::String("one"), Datum::String("two")]),
-        );
-    }
+    output.as_collection().map(|result| match result {
+        Ok(ok) => Ok(ok),
+        Err(err) => Err(DataflowError::from(EnvelopeError::Upsert(err))),
+    })
 }

--- a/test/cluster/upsert/02-after-clusterd-restart.td
+++ b/test/cluster/upsert/02-after-clusterd-restart.td
@@ -54,19 +54,19 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
 
 # Verify that the errors from before are still there
 ! SELECT * FROM upsert
-contains: Value error
-
-# Update the bad value
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema}
-{"id": 2} {"before": null, "after": {"row": {"id": 2, "creature": "cow"}}}
-
-# There is still an error, due to the bad key.
-! SELECT * FROM upsert
 contains: Key decode
 
 # Retract the bad key
 $ kafka-ingest format=bytes topic=dbzupsert key-format=bytes omit-value=true
 broken-key:
+
+# There is still an error, due to the bad key.
+! SELECT * FROM upsert
+contains: Value error
+
+# Update the bad value
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"id": 2} {"before": null, "after": {"row": {"id": 2, "creature": "cow"}}}
 
 > SELECT * FROM upsert
 id creature


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

The upsert operator had accumulated many changes over the years that
made it a lot more complicated than it needed to be.

This PR offers a cleanup of the upsert logic which dramatically reduces
the amount of code needed.


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

It's probably easier to read `upsert.rs` in its new form and disregard the diff altogether.
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
