### PR TITLE
Rework `projection_~` transforms to make them `recursion_safe`

### DIFF
--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -283,7 +283,7 @@ where
     // Collect the mutable references to views after pushing projection down
     // in order to run cleanup actions on them in a second loop.
     let mut view_refs = Vec::new();
-    let projection_pushdown = crate::projection_pushdown::ProjectionPushdown;
+    let projection_pushdown = crate::movement::ProjectionPushdown;
     for (id, view) in view_sequence {
         if let Some(columns) = demand.get(&id) {
             let projection_pushed_down = columns.iter().map(|c| *c).collect();

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -119,7 +119,6 @@ pub mod normalize_lets;
 pub mod normalize_ops;
 pub mod ordering;
 pub mod predicate_pushdown;
-pub mod projection_pushdown;
 pub mod reduce_elision;
 pub mod reduction_pushdown;
 pub mod redundant_join;

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -119,7 +119,6 @@ pub mod normalize_lets;
 pub mod normalize_ops;
 pub mod ordering;
 pub mod predicate_pushdown;
-pub mod projection_lifting;
 pub mod projection_pushdown;
 pub mod reduce_elision;
 pub mod reduction_pushdown;
@@ -340,7 +339,7 @@ impl Default for FuseAndCollapse {
             //  and `RedundantJoin` can be implemented as free functions.
             transforms: vec![
                 Box::new(crate::canonicalization::ProjectionExtraction),
-                Box::new(crate::projection_lifting::ProjectionLifting::default()),
+                Box::new(crate::movement::ProjectionLifting::default()),
                 Box::new(crate::fusion::Fusion),
                 Box::new(crate::canonicalization::FlatMapToMap),
                 Box::new(crate::fusion::join::Join),

--- a/src/transform/src/literal_constraints.rs
+++ b/src/transform/src/literal_constraints.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! See if there are predicates of the form `<expr>=literal` that can be sped up using an index.
+//! See if there are predicates of the form `<expr> = literal` that can be sped up using an index.
 //! More specifically, look for an MFP on top of a Get, where the MFP has an appropriate filter, and
 //! the Get has a matching index. Convert these to `IndexedFilter` joins, which is a semi-join with
 //! a constant collection.
@@ -37,6 +37,10 @@ use std::collections::{BTreeMap, BTreeSet};
 pub struct LiteralConstraints;
 
 impl crate::Transform for LiteralConstraints {
+    fn recursion_safe(&self) -> bool {
+        true
+    }
+
     #[tracing::instrument(
     target = "optimizer"
     level = "trace",

--- a/src/transform/src/movement/mod.rs
+++ b/src/transform/src/movement/mod.rs
@@ -15,5 +15,7 @@
 //! achieved by implementing a more restricted form of the latter.
 
 mod projection_lifting;
+mod projection_pushdown;
 
 pub use projection_lifting::ProjectionLifting;
+pub use projection_pushdown::ProjectionPushdown;

--- a/src/transform/src/movement/mod.rs
+++ b/src/transform/src/movement/mod.rs
@@ -13,3 +13,7 @@
 //! Transformations inhabiting this module can be used both as part of a
 //! normalization pass and as a stand-alone optimization. The former is usually
 //! achieved by implementing a more restricted form of the latter.
+
+mod projection_lifting;
+
+pub use projection_lifting::ProjectionLifting;

--- a/src/transform/src/movement/projection_lifting.rs
+++ b/src/transform/src/movement/projection_lifting.rs
@@ -91,7 +91,10 @@ impl ProjectionLifting {
                     gets.remove(&id);
                     Ok(())
                 }
-                MirRelationExpr::LetRec { .. } => Err(crate::TransformError::LetRecUnsupported)?,
+                MirRelationExpr::LetRec { .. } => {
+                    // TODO
+                    Err(crate::TransformError::LetRecUnsupported)?
+                }
                 MirRelationExpr::Project { input, outputs } => {
                     self.action(input, gets)?;
                     if let MirRelationExpr::Project {
@@ -199,6 +202,7 @@ impl ProjectionLifting {
                         }
                     }
 
+                    // Don't add the identity permutation as a projection.
                     if projection.len() != temp_arity || (0..temp_arity).any(|i| projection[i] != i)
                     {
                         // Update equivalences and implementation.

--- a/src/transform/src/movement/projection_pushdown.rs
+++ b/src/transform/src/movement/projection_pushdown.rs
@@ -154,8 +154,7 @@ impl ProjectionPushdown {
 
                 // Recursively indicate the requirements.
                 for (input, inp_columns) in inputs.iter_mut().zip(new_columns) {
-                    let mut inp_columns = inp_columns.into_iter().collect::<Vec<_>>();
-                    inp_columns.sort();
+                    let inp_columns = inp_columns.into_iter().collect::<Vec<_>>();
                     self.action(input, &inp_columns, gets)?;
                 }
 

--- a/src/transform/src/movement/projection_pushdown.rs
+++ b/src/transform/src/movement/projection_pushdown.rs
@@ -38,7 +38,7 @@ use mz_expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr};
 use crate::{TransformArgs, TransformError};
 
 /// Pushes projections down through other operators.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ProjectionPushdown;
 
 impl crate::Transform for ProjectionPushdown {

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -352,7 +352,7 @@ mod tests {
                 mz_transform::canonicalization::ProjectionExtraction,
             )),
             "ProjectionLifting" => Ok(Box::new(
-                mz_transform::projection_lifting::ProjectionLifting::default(),
+                mz_transform::movement::ProjectionLifting::default(),
             )),
             "ProjectionPushdown" => Ok(Box::new(
                 mz_transform::projection_pushdown::ProjectionPushdown,

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -118,7 +118,7 @@ mod tests {
                 .transforms
                 .into_iter()
                 .chain(std::iter::once::<Box<dyn Transform>>(
-                    Box::new(mz_transform::projection_pushdown::ProjectionPushdown)
+                    Box::new(mz_transform::movement::ProjectionPushdown)
                 ))
                 .chain(std::iter::once::<Box<dyn Transform>>(
                     Box::new(mz_transform::normalize_lets::NormalizeLets::new(false))
@@ -354,9 +354,7 @@ mod tests {
             "ProjectionLifting" => Ok(Box::new(
                 mz_transform::movement::ProjectionLifting::default(),
             )),
-            "ProjectionPushdown" => Ok(Box::new(
-                mz_transform::projection_pushdown::ProjectionPushdown,
-            )),
+            "ProjectionPushdown" => Ok(Box::new(mz_transform::movement::ProjectionPushdown)),
             "ReductionPushdown" => Ok(Box::new(
                 mz_transform::reduction_pushdown::ReductionPushdown,
             )),

--- a/test/sqllogictest/transform/projection_lifting.slt
+++ b/test/sqllogictest/transform/projection_lifting.slt
@@ -1,0 +1,116 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This file contains tests for the ProjectionLifting transform.
+
+mode cockroach
+
+statement ok
+CREATE TABLE edges (src int, dst int)
+
+# Lifting the projections from the inner SELECT enables join fusion, resulting
+# in a single 3-way join in the optimized plan.
+query T multiline
+EXPLAIN
+SELECT
+  a, b, c
+FROM
+  edges as edge,
+  (
+    SELECT
+      e2.src as a,
+      e2.dst as b,
+      e3.dst as c
+    FROM
+      edges as e2,
+      edges as e3
+    WHERE
+      e2.dst = e3.src
+  ) as apex(a, b, c)
+WHERE
+  edge.dst = apex.a AND
+  edge.src = apex.c;
+----
+Explained Query:
+  Return
+    Project (#1, #3, #0)
+      Join on=(#0 = #5 AND #1 = #2 AND #3 = #4) type=differential
+        ArrangeBy keys=[[#1]]
+          Get l0
+        ArrangeBy keys=[[#0]]
+          Get l0
+        ArrangeBy keys=[[#0, #1]]
+          Get l0
+  With
+    cte l0 =
+      Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+        Get materialize.public.edges
+
+Source materialize.public.edges
+  filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+
+EOF
+
+
+# The above works also in WMR blocks.
+query T multiline
+EXPLAIN
+WITH MUTUALLY RECURSIVE
+  triangles(a int, b int, c int) AS (
+    SELECT
+      a, b, c
+    FROM
+      edges as edge,
+      (
+        SELECT
+        e2.src as a,
+        e2.dst as b,
+        e3.dst as c
+        FROM
+          edges as e2,
+          edges as e3
+        WHERE
+          e2.dst = e3.src
+      ) as apex(a, b, c)
+    WHERE
+      edge.dst = apex.a AND
+      edge.src = apex.c
+  ),
+  triangle_cycles(a int, b int, c int) AS (
+    SELECT a, b, c FROM triangles
+    UNION
+    SELECT c, a, b FROM triangle_cycles
+  )
+SELECT * FROM triangle_cycles;
+----
+Explained Query:
+  Return
+    Get l0
+  With Mutually Recursive
+    cte l0 =
+      Distinct group_by=[#0..=#2]
+        Union
+          Project (#2, #3, #5)
+            Join on=(#0 = #5 AND #1 = #2 AND #3 = #4) type=differential
+              ArrangeBy keys=[[#1]]
+                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Get materialize.public.edges
+              ArrangeBy keys=[[#0]]
+                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Get materialize.public.edges
+              ArrangeBy keys=[[#0, #1]]
+                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Get materialize.public.edges
+          Project (#2, #0, #1)
+            Get l0
+
+Source materialize.public.edges
+  filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+
+EOF


### PR DESCRIPTION
Make `projection_lifting` and `projection_pushdown` recursion safe. This also adds a marker to `literal_constraints`, which I forgot to handle as part of #18123.

Closes #18168.
Closes #18169.

Design doc PR: #17820 ([rendered version](https://github.com/aalexandrov/materialize/blob/issue_17012/doc/developer/design/20230223_stabilize_with_mutually_recursive.md)).

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

* The first commit is part of #18510 and will be merged separately - do not review it here.
* I've used the occasion to move the `projection_lifting` and `projection_pushdown` transforms to the `movement` module.
* I've added `MIR ⇒ MIR` behavior-driven tests in a separate branch. I'll try to come up with some `*.slt` tests on Monday, but it could be hard, as the movement by itself is not an optimization.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
