### PR TITLE
ci: Disable SQLancer Having in nightly

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -60,7 +60,7 @@ steps:
           - { value: cloud-canary }
           - { value: sqlsmith-2-joins }
           - { value: sqlsmith-explain }
-          #- { value: sqlancer-pqs }
+          - { value: sqlancer-pqs }
           - { value: sqlancer-norec }
           - { value: sqlancer-having }
           - { value: sqlancer-query-partitioning }
@@ -585,17 +585,18 @@ steps:
           composition: sqlsmith
           args: [--max-joins=15, --explain-only, --runtime=3300]
 
-  # TODO(def-) Seems not to work well yet
-  #- id: sqlancer-pqs
-  #  label: "SQLancer PQS"
-  #  artifact_paths: junit_*.xml
-  #  timeout_in_minutes: 58
-  #  agents:
-  #    queue: linux-x86_64
-  #  plugins:
-  #    - ./ci/plugins/mzcompose:
-  #        composition: sqlancer
-  #        args: [--runtime=3300, --oracle=PQS]
+  # TODO(def-) Reenable when figured out why no queries run
+  - id: sqlancer-pqs
+    label: "SQLancer PQS"
+    skip: true
+    artifact_paths: junit_*.xml
+    timeout_in_minutes: 58
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: sqlancer
+          args: [--runtime=3300, --oracle=PQS]
 
   - id: sqlancer-norec
     label: "SQLancer NoREC"
@@ -619,8 +620,10 @@ steps:
           composition: sqlancer
           args: [--runtime=3300, --oracle=QUERY_PARTITIONING]
 
+  # TODO(def-) Reenable when I have a SQLancer workaround for #18346
   - id: sqlancer-having
     label: "SQLancer Having"
+    skip: true
     artifact_paths: junit_*.xml
     timeout_in_minutes: 58
     agents:


### PR DESCRIPTION
I have seen ~4 failures of it, always seems to be #18346, so probably not worth looking into further failures of it for now.

I don't think it's realistic to block all expressions that can cause errors (overflow, division by zero, invalid regex, ...)

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
