### PR TITLE
compute: remove unused `SinkToken::is_subscribe`

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -112,11 +112,13 @@ pub struct ActiveComputeState<'a, A: Allocate> {
 }
 
 /// A token that keeps a sink alive.
-pub struct SinkToken {
-    /// The underlying token.
-    pub token: Box<dyn Any>,
-    /// Whether the sink token is keeping a subscribe alive.
-    pub is_subscribe: bool,
+pub struct SinkToken(Box<dyn Any>);
+
+impl SinkToken {
+    /// Create a new `SinkToken`.
+    pub fn new(t: Box<dyn Any>) -> Self {
+        Self(t)
+    }
 }
 
 impl<'a, A: Allocate> ActiveComputeState<'a, A> {

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -99,16 +99,9 @@ where
                     needed_tokens.push(sink_token);
                 }
 
-                compute_state.sink_tokens.insert(
-                    sink_id,
-                    SinkToken {
-                        token: Box::new(needed_tokens),
-                        is_subscribe: matches!(
-                            sink.connection,
-                            ComputeSinkConnection::Subscribe(_)
-                        ),
-                    },
-                );
+                compute_state
+                    .sink_tokens
+                    .insert(sink_id, SinkToken::new(Box::new(needed_tokens)));
             });
     }
 }


### PR DESCRIPTION
This field is dead code. Its last/only use has been removed in #13526.

This PR removes the `is_subscribe` field and bring the compute `SinkToken` in line with the same type defined in `storage`.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
