### PR TITLE
sql: improve WMR error message on type mismatch

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1212,10 +1212,22 @@ pub fn plan_ctes(
                 let typ = qcx.relation_type(&val);
                 // TODO: Use implicit casts to convert among types rather than error.
                 if !typ.subtypes(qcx.ctes[&cte.id].desc.typ()) {
+                    let declared_typ = qcx.ctes[&cte.id]
+                        .desc
+                        .typ()
+                        .column_types
+                        .iter()
+                        .map(|ty| qcx.humanize_scalar_type(&ty.scalar_type))
+                        .collect::<Vec<_>>();
+                    let inferred_typ = typ
+                        .column_types
+                        .iter()
+                        .map(|ty| qcx.humanize_scalar_type(&ty.scalar_type))
+                        .collect::<Vec<_>>();
                     Err(PlanError::RecursiveTypeMismatch(
                         cte_name,
-                        qcx.ctes[&cte.id].desc.typ().clone(),
-                        typ,
+                        declared_typ,
+                        inferred_typ,
                     ))?;
                 }
 

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -199,6 +199,14 @@ WITH MUTUALLY RECURSIVE
     bar (a int) as (SELECT a FROM foo)
 SELECT a FROM foo, bar;
 
+## Test incompatible declared and inferred types
+statement error db error: ERROR: declared type \(integer, text\) of WITH MUTUALLY RECURSIVE query "forever" did not match inferred type \(bigint, text\)
+WITH MUTUALLY RECURSIVE
+  forever (i int, y text) as (
+    SELECT COUNT(*), 'oops' FROM mz_views UNION (SELECT i + 1, 'oops' FROM forever)
+  )
+SELECT * FROM forever;
+
 # Tests for nested WITH MUTUALLY RECURSIVE
 
 statement ok


### PR DESCRIPTION
Improve the message by pre-processing the `inferred` and `declared` types of a WMR binding from a `RelationType` to a `Vec<String>`. This is in line with the idiom adopted by other type-related errors.

Resolves #18501.

Associated design doc PR: #17820 ([rendered version](https://github.com/aalexandrov/materialize/blob/issue_17012/doc/developer/design/20230223_stabilize_with_mutually_recursive.md)).

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

@teskje note that the `plan_ctes` function has a `TODO` in the WMR planning block for relaxing the current behavior by adding a `Map` with implicit casts. However, an extra `Map` might prevent some optimizations, so I would prefer to only do this if we have evidence of real customer pain.

https://github.com/MaterializeInc/materialize/blob/dcd02a44a4355d9b6841d609e0097cd50b5bbdd3/src/sql/src/plan/query.rs#L1207-L1223

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
