### PR TITLE
#18211/#18212/#17509: error handling in various reductions

### DIFF
--- a/src/compute-client/src/plan/reduce.rs
+++ b/src/compute-client/src/plan/reduce.rs
@@ -127,6 +127,19 @@ impl RustType<ProtoReductionType> for ReductionType {
     }
 }
 
+impl TryFrom<&ReducePlan> for ReductionType {
+    type Error = ();
+
+    fn try_from(plan: &ReducePlan) -> Result<Self, Self::Error> {
+        match plan {
+            ReducePlan::Hierarchical(_) => Ok(ReductionType::Hierarchical),
+            ReducePlan::Accumulable(_) => Ok(ReductionType::Accumulable),
+            ReducePlan::Basic(_) => Ok(ReductionType::Basic),
+            _ => Err(()),
+        }
+    }
+}
+
 /// A `ReducePlan` provides a concise description for how we will
 /// execute a given reduce expression.
 ///

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -39,8 +39,9 @@ use mz_timely_util::operator::CollectionExt;
 use crate::typedefs::{ErrSpine, RowSpine, TraceErrHandle, TraceRowHandle};
 
 // Local type definition to avoid the horror in signatures.
-pub(crate) type Arrangement<S, V> =
-    Arranged<S, TraceRowHandle<V, V, <S as ScopeParent>::Timestamp, Diff>>;
+pub(crate) type KeyArrangement<S, K, V> =
+    Arranged<S, TraceRowHandle<K, V, <S as ScopeParent>::Timestamp, Diff>>;
+pub(crate) type Arrangement<S, V> = KeyArrangement<S, V, V>;
 pub(crate) type ErrArrangement<S> =
     Arranged<S, TraceErrHandle<DataflowError, <S as ScopeParent>::Timestamp, Diff>>;
 pub(crate) type ArrangementImport<S, V, T> = Arranged<

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -939,6 +939,15 @@ impl<E> MaybeValidatingRow<Row, E> for Row {
     }
 }
 
+impl<E> MaybeValidatingRow<(), E> for () {
+    fn ok(t: ()) -> Self {
+        t
+    }
+    fn into_error() -> Option<fn(E) -> Self> {
+        None
+    }
+}
+
 impl<E, R> MaybeValidatingRow<Vec<R>, E> for Vec<R>
 where
     R: ExchangeData + Columnation + Hash,

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -434,10 +434,7 @@ where
                     let message = "Non-positive multiplicity in DistinctBy";
                     warn!(?row, ?count, debug_name, "[customer-data] {message}");
                     error!("{message}");
-                    output.push((
-                        DataflowError::EvalError(EvalError::Internal(message.to_string()).into()),
-                        1,
-                    ));
+                    output.push((EvalError::Internal(message.to_string()).into(), 1));
                     return;
                 }
             },
@@ -484,9 +481,7 @@ where
         .as_collection(|k, v| (k.clone(), v.clone()))
         .map_fallible("Demux Errors", |(key, result)| match result {
             Ok(row) => Ok((key, row)),
-            Err(message) => Err(DataflowError::EvalError(
-                EvalError::Internal(message).into(),
-            )),
+            Err(message) => Err(EvalError::Internal(message).into()),
         });
     use timely::dataflow::operators::Map;
     (
@@ -598,7 +593,7 @@ where
                     .as_collection(|k, v| (k.clone(), v.clone()))
                     .map_fallible("Demux Errors", move |(key, result)| match result {
                         Ok(()) => Ok(key),
-                        Err(m) => Err(DataflowError::from(EvalError::Internal(m))),
+                        Err(m) => Err(EvalError::Internal(m).into()),
                     });
             err_output = Some(errs);
             partial = oks;
@@ -645,10 +640,7 @@ where
                     let message = "Non-positive accumulation in ReduceInaccumulable";
                     warn!(?value, ?count, debug_name, "[customer-data] {message}");
                     error!("{message}");
-                    target.push((
-                        DataflowError::from(EvalError::Internal(message.to_string())),
-                        1,
-                    ));
+                    target.push((EvalError::Internal(message.to_string()).into(), 1));
                     return;
                 }
             },
@@ -801,10 +793,7 @@ where
                             let message = "Non-positive accumulation in ReduceMinsMaxes";
                             warn!(?val, ?count, debug_name, "[customer-data] {message}");
                             error!("{message}");
-                            target.push((
-                                DataflowError::from(EvalError::Internal(message.to_string())),
-                                1,
-                            ));
+                            target.push((EvalError::Internal(message.to_string()).into(), 1));
                             return;
                         }
                     },
