### PR TITLE
Rework `fold_constants` so it is `recursion_safe`

### DIFF
--- a/src/transform/src/fold_constants.rs
+++ b/src/transform/src/fold_constants.rs
@@ -32,6 +32,10 @@ pub struct FoldConstants {
 }
 
 impl crate::Transform for FoldConstants {
+    fn recursion_safe(&self) -> bool {
+        true
+    }
+
     #[tracing::instrument(
         target = "optimizer"
         level = "trace",
@@ -80,9 +84,9 @@ impl FoldConstants {
         match relation {
             MirRelationExpr::Constant { .. } => { /* handled after match */ }
             MirRelationExpr::Get { .. } => {}
-            MirRelationExpr::Let { .. } => { /* constant prop done in NormalizeLets */ }
-            MirRelationExpr::LetRec { .. } => {
-                Err(crate::TransformError::LetRecUnsupported)?;
+            MirRelationExpr::Let { .. } | MirRelationExpr::LetRec { .. } => {
+                // Constant propagation through bindings is currently handled by in NormalizeLets.
+                // Maybe we should move it / replicate it here (see #18180 for context)?
             }
             MirRelationExpr::Reduce {
                 input,

--- a/src/transform/src/fusion/mod.rs
+++ b/src/transform/src/fusion/mod.rs
@@ -18,7 +18,7 @@ pub mod reduce;
 pub mod top_k;
 pub mod union;
 
-use crate::TransformArgs;
+use crate::{all, TransformArgs};
 use mz_expr::MirRelationExpr;
 
 /// Fuses multiple like operators together when possible.
@@ -27,7 +27,15 @@ pub struct Fusion;
 
 impl crate::Transform for Fusion {
     fn recursion_safe(&self) -> bool {
-        true
+        // Keep this in sync with the actions called in `Fusion::action`!
+        all![
+            filter::Filter.recursion_safe(),
+            map::Map.recursion_safe(),
+            project::Project.recursion_safe(),
+            negate::Negate.recursion_safe(),
+            top_k::TopK.recursion_safe(),
+            union::Union.recursion_safe(),
+        ]
     }
 
     #[tracing::instrument(

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -135,6 +135,20 @@ use mz_ore::stack::RecursionLimitError;
 #[macro_use]
 extern crate num_derive;
 
+/// Compute the conjunction of a variadic number of expressions.
+#[macro_export]
+macro_rules! all {
+    ($x:expr) => ($x);
+    ($($x:expr,)+) => ( $($x)&&+ )
+}
+
+/// Compute the disjunction of a variadic number of expressions.
+#[macro_export]
+macro_rules! any {
+    ($x:expr) => ($x);
+    ($($x:expr,)+) => ( $($x)||+ )
+}
+
 /// Arguments that get threaded through all transforms.
 #[derive(Debug)]
 pub struct TransformArgs<'a> {
@@ -359,6 +373,10 @@ impl Default for FuseAndCollapse {
 }
 
 impl Transform for FuseAndCollapse {
+    fn recursion_safe(&self) -> bool {
+        self.transforms.iter().all(|t| t.recursion_safe())
+    }
+
     #[tracing::instrument(
         target = "optimizer"
         level = "trace",

--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -10,6 +10,9 @@
 statement ok
 CREATE VIEW billion AS SELECT * FROM generate_series(0, 999) AS x, generate_series(0, 999) AS y, generate_series(0, 999) AS z;
 
+statement ok
+CREATE TABLE edges(src INTEGER NOT NULL, dst INTEGER NOT NULL);
+
 # Test that this query doesn't compute the answer entirely as a constant
 # (as the way that works currently would require a huge memory blowup).
 #
@@ -51,3 +54,95 @@ CREATE TABLE t2 (f1 int, f2 int);
 query IIIRR
 SELECT  (a1.f1) AS c1, (a2.f1) AS c2, (a1.f2) AS c3, (MIN ( 4 )) AS agg1 , (AVG ( a1 . f2 + 4 )) AS agg2 FROM ( SELECT a1 . f2 + 4 AS f1 , a2 . f2 AS f2 FROM t1 AS a1  JOIN t2 AS a2 ON ( a1 . f1 = a1 . f2 + 8 ) WHERE a1 . f1 + a1 . f2 < a2 . f2 + a1 . f2 AND NOT ( NOT ( a2 . f2 IS NOT NULL ) ) ORDER BY 1 , 2 LIMIT 4  ) AS a1  JOIN ( SELECT AVG ( a2 . f2 + a2 . f2 ) AS f1 , AVG ( a2 . f2 ) AS f2 FROM t2 AS a1  JOIN t2 AS a2 ON ( NOT ( NOT ( a2 . f2 = 5 ) ) ) WHERE a2 . f1 IS NOT NULL AND a2 . f2  IN ( 0 , 3 , 0 , 4 , 9 , 6 ) ORDER BY 1 , 2 LIMIT 2  ) AS a2 ON ( NOT ( 4 = 3 ) ) WHERE a1 . f2 + a2 . f1  IN ( 0 , 7 ) AND 5 NOT IN ( SELECT  c3 AS x1 FROM ( SELECT  (a1.f1) AS c1, (a2.f1) AS c2, (a1.f2) AS c3, (FIRST_VALUE ( a2.f1 ) OVER (  ORDER BY a1.f1 , a2.f1 , a1.f2 )) AS agg1 , (MIN ( 7 )) AS agg2 FROM ( SELECT a2 . f1 AS f1 , COUNT ( 2 ) AS f2 FROM t1 AS a1  JOIN t1 AS a2 ON ( 8 NOT IN ( 3 , 2 ) ) WHERE a1 . f1 + a2 . f2 IS NOT NULL AND a2 . f2  IN ( SELECT DISTINCT agg2 AS x1 FROM ( SELECT  (a1.f1) AS c1, (a2.f1) AS c2, (a1.f2) AS c3, (MIN ( a2 . f1 )) AS agg1 , (MIN ( 2 )) AS agg2 FROM t1 AS a1  JOIN ( SELECT 8 AS f1 , COUNT ( 8 ) AS f2 FROM t2 AS a1 LEFT JOIN t2 AS a2 ON ( 1 < a1 . f2 ) WHERE 2 > 7 AND a2 . f2 + a1 . f2 > a1 . f2 + a1 . f2 AND a2 . f2 + a2 . f1 IS  NULL GROUP BY 1 ORDER BY 1 , 2 LIMIT 5 OFFSET 2 ) AS a2 USING ( f2 , f1 ) WHERE a1 . f1 + a1 . f2 IS NOT NULL AND NOT ( 2  IN ( 8 , 2 ) ) AND 3 > a1 . f1 AND a2 . f2 IS  NULL GROUP BY 1 , 2 , 3  ) AS dt ORDER BY 1 LIMIT 5  ) OR 3 = a1 . f1 GROUP BY 1 ORDER BY 1 , 2 LIMIT 8  ) AS a1 RIGHT JOIN t1 AS a2 ON ( NOT ( 4 NOT IN ( 5 , 3 ) ) ) WHERE NOT ( 8 > a1 . f2 + a1 . f1 ) OR a2 . f2 IS NOT NULL AND 5 NOT IN ( 4 , 4 , 2 , 6 ) GROUP BY 1 , 2 , 3  ) AS dt ORDER BY 1 LIMIT 9 OFFSET 8 ) GROUP BY 1 , 2 , 3 ;
 ----
+
+
+
+# WITH MUTUALLY RECURSIVE support
+# -------------------------------
+
+# Fold `Constant` inputs in WMR branches.
+# In theory we should be able to run the WMR loop once under the assumption
+# that all initial LetRec bindings are empty. If do this, the `l0` binding
+# below will simplify to a constant.
+query T multiline
+EXPLAIN WITH(arity, join_impls)
+WITH MUTUALLY RECURSIVE
+  c0(src INT, dst INT) AS (
+    SELECT * FROM c0
+    UNION
+    SELECT src * 2, dst * 2 FROM (VALUES (31, 32), (33, 34)) AS constant(src, dst)
+    UNION
+    (
+      SELECT src + 1, dst + 1 FROM (VALUES (41, 42), (43, 44), (44, 45)) AS constant(src, dst) WHERE src > 1
+      EXCEPT
+      SELECT src + 2, dst + 2 FROM (VALUES (41, 42), (43, 44), (44, 45)) AS constant(src, dst)
+    )
+    UNION
+    (
+      SELECT DISTINCT
+        x.src, y.dst
+      FROM
+        (VALUES (51, 52), (52, 53), (53, 54), (54, 55)) AS x(src, dst),
+        (VALUES (52, 53), (53, 54), (54, 55)) AS y(src, dst),
+        (VALUES (53, 51), (54, 52), (54, 53)) AS z(src, dst)
+      WHERE
+        x.dst = y.src AND y.dst = z.src AND z.dst = x.src
+    )
+  )
+SELECT * FROM c0
+----
+Explained Query:
+  Return // { arity: 2 }
+    Get l0 // { arity: 2 }
+  With Mutually Recursive
+    cte l0 =
+      Distinct group_by=[#0, #1] // { arity: 2 }
+        Union // { arity: 2 }
+          Distinct group_by=[#0, #1] // { arity: 2 }
+            Union // { arity: 2 }
+              Distinct group_by=[#0, #1] // { arity: 2 }
+                Union // { arity: 2 }
+                  Get l0 // { arity: 2 }
+                  Constant // { arity: 2 }
+                    - (62, 64)
+                    - (66, 68)
+              Constant // { arity: 2 }
+                - (42, 43)
+                - (44, 45)
+          Constant // { arity: 2 }
+            - (51, 53)
+            - (52, 54)
+
+EOF
+
+
+# Replace subtrees rooted at `Filter false` with `Constant <empty>`
+query T multiline
+EXPLAIN WITH(arity, join_impls)
+WITH MUTUALLY RECURSIVE
+  c0(n INT) AS (
+    SELECT src FROM edges WHERE false -- literal false
+    UNION ALL
+    SELECT dst FROM edges
+    UNION ALL
+    SELECT * FROM c0 WHERE n IS NULL -- impossible condition (depends on column_knowledge)
+    UNION
+    SELECT * FROM c0 WHERE n IS NOT NULL -- complement (always true)
+  )
+SELECT * FROM c0
+----
+Explained Query:
+  Return // { arity: 1 }
+    Get l0 // { arity: 1 }
+  With Mutually Recursive
+    cte l0 =
+      Distinct group_by=[#0] // { arity: 1 }
+        Union // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Get materialize.public.edges // { arity: 2 }
+          Filter (#0) IS NULL // { arity: 1 }
+            Get l0 // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 1 }
+            Get l0 // { arity: 1 }
+
+EOF

--- a/test/sqllogictest/transform/union_cancel.slt
+++ b/test/sqllogictest/transform/union_cancel.slt
@@ -264,14 +264,9 @@ Explained Query:
         Get l1
         Get l1
     cte l1 =
-      Union
-        Project (#1)
-          Map ((#0 + #0))
-            Get l0
-        Threshold
-          Union
-            Constant <empty>
-            Constant <empty>
+      Project (#1)
+        Map ((#0 + #0))
+          Get l0
     cte l0 =
       Union
         Project (#0)

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -216,11 +216,10 @@ Explained Query:
       Project (#0)
         Distinct group_by=[#0, #1]
           Union
-            Map (1, 2)
-              Constant
-                - ()
             Map (7)
               Get l0
+            Constant
+              - (1, 2)
 
 EOF
 


### PR DESCRIPTION
Fixes #18163 by implementing the proposed "basic" option.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

* Please review only the last two commits. The first few commits are part of #18323 and should be reviewed there.
* I added some tests to `fold_constants.slt`. One of them explains how things can be improved (basically re-stating the more elaborate scheme proposed under **`LetRec` implementation (advanced)**

@philip-stoev: I'm not sure if you want to check this, there should be no regressions to existing plans because I'm only adding stuff. If you feel that you want to play around with RQGs that have constant or `Filter false` inputs within WMR blocks, let me know.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
