### PR TITLE
persist: calculate and store stats for all `T: Data` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "futures",
  "getrandom",
  "hash_hasher",
+ "multiversion",
  "num-traits",
  "parquet2",
  "rustc_version",
@@ -3201,6 +3202,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "multiversion"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "025c962a3dd3cc5e0e520aa9c612201d127dcdf28616974961a649dca64f5373"
+dependencies = [
+ "multiversion-macros",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a3e2bde382ebf960c1f3e79689fa5941625fe9bf694a1cb64af3e85faff3af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mysql_async"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4258,7 +4279,12 @@ dependencies = [
  "anyhow",
  "arrow2",
  "bytes",
+ "mz-proto",
  "parquet2",
+ "prost",
+ "prost-build",
+ "protobuf-src",
+ "serde",
  "workspace-hack",
 ]
 
@@ -8224,7 +8250,6 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
- "getrandom",
  "globset",
  "hashbrown",
  "hyper",

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -79,7 +79,6 @@ tempfile = "3.2.0"
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-serde = { version = "1.0.152", features = ["derive"] }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -9,6 +9,8 @@
 
 syntax = "proto3";
 
+import "persist-types/src/stats.proto";
+
 package mz_persist_client.internal.state;
 
 message ProtoU64Antichain {
@@ -26,14 +28,8 @@ message ProtoHollowBatchPart {
     uint64 encoded_size_bytes = 2;
 
     // TODO(mfp): This is definitely not the final way for us to store this.
-    repeated ProtoU64ColStats key_col_stats = 536870911;
-}
-
-message ProtoU64ColStats {
-    string name = 1;
-    uint64 min = 2;
-    uint64 max = 3;
-    uint64 nulls = 4;
+    mz_persist_types.stats.ProtoStructStats key_stats = 536870910;
+    reserved 536870911;
 }
 
 message ProtoHollowBatch {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -141,7 +141,7 @@ pub struct HandleDebugState {
 }
 
 /// A subset of a [HollowBatch] corresponding 1:1 to a blob.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug)]
 pub struct HollowBatchPart {
     /// Pointer usable to retrieve the updates.
     pub key: PartialBatchKey,
@@ -152,6 +152,37 @@ pub struct HollowBatchPart {
     /// Stored inside an Arc because HollowBatchPart needs to be cheaply
     /// clone-able.
     pub stats: Option<Arc<PartStats>>,
+}
+
+impl PartialEq for HollowBatchPart {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for HollowBatchPart {}
+
+impl PartialOrd for HollowBatchPart {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for HollowBatchPart {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // TODO(mfp): Extremely sus, but it's not clear what else we can do.
+        let HollowBatchPart {
+            key: self_key,
+            encoded_size_bytes: _,
+            stats: _,
+        } = self;
+        let HollowBatchPart {
+            key: other_key,
+            encoded_size_bytes: _,
+            stats: _,
+        } = other;
+        self_key.cmp(other_key)
+    }
 }
 
 /// A [Batch] but with the updates themselves stored externally.

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -9,22 +9,19 @@
 
 //! Aggregate statistics about data stored in persist.
 
-use std::collections::BTreeMap;
-
 use mz_persist::indexed::columnar::ColumnarRecords;
-use mz_persist_types::columnar::{ColumnFormat, PartEncoder, Schema};
+use mz_persist_types::columnar::{PartEncoder, Schema};
 use mz_persist_types::part::{Part, PartBuilder};
+use mz_persist_types::stats::StructStats;
 use mz_persist_types::Codec;
 
 use crate::internal::encoding::Schemas;
 
 /// Aggregate statistics about data contained in a [Part].
-///
-/// TODO(mfp): PartialEq, Eq, PartialOrd, Ord are sus.
-#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug)]
 pub struct PartStats {
-    // TODO(mfp): Only contains Option<u64> columns in this initial skeleton.
-    pub(crate) key_col_min_max_nulls: BTreeMap<String, (u64, u64, usize)>,
+    /// Aggregate statistics about key data contained in a [Part].
+    pub key: StructStats,
 }
 
 impl PartStats {
@@ -32,40 +29,21 @@ impl PartStats {
         schemas: &Schemas<K, V>,
         part: &Part,
     ) -> Result<Self, String> {
-        // TODO(mfp): This impl is all entirely just a placeholder. Zero chance
-        // it works like this by the time it ships.
-        let mut key_cols = part.key_ref();
-        let mut key_col_min_max_nulls = BTreeMap::new();
+        let mut key = StructStats {
+            len: part.len(),
+            cols: Default::default(),
+        };
         // TODO(mfp): We only need to plumb the schemas here if we end up
         // allowing them to specify arbitrary min/max logic for complex types.
         // If we don't end up doing that, consider pulling the schemas out of
         // here.
-        for (name, typ) in schemas.key.columns() {
-            let col = match (typ.optional, typ.format) {
-                (true, ColumnFormat::U64) => key_cols.col::<Option<u64>>(name.as_str())?,
-                // TODO(mfp): Support stats on other column types.
-                _ => continue,
-            };
-            let (mut min, mut max, mut nulls) = (u64::MAX, u64::MIN, 0usize);
-            for x in col.iter() {
-                if let Some(x) = x {
-                    min = std::cmp::min(*x, min);
-                    max = std::cmp::max(*x, max);
-                } else {
-                    nulls += 1;
-                }
-            }
-            // Skip adding nonsensical min=u64::MAX max=u64::MIN. This might
-            // lose null count for an all null batch, but we keep sparse metrics
-            // so fine for placeholder impl.
-            if min <= max {
-                key_col_min_max_nulls.insert(name, (min, max, nulls));
-            }
+        let mut key_cols = part.key_ref();
+        for (name, _typ) in schemas.key.columns() {
+            let col_stats = key_cols.stats(&name)?;
+            key.cols.insert(name, col_stats);
         }
-        drop(key_cols);
-        Ok(PartStats {
-            key_col_min_max_nulls,
-        })
+        key_cols.finish()?;
+        Ok(PartStats { key })
     }
 
     pub(crate) fn legacy_part_format<K: Codec, V: Codec>(
@@ -96,17 +74,7 @@ impl PartStats {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self == &Self::default()
-    }
-
-    /// The min and max values as well as null count for an `Option<u64>` column
-    /// in this part.
-    ///
-    /// Returns `None` if persist doesn't have stats about this column, or if
-    /// the column is not `Option<u64>`.
-    ///
-    /// TODO(mfp): This is decidedly not the final public interface.
-    pub fn opt_u64_key_col_min_max_nulls(&self, name: &str) -> Option<(u64, u64, usize)> {
-        self.key_col_min_max_nulls.get(name).copied()
+        let Self { key } = self;
+        key.len == 0
     }
 }

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -10,10 +10,17 @@ publish = false
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-arrow2 = { version = "0.16.0", features = ["io_ipc", "io_parquet"] }
+arrow2 = { version = "0.16.0", features = ["compute_aggregate", "io_ipc", "io_parquet"] }
 bytes = "1.3.0"
+mz-proto = { path = "../proto" }
 parquet2 = { version = "0.17.1", default-features = false }
+prost = { version = "0.11.3", features = ["no-recursion-limit"] }
+serde = { version = "1.0.152", features = ["derive"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+
+[build-dependencies]
+prost-build = "0.11.2"
+protobuf-src = "1.1.0"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/persist-types/build.rs
+++ b/src/persist-types/build.rs
@@ -81,24 +81,8 @@ fn main() {
     env::set_var("PROTOC", protobuf_src::protoc());
 
     prost_build::Config::new()
-        .extern_path(".mz_persist_types", "::mz_persist_types")
-        .extern_path(".mz_proto", "::mz_proto")
-        // Note(parkertimmerman): We purposefully omit `.mz_persist_client.internal.diff` from here
-        // because we want to use `bytes::Bytes` for the types in that package, and `Bytes` doesn't
-        // implement `serde::Serialize`
-        .type_attribute(
-            ".mz_persist_client.internal.state",
-            "#[derive(serde::Serialize)]",
-        )
+        .type_attribute(".", "#[derive(serde::Serialize)]")
         .btree_map(["."])
-        .bytes([".mz_persist_client.internal.diff.ProtoStateFieldDiffs"])
-        .compile_protos(
-            &[
-                "persist-client/src/cfg.proto",
-                "persist-client/src/internal/state.proto",
-                "persist-client/src/internal/diff.proto",
-            ],
-            &[".."],
-        )
+        .compile_protos(&["persist-types/src/stats.proto"], &[".."])
         .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -28,6 +28,7 @@ use crate::columnar::{
     ColumnFormat, ColumnGet, ColumnPush, Data, DataType, PartDecoder, PartEncoder, Schema,
 };
 use crate::part::{ColumnsMut, ColumnsRef};
+use crate::stats::{OptionStats, PrimitiveStats};
 use crate::{Codec, Codec64, Opaque};
 
 /// An implementation of [Schema] for [()].
@@ -281,6 +282,7 @@ impl Data for bool {
     type Ref<'a> = bool;
     type Col = Bitmap;
     type Mut = MutableBitmap;
+    type Stats = PrimitiveStats<bool>;
 }
 
 impl Data for Option<bool> {
@@ -291,6 +293,7 @@ impl Data for Option<bool> {
     type Ref<'a> = Option<bool>;
     type Col = BooleanArray;
     type Mut = MutableBooleanArray;
+    type Stats = OptionStats<PrimitiveStats<bool>>;
 }
 
 macro_rules! data_primitive {
@@ -303,6 +306,7 @@ macro_rules! data_primitive {
             type Ref<'a> = $data;
             type Col = Buffer<$data>;
             type Mut = Vec<$data>;
+            type Stats = PrimitiveStats<$data>;
         }
 
         impl Data for Option<$data> {
@@ -313,6 +317,7 @@ macro_rules! data_primitive {
             type Ref<'a> = Option<$data>;
             type Col = PrimitiveArray<$data>;
             type Mut = MutablePrimitiveArray<$data>;
+            type Stats = OptionStats<PrimitiveStats<$data>>;
         }
     };
 }
@@ -337,6 +342,7 @@ impl Data for Vec<u8> {
     // TODO: Something that more obviously isn't optional.
     type Col = BinaryArray<i32>;
     type Mut = MutableBinaryArray<i32>;
+    type Stats = PrimitiveStats<Vec<u8>>;
 }
 
 impl Data for Option<Vec<u8>> {
@@ -347,6 +353,7 @@ impl Data for Option<Vec<u8>> {
     type Ref<'a> = Option<&'a [u8]>;
     type Col = BinaryArray<i32>;
     type Mut = MutableBinaryArray<i32>;
+    type Stats = OptionStats<PrimitiveStats<Vec<u8>>>;
 }
 
 impl Data for String {
@@ -358,6 +365,7 @@ impl Data for String {
     // TODO: Something that more obviously isn't optional.
     type Col = Utf8Array<i32>;
     type Mut = MutableUtf8Array<i32>;
+    type Stats = PrimitiveStats<String>;
 }
 
 impl Data for Option<String> {
@@ -368,6 +376,7 @@ impl Data for Option<String> {
     type Ref<'a> = Option<&'a str>;
     type Col = Utf8Array<i32>;
     type Mut = MutableUtf8Array<i32>;
+    type Stats = OptionStats<PrimitiveStats<String>>;
 }
 
 impl ColumnRef for Bitmap {

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -53,6 +53,7 @@ use std::fmt::Debug;
 use crate::codec_impls::UnitSchema;
 use crate::columnar::sealed::ColumnRef;
 use crate::part::{ColumnsMut, ColumnsRef, PartBuilder};
+use crate::stats::DynStats;
 use crate::Codec;
 
 /// A type understood by persist.
@@ -80,10 +81,6 @@ pub trait Data: Debug + Send + Sync + Sized + 'static {
 
     /// The associated reference type of [Self] used for reads and writes on
     /// columns of this type.
-    ///
-    /// TODO: We may want to eventually separate this into In and Out types
-    /// because one wants to be covariant and the other wants to be
-    /// contravariant.
     type Ref<'a>
     where
         Self: 'a;
@@ -93,6 +90,9 @@ pub trait Data: Debug + Send + Sync + Sized + 'static {
 
     /// The exclusive builder of columns of this type of data.
     type Mut: ColumnPush<Self> + Default;
+
+    /// The statistics type of columns of this type of data.
+    type Stats: DynStats + for<'a> From<&'a Self::Col>;
 }
 
 /// A type that may be retrieved from a column of `[T]`.

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -92,6 +92,7 @@ pub mod codec_impls;
 pub mod columnar;
 pub mod parquet;
 pub mod part;
+pub mod stats;
 
 /// Encoding and decoding operations for a type usable as a persisted key or
 /// value.

--- a/src/persist-types/src/stats.proto
+++ b/src/persist-types/src/stats.proto
@@ -1,0 +1,67 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package mz_persist_types.stats;
+
+message ProtoStructStats {
+    uint64 len = 1;
+    map<string, ProtoDynStats> cols = 2;
+}
+
+message ProtoDynStats {
+    // ProtoOptionStats could instead be have a `ProtoDynStats some` field and
+    // be in the oneof, but that's unnecesary (we don't need
+    // `OptionStats<OptionStats<T>>`) and causes some problems (OptionStats
+    // would need to represent `some` as a `Box<dyn DynStats>` instead of a `T`,
+    // which is far less ergonomic).
+    optional ProtoOptionStats option = 1;
+    oneof kind {
+        ProtoStructStats struct = 2;
+        ProtoPrimitiveStats primitive = 3;
+    }
+}
+
+message ProtoOptionStats {
+    uint64 none = 1;
+}
+
+message ProtoPrimitiveStats {
+    oneof lower {
+        bool lower_bool = 1;
+        uint32 lower_u8 = 2;
+        uint32 lower_u16 = 3;
+        uint32 lower_u32 = 4;
+        uint64 lower_u64 = 5;
+        int32 lower_i8 = 6;
+        int32 lower_i16 = 7;
+        int32 lower_i32 = 8;
+        int64 lower_i64 = 9;
+        float lower_f32 = 10;
+        double lower_f64 = 11;
+        bytes lower_bytes = 12;
+        string lower_string = 13;
+    }
+    oneof upper {
+        bool upper_bool = 14;
+        uint32 upper_u8 = 15;
+        uint32 upper_u16 = 16;
+        uint32 upper_u32 = 17;
+        uint64 upper_u64 = 18;
+        int32 upper_i8 = 19;
+        int32 upper_i16 = 20;
+        int32 upper_i32 = 21;
+        int64 upper_i64 = 22;
+        float upper_f32 = 23;
+        double upper_f64 = 24;
+        bytes upper_bytes = 25;
+        string upper_string = 26;
+    }
+}

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -1,0 +1,471 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#![allow(missing_docs)] // For generated protos.
+
+//! Aggregate statistics about data stored in persist.
+
+use std::any::Any;
+use std::collections::BTreeMap;
+
+use crate::columnar::Data;
+
+include!(concat!(env!("OUT_DIR"), "/mz_persist_types.stats.rs"));
+
+/// Type-erased aggregate statistics about a column of data.
+///
+/// TODO(mfp): It feels like we haven't hit a global maximum here, both with
+/// this `DynStats` trait and also with ProtoOptionStats.
+pub trait DynStats: std::fmt::Debug + Send + Sync + 'static {
+    /// Returns self as a `dyn Any` for downcasting.
+    fn as_any(&self) -> &dyn Any;
+    /// Returns the name of the erased type for use in error messages.
+    fn type_name(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+    /// See [mz_proto::RustType::into_proto].
+    fn into_proto(&self) -> ProtoDynStats;
+}
+
+/// Statistics about a column of some non-optional parquet type.
+pub struct PrimitiveStats<T> {
+    /// An inclusive lower bound on the data contained in the column.
+    ///
+    /// This will often be a tight bound, but it's not guaranteed. Persist
+    /// reserves the right to (for example) invent smaller bounds for long byte
+    /// strings. SUBTLE: This means that this exact value may not be present in
+    /// the column.
+    ///
+    /// Similarly, if the column is empty, this will contain `T: Default`.
+    /// Emptiness will be indicated in statistics higher up (i.e.
+    /// [StructStats]).
+    pub lower: T,
+    /// Same as [Self::lower] but an (also inclusive) upper bound.
+    pub upper: T,
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for PrimitiveStats<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let PrimitiveStats { lower, upper } = self;
+        f.debug_tuple("p").field(lower).field(upper).finish()
+    }
+}
+
+/// Statistics about a column of some optional type.
+pub struct OptionStats<T> {
+    /// Statistics about the `Some` values in the column.
+    pub some: T,
+    /// The count of `None` values in the column.
+    pub none: usize,
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for OptionStats<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let OptionStats { some, none } = self;
+        f.debug_tuple("o").field(some).field(none).finish()
+    }
+}
+
+/// Statistics about a column of a struct type with a uniform schema (the same
+/// columns and associated `T: Data` types in each instance of the struct).
+#[derive(Debug, Default)]
+pub struct StructStats {
+    /// The count of structs in the column.
+    pub len: usize,
+    /// Statistics about each of the columns in the struct.
+    ///
+    /// This will often be all of the columns, but it's not guaranteed. Persist
+    /// reserves the right to prune statistics about some or all of the columns.
+    pub cols: BTreeMap<String, Box<dyn DynStats>>,
+}
+
+impl StructStats {
+    /// Returns the statistics for the given column in the struct.
+    ///
+    /// This will often be all of the columns, but it's not guaranteed. Persist
+    /// reserves the right to prune statistics about some or all of the columns.
+    pub fn col<T: Data>(&self, name: &str) -> Result<Option<&T::Stats>, String> {
+        let Some(stats) = self.cols.get(name) else {
+            return Ok(None);
+        };
+        match stats.as_any().downcast_ref() {
+            Some(x) => Ok(Some(x)),
+            None => Err(format!(
+                "expected stats type {} got {}",
+                std::any::type_name::<T::Stats>(),
+                stats.type_name()
+            )),
+        }
+    }
+}
+
+mod impls {
+    use std::any::Any;
+    use std::collections::BTreeMap;
+
+    use arrow2::array::{BinaryArray, BooleanArray, PrimitiveArray, Utf8Array};
+    use arrow2::bitmap::Bitmap;
+    use arrow2::buffer::Buffer;
+    use arrow2::compute::aggregate::SimdOrd;
+    use arrow2::types::simd::Simd;
+    use arrow2::types::NativeType;
+    use mz_proto::{ProtoType, RustType, TryFromProtoError};
+
+    use crate::stats::{
+        proto_dyn_stats, proto_primitive_stats, DynStats, OptionStats, PrimitiveStats,
+        ProtoDynStats, ProtoOptionStats, ProtoPrimitiveStats, ProtoStructStats, StructStats,
+    };
+
+    impl<T> DynStats for PrimitiveStats<T>
+    where
+        PrimitiveStats<T>: RustType<ProtoPrimitiveStats> + std::fmt::Debug + Send + Sync + 'static,
+    {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn into_proto(&self) -> ProtoDynStats {
+            ProtoDynStats {
+                option: None,
+                kind: Some(proto_dyn_stats::Kind::Primitive(RustType::into_proto(self))),
+            }
+        }
+    }
+
+    impl<T: DynStats> DynStats for OptionStats<T> {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn into_proto(&self) -> ProtoDynStats {
+            let mut ret = self.some.into_proto();
+            // This prevents us from serializing `OptionStats<OptionStats<T>>`, but
+            // that's intentionally out of scope. See the comment on ProtoDynStats.
+            assert!(ret.option.is_none());
+            ret.option = Some(ProtoOptionStats {
+                none: self.none.into_proto(),
+            });
+            ret
+        }
+    }
+
+    impl DynStats for StructStats {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn into_proto(&self) -> ProtoDynStats {
+            ProtoDynStats {
+                option: None,
+                kind: Some(proto_dyn_stats::Kind::Struct(ProtoStructStats {
+                    len: self.len.into_proto(),
+                    cols: self
+                        .cols
+                        .iter()
+                        .map(|(k, v)| (k.into_proto(), v.into_proto()))
+                        .collect(),
+                })),
+            }
+        }
+    }
+
+    impl From<&Bitmap> for PrimitiveStats<bool> {
+        fn from(value: &Bitmap) -> Self {
+            // Needing this Array is a bit unfortunate, but the clone is cheap.
+            // We could probably avoid it entirely with a PR to arrow2.
+            let value =
+                BooleanArray::new(arrow2::datatypes::DataType::Boolean, value.clone(), None);
+            let lower = arrow2::compute::aggregate::min_boolean(&value).unwrap_or_default();
+            let upper = arrow2::compute::aggregate::min_boolean(&value).unwrap_or_default();
+            PrimitiveStats { lower, upper }
+        }
+    }
+
+    impl From<&BooleanArray> for OptionStats<PrimitiveStats<bool>> {
+        fn from(value: &BooleanArray) -> Self {
+            let lower = arrow2::compute::aggregate::min_boolean(value).unwrap_or_default();
+            let upper = arrow2::compute::aggregate::min_boolean(value).unwrap_or_default();
+            let none = value.validity().map_or(0, |x| x.unset_bits());
+            OptionStats {
+                none,
+                some: PrimitiveStats { lower, upper },
+            }
+        }
+    }
+
+    impl<T> From<&Buffer<T>> for PrimitiveStats<T>
+    where
+        T: NativeType + Simd,
+        T::Simd: SimdOrd<T>,
+    {
+        fn from(value: &Buffer<T>) -> Self {
+            // Needing this Array is a bit unfortunate, but the clone is cheap.
+            // We could probably avoid it entirely with a PR to arrow2.
+            let value = PrimitiveArray::new(T::PRIMITIVE.into(), value.clone(), None);
+            let lower = arrow2::compute::aggregate::min_primitive::<T>(&value).unwrap_or_default();
+            let upper = arrow2::compute::aggregate::max_primitive::<T>(&value).unwrap_or_default();
+            PrimitiveStats { lower, upper }
+        }
+    }
+
+    impl<T> From<&PrimitiveArray<T>> for OptionStats<PrimitiveStats<T>>
+    where
+        T: NativeType + Simd,
+        T::Simd: SimdOrd<T>,
+    {
+        fn from(value: &PrimitiveArray<T>) -> Self {
+            let lower = arrow2::compute::aggregate::min_primitive::<T>(value).unwrap_or_default();
+            let upper = arrow2::compute::aggregate::max_primitive::<T>(value).unwrap_or_default();
+            let none = value.validity().map_or(0, |x| x.unset_bits());
+            OptionStats {
+                none,
+                some: PrimitiveStats { lower, upper },
+            }
+        }
+    }
+
+    impl From<&BinaryArray<i32>> for PrimitiveStats<Vec<u8>> {
+        fn from(value: &BinaryArray<i32>) -> Self {
+            assert!(value.validity().is_none());
+            let lower = arrow2::compute::aggregate::min_binary(value)
+                .unwrap_or_default()
+                .to_owned();
+            let upper = arrow2::compute::aggregate::max_binary(value)
+                .unwrap_or_default()
+                .to_owned();
+            PrimitiveStats { lower, upper }
+        }
+    }
+
+    impl From<&BinaryArray<i32>> for OptionStats<PrimitiveStats<Vec<u8>>> {
+        fn from(value: &BinaryArray<i32>) -> Self {
+            let lower = arrow2::compute::aggregate::min_binary(value)
+                .unwrap_or_default()
+                .to_owned();
+            let upper = arrow2::compute::aggregate::max_binary(value)
+                .unwrap_or_default()
+                .to_owned();
+            let none = value.validity().map_or(0, |x| x.unset_bits());
+            OptionStats {
+                none,
+                some: PrimitiveStats { lower, upper },
+            }
+        }
+    }
+
+    impl From<&Utf8Array<i32>> for PrimitiveStats<String> {
+        fn from(value: &Utf8Array<i32>) -> Self {
+            assert!(value.validity().is_none());
+            let lower = arrow2::compute::aggregate::min_string(value)
+                .unwrap_or_default()
+                .to_owned();
+            let upper = arrow2::compute::aggregate::max_string(value)
+                .unwrap_or_default()
+                .to_owned();
+            PrimitiveStats { lower, upper }
+        }
+    }
+
+    impl From<&Utf8Array<i32>> for OptionStats<PrimitiveStats<String>> {
+        fn from(value: &Utf8Array<i32>) -> Self {
+            let lower = arrow2::compute::aggregate::min_string(value)
+                .unwrap_or_default()
+                .to_owned();
+            let upper = arrow2::compute::aggregate::max_string(value)
+                .unwrap_or_default()
+                .to_owned();
+            let none = value.validity().map_or(0, |x| x.unset_bits());
+            OptionStats {
+                none,
+                some: PrimitiveStats { lower, upper },
+            }
+        }
+    }
+
+    impl RustType<ProtoStructStats> for StructStats {
+        fn into_proto(&self) -> ProtoStructStats {
+            ProtoStructStats {
+                len: self.len.into_proto(),
+                cols: self
+                    .cols
+                    .iter()
+                    .map(|(k, v)| (k.into_proto(), v.into_proto()))
+                    .collect(),
+            }
+        }
+
+        fn from_proto(proto: ProtoStructStats) -> Result<Self, TryFromProtoError> {
+            let mut cols = BTreeMap::new();
+            for (k, v) in proto.cols {
+                cols.insert(k.into_rust()?, v.into_rust()?);
+            }
+            Ok(StructStats {
+                len: proto.len.into_rust()?,
+                cols,
+            })
+        }
+    }
+
+    impl RustType<ProtoDynStats> for Box<dyn DynStats> {
+        fn into_proto(&self) -> ProtoDynStats {
+            DynStats::into_proto(self.as_ref())
+        }
+
+        fn from_proto(mut proto: ProtoDynStats) -> Result<Self, TryFromProtoError> {
+            struct BoxFn;
+            impl DynStatsFn<Box<dyn DynStats>> for BoxFn {
+                fn call<T: DynStats>(self, t: T) -> Result<Box<dyn DynStats>, TryFromProtoError> {
+                    Ok(Box::new(t))
+                }
+            }
+            struct OptionStatsFn<F>(usize, F);
+            impl<R, F: DynStatsFn<R>> DynStatsFn<R> for OptionStatsFn<F> {
+                fn call<T: DynStats>(self, some: T) -> Result<R, TryFromProtoError> {
+                    let OptionStatsFn(none, f) = self;
+                    f.call(OptionStats { none, some })
+                }
+            }
+
+            match proto.option.take() {
+                Some(option) => {
+                    let none = option.none.into_rust()?;
+                    dyn_from_proto(proto, OptionStatsFn(none, BoxFn))
+                }
+                None => dyn_from_proto(proto, BoxFn),
+            }
+        }
+    }
+
+    /// Basically `FnOnce<T: DynStats>(self, t: T) -> R`, if rust would let us
+    /// type that.
+    ///
+    /// We use this in `dyn_from_proto` so that OptionStats can hold a `some: T`
+    /// instead of a `Box<dyn DynStats>`.
+    trait DynStatsFn<R> {
+        fn call<T: DynStats>(self, t: T) -> Result<R, TryFromProtoError>;
+    }
+
+    fn dyn_from_proto<R, F: DynStatsFn<R>>(
+        proto: ProtoDynStats,
+        f: F,
+    ) -> Result<R, TryFromProtoError> {
+        assert!(proto.option.is_none());
+        let kind = proto
+            .kind
+            .ok_or_else(|| TryFromProtoError::missing_field("ProtoDynStats::kind"))?;
+        match kind {
+            // Sniff the type of x.lower and use that to determine which type of
+            // PrimitiveStats to decode it as.
+            proto_dyn_stats::Kind::Primitive(x) => match x.lower {
+                Some(proto_primitive_stats::Lower::LowerBool(_)) => {
+                    f.call(PrimitiveStats::<bool>::from_proto(x)?)
+                }
+                Some(proto_primitive_stats::Lower::LowerU8(_)) => {
+                    f.call(PrimitiveStats::<u8>::from_proto(x)?)
+                }
+                Some(proto_primitive_stats::Lower::LowerU16(_)) => {
+                    f.call(PrimitiveStats::<u16>::from_proto(x)?)
+                }
+                Some(proto_primitive_stats::Lower::LowerU32(_)) => {
+                    f.call(PrimitiveStats::<u32>::from_proto(x)?)
+                }
+                Some(proto_primitive_stats::Lower::LowerU64(_)) => {
+                    f.call(PrimitiveStats::<u64>::from_proto(x)?)
+                }
+                Some(proto_primitive_stats::Lower::LowerI8(_)) => {
+                    f.call(PrimitiveStats::<i8>::from_proto(x)?)
+                }
+                Some(proto_primitive_stats::Lower::LowerI16(_)) => {
+                    f.call(PrimitiveStats::<i16>::from_proto(x)?)
+                }
+                Some(proto_primitive_stats::Lower::LowerI32(_)) => {
+                    f.call(PrimitiveStats::<i32>::from_proto(x)?)
+                }
+                Some(proto_primitive_stats::Lower::LowerI64(_)) => {
+                    f.call(PrimitiveStats::<i64>::from_proto(x)?)
+                }
+                Some(proto_primitive_stats::Lower::LowerF32(_)) => {
+                    f.call(PrimitiveStats::<f32>::from_proto(x)?)
+                }
+                Some(proto_primitive_stats::Lower::LowerF64(_)) => {
+                    f.call(PrimitiveStats::<f64>::from_proto(x)?)
+                }
+                Some(proto_primitive_stats::Lower::LowerBytes(_)) => {
+                    f.call(PrimitiveStats::<Vec<u8>>::from_proto(x)?)
+                }
+                Some(proto_primitive_stats::Lower::LowerString(_)) => {
+                    f.call(PrimitiveStats::<String>::from_proto(x)?)
+                }
+                None => Err(TryFromProtoError::missing_field("ProtoPrimitiveStats::min")),
+            },
+            proto_dyn_stats::Kind::Struct(x) => {
+                let len = x.len.into_rust()?;
+                let mut cols = BTreeMap::new();
+                for (k, v) in x.cols {
+                    cols.insert(k.into_rust()?, v.into_rust()?);
+                }
+                f.call(StructStats { len, cols })
+            }
+        }
+    }
+
+    macro_rules! primitive_stats_rust_type {
+        ($typ:ty, $lower:ident, $upper:ident) => {
+            impl RustType<ProtoPrimitiveStats> for PrimitiveStats<$typ> {
+                fn into_proto(&self) -> ProtoPrimitiveStats {
+                    ProtoPrimitiveStats {
+                        lower: Some(proto_primitive_stats::Lower::$lower(
+                            self.lower.into_proto(),
+                        )),
+                        upper: Some(proto_primitive_stats::Upper::$upper(
+                            self.upper.into_proto(),
+                        )),
+                    }
+                }
+
+                fn from_proto(proto: ProtoPrimitiveStats) -> Result<Self, TryFromProtoError> {
+                    let lower = proto.lower.ok_or_else(|| {
+                        TryFromProtoError::missing_field("ProtoPrimitiveStats::lower")
+                    })?;
+                    let lower = match lower {
+                        proto_primitive_stats::Lower::$lower(x) => x.into_rust()?,
+                        _ => {
+                            return Err(TryFromProtoError::missing_field(
+                                "proto_primitive_stats::Lower::$lower",
+                            ))
+                        }
+                    };
+                    let upper = proto.upper.ok_or_else(|| {
+                        TryFromProtoError::missing_field("ProtoPrimitiveStats::max")
+                    })?;
+                    let upper = match upper {
+                        proto_primitive_stats::Upper::$upper(x) => x.into_rust()?,
+                        _ => {
+                            return Err(TryFromProtoError::missing_field(
+                                "proto_primitive_stats::Upper::$upper",
+                            ))
+                        }
+                    };
+                    Ok(PrimitiveStats { lower, upper })
+                }
+            }
+        };
+    }
+
+    primitive_stats_rust_type!(bool, LowerBool, UpperBool);
+    primitive_stats_rust_type!(u8, LowerU8, UpperU8);
+    primitive_stats_rust_type!(u16, LowerU16, UpperU16);
+    primitive_stats_rust_type!(u32, LowerU32, UpperU32);
+    primitive_stats_rust_type!(u64, LowerU64, UpperU64);
+    primitive_stats_rust_type!(i8, LowerI8, UpperI8);
+    primitive_stats_rust_type!(i16, LowerI16, UpperI16);
+    primitive_stats_rust_type!(i32, LowerI32, UpperI32);
+    primitive_stats_rust_type!(i64, LowerI64, UpperI64);
+    primitive_stats_rust_type!(f32, LowerF32, UpperF32);
+    primitive_stats_rust_type!(f64, LowerF64, UpperF64);
+    primitive_stats_rust_type!(Vec<u8>, LowerBytes, UpperBytes);
+    primitive_stats_rust_type!(String, LowerString, UpperString);
+}

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -2564,7 +2564,7 @@ impl<'a> PartEncoder<'a, SourceData> for SourceDataEncoder<'a> {
     }
 }
 
-const SOURCE_DATA_ERROR: &str = "mz_internal_super_secret_source_data_errors";
+pub(crate) const SOURCE_DATA_ERROR: &str = "mz_internal_super_secret_source_data_errors";
 fn fake_relation_desc(desc: &RelationDesc) -> RelationDesc {
     let names = desc.iter_names().cloned();
     let typs = desc.iter_types().map(|x| {

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -211,7 +211,6 @@ zeroize = { version = "1.5.7", features = ["serde"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 byteorder = { version = "1.4.3", default-features = false, features = ["i128"] }
-getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
 rustix = { version = "0.36.7", features = ["param", "process", "thread"] }
@@ -219,20 +218,17 @@ tikv-jemalloc-sys = { version = "0.5.2", features = ["background_threads", "prof
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 byteorder = { version = "1.4.3", default-features = false, features = ["i128"] }
-getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
 rustix = { version = "0.36.7", features = ["param", "process", "thread"] }
 tikv-jemalloc-sys = { version = "0.5.2", features = ["background_threads", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.x86_64-apple-darwin.dependencies]
-getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
 security-framework = { version = "2.7.0", features = ["alpn"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
 security-framework = { version = "2.7.0", features = ["alpn"] }


### PR DESCRIPTION
This expands the set of column types that persist internally whitelists stats to all types (it was previously only Option<u64> in the skeleton). This might considerably increase the size of the stats metadata, but it's behind a feature flag.

Combined with #18386, we'll get useful stats for a much larger number of ScalarTypes. Finishing off the last few will require a Schema impl to override the stats logic (e.g. for schemaless json stats, understanding Decimals, Lists, etc) is left for followup work. In the meantime, we'll store meaningless stats about their ProtoDatum representations. Actually using these new stats in MFP pushdown is also left for a followup PR.

To accomplish this, we introduce column stats as a first-class concept in mz_persist_types. It's possible this ends up being unnecessary, but it seems like a likely enough bet and we can always pull them back into mz_persist_client if it turns out to be wrong.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
