### PR TITLE
Guard against negative multiplicities in TopK

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -101,6 +101,7 @@
 //! if/when the errors are retracted.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::hash::Hash;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -108,8 +109,9 @@ use differential_dataflow::dynamic::pointstamp::PointStamp;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arrange;
 use differential_dataflow::operators::reduce::ReduceCore;
-use differential_dataflow::AsCollection;
+use differential_dataflow::{AsCollection, ExchangeData};
 use timely::communication::Allocate;
+use timely::container::columnation::Columnation;
 use timely::dataflow::operators::to_stream::ToStream;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
@@ -917,5 +919,47 @@ impl<T: Timestamp + Lattice> RenderTimestamp for Product<mz_repr::Timestamp, T> 
     }
     fn step_back(&self) -> Self {
         Product::new(self.outer.saturating_sub(1), self.inner.clone())
+    }
+}
+
+/// Used to make possibly-validating code generic: think of this as a kind of `MaybeResult`,
+/// specialized for use in compute.  Validation code will only run when the error constructor is
+/// Some.
+trait MaybeValidatingRow<T, E>: ExchangeData + Columnation + Hash {
+    fn ok(t: T) -> Self;
+    fn into_error() -> Option<fn(E) -> Self>;
+}
+
+impl<E> MaybeValidatingRow<Row, E> for Row {
+    fn ok(t: Row) -> Self {
+        t
+    }
+    fn into_error() -> Option<fn(E) -> Self> {
+        None
+    }
+}
+
+impl<E, R> MaybeValidatingRow<Vec<R>, E> for Vec<R>
+where
+    R: ExchangeData + Columnation + Hash,
+{
+    fn ok(t: Vec<R>) -> Self {
+        t
+    }
+    fn into_error() -> Option<fn(E) -> Self> {
+        None
+    }
+}
+
+impl<T, E> MaybeValidatingRow<T, E> for Result<T, E>
+where
+    T: ExchangeData + Columnation + Hash,
+    E: ExchangeData + Columnation + Hash,
+{
+    fn ok(row: T) -> Self {
+        Ok(row)
+    }
+    fn into_error() -> Option<fn(E) -> Self> {
+        Some(Err)
     }
 }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -30,12 +30,14 @@ use mz_compute_client::plan::top_k::{
     BasicTopKPlan, MonotonicTop1Plan, MonotonicTopKPlan, TopKPlan,
 };
 use mz_expr::EvalError;
+use mz_ore::soft_assert_or_log;
 use mz_repr::{DatumVec, Diff, Row};
 use mz_storage_client::types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
 
 use crate::render::context::CollectionBundle;
 use crate::render::context::Context;
+use crate::render::MaybeValidatingRow;
 use crate::typedefs::{RowKeySpine, RowSpine};
 
 // The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.
@@ -122,8 +124,21 @@ where
                     // intra-ts thinning. The maximum number of records per timestamp is
                     // (num_workers * limit), which we expect to be a small number and so we render
                     // a single topk stage.
-                    let result = build_topk_stage(thinned, order_key, 1u64, 0, limit, arity);
+                    let (result, errs) = build_topk_stage(
+                        thinned,
+                        order_key,
+                        1u64,
+                        0,
+                        limit,
+                        arity,
+                        false,
+                        &self.debug_name,
+                    );
                     retractions.set(&collection.concat(&result.negate()));
+                    soft_assert_or_log!(
+                        errs.is_none(),
+                        "requested no validation, but received error collection"
+                    );
 
                     result.map(|((_key, _hash), row)| row)
                 }
@@ -133,7 +148,19 @@ where
                     offset,
                     limit,
                     arity,
-                }) => build_topk(ok_input, group_key, order_key, offset, limit, arity),
+                }) => {
+                    let (oks, errs) = build_topk(
+                        ok_input,
+                        group_key,
+                        order_key,
+                        offset,
+                        limit,
+                        arity,
+                        &self.debug_name,
+                    );
+                    err_collection = errs;
+                    oks
+                }
             };
             // Extract the results from the region.
             (ok_result.leave_region(), err_collection.leave_region())
@@ -149,7 +176,8 @@ where
             offset: usize,
             limit: Option<usize>,
             arity: usize,
-        ) -> Collection<G, Row, Diff>
+            debug_name: &str,
+        ) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
         where
             G: Scope,
             G::Timestamp: Lattice,
@@ -169,6 +197,10 @@ where
                     ((group_row, row_hash), row)
                 }
             });
