### PR TITLE
ci: SQLsmith and ci-logged-error fixes

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -165,9 +165,6 @@ def annotate_logged_errors(log_files: List[str]) -> None:
                     allow_multiple_subelements=True,
                 )
                 test_case.add_failure_info(message=message, output=error.line)
-                dict_issue_number_to_test_case_index[issue.info["number"]] = len(
-                    junit_suite.test_cases
-                )
                 junit_suite.test_cases.append(test_case)
 
     junit_name = f"{step_key}_logged_errors" if step_key else "logged_errors"

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -69,6 +69,7 @@ known_errors = [
     "violates not-null constraint",
     "division by zero",
     "operator does not exist",  # For list types
+    "length must be nonnegative",
     "is only defined for finite arguments",
     "more than one record produced in subquery",
     "invalid range bound flags",


### PR DESCRIPTION
To prevent wrongly assigned error messages. The variable issue was still set from the previous loop, but was nonsensical in this context

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
