### PR TITLE
ore: Add infallible_unwrap to ResultExt

### DIFF
--- a/src/ore/src/result.rs
+++ b/src/ore/src/result.rs
@@ -37,6 +37,14 @@ pub trait ResultExt<T, E> {
     fn map_err_to_string(self) -> Result<T, String>
     where
         E: std::fmt::Display;
+
+    /// Safely unwraps a `Result<T, Infallible>`, where [`Infallible`] is a type that represents when
+    /// an error cannot occur.
+    ///
+    /// [`Infallible`]: core::convert::Infallible
+    fn infallible_unwrap(self) -> T
+    where
+        E: Into<core::convert::Infallible>;
 }
 
 impl<T, E> ResultExt<T, E> for Result<T, E> {
@@ -59,6 +67,25 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
         E: std::fmt::Display,
     {
         self.map_err(|e| DisplayExt::to_string_alt(&e))
+    }
+
+    fn infallible_unwrap(self) -> T
+    where
+        E: Into<core::convert::Infallible>,
+    {
+        match self {
+            Ok(t) => t,
+            Err(e) => {
+                let _infallible = e.into();
+
+                // This code will forever be unreachable because Infallible is an enum
+                // with no variants, so it's impossible to consturct. If it ever does
+                // become possible to construct this will become a compile time error
+                // since there will be a variant we're not matching on.
+                #[allow(unreachable_code)]
+                match _infallible {}
+            }
+        }
     }
 }
 

--- a/src/ore/src/result.rs
+++ b/src/ore/src/result.rs
@@ -15,6 +15,8 @@
 
 //! Result utilities.
 
+use std::convert::Infallible;
+
 use crate::display::DisplayExt;
 
 /// Extension methods for [`std::result::Result`].
@@ -40,11 +42,9 @@ pub trait ResultExt<T, E> {
 
     /// Safely unwraps a `Result<T, Infallible>`, where [`Infallible`] is a type that represents when
     /// an error cannot occur.
-    ///
-    /// [`Infallible`]: core::convert::Infallible
     fn infallible_unwrap(self) -> T
     where
-        E: Into<core::convert::Infallible>;
+        E: Into<Infallible>;
 }
 
 impl<T, E> ResultExt<T, E> for Result<T, E> {
@@ -71,7 +71,7 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
 
     fn infallible_unwrap(self) -> T
     where
-        E: Into<core::convert::Infallible>,
+        E: Into<Infallible>,
     {
         match self {
             Ok(t) => t,
@@ -79,7 +79,7 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
                 let _infallible = e.into();
 
                 // This code will forever be unreachable because Infallible is an enum
-                // with no variants, so it's impossible to consturct. If it ever does
+                // with no variants, so it's impossible to construct. If it ever does
                 // become possible to construct this will become a compile time error
                 // since there will be a variant we're not matching on.
                 #[allow(unreachable_code)]


### PR DESCRIPTION
### Motivation

I recently ran into a situation where I wanted to implement `FromStr` for a type, but `from_str(...)` returns a `Result`, and in my case it was impossible for this conversion to fail, so returning a `Result` would have been cumbersome. Ideally in this situation I would have used [`std::convert::Infallible`](https://doc.rust-lang.org/std/convert/enum.Infallible.html) for the error type, which represent a Result that can never fail, but helpers to make the [use of `Infallible` ergonomic, are still not stable](https://github.com/rust-lang/rust/issues/61695).

In this PR I added a new method to `mz_ore::result::ResultExt` called `infallible_unwrap()`, which is implemented only for `Result<T, Infallible>`. This method allows you to safely unwrap a `Result` that we know will never error. And if the error type ever changes, your code will fail to compile.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
