### PR TITLE
pg sources: apply constraints + tolerate upstream changes

### DIFF
--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -69,7 +69,7 @@ pub struct Config<'a> {
     /// skip any migrations that require it, which will likely cause tests to
     /// fail.
     ///
-    /// TODO(migration): delete in version v.50 (released in v0.48 + 1
+    /// TODO(migration): delete in version v.51 (released in v0.49 + 1
     /// additional release)
     pub connection_context: Option<mz_storage_client::types::connections::ConnectionContext>,
 }

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -126,7 +126,7 @@ pub(crate) async fn migrate(
 // they were not used to generate the DDL for the subsources and it is now too
 // late to apply them.
 //
-// TODO(migration): delete in version v.50 (released in v0.48 + 1 additional
+// TODO(migration): delete in version v.51 (released in v0.49 + 1 additional
 // release)
 async fn pg_source_table_metadata_rewrite(
     catalog: &ConnCatalog<'_>,

--- a/src/postgres-util/src/desc.proto
+++ b/src/postgres-util/src/desc.proto
@@ -34,6 +34,7 @@ message ProtoPostgresColumnDesc {
     uint32 type_oid = 2;
     int32 type_mod = 3;
     bool nullable = 4;
-    // TODO(migration): remove optional in v0.48
+    // TODO(migration): remove optional in version v.50 (released in v0.48 + 1
+    // additional release)
     optional uint32 col_num = 6;
 }

--- a/src/postgres-util/src/desc.proto
+++ b/src/postgres-util/src/desc.proto
@@ -11,11 +11,20 @@ syntax = "proto3";
 
 package mz_postgres_util.desc;
 
+message ProtoPostgresKeyDesc {
+    uint32 oid = 1;
+    string name = 2;
+    repeated uint32 cols = 3;
+    bool is_primary = 4;
+    bool nulls_not_distinct = 5;
+}
+
 message ProtoPostgresTableDesc {
     string name = 1;
     string namespace = 2;
     uint32 oid = 3;
     repeated ProtoPostgresColumnDesc columns = 4;
+    repeated ProtoPostgresKeyDesc keys = 5;
 }
 
 message ProtoPostgresColumnDesc {

--- a/src/postgres-util/src/desc.proto
+++ b/src/postgres-util/src/desc.proto
@@ -34,7 +34,7 @@ message ProtoPostgresColumnDesc {
     uint32 type_oid = 2;
     int32 type_mod = 3;
     bool nullable = 4;
-    // TODO(migration): remove optional in version v.50 (released in v0.48 + 1
+    // TODO(migration): remove optional in version v.51 (released in v0.49 + 1
     // additional release)
     optional uint32 col_num = 6;
 }

--- a/src/postgres-util/src/desc.proto
+++ b/src/postgres-util/src/desc.proto
@@ -28,11 +28,12 @@ message ProtoPostgresTableDesc {
 }
 
 message ProtoPostgresColumnDesc {
+    reserved 5;
+    reserved "primary_key";
     string name = 1;
     uint32 type_oid = 2;
     int32 type_mod = 3;
     bool nullable = 4;
-    bool primary_key = 5;
     // TODO(migration): remove optional in v0.48
     optional uint32 col_num = 6;
 }

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -105,11 +105,6 @@ pub struct PostgresColumnDesc {
     pub type_mod: i32,
     /// True if the column lacks a `NOT NULL` constraint.
     pub nullable: bool,
-    /// Whether the column is part of the table's primary key.
-    ///
-    /// TODO(benesch): this doesn't look descriptive enough. The order of the
-    /// columns in the primary key matters too.
-    pub primary_key: bool,
 }
 
 impl RustType<ProtoPostgresColumnDesc> for PostgresColumnDesc {
@@ -120,7 +115,6 @@ impl RustType<ProtoPostgresColumnDesc> for PostgresColumnDesc {
             type_oid: self.type_oid,
             type_mod: self.type_mod,
             nullable: self.nullable,
-            primary_key: self.primary_key,
         }
     }
 
@@ -133,7 +127,6 @@ impl RustType<ProtoPostgresColumnDesc> for PostgresColumnDesc {
             type_oid: proto.type_oid,
             type_mod: proto.type_mod,
             nullable: proto.nullable,
-            primary_key: proto.primary_key,
         })
     }
 }
