### PR TITLE
github: remove dependency-czars reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     day: sunday
     time: "22:00"
   open-pull-requests-limit: 10
-  reviewers: [MaterializeInc/dependency-czars]
   labels: [A-dependencies]
 - package-ecosystem: pip
   directory: /misc/dbt-materialize
@@ -16,7 +15,6 @@ updates:
     # of releasing a new version of dbt-materialize when a new version of
     # dbt drops.
     interval: daily
-  reviewers: [MaterializeInc/dependency-czars]
   labels: [A-dependencies]
 - package-ecosystem: docker
   directory: /misc/images/ubuntu-base
@@ -25,7 +23,6 @@ updates:
     day: sunday
     time: "22:00"
   open-pull-requests-limit: 10
-  reviewers: [MaterializeInc/dependency-czars]
   labels: [A-dependencies]
 - package-ecosystem: docker
   directory: /ci/builder
@@ -34,7 +31,6 @@ updates:
     day: sunday
     time: "22:00"
   open-pull-requests-limit: 10
-  reviewers: [MaterializeInc/dependency-czars]
   labels: [A-dependencies]
 - package-ecosystem: pip
   directory: /ci/builder
@@ -43,5 +39,4 @@ updates:
     day: sunday
     time: "22:00"
   open-pull-requests-limit: 10
-  reviewers: [MaterializeInc/dependency-czars]
   labels: [A-dependencies]


### PR DESCRIPTION
That group does not exist anymore and Github gets confused about it.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
