### PR TITLE
Support passing in and setting the scheduler name in the pod spec

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -292,6 +292,9 @@ pub struct Args {
     /// The service orchestrator implementation to use.
     #[structopt(long, arg_enum, env = "ORCHESTRATOR")]
     orchestrator: OrchestratorKind,
+    /// Name of a non-default Kubernetes scheduler, if any.
+    #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SCHEDULER_NAME")]
+    orchestrator_kubernetes_scheduler_name: Option<String>,
     /// Labels to apply to all services created by the Kubernetes orchestrator
     /// in the form `KEY=VALUE`.
     #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_LABEL")]
@@ -654,6 +657,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 runtime
                     .block_on(KubernetesOrchestrator::new(KubernetesOrchestratorConfig {
                         context: args.orchestrator_kubernetes_context.clone(),
+                        scheduler_name: args.orchestrator_kubernetes_scheduler_name,
                         service_labels: args
                             .orchestrator_kubernetes_service_label
                             .into_iter()

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -122,6 +122,8 @@ pub struct KubernetesOrchestratorConfig {
     /// The name of a Kubernetes context to use, if the Kubernetes configuration
     /// is loaded from the local kubeconfig.
     pub context: String,
+    /// The name of a non-default Kubernetes scheduler to use, if any.
+    pub scheduler_name: Option<String>,
     /// Labels to install on every service created by the orchestrator.
     pub service_labels: BTreeMap<String, String>,
     /// Node selector to install on every service created by the orchestrator.
@@ -710,6 +712,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                     ..Default::default()
                 }],
                 node_selector: Some(node_selector),
+                scheduler_name: self.config.scheduler_name.clone(),
                 service_account: self.config.service_account.clone(),
                 affinity: Some(Affinity {
                     pod_anti_affinity: anti_affinity,


### PR DESCRIPTION
Support passing in and setting the scheduler name in the pod spec with a new argument for `--orchestrator-kuberntes-scheduler-name`.

### Motivation

  * This PR adds a known-desirable feature.

Resolves https://github.com/MaterializeInc/materialize/issues/18345

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
>[Nikhil] We could rig something up with cloudtest, but I think it’s probably not worth it, given that the long term plans is to switch to a mutating webhook, and if we do that we should probably just rip out this code.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  - Small enough to probably not need design doc. Design comment in slack at https://materializeinc.slack.com/archives/C04NJBBS42D/p1679521605569419
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
    - No proto mapping changes
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label. https://github.com/MaterializeInc/cloud/pull/5933
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - no user-facing behavior changes
