### PR TITLE
test: Deflake storage usage test

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -933,7 +933,7 @@ impl Connection {
         // is removed.
         let cutoff_ts = match retention_period {
             None => u128::MIN,
-            Some(period) => u128::from(self.boot_ts) - period.as_millis(),
+            Some(period) => u128::from(self.boot_ts).saturating_sub(period.as_millis()),
         };
         Ok(self
             .stash


### PR DESCRIPTION
This commit de- flakes the
test_old_storage_usage_records_are_reaped_on_restart test. Previously, the test would

  1. Start Materialize.
  2. Wait for some storage usage collection to happen.
  3. Stop Materialize.
  4. Sleep for the retention period.
  5. Start Materialize.
  6. Assert that there are no storage usage metrics.

There was a race condition between steps (5) and (6) where Materialize could generate new storage usage metrics after the restart and the assert would fail.

This commit alters the logic to assert that the maximum timestamp from all storage usage metrics before the restart is less than the minimum timestamp from all storage usage metrics after the restart, which avoids the race condition.

This commit also switches from using sleeps to using deterministic timestamps in order to be more deterministic and consistent.

Fixes #18108

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
