### PR TITLE
repr: hook up real columnar encodings for more ScalarTypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,6 +1876,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4421,6 +4433,7 @@ dependencies = [
  "dec",
  "differential-dataflow",
  "enum-kinds",
+ "enum_dispatch",
  "fast-float",
  "hex",
  "itertools",

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -23,6 +23,7 @@ chrono = { version = "0.4.23", default-features = false, features = ["serde", "s
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
 dec = "0.4.8"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+enum_dispatch = "0.3.11"
 enum-kinds = "0.5.1"
 fast-float = "0.2.0"
 hex = "0.4.3"

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -114,7 +114,7 @@ pub use crate::relation::{
     ColumnName, ColumnType, NotNullViolation, ProtoColumnName, ProtoColumnType, ProtoRelationDesc,
     ProtoRelationType, RelationDesc, RelationType,
 };
-pub use crate::row::encoding::{RowDecoder, RowEncoder};
+pub use crate::row::encoding::{DatumDecoderT, DatumEncoderT, RowDecoder, RowEncoder};
 pub use crate::row::{
     datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, ProtoRow, Row,
     RowArena, RowPacker, RowRef,

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -896,6 +896,12 @@ impl<'a> From<i64> for Datum<'a> {
     }
 }
 
+impl<'a> From<u8> for Datum<'a> {
+    fn from(u: u8) -> Datum<'a> {
+        Datum::UInt8(u)
+    }
+}
+
 impl<'a> From<u16> for Datum<'a> {
     fn from(u: u16) -> Datum<'a> {
         Datum::UInt16(u)

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -45,8 +45,8 @@ use mz_persist_types::{Codec, Codec64};
 use mz_proto::{IntoRustIfSome, ProtoMapEntry, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::numeric::{Numeric, NumericMaxScale};
 use mz_repr::{
-    ColumnName, ColumnType, Datum, Diff, GlobalId, RelationDesc, RelationType, Row, RowEncoder,
-    ScalarType,
+    ColumnName, ColumnType, Datum, DatumEncoderT, Diff, GlobalId, RelationDesc, RelationType, Row,
+    RowEncoder, ScalarType,
 };
 use mz_timely_util::order::{Interval, Partitioned, RangeBound};
 


### PR DESCRIPTION
For all of these, the columnar encoding's ordering matches the Datum's
ordering, so they are ones we could easily keep stats for.

To make this less boilerplate-y, we introduce the `enum_dispatch` crate.

Benchmarks seem to be slightly improved. Not sure why, but I've flipped
back and forth a bit and I think both are real.

    roundtrip_encode_structured
                            time:   [736.94 µs 737.33 µs 737.78 µs]
                            change: [-18.475% -18.351% -18.230%] (p = 0.00 < 0.05)
                            Performance has improved.

    roundtrip_decode_structured
                            time:   [633.84 µs 634.18 µs 634.57 µs]
                            change: [-3.8598% -3.7183% -3.5883%] (p = 0.00 < 0.05)
                            Performance has improved.

Interestingly the improvements seem to only be on my laptop (M1). Here's
a perisist-benchmarking bin/scratch machine.

    roundtrip_encode_structured
                            time:   [1.1418 ms 1.1419 ms 1.1421 ms]
                            change: [-3.8835% -3.8516% -3.8166%] (p = 0.00 < 0.05)
    
    roundtrip_decode_structured
                            time:   [749.31 µs 749.44 µs 749.58 µs]
                            change: [+1.2455% +1.2743% +1.3042%] (p = 0.00 < 0.05)

Touches #12684

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
