### PR TITLE
testdrive: fix subscribe frontier test

### DIFF
--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -172,7 +172,10 @@ contains: Timestamp (0) is not valid for all inputs
 $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
 > BEGIN
-> DECLARE c CURSOR FOR SUBSCRIBE (SELECT true FROM mz_internal.mz_compute_frontiers WHERE export_id LIKE 't%' AND time > 0)
+> DECLARE c CURSOR FOR SUBSCRIBE (
+  SELECT true
+  FROM mz_internal.mz_compute_frontiers f, mz_internal.mz_subscriptions s
+  WHERE f.export_id = s.id AND time > 0)
 > FETCH 1 c WITH (timeout='5s');
 <TIMESTAMP> 1 true
 > COMMIT


### PR DESCRIPTION
This test runs a `SUBSCRIBE` that is supposed to verify that its own frontier is advancing in the introspection sources. Previously, it simply looked for its own frontier by searching for dataflow exports with a "t%" ID. Unfortunately, transient GlobalIds are not only given to subscribe dataflows but also to ad-hoc `SELECT` dataflows. As a consequence, this test was likely to check the logged frontier of one of the previous `SELECT`s, rather than that of the subscribe. This is now fixed by looking the subscribe ID up in `mz_subscriptions`.

### Motivation

  * This PR fixes a previously unreported bug.

`introspection_sources.td` [is flaky](https://buildkite.com/materialize/nightlies/builds/2093#01872865-1d4a-43dd-8c2f-ab6902471095).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