+
+            let mut validating = true;
+            let mut err_collection: Option<Collection<G, _, _>> = None;
+
             // This sequence of numbers defines the shifts that happen to the 64 bit hash
             // of the record, and has the properties that 1. there are not too many of them,
             // and 2. each has a modest difference to the next.
@@ -183,22 +215,38 @@ where
                     // here we do not apply `offset`, but instead restrict ourself with a limit
                     // that includes the offset. We cannot apply `offset` until we perform the
                     // final, complete reduction.
-                    collection = build_topk_stage(
+                    let (oks, errs) = build_topk_stage(
                         collection,
                         order_key.clone(),
                         1u64 << log_modulus,
                         0,
                         Some(offset + limit),
                         arity,
+                        validating,
+                        debug_name,
                     );
+                    collection = oks;
+                    if validating {
+                        err_collection = errs;
+                        validating = false;
+                    }
                 }
             }
 
             // We do a final step, both to make sure that we complete the reduction, and to correctly
             // apply `offset` to the final group, as we have not yet been applying it to the partially
             // formed groups.
-            build_topk_stage(collection, order_key, 1u64, offset, limit, arity)
-                .map(|((_key, _hash), row)| row)
+            let (oks, errs) = build_topk_stage(
+                collection, order_key, 1u64, offset, limit, arity, validating, debug_name,
+            );
+            collection = oks;
+            if validating {
+                err_collection = errs;
+            }
+            (
+                collection.map(|((_key, _hash), row)| row),
+                err_collection.expect("at least one stage validated its inputs"),
+            )
         }
 
         // To provide a robust incremental orderby-limit experience, we want to avoid grouping
@@ -216,18 +264,78 @@ where
             offset: usize,
             limit: Option<usize>,
             arity: usize,
