### PR TITLE
interchange: add an avro-decode helper program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3911,6 +3911,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "chrono",
+ "clap",
  "criterion",
  "differential-dataflow",
  "itertools",

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -15,6 +15,7 @@ harness = false
 anyhow = "1.0.66"
 byteorder = "1.4.3"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
+clap = { version = "3.2.20", features = ["derive"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 itertools = "0.10.5"
 once_cell = "1.16.0"
@@ -29,6 +30,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 prost-reflect = "0.9.2"
 serde_json = "1.0.89"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+tokio = { version = "1.24.2", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/interchange/src/bin/avro-decode.rs
+++ b/src/interchange/src/bin/avro-decode.rs
@@ -75,13 +75,56 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
-//! Translations for various data serialization formats.
+use std::path::PathBuf;
+use std::process;
 
-#![warn(missing_debug_implementations)]
+use anyhow::Context;
+use tokio::fs;
 
-pub mod avro;
-pub mod confluent;
-pub mod encode;
-pub mod envelopes;
-pub mod json;
-pub mod protobuf;
+use mz_interchange::avro::Decoder;
+use mz_interchange::confluent;
+use mz_ore::cli;
+use mz_ore::cli::CliConfig;
+
+/// Decode a single Avro row using Materialize's Avro decoder.
+#[derive(clap::Parser)]
+struct Args {
+    /// The path to a file containing the raw bytes of a single Avro datum.
+    data_file: PathBuf,
+    /// The path to a file containing the Avro schema.
+    schema_file: PathBuf,
+    /// Whether the data file uses the Confluent wire format.
+    #[clap(long)]
+    confluent_wire_format: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    let args: Args = cli::parse_args(CliConfig::default());
+    if let Err(e) = run(args).await {
+        println!("{e:#}");
+        process::exit(1);
+    }
+}
+
+async fn run(args: Args) -> Result<(), anyhow::Error> {
+    let mut data = &*fs::read(&args.data_file)
+        .await
+        .context("reading data file")?;
+    if args.confluent_wire_format {
+        let (schema_id, adjusted_data) = confluent::extract_avro_header(data)?;
+        data = adjusted_data;
+        println!("schema id: {schema_id}");
+    }
+    let schema = fs::read_to_string(&args.schema_file)
+        .await
+        .context("reading schema file")?;
+    let ccsr_client: Option<Box<mz_ccsr::Client>> = None;
+    let debug_name = String::from("avro-decode");
+    let confluent_wire_format = false;
+    let mut decoder = Decoder::new(&schema, ccsr_client, debug_name, confluent_wire_format)
+        .context("creating decoder")?;
+    let row = decoder.decode(&mut data).await.context("decoding data")?;
+    println!("row: {row:?}");
+    Ok(())
+}


### PR DESCRIPTION
This commit adds a new avro-decode program, which is useful for debugging issues with Materialize's custom Avro decoding logic.  The program takes a file containing the raw Avro data and a file containing the Avro schema, decodes the Avro data, and prints the decoded row to stdout.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR adds a helpful debugging program.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
