### PR TITLE
Bump openssl to version 0.10.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chrono"
 version = "0.4.24"
-source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#daa86a77d36d74f474913fd3b560a40f1424bd77"
+source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#1f1e2f8ff0e166ffd80ae95218a80b54fe26e003"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -5233,9 +5233,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.43"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -5274,9 +5274,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 native-tls = "0.2.11"
-openssl = { version = "0.10.43", features = ["vendored"] }
+openssl = { version = "0.10.48", features = ["vendored"] }
 reqwest = { version = "0.11.13", features = ["blocking", "json", "native-tls-vendored"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"

--- a/src/ccsr/src/tls.rs
+++ b/src/ccsr/src/tls.rs
@@ -38,15 +38,17 @@ impl Identity {
         for cert in cert_iter {
             certs.push(cert)?;
         }
-        let mut pkcs_builder = Pkcs12::builder();
-        pkcs_builder.ca(certs);
         // We build a PKCS #12 archive solely to have something to pass to
         // `reqwest::Identity::from_pkcs12_der`, so the password and friendly
         // name don't matter.
         let pass = String::new();
         let friendly_name = "";
-        let der = pkcs_builder
-            .build(&pass, friendly_name, &pkey, &cert)?
+        let der = Pkcs12::builder()
+            .name(friendly_name)
+            .pkey(&pkey)
+            .cert(&cert)
+            .ca(certs)
+            .build2(&pass)?
             .to_der()?;
         Ok(Identity { der, pass })
     }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -58,7 +58,7 @@ mz-stash = { path = "../stash" }
 mz-storage-client = { path = "../storage-client" }
 nix = "0.26.1"
 num_cpus = "1.14.0"
-openssl = { version = "0.10.43", features = ["vendored"] }
+openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
 opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", features = ["rt-tokio", "trace"] }
 prometheus = { version = "0.13.3", default-features = false }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -24,7 +24,7 @@ either = "1.8.0"
 futures = { version = "0.3.25", optional = true }
 once_cell = "1.16.0"
 # The vendored feature is transitively depended upon by tokio-openssl.
-openssl = { version = "0.10.43", features = ["vendored"], optional = true }
+openssl = { version = "0.10.48", features = ["vendored"], optional = true }
 paste = "1.0.11"
 pin-project = "1.0.12"
 prometheus = { version = "0.13.3", default-features = false, optional = true }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -38,7 +38,7 @@ mz-aws-s3-util = { path = "../aws-s3-util" }
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async"] }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
-openssl = { version = "0.10.43", features = ["vendored"] }
+openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 prometheus = { version = "0.13.3", default-features = false }

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -22,7 +22,7 @@ mz-pgcopy = { path = "../pgcopy" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-repr = { path = "../repr" }
 mz-sql = { path = "../sql" }
-openssl = { version = "0.10.43", features = ["vendored"] }
+openssl = { version = "0.10.48", features = ["vendored"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio = "1.24.2"
 tokio-openssl = "0.6.3"

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -13,7 +13,7 @@ mz-ore = { path = "../ore", features = ["async"] }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-ssh-util = { path = "../ssh-util" }
-openssl = { version = "0.10.43", features = ["vendored"] }
+openssl = { version = "0.10.48", features = ["vendored"] }
 openssh = "0.9.8"
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}

--- a/src/ssh-util/Cargo.toml
+++ b/src/ssh-util/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = { version = "1.0.66" }
 openssh = "0.9.8"
-openssl = { version = "0.10.43", features = ["vendored"] }
+openssl = { version = "0.10.48", features = ["vendored"] }
 rand = "0.8.5"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -64,8 +64,8 @@ nom = { version = "7.1.2" }
 num-bigint = { version = "0.4.3" }
 num-integer = { version = "0.1.44", features = ["i128"] }
 num-traits = { version = "0.2.15", features = ["i128"] }
-openssl = { version = "0.10.43", features = ["vendored"] }
-openssl-sys = { version = "0.9.80", default-features = false, features = ["vendored"] }
+openssl = { version = "0.10.48", features = ["vendored"] }
+openssl-sys = { version = "0.9.83", default-features = false, features = ["vendored"] }
 ordered-float = { version = "3.4.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 phf = { version = "0.11.1", features = ["uncased"] }
@@ -162,8 +162,8 @@ nom = { version = "7.1.2" }
 num-bigint = { version = "0.4.3" }
 num-integer = { version = "0.1.44", features = ["i128"] }
 num-traits = { version = "0.2.15", features = ["i128"] }
-openssl = { version = "0.10.43", features = ["vendored"] }
-openssl-sys = { version = "0.9.80", default-features = false, features = ["vendored"] }
+openssl = { version = "0.10.48", features = ["vendored"] }
+openssl-sys = { version = "0.9.83", default-features = false, features = ["vendored"] }
 ordered-float = { version = "3.4.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 phf = { version = "0.11.1", features = ["uncased"] }


### PR DESCRIPTION
This is to avoid the recently reported security issues:
* https://rustsec.org/advisories/RUSTSEC-2023-0022
* https://rustsec.org/advisories/RUSTSEC-2023-0023
* https://rustsec.org/advisories/RUSTSEC-2023-0024

### Motivation

* This PR addresses a security advisory.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
