### PR TITLE
doc/user: Enable deeplinks to tabs

### DIFF
--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -144,22 +144,22 @@ toCSS | fingerprint }}
 <script>
   $(document).ready(function () {
     // make nav-tab lists from tab-panes
-    $(".tab-content")
-      .find(".tab-pane")
-      .each(function (idx, item) {
-        var navTabs = $(this).closest(".code-tabs").find(".nav-tabs"),
-          title = $(this).attr("title");
-        navTabs.append('<li><a href="#">' + title + "</a></li");
-      });
+    $(".tab-content").each(function (idx, tab) {
+      $(tab)
+        .find(".tab-pane")
+        .each(function (item) {
+          var navTabs = $(this).closest(".code-tabs").find(".nav-tabs"),
+            title = $(this).attr("title"),
+            id = title
+              .toLowerCase()
+              .replace(/ /g, "-")
+              .replace(/[^\w-]+/g, "");
+          navTabs.append(`<li><a href="#${id}-t${idx}">${title}</a></li>`);
+        });
+    });
 
-    // activate first tab and tab-pane
-    $(".nav-tabs li:first-child").addClass("active").click();
-    $(".tab-content div:first-child").addClass("active").click();
-
-    // click
+    // handle click events
     $(".nav-tabs a").click(function (e) {
-      e.preventDefault();
-
       var tab = $(this).parent(),
         tabIndex = tab.index(),
         tabPanel = $(this).closest(".code-tabs"),
@@ -168,5 +168,11 @@ toCSS | fingerprint }}
       tab.addClass("active");
       tabPane.addClass("active");
     });
+
+    // activate first tab
+    $(".nav-tabs li:first-child a").click();
+    // if the url anchor matches the id of a tab, activate that tab
+    var deeplinkedTab = $(`.nav-tabs a[href='${document.location.hash}']`);
+    if (deeplinkedTab) deeplinkedTab.click().get(0).scrollIntoView();
   });
 </script>


### PR DESCRIPTION
This is a UI functionality change to make it possible to deeplink to tabs, but it's made me think we really shouldn't be using tabs in some of the places where we do.

**Change:** 

Go to a page like /sql/create-connection/ and click on the PrivateLink / SSH Tunnel or "SSL / SASL" tabs. You should see your browser's anchor hash changing as you click. Once you've clicked to a specific tab, sharing the URL will deeplink a user to the page with that tab active and in view.


https://user-images.githubusercontent.com/11527560/229209786-e1c0c6a2-9dda-45d2-8793-f7ba210e627e.mp4


**Complicating factors:** 

On that page in particular (and possibly others) we have several sets of tabs with the same tab names. (AWS Private Link / SSH Tunnel for example.)

What is unclear is whether it's better to just put `#ssh-tunnel` in the url anchor and deeplink to the TOP of the page with all SSH Tunnel tabs active, or to use unique anchors for each instance of an "SSH Tunnel" tab and deeplink directly to that specific tab, as I have with `#ssh-tunnel-t2` etc...

In the end, I chose the second approach but it also made me think we would be better off just writing these out as sections. I don't think it's a good UX to hide so much content behind a tab:
- When I ctrl-f on the "Create Connection" page for "SASL Mechanisms" I get no results because it's hidden behind a tab.
- I can't properly deeplink to headings hidden within a non-default tab
- Sometimes it's not obvious that the tab content has changed because the first few lines are very similar

https://user-images.githubusercontent.com/11527560/229210887-7f6ea1b4-47cb-4dbe-85e2-02e746a476bf.mp4

Anyways - Just some food for thought.

**How to review:** 

- Check that clicking a tab still properly activates the tabbed content and changes the url
- Check that opening a new window and pasting in the url with tab anchor properly activates the tab and scrolls it into view
- Check that no existing tab functionality breaks as a result of this
- Check that no existing deeplink functionality breaks as a result of this
