### PR TITLE
ci: Reenable SQLancer Having and enable SQLancer PQS

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -585,10 +585,8 @@ steps:
           composition: sqlsmith
           args: [--max-joins=15, --explain-only, --runtime=3300]
 
-  # TODO(def-) Reenable when figured out why no queries run
   - id: sqlancer-pqs
     label: "SQLancer PQS"
-    skip: true
     artifact_paths: junit_*.xml
     timeout_in_minutes: 58
     agents:

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -620,10 +620,8 @@ steps:
           composition: sqlancer
           args: [--runtime=3300, --oracle=QUERY_PARTITIONING]
 
-  # TODO(def-) Reenable when I have a SQLancer workaround for #18346
   - id: sqlancer-having
     label: "SQLancer Having"
-    skip: true
     artifact_paths: junit_*.xml
     timeout_in_minutes: 58
     agents:


### PR DESCRIPTION
Should be fine with https://github.com/def-/sqlancer/commit/c96bdbe79465ac2414a5651affc54d9fce3258e8

Consequence of https://github.com/MaterializeInc/materialize/issues/18346

Also enabling PQS, these changes fixed it:
    https://github.com/sqlancer/sqlancer/commit/e22434b0d27389dd934b7b40f3552b31a8d48520
    https://github.com/sqlancer/sqlancer/commit/4fbd6f7b63cec53b3596c69e5099921daad1e0e2
    https://github.com/sqlancer/sqlancer/commit/6ccf40b6e47e93fda3672885c49bb4fe30f54ec5

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
