### PR TITLE
doc/user: polish v0.48 release notes

### DIFF
--- a/doc/user/content/releases/v0.47.md
+++ b/doc/user/content/releases/v0.47.md
@@ -2,6 +2,7 @@
 title: "Materialize v0.47"
 date: 2023-03-22
 released: true
+patch: 1
 ---
 
 ## v0.47.0

--- a/doc/user/content/releases/v0.47.md
+++ b/doc/user/content/releases/v0.47.md
@@ -11,11 +11,11 @@ released: true
 * Add the [`GRANT ROLE`](/sql/grant-role) and [`REVOKE ROLE`](/sql/revoke-role)
   commands, which allow granting/revoking membership of one role to/from another
   role. This is part of the work to enable **Role-based access control** (RBAC)
-  {{% gh 11579 %}}.
+  in a future release {{% gh 11579 %}}.
 
 * Allow rejecting user queries based on role attributes. This privilege is
   exclusive to _superusers_. This is part of the work to enable **Role-based
-  access control** (RBAC){{% gh 11579 %}}.
+  access control** (RBAC) in a future release {{% gh 11579 %}}.
 
 * Add [`mz_internal.mz_dataflow_operator_parents`](/sql/system-catalog/mz_internal/#mz_dataflow_operator_parents)
   to the system catalog. This view describes how operators are nested into

--- a/doc/user/content/releases/v0.48.md
+++ b/doc/user/content/releases/v0.48.md
@@ -9,7 +9,7 @@ patch: 2
 
 #### SQL
 
-* Introduce **object owners**, which can manage privileges for other roles on
+* Introduce **object owners**, who can manage privileges for other roles on
   each object in the system by adding or revoking grants. In this release,
   object owners have limited functionality and are assigned as follows:
 

--- a/doc/user/content/releases/v0.48.md
+++ b/doc/user/content/releases/v0.48.md
@@ -1,13 +1,71 @@
 ---
 title: "Materialize v0.48"
 date: 2023-03-29
-released: false
+released: true
+patch: 2
 ---
-
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
 
 ## v0.48.0
 
-* No documented changes yet.
+#### SQL
+
+* Introduce **object owners**, which can manage privileges for other roles on
+  each object in the system by adding or revoking grants. In this release,
+  object owners have limited functionality and are assigned as follows:
+
+  * All objects that exist at the time of a new Materialize deployment
+    (including all system objects) are owned by the `mz_system` role;
+  * All objects that predate the release are owned by the new `default_owner`
+    role;
+  * Any new object is owned by the user who created it.
+
+  This is part of the work to enable **Role-based access control** (RBAC) in a
+  future release {{% gh 11579 %}}.
+
+* Support specifying multiple roles in the [`GRANT ROLE`](/sql/grant-role) and
+  [`REVOKE ROLE`](/sql/revoke-role) commands.
+
+  ```sql
+  -- Grant role
+  GRANT data_scientist TO joe, mike;
+
+  -- Revoke role
+  REVOKE data_scientist FROM joe, mike;
+  ```
+
+  This is part of the work to enable **Role-based access control** (RBAC) in a
+  future release {{% gh 11579 %}}.
+
+* Add [`mz_internal.mz_sessions`](/sql/system-catalog/mz_internal/#mz_sessions)
+  to the system catalog. This table describes all active sessions in the
+  system.
+
+#### Bug fixes and other improvements
+
+* Fix a bug where subsources were created in the `public` schema instead of
+  being correctly created in the same schema as the source {{% gh 17868 %}}.
+  This resulted in confusing name resolution for users of the PostgreSQL and
+  load generator sources.
+
+[//]: # "NOTE(morsapaes) The `details` column was introduced in v0.47, but we
+missed the release note then and it now fits a little cosier with the change
+shipping in v0.48 -— so mentioning it here."
+
+* Improve the error messages reported in `mz_internal.mz_{source|sink}_status_history`
+  and `mz_internal.mz_{source|sink}_statuses` with more helpful pointers to
+  troubleshoot Kafka sources and sinks {{% gh 17805 %}}. From this release, the
+  `error` column reports the full error message, and other helpful suggestions
+  are added under `details`.
+
+* Stop silently ignoring `NULL` keys in sources using `ENVELOPE UPSERT` {{% gh 6350 %}}.
+  The new behavior is to throw an error when trying to query the source. To
+  recover an errored source, the upstream system must emit a record with a `NULL`
+  value and a `NULL` key.
+
+* Fix a bug that prevented the correct parsing of connection settings specified
+  using the [`-c` option](https://www.postgresql.org/docs/current/app-psql.html)
+  {{% gh 18239 %}}.
+
+* Respect session settings even in the case where the first statement executed
+  errors {{% gh 18317 %}}. Previously, such errors led to these settings being
+  ignored.

--- a/doc/user/content/releases/v0.48.md
+++ b/doc/user/content/releases/v0.48.md
@@ -2,7 +2,7 @@
 title: "Materialize v0.48"
 date: 2023-03-29
 released: true
-patch: 2
+patch: 3
 ---
 
 ## v0.48.0
@@ -14,9 +14,9 @@ patch: 2
   object owners have limited functionality and are assigned as follows:
 
   * All objects that exist at the time of a new Materialize deployment
-    (including all system objects) are owned by the `mz_system` role;
+    (including all system objects) are owned by the `mz_system` role.
   * All objects that predate the release are owned by the new `default_owner`
-    role;
+    role.
   * Any new object is owned by the user who created it.
 
   This is part of the work to enable **Role-based access control** (RBAC) in a

--- a/doc/user/content/releases/v0.49.md
+++ b/doc/user/content/releases/v0.49.md
@@ -1,0 +1,13 @@
+---
+title: "Materialize v0.49"
+date: 2023-04-05
+released: false
+---
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}
+
+## v0.49.0
+
+* No documented changes yet.

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -740,7 +740,7 @@
       Reconstructs the creating command for an index. (This is a decompiled
       reconstruction, not the original text of the command.) If column is
       supplied and is not zero, only the definition of that column is reconstructed.
-  - signature: 'pg_get_userbyid(role:oid) -> text'
+  - signature: 'pg_get_userbyid(role: oid) -> text'
     description: >-
       Returns the role (user) name for the given `oid`. If no role matches the
       specified OID, the string `unknown (OID=oid)` is returned.

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -740,6 +740,10 @@
       Reconstructs the creating command for an index. (This is a decompiled
       reconstruction, not the original text of the command.) If column is
       supplied and is not zero, only the definition of that column is reconstructed.
+  - signature: 'pg_get_userbyid(role:oid) -> text'
+    description: >-
+      Returns the role (user) name for the given `oid`. If no role matches the
+      specified OID, the string `unknown (OID=oid)` is returned.
   - signature: 'pg_get_viewdef(view_name: text[, pretty: bool]) -> text'
     description: Returns the underlying SELECT command for the given view.
   - signature: 'pg_get_viewdef(view_oid: oid[, pretty: bool]) -> text'


### PR DESCRIPTION
Release notes for v0.48. 🪴 

## Tips for reviewer

* @benesch: is #18371 worth a release note? AFAIU, we shipped the patch to a user environment as v0.47.1, so it sounds like it might be!
* Skipped #18299 since `pg_get_userbyid()` is a PostgreSQL compatibility function, but added it to the appropriate documentation page.

<hr>

@jseldess, I'll be on vacation next week. Would you or @tr0njavolta like to take a stab at getting the release notes up for v0.49?