### PR TITLE
proto: add RustType impls for i8 and i16

### DIFF
--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -445,6 +445,26 @@ impl RustType<u32> for u16 {
     }
 }
 
+impl RustType<i32> for i8 {
+    fn into_proto(&self) -> i32 {
+        i32::from(*self)
+    }
+
+    fn from_proto(proto: i32) -> Result<Self, TryFromProtoError> {
+        i8::try_from(proto).map_err(TryFromProtoError::from)
+    }
+}
+
+impl RustType<i32> for i16 {
+    fn into_proto(&self) -> i32 {
+        i32::from(*self)
+    }
+
+    fn from_proto(repr: i32) -> Result<Self, TryFromProtoError> {
+        i16::try_from(repr).map_err(TryFromProtoError::from)
+    }
+}
+
 impl RustType<ProtoU128> for u128 {
     // TODO(benesch): add a trait for explicitly performing truncating casts.
     #[allow(clippy::as_conversions)]


### PR DESCRIPTION
Used in upcoming persist work.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
