### PR TITLE
sql: Add mz_sessions system table

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -291,10 +291,11 @@ Field      | Type       | Meaning
 
 The `mz_sessions` table contains a row for each active session in the system.
 
-Field     | Type      | Meaning
-----------|-----------|--------
-`id`      | [`uint4`] | The ID of the session.
-`role_id` | [`text`]  | The role ID of the role that the session is logged in as. Corresponds to [`mz_catalog.mz_roles`](../mz_catalog#mz_roles).
+Field          | Type                         | Meaning
+---------------|------------------------------|--------
+`id`           | [`uint4`]                    | The ID of the session.
+`role_id`      | [`text`]                     | The role ID of the role that the session is logged in as. Corresponds to [`mz_catalog.mz_roles`](../mz_catalog#mz_roles).
+`connected_at` | [`timestamp with time zone`] | The time at which the session connected to the system.
 
 ### `mz_subscriptions`
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -294,7 +294,7 @@ The `mz_sessions` table contains a row for each active session in the system.
 Field     | Type      | Meaning
 ----------|-----------|--------
 `id`      | [`uint4`] | The ID of the session.
-`role_id` | [`text`]  | The role ID of the role that the session is loggen in as. Corresponds to [`mz_catalog.mz_roles`](../mz_catalog#mz_roles).
+`role_id` | [`text`]  | The role ID of the role that the session is logged in as. Corresponds to [`mz_catalog.mz_roles`](../mz_catalog#mz_roles).
 
 ### `mz_subscriptions`
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -287,6 +287,15 @@ Field      | Type       | Meaning
 `index_id` | [`text`]   | The ID of the index the peek is targeting.
 `time`     | [`mz_timestamp`] | The timestamp the peek has requested.
 
+### `mz_sessions`
+
+The `mz_sessions` table contains a row for each active session in the system.
+
+Field     | Type      | Meaning
+----------|-----------|--------
+`id`      | [`uint4`] | The ID of the session.
+`role_id` | [`text`]  | The role ID of the role that the session is loggen in as. Corresponds to [`mz_catalog.mz_roles`](../mz_catalog#mz_roles).
+
 ### `mz_subscriptions`
 
 The `mz_subscriptions` table describes all active [`SUBSCRIBE`](/sql/subscribe)
@@ -330,15 +339,6 @@ Field              | Type           | Meaning
 -------------------|----------------|--------
 `id`               | [`text`]       | The ID of the source. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources).
 `replication_slot` | [`text`]       | The name of the replication slot in the PostgreSQL database that Materialize will create and stream data from.
-
-### `mz_sessions`
-
-The `mz_sessions` table contains a row for each active session in the system.
-
-Field     | Type      | Meaning
-----------|-----------|--------
-`id`      | [`uint4`] | The ID of the session.
-`role_id` | [`text`]  | The role ID of the role that the session is loggen in as. Corresponds to [`mz_catalog.mz_roles`](../mz_catalog#mz_roles).
 
 ### `mz_records_per_dataflow`
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -337,7 +337,7 @@ The `mz_sessions` table contains a row for each active session in the system.
 
 Field     | Type      | Meaning
 ----------|-----------|--------
-`id`      | [`uint4`] | The ID of the session. 
+`id`      | [`uint4`] | The ID of the session.
 `role_id` | [`text`]  | The role ID of the role that the session is loggen in as. Corresponds to [`mz_catalog.mz_roles`](../mz_catalog#mz_roles).
 
 ### `mz_records_per_dataflow`

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -331,6 +331,15 @@ Field              | Type           | Meaning
 `id`               | [`text`]       | The ID of the source. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources).
 `replication_slot` | [`text`]       | The name of the replication slot in the PostgreSQL database that Materialize will create and stream data from.
 
+### `mz_sessions`
+
+The `mz_sessions` table contains a row for each active session in the system.
+
+Field     | Type      | Meaning
+----------|-----------|--------
+`id`      | [`uint4`] | The ID of the session. 
+`role_id` | [`text`]  | The role ID of the role that the session is loggen in as. Corresponds to [`mz_catalog.mz_roles`](../mz_catalog#mz_roles).
+
 ### `mz_records_per_dataflow`
 
 The `mz_records_per_dataflow` view describes the number of records in each

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1836,7 +1836,8 @@ pub static MZ_SESSIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::UInt32.nullable(false))
-        .with_column("role_id", ScalarType::String.nullable(false)),
+        .with_column("role_id", ScalarType::String.nullable(false))
+        .with_column("connected_at", ScalarType::TimestampTz.nullable(false)),
     is_retained_metrics_relation: false,
 });
 

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1831,6 +1831,15 @@ pub static MZ_SUBSCRIPTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     is_retained_metrics_relation: false,
 });
 
+pub static MZ_SESSIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_sessions",
+    schema: MZ_INTERNAL_SCHEMA,
+    desc: RelationDesc::empty()
+        .with_column("id", ScalarType::UInt32.nullable(false))
+        .with_column("role_id", ScalarType::String.nullable(false)),
+    is_retained_metrics_relation: false,
+});
+
 // These will be replaced with per-replica tables once source/sink multiplexing on
 // a single cluster is supported.
 pub static MZ_SOURCE_STATISTICS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
