### PR TITLE
Fix incorrect log message

### DIFF
--- a/src/cluster/src/communication.rs
+++ b/src/cluster/src/communication.rs
@@ -60,7 +60,7 @@ pub async fn initialize_networking(
     info!(
         process = process,
         ?addresses,
-        "initializing network for multi-process timely instance, with {} processes for epoch number {epoch}",
+        "initializing network for timely instance, with {} processes for epoch number {epoch}",
         addresses.len()
     );
     let sockets = create_sockets(addresses, u64::cast_from(process), epoch)


### PR DESCRIPTION
At some point, some refactor caused this code path to be entered for all timely instance, not just multi-process ones. Thus, fix the now-erroneous error message.
