### PR TITLE
cloudtest: Make Mz available as 'materialized' as well

### DIFF
--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -22,6 +22,7 @@ from materialize.cloudtest.k8s.debezium import DEBEZIUM_RESOURCES
 from materialize.cloudtest.k8s.environmentd import (
     EnvironmentdService,
     EnvironmentdStatefulSet,
+    MaterializedAliasService,
 )
 from materialize.cloudtest.k8s.minio import Minio
 from materialize.cloudtest.k8s.postgres import POSTGRES_RESOURCES
@@ -81,6 +82,7 @@ class MaterializeApplication(Application):
         log_filter: Optional[str] = None,
     ) -> None:
         self.environmentd = EnvironmentdService()
+        self.materialized_alias = MaterializedAliasService()
         self.testdrive = Testdrive(release_mode=release_mode, aws_region=aws_region)
         self.release_mode = release_mode
         self.aws_region = aws_region
@@ -127,6 +129,7 @@ class MaterializeApplication(Application):
                 release_mode=release_mode, tag=tag, log_filter=log_filter
             ),
             self.environmentd,
+            self.materialized_alias,
             self.testdrive,
         ]
 

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -51,6 +51,21 @@ class EnvironmentdService(K8sService):
         )
 
 
+class MaterializedAliasService(K8sService):
+    """Some testdrive tests expect that Mz is accessible as 'materialized'"""
+
+    def __init__(self) -> None:
+        self.service = V1Service(
+            api_version="v1",
+            kind="Service",
+            metadata=V1ObjectMeta(name="materialized"),
+            spec=V1ServiceSpec(
+                type="ExternalName",
+                external_name="environmentd.default.svc.cluster.local",
+            ),
+        )
+
+
 class EnvironmentdStatefulSet(K8sStatefulSet):
     def __init__(
         self,


### PR DESCRIPTION
This ensures compatibility with tests that expect
that the Mz instance will be named 'materialized', the way it has been named in mzcompose contexts.

### Motivation

  * This PR fixes a previously unreported bug.
Nightly "platform checks upgrade in cloudtest" was failing like this:

```
[2023-03-28T23:43:30Z] 2:1: error: connecting to postgres: error connecting to server: failed to lookup address information: Name or service not known: failed to lookup address information: Name or service not known
--
  | [2023-03-28T23:43:30Z]      \|
  | [2023-03-28T23:43:30Z]    1 \| > CREATE ROLE owner_role_01
  | [2023-03-28T23:43:30Z]    2 \| $ postgres-execute connection=postgres://owner_role_01@materialized:6875/materialize
  | [2023-03-28T23:43:30Z]      \| ^
```

The reason is that in cloudtest, Mz was accessible as `environmentd` and not `materialized`