### PR TITLE
sql: Add owner column to pg catalog views

### DIFF
--- a/test/sqllogictest/pg_catalog_matviews.slt
+++ b/test/sqllogictest/pg_catalog_matviews.slt
@@ -34,4 +34,4 @@ query TT
 SHOW CREATE VIEW pg_matviews
 ----
 pg_catalog.pg_matviews
-CREATE VIEW "pg_catalog"."pg_matviews" AS SELECT "s"."name" AS "schemaname", "m"."name" AS "matviewname", "role_owner"."oid" AS "matviewowner", "m"."definition" AS "definition" FROM "mz_catalog"."mz_materialized_views" AS "m" LEFT JOIN "mz_catalog"."mz_schemas" AS "s" ON "s"."id" = "m"."schema_id" LEFT JOIN "mz_catalog"."mz_databases" AS "d" ON "d"."id" = "s"."database_id" LEFT JOIN "mz_catalog"."mz_roles" AS "role_owner" ON "role_owner"."id" = "m"."owner_id" WHERE "s"."database_id" IS NULL OR "d"."name" = "pg_catalog"."current_database"()
+CREATE VIEW "pg_catalog"."pg_matviews" AS SELECT "s"."name" AS "schemaname", "m"."name" AS "matviewname", "role_owner"."oid" AS "matviewowner", "m"."definition" AS "definition" FROM "mz_catalog"."mz_materialized_views" AS "m" LEFT JOIN "mz_catalog"."mz_schemas" AS "s" ON "s"."id" = "m"."schema_id" LEFT JOIN "mz_catalog"."mz_databases" AS "d" ON "d"."id" = "s"."database_id" JOIN "mz_catalog"."mz_roles" AS "role_owner" ON "role_owner"."id" = "m"."owner_id" WHERE "s"."database_id" IS NULL OR "d"."name" = "pg_catalog"."current_database"()

--- a/test/sqllogictest/pg_catalog_matviews.slt
+++ b/test/sqllogictest/pg_catalog_matviews.slt
@@ -15,12 +15,17 @@ CREATE MATERIALIZED VIEW test_view1 AS SELECT 1
 statement ok
 CREATE MATERIALIZED VIEW test_view2 AS SELECT 2
 
-query TTTT colnames
-SELECT * FROM pg_catalog.pg_matviews WHERE matviewname LIKE 'test_%'
+query TTT colnames
+SELECT schemaname, matviewname, definition FROM pg_catalog.pg_matviews WHERE matviewname LIKE 'test_%'
 ----
-schemaname  matviewname  matviewowner  definition
-public      test_view1   NULL          SELECT␠1;
-public      test_view2   NULL          SELECT␠2;
+schemaname  matviewname  definition
+public      test_view1   SELECT␠1;
+public      test_view2   SELECT␠2;
+
+query I
+SELECT COUNT(*) FROM pg_catalog.pg_matviews WHERE matviewowner IS NOT NULL
+----
+2
 
 mode standard
 
@@ -29,4 +34,4 @@ query TT
 SHOW CREATE VIEW pg_matviews
 ----
 pg_catalog.pg_matviews
-CREATE VIEW "pg_catalog"."pg_matviews" AS SELECT "s"."name" AS "schemaname", "m"."name" AS "matviewname", NULL::"pg_catalog"."oid" AS "matviewowner", "m"."definition" AS "definition" FROM "mz_catalog"."mz_materialized_views" AS "m" LEFT JOIN "mz_catalog"."mz_schemas" AS "s" ON "s"."id" = "m"."schema_id" LEFT JOIN "mz_catalog"."mz_databases" AS "d" ON "d"."id" = "s"."database_id" WHERE "s"."database_id" IS NULL OR "d"."name" = "pg_catalog"."current_database"()
+CREATE VIEW "pg_catalog"."pg_matviews" AS SELECT "s"."name" AS "schemaname", "m"."name" AS "matviewname", "role_owner"."oid" AS "matviewowner", "m"."definition" AS "definition" FROM "mz_catalog"."mz_materialized_views" AS "m" LEFT JOIN "mz_catalog"."mz_schemas" AS "s" ON "s"."id" = "m"."schema_id" LEFT JOIN "mz_catalog"."mz_databases" AS "d" ON "d"."id" = "s"."database_id" LEFT JOIN "mz_catalog"."mz_roles" AS "role_owner" ON "role_owner"."id" = "m"."owner_id" WHERE "s"."database_id" IS NULL OR "d"."name" = "pg_catalog"."current_database"()

