### PR TITLE
[persist] MFP explain config

### DIFF
--- a/src/adapter/src/explain/mir/mod.rs
+++ b/src/adapter/src/explain/mir/mod.rs
@@ -18,7 +18,8 @@
 
 use mz_compute_client::types::dataflows::DataflowDescription;
 use mz_expr::explain::{
-    enforce_linear_chains, ExplainContext, ExplainMultiPlan, ExplainSinglePlan,
+    enforce_linear_chains, ExplainContext, ExplainMultiPlan, ExplainMultiPlanSource,
+    ExplainSinglePlan,
 };
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
 use mz_repr::explain::{Explain, ExplainError, UnsupportedFormat};
@@ -131,7 +132,7 @@ impl<'a> Explainable<'a, DataflowDescription<OptimizedMirRelationExpr>> {
                         .humanizer
                         .humanize_id(*id)
                         .unwrap_or_else(|| id.to_string());
-                    (id, op)
+                    ExplainMultiPlanSource::new(id, op, context)
                 })
             })
             .collect::<Vec<_>>();

--- a/src/adapter/src/explain/mir/mod.rs
+++ b/src/adapter/src/explain/mir/mod.rs
@@ -18,8 +18,7 @@
 
 use mz_compute_client::types::dataflows::DataflowDescription;
 use mz_expr::explain::{
-    enforce_linear_chains, ExplainContext, ExplainMultiPlan, ExplainMultiPlanSource,
-    ExplainSinglePlan,
+    enforce_linear_chains, ExplainContext, ExplainMultiPlan, ExplainSinglePlan, ExplainSource,
 };
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
 use mz_repr::explain::{Explain, ExplainError, UnsupportedFormat};
@@ -132,7 +131,7 @@ impl<'a> Explainable<'a, DataflowDescription<OptimizedMirRelationExpr>> {
                         .humanizer
                         .humanize_id(*id)
                         .unwrap_or_else(|| id.to_string());
-                    ExplainMultiPlanSource::new(id, op, context)
+                    ExplainSource::new(id, op, context)
                 })
             })
             .collect::<Vec<_>>();

--- a/src/compute-client/src/explain/mod.rs
+++ b/src/compute-client/src/explain/mod.rs
@@ -13,9 +13,7 @@ pub(crate) mod text;
 
 use std::collections::BTreeMap;
 
-use mz_expr::explain::{
-    enforce_linear_chains, ExplainContext, ExplainMultiPlan, ExplainMultiPlanSource,
-};
+use mz_expr::explain::{enforce_linear_chains, ExplainContext, ExplainMultiPlan, ExplainSource};
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
 use mz_repr::explain::{AnnotatedPlan, Explain, ExplainError, UnsupportedFormat};
 
@@ -71,7 +69,7 @@ impl<'a> DataflowDescription<Plan> {
                         .humanizer
                         .humanize_id(*id)
                         .unwrap_or_else(|| id.to_string());
-                    ExplainMultiPlanSource::new(id, op, context)
+                    ExplainSource::new(id, op, context)
                 })
             })
             .collect::<Vec<_>>();
@@ -139,7 +137,7 @@ impl<'a> DataflowDescription<OptimizedMirRelationExpr> {
                         .humanizer
                         .humanize_id(*id)
                         .unwrap_or_else(|| id.to_string());
-                    ExplainMultiPlanSource::new(id, op, context)
+                    ExplainSource::new(id, op, context)
                 })
             })
             .collect::<Vec<_>>();

--- a/src/compute-client/src/explain/mod.rs
+++ b/src/compute-client/src/explain/mod.rs
@@ -13,7 +13,9 @@ pub(crate) mod text;
 
 use std::collections::BTreeMap;
 
-use mz_expr::explain::{enforce_linear_chains, ExplainContext, ExplainMultiPlan};
+use mz_expr::explain::{
+    enforce_linear_chains, ExplainContext, ExplainMultiPlan, ExplainMultiPlanSource,
+};
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
 use mz_repr::explain::{AnnotatedPlan, Explain, ExplainError, UnsupportedFormat};
 
@@ -69,7 +71,7 @@ impl<'a> DataflowDescription<Plan> {
                         .humanizer
                         .humanize_id(*id)
                         .unwrap_or_else(|| id.to_string());
