### PR TITLE
release-qualification: Adjust the execution time of zippy-cluster-rep…

### DIFF
--- a/ci/release-qualification/pipeline.yml
+++ b/ci/release-qualification/pipeline.yml
@@ -86,7 +86,8 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=ClusterReplicas, --actions=10000]
+          # Execution times longer than 4h are apparently not feasible at this time due to #17845
+          args: [--scenario=ClusterReplicas, --actions=10000, --max-execution-time=4h]
 
   - id: zippy-user-tables-large
     label: "Long Zippy w/ user tables"


### PR DESCRIPTION
…licas-large

Execution times longer than 4h are apparently not feasible at this time due to #17845

### Motivation

  * This PR fixes a previously unreported bug.
The Release Qualification test is failing with a bug in the "process orchestrator", which is a component not used in production. It is better for the test to pass as its purpose is to show release readiness, rather than expose bugs unrelated to production.