### PR TITLE
storage: improve the detail of errors around kafka+ssh that are logged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,6 +4826,7 @@ dependencies = [
  "mz-stash",
  "mz-timely-util",
  "once_cell",
+ "openssh",
  "prometheus",
  "proptest",
  "proptest-derive",

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -41,6 +41,7 @@ mz-service = { path = "../service" }
 mz-ssh-util = { path = "../ssh-util" }
 mz-stash = { path = "../stash" }
 mz-timely-util = { path = "../timely-util" }
+openssh = { version = "0.9.8", default-features = false, features = ["native-mux"] }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
 prometheus = { version = "0.13.3", default-features = false }
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -221,6 +221,7 @@ impl KafkaSinkSendRetryManager {
     }
 }
 
+#[derive(Clone)]
 pub struct SinkProducerContext {
     metrics: Arc<SinkMetrics>,
     status_tx: mpsc::Sender<SinkStatus>,
@@ -405,6 +406,7 @@ struct KafkaSinkState {
     write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
 }
 
+#[derive(Clone)]
 struct SinkConsumerContext {
     status_tx: mpsc::Sender<SinkStatus>,
 }

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -891,6 +891,7 @@ impl PartitionConsumer {
 
 /// An implementation of [`ConsumerContext`] that forwards statistics to the
 /// worker
+#[derive(Clone)]
 struct GlueConsumerContext {
     activator: SyncActivator,
     stats_tx: crossbeam_channel::Sender<Jsonb>,

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -345,7 +345,7 @@ where
         if source_upper.is_empty() {
             return;
         }
-        let (source_reader, offset_committer) = source_connection
+        let (source_reader, offset_committer) = match source_connection
             .into_reader(
                 name.clone(),
                 id,
@@ -358,8 +358,12 @@ where
                 encoding,
                 base_metrics,
                 connection_context.clone(),
-            )
-            .expect("Failed to create source");
+            ) {
+                Ok(res) => res,
+                Err(e) => {
+                    panic!("Failed to create source: {:#}", e);
+                }
+            };
 
         let source_stream = source_reader.into_stream(timestamp_interval).peekable();
         tokio::pin!(source_stream);


### PR DESCRIPTION
Related to https://github.com/MaterializeInc/materialize/issues/18490, though this issue definitely does not categorically solve that issue. This pr is a collection of various change that should hopefully make it easier to debug broken kafka + `SSH TUNNEL` sources in production. We intend make a patch release with this change on environments with problematic ssh tunnels. In this pr we:

- Print the _full chain of ssh errors_ that cause failed `CREATE SOURCE` statements, or panic's when restarting a source.
- Periodically `check` the underlying ssh session for each tunnel (every 30 seconds).
  - This is about the best we can do here. With https://github.com/MaterializeInc/materialize/pull/18454 we can actually check the error on re-creating the tunnel, which is non-trivial to do here without some deeper changes. I may consider it if this pr doesn't reveal the underlying problems.
- When creating a source, wait 2 seconds (instead of 1) to see if kafka errors, to increase the probability that the user see an error before we schedule the source.
  - Additionally, in some cases, report the full error chain that rdkafka will give us (rdkafka really tries to tell us as little as possible though...)

I expect this pr to fail ci for a bit, as some error messages are changing, but I will clean them up.

### Motivation


  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