-        ) -> Collection<G, ((Row, u64), Row), Diff>
+            validating: bool,
+            debug_name: &str,
+        ) -> (
+            Collection<G, ((Row, u64), Row), Diff>,
+            Option<Collection<G, DataflowError, Diff>>,
+        )
         where
             G: Scope,
             G::Timestamp: Lattice,
         {
             let input = collection.map(move |((key, hash), row)| ((key, hash % modulus), row));
+            let (oks, errs) = if validating {
+                let stage = build_topk_negated_stage::<G, Result<Row, Row>>(
+                    &input, order_key, offset, limit, arity,
+                );
+
+                let debug_name = debug_name.to_string();
+                let (oks, errs) =
+                    stage.map_fallible("Demuxing Errors", move |((k, h), result)| match result {
+                        Err(v) => {
+                            let message = "Negative multiplicities in TopK";
+                            warn!(?k, ?h, ?v, debug_name, "[customer-data] {message}");
+                            error!(message);
+                            Err(DataflowError::EvalError(
+                                EvalError::Internal(message.to_string()).into(),
+                            ))
+                        }
+                        Ok(t) => Ok(((k, h), t)),
+                    });
+                (oks, Some(errs))
+            } else {
+                (
+                    build_topk_negated_stage::<G, Row>(&input, order_key, offset, limit, arity),
+                    None,
+                )
+            };
+            (
+                oks.negate()
+                    .concat(&input)
+                    .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated TopK"),
+                errs,
+            )
+        }
+
+        fn build_topk_negated_stage<G, R>(
+            input: &Collection<G, ((Row, u64), Row), Diff>,
+            order_key: Vec<mz_expr::ColumnOrder>,
+            offset: usize,
+            limit: Option<usize>,
+            arity: usize,
+        ) -> Collection<G, ((Row, u64), R), Diff>
+        where
+            G: Scope,
+            G::Timestamp: Lattice,
+            R: MaybeValidatingRow<Row, Row>,
+        {
             // We only want to arrange parts of the input that are not part of the actual output
             // such that `input.concat(&negated_output.negate())` yields the correct TopK
-            let negated_output = input
+            input
                 .arrange_named::<RowSpine<(Row, u64), _, _, _>>("Arranged TopK input")
                 .reduce_abelian::<_, RowSpine<_, _, _, _>>("Reduced TopK input", {
-                    move |_key, source, target: &mut Vec<(Row, Diff)>| {
+                    move |_key, source, target: &mut Vec<(R, Diff)>| {
+                        if let Some(err) = R::into_error() {
+                            for (row, diff) in source.iter() {
+                                if diff.is_positive() {
+                                    continue;
+                                }
+                                target.push((err((*row).clone()), -1));
+                                return;
+                            }
+                        }
+
                         // Determine if we must actually shrink the result set.
                         // TODO(benesch): avoid dangerous `as` conversion.
                         #[allow(clippy::as_conversions)]
@@ -241,7 +349,7 @@ where
 
                         // First go ahead and emit all records
                         for (row, diff) in source.iter() {
-                            target.push(((*row).clone(), diff.clone()));
+                            target.push((R::ok((*row).clone()), diff.clone()));
                         }
                         // local copies that may count down to zero.
                         let mut offset = offset;
@@ -271,37 +379,32 @@ where
                         // the `offset` and `limit` constraints.
                         for index in indexes.into_iter() {
                             let (row, mut diff) = source[index];
+                            if !diff.is_positive() {
+                                continue;
+                            }
+                            // If we are still skipping early records ...
+                            if offset > 0 {
+                                let to_skip = std::cmp::min(offset, usize::try_from(diff).unwrap());
+                                offset -= to_skip;
+                                diff -= Diff::try_from(to_skip).unwrap();
+                            }
+                            // We should produce at most `limit` records.
+                            // TODO(benesch): avoid dangerous `as` conversion.
+                            #[allow(clippy::as_conversions)]
+                            if let Some(limit) = &mut limit {
+                                diff = std::cmp::min(diff, Diff::try_from(*limit).unwrap());
+                                *limit -= diff as usize;
+                            }
+                            // Output the indicated number of rows.
                             if diff > 0 {
-                                // If we are still skipping early records ...
-                                if offset > 0 {
-                                    let to_skip =
-                                        std::cmp::min(offset, usize::try_from(diff).unwrap());
-                                    offset -= to_skip;
-                                    diff -= Diff::try_from(to_skip).unwrap();
-                                }
-                                // We should produce at most `limit` records.
-                                // TODO(benesch): avoid dangerous `as` conversion.
-                                #[allow(clippy::as_conversions)]
-                                if let Some(limit) = &mut limit {
-                                    diff = std::cmp::min(diff, Diff::try_from(*limit).unwrap());
-                                    *limit -= diff as usize;
-                                }
-                                // Output the indicated number of rows.
-                                if diff > 0 {
-                                    // Emit retractions for the elements actually part of
-                                    // the set of TopK elements.
-                                    target.push((row.clone(), -diff));
-                                }
+                                // Emit retractions for the elements actually part of
+                                // the set of TopK elements.
+                                target.push((R::ok(row.clone()), -diff));
                             }
                         }
                     }
                 })
-                .as_collection(|k, v| (k.clone(), v.clone()));
-
-            negated_output
-                .negate()
-                .concat(&input)
-                .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated TopK")
+                .as_collection(|k, v| (k.clone(), v.clone()))
         }
 
         fn render_top1_monotonic<G>(

--- a/test/testdrive/negative-multiplicities.td
+++ b/test/testdrive/negative-multiplicities.td
@@ -29,3 +29,11 @@ contains:Invalid data in source, saw retractions (1) for row that does not exist
 
 ! SELECT * FROM data
 contains:Invalid data in source, saw retractions (2) for row that does not exist: [Int64(1)]
+
+# regression scenario per #17963
+! SELECT grp.id, count(t.data) AS top_2_count,
+         (SELECT COUNT(d.data) FROM data d WHERE d.data % 2 = grp.id) AS total_count
+  FROM (SELECT generate_series(0,1) id) grp,
+         LATERAL (SELECT data FROM data WHERE data % 2 = grp.id ORDER BY data LIMIT 2) t
+  GROUP BY grp.id;
+contains:Negative multiplicities in TopK


### PR DESCRIPTION
~Opening a draft to get feedback on two alternative approaches included as WIP commits over the inner function approach used in #17918.~  This is now adjusted to use the `MaybeValidatingRow` abstraction in two places.  I still want to think about this and look at this code again with fresh eyes and decide if I like it better than the alternative, but I'm opening this up for review to get some feedback.  I can always drop this back to the earlier implementation (https://github.com/tokenrove/materialize/commit/8289d0fe92231a2a10ad7a2f1b8318e4561752dd) if we decide this is horrible.

I still haven't been able to convince myself that we want to do this, but it is clear that these reductions like TopK are the only places we can legitimately catch this cases, and that in the absence of checks like this, strange inconsistencies can occur -- even if they're only the consequence of bugs elsewhere, we can only effectively detect them here.  So largely I think this is the right thing to do.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

 * This PR fixes a recognized bug: #17963.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Probably worth reviewing the commits individually, as the first adjusts some whitespace.

The `MaybeValidatingRow` trait seems to clean up the code, but I myself need to step away from it for a bit to come back and see if that's really true, since I've been staring at it a lot lately.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