@@ -3226,6 +3235,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_EGRESS_IPS),
         Builtin::Table(&MZ_AWS_PRIVATELINK_CONNECTIONS),
         Builtin::Table(&MZ_SUBSCRIPTIONS),
+        Builtin::Table(&MZ_SESSIONS),
         Builtin::View(&MZ_RELATIONS),
         Builtin::View(&MZ_OBJECTS),
         Builtin::View(&MZ_ARRANGEMENT_SHARING),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -41,13 +41,14 @@ use crate::catalog::builtin::{
     MZ_FUNCTIONS, MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_KAFKA_CONNECTIONS, MZ_KAFKA_SINKS,
     MZ_LIST_TYPES, MZ_MAP_TYPES, MZ_MATERIALIZED_VIEWS, MZ_OBJECT_DEPENDENCIES, MZ_OPERATORS,
     MZ_POSTGRES_SOURCES, MZ_PSEUDO_TYPES, MZ_ROLES, MZ_ROLE_MEMBERS, MZ_SCHEMAS, MZ_SECRETS,
-    MZ_SINKS, MZ_SOURCES, MZ_SSH_TUNNEL_CONNECTIONS, MZ_STORAGE_USAGE_BY_SHARD, MZ_SUBSCRIPTIONS,
-    MZ_TABLES, MZ_TYPES, MZ_VIEWS,
+    MZ_SESSIONS, MZ_SINKS, MZ_SOURCES, MZ_SSH_TUNNEL_CONNECTIONS, MZ_STORAGE_USAGE_BY_SHARD,
+    MZ_SUBSCRIPTIONS, MZ_TABLES, MZ_TYPES, MZ_VIEWS,
 };
 use crate::catalog::{
     CatalogItem, CatalogState, Connection, DataSourceDesc, Database, Error, ErrorKind, Func, Index,
     MaterializedView, Sink, StorageSinkConnectionState, Type, View, SYSTEM_CONN_ID,
 };
+use crate::client::ConnectionId;
 use crate::subscribe::ActiveSubscribe;
 
 use super::AwsPrincipalContext;
@@ -1159,6 +1160,19 @@ impl CatalogState {
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_SUBSCRIPTIONS),
             row,
+            diff,
+        }
+    }
+
+    pub fn pack_session_update(
+        &self,
+        id: ConnectionId,
+        role_id: RoleId,
+        diff: Diff,
+    ) -> BuiltinTableUpdate {
+        BuiltinTableUpdate {
+            id: self.resolve_builtin_table(&MZ_SESSIONS),
+            row: Row::pack_slice(&[Datum::UInt32(id), Datum::String(&role_id.to_string())]),
             diff,
         }
     }

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -21,6 +21,7 @@ use mz_expr::MirScalarExpr;
 use mz_orchestrator::{CpuLimit, MemoryLimit, ServiceProcessMetrics};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
