### PR TITLE
walkabout: allow building without workspace-hack

### DIFF
--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -25,7 +25,7 @@ unicode-width = "0.1.10"
 [build-dependencies]
 anyhow = "1.0.66"
 mz-ore = { path = "../ore", default-features = false }
-mz-walkabout = { path = "../walkabout" }
+mz-walkabout = { path = "../walkabout", default-features = false }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_codegen = "0.11.1"
 uncased = "0.9.7"

--- a/src/walkabout/Cargo.toml
+++ b/src/walkabout/Cargo.toml
@@ -12,11 +12,14 @@ itertools = "0.10.5"
 mz-ore = { path = "../ore", default-features = false }
 quote = "1.0.23"
 syn = { version = "1.0.107", features = ["extra-traits", "full", "parsing"] }
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
 datadriven = "0.6.0"
 tempfile = "3.2.0"
+
+[features]
+default = ["workspace-hack"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]


### PR DESCRIPTION
This allows the parser to be built without deps, useful for cross arch compilation.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a