### PR TITLE
Bump metrics interval from 10s to 60s

### DIFF
--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -496,7 +496,7 @@ where
             let orchestrator = Arc::clone(&self.orchestrator);
             let service_name = service_name.clone();
             async move {
-                const METRICS_INTERVAL: Duration = Duration::from_secs(10);
+                const METRICS_INTERVAL: Duration = Duration::from_secs(60);
 
                 // TODO[btv] -- I tried implementing a `watch_metrics` function,
                 // similar to `watch_services`, but it crashed due to


### PR DESCRIPTION
In preparation for indexing the metrics relation, we want to turn down the rate at which it's collected.

This should result in a straightforward 6x improvement in worst-case memory usage once we do turn on the index. It should also decrease Persist traffic by a similar amount.

### Motivation

Part of https://github.com/MaterializeInc/materialize/issues/18347
