### PR TITLE
pg sources: track publication's WAL ID

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -224,7 +224,7 @@ async fn pg_source_table_metadata_rewrite(
             .expect("valid config");
 
         // Get the current publication tables from the upstream PG source.
-        let mut current_publication_tables =
+        let (_database_system_id, mut current_publication_tables) =
             match mz_postgres_util::publication_info(&config, publication, None).await {
                 Ok(v) => v,
                 Err(_) => {

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -224,7 +224,7 @@ async fn pg_source_table_metadata_rewrite(
             .expect("valid config");
 
         // Get the current publication tables from the upstream PG source.
-        let (_database_system_id, mut current_publication_tables) =
+        let (database_system_id, mut current_publication_tables) =
             match mz_postgres_util::publication_info(&config, publication, None).await {
                 Ok(v) => v,
                 Err(_) => {
@@ -294,6 +294,7 @@ async fn pg_source_table_metadata_rewrite(
         let _ = options.remove(details_idx).value.expect("valid catalog");
 
         publication_details.tables = current_publication_tables;
+        publication_details.database_system_id = Some(database_system_id);
 
         options.push(PgConfigOption {
             name: PgConfigOptionName::Details,

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -203,7 +203,7 @@ pub async fn publication_info(
     config: &Config,
     publication: &str,
     oid_filter: Option<u32>,
-) -> Result<Vec<PostgresTableDesc>, PostgresError> {
+) -> Result<(i64, Vec<PostgresTableDesc>), PostgresError> {
     let client = config.connect("postgres_publication_info").await?;
 
     client
@@ -354,7 +354,12 @@ pub async fn publication_info(
         });
     }
 
-    Ok(table_infos)
+    let id = client
+        .query_one("SELECT system_identifier FROM pg_control_system()", &[])
+        .await?;
+    let id = id.get("system_identifier");
+
+    Ok((id, table_infos))
 }
 
 pub async fn drop_replication_slots(config: Config, slots: &[&str]) -> Result<(), PostgresError> {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -293,7 +293,7 @@ pub async fn purify_create_source(
             let config = connection
                 .config(&*connection_context.secrets_reader)
                 .await?;
-            let publication_tables =
+            let (database_system_id, publication_tables) =
                 mz_postgres_util::publication_info(&config, &publication, None)
                     .await
                     .map_err(|cause| PlanError::FetchingPostgresPublicationInfoFailed {
@@ -543,6 +543,7 @@ pub async fn purify_create_source(
                     "materialize_{}",
                     Uuid::new_v4().to_string().replace('-', "")
                 ),
+                database_system_id: Some(database_system_id),
             };
             options.push(PgConfigOption {
                 name: PgConfigOptionName::Details,

--- a/src/storage-client/src/types/sources.proto
+++ b/src/storage-client/src/types/sources.proto
@@ -202,6 +202,8 @@ message ProtoPostgresSourceConnection {
 message ProtoPostgresSourcePublicationDetails {
     repeated mz_postgres_util.desc.ProtoPostgresTableDesc tables = 1;
     string slot = 2;
+    // TODO(migration): Remove optional in v0.51 (introduced v0.49 + 1 version)
+    optional int64 database_system_id = 3;
 }
 
 message ProtoLoadGeneratorSourceConnection {

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -2040,6 +2040,10 @@ impl RustType<ProtoPostgresSourceConnection> for PostgresSourceConnection {
 pub struct PostgresSourcePublicationDetails {
     pub tables: Vec<mz_postgres_util::desc::PostgresTableDesc>,
     pub slot: String,
+    /// Uniquely identifies the WAL that the publication is reading from. For more details, see
+    /// [pgPedia](https://pgpedia.info/d/database-system-identifier.html).
+    // TODO(migration): Remove optional in v0.51 (introduced v0.49 + 1 version)
+    pub database_system_id: Option<i64>,
 }
 
 impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicationDetails {
@@ -2047,6 +2051,7 @@ impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicati
         ProtoPostgresSourcePublicationDetails {
             tables: self.tables.iter().map(|t| t.into_proto()).collect(),
             slot: self.slot.clone(),
+            database_system_id: self.database_system_id,
         }
     }
 
@@ -2058,6 +2063,7 @@ impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicati
                 .map(mz_postgres_util::desc::PostgresTableDesc::from_proto)
                 .collect::<Result<_, _>>()?,
             slot: proto.slot,
+            database_system_id: proto.database_system_id,
         })
     }
 }


### PR DESCRIPTION
To support #16371, we need to ensure that each replication slot is only being read from by one source. We can ensure this by verifying that each `(WAL ID, slot name)` tuple is unique. The first step to accomplishing this is tracking the WAL ID, known as the [Database system identifier](https://pgpedia.info/d/database-system-identifier.html).

I am doing this out-of-band of the rest of the feature so we can use the existing migration that's reaching out to the PG source and updating the `PostgresSourcePublicationDetails`.

### Motivation

This PR adds a known-desirable feature. #16371

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
