### PR TITLE
storage: add test for NULL-key retraction across restarts

### DIFF
--- a/test/cluster/upsert/01-create-sources.td
+++ b/test/cluster/upsert/01-create-sources.td
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# The main purpose of these tests is to make sure that we can correctly retract
+# key/value errors (mostly decoding errors) even after we have restarted a
+# materialize instance.
+
 # must be a subset of the keys in the rows
 $ set keyschema={
     "type": "record",
@@ -59,6 +63,8 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
     URL '${testdrive.schema-registry-url}'
   );
 
+# With this first source, we verify that we can retract key/value decoding errors.
+
 > CREATE SOURCE upsert
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
@@ -76,3 +82,22 @@ broken-key:bar
 # Ingest a broken value with a good key
 $ kafka-ingest format=bytes topic=dbzupsert key-format=avro key-schema=${keyschema}
 {"id": 2}bar2
+
+# With this second source, we verify that we can retract NULL-key errors by
+# ingesting a NULL:NULL record (a record where both key and value are NULL).
+
+$ kafka-create-topic topic=upsert-nullkey partitions=1
+
+# A null key should result in an error decoding that row but not a panic
+$ kafka-ingest format=bytes topic=upsert-nullkey key-format=bytes key-terminator=:
+bird1:goose
+:geese
+
+> CREATE SOURCE upsert_nullkey
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-nullkey-${testdrive.seed}')
+  KEY FORMAT TEXT
+  VALUE FORMAT TEXT
+  ENVELOPE UPSERT
+
+! select * from upsert_nullkey
+contains: record with NULL key in UPSERT source in partition 0

--- a/test/cluster/upsert/02-after-clusterd-restart.td
+++ b/test/cluster/upsert/02-after-clusterd-restart.td
@@ -73,3 +73,17 @@ id creature
 -----------
 1  dragon
 2  cow
+
+# Verify that we still can't query, because of the NULL-key error.
+! select * from upsert_nullkey
+contains: record with NULL key in UPSERT source
+
+# Ingest a NULL value for our null key, to retract it.
+$ kafka-ingest format=bytes topic=upsert-nullkey key-format=bytes key-terminator=:
+:
+
+# Now we should be able to query the source.
+> select * from upsert_nullkey
+key           text
+-------------------
+bird1         goose


### PR DESCRIPTION
### Motivation

Making sure we don't accidentally break this behaviour in the future. This is purely an added test for an existing feature, no production code added!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
