### PR TITLE
cloud canary: Add explicit indexes to all sources and views used

### DIFF
--- a/test/cloud-canary/canary-clusters.td
+++ b/test/cloud-canary/canary-clusters.td
@@ -25,6 +25,8 @@ cluster1 replica2 3xsmall true
 
 > CREATE MATERIALIZED VIEW cluster_view1 AS SELECT COUNT(*) AS cnt FROM mz_tables;
 
+> CREATE DEFAULT INDEX ON cluster_view1;
+
 > SELECT cnt > 0 FROM cluster_view1;
 true
 

--- a/test/cloud-canary/canary-load-generator.td
+++ b/test/cloud-canary/canary-load-generator.td
@@ -13,5 +13,7 @@
 
 > CREATE MATERIALIZED VIEW generator_view1 AS SELECT COUNT(*) AS cnt FROM generator1;
 
+> CREATE DEFAULT INDEX ON generator_view1;
+
 > SELECT cnt > 0 FROM generator_view1;
 true

--- a/test/cloud-canary/canary-sources.td
+++ b/test/cloud-canary/canary-sources.td
@@ -36,5 +36,7 @@ abc:abc
   ENVELOPE NONE
   WITH (SIZE '3xsmall');
 
+> CREATE DEFAULT INDEX ON bytes;
+
 > SELECT COUNT(*) > 0 from bytes
 true

--- a/test/cloud-canary/canary-tables.td
+++ b/test/cloud-canary/canary-tables.td
@@ -15,6 +15,8 @@
 
 > CREATE MATERIALIZED VIEW table_view1 AS SELECT COUNT(*) FROM table1;
 
+> CREATE DEFAULT INDEX ON table_view1;
+
 > INSERT INTO table1 VALUES (2);
 
 > SELECT * FROM table_view1;


### PR DESCRIPTION
Since the cloud canary files are also used during the load test, make sure that they all use `CREATE INDEX`. This will avoid any post-load-test questions as to whether using indexes could have improved query performance.

### Motivation

  * This PR fixes a previously unreported bug.

During the previous load test, all latency measurements were taken against unindexed sources and materialized views, which was sub-optimal.