-                    (id, op)
+                    ExplainMultiPlanSource::new(id, op, context)
                 })
             })
             .collect::<Vec<_>>();
@@ -137,7 +139,7 @@ impl<'a> DataflowDescription<OptimizedMirRelationExpr> {
                         .humanizer
                         .humanize_id(*id)
                         .unwrap_or_else(|| id.to_string());
-                    (id, op)
+                    ExplainMultiPlanSource::new(id, op, context)
                 })
             })
             .collect::<Vec<_>>();

--- a/src/expr/src/explain/json.rs
+++ b/src/expr/src/explain/json.rs
@@ -9,7 +9,7 @@
 
 //! `EXPLAIN AS JSON` support for structures defined in this crate.
 
-use crate::explain::ExplainMultiPlanSource;
+use crate::explain::ExplainSource;
 use mz_repr::explain::json::DisplayJson;
 
 use super::{ExplainMultiPlan, ExplainSinglePlan};
@@ -43,7 +43,7 @@ where
         let sources = self
             .sources
             .iter()
-            .map(|ExplainMultiPlanSource { id, op, .. }| {
+            .map(|ExplainSource { id, op, .. }| {
                 serde_json::json!({
                     "id": id,
                     "op": op

--- a/src/expr/src/explain/json.rs
+++ b/src/expr/src/explain/json.rs
@@ -9,6 +9,7 @@
 
 //! `EXPLAIN AS JSON` support for structures defined in this crate.
 
+use crate::explain::ExplainMultiPlanSource;
 use mz_repr::explain::json::DisplayJson;
 
 use super::{ExplainMultiPlan, ExplainSinglePlan};
@@ -42,7 +43,7 @@ where
         let sources = self
             .sources
             .iter()
-            .map(|(id, op)| {
+            .map(|ExplainMultiPlanSource { id, op, .. }| {
                 serde_json::json!({
                     "id": id,
                     "op": op

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -46,6 +46,32 @@ pub struct ExplainSinglePlan<'a, T> {
     pub plan: AnnotatedPlan<'a, T>,
 }
 
+/// Carries metadata about the possibility of MFP pushdown for a source.
+/// (Likely to change, and only emitted when a context flag is enabled.)
+#[allow(missing_debug_implementations)]
+pub struct PushdownInfo {}
+
+#[allow(missing_debug_implementations)]
+pub struct ExplainMultiPlanSource<'a> {
+    pub id: String,
+    pub op: &'a MapFilterProject,
+    pub pushdown_info: Option<PushdownInfo>,
+}
+
+impl<'a> ExplainMultiPlanSource<'a> {
+    pub fn new(
+        name: String,
+        mfp: &'a MapFilterProject,
+        _context: &ExplainContext<'a>,
+    ) -> ExplainMultiPlanSource<'a> {
+        ExplainMultiPlanSource {
+            id: name,
+            op: mfp,
+            pushdown_info: None,
+        }
+    }
+}
+
 /// A structure produced by the `explain_$format` methods in
 /// [`mz_repr::explain::Explain`] implementations at points
 /// in the optimization pipeline identified with a
@@ -55,7 +81,7 @@ pub struct ExplainMultiPlan<'a, T> {
     pub context: &'a ExplainContext<'a>,
     // Maps the names of the sources to the linear operators that will be
     // on them.
-    pub sources: Vec<(String, &'a MapFilterProject)>,
+    pub sources: Vec<ExplainMultiPlanSource<'a>>,
     // elements of the vector are in topological order
     pub plans: Vec<(String, AnnotatedPlan<'a, T>)>,
 }

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -9,6 +9,8 @@
 
 //! `EXPLAIN` support for structures defined in this crate.
 
+
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
@@ -17,9 +19,12 @@ use mz_repr::explain::{
     AnnotatedPlan, Explain, ExplainConfig, ExplainError, ExprHumanizer, ScalarOps,
     UnsupportedFormat, UsedIndexes,
 };
+use mz_repr::stats::PersistSourceDataStats;
+use mz_repr::{Datum, RowArena};
 
 use crate::{
-    visit::Visit, Id, LocalId, MapFilterProject, MirRelationExpr, MirScalarExpr, RowSetFinishing,
+    visit::Visit, Id, LocalId, MapFilterProject, MfpPlan, MfpPushdown, MirRelationExpr,
+    MirScalarExpr, RowSetFinishing,
 };
 
 mod json;
@@ -49,7 +54,10 @@ pub struct ExplainSinglePlan<'a, T> {
 /// Carries metadata about the possibility of MFP pushdown for a source.
 /// (Likely to change, and only emitted when a context flag is enabled.)
 #[allow(missing_debug_implementations)]
-pub struct PushdownInfo {}
+pub struct PushdownInfo {
+    /// Pushdown-able columns in the source.
+    pub cols: Vec<usize>,
+}
 
 #[allow(missing_debug_implementations)]
 pub struct ExplainMultiPlanSource<'a> {
@@ -60,14 +68,53 @@ pub struct ExplainMultiPlanSource<'a> {
 
 impl<'a> ExplainMultiPlanSource<'a> {
     pub fn new(
-        name: String,
-        mfp: &'a MapFilterProject,
-        _context: &ExplainContext<'a>,
+        id: String,
+        op: &'a MapFilterProject,
+        context: &ExplainContext<'a>,
     ) -> ExplainMultiPlanSource<'a> {
+        let pushdown_info = if context.config.mfp_pushdown {
+            // Placeholder! Runs through the pushdown process with a mocked stats impl to
+            // figure out which columns have pushdown-able predicates.
+            #[derive(Debug)]
+            struct Tracker(RefCell<Vec<bool>>);
+
+            impl PersistSourceDataStats for Tracker {
+                fn col_min<'a>(&'a self, idx: usize, _arena: &'a RowArena) -> Option<Datum<'a>> {
+                    self.0.borrow_mut()[idx] = true;
+                    None
+                }
+
+                fn col_max<'a>(&'a self, idx: usize, _arena: &'a RowArena) -> Option<Datum<'a>> {
+                    self.0.borrow_mut()[idx] = true;
+                    None
+                }
+            }
+            if let Ok(plan) = MfpPlan::create_from((*op).clone()) {
+                let mfp_pushdown = MfpPushdown::new(&plan);
+                let tracker = Tracker(RefCell::new(vec![false; op.input_arity]));
+                let _ = mfp_pushdown.should_fetch(&tracker);
+                let mut cols: Vec<_> = tracker
+                    .0
+                    .into_inner()
+                    .into_iter()
+                    .enumerate()
+                    .filter(|(_, referenced)| *referenced)
+                    .map(|(id, _)| id)
+                    .collect();
+
+                cols.sort();
+                Some(PushdownInfo { cols })
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         ExplainMultiPlanSource {
-            id: name,
-            op: mfp,
-            pushdown_info: None,
+            id,
+            op,
+            pushdown_info,
         }
     }
 }

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -77,18 +77,18 @@ impl<C: AsMut<Indent>> DisplayText<C> for PushdownInfo {
 }
 
 #[allow(missing_debug_implementations)]
-pub struct ExplainMultiPlanSource<'a> {
+pub struct ExplainSource<'a> {
     pub id: String,
     pub op: &'a MapFilterProject,
     pub pushdown_info: Option<PushdownInfo>,
 }
 
-impl<'a> ExplainMultiPlanSource<'a> {
+impl<'a> ExplainSource<'a> {
     pub fn new(
         id: String,
         op: &'a MapFilterProject,
         context: &ExplainContext<'a>,
-    ) -> ExplainMultiPlanSource<'a> {
+    ) -> ExplainSource<'a> {
         let pushdown_info = if context.config.mfp_pushdown {
             // Placeholder! Runs through the pushdown process with a mocked stats impl to
             // figure out which columns have pushdown-able predicates.
@@ -128,7 +128,7 @@ impl<'a> ExplainMultiPlanSource<'a> {
             None
         };
 
-        ExplainMultiPlanSource {
+        ExplainSource {
             id,
             op,
             pushdown_info,
@@ -145,7 +145,7 @@ pub struct ExplainMultiPlan<'a, T> {
     pub context: &'a ExplainContext<'a>,
     // Maps the names of the sources to the linear operators that will be
     // on them.
-    pub sources: Vec<ExplainMultiPlanSource<'a>>,
+    pub sources: Vec<ExplainSource<'a>>,
     // elements of the vector are in topological order
     pub plans: Vec<(String, AnnotatedPlan<'a, T>)>,
 }

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -9,12 +9,15 @@
 
 //! `EXPLAIN` support for structures defined in this crate.
 
-
+use itertools::Itertools;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::fmt::Formatter;
 use std::time::Duration;
 
 use mz_ore::stack::RecursionLimitError;
+use mz_ore::str::Indent;
+use mz_repr::explain::text::DisplayText;
 use mz_repr::explain::{
     AnnotatedPlan, Explain, ExplainConfig, ExplainError, ExprHumanizer, ScalarOps,
     UnsupportedFormat, UsedIndexes,
@@ -57,6 +60,20 @@ pub struct ExplainSinglePlan<'a, T> {
 pub struct PushdownInfo {
     /// Pushdown-able columns in the source.
     pub cols: Vec<usize>,
+}
+
+impl<C: AsMut<Indent>> DisplayText<C> for PushdownInfo {
+    fn fmt_text(&self, f: &mut Formatter<'_>, ctx: &mut C) -> std::fmt::Result {
+        if !self.cols.is_empty() {
+            writeln!(
+                f,
+                "{}pushdown=(#{})",
+                ctx.as_mut(),
+                self.cols.iter().join(", #")
+            )?;
+        }
+        Ok(())
+    }
 }
 
 #[allow(missing_debug_implementations)]

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -101,6 +101,10 @@ where
             for (id, op) in self.sources.iter().filter(|(_, op)| !op.is_identity()) {
                 writeln!(f, "{}Source {}", ctx.indent, id)?;
                 ctx.indented(|ctx| op.fmt_text(f, ctx))?;
+                if self.context.config.mfp_pushdown {
+                    let pushdown = "?"; // TODO: extract this info from the MFP!
+                    ctx.indented(|ctx| writeln!(f, "{}mfp_pushdown={pushdown}", ctx.indent))?;
+                }
             }
         }
 

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -9,6 +9,8 @@
 
 //! `EXPLAIN ... AS TEXT` support for structures defined in this crate.
 
+use itertools::Itertools;
+use std::cell::RefCell;
 use std::fmt;
 
 use mz_ore::soft_assert;
@@ -17,12 +19,13 @@ use mz_repr::explain::text::{fmt_text_constant_rows, DisplayText};
 use mz_repr::explain::{
     CompactScalarSeq, ExprHumanizer, Indices, PlanRenderingContext, RenderingContext,
 };
-use mz_repr::{GlobalId, Row};
+use mz_repr::stats::PersistSourceDataStats;
+use mz_repr::{Datum, GlobalId, Row, RowArena};
 
 use super::{ExplainMultiPlan, ExplainSinglePlan};
 use crate::{
-    AggregateExpr, Id, JoinImplementation, JoinInputCharacteristics, MapFilterProject,
-    MirRelationExpr, MirScalarExpr, RowSetFinishing,
+    AggregateExpr, Id, JoinImplementation, JoinInputCharacteristics, MapFilterProject, MfpPlan,
+    MfpPushdown, MirRelationExpr, MirScalarExpr, RowSetFinishing,
 };
 
 impl<'a, T: 'a> DisplayText for ExplainSinglePlan<'a, T>
@@ -102,8 +105,46 @@ where
                 writeln!(f, "{}Source {}", ctx.indent, id)?;
                 ctx.indented(|ctx| op.fmt_text(f, ctx))?;
                 if self.context.config.mfp_pushdown {
-                    let pushdown = "?"; // TODO: extract this info from the MFP!
-                    ctx.indented(|ctx| writeln!(f, "{}mfp_pushdown={pushdown}", ctx.indent))?;
+                    // Placeholder! Runs through the pushdown process with a mocked stats impl to
+                    // figure out which columns have pushdown-able predicates.
+                    #[derive(Debug)]
+                    struct Tracker(RefCell<Vec<bool>>);
+
+                    impl PersistSourceDataStats for Tracker {
+                        fn col_min<'a>(
+                            &'a self,
+                            idx: usize,
+                            _arena: &'a RowArena,
+                        ) -> Option<Datum<'a>> {
+                            self.0.borrow_mut()[idx] = true;
+                            None
+                        }
+
+                        fn col_max<'a>(
+                            &'a self,
+                            idx: usize,
+                            _arena: &'a RowArena,
+                        ) -> Option<Datum<'a>> {
+                            self.0.borrow_mut()[idx] = true;
+                            None
+                        }
+                    }
+                    if let Ok(plan) = MfpPlan::create_from((*op).clone()) {
+                        let mfp_pushdown = MfpPushdown::new(&plan);
+                        let tracker = Tracker(RefCell::new(vec![false; op.input_arity]));
+                        let _ = mfp_pushdown.should_fetch(&tracker);
+                        let referenced = tracker
+                            .0
+                            .into_inner()
+                            .into_iter()
+                            .enumerate()
+                            .filter(|(_, referenced)| *referenced)
+                            .map(|(id, _)| id)
+                            .join(", #");
+                        ctx.indented(|ctx| {
+                            writeln!(f, "{}mfp_pushdown=(#{referenced})", ctx.indent)
+                        })?;
+                    }
                 }
             }
         }

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -103,13 +103,23 @@ where
             // render one blank line between the plans and sources
             writeln!(f, "")?;
             // render sources
-            for ExplainMultiPlanSource { id, op, .. } in self
+            for ExplainMultiPlanSource {
+                id,
+                op,
+                pushdown_info,
+            } in self
                 .sources
                 .iter()
                 .filter(|ExplainMultiPlanSource { op, .. }| !op.is_identity())
             {
                 writeln!(f, "{}Source {}", ctx.indent, id)?;
-                ctx.indented(|ctx| op.fmt_text(f, ctx))?;
+                ctx.indented(|ctx| {
+                    op.fmt_text(f, ctx)?;
+                    if let Some(info) = pushdown_info {
+                        info.fmt_text(f, ctx)?;
+                    }
+                    Ok(())
+                })?;
             }
         }
 

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -20,7 +20,7 @@ use mz_repr::explain::{
 use mz_repr::{GlobalId, Row};
 
 use super::{ExplainMultiPlan, ExplainSinglePlan};
-use crate::explain::ExplainMultiPlanSource;
+use crate::explain::ExplainSource;
 use crate::{
     AggregateExpr, Id, JoinImplementation, JoinInputCharacteristics, MapFilterProject,
     MirRelationExpr, MirScalarExpr, RowSetFinishing,
@@ -98,26 +98,24 @@ where
         if self
             .sources
             .iter()
-            .any(|ExplainMultiPlanSource { op, .. }| !op.is_identity())
+            .any(|ExplainSource { op, .. }| !op.is_identity())
         {
             // render one blank line between the plans and sources
             writeln!(f, "")?;
             // render sources
-            for ExplainMultiPlanSource {
+            for ExplainSource {
                 id,
                 op,
                 pushdown_info,
             } in self
                 .sources
                 .iter()
-                .filter(|ExplainMultiPlanSource { op, .. }| !op.is_identity())
+                .filter(|ExplainSource { op, .. }| !op.is_identity())
             {
                 writeln!(f, "{}Source {}", ctx.indent, id)?;
                 ctx.indented(|ctx| {
                     op.fmt_text(f, ctx)?;
-                    if let Some(info) = pushdown_info {
-                        info.fmt_text(f, ctx)?;
-                    }
+                    pushdown_info.fmt_text(f, ctx)?;
                     Ok(())
                 })?;
             }

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -23,6 +23,7 @@ use mz_repr::stats::PersistSourceDataStats;
 use mz_repr::{Datum, GlobalId, Row, RowArena};
 
 use super::{ExplainMultiPlan, ExplainSinglePlan};
+use crate::explain::ExplainMultiPlanSource;
 use crate::{
     AggregateExpr, Id, JoinImplementation, JoinInputCharacteristics, MapFilterProject, MfpPlan,
     MfpPushdown, MirRelationExpr, MirScalarExpr, RowSetFinishing,
@@ -97,11 +98,19 @@ where
                 Ok(())
             })?;
         }
-        if self.sources.iter().any(|(_, op)| !op.is_identity()) {
+        if self
+            .sources
+            .iter()
+            .any(|ExplainMultiPlanSource {  op, .. }| !op.is_identity())
+        {
             // render one blank line between the plans and sources
             writeln!(f, "")?;
             // render sources
-            for (id, op) in self.sources.iter().filter(|(_, op)| !op.is_identity()) {
+            for ExplainMultiPlanSource { id, op, .. } in self
+                .sources
+                .iter()
+                .filter(|ExplainMultiPlanSource {  op, .. }| !op.is_identity())
+            {
                 writeln!(f, "{}Source {}", ctx.indent, id)?;
                 ctx.indented(|ctx| op.fmt_text(f, ctx))?;
                 if self.context.config.mfp_pushdown {

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -2007,7 +2007,9 @@ pub mod plan {
                     // preserves_uniqueness to mark an inverse function safe for
                     // applying on both sides of an inequality.
                     func:
-                        UnaryFunc::CastUint64ToNumeric(..) | UnaryFunc::CastUint64ToMzTimestamp(..),
+                        UnaryFunc::CastUint64ToNumeric(..)
+                        | UnaryFunc::CastUint64ToMzTimestamp(..)
+                        | UnaryFunc::CastTimestampToMzTimestamp(..),
                     expr,
                 } => Self::one_column_reference(expr),
                 _ => None,

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1432,7 +1432,7 @@ pub mod plan {
 
     use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
     use mz_repr::stats::PersistSourceDataStats;
-    use mz_repr::{Datum, Diff, RelationDesc, Row, RowArena};
+    use mz_repr::{Datum, Diff, Row, RowArena};
 
     use crate::{
         func, BinaryFunc, EvalError, MapFilterProject, MirScalarExpr, ProtoMfpPlan,
@@ -1888,7 +1888,6 @@ pub mod plan {
     /// min/max) about the data contained in it.
     #[derive(Debug)]
     pub struct MfpPushdown {
-        relation_desc: RelationDesc,
         // TODO(mfp): Probably some preprocessing we could do to make
         // `should_fetch` calls more efficient.
         mfp: MfpPlan,
@@ -1898,14 +1897,10 @@ pub mod plan {
         /// Returns a new [MfpPushdown] for the given [MfpPlan] and support
         /// info.
         pub fn new(
-            relation_desc: RelationDesc,
             mfp: &MfpPlan,
             // TODO: timestamp/as_of and until.
         ) -> Self {
-            MfpPushdown {
-                relation_desc,
-                mfp: mfp.clone(),
-            }
+            MfpPushdown { mfp: mfp.clone() }
         }
 
         /// Returns `false` if a chunk of data with the given statistics would
@@ -1962,21 +1957,20 @@ pub mod plan {
                 // Should the `col_min` and `col_max` methods instead take
                 // indexes? That would allow us to remove the RelationDesc from
                 // MfpPushdown.
-                let col_name = self.relation_desc.get_name(col_idx);
                 let min_or_max = match func {
-                    BinaryFunc::Lt | BinaryFunc::Lte => stats.col_min(col_name.as_str(), &arena)?,
-                    BinaryFunc::Gt | BinaryFunc::Gte => stats.col_max(col_name.as_str(), &arena)?,
+                    BinaryFunc::Lt | BinaryFunc::Lte => stats.col_min(col_idx, &arena)?,
+                    BinaryFunc::Gt | BinaryFunc::Gte => stats.col_max(col_idx, &arena)?,
                     _ => return None,
                 };
                 if !Self::zero_column_references(expr2)? {
                     return None;
                 }
-                let mut datums = Vec::with_capacity(self.relation_desc.arity());
+                let mut datums = Vec::with_capacity(self.mfp.mfp.input_arity);
                 while datums.len() < col_idx {
                     datums.push(Datum::Null);
                 }
                 datums.push(min_or_max);
-                while datums.len() < self.relation_desc.arity() {
+                while datums.len() < self.mfp.mfp.input_arity {
                     datums.push(Datum::Null);
                 }
                 match expr.eval(datums.as_slice(), &arena) {

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -161,6 +161,8 @@ pub struct ExplainConfig {
     pub timing: bool,
     /// Show the `type` attribute in the explanation.
     pub types: bool,
+    /// Show MFP pushdown information.
+    pub mfp_pushdown: bool,
 }
 
 impl Default for ExplainConfig {
@@ -177,6 +179,7 @@ impl Default for ExplainConfig {
             subtree_size: false,
             timing: false,
             types: false,
+            mfp_pushdown: false,
         }
     }
 }
@@ -208,6 +211,7 @@ impl TryFrom<BTreeSet<String>> for ExplainConfig {
             subtree_size: flags.remove("subtree_size"),
             timing: flags.remove("timing"),
             types: flags.remove("types"),
+            mfp_pushdown: flags.remove("mfp_pushdown"),
         };
         if flags.is_empty() {
             Ok(result)
@@ -606,6 +610,7 @@ mod tests {
             subtree_size: false,
             timing: true,
             types: false,
+            mfp_pushdown: false,
         };
         let context = ExplainContext {
             env,

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -18,23 +18,33 @@ use crate::{Datum, Row, RowArena};
 /// if we wrote the data before we started collecting statistics, etc.
 pub trait PersistSourceDataStats: std::fmt::Debug {
     /// The number of updates (Rows + errors) in the part.
-    fn len(&self) -> Option<usize>;
+    fn len(&self) -> Option<usize> {
+        None
+    }
 
     /// The number of errors in the part.
-    fn err_count(&self) -> Option<usize>;
+    fn err_count(&self) -> Option<usize> {
+        None
+    }
 
     /// The part's minimum value for the named column, if available.
     /// A return value of `None` indicates that Persist did not / was
     /// not able to calculate a minimum for this column.
-    fn col_min<'a>(&'a self, name: &str, arena: &'a RowArena) -> Option<Datum<'a>>;
+    fn col_min<'a>(&'a self, _idx: usize, _arena: &'a RowArena) -> Option<Datum<'a>> {
+        None
+    }
 
     /// (ditto above, but for the maximum column value)
-    fn col_max<'a>(&'a self, name: &str, arena: &'a RowArena) -> Option<Datum<'a>>;
+    fn col_max<'a>(&'a self, _idx: usize, _arena: &'a RowArena) -> Option<Datum<'a>> {
+        None
+    }
 
     /// The part's null count for the named column, if available. A
     /// return value of `None` indicates that Persist did not / was
     /// not able to calculate the null count for this column.
-    fn col_null_count(&self, name: &str) -> Option<usize>;
+    fn col_null_count(&self, _idx: usize) -> Option<usize> {
+        None
+    }
 
     /// A prefix of column values for the minimum Row in the part. A
     /// return of `None` indicates that Persist did not / was not able
@@ -46,8 +56,12 @@ pub trait PersistSourceDataStats: std::fmt::Debug {
     /// TODO: If persist adds more "indexes" than the "primary" one (the order
     /// of columns returned by Schema), we'll want to generalize this to support
     /// other subsets of columns.
-    fn row_min(&self, row: &mut Row) -> Option<usize>;
+    fn row_min(&self, _row: &mut Row) -> Option<usize> {
+        None
+    }
 
     /// (ditto above, but for the maximum row)
-    fn row_max(&self, row: &mut Row) -> Option<usize>;
+    fn row_max(&self, _row: &mut Row) -> Option<usize> {
+        None
+    }
 }

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -332,6 +332,10 @@ pub fn plan_explain(
         .collect::<BTreeSet<_>>();
     let config = ExplainConfig::try_from(config_flags)?;
 
+    if config.mfp_pushdown {
+        scx.require_unsafe_mode("`mfp_pushdown` explain flag")?;
+    }
+
     let format = match format {
         mz_sql_parser::ast::ExplainFormat::Text => ExplainFormat::Text,
         mz_sql_parser::ast::ExplainFormat::Json => ExplainFormat::Json,

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -203,6 +203,7 @@ mod tests {
                     subtree_size: false,
                     timing: false,
                     types: format_contains("types"),
+                    ..ExplainConfig::default()
                 };
 
                 let context = ExplainContext {


### PR DESCRIPTION
Allow queries in unsafe mode to request `mfp_pushdown` info in an explain plan.

(Currently, this just lists out the columns that we think we could successfully push down predicates against, but this is fairly likely to change in future.)

```
materialize=> explain physical plan with (mfp_pushdown) for SELECT count(*)
FROM events_uint
WHERE insert_ms < 100;
                              Physical Plan                              
-------------------------------------------------------------------------
 Explained Query:                                                       +
[...]
 Source materialize.public.events_uint                                  +
   project=()                                                           +
   filter=((bigint_to_numeric(#0) < 100))                               +
   mfp_pushdown=(#0) 
```

### Motivation

A first pass at #18305. 

### Tips for reviewer

The explain plan is meant to be the "simplest useful version" -- happy for feedback on what's more useful here but I'm likely to want to take those in a followup.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
