### PR TITLE
storage: don't panic on source reader init errors

### DIFF
--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -390,7 +390,8 @@ impl KafkaConnection {
                             broker_port,
                             "kafka",
                         )
-                        .await?;
+                        .await
+                        .context("creating ssh tunnel")?;
 
                     context.add_broker_rewrite_with_token(
                         &broker.address,

--- a/test/ssh-connection/kafka-source-after-ssh-failure.td
+++ b/test/ssh-connection/kafka-source-after-ssh-failure.td
@@ -1,0 +1,29 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This test script runs after the SSH bastion host has been terminated.
+
+# Ensure that the source status reflects the error before the source restarts.
+# This error comes from the Kafka source's metadata fetch loop.
+> SELECT status FROM mz_internal.mz_source_statuses st
+  JOIN mz_sources s ON st.id = s.id
+  WHERE s.name = 'mz_source' AND error LIKE '%Meta data fetch error%'
+stalled
+
+# Drop and recreate the source cluster's replica so we can test behavior after
+# a restart.
+> DROP CLUSTER REPLICA sc.r1;
+> CREATE CLUSTER REPLICA sc.r1 SIZE '1';
+
+# Verify that the, after restart, the source reports that the SSH tunnel was
+# unable to connect.
+> SELECT status FROM mz_internal.mz_source_statuses st
+  JOIN mz_sources s ON st.id = s.id
+  WHERE s.name = 'mz_source' AND error LIKE '%failed creating source reader: creating ssh tunnel: failed to connect to the remote host%'
+stalled

--- a/test/ssh-connection/kafka-source-after-ssh-restart.td
+++ b/test/ssh-connection/kafka-source-after-ssh-restart.td
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Ensure that the source becomes healthy again once the SSH tunnel is restarted.
+# We specifically make sure that new data written to the Kafka topic is visible
+# in the source, as that is the true measure of health, vs what is reported in
+# the mz_source_statuses relation.
+
+$ kafka-ingest topic=thetopic format=bytes
+three
+
+> SELECT * FROM mz_source
+text
+----
+one
+two
+three
+
+> SELECT status FROM mz_internal.mz_source_statuses st
+  JOIN mz_sources s ON st.id = s.id
+  WHERE s.name = 'mz_source'
+running

--- a/test/ssh-connection/kafka-source.td
+++ b/test/ssh-connection/kafka-source.td
@@ -14,11 +14,19 @@ $ kafka-create-topic topic=thetopic
 $ kafka-ingest topic=thetopic format=bytes
 one
 
+# Create a dedicated cluster for the source, so we can easily restart the
+# source by dropping and recreating the clsuter's replica.
+> DROP CLUSTER IF EXISTS sc;
+> CREATE CLUSTER sc REPLICAS (r1 (SIZE '1'))
+
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}' USING SSH TUNNEL thancred);
 
-> CREATE SOURCE mz_source
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-thetopic-${testdrive.seed}')
+> CREATE SOURCE mz_source IN CLUSTER sc
+  FROM KAFKA CONNECTION kafka_conn (
+    TOPIC 'testdrive-thetopic-${testdrive.seed}',
+    TOPIC METADATA REFRESH INTERVAL MS 1000
+  )
   FORMAT TEXT
   ENVELOPE NONE
 

--- a/test/ssh-connection/mzcompose.py
+++ b/test/ssh-connection/mzcompose.py
@@ -24,7 +24,7 @@ SERVICES = [
     Kafka(),
     SchemaRegistry(),
     Materialized(),
-    Testdrive(),
+    Testdrive(consistent_seed=True),
     SshBastionHost(),
     Postgres(),
     TestCerts(),
@@ -85,6 +85,10 @@ def workflow_kafka_csr_via_ssh_tunnel(c: Composition) -> None:
     )
 
     c.run("testdrive", "--no-reset", "kafka-source.td")
+    c.kill("ssh-bastion-host")
+    c.run("testdrive", "--no-reset", "kafka-source-after-ssh-failure.td")
+    c.up("ssh-bastion-host")
+    c.run("testdrive", "--no-reset", "kafka-source-after-ssh-restart.td")
 
 
 # Test that if we restart the bastion AND change its server keys(s), we can


### PR DESCRIPTION
Instead, log the error to the source status collection and request a `SuspendAndRestart`. This requires some tricky capability handling to avoid bricking the remap shard.

This commit also introduces a mandatory 30s backoff before a `SuspendAndResume` takes place, to limit hot retry loops. This comes at the expense of latency in the case of a transient error; unfortunately implementing a smarter retry policy (like exponential backoff) is difficult.

Fix #18491.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

Please pay extra close attention to this PR! I'm quite unfamiliar with this code, and the semantics of this change are quite subtle.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improve the error messages that are emitted to `mz_source_status_history`, particularly when SSH tunnels are in use.