+use mz_ore::now::SYSTEM_TIME;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::jsonb::Jsonb;
 use mz_repr::{Datum, Diff, GlobalId, Row};
@@ -1170,9 +1171,18 @@ impl CatalogState {
         role_id: RoleId,
         diff: Diff,
     ) -> BuiltinTableUpdate {
+        // We use the system clock to determine when a session
+        // connected to Materialize. This is not intended to be 100%
+        // accurate and correct, so we don't burden the timestamp
+        // oracle with generating a more correct timestamp.
+        let connect_dt = mz_ore::now::to_datetime(SYSTEM_TIME());
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_SESSIONS),
-            row: Row::pack_slice(&[Datum::UInt32(id), Datum::String(&role_id.to_string())]),
+            row: Row::pack_slice(&[
+                Datum::UInt32(id),
+                Datum::String(&role_id.to_string()),
+                Datum::TimestampTz(connect_dt.try_into().expect("must fit")),
+            ]),
             diff,
         }
     }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -34,7 +34,7 @@ use crate::client::ConnectionId;
 use crate::command::{
     Canceled, Command, ExecuteResponse, Response, StartupMessage, StartupResponse,
 };
-use crate::coord::appends::{Deferred, PendingWriteTxn};
+use crate::coord::appends::{BuiltinTableUpdateSource, Deferred, PendingWriteTxn};
 use crate::coord::peek::PendingPeek;
 use crate::coord::{ConnMeta, Coordinator, CreateSourceStatementReady, Message, PendingTxn};
 use crate::error::AdapterError;
@@ -269,6 +269,12 @@ impl Coordinator {
                 drop_sinks: Vec::new(),
             },
         );
+        let update =
+            self.catalog()
+                .state()
+                .pack_session_update(session.conn_id(), *session.role_id(), 1);
+        self.send_builtin_table_updates(vec![update], BuiltinTableUpdateSource::DDL)
+            .await;
 
         ClientTransmitter::new(tx, self.internal_cmd_tx.clone())
             .send(Ok(StartupResponse { messages }), session)
@@ -636,5 +642,11 @@ impl Coordinator {
             .dec();
         self.active_conns.remove(&session.conn_id());
         self.cancel_pending_peeks(&session.conn_id());
+        let update =
+            self.catalog()
+                .state()
+                .pack_session_update(session.conn_id(), *session.role_id(), -1);
+        self.send_builtin_table_updates(vec![update], BuiltinTableUpdateSource::DDL)
+            .await;
     }
 }

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2542,7 +2542,6 @@ fn test_mz_sessions() {
         .unwrap();
 
     // Active session appears in mz_sessions.
-
     assert_eq!(
         foo_client
             .query_one("SELECT count(*) FROM mz_internal.mz_sessions", &[])

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -338,6 +338,10 @@ VIEW
 materialize
 mz_internal
 mz_scheduling_parks_histogram_internal
+BASE TABLE
+materialize
+mz_internal
+mz_sessions
 SOURCE
 materialize
 mz_internal

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -338,11 +338,11 @@ VIEW
 materialize
 mz_internal
 mz_scheduling_parks_histogram_internal
-BASE TABLE
+SOURCE
 materialize
 mz_internal
 mz_sessions
-SOURCE
+BASE TABLE
 materialize
 mz_internal
 mz_show_cluster_replicas

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -539,6 +539,7 @@ mz_cluster_replica_metrics
 mz_cluster_replica_sizes
 mz_cluster_replica_statuses
 mz_postgres_sources
+mz_sessions
 mz_storage_usage_by_shard
 mz_subscriptions
 mz_view_foreign_keys

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -587,7 +587,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-42
+43
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'


### PR DESCRIPTION
This commit adds the mz_sessions system catalog table, which tracks the connection id and role id of all active sessions.

Resolves #18289


### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release will add an `mz_internal` system table called `mz_sessions` that tracks the connection id and role id of all active sessions.