@@ -940,7 +929,7 @@ where
         );
         error!("Non-monotonic input to ReduceMonotonic");
         let m = "tried to build a monotonic reduction on non-monotonic input".to_string();
-        (DataflowError::from(EvalError::Internal(m)), 1)
+        (EvalError::Internal(m).into(), 1)
     });
     // We can place our rows directly into the diff field, and
     // only keep the relevant one corresponding to evaluating our

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -287,9 +287,7 @@ where
                             let message = "Negative multiplicities in TopK";
                             warn!(?k, ?h, ?v, debug_name, "[customer-data] {message}");
                             error!(message);
-                            Err(DataflowError::EvalError(
-                                EvalError::Internal(message.to_string()).into(),
-                            ))
+                            Err(EvalError::Internal(message.to_string()).into())
                         }
                         Ok(t) => Ok(((k, h), t)),
                     });
@@ -447,7 +445,7 @@ where
                 );
                 error!("Non-monotonic input to MonotonicTop1");
                 let m = "tried to build monotonic top-1 on non-monotonic input".to_string();
-                (DataflowError::from(EvalError::Internal(m)), 1)
+                (EvalError::Internal(m).into(), 1)
             });
             let partial = partial.explode_one(move |(group_key, row)| {
                 (

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -569,15 +569,9 @@ def workflow_test_github_15496(c: Composition) -> None:
 
             > INSERT INTO base VALUES (1, -1), (1, -1);
 
-            # Run a query that would generate a panic before the fix. Note that
-            # we expect the query to succeed for now, but follow-up work might
-            # eventually lead us to favor a SQL-level error for such a query, as
-            # tracked by issue #17178.
-            # Note that we employ below a query hint to hit the case of not yet
-            # generating a SQL-level error, given the partial fix to bucketed
-            # aggregates introduced in PR #17918.
-            > SELECT SUM(data), MAX(data) FROM data OPTIONS (EXPECTED GROUP SIZE = 1);
-            <null> <null>
+            # Run a query that would generate a panic before the fix.
+            ! SELECT SUM(data), MAX(data) FROM data OPTIONS (EXPECTED GROUP SIZE = 1);
+            contains:Non-positive accumulation in ReduceMinsMaxes
             """
             )
         )
@@ -864,10 +858,10 @@ def workflow_test_github_17509(c: Composition) -> None:
 
             # The query below would return a null previously, but now fails cleanly.
             ! SELECT MAX(data) FROM data;
-            contains:Invalid data in source, saw negative accumulation for key
+            contains:Invalid data in source, saw non-positive accumulation for key
 
             ! SELECT data, MAX(data) FROM data GROUP BY data;
-            contains:Invalid data in source, saw negative accumulation for key
+            contains:Invalid data in source, saw non-positive accumulation for key
 
             # Repairing the error must be possible.
             > INSERT INTO base VALUES (1, 2), (2, 1);

--- a/test/testdrive/negative-multiplicities.td
+++ b/test/testdrive/negative-multiplicities.td
@@ -49,3 +49,7 @@ contains:Non-positive accumulation in ReduceInaccumulable DISTINCT
 # regression scenario per #18212
 ! SELECT list_agg(data)[1] FROM data;
 contains:Non-positive accumulation in ReduceInaccumulable
+
+# regression scenario per #17509
+! SELECT MAX(data) FROM data;
+contains:Invalid data in source, saw non-positive accumulation

--- a/test/testdrive/negative-multiplicities.td
+++ b/test/testdrive/negative-multiplicities.td
@@ -41,3 +41,11 @@ contains:Negative multiplicities in TopK
 # regression scenario per #17908
 ! SELECT DISTINCT data FROM data;
 contains:Non-positive multiplicity in DistinctBy
+
+# regression scenario per #18211
+! SELECT list_agg(DISTINCT data)[1] FROM data;
+contains:Non-positive accumulation in ReduceInaccumulable DISTINCT
+
+# regression scenario per #18212
+! SELECT list_agg(data)[1] FROM data;
+contains:Non-positive accumulation in ReduceInaccumulable


### PR DESCRIPTION
See #17178 for the epic covering these issues and their respective design doc.  I had hoped to address #18215 and #18216 in this set of changes, too, but unfortunately the former is somewhat cumbersome and should be reviewed separately, and it effectively touches the latter.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

 * This PR fixes recognized bugs: #17509 (its remaining cleanups, only), #18211, #18212.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
