### PR TITLE
adapter: Allow superusers to alter object owners

### DIFF
--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -149,9 +149,6 @@ pub enum PlanError {
         name: String,
         item_type: CatalogItemType,
     },
-    AlterOwnerMembership {
-        role_name: String,
-    },
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -393,7 +390,6 @@ impl fmt::Display for PlanError {
             Self::InvalidPrivatelinkAvailabilityZone { name, ..} => write!(f, "invalid AWS PrivateLink availability zone {}", name.quoted()),
             Self::InvalidSchemaName => write!(f, "no schema has been selected to create in"),
             Self::ItemAlreadyExists { name, item_type } => write!(f, "{item_type} {} already exists", name.quoted()),
-            Self::AlterOwnerMembership {role_name} => write!(f, "must be a member of {}", role_name.quoted()),
         }
     }
 }

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -1258,6 +1258,21 @@ ALTER INDEX mz_internal.mz_show_databases_ind OWNER TO mz_system
 ----
 db error: ERROR: cannot alter item mz_internal.mz_show_databases_ind because it is required by the database system
 
+# Superusers can alter the owner to a role that they are not a member of
+
+statement ok
+CREATE TABLE t ()
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE group;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER TABLE t OWNER TO group;
+----
+COMPLETE 0
+
 # Disable rbac checks.
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -1264,12 +1264,20 @@ statement ok
 CREATE TABLE t ()
 
 simple conn=mz_system,user=mz_system
-CREATE ROLE group;
+CREATE ROLE group1;
 ----
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-ALTER TABLE t OWNER TO group;
+ALTER TABLE t OWNER TO group1;
+----
+COMPLETE 0
+
+statement ok
+CREATE ROLE group2;
+
+simple conn=mz_system,user=mz_system
+ALTER TABLE t OWNER TO group2;
 ----
 COMPLETE 0
 


### PR DESCRIPTION
Previously, there was a bug that superusers couldn't alter an object owner if they weren't a member of the new owner's role. This commit fixes that issue so superusers can alter an object's owner even if they aren't a member of the new owner's role.

Fixes #18515

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
