### PR TITLE
Allow `is_retained_metrics_relation` for indexes; turn on indexing for utilization metrics

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1918,6 +1918,28 @@ impl CatalogItem {
         }
     }
 
+    /// If the object is considered a "compute object"
+    /// (i.e., it is managed by the compute controller),
+    /// this function returns its cluster ID. Otherwise, it returns nothing.
+    ///
+    /// This function differs from `cluster_id` because while all
+    /// compute objects run on a cluster, the converse is not true.
+    pub fn is_compute_object_on_cluster(&self) -> Option<ClusterId> {
+        match self {
+            CatalogItem::Index(index) => Some(index.cluster_id),
+            CatalogItem::Table(_)
+            | CatalogItem::Source(_)
+            | CatalogItem::Log(_)
+            | CatalogItem::View(_)
+            | CatalogItem::MaterializedView(_)
+            | CatalogItem::Sink(_)
+            | CatalogItem::Type(_)
+            | CatalogItem::Func(_)
+            | CatalogItem::Secret(_)
+            | CatalogItem::Connection(_) => None,
+        }
+    }
+
     pub fn cluster_id(&self) -> Option<ClusterId> {
         match self {
             CatalogItem::MaterializedView(mv) => Some(mv.cluster_id),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -110,7 +110,7 @@ pub struct BuiltinTable {
     pub desc: RelationDesc,
     /// Whether the table's retention policy is controlled by
     /// the system variable `METRICS_RETENTION`
-    pub is_retained_metrics_relation: bool,
+    pub is_retained_metrics_object: bool,
 }
 
 #[derive(Clone, Debug, Hash, Serialize)]
@@ -121,7 +121,7 @@ pub struct BuiltinSource {
     pub data_source: Option<IntrospectionType>,
     /// Whether the source's retention policy is controlled by
     /// the system variable `METRICS_RETENTION`
-    pub is_retained_metrics_relation: bool,
+    pub is_retained_metrics_object: bool,
 }
 
 #[derive(Hash, Debug)]
@@ -151,7 +151,7 @@ pub struct BuiltinIndex {
     pub name: &'static str,
     pub schema: &'static str,
     pub sql: &'static str,
-    pub is_retained_metrics_relation: bool,
+    pub is_retained_metrics_object: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -1304,7 +1304,7 @@ pub static MZ_VIEW_KEYS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("object_id", ScalarType::String.nullable(false))
         .with_column("column", ScalarType::UInt64.nullable(false))
         .with_column("key_group", ScalarType::UInt64.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_VIEW_FOREIGN_KEYS: Lazy<BuiltinTable> = Lazy::new(|| {
     BuiltinTable {
@@ -1317,7 +1317,7 @@ pub static MZ_VIEW_FOREIGN_KEYS: Lazy<BuiltinTable> = Lazy::new(|| {
             .with_column("parent_column", ScalarType::UInt64.nullable(false))
             .with_column("key_group", ScalarType::UInt64.nullable(false))
             .with_key(vec![0, 1, 4]), // TODO: explain why this is a key.
-        is_retained_metrics_relation: false,
+        is_retained_metrics_object: false,
     }
 });
 pub static MZ_KAFKA_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1327,7 +1327,7 @@ pub static MZ_KAFKA_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("topic", ScalarType::String.nullable(false))
         .with_key(vec![0]),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_KAFKA_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_kafka_connections",
@@ -1339,7 +1339,7 @@ pub static MZ_KAFKA_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable 
             ScalarType::Array(Box::new(ScalarType::String)).nullable(false),
         )
         .with_column("sink_progress_topic", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_POSTGRES_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_postgres_sources",
@@ -1347,7 +1347,7 @@ pub static MZ_POSTGRES_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("replication_slot", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_OBJECT_DEPENDENCIES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_object_dependencies",
@@ -1355,7 +1355,7 @@ pub static MZ_OBJECT_DEPENDENCIES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTabl
     desc: RelationDesc::empty()
         .with_column("object_id", ScalarType::String.nullable(false))
         .with_column("referenced_object_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_databases",
@@ -1365,7 +1365,7 @@ pub static MZ_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_SCHEMAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_schemas",
@@ -1376,7 +1376,7 @@ pub static MZ_SCHEMAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("database_id", ScalarType::UInt64.nullable(true))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_columns",
@@ -1389,7 +1389,7 @@ pub static MZ_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("type", ScalarType::String.nullable(false))
         .with_column("default", ScalarType::String.nullable(true))
         .with_column("type_oid", ScalarType::Oid.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_INDEXES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_indexes",
@@ -1401,7 +1401,7 @@ pub static MZ_INDEXES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("on_id", ScalarType::String.nullable(false))
         .with_column("cluster_id", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_INDEX_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_index_columns",
@@ -1412,7 +1412,7 @@ pub static MZ_INDEX_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("on_position", ScalarType::UInt64.nullable(true))
         .with_column("on_expression", ScalarType::String.nullable(true))
         .with_column("nullable", ScalarType::Bool.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_TABLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_tables",
@@ -1423,7 +1423,7 @@ pub static MZ_TABLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("schema_id", ScalarType::UInt64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_connections",
@@ -1435,7 +1435,7 @@ pub static MZ_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("type", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_SSH_TUNNEL_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_ssh_tunnel_connections",
@@ -1444,7 +1444,7 @@ pub static MZ_SSH_TUNNEL_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinT
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("public_key_1", ScalarType::String.nullable(false))
         .with_column("public_key_2", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_sources",
@@ -1460,7 +1460,7 @@ pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("envelope_type", ScalarType::String.nullable(true))
         .with_column("cluster_id", ScalarType::String.nullable(true))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: true,
+    is_retained_metrics_object: true,
 });
 pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_sinks",
@@ -1476,7 +1476,7 @@ pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("envelope_type", ScalarType::String.nullable(true))
         .with_column("cluster_id", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: true,
+    is_retained_metrics_object: true,
 });
 pub static MZ_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_views",
@@ -1488,7 +1488,7 @@ pub static MZ_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("definition", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_MATERIALIZED_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_materialized_views",
@@ -1501,7 +1501,7 @@ pub static MZ_MATERIALIZED_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable
         .with_column("cluster_id", ScalarType::String.nullable(false))
         .with_column("definition", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_types",
@@ -1513,7 +1513,7 @@ pub static MZ_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("category", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_ARRAY_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_array_types",
@@ -1521,13 +1521,13 @@ pub static MZ_ARRAY_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("element_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_BASE_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_base_types",
     schema: MZ_CATALOG_SCHEMA,
     desc: RelationDesc::empty().with_column("id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_LIST_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_list_types",
@@ -1535,7 +1535,7 @@ pub static MZ_LIST_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("element_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_MAP_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_map_types",
@@ -1544,7 +1544,7 @@ pub static MZ_MAP_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("key_id", ScalarType::String.nullable(false))
         .with_column("value_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_ROLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_roles",
@@ -1557,7 +1557,7 @@ pub static MZ_ROLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("create_role", ScalarType::Bool.nullable(false))
         .with_column("create_db", ScalarType::Bool.nullable(false))
         .with_column("create_cluster", ScalarType::Bool.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_ROLE_MEMBERS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_role_members",
@@ -1566,13 +1566,13 @@ pub static MZ_ROLE_MEMBERS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("role_id", ScalarType::String.nullable(false))
         .with_column("member", ScalarType::String.nullable(false))
         .with_column("grantor", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_PSEUDO_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_pseudo_types",
     schema: MZ_CATALOG_SCHEMA,
     desc: RelationDesc::empty().with_column("id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_FUNCTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_functions",
@@ -1593,7 +1593,7 @@ pub static MZ_FUNCTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("return_type_id", ScalarType::String.nullable(true))
         .with_column("returns_set", ScalarType::Bool.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_OPERATORS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_operators",
@@ -1606,7 +1606,7 @@ pub static MZ_OPERATORS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
             ScalarType::Array(Box::new(ScalarType::String)).nullable(false),
         )
         .with_column("return_type_id", ScalarType::String.nullable(true)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_CLUSTERS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1616,7 +1616,7 @@ pub static MZ_CLUSTERS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_CLUSTER_LINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1625,7 +1625,7 @@ pub static MZ_CLUSTER_LINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     desc: RelationDesc::empty()
         .with_column("cluster_id", ScalarType::String.nullable(false))
         .with_column("object_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_SECRETS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1636,7 +1636,7 @@ pub static MZ_SECRETS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("schema_id", ScalarType::UInt64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 pub static MZ_CLUSTER_REPLICAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replicas",
@@ -1648,7 +1648,7 @@ pub static MZ_CLUSTER_REPLICAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("size", ScalarType::String.nullable(true))
         .with_column("availability_zone", ScalarType::String.nullable(true))
         .with_column("owner_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: true,
+    is_retained_metrics_object: true,
 });
 
 pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1659,7 +1659,7 @@ pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| Builti
         .with_column("process_id", ScalarType::UInt64.nullable(false))
         .with_column("status", ScalarType::String.nullable(false))
         .with_column("updated_at", ScalarType::TimestampTz.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_CLUSTER_REPLICA_SIZES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1671,7 +1671,7 @@ pub static MZ_CLUSTER_REPLICA_SIZES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTa
         .with_column("workers", ScalarType::UInt64.nullable(false))
         .with_column("cpu_nano_cores", ScalarType::UInt64.nullable(false))
         .with_column("memory_bytes", ScalarType::UInt64.nullable(false)),
-    is_retained_metrics_relation: true,
+    is_retained_metrics_object: true,
 });
 
 pub static MZ_CLUSTER_REPLICA_HEARTBEATS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1680,7 +1680,7 @@ pub static MZ_CLUSTER_REPLICA_HEARTBEATS: Lazy<BuiltinTable> = Lazy::new(|| Buil
     desc: RelationDesc::empty()
         .with_column("replica_id", ScalarType::String.nullable(false))
         .with_column("last_heartbeat", ScalarType::TimestampTz.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_AUDIT_EVENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1693,7 +1693,7 @@ pub static MZ_AUDIT_EVENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("details", ScalarType::Jsonb.nullable(false))
         .with_column("user", ScalarType::String.nullable(true))
         .with_column("occurred_at", ScalarType::TimestampTz.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
@@ -1701,7 +1701,7 @@ pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinS
     schema: MZ_INTERNAL_SCHEMA,
     data_source: Some(IntrospectionType::SourceStatusHistory),
     desc: MZ_SOURCE_STATUS_HISTORY_DESC.clone(),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub const MZ_SOURCE_STATUSES: BuiltinView = BuiltinView {
@@ -1733,7 +1733,7 @@ pub static MZ_SINK_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSou
     schema: MZ_INTERNAL_SCHEMA,
     data_source: Some(IntrospectionType::SinkStatusHistory),
     desc: MZ_SINK_STATUS_HISTORY_DESC.clone(),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub const MZ_SINK_STATUSES: BuiltinView = BuiltinView {
@@ -1771,14 +1771,14 @@ pub static MZ_STORAGE_USAGE_BY_SHARD: Lazy<BuiltinTable> = Lazy::new(|| BuiltinT
             "collection_timestamp",
             ScalarType::TimestampTz.nullable(false),
         ),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_EGRESS_IPS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_egress_ips",
     schema: MZ_CATALOG_SCHEMA,
     desc: RelationDesc::empty().with_column("egress_ip", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_AWS_PRIVATELINK_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1787,7 +1787,7 @@ pub static MZ_AWS_PRIVATELINK_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| Bui
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("principal", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_CLUSTER_REPLICA_METRICS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1800,7 +1800,7 @@ pub static MZ_CLUSTER_REPLICA_METRICS: Lazy<BuiltinTable> = Lazy::new(|| Builtin
         .with_column("process_id", ScalarType::UInt64.nullable(false))
         .with_column("cpu_nano_cores", ScalarType::UInt64.nullable(true))
         .with_column("memory_bytes", ScalarType::UInt64.nullable(true)),
-    is_retained_metrics_relation: true,
+    is_retained_metrics_object: true,
 });
 
 pub static MZ_CLUSTER_REPLICA_FRONTIERS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1810,7 +1810,7 @@ pub static MZ_CLUSTER_REPLICA_FRONTIERS: Lazy<BuiltinTable> = Lazy::new(|| Built
         .with_column("replica_id", ScalarType::String.nullable(false))
         .with_column("export_id", ScalarType::String.nullable(false))
         .with_column("time", ScalarType::MzTimestamp.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_SUBSCRIPTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1829,7 +1829,7 @@ pub static MZ_SUBSCRIPTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
             }
             .nullable(false),
         ),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_SESSIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1839,7 +1839,7 @@ pub static MZ_SESSIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("id", ScalarType::UInt32.nullable(false))
         .with_column("role_id", ScalarType::String.nullable(false))
         .with_column("connected_at", ScalarType::TimestampTz.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 // These will be replaced with per-replica tables once source/sink multiplexing on
@@ -1856,7 +1856,7 @@ pub static MZ_SOURCE_STATISTICS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSourc
         .with_column("updates_staged", ScalarType::UInt64.nullable(false))
         .with_column("updates_committed", ScalarType::UInt64.nullable(false))
         .with_column("bytes_received", ScalarType::UInt64.nullable(false)),
-    is_retained_metrics_relation: true,
+    is_retained_metrics_object: true,
 });
 pub static MZ_SINK_STATISTICS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_sink_statistics",
@@ -1869,7 +1869,7 @@ pub static MZ_SINK_STATISTICS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource 
         .with_column("messages_committed", ScalarType::UInt64.nullable(false))
         .with_column("bytes_staged", ScalarType::UInt64.nullable(false))
         .with_column("bytes_committed", ScalarType::UInt64.nullable(false)),
-    is_retained_metrics_relation: true,
+    is_retained_metrics_object: true,
 });
 
 pub static MZ_STORAGE_SHARDS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
@@ -1879,7 +1879,7 @@ pub static MZ_STORAGE_SHARDS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     desc: RelationDesc::empty()
         .with_column("object_id", ScalarType::String.nullable(false))
         .with_column("shard_id", ScalarType::String.nullable(false)),
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_STORAGE_USAGE: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
@@ -2903,7 +2903,7 @@ pub const MZ_SHOW_DATABASES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_databases_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_databases (name)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_SCHEMAS_IND: BuiltinIndex = BuiltinIndex {
@@ -2912,7 +2912,7 @@ pub const MZ_SHOW_SCHEMAS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_schemas_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_schemas (database_id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_CONNECTIONS_IND: BuiltinIndex = BuiltinIndex {
@@ -2921,7 +2921,7 @@ pub const MZ_SHOW_CONNECTIONS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_connections_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_connections (schema_id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_TABLES_IND: BuiltinIndex = BuiltinIndex {
@@ -2930,7 +2930,7 @@ pub const MZ_SHOW_TABLES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_tables_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_tables (schema_id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_SOURCES_IND: BuiltinIndex = BuiltinIndex {
@@ -2939,7 +2939,7 @@ pub const MZ_SHOW_SOURCES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_sources_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_sources (schema_id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_VIEWS_IND: BuiltinIndex = BuiltinIndex {
@@ -2948,7 +2948,7 @@ pub const MZ_SHOW_VIEWS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_views_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_views (schema_id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_MATERIALIZED_VIEWS_IND: BuiltinIndex = BuiltinIndex {
@@ -2957,7 +2957,7 @@ pub const MZ_SHOW_MATERIALIZED_VIEWS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_materialized_views_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_show_materialized_views (schema_id, cluster_id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_SINKS_IND: BuiltinIndex = BuiltinIndex {
@@ -2966,7 +2966,7 @@ pub const MZ_SHOW_SINKS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_sinks_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_sinks (schema_id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_TYPES_IND: BuiltinIndex = BuiltinIndex {
@@ -2975,7 +2975,7 @@ pub const MZ_SHOW_TYPES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_types_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_types (schema_id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_ALL_OBJECTS_IND: BuiltinIndex = BuiltinIndex {
@@ -2984,7 +2984,7 @@ pub const MZ_SHOW_ALL_OBJECTS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_all_objects_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_objects (schema_id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_INDEXES_IND: BuiltinIndex = BuiltinIndex {
@@ -2993,7 +2993,7 @@ pub const MZ_SHOW_INDEXES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_indexes_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_show_indexes (on_id, schema_id, cluster_id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_COLUMNS_IND: BuiltinIndex = BuiltinIndex {
@@ -3002,7 +3002,7 @@ pub const MZ_SHOW_COLUMNS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_columns_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_columns (id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_CLUSTERS_IND: BuiltinIndex = BuiltinIndex {
@@ -3011,7 +3011,7 @@ pub const MZ_SHOW_CLUSTERS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_clusters_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_clusters (name)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
@@ -3020,7 +3020,7 @@ pub const MZ_SHOW_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_cluster_replicas_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_show_cluster_replicas (cluster, replica, size, ready)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SHOW_SECRETS_IND: BuiltinIndex = BuiltinIndex {
@@ -3029,7 +3029,7 @@ pub const MZ_SHOW_SECRETS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_secrets_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_secrets (schema_id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_CLUSTERS_IND: BuiltinIndex = BuiltinIndex {
@@ -3038,7 +3038,7 @@ pub const MZ_CLUSTERS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_clusters_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_clusters (id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SOURCE_STATUSES_IND: BuiltinIndex = BuiltinIndex {
@@ -3047,7 +3047,7 @@ pub const MZ_SOURCE_STATUSES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_source_statuses_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_source_statuses (id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_SOURCE_STATUS_HISTORY_IND: BuiltinIndex = BuiltinIndex {
@@ -3056,7 +3056,7 @@ pub const MZ_SOURCE_STATUS_HISTORY_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_source_status_history_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_source_status_history (source_id)",
-    is_retained_metrics_relation: false,
+    is_retained_metrics_object: false,
 };
 
 pub const MZ_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
@@ -3065,7 +3065,7 @@ pub const MZ_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_cluster_replicas_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_cluster_replicas (id)",
-    is_retained_metrics_relation: true,
+    is_retained_metrics_object: true,
 };
 
 pub const MZ_CLUSTER_REPLICA_SIZES_IND: BuiltinIndex = BuiltinIndex {
@@ -3074,7 +3074,7 @@ pub const MZ_CLUSTER_REPLICA_SIZES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_cluster_replica_sizes_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_cluster_replica_sizes (size)",
-    is_retained_metrics_relation: true,
+    is_retained_metrics_object: true,
 };
 
 pub const MZ_CLUSTER_REPLICA_METRICS_IND: BuiltinIndex = BuiltinIndex {
@@ -3083,7 +3083,7 @@ pub const MZ_CLUSTER_REPLICA_METRICS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_cluster_replica_metrics_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_cluster_replica_metrics (replica_id)",
-    is_retained_metrics_relation: true,
+    is_retained_metrics_object: true,
 };
 
 pub static MZ_SYSTEM_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -151,6 +151,7 @@ pub struct BuiltinIndex {
     pub name: &'static str,
     pub schema: &'static str,
     pub sql: &'static str,
+    pub is_retained_metrics_relation: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -2902,6 +2903,7 @@ pub const MZ_SHOW_DATABASES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_databases_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_databases (name)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_SCHEMAS_IND: BuiltinIndex = BuiltinIndex {
@@ -2910,6 +2912,7 @@ pub const MZ_SHOW_SCHEMAS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_schemas_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_schemas (database_id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_CONNECTIONS_IND: BuiltinIndex = BuiltinIndex {
@@ -2918,6 +2921,7 @@ pub const MZ_SHOW_CONNECTIONS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_connections_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_connections (schema_id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_TABLES_IND: BuiltinIndex = BuiltinIndex {
@@ -2926,6 +2930,7 @@ pub const MZ_SHOW_TABLES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_tables_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_tables (schema_id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_SOURCES_IND: BuiltinIndex = BuiltinIndex {
@@ -2934,6 +2939,7 @@ pub const MZ_SHOW_SOURCES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_sources_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_sources (schema_id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_VIEWS_IND: BuiltinIndex = BuiltinIndex {
@@ -2942,6 +2948,7 @@ pub const MZ_SHOW_VIEWS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_views_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_views (schema_id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_MATERIALIZED_VIEWS_IND: BuiltinIndex = BuiltinIndex {
@@ -2950,6 +2957,7 @@ pub const MZ_SHOW_MATERIALIZED_VIEWS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_materialized_views_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_show_materialized_views (schema_id, cluster_id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_SINKS_IND: BuiltinIndex = BuiltinIndex {
@@ -2958,6 +2966,7 @@ pub const MZ_SHOW_SINKS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_sinks_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_sinks (schema_id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_TYPES_IND: BuiltinIndex = BuiltinIndex {
@@ -2966,6 +2975,7 @@ pub const MZ_SHOW_TYPES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_types_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_types (schema_id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_ALL_OBJECTS_IND: BuiltinIndex = BuiltinIndex {
@@ -2974,6 +2984,7 @@ pub const MZ_SHOW_ALL_OBJECTS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_all_objects_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_objects (schema_id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_INDEXES_IND: BuiltinIndex = BuiltinIndex {
@@ -2982,6 +2993,7 @@ pub const MZ_SHOW_INDEXES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_indexes_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_show_indexes (on_id, schema_id, cluster_id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_COLUMNS_IND: BuiltinIndex = BuiltinIndex {
@@ -2990,6 +3002,7 @@ pub const MZ_SHOW_COLUMNS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_columns_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_columns (id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_CLUSTERS_IND: BuiltinIndex = BuiltinIndex {
@@ -2998,6 +3011,7 @@ pub const MZ_SHOW_CLUSTERS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_clusters_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_clusters (name)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
@@ -3006,6 +3020,7 @@ pub const MZ_SHOW_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_cluster_replicas_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_show_cluster_replicas (cluster, replica, size, ready)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SHOW_SECRETS_IND: BuiltinIndex = BuiltinIndex {
@@ -3014,6 +3029,7 @@ pub const MZ_SHOW_SECRETS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_show_secrets_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_secrets (schema_id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_CLUSTERS_IND: BuiltinIndex = BuiltinIndex {
@@ -3022,6 +3038,7 @@ pub const MZ_CLUSTERS_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_clusters_ind
 IN CLUSTER mz_introspection
 ON mz_catalog.mz_clusters (id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SOURCE_STATUSES_IND: BuiltinIndex = BuiltinIndex {
@@ -3030,6 +3047,7 @@ pub const MZ_SOURCE_STATUSES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_source_statuses_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_source_statuses (id)",
+    is_retained_metrics_relation: false,
 };
 
 pub const MZ_SOURCE_STATUS_HISTORY_IND: BuiltinIndex = BuiltinIndex {
@@ -3038,6 +3056,34 @@ pub const MZ_SOURCE_STATUS_HISTORY_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_source_status_history_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_source_status_history (source_id)",
+    is_retained_metrics_relation: false,
+};
+
+pub const MZ_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_cluster_replicas_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_cluster_replicas_ind
+IN CLUSTER mz_introspection
+ON mz_catalog.mz_cluster_replicas (id)",
+    is_retained_metrics_relation: true,
+};
+
+pub const MZ_CLUSTER_REPLICA_SIZES_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_cluster_replica_sizes_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_cluster_replica_sizes_ind
+IN CLUSTER mz_introspection
+ON mz_internal.mz_cluster_replica_sizes (size)",
+    is_retained_metrics_relation: true,
+};
+
+pub const MZ_CLUSTER_REPLICA_METRICS_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_cluster_replica_metrics_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_cluster_replica_metrics_ind
+IN CLUSTER mz_introspection
+ON mz_internal.mz_cluster_replica_metrics (replica_id)",
+    is_retained_metrics_relation: true,
 };
 
 pub static MZ_SYSTEM_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {
@@ -3313,6 +3359,9 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Index(&MZ_CLUSTERS_IND),
         Builtin::Index(&MZ_SOURCE_STATUSES_IND),
         Builtin::Index(&MZ_SOURCE_STATUS_HISTORY_IND),
+        Builtin::Index(&MZ_CLUSTER_REPLICAS_IND),
+        Builtin::Index(&MZ_CLUSTER_REPLICA_SIZES_IND),
+        Builtin::Index(&MZ_CLUSTER_REPLICA_METRICS_IND),
     ]);
 
     builtins

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -657,7 +657,8 @@ impl Coordinator {
             .catalog()
             .entries()
             .filter(|entry| {
-                entry.item().is_retained_metrics_object() && entry.item().cluster_id().is_none()
+                entry.item().is_retained_metrics_object()
+                    && entry.item().is_compute_object_on_cluster().is_none()
             })
             .map(|entry| (entry.id(), policy.clone()))
             .collect::<Vec<_>>();
@@ -667,7 +668,7 @@ impl Coordinator {
             .filter_map(|entry| {
                 if let (true, Some(cluster_id)) = (
                     entry.item().is_retained_metrics_object(),
-                    entry.item().cluster_id(),
+                    entry.item().is_compute_object_on_cluster(),
                 ) {
                     Some((cluster_id, entry.id(), policy.clone()))
                 } else {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -657,7 +657,7 @@ impl Coordinator {
             .catalog()
             .entries()
             .filter(|entry| {
-                entry.item().is_retained_metrics_relation() && entry.item().cluster_id().is_none()
+                entry.item().is_retained_metrics_object() && entry.item().cluster_id().is_none()
             })
             .map(|entry| (entry.id(), policy.clone()))
             .collect::<Vec<_>>();
@@ -666,7 +666,7 @@ impl Coordinator {
             .entries()
             .filter_map(|entry| {
                 if let (true, Some(cluster_id)) = (
-                    entry.item().is_retained_metrics_relation(),
+                    entry.item().is_retained_metrics_object(),
                     entry.item().cluster_id(),
                 ) {
                     Some((cluster_id, entry.id(), policy.clone()))

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -329,21 +329,40 @@ impl crate::coord::Coordinator {
         self.controller.storage.set_read_policy(policies)
     }
 
+    pub(crate) fn update_compute_base_read_policies(
+        &mut self,
+        mut base_policies: Vec<(ComputeInstanceId, GlobalId, ReadPolicy<mz_repr::Timestamp>)>,
+    ) {
+        base_policies.sort_by_key(|&(cluster_id, _, _)| cluster_id);
+        use itertools::Itertools;
+        for (cluster_id, group) in &base_policies
+            .into_iter()
+            .group_by(|&(cluster_id, _, _)| cluster_id)
+        {
+            let group = group
+                .map(|(_, id, base_policy)| {
+                    let capability = self
+                        .compute_read_capabilities
+                        .get_mut(&id)
+                        .expect("coord out of sync");
+                    capability.base_policy = base_policy;
+                    (id, capability.policy())
+                })
+                .collect::<Vec<_>>();
+            self.controller
+                .active_compute()
+                .set_read_policy(cluster_id, group)
+                .unwrap_or_terminate("cannot fail to set read policy");
+        }
+    }
+
     pub(crate) fn update_compute_base_read_policy(
         &mut self,
         compute_instance: ComputeInstanceId,
         id: GlobalId,
         base_policy: ReadPolicy<mz_repr::Timestamp>,
     ) {
-        let capability = self
-            .compute_read_capabilities
-            .get_mut(&id)
-            .expect("coord out of sync");
-        capability.base_policy = base_policy;
-        self.controller
-            .active_compute()
-            .set_read_policy(compute_instance, vec![(id, capability.policy())])
-            .unwrap_or_terminate("cannot fail to set read policy");
+        self.update_compute_base_read_policies(vec![(compute_instance, id, base_policy)])
     }
 
     /// Drop read policy in STORAGE for `id`.

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -20,10 +20,11 @@
 //! `mz_ore` wrapper either.
 #![allow(clippy::disallowed_types)]
 
-use differential_dataflow::lattice::Lattice;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::hash::Hash;
 
+use differential_dataflow::lattice::Lattice;
+use itertools::Itertools;
 use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 
@@ -334,7 +335,6 @@ impl crate::coord::Coordinator {
         mut base_policies: Vec<(ComputeInstanceId, GlobalId, ReadPolicy<mz_repr::Timestamp>)>,
     ) {
         base_policies.sort_by_key(|&(cluster_id, _, _)| cluster_id);
-        use itertools::Itertools;
         for (cluster_id, group) in &base_policies
             .into_iter()
             .group_by(|&(cluster_id, _, _)| cluster_id)

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1319,6 +1319,8 @@ impl Coordinator {
             conn_id: None,
             depends_on,
             cluster_id,
+            is_retained_metrics_relation: false,
+            custom_logical_compaction_window: None,
         };
         let oid = self.catalog_mut().allocate_oid()?;
         let op = catalog::Op::CreateItem {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -179,7 +179,7 @@ impl Coordinator {
                 timeline: plan.timeline,
                 depends_on,
                 custom_logical_compaction_window: None,
-                is_retained_metrics_relation: false,
+                is_retained_metrics_object: false,
             };
             ops.push(catalog::Op::CreateItem {
                 id: source_id,
@@ -777,7 +777,7 @@ impl Coordinator {
             conn_id,
             depends_on,
             custom_logical_compaction_window: None,
-            is_retained_metrics_relation: false,
+            is_retained_metrics_object: false,
         };
         let table_oid = self.catalog_mut().allocate_oid()?;
         let ops = vec![catalog::Op::CreateItem {
@@ -1319,7 +1319,7 @@ impl Coordinator {
             conn_id: None,
             depends_on,
             cluster_id,
-            is_retained_metrics_relation: false,
+            is_retained_metrics_object: false,
             custom_logical_compaction_window: None,
         };
         let oid = self.catalog_mut().allocate_oid()?;

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -160,7 +160,7 @@ async fn datadriven() {
                                             conn_id: None,
                                             depends_on: vec![],
                                             custom_logical_compaction_window: None,
-                                            is_retained_metrics_relation: false,
+                                            is_retained_metrics_object: false,
                                         }),
                                         owner_id: MZ_SYSTEM_ROLE_ID,
                                     }],

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1270,6 +1270,9 @@ fn test_explain_timestamp_json() {
 #[test]
 fn test_utilization_hold() {
     const THIRTY_DAYS_MS: u64 = 30 * 24 * 60 * 60 * 1000;
+    // `mz_introspection` tests indexes, `default` tests tables.
+    // The bool determines whether we are testing indexes.
+    const CLUSTERS_TO_TRY: &[(&str, bool)] = &[("mz_introspection", true), ("default", false)];
 
     let now_millis = u64::try_from(
         SystemTime::now()
@@ -1298,35 +1301,42 @@ fn test_utilization_hold() {
 
     let mut client = server.connect(postgres::NoTls).unwrap();
 
-    // Use the indexes
-    client.execute("SET cluster=mz_introspection", &[]).unwrap();
-
     let q =
         "EXPLAIN TIMESTAMP AS JSON FOR SELECT * FROM mz_internal.mz_cluster_replica_utilization";
-    let row = client.query_one(q, &[]).unwrap();
-    let explain: String = row.get(0);
-    let explain: TimestampExplanation<Timestamp> = serde_json::from_str(&explain).unwrap();
-    // Assert that we actually used the indexes
-    for s in &explain.sources {
-        assert!(s.name.ends_with("compute)"));
-    }
+    for (cluster, should_be_indexed) in CLUSTERS_TO_TRY {
+        client
+            .execute(&format!("SET cluster={cluster}"), &[])
+            .unwrap();
 
-    // If we're not in EpochMilliseconds, the timestamp math below is invalid, so assert that here.
-    assert!(matches!(
-        explain.determination.timestamp_context,
-        TimestampContext::TimelineTimestamp(Timeline::EpochMilliseconds, _)
-    ));
-    let since = explain
-        .determination
-        .since
-        .into_option()
-        .expect("The since must be finite");
-    let past_since = Timestamp::from(past_millis);
-    assert!(since.less_equal(&past_since));
-    // Assert we aren't lagging by more than 30 days + 1 second.
-    // If we ever make the since granularity configurable, this line will
-    // need to be changed.
-    assert!(past_since.less_equal(&since.checked_add(1000).unwrap()));
+        let row = client.query_one(q, &[]).unwrap();
+        let explain: String = row.get(0);
+        let explain: TimestampExplanation<Timestamp> = serde_json::from_str(&explain).unwrap();
+        // Assert that we actually used the indexes/tables, as required
+        for s in &explain.sources {
+            if *should_be_indexed {
+                assert!(s.name.ends_with("compute)"));
+            } else {
+                assert!(s.name.ends_with("storage)"));
+            }
+        }
+
+        // If we're not in EpochMilliseconds, the timestamp math below is invalid, so assert that here.
+        assert!(matches!(
+            explain.determination.timestamp_context,
+            TimestampContext::TimelineTimestamp(Timeline::EpochMilliseconds, _)
+        ));
+        let since = explain
+            .determination
+            .since
+            .into_option()
+            .expect("The since must be finite");
+        let past_since = Timestamp::from(past_millis);
+        assert!(since.less_equal(&past_since));
+        // Assert we aren't lagging by more than 30 days + 1 second.
+        // If we ever make the since granularity configurable, this line will
+        // need to be changed.
+        assert!(past_since.less_equal(&since.checked_add(1000).unwrap()));
+    }
 
     // Check that we can turn off retention
     let mut sys_client = server
@@ -1339,16 +1349,23 @@ fn test_utilization_hold() {
         .execute("ALTER SYSTEM SET metrics_retention='1s'", &[])
         .unwrap();
 
-    let row = client.query_one(q, &[]).unwrap();
-    let explain: String = row.get(0);
-    let explain: TimestampExplanation<Timestamp> = serde_json::from_str(&explain).unwrap();
-    let since = explain
-        .determination
-        .since
-        .into_option()
-        .expect("The since must be finite");
-    // Check that since is not more than 2 seconds in the past
-    assert!(Timestamp::new(now_millis).less_equal(&since.step_forward_by(&Timestamp::new(2000))));
+    for (cluster, _) in CLUSTERS_TO_TRY {
+        client
+            .execute(&format!("SET cluster={cluster}"), &[])
+            .unwrap();
+        let row = client.query_one(q, &[]).unwrap();
+        let explain: String = row.get(0);
+        let explain: TimestampExplanation<Timestamp> = serde_json::from_str(&explain).unwrap();
+        let since = explain
+            .determination
+            .since
+            .into_option()
+            .expect("The since must be finite");
+        // Check that since is not more than 2 seconds in the past
+        assert!(
+            Timestamp::new(now_millis).less_equal(&since.step_forward_by(&Timestamp::new(2000)))
+        );
+    }
 }
 
 // Test that a query that causes a compute instance to panic will resolve

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -368,7 +368,7 @@ CREATE CLUSTER test REPLICAS (foo (SIZE '1'));
 query I
 SELECT COUNT(name) FROM mz_indexes;
 ----
-94
+97
 
 statement ok
 DROP CLUSTER test CASCADE
@@ -376,7 +376,7 @@ DROP CLUSTER test CASCADE
 query T
 SELECT COUNT(name) FROM mz_indexes;
 ----
-75
+78
 
 statement error nvalid SIZE: must provide a string value
 CREATE CLUSTER REPLICA default.size_1 SIZE;

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -232,22 +232,22 @@ Explained Query:
         ArrangeBy keys=[[#0]]
           Get mz_catalog.mz_clusters
         ArrangeBy keys=[[#0]]
-          Project (#0, #6)
-            Map (((uint8_to_double(#5) / uint8_to_double(#3)) * 100))
-              Join on=(#0 = #4 AND #1 = #2) type=differential
-                ArrangeBy keys=[[#1]]
-                  Project (#0, #3)
-                    Filter (#3) IS NOT NULL
-                      Get mz_catalog.mz_cluster_replicas
-                ArrangeBy keys=[[#0]]
-                  Project (#0, #4)
+          Project (#0, #15)
+            Filter (#3) IS NOT NULL
+              Map (((uint8_to_double(#14) / uint8_to_double(#10)) * 100))
+                Join on=(#0 = #11 AND #3 = #6) type=differential
+                  ArrangeBy keys=[[#0]]
+                    Get mz_catalog.mz_cluster_replicas
+                  ArrangeBy keys=[[#0]]
                     Get mz_internal.mz_cluster_replica_sizes
-                ArrangeBy keys=[[#0]]
-                  Project (#0, #3)
+                  ArrangeBy keys=[[#0]]
                     Get mz_internal.mz_cluster_replica_metrics
 
 Used Indexes:
   - mz_internal.mz_clusters_ind
+  - mz_internal.mz_cluster_replicas_ind
+  - mz_internal.mz_cluster_replica_sizes_ind
+  - mz_internal.mz_cluster_replica_metrics_ind
 
 EOF
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -591,7 +591,7 @@ test_table
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'
-75
+78
 
 # Create a second schema with the same table name as above
 > CREATE SCHEMA tester2

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -280,6 +280,9 @@ mz_arrangement_batches_internal_s2_primary_idx                   mz_arrangement_
 mz_arrangement_records_internal_s2_primary_idx                   mz_arrangement_records_internal                   mz_introspection    {operator_id,worker_id}
 mz_arrangement_sharing_internal_s2_primary_idx                   mz_arrangement_sharing_internal                   mz_introspection    {operator_id,worker_id}
 mz_clusters_ind                                                  mz_clusters                                       mz_introspection    {id}
+mz_cluster_replica_metrics_ind                                   mz_cluster_replica_metrics                        mz_introspection    {replica_id}
+mz_cluster_replica_sizes_ind                                     mz_cluster_replica_sizes                          mz_introspection    {size}
+mz_cluster_replicas_ind                                          mz_cluster_replicas                               mz_introspection    {id}
 mz_compute_exports_s2_primary_idx                                mz_compute_exports                                mz_introspection    {export_id,worker_id}
 mz_compute_operator_durations_histogram_internal_s2_primary_idx  mz_compute_operator_durations_histogram_internal  mz_introspection    {id,worker_id,duration_ns}
 mz_dataflow_addresses_s2_primary_idx                             mz_dataflow_addresses                             mz_introspection    {id,worker_id}


### PR DESCRIPTION
We want to turn on indexes for the queries used by the console to populate CPU/memory data, in order to decrease the latency of those queries as well as the load on S3. To do so, we need to allow indexes to be retained according to the metrics retention window, the same way tables and sources already can be.

This PR is a relatively straightforward port of the `is_retained_metrics_relation` logic to indexes. 

For testing, we modify the existing `test_utilization_hold` to run its queries in `mz_introspection`, verifying both that the indexes are available and that their since is properly held back.

Before landing, I will run this in staging for a day or two to make sure the memory usage is not too extreme. 