--- a/test/sqllogictest/pg_catalog_namespace.slt
+++ b/test/sqllogictest/pg_catalog_namespace.slt
@@ -15,24 +15,34 @@ CREATE SCHEMA other;
 statement ok
 CREATE DATABASE other
 
-query TTT rowsort
-SELECT nspname, nspowner, nspacl FROM pg_catalog.pg_namespace
+query TT rowsort
+SELECT nspname, nspacl FROM pg_catalog.pg_namespace
 ----
-information_schema NULL NULL
-mz_catalog   NULL NULL
-mz_internal  NULL  NULL
-other   NULL  NULL
-pg_catalog   NULL  NULL
-public   NULL  NULL
+information_schema NULL
+mz_catalog   NULL
+mz_internal  NULL
+other   NULL
+pg_catalog   NULL
+public   NULL
+
+query I
+SELECT COUNT(*) FROM pg_catalog.pg_namespace WHERE nspowner IS NOT NULL
+----
+6
 
 statement ok
 SET database = other;
 
-query TTT rowsort
-SELECT nspname, nspowner, nspacl FROM pg_catalog.pg_namespace
+query TT rowsort
+SELECT nspname, nspacl FROM pg_catalog.pg_namespace
 ----
-information_schema NULL NULL
-mz_catalog   NULL NULL
-mz_internal  NULL  NULL
-pg_catalog   NULL  NULL
-public   NULL  NULL
+information_schema NULL
+mz_catalog   NULL
+mz_internal  NULL
+pg_catalog   NULL
+public   NULL
+
+query I
+SELECT COUNT(*) FROM pg_catalog.pg_namespace WHERE nspowner IS NOT NULL
+----
+5

--- a/test/sqllogictest/pg_catalog_views.slt
+++ b/test/sqllogictest/pg_catalog_views.slt
@@ -15,12 +15,17 @@ CREATE VIEW test_view1 AS SELECT 1
 statement ok
 CREATE VIEW test_view2 AS SELECT 2
 
-query TTTT colnames
-SELECT * FROM pg_catalog.pg_views WHERE viewname LIKE 'test_%'
+query TTT colnames
+SELECT schemaname, viewname, definition FROM pg_catalog.pg_views WHERE viewname LIKE 'test_%'
 ----
-schemaname  viewname    viewowner  definition
-public      test_view1  NULL       SELECT␠1;
-public      test_view2  NULL       SELECT␠2;
+schemaname  viewname    definition
+public      test_view1  SELECT␠1;
+public      test_view2  SELECT␠2;
+
+query I
+SELECT COUNT(*) FROM pg_catalog.pg_views WHERE viewname LIKE 'test_%' AND viewowner IS NOT NULL
+----
+2
 
 mode standard
 
@@ -29,7 +34,7 @@ query TT
 SHOW CREATE VIEW pg_views
 ----
 pg_catalog.pg_views
