### PR TITLE
misc: use LLVM's continuous profiling mode for coverage

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -20,7 +20,7 @@ from urllib.parse import urlparse
 
 import psutil
 
-from materialize import ROOT, spawn, ui
+from materialize import ROOT, rustc_flags, spawn, ui
 from materialize.ui import UIError
 
 KNOWN_PROGRAMS = ["environmentd", "sqllogictest"]
@@ -268,7 +268,9 @@ def _build(args: argparse.Namespace, extra_programs: list[str] = []) -> int:
         features += ["tokio-console"]
         env["RUSTFLAGS"] = env.get("RUSTFLAGS", "") + " --cfg=tokio_unstable"
     if args.coverage:
-        env["RUSTFLAGS"] = env.get("RUSTFLAGS", "") + " -Cinstrument-coverage"
+        env["RUSTFLAGS"] = (
+            env.get("RUSTFLAGS", "") + " " + " ".join(rustc_flags.coverage)
+        )
     if args.features:
         features.extend(args.features.split(","))
     if features:

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -33,7 +33,7 @@ from typing import IO, Any, Dict, Iterable, Iterator, List, Optional, Sequence, 
 
 import yaml
 
-from materialize import cargo, git, spawn, ui, xcompile
+from materialize import cargo, git, rustc_flags, spawn, ui, xcompile
 from materialize.xcompile import Arch
 
 
@@ -230,9 +230,7 @@ class CargoBuild(CargoPreImage):
         self.rustflags = config.pop("rustflags", [])
         self.channel = None
         if rd.coverage:
-            self.rustflags += [
-                "-Cinstrument-coverage",
-            ]
+            self.rustflags += rustc_flags.coverage
         if len(self.bins) == 0 and len(self.examples) == 0:
             raise ValueError("mzbuild config is missing pre-build target")
 

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -196,7 +196,7 @@ class Composition:
                 # binaries.
                 config.setdefault("volumes", []).append(coverage_volume)
                 config.setdefault("environment", []).append(
-                    f"LLVM_PROFILE_FILE=/coverage/{name}-%p-%9m.profraw"
+                    f"LLVM_PROFILE_FILE=/coverage/{name}-%p-%9m%c.profraw"
                 )
 
         # Determine mzbuild specs and inject them into services accordingly.

--- a/misc/python/materialize/rustc_flags.py
+++ b/misc/python/materialize/rustc_flags.py
@@ -1,0 +1,23 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""rustc flags."""
+
+# Flags to enable code coverage.
+#
+# Note that because clusterd gets terminated by a signal in most
+# cases, it needs to use LLVM's continuous profiling mode, and though
+# the documentation is contradictory about this, on Linux this
+# requires the additional -runtime-counter-relocation flag or you'll
+# get errors of the form "__llvm_profile_counter_bias is undefined"
+# and no profiles will be written.
+coverage = [
+    "-Cinstrument-coverage",
+    "-Cllvm-args=-runtime-counter-relocation",
+]


### PR DESCRIPTION
Currently clusterd gets killed off by a signal when tests finish. Unfortunately, that means that libc's atexit handlers don't run, which would normally invoke __llvm_profile_write_file.

Continuous mode gets around this, but on Linux, this also requires passing -Cllvm-args=-runtime-counter-relocation to rustc otherwise LLVM's coverage code just bails:

  https://github.com/llvm/llvm-project/blob/0eabf59528f3c3f64923900cae740d9f26c45ae8/compiler-rt/lib/profile/InstrProfilingFile.c#L574

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

 * This PR adds a known-desirable feature: coverage for clusterd.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Bikeshedding opportunity: should `rustc_flags.py` be `rustc.py` or just part of something else?

Actual debate: whether it's better to solve this by handling SIGTERM in clusterd.  This is kind of a pain in the ass so I'm inclined to do this instead, but I am happy to entertain other arguments.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
