### PR TITLE
adapter: Log origin of requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,6 +3802,7 @@ dependencies = [
  "sentry-tracing",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "shell-words",
  "socket2",
  "sysctl",

--- a/doc/user/content/integrations/websocket-api.md
+++ b/doc/user/content/integrations/websocket-api.md
@@ -61,7 +61,7 @@ To authenticate using a username and password, send an initial text or binary me
 {
     "user": "<Your email to access Materialize>",
     "password": "<Your app password>",
-    "options": { <Optional map of run-time settings> }
+    "options": { <Optional map of session variables> }
 }
 ```
 
@@ -70,7 +70,7 @@ To authenticate using a token, send an initial text or binary message containing
 ```
 {
 	"token": "<Your access token>",
-    "options": { <Optional map of run-time settings> }
+    "options": { <Optional map of session variables> }
 }
 ```
 

--- a/doc/user/content/integrations/websocket-api.md
+++ b/doc/user/content/integrations/websocket-api.md
@@ -59,8 +59,9 @@ To authenticate using a username and password, send an initial text or binary me
 
 ```
 {
-  "user": "<Your email to access Materialize>"
-	"password": "<Your app password>",
+    "user": "<Your email to access Materialize>",
+    "password": "<Your app password>",
+    "options": { <Optional map of run-time settings> }
 }
 ```
 
@@ -69,6 +70,7 @@ To authenticate using a token, send an initial text or binary message containing
 ```
 {
 	"token": "<Your access token>",
+    "options": { <Optional map of run-time settings> }
 }
 ```
 

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -484,8 +484,8 @@ impl SessionClient {
     {
         let session = self.session.take().expect("session invariant violated");
         let mut typ = None;
-        let application_name = session.vars().application_name();
-        let name_hint = ApplicationNameHint::from_str(Some(application_name));
+        let application_name = session.application_name();
+        let name_hint = ApplicationNameHint::from_str(application_name);
         let res = self
             .inner_mut()
             .send(|tx| {

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::bail;
 use chrono::{DateTime, Utc};
+use mz_sql::session::hint::ApplicationNameHint;
 use tokio::sync::{mpsc, oneshot, watch};
 use tracing::error;
 use uuid::Uuid;
@@ -483,6 +484,8 @@ impl SessionClient {
     {
         let session = self.session.take().expect("session invariant violated");
         let mut typ = None;
+        let application_name = session.vars().application_name();
+        let name_hint = ApplicationNameHint::from_str(Some(application_name));
         let res = self
             .inner_mut()
             .send(|tx| {
@@ -517,7 +520,7 @@ impl SessionClient {
                 .inner
                 .metrics
                 .commands
-                .with_label_values(&[typ, status])
+                .with_label_values(&[typ, status, name_hint.as_str()])
                 .inc();
         }
         self.session = Some(res.session);

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -57,7 +57,7 @@ impl Metrics {
             commands: registry.register(metric!(
                 name: "mz_adapter_commands",
                 help: "The total number of adapter commands issued of the given type since process start.",
-                var_labels: ["command_type", "status"],
+                var_labels: ["command_type", "status", "application_name"],
             )),
             storage_usage_collection_time_seconds: registry.register(metric!(
                 name: "mz_storage_usage_collection_time_seconds",

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -599,6 +599,13 @@ impl<T: TimestampManipulation> Session<T> {
         self.vars.user()
     }
 
+    /// Returns the [application_name] that created this session.
+    /// 
+    /// [application_name]: (https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-APPLICATION-NAME)
+    pub fn application_name(&self) -> &str {
+        self.vars.application_name()
+    }
+
     /// Returns a reference to the variables in this session.
     pub fn vars(&self) -> &SessionVars {
         &self.vars

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -600,7 +600,7 @@ impl<T: TimestampManipulation> Session<T> {
     }
 
     /// Returns the [application_name] that created this session.
-    /// 
+    ///
     /// [application_name]: (https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-APPLICATION-NAME)
     pub fn application_name(&self) -> &str {
         self.vars.application_name()

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -108,6 +108,7 @@ predicates = "2.1.4"
 regex = "1.7.0"
 reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.89"
+serde_urlencoded = "0.7.1"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4"] }
 

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -448,7 +448,6 @@ async fn init_ws(
     let mut client = AuthedClient::new(adapter_client, user).await?;
 
     // Assign any options we got from our WebSocket startup.
-    let options = options.unwrap_or_default();
     let session = client.0.session();
     for (key, val) in options {
         const LOCAL: bool = false;

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -453,7 +453,6 @@ async fn init_ws(
     for (key, val) in options {
         const LOCAL: bool = false;
         if let Err(err) = session.vars_mut().set(&key, VarInput::Flat(&val), LOCAL) {
-            println!("bad val");
             session.add_notice(AdapterNotice::BadStartupSetting {
                 name: key,
                 reason: err.to_string(),

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -987,6 +987,7 @@ fn test_auth_base() {
                 auth: &WebSocketAuth::Basic {
                     user: frontegg_user.to_string(),
                     password: frontegg_password.to_string(),
+                    options: None,
                 },
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
@@ -994,6 +995,7 @@ fn test_auth_base() {
             TestCase::Ws {
                 auth: &WebSocketAuth::Bearer {
                     token: frontegg_jwt.clone(),
+                    options: None,
                 },
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
@@ -1002,6 +1004,7 @@ fn test_auth_base() {
                 auth: &WebSocketAuth::Basic {
                     user: "bad user".to_string(),
                     password: frontegg_password.to_string(),
+                    options: Some(BTreeMap::default()),
                 },
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Err(Box::new(|code, message| {
@@ -1245,6 +1248,7 @@ fn test_auth_base() {
                 auth: &WebSocketAuth::Basic {
                     user: (&*SYSTEM_USER.name).into(),
                     password: frontegg_system_password.to_string(),
+                    options: Some(BTreeMap::default()),
                 },
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Err(Box::new(|code, message| {
@@ -1276,6 +1280,7 @@ fn test_auth_base() {
                 auth: &WebSocketAuth::Basic {
                     user: (PUBLIC_ROLE_NAME.as_str()).into(),
                     password: frontegg_system_password.to_string(),
+                    options: None,
                 },
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Err(Box::new(|code, message| {
@@ -1627,6 +1632,7 @@ fn test_auth_admin() {
                     auth: &WebSocketAuth::Basic {
                         user: frontegg_user.to_string(),
                         password: frontegg_password.to_string(),
+                        options: Some(BTreeMap::default()),
                     },
                     configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                     assert: Assert::SuccessSuperuserCheck(false),
@@ -1663,6 +1669,7 @@ fn test_auth_admin() {
                     auth: &WebSocketAuth::Basic {
                         user: admin_frontegg_user.to_string(),
                         password: admin_frontegg_password.to_string(),
+                        options: Some(BTreeMap::default()),
                     },
                     configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                     assert: Assert::SuccessSuperuserCheck(true),

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -987,7 +987,7 @@ fn test_auth_base() {
                 auth: &WebSocketAuth::Basic {
                     user: frontegg_user.to_string(),
                     password: frontegg_password.to_string(),
-                    options: None,
+                    options: BTreeMap::default(),
                 },
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
@@ -995,7 +995,7 @@ fn test_auth_base() {
             TestCase::Ws {
                 auth: &WebSocketAuth::Bearer {
                     token: frontegg_jwt.clone(),
-                    options: None,
+                    options: BTreeMap::default(),
                 },
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
@@ -1004,7 +1004,7 @@ fn test_auth_base() {
                 auth: &WebSocketAuth::Basic {
                     user: "bad user".to_string(),
                     password: frontegg_password.to_string(),
-                    options: Some(BTreeMap::default()),
+                    options: BTreeMap::default(),
                 },
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Err(Box::new(|code, message| {
@@ -1248,7 +1248,7 @@ fn test_auth_base() {
                 auth: &WebSocketAuth::Basic {
                     user: (&*SYSTEM_USER.name).into(),
                     password: frontegg_system_password.to_string(),
-                    options: Some(BTreeMap::default()),
+                    options: BTreeMap::default(),
                 },
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Err(Box::new(|code, message| {
@@ -1280,7 +1280,7 @@ fn test_auth_base() {
                 auth: &WebSocketAuth::Basic {
                     user: (PUBLIC_ROLE_NAME.as_str()).into(),
                     password: frontegg_system_password.to_string(),
-                    options: None,
+                    options: BTreeMap::default(),
                 },
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Err(Box::new(|code, message| {
@@ -1632,7 +1632,7 @@ fn test_auth_admin() {
                     auth: &WebSocketAuth::Basic {
                         user: frontegg_user.to_string(),
                         password: frontegg_password.to_string(),
-                        options: Some(BTreeMap::default()),
+                        options: BTreeMap::default(),
                     },
                     configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                     assert: Assert::SuccessSuperuserCheck(false),
@@ -1669,7 +1669,7 @@ fn test_auth_admin() {
                     auth: &WebSocketAuth::Basic {
                         user: admin_frontegg_user.to_string(),
                         password: admin_frontegg_password.to_string(),
-                        options: Some(BTreeMap::default()),
+                        options: BTreeMap::default(),
                     },
                     configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                     assert: Assert::SuccessSuperuserCheck(true),

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -979,7 +979,7 @@ fn test_ws_passes_options() {
 
     // Query to make sure we get back the correct session var, which should be
     // set from the options map we passed with the auth.
-    let json = "{{\"query\":\"SHOW application_name;\"}}";
+    let json = "{\"query\":\"SHOW application_name;\"}";
     let json: serde_json::Value = serde_json::from_str(json).unwrap();
     ws.write_message(Message::Text(json.to_string())).unwrap();
 

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -979,8 +979,8 @@ fn test_ws_passes_options() {
 
     // Query to make sure we get back the correct session var, which should be
     // set from the options map we passed with the auth.
-    let json = format!("{{\"query\":\"SHOW application_name;\"}}");
-    let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let json = "{{\"query\":\"SHOW application_name;\"}}";
+    let json: serde_json::Value = serde_json::from_str(json).unwrap();
     ws.write_message(Message::Text(json.to_string())).unwrap();
 
     let mut read_msg = || -> WebSocketResponse {

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -265,7 +265,7 @@ fn test_http_sql() {
         ))
         .unwrap();
         let (mut ws, _resp) = tungstenite::connect(ws_url).unwrap();
-        util::auth_with_ws(&mut ws, None);
+        util::auth_with_ws(&mut ws, BTreeMap::default());
 
         f.run(|tc| {
             let msg = match tc.directive.as_str() {
@@ -843,7 +843,7 @@ fn test_max_request_size() {
         ))
         .unwrap();
         let (mut ws, _resp) = tungstenite::connect(ws_url).unwrap();
-        util::auth_with_ws(&mut ws, None);
+        util::auth_with_ws(&mut ws, BTreeMap::default());
         let json =
             format!("{{\"queries\":[{{\"query\":\"{statement}\",\"params\":[\"{param}\"]}}]}}");
         let json: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -915,7 +915,7 @@ fn test_max_statement_batch_size() {
         ))
         .unwrap();
         let (mut ws, _resp) = tungstenite::connect(ws_url).unwrap();
-        util::auth_with_ws(&mut ws, None);
+        util::auth_with_ws(&mut ws, BTreeMap::default());
         let json = format!("{{\"query\":\"{statements}\"}}");
         let json: serde_json::Value = serde_json::from_str(&json).unwrap();
         ws.write_message(Message::Text(json.to_string())).unwrap();
@@ -975,7 +975,7 @@ fn test_ws_passes_options() {
         "application_name".to_string(),
         "billion_dollar_idea".to_string(),
     )]);
-    util::auth_with_ws(&mut ws, Some(options));
+    util::auth_with_ws(&mut ws, options);
 
     // Query to make sure we get back the correct session var, which should be
     // set from the options map we passed with the auth.
@@ -1018,7 +1018,7 @@ fn test_ws_notifies_for_bad_options() {
     .unwrap();
     let (mut ws, _resp) = tungstenite::connect(ws_url).unwrap();
     let options = BTreeMap::from([("bad_var_name".to_string(), "i_do_not_exist".to_string())]);
-    util::auth_with_ws(&mut ws, Some(options));
+    util::auth_with_ws(&mut ws, options);
 
     let mut read_msg = || -> WebSocketResponse {
         let msg = ws.read_message().unwrap();

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -75,6 +75,7 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
 use std::path::PathBuf;
@@ -665,11 +666,15 @@ pub fn wait_for_view_population(
     Ok(())
 }
 
-pub fn auth_with_ws(ws: &mut WebSocket<MaybeTlsStream<TcpStream>>) {
+pub fn auth_with_ws(
+    ws: &mut WebSocket<MaybeTlsStream<TcpStream>>,
+    options: Option<BTreeMap<String, String>>,
+) {
     ws.write_message(Message::Text(
         serde_json::to_string(&WebSocketAuth::Basic {
             user: "materialize".into(),
             password: "".into(),
+            options,
         })
         .unwrap(),
     ))

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -668,7 +668,7 @@ pub fn wait_for_view_population(
 
 pub fn auth_with_ws(
     ws: &mut WebSocket<MaybeTlsStream<TcpStream>>,
-    options: Option<BTreeMap<String, String>>,
+    options: BTreeMap<String, String>,
 ) {
     ws.write_message(Message::Text(
         serde_json::to_string(&WebSocketAuth::Basic {

--- a/src/sql/src/session.rs
+++ b/src/sql/src/session.rs
@@ -13,5 +13,6 @@
 //! The split between this module and the `mz_adapter::session` is organic and
 //! should be revisited with more intention in the future.
 
+pub mod hint;
 pub mod user;
 pub mod vars;

--- a/src/sql/src/session/hint.rs
+++ b/src/sql/src/session/hint.rs
@@ -1,0 +1,73 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use internal::Private;
+
+/// Prometheus label for [`ApplicationNameHint::Unspecified`].
+const UNSPECIFIED_LABEL: &str = "unspecified";
+/// Prometheus label for [`ApplicationNameHint::Unrecognized`].
+const UNRECOGNIZED_LABEL: &str = "unrecognized";
+/// Prometheus label for [`ApplicationNameHint::Psql`].
+const PSQL_LABEL: &str = "psql";
+/// Prometheus label for [`ApplicationNameHint::Dbt`].
+const DBT_LABEL: &str = "dbt";
+/// Prometheus label for [`ApplicationNameHint::WebConsole`].
+const WEB_CONSOLE_LABEL: &str = "web_console";
+
+/// A hint for what application is making a request to the adapter.
+///
+/// Note: [`ApplicationNameHint`] gets logged as a label in our Prometheus metrics, and for
+/// labels we need to be conscious of the cardinality, so please be careful with how many
+/// variants we add to this enum.
+///
+/// Note: each enum variant contains an [`internal::Private`] to prevent creating this enum
+/// directly. To create an instance of [`ApplicationNameHint`] please see
+/// [`ApplicationNameHint::from_str`].
+#[derive(Debug, Copy, Clone)]
+pub enum ApplicationNameHint {
+    /// No `application_name` was set.
+    Unspecified(Private),
+    /// An `application_name` was set, but it's not one we recognize.
+    Unrecognized(Private),
+    /// Request came from `psql`.
+    Psql(Private),
+    /// Request came from `dbt`.
+    Dbt(Private),
+    /// Request came from our web console.
+    WebConsole(Private),
+}
+
+impl ApplicationNameHint {
+    pub fn from_str(s: Option<&str>) -> Self {
+        match s.map(|s| s.to_lowercase()).as_deref() {
+            Some("psql") => ApplicationNameHint::Psql(Private),
+            Some("dbt") => ApplicationNameHint::Dbt(Private),
+            Some("web_console") => ApplicationNameHint::WebConsole(Private),
+            None | Some("") => ApplicationNameHint::Unspecified(Private),
+            // TODO(parkertimmerman): We should keep some record of these "unrecognized"
+            // names, and possibly support more popular ones in the future.
+            Some(_) => ApplicationNameHint::Unrecognized(Private),
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ApplicationNameHint::Unspecified(_) => UNSPECIFIED_LABEL,
+            ApplicationNameHint::Unrecognized(_) => UNRECOGNIZED_LABEL,
+            ApplicationNameHint::Psql(_) => PSQL_LABEL,
+            ApplicationNameHint::Dbt(_) => DBT_LABEL,
+            ApplicationNameHint::WebConsole(_) => WEB_CONSOLE_LABEL,
+        }
+    }
+}
+
+mod internal {
+    #[derive(Debug, Copy, Clone)]
+    pub struct Private;
+}

--- a/src/sql/src/session/hint.rs
+++ b/src/sql/src/session/hint.rs
@@ -44,15 +44,15 @@ pub enum ApplicationNameHint {
 }
 
 impl ApplicationNameHint {
-    pub fn from_str(s: Option<&str>) -> Self {
-        match s.map(|s| s.to_lowercase()).as_deref() {
-            Some("psql") => ApplicationNameHint::Psql(Private),
-            Some("dbt") => ApplicationNameHint::Dbt(Private),
-            Some("web_console") => ApplicationNameHint::WebConsole(Private),
-            None | Some("") => ApplicationNameHint::Unspecified(Private),
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "psql" => ApplicationNameHint::Psql(Private),
+            "dbt" => ApplicationNameHint::Dbt(Private),
+            "web_console" => ApplicationNameHint::WebConsole(Private),
+            "" => ApplicationNameHint::Unspecified(Private),
             // TODO(parkertimmerman): We should keep some record of these "unrecognized"
             // names, and possibly support more popular ones in the future.
-            Some(_) => ApplicationNameHint::Unrecognized(Private),
+            _ => ApplicationNameHint::Unrecognized(Private),
         }
     }
 

--- a/src/sql/src/session/hint.rs
+++ b/src/sql/src/session/hint.rs
@@ -26,7 +26,7 @@ const WEB_CONSOLE_LABEL: &str = "web_console";
 /// labels we need to be conscious of the cardinality, so please be careful with how many
 /// variants we add to this enum.
 ///
-/// Note: each enum variant contains an [`internal::Private`] to prevent creating this enum
+/// Note: each enum variant contains an `internal::Private` to prevent creating this enum
 /// directly. To create an instance of [`ApplicationNameHint`] please see
 /// [`ApplicationNameHint::from_str`].
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
### Motivation
* This PR adds a known-desirable feature.
    * #18094 

There have been several times that a cluster has come under heavy load, but we don't know where the requests are coming from. This PR begins logging the `application_name` session var to prometheus as a label in the `mz_adapter_commands` metric. We map the `application_name` to one of a few possible values:

* `unspecified`
* `unrecognized`
* `psql`
* `dbt`
* `web_console`

This way we can keep the cardinality of our prometheus metric under control, but get context as to where a request is coming from.

In addition to logging the `application_name`, this PR also updates our `WebSocketAuth` JSON message to optionally deserialize an `options` map, and our `api/sql` HTTP endpoint to deserialize an `options` map query param. And for every entry we then set the corresponding session var. This is very similar to what we do when [initially handling a pgwire connection](https://github.com/MaterializeInc/materialize/blob/main/src/pgwire/src/protocol.rs#L233).

### Tips for reviewers
* All of the changes to support the HTTP endpoint are in a single commit called `http support`. Those changes can be reviewed entirely on their own. (I wish GitHub supported stacked PRs 😞)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
