### PR TITLE
storage: ingest PG tables with add'l columns

### DIFF
--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -63,7 +63,7 @@ impl PostgresTableDesc {
 
         // Table columns cannot change position, so only need to ensure that
         // `self.columns` is a prefix of `other_cols`.
-        if self.columns.len() == other_cols.len()
+        if self.columns.len() <= other_cols.len()
             && self.columns.iter().zip(other_cols.iter()).all(|(s, o)| s.is_compatible(o))
             && &self.name == other_name
             && &self.oid == other_oid

--- a/test/pg-cdc-resumption/alter-table.td
+++ b/test/pg-cdc-resumption/alter-table.td
@@ -8,8 +8,8 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-ALTER TABLE alter_fail_add_col ADD COLUMN f2 INTEGER;
-INSERT INTO alter_fail_add_col VALUES (1, 2);
+ALTER TABLE alter_fail_drop_col DROP COLUMN f2;
+INSERT INTO alter_fail_drop_col VALUES (2);
 
 ALTER TABLE alter_fail_drop_constraint ALTER COLUMN f1 DROP NOT NULL;
 INSERT INTO alter_fail_drop_constraint VALUES (NULL);

--- a/test/pg-cdc-resumption/populate-tables.td
+++ b/test/pg-cdc-resumption/populate-tables.td
@@ -32,12 +32,12 @@ ALTER PUBLICATION mz_source ADD TABLE t2;
 
 INSERT INTO t2 SELECT a1.f1 + a6.f1 , E'abc\nxyz' FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
 
-DROP TABLE IF EXISTS alter_fail_add_col;
-CREATE TABLE alter_fail_add_col (f1 INTEGER);
-ALTER TABLE alter_fail_add_col REPLICA IDENTITY FULL;
+DROP TABLE IF EXISTS alter_fail_drop_col;
+CREATE TABLE alter_fail_drop_col (f1 INTEGER, f2 INTEGER);
+ALTER TABLE alter_fail_drop_col REPLICA IDENTITY FULL;
 
-INSERT INTO alter_fail_add_col VALUES (1);
-ALTER PUBLICATION mz_source_alter_add_col ADD TABLE alter_fail_add_col;
+INSERT INTO alter_fail_drop_col VALUES (1, 1);
+ALTER PUBLICATION mz_source_alter_add_col ADD TABLE alter_fail_drop_col;
 
 DROP TABLE IF EXISTS alter_fail_drop_constraint;
 CREATE TABLE alter_fail_drop_constraint (f1 INTEGER NOT NULL);

--- a/test/pg-cdc-resumption/verify-data.td
+++ b/test/pg-cdc-resumption/verify-data.td
@@ -15,5 +15,5 @@
 ! SELECT * FROM alter_fail_drop_constraint;
 contains:has been altered
 
-! SELECT * FROM alter_fail_add_col;
+! SELECT * FROM alter_fail_drop_col;
 contains:has been altered

--- a/test/pg-cdc/alter-table-after-source.td
+++ b/test/pg-cdc/alter-table-after-source.td
@@ -47,8 +47,9 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE add_columns ADD COLUMN f2 varchar(2);
 INSERT INTO add_columns VALUES (2, 'ab');
 
-! SELECT * from add_columns;
-contains:altered
+> SELECT * from add_columns;
+1
+2
 
 > DROP SOURCE mz_source;
 
@@ -593,7 +594,7 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR ALL TABLES;
 
-> SELECT * from alter_table_rename_column;
+> SELECT * FROM alter_table_rename_column;
 f1_orig f2_orig
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
@@ -638,6 +639,53 @@ ALTER TABLE alter_table_change_attnum ADD COLUMN f2 VARCHAR(10);
 INSERT INTO alter_table_change_attnum (f1, f2) VALUES ('f1_changed', 'f2_changed');
 
 ! SELECT * FROM alter_table_change_attnum;
+contains:altered
+
+> DROP SOURCE mz_source;
+
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE alter_table_supported (f1 int, f2 int);
+ALTER TABLE alter_table_supported REPLICA IDENTITY FULL;
+INSERT INTO alter_table_supported (f1, f2) VALUES (1, 1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES ("alter_table_supported") WITH (size = '1');
+
+> SELECT * from alter_table_supported;
+1 1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_table_supported ADD COLUMN f3 int;
+INSERT INTO alter_table_supported (f1, f2, f3) VALUES (2, 2, 2);
+
+> SELECT * from alter_table_supported;
+1 1
+2 2
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_table_supported DROP COLUMN f3;
+INSERT INTO alter_table_supported (f1, f2) VALUES (3, 3);
+
+> SELECT * from alter_table_supported;
+1 1
+2 2
+3 3
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_table_supported DROP COLUMN f2;
+INSERT INTO alter_table_supported (f1) VALUES (1);
+
+! SELECT * from alter_table_supported;
 contains:altered
 
 > DROP SOURCE mz_source;

--- a/test/pg-cdc/alter-table-irrelevant.td
+++ b/test/pg-cdc/alter-table-irrelevant.td
@@ -51,10 +51,11 @@ INSERT INTO base_table VALUES (2);
 1
 2
 
-# Alter the irrelevant table and insert a row to force a second relation message
+# Alter the irrelevant table and insert a row to force a second relation message that would be incompatible
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE irrelevant_table ADD COLUMN f2 varchar(2);
-INSERT INTO irrelevant_table VALUES (2, 'ab');
+ALTER TABLE irrelevant_table DROP COLUMN f1;
+INSERT INTO irrelevant_table VALUES ('ab');
 
 # Query still works because the relation was ignored for being irrelevant
 > SELECT * FROM base_table;
@@ -74,13 +75,27 @@ INSERT INTO irrelevant_table VALUES (2, 'ab');
 
 # Confirm the second table now has a corresponding view and it has the expected data
 > SELECT * FROM irrelevant_table
-1 <null>
-2 ab
+<null>
+ab
 
-# Alter the irrelevant_table now that it is relevant and confirm replication errors
+# Alter the irrelevant_table now that it is relevant
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE irrelevant_table ADD COLUMN f3 char(2);
-INSERT INTO irrelevant_table VALUES (3, 'bc', 'de');
+INSERT INTO irrelevant_table VALUES ('bc', 'de');
+
+> SELECT * FROM base_table;
+1
+2
+
+> SELECT * FROM irrelevant_table
+<null>
+ab
+bc
+
+# Alter in an incompatible way and ensure replication errors occur
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE irrelevant_table DROP COLUMN f2;
+INSERT INTO irrelevant_table VALUES ('gh');
 
 ! SELECT * FROM base_table;
 contains:irrelevant_table

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -424,8 +424,8 @@ def alter_pg_table(c: Composition) -> None:
         dedent(
             """
                  $ postgres-execute connection=postgres://postgres:postgres@postgres
-                 ALTER TABLE t1 ADD COLUMN f3 INTEGER;
-                 INSERT INTO t1 VALUES (3, NULL, 4)
+                 ALTER TABLE t1 DROP COLUMN f1;
+                 INSERT INTO t1 VALUES (NULL)
                  """
         )
     )


### PR DESCRIPTION
We previously errored if an upstream PG table grew new columns. However, we can instead avoid erroring by simply dropping the add'l columns on the floor.

Note that the design in #17595 proposes keeping a set of projections for each relation; however, this isn't necessary because [columns in PG cannot be reordered](https://wiki.postgresql.org/wiki/Alter_column_position), so we always want `[..original_columns.len()]`. If PG did support this operation in the future, we would likely error on the schema change, and could introduce projections at that point.

### Motivation

Implements a desirable feature. Closes #17595

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - PostgreSQL sources no longer error when adding columns to the upstream relation; we instead do not propagate the added columns into the subsources reflecting the tables' data. However, dropping any columns that Materialize ingests still results in an error.
