### PR TITLE
mzcompose: Fix the misc/rqg mzcompose

### DIFF
--- a/misc/rqg/mzcompose.py
+++ b/misc/rqg/mzcompose.py
@@ -31,6 +31,7 @@ def workflow_start_two_mzs(c: Composition, parser: WorkflowArgumentParser) -> No
             if args.this_tag
             else None,
             ports=["6875:6875"],
+            use_default_volumes=False,
         ),
         Materialized(
             name="mz_other",
@@ -38,6 +39,7 @@ def workflow_start_two_mzs(c: Composition, parser: WorkflowArgumentParser) -> No
             if args.other_tag
             else None,
             ports=["16875:6875"],
+            use_default_volumes=False,
         ),
     ):
         for mz in ["mz_this", "mz_other"]:


### PR DESCRIPTION
The workflow starts two Mz instances and they need to be prevented from sharing /mzadata otherwise they will not start up correctly.

### Motivation

  * This PR fixes a previously unreported bug.

The mzcompose workflow that supports RQG testing broke after a series of recent refactorings.

### Tips for reviewer

@def- this does not run in CI, I run it manually to start two Mz instances from different docker tags running on different ports. I then manually run comparison tests using them.