### PR TITLE
Revert "storage: finalize persist shards when their collections drop"

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -2050,31 +2050,9 @@ where
             Some(StorageResponse::FrontierUppers(updates)) => {
                 self.update_write_frontiers(&updates);
             }
-            Some(StorageResponse::DroppedIds(ids)) => {
-                // TODO(petrosagg): It looks like the storage controller never
-                // cleans up GlobalIds from its state. It should probably be
-                // done as a reaction to this response. Note that this should
-                // not be done until we know for certain that the shards
-                // associated with this ID are finalized.
-
-                let shards_to_finalize: Vec<_> = ids
-                    .into_iter()
-                    .filter_map(|id| {
-                        self.state.collections.get(&id).map(
-                            |CollectionState {
-                                 collection_metadata: CollectionMetadata { data_shard, .. },
-                                 ..
-                             }| *data_shard,
-                        )
-                    })
-                    .collect();
-
-                // Ensure we don't leak any shards by tracking all of them we intend to
-                // finalize.
-                self.register_shards_for_finalization(shards_to_finalize.iter().cloned())
-                    .await;
-
-                self.finalize_shards(shards_to_finalize).await;
+            Some(StorageResponse::DroppedIds(_ids)) => {
+                // TODO(petrosagg): It looks like the storage controller never cleans up GlobalIds
+                // from its state. It should probably be done as a reaction to this response.
             }
             Some(StorageResponse::StatisticsUpdates(source_stats, sink_stats)) => {
                 // Note we only hold the locks while moving some plain-old-data around here.
@@ -2702,7 +2680,7 @@ where
         let this = &*self;
 
         use futures::stream::StreamExt;
-        let finalized_shards: BTreeSet<ShardId> = futures::stream::iter(shards)
+        let finalized_shards: BTreeSet<_> = futures::stream::iter(shards)
             .map(|shard_id| async move {
                 let (mut write, mut critical_since_handle) = this
                     .open_data_handles(
@@ -2736,25 +2714,14 @@ where
                         .expect("failed to connect")
                         .expect("failed to truncate write handle");
                 }
-
-                // We only want to  clear shards from the finalization register
-                // if the since if actually empty.
-                if critical_since_handle.since().is_empty() {
-                    Some(shard_id)
-                } else {
-                    // TODO: periodically check shards that have not been successfully finalized.
-                    None
-                }
+                shard_id
             })
             // Poll each future for each collection concurrently, maximum of 10 at a time.
             .buffer_unordered(10)
             // HERE BE DRAGONS: see warning on other uses of buffer_unordered
             // before any changes to `collect`
-            .collect::<BTreeSet<Option<ShardId>>>()
-            .await
-            .into_iter()
-            .filter_map(|shard| shard)
-            .collect();
+            .collect()
+            .await;
 
         self.clear_from_shard_finalization_register(finalized_shards)
             .await;


### PR DESCRIPTION
This reverts commit 94801732b9d03f0351d2dbf7cb6e6c54e256cc35.

@philip-stoev bisected failures in #18378 and determined it's this commit; we just need to come up with another approach for sealing shards from writes or make sinks more robust to this state.

### Motivation

 This PR fixes a recognized bug. Fixes #18378

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