@@ -149,16 +142,14 @@ impl Arbitrary for PostgresColumnDesc {
             any::<u32>(),
             any::<i32>(),
             any::<bool>(),
-            any::<bool>(),
         )
             .prop_map(
-                |(name, col_num, type_oid, type_mod, nullable, primary_key)| PostgresColumnDesc {
+                |(name, col_num, type_oid, type_mod, nullable)| PostgresColumnDesc {
                     name,
                     col_num: Some(col_num),
                     type_oid,
                     type_mod,
                     nullable,
-                    primary_key,
                 },
             )
             .boxed()

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeSet;
 use proptest::prelude::{any, Arbitrary};
 use proptest::strategy::{BoxedStrategy, Strategy};
 use serde::{Deserialize, Serialize};
+use tokio_postgres::types::Oid;
 
 use mz_proto::{RustType, TryFromProtoError};
 
@@ -23,7 +24,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_postgres_util.desc.rs"));
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PostgresTableDesc {
     /// The OID of the table.
-    pub oid: u32,
+    pub oid: Oid,
     /// The name of the schema that the table belongs to.
     pub namespace: String,
     /// The name of the table.
@@ -99,7 +100,7 @@ pub struct PostgresColumnDesc {
     // additional release)
     pub col_num: Option<u16>,
     /// The OID of the column's type.
-    pub type_oid: u32,
+    pub type_oid: Oid,
     /// The modifier for the column's type.
     pub type_mod: i32,
     /// True if the column lacks a `NOT NULL` constraint.
@@ -168,7 +169,7 @@ impl Arbitrary for PostgresColumnDesc {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct PostgresKeyDesc {
     /// This key is derived from the `pg_constraint` with this OID.
-    pub oid: u32,
+    pub oid: Oid,
     /// The name of the constraints.
     pub name: String,
     /// The `attnum` of the columns comprising the key. `attnum` is a unique identifier for a column

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -146,7 +146,7 @@ pub struct PostgresColumnDesc {
     pub name: String,
     /// The column's monotonic position in its table, i.e. "this was the _i_th
     /// column created" irrespective of the current number of columns.
-    // TODO(migration): remove option in version v.50 (released in v0.48 + 1
+    // TODO(migration): remove option in version v.51 (released in v0.49 + 1
     // additional release)
     pub col_num: Option<u16>,
     /// The OID of the column's type.

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -9,6 +9,8 @@
 
 //! Descriptions of PostgreSQL objects.
 
+use std::collections::BTreeSet;
+
 use proptest::prelude::{any, Arbitrary};
 use proptest::strategy::{BoxedStrategy, Strategy};
 use serde::{Deserialize, Serialize};
@@ -28,6 +30,9 @@ pub struct PostgresTableDesc {
     pub name: String,
     /// The description of each column, in order of their position in the table.
     pub columns: Vec<PostgresColumnDesc>,
+    /// Applicable keys for this table (i.e. primary key and unique
+    /// constraints).
+    pub keys: BTreeSet<PostgresKeyDesc>,
 }
 
 impl RustType<ProtoPostgresTableDesc> for PostgresTableDesc {
@@ -37,6 +42,7 @@ impl RustType<ProtoPostgresTableDesc> for PostgresTableDesc {
             namespace: self.namespace.clone(),
             name: self.name.clone(),
             columns: self.columns.iter().map(|c| c.into_proto()).collect(),
+            keys: self.keys.iter().map(PostgresKeyDesc::into_proto).collect(),
         }
     }
 
@@ -49,6 +55,11 @@ impl RustType<ProtoPostgresTableDesc> for PostgresTableDesc {
                 .columns
                 .into_iter()
                 .map(PostgresColumnDesc::from_proto)
+                .collect::<Result<_, _>>()?,
+            keys: proto
+                .keys
+                .into_iter()
+                .map(PostgresKeyDesc::from_proto)
                 .collect::<Result<_, _>>()?,
         })
     }
@@ -64,12 +75,14 @@ impl Arbitrary for PostgresTableDesc {
             any::<String>(),
             any::<u32>(),
             any::<Vec<PostgresColumnDesc>>(),
+            any::<BTreeSet<PostgresKeyDesc>>(),
         )
-            .prop_map(|(name, namespace, oid, columns)| PostgresTableDesc {
+            .prop_map(|(name, namespace, oid, columns, keys)| PostgresTableDesc {
                 name,
                 namespace,
                 oid,
                 columns,
+                keys,
             })
             .boxed()
     }
@@ -145,6 +158,74 @@ impl Arbitrary for PostgresColumnDesc {
                     type_mod,
                     nullable,
                     primary_key,
+                },
+            )
+            .boxed()
+    }
+}
+
+/// Describes a key in a [`PostgresTableDesc`].
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord)]
+pub struct PostgresKeyDesc {
+    /// This key is derived from the `pg_constraint` with this OID.
+    pub oid: u32,
+    /// The name of the constraints.
+    pub name: String,
+    /// The `attnum` of the columns comprising the key. `attnum` is a unique identifier for a column
+    /// in a PG table; see <https://www.postgresql.org/docs/current/catalog-pg-attribute.html>
+    pub cols: Vec<u16>,
+    /// Whether or not this key is the primary key.
+    pub is_primary: bool,
+    /// If this constraint was generated with NULLS NOT DISTINCT; see
+    /// <https://www.postgresql.org/about/featurematrix/detail/392/>
+    pub nulls_not_distinct: bool,
+}
+
+impl RustType<ProtoPostgresKeyDesc> for PostgresKeyDesc {
+    fn into_proto(&self) -> ProtoPostgresKeyDesc {
+        ProtoPostgresKeyDesc {
+            oid: self.oid,
+            name: self.name.clone(),
+            cols: self.cols.clone().into_iter().map(u32::from).collect(),
+            is_primary: self.is_primary,
+            nulls_not_distinct: self.nulls_not_distinct,
+        }
+    }
+
+    fn from_proto(proto: ProtoPostgresKeyDesc) -> Result<Self, TryFromProtoError> {
+        Ok(PostgresKeyDesc {
+            oid: proto.oid,
+            name: proto.name,
+            cols: proto
+                .cols
+                .into_iter()
+                .map(|c| c.try_into().expect("values roundtrip"))
+                .collect(),
+            is_primary: proto.is_primary,
+            nulls_not_distinct: proto.nulls_not_distinct,
+        })
+    }
+}
+
+impl Arbitrary for PostgresKeyDesc {
+    type Strategy = BoxedStrategy<Self>;
+    type Parameters = ();
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        (
+            any::<u32>(),
+            any::<String>(),
+            any::<Vec<u16>>(),
+            any::<bool>(),
+            any::<bool>(),
+        )
+            .prop_map(
+                |(oid, name, cols, is_primary, nulls_not_distinct)| PostgresKeyDesc {
+                    oid,
+                    name,
+                    cols,
+                    is_primary,
+                    nulls_not_distinct,
                 },
             )
             .boxed()

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -267,14 +267,12 @@ pub async fn publication_info(
                 );
                 let type_mod: i32 = row.get("typmod");
                 let not_null: bool = row.get("not_null");
-                let primary_key = row.get("primary_key");
                 Ok(PostgresColumnDesc {
                     name,
                     col_num,
                     type_oid,
                     type_mod,
                     nullable: !not_null,
-                    primary_key,
                 })
             })
             .collect::<Result<Vec<_>, PostgresError>>()?;

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -106,14 +106,21 @@ CREATE TABLE foo (id int, CONSTRAINT address_pkey PRIMARY KEY (address_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT address_pkey PRIMARY KEY (address_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("address_pkey")), columns: [Ident("address_id")], is_primary: true }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("address_pkey")), columns: [Ident("address_id")], is_primary: true, nulls_not_distinct: false }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT uk_task UNIQUE (report_date, task_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT uk_task UNIQUE (report_date, task_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false, nulls_not_distinct: false }], if_not_exists: false, temporary: false })
+
+parse-statement
+CREATE TABLE foo (id int, CONSTRAINT uk_task UNIQUE NULLS NOT DISTINCT (report_date, task_id))
+----
+CREATE TABLE foo (id int4, CONSTRAINT uk_task UNIQUE NULLS NOT DISTINCT (report_date, task_id))
+=>
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false, nulls_not_distinct: true }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id))
@@ -134,14 +141,14 @@ CREATE TABLE foo (id int, PRIMARY KEY (foo, bar))
 ----
 CREATE TABLE foo (id int4, PRIMARY KEY (foo, bar))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("foo"), Ident("bar")], is_primary: true }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("foo"), Ident("bar")], is_primary: true, nulls_not_distinct: false }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, UNIQUE (id))
 ----
 CREATE TABLE foo (id int4, UNIQUE (id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false, nulls_not_distinct: false }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar))

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -239,6 +239,7 @@ pub fn plan_create_table(
         defaults.push(default);
     }
 
