### PR TITLE
Make replica IDs strings in the system tables

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -64,7 +64,7 @@ The `mz_cluster_replicas` table contains a row for each cluster replica in the s
 
 Field               | Type      | Meaning
 --------------------|-----------|--------
-`id`                | [`uint8`] | Materialize's unique ID for the cluster replica.
+`id`                | [`text`]  | Materialize's unique ID for the cluster replica.
 `name`              | [`text`]  | The name of the cluster replica.
 `cluster_id`        | [`text`]  | The ID of the cluster to which the replica belongs. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters).
 `size`              | [`text`]  | The cluster replica's size, selected during creation.

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -52,7 +52,7 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 
 Field              | Type       | Meaning
 -------------------|------------|--------
-`replica_id`       | [`bigint`] | The ID of a cluster replica.
+`replica_id`       | [`text`]   | The ID of a cluster replica.
 `process_id`       | [`bigint`] | An identifier of a compute process within a replica.
 `cpu_nano_cores`   | [`bigint`] | Approximate CPU usage, in billionths of a vCPU core.
 `memory_bytes`     | [`bigint`] | Approximate RAM usage, in bytes.
@@ -102,7 +102,7 @@ of each process in each cluster replica in the system.
 
 Field               | Type                          | Meaning
 --------------------|-------------------------------|--------
-`replica_id`        | [`uint8`]                     | Materialize's unique ID for the cluster replica.
+`replica_id`        | [`text`]                      | Materialize's unique ID for the cluster replica.
 `process_id`        | [`uint8`]                     | The ID of the process within the cluster replica.
 `status`            | [`text`]                      | The status of the cluster replica: `ready` or `not-ready`.
 `updated_at`        | [`timestamp with time zone`]  | The time at which the status was last updated.
@@ -116,7 +116,7 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 
 | Field            | Type      | Meaning                                                    |
 |------------------|-----------|------------------------------------------------------------|
-| `replica_id`     | [`uint8`] | The ID of a cluster replica.                               |
+| `replica_id`     | [`text`]  | The ID of a cluster replica.                               |
 | `process_id`     | [`uint8`] | An identifier of a compute process within a replica.       |
 | `cpu_percent`    | [`uint8`] | Approximate CPU usage, in percent of the total allocation. |
 | `memory_percent` | [`uint8`] | Approximate RAM usage, in percent of the total allocation. |
@@ -242,7 +242,7 @@ At this time, we do not make any guarantees about the freshness of these numbers
 
 Field        | Type       | Meaning
 -------------|------------|--------
-`replica_id` | [`bigint`] | The ID of a cluster replica.
+`replica_id` | [`text`]   | The ID of a cluster replica.
 `export_id ` | [`text`]   | The ID of the index, materialized view, or subscription that created the dataflow. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports).
 `time`       | [`mz_timestamp`] | The next timestamp at which the output may change.
 

--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -314,3 +314,21 @@ class K8sSecret(K8sResource):
         core_v1_api.create_namespaced_secret(
             body=self.secret, namespace=self.namespace()  # type: ignore
         )
+
+
+def cluster_pod_name(cluster_id: str, replica_id: str, process: int = 0) -> str:
+    # Replica IDs now appear as `GlobalId`s in `mz_cluster_replicas`, while
+    # the pod names still contain only the numeric ID.
+    # TODO(teskje): Change pod names to contain the replica `GlobalId`.
+    replica_id = replica_id.lstrip("u")
+
+    return f"pod/cluster-{cluster_id}-replica-{replica_id}-{process}"
+
+
+def cluster_service_name(cluster_id: str, replica_id: str) -> str:
+    # Replica IDs now appear as `GlobalId`s in `mz_cluster_replicas`, while
+    # the pod names still contain only the numeric ID.
+    # TODO(teskje): Change pod names to contain the replica `GlobalId`.
+    replica_id = replica_id.lstrip("u")
+
+    return f"service/cluster-{cluster_id}-replica-{replica_id}"

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1641,7 +1641,7 @@ pub static MZ_CLUSTER_REPLICAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replicas",
     schema: MZ_CATALOG_SCHEMA,
     desc: RelationDesc::empty()
