### PR TITLE
docs: fix architecture overview link

### DIFF
--- a/doc/developer/README.md
+++ b/doc/developer/README.md
@@ -14,7 +14,7 @@ user documentation, if you haven't already:
 
   1. [Get Started](https://materialize.com/docs/get-started/)
   2. [What Is Materialized?](https://materialize.com/docs/overview/what-is-materialize/)
-  3. [Architecture Overview](platform/architecture-db.md)
+  3. [Architecture Overview](https://materialize.com/blog/materialize-architecture/)
 
 Then, once you're up to speed, dive into the [developer guide](guide.md). The
 guide is intended to be skimmed from start to finish, to give you the lay of the


### PR DESCRIPTION
In #18369, I fixed a broken "Architecture Overview" link in the developer reader. However, the page I linked to is out-of-date, so this PR changes the link to point at an up-to-date blog post.