-CREATE VIEW "pg_catalog"."pg_views" AS SELECT "s"."name" AS "schemaname", "v"."name" AS "viewname", NULL::"pg_catalog"."oid" AS "viewowner", "v"."definition" AS "definition" FROM "mz_catalog"."mz_views" AS "v" LEFT JOIN "mz_catalog"."mz_schemas" AS "s" ON "s"."id" = "v"."schema_id" LEFT JOIN "mz_catalog"."mz_databases" AS "d" ON "d"."id" = "s"."database_id" WHERE "s"."database_id" IS NULL OR "d"."name" = "pg_catalog"."current_database"()
+CREATE VIEW "pg_catalog"."pg_views" AS SELECT "s"."name" AS "schemaname", "v"."name" AS "viewname", "role_owner"."oid" AS "viewowner", "v"."definition" AS "definition" FROM "mz_catalog"."mz_views" AS "v" LEFT JOIN "mz_catalog"."mz_schemas" AS "s" ON "s"."id" = "v"."schema_id" LEFT JOIN "mz_catalog"."mz_databases" AS "d" ON "d"."id" = "s"."database_id" JOIN "mz_catalog"."mz_roles" AS "role_owner" ON "role_owner"."id" = "v"."owner_id" WHERE "s"."database_id" IS NULL OR "d"."name" = "pg_catalog"."current_database"()
 
 # test that nothing in the pg_catalog or information_schema schemas use unsinged ints
 query ITITTITT

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -44,26 +44,27 @@ mz_catalog
 mz_internal
 pg_catalog
 $ psql-execute command=\dn
-\   List of schemas
-    Name     | Owner
--------------+-------
- mz_catalog  |
- mz_internal |
- public      |
+\     List of schemas
+    Name     |   Owner
+-------------+-----------
+ mz_catalog  | mz_system
+ mz_internal | mz_system
+ public      | mz_system
+
 
 $ psql-execute command="\dn mz_catalog"
-\  List of schemas
-    Name    | Owner
-------------+-------
- mz_catalog |
+\    List of schemas
+    Name    |   Owner
+------------+-----------
+ mz_catalog | mz_system
 
 
 $ psql-execute command="\dn mz_*"
-\   List of schemas
-    Name     | Owner
--------------+-------
- mz_catalog  |
- mz_internal |
+\     List of schemas
+    Name     |   Owner
+-------------+-----------
+ mz_catalog  | mz_system
+ mz_internal | mz_system
 
 # What objects do we have by default?
 > SHOW OBJECTS
@@ -120,11 +121,12 @@ materialize
 
 # ...and also in `\l`
 $ psql-execute command="\l"
-\                          List of databases
-    Name     | Owner | Encoding | Collate | Ctype | Access privileges
--------------+-------+----------+---------+-------+-------------------
- d           |       | UTF8     | C       | C     |
- materialize |       | UTF8     | C       | C     |
+\                             List of databases
+    Name     |    Owner    | Encoding | Collate | Ctype | Access privileges
+-------------+-------------+----------+---------+-------+-------------------
+ d           | materialize | UTF8     | C       | C     |
+ materialize | mz_system   | UTF8     | C       | C     |
+
 
 
 > SELECT name FROM mz_databases
@@ -616,3 +618,14 @@ $ psql-execute command="\dt *.test_table"
 ---------+------------+-------+-------------
  tester  | test_table | table | materialize
  tester2 | test_table | table | materialize
+
+> CREATE TYPE type1 AS LIST (ELEMENT TYPE = text)
+
+> SHOW TYPES
+type1
+
+$ psql-execute command="\dT"
+\      List of data types
+ Schema | Name  | Description
+--------+-------+-------------
+ public | type1 |

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -12,7 +12,7 @@ name     nullable  type
 --------------------------
 oid      false     oid
 nspname  false     text
-nspowner true      oid
+nspowner false     oid
 nspacl   true      text[]
 
 > SHOW COLUMNS FROM pg_class
@@ -44,7 +44,7 @@ name         nullable  type
 ---------------------------
  oid         false     oid
  datname     false     text
- datdba      true      oid
+ datdba      false     oid
  encoding    false     integer
  datcollate  false     text
  datctype    false     text


### PR DESCRIPTION
This commit adds a column for role owners to various pg catalog tables and views. This also fixes the output of various meta-commands that use the owner column.

Fixes #18414

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This PR adds a known-desirable feature.


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
