### PR TITLE
cargo: update signal-hook-registry to prevent a weird bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,12 +81,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
-
-[[package]]
 name = "array-init-cursor"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5218,9 +5212,9 @@ dependencies = [
 
 [[package]]
 name = "openssh"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ea878a02cb72a04424ff906def2b37007b61cf6572ee31dc0d0a912990763"
+checksum = "8ca6c277973fb549b36dd8980941b5ea3ecebea026f5b1f0060acde74d893c22"
 dependencies = [
  "dirs",
  "libc",
@@ -6809,11 +6803,10 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
- "arc-swap",
  "libc",
 ]
 


### PR DESCRIPTION
When working on https://github.com/MaterializeInc/materialize/issues/18375, I hit some absolutely _BIZARRE_ bugs. One of them was:

- on macos
- when spawning a subcommand through tokio
- inside openssh
- when on a thread that isnt a tokio or timely one

Sometimes wakeups are just lost, and spawning hangs. After some diving, I figured out that a bug in the older version of `signal-hook-registry` caused this, and updating it fixed it. This bug is not known to be possible on main, without my other ssh-related changes, but there is no proof that it couldn't pop up. To avoid this, im just bumping the version now. I also am bumping the `openssh` version, just so we stay up to date on that too. Note that `signal-hook-registry` is a dependency of the `tokio` `process` feature, and not of `openssh` directly.

### Motivation

  * This PR fixes a previously unreported bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