+    let mut seen_primary = false;
     for constraint in constraints {
         match constraint {
             TableConstraint::Unique {
@@ -246,6 +247,14 @@ pub fn plan_create_table(
                 columns,
                 is_primary,
             } => {
+                if seen_primary && *is_primary {
+                    sql_bail!(
+                        "multiple primary keys for table {} are not allowed",
+                        name.to_ast_string_stable()
+                    );
+                }
+                seen_primary = *is_primary || seen_primary;
+
                 let mut key = vec![];
                 for column in columns {
                     let column = normalize::column_name(column.clone());
@@ -1092,6 +1101,7 @@ pub fn plan_create_subsource(
         column_types.push(ty.nullable(nullable));
     }
 
+    let mut seen_primary = false;
     for constraint in constraints {
         match constraint {
             TableConstraint::Unique {
@@ -1099,6 +1109,14 @@ pub fn plan_create_subsource(
                 columns,
                 is_primary,
             } => {
+                if seen_primary && *is_primary {
+                    sql_bail!(
+                        "multiple primary keys for source {} are not allowed",
+                        name.to_ast_string_stable()
+                    );
+                }
+                seen_primary = *is_primary || seen_primary;
+
                 let mut key = vec![];
                 for column in columns {
                     let column = normalize::column_name(column.clone());

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -281,7 +281,12 @@ pub fn plan_create_table(
                         }
                     }
                 }
-                keys.push(key);
+
+                if *is_primary {
+                    keys.insert(0, key);
+                } else {
+                    keys.push(key);
+                }
             }
             TableConstraint::ForeignKey { .. } => {
                 // Foreign key constraints are not presently enforced. We allow
@@ -1179,7 +1184,12 @@ pub fn plan_create_subsource(
                         }
                     }
                 }
-                keys.push(key);
+
+                if *is_primary {
+                    keys.insert(0, key);
+                } else {
+                    keys.push(key);
+                }
             }
             TableConstraint::ForeignKey { .. } => {
                 bail_unsupported!("CREATE SUBSOURCE with a foreign key")

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -246,6 +246,7 @@ pub fn plan_create_table(
                 name: _,
                 columns,
                 is_primary,
+                nulls_not_distinct: _,
             } => {
                 if seen_primary && *is_primary {
                     sql_bail!(
@@ -1108,6 +1109,7 @@ pub fn plan_create_subsource(
                 name: _,
                 columns,
                 is_primary,
+                nulls_not_distinct: _,
             } => {
                 if seen_primary && *is_primary {
                     sql_bail!(

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -463,6 +463,37 @@ pub async fn purify_create_source(
                     });
                 }
 
+                let mut constraints = vec![];
+                for key in table.keys.clone() {
+                    let mut key_columns = vec![];
+
+                    for col_num in key.cols {
+                        key_columns.push(Ident::new(
+                            table
+                                .columns
+                                .iter()
+                                .find(|col| col.col_num == Some(col_num))
+                                .expect("key exists as column")
+                                .name
+                                .clone(),
+                        ))
+                    }
+
+                    let constraint = mz_sql_parser::ast::TableConstraint::Unique {
+                        name: Some(Ident::new(key.name)),
+                        columns: key_columns,
+                        is_primary: key.is_primary,
+                        nulls_not_distinct: key.nulls_not_distinct,
+                    };
+
+                    // We take the first constraint available to be the primary key.
+                    if key.is_primary {
+                        constraints.insert(0, constraint);
+                    } else {
+                        constraints.push(constraint);
+                    }
+                }
+
                 // Create the targeted AST node for the original CREATE SOURCE statement
                 let transient_id = GlobalId::Transient(get_transient_subsource_id());
 
@@ -486,7 +517,7 @@ pub async fn purify_create_source(
                     // replication stream*, if our assumptions change. Failure to do that could
                     // mean that an upstream table that started with an index was then altered to
                     // one without and now we're producing garbage data.
-                    constraints: vec![],
+                    constraints,
                     if_not_exists: false,
                     with_options: vec![CreateSubsourceOption {
                         name: CreateSubsourceOptionName::References,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -446,12 +446,20 @@ pub async fn purify_create_source(
                     };
 
                     let data_type = scx.resolve_type(ty)?;
+                    let mut options = vec![];
+
+                    if !c.nullable {
+                        options.push(mz_sql_parser::ast::ColumnOptionDef {
+                            name: None,
+                            option: mz_sql_parser::ast::ColumnOption::NotNull,
+                        });
+                    }
 
                     columns.push(ColumnDef {
                         name,
                         data_type,
                         collation: None,
-                        options: vec![],
+                        options,
                     });
                 }
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -339,18 +339,6 @@ pub async fn purify_create_source(
                     // The user manually selected a subset of upstream tables so we need to
                     // validate that the names actually exist and are not ambiguous
 
-                    // An index from table name -> schema name -> database name -> PostgresTableDesc
-                    let mut tables_by_name = BTreeMap::new();
-                    for table in &publication_tables {
-                        tables_by_name
-                            .entry(table.name.clone())
-                            .or_insert_with(BTreeMap::new)
-                            .entry(table.namespace.clone())
-                            .or_insert_with(BTreeMap::new)
-                            .entry(connection.database.clone())
-                            .or_insert(table);
-                    }
-
                     validated_requested_subsources.extend(subsource_gen(
                         subsources,
                         &publication_catalog,

--- a/test/cluster/pg-snapshot-resumption/01-configure-postgres.td
+++ b/test/cluster/pg-snapshot-resumption/01-configure-postgres.td
@@ -13,7 +13,8 @@ GRANT ALL PRIVILEGES ON DATABASE "postgres" TO debezium;
 GRANT ALL PRIVILEGES ON SCHEMA "public" TO debezium;
 
 CREATE PUBLICATION mz_source;
-CREATE PUBLICATION mz_source_alter;
+CREATE PUBLICATION mz_source_alter_add_col;
+CREATE PUBLICATION mz_source_alter_drop_constraint;
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP TABLE IF EXISTS ten;

--- a/test/pg-cdc-resumption/alter-table.td
+++ b/test/pg-cdc-resumption/alter-table.td
@@ -8,8 +8,8 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-ALTER TABLE to_be_altered_fail ADD COLUMN f2 INTEGER;
-INSERT INTO to_be_altered_fail VALUES (1, 2);
+ALTER TABLE alter_fail_add_col ADD COLUMN f2 INTEGER;
+INSERT INTO alter_fail_add_col VALUES (1, 2);
 
-ALTER TABLE to_be_altered_ok ALTER COLUMN f1 DROP NOT NULL;
-INSERT INTO to_be_altered_ok VALUES (NULL);
+ALTER TABLE alter_fail_drop_constraint ALTER COLUMN f1 DROP NOT NULL;
+INSERT INTO alter_fail_drop_constraint VALUES (NULL);

--- a/test/pg-cdc-resumption/alter-table.td
+++ b/test/pg-cdc-resumption/alter-table.td
@@ -8,5 +8,8 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-ALTER TABLE to_be_altered ADD COLUMN f2 INTEGER;
-INSERT INTO to_be_altered VALUES (1, 2);
+ALTER TABLE to_be_altered_fail ADD COLUMN f2 INTEGER;
+INSERT INTO to_be_altered_fail VALUES (1, 2);
+
+ALTER TABLE to_be_altered_ok ALTER COLUMN f1 DROP NOT NULL;
+INSERT INTO to_be_altered_ok VALUES (NULL);

--- a/test/pg-cdc-resumption/configure-materalize.td
+++ b/test/pg-cdc-resumption/configure-materalize.td
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> DROP SOURCE IF EXISTS mz_source CASCADE;
 > DROP SECRET IF EXISTS pgpass CASCADE;
 > DROP CONNECTION IF EXISTS pg CASCADE;
 
@@ -19,6 +18,9 @@
     PASSWORD SECRET pgpass
   );
 
+> DROP SOURCE IF EXISTS mz_source CASCADE;
+> DROP SOURCE IF EXISTS mz_source_alter_add_col CASCADE;
+> DROP SOURCE IF EXISTS mz_source_alter_drop_constraint CASCADE;
 
 > CREATE SOURCE mz_source
   FROM POSTGRES
@@ -26,10 +28,14 @@
   (PUBLICATION 'mz_source')
   FOR ALL TABLES;
 
-> DROP SOURCE IF EXISTS mz_source_alter CASCADE;
-
-> CREATE SOURCE mz_source_alter
+> CREATE SOURCE mz_source_alter_add_col
   FROM POSTGRES
   CONNECTION pg
-  (PUBLICATION 'mz_source_alter')
+  (PUBLICATION 'mz_source_alter_add_col')
+  FOR ALL TABLES;
+
+> CREATE SOURCE mz_source_alter_drop_constraint
+  FROM POSTGRES
+  CONNECTION pg
+  (PUBLICATION 'mz_source_alter_drop_constraint')
   FOR ALL TABLES;

--- a/test/pg-cdc-resumption/configure-postgres.td
+++ b/test/pg-cdc-resumption/configure-postgres.td
@@ -13,4 +13,5 @@ GRANT ALL PRIVILEGES ON DATABASE "postgres" TO debezium;
 GRANT ALL PRIVILEGES ON SCHEMA "public" TO debezium;
 
 CREATE PUBLICATION mz_source;
-CREATE PUBLICATION mz_source_alter;
+CREATE PUBLICATION mz_source_alter_add_col;
+CREATE PUBLICATION mz_source_alter_drop_constraint;

--- a/test/pg-cdc-resumption/populate-tables.td
+++ b/test/pg-cdc-resumption/populate-tables.td
@@ -32,9 +32,16 @@ ALTER PUBLICATION mz_source ADD TABLE t2;
 
 INSERT INTO t2 SELECT a1.f1 + a6.f1 , E'abc\nxyz' FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
 
-DROP TABLE IF EXISTS to_be_altered;
-CREATE TABLE to_be_altered (f1 INTEGER);
-ALTER TABLE to_be_altered REPLICA IDENTITY FULL;
+DROP TABLE IF EXISTS to_be_altered_fail;
+CREATE TABLE to_be_altered_fail (f1 INTEGER);
+ALTER TABLE to_be_altered_fail REPLICA IDENTITY FULL;
 
-INSERT INTO to_be_altered VALUES (1);
-ALTER PUBLICATION mz_source_alter ADD TABLE to_be_altered;
+INSERT INTO to_be_altered_fail VALUES (1);
+ALTER PUBLICATION mz_source_alter ADD TABLE to_be_altered_fail;
+
+DROP TABLE IF EXISTS to_be_altered_ok;
+CREATE TABLE to_be_altered_ok (f1 INTEGER NOT NULL);
+ALTER TABLE to_be_altered_ok REPLICA IDENTITY FULL;
+
+INSERT INTO to_be_altered_ok VALUES (1);
+ALTER PUBLICATION mz_source ADD TABLE to_be_altered_ok;

--- a/test/pg-cdc-resumption/populate-tables.td
+++ b/test/pg-cdc-resumption/populate-tables.td
@@ -32,16 +32,16 @@ ALTER PUBLICATION mz_source ADD TABLE t2;
 
 INSERT INTO t2 SELECT a1.f1 + a6.f1 , E'abc\nxyz' FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
 
-DROP TABLE IF EXISTS to_be_altered_fail;
-CREATE TABLE to_be_altered_fail (f1 INTEGER);
-ALTER TABLE to_be_altered_fail REPLICA IDENTITY FULL;
+DROP TABLE IF EXISTS alter_fail_add_col;
+CREATE TABLE alter_fail_add_col (f1 INTEGER);
+ALTER TABLE alter_fail_add_col REPLICA IDENTITY FULL;
 
-INSERT INTO to_be_altered_fail VALUES (1);
-ALTER PUBLICATION mz_source_alter ADD TABLE to_be_altered_fail;
+INSERT INTO alter_fail_add_col VALUES (1);
+ALTER PUBLICATION mz_source_alter_add_col ADD TABLE alter_fail_add_col;
 
-DROP TABLE IF EXISTS to_be_altered_ok;
-CREATE TABLE to_be_altered_ok (f1 INTEGER NOT NULL);
-ALTER TABLE to_be_altered_ok REPLICA IDENTITY FULL;
+DROP TABLE IF EXISTS alter_fail_drop_constraint;
+CREATE TABLE alter_fail_drop_constraint (f1 INTEGER NOT NULL);
+ALTER TABLE alter_fail_drop_constraint REPLICA IDENTITY FULL;
 
-INSERT INTO to_be_altered_ok VALUES (1);
-ALTER PUBLICATION mz_source ADD TABLE to_be_altered_ok;
+INSERT INTO alter_fail_drop_constraint VALUES (1);
+ALTER PUBLICATION mz_source_alter_drop_constraint ADD TABLE alter_fail_drop_constraint;

--- a/test/pg-cdc-resumption/verify-data.td
+++ b/test/pg-cdc-resumption/verify-data.td
@@ -12,9 +12,8 @@
 > SELECT COUNT(*) FROM t2;
 500000
 
-> SELECT * FROM to_be_altered_ok;
-1
-<null>
+! SELECT * FROM alter_fail_drop_constraint;
+contains:has been altered
 
-! SELECT * FROM to_be_altered_fail;
+! SELECT * FROM alter_fail_add_col;
 contains:has been altered

--- a/test/pg-cdc-resumption/verify-data.td
+++ b/test/pg-cdc-resumption/verify-data.td
@@ -12,5 +12,9 @@
 > SELECT COUNT(*) FROM t2;
 500000
 
-! SELECT * FROM to_be_altered;
-contains:altered
+> SELECT * FROM to_be_altered_ok;
+1
+<null>
+
+! SELECT * FROM to_be_altered_fail;
+contains:has been altered

--- a/test/pg-cdc/alter-table-after-source.td
+++ b/test/pg-cdc/alter-table-after-source.td
@@ -19,6 +19,10 @@
     PASSWORD SECRET pgpass
   )
 
+
+#
+# Add column
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
@@ -47,6 +51,10 @@ INSERT INTO add_columns VALUES (2, 'ab');
 contains:altered
 
 > DROP SOURCE mz_source;
+
+
+#
+# Remove column
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -77,6 +85,10 @@ contains:altered
 
 > DROP SOURCE mz_source;
 
+
+#
+# Alter column type
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
@@ -106,6 +118,10 @@ contains:altered
 
 > DROP SOURCE mz_source;
 
+
+#
+# Drop NOT NULL
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
@@ -113,9 +129,9 @@ DROP PUBLICATION IF EXISTS mz_source;
 
 CREATE SCHEMA public;
 
-CREATE TABLE alter_nullability (f1 INTEGER NOT NULL);
-ALTER TABLE alter_nullability REPLICA IDENTITY FULL;
-INSERT INTO alter_nullability VALUES (1);
+CREATE TABLE alter_drop_nullability (f1 INTEGER NOT NULL);
+ALTER TABLE alter_drop_nullability REPLICA IDENTITY FULL;
+INSERT INTO alter_drop_nullability VALUES (1);
 
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
@@ -123,20 +139,58 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR ALL TABLES;
 
-> SELECT * from alter_nullability
+> SELECT * from alter_drop_nullability
 1
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-ALTER TABLE alter_nullability ALTER COLUMN f1 DROP NOT NULL;
-INSERT INTO alter_nullability VALUES (NULL);
+ALTER TABLE alter_drop_nullability ALTER COLUMN f1 DROP NOT NULL;
+INSERT INTO alter_drop_nullability VALUES (NULL);
 
-! SELECT * FROM alter_nullability WHERE f1 IS NOT NULL;
+! SELECT * FROM alter_drop_nullability WHERE f1 IS NOT NULL;
 contains:altered
 
-! SELECT * FROM alter_nullability WHERE f1 IS NULL;
+# We have guaranteed that this column is not null so the optimizer eagerly
+# returns the empty set.
+> SELECT * FROM alter_drop_nullability WHERE f1 IS NULL;
+
+> DROP SOURCE mz_source;
+
+
+#
+# Add NOT NULL
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_add_nullability (f1 INTEGER);
+ALTER TABLE alter_add_nullability REPLICA IDENTITY FULL;
+INSERT INTO alter_add_nullability VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * from alter_add_nullability
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_add_nullability ALTER COLUMN f1 SET NOT NULL;
+INSERT INTO alter_add_nullability VALUES (1);
+
+! SELECT * FROM alter_add_nullability WHERE f1 IS NOT NULL;
 contains:altered
 
 > DROP SOURCE mz_source;
+
+
+#
+# Drop PK
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -162,12 +216,14 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE alter_drop_pk DROP CONSTRAINT alter_drop_pk_pkey;
 INSERT INTO alter_drop_pk VALUES (1);
 
-# Because ALTERing constraints does not show up in replication this does not cause an error
-> SELECT DISTINCT f1 FROM alter_drop_pk;
-1
+! SELECT f1 FROM alter_drop_pk;
+contains:altered
 
 > DROP SOURCE mz_source;
 
+
+#
+# Add PK
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -176,6 +232,165 @@ DROP PUBLICATION IF EXISTS mz_source;
 
 CREATE SCHEMA public;
 
+CREATE TABLE alter_add_pk (f1 INTEGER);
+ALTER TABLE alter_add_pk REPLICA IDENTITY FULL;
+INSERT INTO alter_add_pk VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * from alter_add_pk
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_add_pk ADD PRIMARY KEY(f1);
+INSERT INTO alter_add_pk VALUES (2);
+
+! SELECT * FROM alter_add_pk;
+contains:altered
+
+> DROP SOURCE mz_source;
+
+
+#
+# Cycle PK
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_cycle_pk (f1 INTEGER PRIMARY KEY);
+ALTER TABLE alter_cycle_pk REPLICA IDENTITY FULL;
+INSERT INTO alter_cycle_pk VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * from alter_cycle_pk
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_cycle_pk DROP CONSTRAINT alter_cycle_pk_pkey;
+ALTER TABLE alter_cycle_pk ADD PRIMARY KEY(f1);
+INSERT INTO alter_cycle_pk VALUES (2);
+
+! SELECT * FROM alter_cycle_pk;
+contains:altered
+
+> DROP SOURCE mz_source;
+
+
+#
+# Cycle PK off (no pk, pk, no pk)
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_cycle_pk_off (f1 INTEGER);
+ALTER TABLE alter_cycle_pk_off REPLICA IDENTITY FULL;
+INSERT INTO alter_cycle_pk_off VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * from alter_cycle_pk_off
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_cycle_pk_off ADD PRIMARY KEY(f1);
+ALTER TABLE alter_cycle_pk_off DROP CONSTRAINT alter_cycle_pk_off_pkey;
+INSERT INTO alter_cycle_pk_off VALUES (1);
+
+! SELECT * FROM alter_cycle_pk_off;
+contains:altered
+
+> DROP SOURCE mz_source;
+
+
+#
+# Drop unique
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_drop_unique (f1 INTEGER UNIQUE);
+ALTER TABLE alter_drop_unique REPLICA IDENTITY FULL;
+INSERT INTO alter_drop_unique VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * from alter_drop_unique
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_drop_unique DROP CONSTRAINT alter_drop_unique_f1_key;
+INSERT INTO alter_drop_unique VALUES (1);
+
+! SELECT f1 FROM alter_drop_unique;
+contains:altered
+
+> DROP SOURCE mz_source;
+
+
+#
+# Add unique
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_add_unique (f1 INTEGER);
+ALTER TABLE alter_add_unique REPLICA IDENTITY FULL;
+INSERT INTO alter_add_unique VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT * from alter_add_unique
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_add_unique ADD UNIQUE(f1);
+INSERT INTO alter_add_unique VALUES (2);
+
+! SELECT * FROM alter_add_unique;
+contains:altered
+
+> DROP SOURCE mz_source;
+
+
+#
+# Extend column
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -207,6 +422,8 @@ contains:altered
 > DROP SOURCE mz_source;
 
 
+#
+# Alter decimal
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -238,6 +455,8 @@ contains:altered
 > DROP SOURCE mz_source;
 
 
+#
+# Alter set with OIDs
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -270,6 +489,8 @@ INSERT INTO alter_set_with_oids VALUES (2);
 > DROP SOURCE mz_source;
 
 
+#
+# Alter set without OIDs
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -302,6 +523,8 @@ INSERT INTO alter_set_without_oids VALUES (2);
 > DROP SOURCE mz_source;
 
 
+#
+# Alter table rename
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
@@ -345,6 +568,10 @@ INSERT INTO alter_table_renamed VALUES (3);
 
 > DROP SOURCE mz_source;
 
+
+#
+# Alter table rename colum
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
@@ -377,6 +604,8 @@ contains:altered
 > DROP SOURCE mz_source;
 
 
+#
+# Change column attnum
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;

--- a/test/pg-cdc/alter-table-after-source.td
+++ b/test/pg-cdc/alter-table-after-source.td
@@ -183,8 +183,9 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE alter_add_nullability ALTER COLUMN f1 SET NOT NULL;
 INSERT INTO alter_add_nullability VALUES (1);
 
-! SELECT * FROM alter_add_nullability WHERE f1 IS NOT NULL;
-contains:altered
+> SELECT * FROM alter_add_nullability;
+1
+1
 
 > DROP SOURCE mz_source;
 
@@ -249,8 +250,9 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE alter_add_pk ADD PRIMARY KEY(f1);
 INSERT INTO alter_add_pk VALUES (2);
 
-! SELECT * FROM alter_add_pk;
-contains:altered
+> SELECT * FROM alter_add_pk;
+1
+2
 
 > DROP SOURCE mz_source;
 
@@ -317,8 +319,9 @@ ALTER TABLE alter_cycle_pk_off ADD PRIMARY KEY(f1);
 ALTER TABLE alter_cycle_pk_off DROP CONSTRAINT alter_cycle_pk_off_pkey;
 INSERT INTO alter_cycle_pk_off VALUES (1);
 
-! SELECT * FROM alter_cycle_pk_off;
-contains:altered
+> SELECT * FROM alter_cycle_pk_off;
+1
+1
 
 > DROP SOURCE mz_source;
 
@@ -383,8 +386,9 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE alter_add_unique ADD UNIQUE(f1);
 INSERT INTO alter_add_unique VALUES (2);
 
-! SELECT * FROM alter_add_unique;
-contains:altered
+> SELECT * FROM alter_add_unique;
+1
+2
 
 > DROP SOURCE mz_source;
 

--- a/test/pg-cdc/constraints.td
+++ b/test/pg-cdc/constraints.td
@@ -27,65 +27,58 @@ CREATE SCHEMA public;
 DROP PUBLICATION IF EXISTS mz_source;
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
-CREATE TABLE pk_table (pk INTEGER PRIMARY KEY, f2 TEXT);
-INSERT INTO pk_table VALUES (1, 'one');
-ALTER TABLE pk_table REPLICA IDENTITY FULL;
-INSERT INTO pk_table VALUES (2, 'two');
+CREATE TABLE pk (f1 INT, f2 INT, f3 INT, PRIMARY KEY (f1, f2));
+INSERT INTO pk VALUES (1,1,null);
+ALTER TABLE pk REPLICA IDENTITY FULL;
 
-INSERT INTO pk_table VALUES (3, 'three');
+CREATE TABLE unique_not_null (f1 INT NOT NULL, f2 INT NOT NULL, f3 INT, UNIQUE (f1, f2));
+INSERT INTO unique_not_null VALUES (1,1,null);
+ALTER TABLE unique_not_null REPLICA IDENTITY FULL;
 
-CREATE TABLE nonpk_table (f1 INTEGER, f2 INTEGER);
-INSERT INTO nonpk_table VALUES (1, 1), (1, 1);
-ALTER TABLE nonpk_table REPLICA IDENTITY FULL;
-INSERT INTO nonpk_table VALUES (2, 2), (2, 2);
-
-CREATE TABLE complex_constraints (pk INTEGER, f2 TEXT NOT NULL, f3 TEXT, UNIQUE (f3, pk), UNIQUE (f2));
-ALTER TABLE complex_constraints ADD PRIMARY KEY (pk);
-INSERT INTO complex_constraints VALUES (1, 'one', 1);
-ALTER TABLE complex_constraints REPLICA IDENTITY FULL;
-INSERT INTO complex_constraints VALUES (2, 'two', 2);
-INSERT INTO complex_constraints VALUES (3, 'three', 3);
+CREATE TABLE unique_nullable (f1 INT, f2 INT, f3 INT, UNIQUE (f1, f2));
+INSERT INTO unique_nullable VALUES (1,1,null), (null,null,null), (null,null,null);
+ALTER TABLE unique_nullable REPLICA IDENTITY FULL;
 
 > CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
-  FOR TABLES (pk_table, nonpk_table, complex_constraints);
+  FOR ALL TABLES;
 
-> CREATE DEFAULT INDEX ON pk_table;
+> CREATE DEFAULT INDEX ON pk;
+> CREATE DEFAULT INDEX ON unique_not_null;
+> CREATE DEFAULT INDEX ON unique_nullable;
 
-# Default index only includes primary key column
-> SHOW CREATE INDEX pk_table_primary_idx;
-name                                     create_sql
--------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.pk_table_primary_idx "CREATE INDEX \"pk_table_primary_idx\" IN CLUSTER \"default\" ON \"materialize\".\"public\".\"pk_table\" (\"pk\")"
+> SELECT key FROM (SHOW INDEXES ON pk);
+{f1,f2}
 
-# Not null constraint optimizes like this:
-> EXPLAIN SELECT * FROM pk_table WHERE pk IS NULL;
-"Explained Query (fast path):\n  Constant <empty>\n"
+> SELECT key FROM (SHOW INDEXES ON unique_not_null);
+{f1,f2}
 
-# Unique is applied
-> EXPLAIN SELECT DISTINCT pk FROM pk_table
-"Explained Query (fast path):\n  Project (#0)\n    ReadExistingIndex materialize.public.pk_table_primary_idx\n\nUsed Indexes:\n  - materialize.public.pk_table_primary_idx\n"
+> SELECT key FROM (SHOW INDEXES ON unique_nullable);
+{f1,f2,f3}
 
-> CREATE DEFAULT INDEX ON nonpk_table;
-
-# Default index only includes primary key column
-> SHOW CREATE INDEX nonpk_table_primary_idx;
-name                                     create_sql
--------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.nonpk_table_primary_idx "CREATE INDEX \"nonpk_table_primary_idx\" IN CLUSTER \"default\" ON \"materialize\".\"public\".\"nonpk_table\" (\"f1\", \"f2\")"
-
-# No not-null constraint
-> EXPLAIN SELECT * FROM nonpk_table WHERE f1 IS NULL;
-"Explained Query (fast path):\n  Filter (#0) IS NULL\n    ReadExistingIndex materialize.public.nonpk_table_primary_idx\n\nUsed Indexes:\n  - materialize.public.nonpk_table_primary_idx\n"
-
-> CREATE DEFAULT INDEX ON complex_constraints;
-
-# Default index only includes primary key column
-> SHOW CREATE INDEX complex_constraints_primary_idx;
-name                                     create_sql
--------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.complex_constraints_primary_idx "CREATE INDEX \"complex_constraints_primary_idx\" IN CLUSTER \"default\" ON \"materialize\".\"public\".\"complex_constraints\" (\"pk\")"
+> SELECT * FROM unique_nullable
+1 1 <null>
+<null> <null> <null>
+<null> <null> <null>
 
 # Not null constraint optimizes like this:
-> EXPLAIN SELECT * FROM pk_table WHERE pk IS NULL;
+> EXPLAIN SELECT * FROM pk WHERE f1 IS NULL OR f2 IS NULL;
 "Explained Query (fast path):\n  Constant <empty>\n"
+
+> EXPLAIN SELECT * FROM unique_not_null WHERE f1 IS NULL OR f2 IS NULL;
+"Explained Query (fast path):\n  Constant <empty>\n"
+
+#
+# Unique converted to keys
+> EXPLAIN SELECT DISTINCT f1, f2 FROM pk
+"Explained Query (fast path):\n  Project (#0, #1)\n    ReadExistingIndex materialize.public.pk_primary_idx\n\nUsed Indexes:\n  - materialize.public.pk_primary_idx\n"
+
+#
+# Unique converted to keys
+> EXPLAIN SELECT DISTINCT f1, f2 FROM unique_not_null
+"Explained Query (fast path):\n  Project (#0, #1)\n    ReadExistingIndex materialize.public.unique_not_null_primary_idx\n\nUsed Indexes:\n  - materialize.public.unique_not_null_primary_idx\n"
+
+#
+# Unique NOT converted to keys because values are nullable
+> EXPLAIN SELECT DISTINCT f1, f2 FROM unique_nullable
+"Explained Query:\n  Distinct group_by=[#0, #1]\n    Project (#0, #1)\n      Get materialize.public.unique_nullable\n\nUsed Indexes:\n  - materialize.public.unique_nullable_primary_idx\n"

--- a/test/pg-cdc/constraints.td
+++ b/test/pg-cdc/constraints.td
@@ -1,0 +1,91 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# IMPORTANT: The Postgres server has a custom pg_hba.conf that only
+# accepts connections from specific users. You will have to update
+# pg_hba.conf if you modify the existing user names or add new ones.
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+CREATE TABLE pk_table (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO pk_table VALUES (1, 'one');
+ALTER TABLE pk_table REPLICA IDENTITY FULL;
+INSERT INTO pk_table VALUES (2, 'two');
+
+INSERT INTO pk_table VALUES (3, 'three');
+
+CREATE TABLE nonpk_table (f1 INTEGER, f2 INTEGER);
+INSERT INTO nonpk_table VALUES (1, 1), (1, 1);
+ALTER TABLE nonpk_table REPLICA IDENTITY FULL;
+INSERT INTO nonpk_table VALUES (2, 2), (2, 2);
+
+CREATE TABLE complex_constraints (pk INTEGER, f2 TEXT NOT NULL, f3 TEXT, UNIQUE (f3, pk), UNIQUE (f2));
+ALTER TABLE complex_constraints ADD PRIMARY KEY (pk);
+INSERT INTO complex_constraints VALUES (1, 'one', 1);
+ALTER TABLE complex_constraints REPLICA IDENTITY FULL;
+INSERT INTO complex_constraints VALUES (2, 'two', 2);
+INSERT INTO complex_constraints VALUES (3, 'three', 3);
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES (pk_table, nonpk_table, complex_constraints);
+
+> CREATE DEFAULT INDEX ON pk_table;
+
+# Default index only includes primary key column
+> SHOW CREATE INDEX pk_table_primary_idx;
+name                                     create_sql
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+materialize.public.pk_table_primary_idx "CREATE INDEX \"pk_table_primary_idx\" IN CLUSTER \"default\" ON \"materialize\".\"public\".\"pk_table\" (\"pk\")"
+
+# Not null constraint optimizes like this:
+> EXPLAIN SELECT * FROM pk_table WHERE pk IS NULL;
+"Explained Query (fast path):\n  Constant <empty>\n"
+
+# Unique is applied
+> EXPLAIN SELECT DISTINCT pk FROM pk_table
+"Explained Query (fast path):\n  Project (#0)\n    ReadExistingIndex materialize.public.pk_table_primary_idx\n\nUsed Indexes:\n  - materialize.public.pk_table_primary_idx\n"
+
+> CREATE DEFAULT INDEX ON nonpk_table;
+
+# Default index only includes primary key column
+> SHOW CREATE INDEX nonpk_table_primary_idx;
+name                                     create_sql
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+materialize.public.nonpk_table_primary_idx "CREATE INDEX \"nonpk_table_primary_idx\" IN CLUSTER \"default\" ON \"materialize\".\"public\".\"nonpk_table\" (\"f1\", \"f2\")"
+
+# No not-null constraint
+> EXPLAIN SELECT * FROM nonpk_table WHERE f1 IS NULL;
+"Explained Query (fast path):\n  Filter (#0) IS NULL\n    ReadExistingIndex materialize.public.nonpk_table_primary_idx\n\nUsed Indexes:\n  - materialize.public.nonpk_table_primary_idx\n"
+
+> CREATE DEFAULT INDEX ON complex_constraints;
+
+# Default index only includes primary key column
+> SHOW CREATE INDEX complex_constraints_primary_idx;
+name                                     create_sql
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+materialize.public.complex_constraints_primary_idx "CREATE INDEX \"complex_constraints_primary_idx\" IN CLUSTER \"default\" ON \"materialize\".\"public\".\"complex_constraints\" (\"pk\")"
+
+# Not null constraint optimizes like this:
+> EXPLAIN SELECT * FROM pk_table WHERE pk IS NULL;
+"Explained Query (fast path):\n  Constant <empty>\n"


### PR DESCRIPTION
This PR
- Applies upstream tables' keys (primary key and unique constraints) to subsources.
- Applies not null constraints to subsources' columns.
- Introduces compatibility checks when receiving messages about schema changes in the replication stream and errors only when necessary, e.g. when a NOT NULL constraint is dropped from the upstream table; we have created dataflows to expect no values to be null on the column, so the only option is to tear down the existing dataflows that depend on this data.

Note that this PR in its current form needs to be merged in the `v0.49` window or the migration it includes is wrong.

### Motivation

This PR adds a feature that has not yet been specified.

To solve #17987, we needed to reach out to the upstream database to understand schema changes because the PG replication stream does not include information about column's `attnum`s. However, this left our support for constraints in an odd spot; we tracked but did not apply them. The solution to this was to either drop them entirely or apply them to the subsources; because we would likely want to do this at some point, the easiest time to do this was now.

### Tips for reviewer

Going through the commits one-by-one should make things more legible, but there is a bug in which we don't apply table constraints "in the proper order" until the final commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - New tables ingested from PostgreSQL sources will apply the table's `PRIMARY KEY` and `UNIQUE` constraints, as well as individual columns' `NOT NULL` constraints.
  - Changing an upstream table's constraints in a compatible way will no longer error the PostgreSQL source, e.g. adding a `NOT NULL` constraint to a column.
