### PR TITLE
mz: Set the application_name

### DIFF
--- a/src/mz/src/bin/mz/shell.rs
+++ b/src/mz/src/bin/mz/shell.rs
@@ -16,6 +16,10 @@ use reqwest::Client;
 use mz::api::{get_provider_region_environment, CloudProviderRegion, Environment};
 use mz::configuration::ValidProfile;
 
+/// The [application_name](https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-APPLICATION-NAME)
+/// which gets reported to the Postgres server we're connecting to.
+const PG_APPLICATION_NAME: &str = "mz_psql";
+
 /// ----------------------------
 /// Shell command
 /// ----------------------------
@@ -25,6 +29,7 @@ fn run_psql_shell(valid_profile: ValidProfile<'_>, environment: &Environment) ->
     let error = Command::new("psql")
         .arg(environment.sql_url(&valid_profile).to_string())
         .env("PGPASSWORD", valid_profile.app_password)
+        .env("PGAPPNAME", PG_APPLICATION_NAME)
         .exec();
 
     Err(error).context("failed to spawn psql")


### PR DESCRIPTION
### Motivation

As part of #18426 we'll log a specific set of [application_name](https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-APPLICATION-NAME)s with our prometheus metrics. This PR sets the application name of the `psql` shell that `mz` launches so we can distinguish `mz` users from normal `psql` users. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