-        .with_column("id", ScalarType::UInt64.nullable(false))
+        .with_column("id", ScalarType::String.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("cluster_id", ScalarType::String.nullable(false))
         .with_column("size", ScalarType::String.nullable(true))
@@ -1654,7 +1654,7 @@ pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| Builti
     name: "mz_cluster_replica_statuses",
     schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
-        .with_column("replica_id", ScalarType::UInt64.nullable(false))
+        .with_column("replica_id", ScalarType::String.nullable(false))
         .with_column("process_id", ScalarType::UInt64.nullable(false))
         .with_column("status", ScalarType::String.nullable(false))
         .with_column("updated_at", ScalarType::TimestampTz.nullable(false)),
@@ -1677,7 +1677,7 @@ pub static MZ_CLUSTER_REPLICA_HEARTBEATS: Lazy<BuiltinTable> = Lazy::new(|| Buil
     name: "mz_cluster_replica_heartbeats",
     schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
-        .with_column("replica_id", ScalarType::UInt64.nullable(false))
+        .with_column("replica_id", ScalarType::String.nullable(false))
         .with_column("last_heartbeat", ScalarType::TimestampTz.nullable(false)),
     is_retained_metrics_relation: false,
 });
@@ -1795,7 +1795,7 @@ pub static MZ_CLUSTER_REPLICA_METRICS: Lazy<BuiltinTable> = Lazy::new(|| Builtin
     // the corresponding Storage tables.
     schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
-        .with_column("replica_id", ScalarType::UInt64.nullable(false))
+        .with_column("replica_id", ScalarType::String.nullable(false))
         .with_column("process_id", ScalarType::UInt64.nullable(false))
         .with_column("cpu_nano_cores", ScalarType::UInt64.nullable(true))
         .with_column("memory_bytes", ScalarType::UInt64.nullable(true)),
@@ -1806,7 +1806,7 @@ pub static MZ_CLUSTER_REPLICA_FRONTIERS: Lazy<BuiltinTable> = Lazy::new(|| Built
     name: "mz_cluster_replica_frontiers",
     schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
-        .with_column("replica_id", ScalarType::UInt64.nullable(false))
+        .with_column("replica_id", ScalarType::String.nullable(false))
         .with_column("export_id", ScalarType::String.nullable(false))
         .with_column("time", ScalarType::MzTimestamp.nullable(false)),
     is_retained_metrics_relation: false,

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -13,6 +13,7 @@ use bytesize::ByteSize;
 use chrono::{DateTime, Utc};
 
 use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent, VersionedStorageUsage};
+use mz_compute_client::controller::NewReplicaId;
 use mz_controller::clusters::{
     ClusterId, ClusterStatus, ManagedReplicaLocation, ProcessId, ReplicaAllocation, ReplicaId,
     ReplicaLocation,
@@ -203,10 +204,13 @@ impl CatalogState {
             ReplicaLocation::Unmanaged(_) => (None, None),
         };
 
+        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
+        let id = NewReplicaId::User(id);
+
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICAS),
             row: Row::pack_slice(&[
-                Datum::UInt64(id),
+                Datum::String(&id.to_string()),
                 Datum::String(name),
                 Datum::String(&cluster_id.to_string()),
                 Datum::from(size),
@@ -247,10 +251,13 @@ impl CatalogState {
             ClusterStatus::NotReady => "not-ready",
         };
 
+        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
+        let replica_id = NewReplicaId::User(replica_id);
+
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_STATUSES),
             row: Row::pack_slice(&[
-                Datum::UInt64(replica_id),
+                Datum::String(&replica_id.to_string()),
                 Datum::UInt64(process_id),
                 Datum::String(status),
                 Datum::TimestampTz(event.time.try_into().expect("must fit")),
@@ -1014,14 +1021,15 @@ impl CatalogState {
         last_heartbeat: DateTime<Utc>,
         diff: Diff,
     ) -> BuiltinTableUpdate {
-        let table = self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_HEARTBEATS);
-        let row = Row::pack_slice(&[
-            Datum::UInt64(id),
-            Datum::TimestampTz(last_heartbeat.try_into().expect("must fit")),
-        ]);
+        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
+        let id = NewReplicaId::User(id);
+
         BuiltinTableUpdate {
-            id: table,
-            row,
+            id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_HEARTBEATS),
+            row: Row::pack_slice(&[
+                Datum::String(&id.to_string()),
+                Datum::TimestampTz(last_heartbeat.try_into().expect("must fit")),
+            ]),
             diff,
         }
     }
@@ -1057,6 +1065,10 @@ impl CatalogState {
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let id = self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_METRICS);
+
+        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
+        let replica_id = NewReplicaId::User(replica_id);
+
         let rows = updates.iter().enumerate().map(
             |(
                 process_id,
@@ -1066,7 +1078,7 @@ impl CatalogState {
                 },
             )| {
                 Row::pack_slice(&[
-                    replica_id.into(),
+                    Datum::String(&replica_id.to_string()),
                     u64::cast_from(process_id).into(),
                     (*cpu_nano_cores).into(),
                     (*memory_bytes).into(),
@@ -1121,9 +1133,13 @@ impl CatalogState {
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let id = self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_FRONTIERS);
+
+        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
+        let replica_id = NewReplicaId::User(replica_id);
+
         let rows = updates.into_iter().map(|(coll_id, time)| {
             Row::pack_slice(&[
-                replica_id.into(),
+                Datum::String(&replica_id.to_string()),
                 Datum::String(&coll_id.to_string()),
                 Datum::MzTimestamp(*time),
             ])

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -30,6 +30,7 @@
 //! recover each dataflow to its current state in case of failure or other reconfiguration.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 use std::num::NonZeroI64;
 use std::time::Duration;
 
@@ -77,6 +78,22 @@ pub type ComputeInstanceId = StorageInstanceId;
 
 /// Identifier of a replica.
 pub type ReplicaId = u64;
+
+/// Identifier of a replica.
+// TODO(#18377): Replace `ReplicaId` with this type.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum NewReplicaId {
+    /// A user replica.
+    User(u64),
+}
+
+impl fmt::Display for NewReplicaId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::User(id) => write!(f, "u{}", id),
+        }
+    }
+}
 
 /// Responses from the compute controller.
 #[derive(Debug)]

--- a/test/cloudtest/test_antiaffinity.py
+++ b/test/cloudtest/test_antiaffinity.py
@@ -10,6 +10,7 @@
 import pytest
 
 from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.k8s import cluster_pod_name
 from materialize.cloudtest.wait import wait
 
 
@@ -27,12 +28,13 @@ def zones_used(mz: MaterializeApplication) -> int:
         )[0]
         assert replica_id is not None
 
-        cluster_pod_name = f"cluster-{cluster_id}-replica-{replica_id}-0"
+        cluster_pod = cluster_pod_name(cluster_id, replica_id)
 
-        wait(condition="condition=Ready", resource=f"pod/{cluster_pod_name}")
+        wait(condition="condition=Ready", resource=cluster_pod)
 
         compute_pod = mz.environmentd.api().read_namespaced_pod(
-            cluster_pod_name, mz.environmentd.namespace()
+            cluster_pod.removeprefix("pod/"),
+            mz.environmentd.namespace(),
         )
         spec = compute_pod.spec
         assert spec is not None

--- a/test/cloudtest/test_compute.py
+++ b/test/cloudtest/test_compute.py
@@ -12,6 +12,7 @@ from pg8000.exceptions import InterfaceError
 
 from materialize.cloudtest.application import MaterializeApplication
 from materialize.cloudtest.exists import exists, not_exists
+from materialize.cloudtest.k8s import cluster_pod_name, cluster_service_name
 from materialize.cloudtest.wait import wait
 
 
@@ -33,7 +34,7 @@ def test_cluster_sizing(mz: MaterializeApplication) -> None:
     assert replica_id is not None
 
     for compute_id in range(0, SIZE):
-        compute_pod = f"pod/cluster-{cluster_id}-replica-{replica_id}-{compute_id}"
+        compute_pod = cluster_pod_name(cluster_id, replica_id, compute_id)
         wait(condition="condition=Ready", resource=compute_pod)
 
     mz.environmentd.sql("DROP CLUSTER sized1 CASCADE")
@@ -77,11 +78,11 @@ def test_cluster_shutdown(mz: MaterializeApplication, failpoint: str) -> None:
         )[0][0]
         assert replica_id is not None
 
-        compute_pod = f"pod/cluster-{cluster_id}-replica-{replica_id}-0"
+        compute_pod = cluster_pod_name(cluster_id, replica_id)
         compute_pods[replica_name] = compute_pod
         wait(condition="condition=Ready", resource=compute_pod)
 
-        compute_svc = f"service/cluster-{cluster_id}-replica-{replica_id}"
+        compute_svc = cluster_service_name(cluster_id, replica_id)
         compute_svcs[replica_name] = compute_svc
         exists(resource=compute_svc)
 

--- a/test/cloudtest/test_compute_shared_fate.py
+++ b/test/cloudtest/test_compute_shared_fate.py
@@ -12,6 +12,7 @@ import time
 from textwrap import dedent
 
 from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.k8s import cluster_pod_name
 
 CLUSTER_SIZE = 8
 
@@ -94,7 +95,7 @@ def kill_clusterd(
         f"SELECT cluster_id, id FROM mz_cluster_replicas WHERE name = 'shared_fate_replica'"
     )[0]
 
-    pod_name = f"pod/cluster-{cluster_id}-replica-{replica_id}-{compute_id}"
+    pod_name = cluster_pod_name(cluster_id, replica_id, compute_id)
 
     print(f"sending signal {signal} to pod {pod_name}...")
 

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -14,6 +14,7 @@ from kubernetes.client import V1Pod, V1StatefulSet
 from pg8000.exceptions import InterfaceError
 
 from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.k8s import cluster_pod_name
 from materialize.cloudtest.wait import wait
 
 
@@ -88,7 +89,7 @@ def test_crash_storage(mz: MaterializeApplication) -> None:
     [cluster_id, replica_id] = mz.environmentd.sql_query(
         f"SELECT s.cluster_id, r.id FROM mz_sources s JOIN mz_cluster_replicas r ON r.cluster_id = s.cluster_id WHERE s.name = 's1'"
     )[0]
-    pod_name = f"pod/cluster-{cluster_id}-replica-{replica_id}-0"
+    pod_name = cluster_pod_name(cluster_id, replica_id)
 
     wait(condition="jsonpath={.status.phase}=Running", resource=pod_name)
     mz.kubectl("exec", pod_name, "--", "bash", "-c", "kill -9 `pidof clusterd` || true")

--- a/test/cloudtest/test_storage_shared_fate.py
+++ b/test/cloudtest/test_storage_shared_fate.py
@@ -12,6 +12,7 @@ import time
 from textwrap import dedent
 
 from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.k8s import cluster_pod_name
 
 CLUSTER_SIZE = 8
 NUM_SOURCES = 4
@@ -128,7 +129,7 @@ def kill_clusterd(
         f"SELECT cluster_id, id FROM mz_cluster_replicas WHERE name = 'storage_shared_fate_replica'"
     )[0]
 
-    pod_name = f"pod/cluster-{cluster_id}-replica-{replica_id}-{compute_id}"
+    pod_name = cluster_pod_name(cluster_id, replica_id, compute_id)
 
     print(f"sending signal {signal} to pod {pod_name}...")
 


### PR DESCRIPTION
This commit changes the type of replica IDs in system tables (i.e. `mz_cluster_replicas.id` and foreign keys referencing that column) to a string in `GlobalId` format.

The intention of this is to prepare for a later introduction of system replicas, which can be marked as such by having a system `GlobalId`.

The change is intentionally kept as small as possible to be easily revertable in case we discover during the release that customers have created last-minute dependencies on `mz_cluster_replicas`. For this reason, actually using `GlobalId` as the type for replica IDs throughout the code is left as future work.

### Blockers

* [ ] https://github.com/MaterializeInc/console/pull/72

### Motivation

  * This PR adds a known-desirable feature.

Advances https://github.com/MaterializeInc/materialize/issues/18377.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - The type of replica IDs in the system catalog is changed from an integer to a string. The affected columns are:
      - `mz_catalog.mz_cluster_replicas.id`
      - `mz_internal.mz_cluster_replica_statuses.replica_id`
      - `mz_internal.mz_cluster_replica_heartbeats.replica_id`
      - `mz_internal.mz_cluster_replica_metrics.replica_id`
      - `mz_internal.mz_cluster_replica_frontiers.replica_id`
