### PR TITLE
ci: Give the zippy-crdb-latest Buildkite step a larger EC2 instance

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -316,7 +316,9 @@ steps:
     label: "Zippy w/ latest CRDB"
     timeout_in_minutes: 120
     agents:
-      queue: linux-x86_64
+      # Workload takes slightly more than 8Gb, so it OOMs
+      # on the instances from the linux-x86_64 queue
+      queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
The zippy-crdb-latest step is a KafkaSources Zippy test using the latest CRDB container image. It has started OOMing recently, so give it a larger EC2 instance to work on. The same instance type, in fact, that is used by the zippy-kafka-sources step that is was cloned from.

### Motivation

  * This PR fixes a previously unreported bug.

The zippy-crdb-latest Nightly job has started OOMing