### PR TITLE
Fix monotonic top-k bug #18445

### DIFF
--- a/test/testdrive/top-k-monotonic.td
+++ b/test/testdrive/top-k-monotonic.td
@@ -7,10 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Test monotonicity analyses which derive from ENVELOPE NONE sources.
-# Note that these only test the implementation for monotonic sources,
-# they do not test that the analysis doesn't have false positives on
-# non-monotonic sources.
+# Test monotonic top-k processing with k > 1.
 
 $ set non-dbz-schema={
     "type": "record",
@@ -34,6 +31,9 @@ $ kafka-ingest format=avro topic=non-dbz-data schema=${non-dbz-schema} timestamp
 {"a": 2, "b": 1002}
 {"a": 2, "b": 1003}
 {"a": 2, "b": 1004}
+{"a": 3, "b": 2000}
+{"a": 3, "b": 2000}
+{"a": 4, "b": 3001}
 
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}');
@@ -51,3 +51,106 @@ a b
 1 2
 2 1000
 2 1001
+3 2000
+3 2000
+4 3001
+
+# The following tests repeat the scenario in #18445.
+$ kafka-create-topic topic=other-non-dbz-data
+
+$ kafka-ingest format=avro topic=other-non-dbz-data schema=${non-dbz-schema} timestamp=1
+{"a": 1, "b": 42}
+{"a": 2, "b": 42}
+{"a": 3, "b": 42}
+{"a": 4, "b": 42}
+{"a": 5, "b": 42}
+{"a": 6, "b": 42}
+{"a": 7, "b": 42}
+{"a": 8, "b": 42}
+{"a": 9, "b": 42}
+{"a": 10, "b": 42}
+{"a": 11, "b": 42}
+{"a": 12, "b": 42}
+{"a": 13, "b": 42}
+{"a": 14, "b": 42}
+{"a": 15, "b": 42}
+{"a": 16, "b": 42}
+{"a": 17, "b": 42}
+{"a": 18, "b": 42}
+{"a": 19, "b": 42}
+{"a": 20, "b": 42}
+{"a": 21, "b": 42}
+{"a": 22, "b": 42}
+{"a": 23, "b": 42}
+{"a": 24, "b": 42}
+{"a": 25, "b": 42}
+{"a": 26, "b": 42}
+{"a": 27, "b": 42}
+{"a": 28, "b": 42}
+{"a": 29, "b": 42}
+{"a": 30, "b": 42}
+{"a": 31, "b": 42}
+{"a": 32, "b": 42}
+{"a": 33, "b": 42}
+{"a": 34, "b": 42}
+{"a": 35, "b": 42}
+{"a": 36, "b": 42}
+{"a": 37, "b": 42}
+{"a": 38, "b": 42}
+{"a": 39, "b": 42}
+
+> CREATE SOURCE other_non_dbz_data
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-other-non-dbz-data-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
+  ENVELOPE NONE
+
+> SELECT sum(a) FROM (SELECT a FROM other_non_dbz_data ORDER BY b LIMIT 37);
+sum
+----
+703
+
+> CREATE VIEW v_other AS
+  SELECT a FROM other_non_dbz_data ORDER BY b LIMIT 37;
+
+> CREATE DEFAULT INDEX ON v_other;
+
+> SELECT * FROM v_other;
+a
+----
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26
+27
+28
+29
+30
+31
+32
+33
+34
+35
+36
+37


### PR DESCRIPTION
This commit fixes a bug (#18445) in monotonic top-k evaluation. The intra-timestamp thinning step included code in TopKBatch that assumed that the value of K would always be smaller or equal to the number of updates in such a batch. This assumption is not true in general, thus creating incorrect output when it is not verified.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/18445

### Tips for reviewer

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes a correctness bug in top-k processing for monotonic, append-only sources.
