### PR TITLE
storage-client: expire crticial since handle when dropping it

### DIFF
--- a/src/storage-client/src/controller/persist_handles.rs
+++ b/src/storage-client/src/controller/persist_handles.rs
@@ -106,11 +106,13 @@ impl<T: Timestamp + Lattice + Codec64> PersistReadWorker<T> {
                             mz_ore::halt!("fenced by envd @ {other_epoch:?}. ours = {epoch:?}");
                         }
 
-                        // If we're not done we put the handle back
-                        if !since.is_empty() {
-                            Some((id, (since_handle)))
-                        } else {
+                        // If we're done, expire and drop the handle
+                        if since.is_empty() {
+                            since_handle.expire();
                             None
+                        } else {
+                            // Otherwise put it back
+                            Some((id, (since_handle)))
                         }
                     });
                 }


### PR DESCRIPTION
In a comment from @danhhz , I realized we might never be expiring the critical since handles held by the `PersistReadWorker`.

### Motivation

This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
