### PR TITLE
stash: Revert serialized role struct

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2391,7 +2391,9 @@ impl Catalog {
                     name: role.name,
                     id,
                     oid,
-                    attributes: role.attributes,
+                    attributes: role
+                        .attributes
+                        .expect("serialized role was not properly migrated"),
                     membership: role
                         .membership
                         .expect("serialized role was not properly migrated"),
@@ -4700,7 +4702,7 @@ impl Catalog {
                     let membership = RoleMembership::new();
                     let serialized_role = SerializedRole {
                         name: name.clone(),
-                        attributes: attributes.clone(),
+                        attributes: Some(attributes.clone()),
                         membership: Some(membership.clone()),
                     };
                     let id = tx.insert_user_role(serialized_role)?;
@@ -6142,7 +6144,8 @@ impl From<ReplicaLocation> for SerializedReplicaLocation {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SerializedRole {
     pub name: String,
-    pub attributes: RoleAttributes,
+    // TODO(jkosh44): Remove Option when stash consolidation bug is fixed
+    pub attributes: Option<RoleAttributes>,
     // TODO(jkosh44): Remove Option in v0.49.0
     pub membership: Option<RoleMembership>,
 }
@@ -6151,7 +6154,7 @@ impl From<Role> for SerializedRole {
     fn from(role: Role) -> Self {
         SerializedRole {
             name: role.name,
-            attributes: role.attributes,
+            attributes: Some(role.attributes),
             membership: Some(role.membership),
         }
     }
@@ -6161,7 +6164,7 @@ impl From<&BuiltinRole> for SerializedRole {
     fn from(role: &BuiltinRole) -> Self {
         SerializedRole {
             name: role.name.to_string(),
-            attributes: role.attributes.clone(),
+            attributes: Some(role.attributes.clone()),
             membership: Some(RoleMembership::new()),
         }
     }

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -398,7 +398,7 @@ async fn migrate(
                 RoleValue {
                     role: SerializedRole {
                         name: PUBLIC_ROLE_NAME.as_str().to_lowercase(),
-                        attributes: RoleAttributes::new(),
+                        attributes: Some(RoleAttributes::new()),
                         membership: Some(RoleMembership::new()),
                     },
                 },
@@ -456,7 +456,7 @@ async fn migrate(
                 None => {
                     let role_id = txn.insert_user_role(SerializedRole {
                         name: default_owner_name.to_string(),
-                        attributes: RoleAttributes::new(),
+                        attributes: Some(RoleAttributes::new()),
                         membership: Some(RoleMembership::new()),
                     })?;
                     let audit_id = txn.get_and_increment_id(AUDIT_LOG_ID_ALLOC_KEY.to_string())?;


### PR DESCRIPTION
In a previous commit `RoleAttribute` was added to the `SerializedRole` struct. It was originally added as an `Option` and accompanied by a migration to always set the value to `Some`. After 3 releases, we removed the `Option`. from `RoleAttribute`. Due to a bug in the stash that failed to consolidate old entries, old values of `SerializedRole` with a null `RoleAttribute` field existed in the stash. The lack of an option on `RoleAttribute` caused deserialization of these null fields to fail, which prevented environmentd from starting up.

This commit adds back the `Option`, so environmentd can start up successfully. The underlying consolidation bug will be fixed in a future commit.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
