### PR TITLE
storage: increase reliability of ssh connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5224,11 +5224,28 @@ dependencies = [
  "dirs",
  "libc",
  "once_cell",
+ "openssh-mux-client",
  "shell-escape",
  "tempfile",
  "thiserror",
  "tokio",
  "tokio-pipe",
+]
+
+[[package]]
+name = "openssh-mux-client"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88eac793af6170bcd6d4f39c3b7ba3f4227cab5680d7189ba30f9d174600b75f"
+dependencies = [
+ "once_cell",
+ "sendfd",
+ "serde",
+ "ssh_format",
+ "thiserror",
+ "tokio",
+ "tokio-io-utility",
+ "typed-builder",
 ]
 
 [[package]]
@@ -6493,6 +6510,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sendfd"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604b71b8fc267e13bb3023a2c901126c8f349393666a6d98ac1ae5729b701798"
+dependencies = [
+ "libc",
+ "tokio",
+]
+
+[[package]]
 name = "sentry"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6899,6 +6926,15 @@ dependencies = [
  "sha2",
  "signature",
  "zeroize",
+]
+
+[[package]]
+name = "ssh_format"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8701239872766d43b8a5f9a560ff7f002b48064fadea87f44a70507069fb482"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -7360,6 +7396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-utility"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948d15bb5da6f565846828025df4d7b503df3890f0fcdb9a667de1c81bc1976"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7728,6 +7773,17 @@ dependencies = [
  "cfg-if",
  "rand",
  "static_assertions",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -14,7 +14,7 @@ mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-ssh-util = { path = "../ssh-util" }
 openssl = { version = "0.10.43", features = ["vendored"] }
-openssh = "0.9.8"
+openssh = { version = "0.9.8", default-features = false, features = ["native-mux"] }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }

--- a/src/ssh-util/Cargo.toml
+++ b/src/ssh-util/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = { version = "1.0.66" }
-openssh = "0.9.8"
+openssh = { version = "0.9.8", default-features = false, features = ["native-mux"] }
 openssl = { version = "0.10.43", features = ["vendored"] }
 rand = "0.8.5"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -360,7 +360,9 @@ impl KafkaConnection {
 
                     context.add_broker_rewrite_with_token(
                         &broker.address,
-                        "localhost",
+                        // This should never be `"localhost"`, as that causes reliability
+                        // problems, _probably_ related to resolving to ipv6.
+                        "127.0.0.1",
                         Some(local_port),
                         // Note, this does double-boxing, but its only relevant during dropping,
                         // so not a performance problem.


### PR DESCRIPTION
See this thread: https://materializeinc.slack.com/archives/C04DJT084KA/p1679595366360079. Originally found in: https://github.com/MaterializeInc/materialize/pull/16158

Its likely that the most important change here is switching off of `"localhost"`, as @benesch and I suspect that there is some ipv6 resolution problems going on here, but this pr also includes changing to the native-mux-impl, and ensuring that the ssh tunnel is actually connectable after its created.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
