### PR TITLE
storage: finalize dropped shards take 2

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -45,7 +45,6 @@ use mz_build_info::BuildInfo;
 use mz_cluster_client::client::ClusterReplicaLocation;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
-use mz_ore::soft_assert;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::critical::SinceHandle;
 use mz_persist_client::write::WriteHandle;
@@ -2073,9 +2072,25 @@ where
             Some(StorageResponse::FrontierUppers(updates)) => {
                 self.update_write_frontiers(&updates);
             }
-            Some(StorageResponse::DroppedIds(_ids)) => {
-                // TODO(petrosagg): It looks like the storage controller never cleans up GlobalIds
-                // from its state. It should probably be done as a reaction to this response.
+            Some(StorageResponse::DroppedIds(ids)) => {
+                let shards_to_finalize: Vec<_> = ids
+                    .iter()
+                    .filter_map(|id| {
+                        self.state.collections.get(id).map(
+                            |CollectionState {
+                                 collection_metadata: CollectionMetadata { data_shard, .. },
+                                 ..
+                             }| *data_shard,
+                        )
+                    })
+                    .collect();
+
+                // Ensure we don't leak any shards by tracking all of them we intend to
+                // finalize.
+                self.register_shards_for_finalization(shards_to_finalize)
+                    .await;
+
+                self.finalize_shards().await;
             }
             Some(StorageResponse::StatisticsUpdates(source_stats, sink_stats)) => {
                 // Note we only hold the locks while moving some plain-old-data around here.
@@ -2619,9 +2634,6 @@ where
             .await
             .expect("connect to stash");
 
-        // Finalize any shards that are no longer-in use.
-        self.finalize_shards(dropped_shards).await;
-
         // Update in-memory state for remap shards.
         for id in remap_shards_to_replace {
             let c = match self.collection_mut(id) {
@@ -2672,23 +2684,25 @@ where
         }
     }
 
-    /// Closes the identified shards from further reads or writes.
+    /// Attempts to close all shards marked for finalization.
     #[allow(dead_code)]
-    async fn finalize_shards<I>(&mut self, shards: I)
-    where
-        I: IntoIterator<Item = ShardId> + Clone,
-    {
-        soft_assert!(
-            {
-                let mut all_registered = true;
-                for shard in shards.clone() {
-                    all_registered =
-                        self.is_shard_registered_for_finalization(shard).await && all_registered
-                }
-                all_registered
-            },
-            "finalized shards must be registered before calling finalize_shards"
-        );
+    async fn finalize_shards(&mut self) {
+        let shards = self
+            .state
+            .stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = tx
+                        .collection::<ShardId, ()>(command_wals::SHARD_FINALIZATION.name())
+                        .await
+                        .expect("named collection must exist");
+                    tx.peek(collection).await
+                })
+            })
+            .await
+            .expect("stash operation succeeds")
+            .into_iter()
+            .map(|(shard, _, _)| shard);
 
         // Open a persist client to delete unused shards.
         let persist_client = self
@@ -2746,8 +2760,10 @@ where
             .collect()
             .await;
 
-        self.clear_from_shard_finalization_register(finalized_shards)
-            .await;
+        if !finalized_shards.is_empty() {
+            self.clear_from_shard_finalization_register(finalized_shards)
+                .await;
+        }
     }
 }
 

--- a/src/storage-client/src/controller/command_wals.rs
+++ b/src/storage-client/src/controller/command_wals.rs
@@ -40,15 +40,6 @@ where
 
     Self: super::StorageController<Timestamp = T>,
 {
-    /// `true` if shard is in register for shards marked for finalization.
-    pub(super) async fn is_shard_registered_for_finalization(&mut self, shard: ShardId) -> bool {
-        SHARD_FINALIZATION
-            .peek_key_one(&mut self.state.stash, shard)
-            .await
-            .expect("must be able to connect to stash")
-            .is_some()
-    }
-
     /// Register shards for finalization. This must be called if you intend to
     /// finalize shards, before you perform any work to e.g. replace one shard
     /// with another.
@@ -136,10 +127,6 @@ where
 
         // Remove any shards that are currently in use from shard finalization register.
         self.clear_from_shard_finalization_register(shard_ids_to_keep)
-            .await;
-
-        // Determine all shards that are registered that are not in use.
-        self.finalize_shards(registered_shards.difference(&in_use_shards).cloned())
             .await;
     }
 }


### PR DESCRIPTION
Re-do of #17327 that should take #18378 into account.

@aljoscha @danhhz @bkirwi -- does this approach look right/sane to you all?

### Motivation

  * This PR adds a known-desirable feature. Discussed in #17327
  * This PR fixes a recognized bug.  #17327 was deficient in that it caused #18378

### Tips for reviewer

Putting this in draft primarily as a talking point; maybe there are other viable approaches we should consider.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
