### PR TITLE
timely-util: eagerly check for input handle frontiers

### DIFF
--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -178,6 +178,18 @@ impl<'handle, T: Timestamp, D: Container, P: Pull<BundleCore<T, D>>> Future
         let state: &'handle mut NextFutState<T, D, P> =
             self.state.take().expect("future polled after completion");
 
+        // Check for frontier notifications first, to urge operators to retire pending work
+        let mut shared_frontiers = state.shared_frontiers.borrow_mut();
+        let (ref frontier, ref mut pending) = shared_frontiers[state.index];
+        if *pending {
+            *pending = false;
+            return Poll::Ready(Some(Event::Progress(frontier.clone())));
+        } else if frontier.is_empty() {
+            // If the frontier is empty and is not pending it means that there is no more data left
+            return Poll::Ready(None);
+        };
+        drop(shared_frontiers);
+
         // This type serves as a type-level function that "shows" the `polonius` function how to
         // create a version of the output type with a specific lifetime 'lt. It does this by
         // implementing the `WithLifetime` trait for all lifetimes 'lt and setting the associated
@@ -192,28 +204,15 @@ impl<'handle, T: Timestamp, D: Container, P: Pull<BundleCore<T, D>>> Future
         {
             Ok((cap, data)) => Poll::Ready(Some(Event::Data(cap, data))),
             Err((state, ())) => {
-                // There is no more data but there may be a pending frontier notification
-                let mut shared_frontiers = state.shared_frontiers.borrow_mut();
-                let (ref frontier, ref mut pending) = shared_frontiers[state.index];
-                if *pending {
-                    *pending = false;
-                    Poll::Ready(Some(Event::Progress(frontier.clone())))
-                } else if frontier.is_empty() {
-                    // If the frontier is empty and is not pending it means that there is no more
-                    // data left in this input stream
-                    Poll::Ready(None)
-                } else {
-                    drop(shared_frontiers);
-                    // Nothing else to produce so install the provided waker in the reactor
-                    state
-                        .reactor_registry
-                        .upgrade()
-                        .expect("handle outlived its operator")
-                        .borrow_mut()
-                        .push(cx.waker().clone());
-                    self.state = Some(state);
-                    Poll::Pending
-                }
+                // Nothing else to produce so install the provided waker in the reactor
+                state
+                    .reactor_registry
+                    .upgrade()
+                    .expect("handle outlived its operator")
+                    .borrow_mut()
+                    .push(cx.waker().clone());
+                self.state = Some(state);
+                Poll::Pending
             }
         }
     }


### PR DESCRIPTION
### Motivation

The handle was originally coded to first check for data and then for frontier notifications due to a misconception of mine that the frontier notification could arrive before the data had been consumed from the handle but I have checked and this is not true.

Since most operators do work on frontier advancement it is beneficial to first notify them about any frontiers and then give them more data.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
