### PR TITLE
persist: activate shard_source_descs on drop of token/channel rx

### DIFF
--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -529,6 +529,11 @@ impl<G: Scope> OperatorBuilder<G> {
     pub fn operator_info(&self) -> OperatorInfo {
         self.builder.operator_info()
     }
+
+    /// Returns the activator for the operator.
+    pub fn activator(&self) -> &Activator {
+        &self.activator
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

I haven't been able to repro it, but we're seeing some stuck read handles in prod that don't advance `since` or their `seqno` holds, holding back compaction + gc for the shard. 

It seems like we have dataflows lingering long after their corresponding Subscribes are gone... perhaps we're missing an activation when the `shard_source_descs` token is dropped? The standard `ShutdownButton` calls an `activate()` on drop, but we're not using it because we want the chance to gracefully terminate by awaiting our feedback edge's completion first.

This PR is admittedly a bit of a guess, not sure if it's needed or not (cc @petrosagg would love your thoughts!)

### Motivation

Part of investigation of seqno hold bug + https://materializeinc.slack.com/archives/CM7ATT65S/p1679938797557519

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
