### PR TITLE
Monotonic select

### DIFF
--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -262,7 +262,13 @@ impl Coordinator {
                 .unwrap_or_terminate("Normalize failed; unrecoverable error");
         }
 
-        mz_compute_client::plan::Plan::finalize_dataflow(dataflow).map_err(AdapterError::Internal)
+        mz_compute_client::plan::Plan::finalize_dataflow(
+            dataflow,
+            self.catalog()
+                .system_config()
+                .enable_monotonic_oneshot_selects(),
+        )
+        .map_err(AdapterError::Internal)
     }
 }
 

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -208,9 +208,13 @@ impl Coordinator {
     /// invariants such as ensuring that the `as_of` frontier is in advance of
     /// the various `since` frontiers of participating data inputs.
     ///
-    /// In particular, there are requirement on the `as_of` field for the dataflow
+    /// In particular, there are requirements on the `as_of` field for the dataflow
     /// and the `since` frontiers of created arrangements, as a function of the `since`
     /// frontiers of dataflow inputs (sources and imported arrangements).
+    ///
+    /// Additionally, this method requires that the `until` field of the dataflow
+    /// has been set, so that any plan improvements based on its difference to `as_of`
+    /// can be carried out.
     ///
     /// This method will return an error if the finalization fails. DO NOT call this
     /// method for DDL. Instead, use the non-fallible version [`Self::must_finalize_dataflow`].

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -273,7 +273,8 @@ impl crate::coord::Coordinator {
                 // By default, `until` will be `Antichain::new()`, which prevents no updates and is safe.
                 if let Some(as_of) = dataflow.as_of.as_ref() {
                     if !as_of.is_empty() {
-                        if let Some(next) = as_of.elements()[0].checked_add(1) {
+                        if let Some(next) = as_of.as_option().and_then(|as_of| as_of.checked_add(1))
+                        {
                             dataflow.until = timely::progress::Antichain::from_elem(next);
                         }
                     }

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -269,16 +269,17 @@ impl crate::coord::Coordinator {
         let peek_plan = fast_path_plan.map_or_else(
             // finalize the dataflow and produce a PeekPlan::SlowPath as a default
             || {
-                let mut desc = self.finalize_dataflow(dataflow, compute_instance)?;
                 // We have the opportunity to name an `until` frontier that will prevent work we needn't perform.
                 // By default, `until` will be `Antichain::new()`, which prevents no updates and is safe.
-                if let Some(as_of) = desc.as_of.as_ref() {
+                if let Some(as_of) = dataflow.as_of.as_ref() {
                     if !as_of.is_empty() {
                         if let Some(next) = as_of.elements()[0].checked_add(1) {
-                            desc.until = timely::progress::Antichain::from_elem(next);
+                            dataflow.until = timely::progress::Antichain::from_elem(next);
                         }
                     }
                 }
+                let desc = self.finalize_dataflow(dataflow, compute_instance)?;
+
                 Ok::<_, AdapterError>(PeekPlan::SlowPath(PeekDataflowPlan {
                     desc,
                     id: index_id,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2591,8 +2591,8 @@ impl Coordinator {
                 _ => None,
             };
 
-            // Execute the `optimize/mir_to_lir` stage.
-            let dataflow_plan = catch_unwind(no_errors, "mir_to_lir", || {
+            // Execute the `optimize/finalize_dataflow` stage.
+            let dataflow_plan = catch_unwind(no_errors, "finalize_dataflow", || {
                 Plan::<mz_repr::Timestamp>::finalize_dataflow(
                     dataflow,
                     self.catalog()

--- a/src/compute-client/src/explain/text.rs
+++ b/src/compute-client/src/explain/text.rs
@@ -265,6 +265,9 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                             let order_by = separated(", ", &plan.order_key);
                             write!(f, " order_by=[{}]", order_by)?;
                         }
+                        if plan.must_consolidate {
+                            writeln!(f, "{}must_consolidate", ctx.indent)?;
+                        }
                     }
                     TopKPlan::MonotonicTopK(plan) => {
                         write!(f, "{}TopK::MonotonicTopK", ctx.indent)?;
@@ -278,6 +281,9 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                         }
                         if let Some(limit) = &plan.limit {
                             write!(f, " limit={}", limit)?;
+                        }
+                        if plan.must_consolidate {
+                            writeln!(f, "{}must_consolidate", ctx.indent)?;
                         }
                     }
                     TopKPlan::Basic(plan) => {
@@ -593,6 +599,9 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for HierarchicalPlan {
                 writeln!(f, "{}aggr_funcs=[{}]", ctx.indent, aggr_funcs)?;
                 let skips = separated(", ", &plan.skips);
                 writeln!(f, "{}skips=[{}]", ctx.indent, skips)?;
+                if plan.must_consolidate {
+                    writeln!(f, "{}must_consolidate", ctx.indent)?;
+                }
             }
             HierarchicalPlan::Bucketed(plan) => {
                 let aggr_funcs = separated(", ", &plan.aggr_funcs);

--- a/src/compute-client/src/explain/text.rs
+++ b/src/compute-client/src/explain/text.rs
@@ -266,7 +266,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                             write!(f, " order_by=[{}]", order_by)?;
                         }
                         if plan.must_consolidate {
-                            writeln!(f, "{}must_consolidate", ctx.indent)?;
+                            write!(f, " must_consolidate")?;
                         }
                     }
                     TopKPlan::MonotonicTopK(plan) => {
@@ -283,7 +283,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                             write!(f, " limit={}", limit)?;
                         }
                         if plan.must_consolidate {
-                            writeln!(f, "{}must_consolidate", ctx.indent)?;
+                            write!(f, " must_consolidate")?;
                         }
                     }
                     TopKPlan::Basic(plan) => {

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1708,14 +1708,13 @@ This is not expected to cause incorrect results, but could indicate a performanc
             while let Some(expression) = todo.pop() {
                 match expression {
                     Plan::Reduce { plan, .. } => {
-                        use crate::plan::reduce::CollationPlan;
                         // Upgrade non-monotonic hierarchical plans to monotonic with mandatory consolidation.
                         match plan {
-                            ReducePlan::Collation(CollationPlan { hierarchical, .. }) => {
-                                hierarchical.as_mut().map(|plan| plan.flag_snapshot());
+                            ReducePlan::Collation(collation) => {
+                                collation.as_monotonic(true);
                             }
                             ReducePlan::Hierarchical(hierarchical) => {
-                                hierarchical.flag_snapshot();
+                                hierarchical.as_monotonic(true);
                             }
                             _ => {
                                 // Nothing to do for other plans, and doing nothing is safe for future variants.
@@ -1724,7 +1723,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                         todo.extend(expression.children_mut());
                     }
                     Plan::TopK { top_k_plan, .. } => {
-                        top_k_plan.flag_snapshot();
+                        top_k_plan.as_monotonic(true);
                         todo.extend(expression.children_mut());
                     }
                     Plan::LetRec { body, .. } => {

--- a/src/compute-client/src/plan/reduce.proto
+++ b/src/compute-client/src/plan/reduce.proto
@@ -50,6 +50,7 @@ message ProtoHierarchicalPlan {
 message ProtoMonotonicPlan {
     repeated mz_expr.relation.ProtoAggregateFunc aggr_funcs = 1;
     repeated uint64 skips = 2;
+    bool must_consolidate = 3;
 }
 
 

--- a/src/compute-client/src/plan/top_k.proto
+++ b/src/compute-client/src/plan/top_k.proto
@@ -35,6 +35,7 @@ message ProtoBasicTopKPlan {
 message ProtoMonotonicTop1Plan {
     repeated uint64 group_key = 1;
     repeated mz_expr.relation.ProtoColumnOrder order_key = 2;
+    bool must_consolidate = 3;
 }
 
 message ProtoMonotonicTopKPlan {
@@ -42,4 +43,5 @@ message ProtoMonotonicTopKPlan {
     repeated mz_expr.relation.ProtoColumnOrder order_key = 2;
     optional uint64 limit = 3;
     uint64 arity = 4;
+    bool must_consolidate = 5;
 }

--- a/src/compute-client/src/plan/top_k.rs
+++ b/src/compute-client/src/plan/top_k.rs
@@ -62,6 +62,7 @@ impl TopKPlan {
             TopKPlan::MonotonicTop1(MonotonicTop1Plan {
                 group_key,
                 order_key,
+                must_consolidate: false,
             })
         } else if monotonic && offset == 0 {
             // For monotonic inputs, we are able to retract inputs that can no longer be produced
@@ -77,6 +78,7 @@ impl TopKPlan {
                 order_key,
                 limit,
                 arity,
+                must_consolidate: false,
             })
         } else {
             // A plan for all other inputs
@@ -138,6 +140,10 @@ pub struct MonotonicTop1Plan {
     pub group_key: Vec<usize>,
     /// Ordering that is used within each group.
     pub order_key: Vec<mz_expr::ColumnOrder>,
+    /// True if the input is logically but not physically monotonic,
+    /// and the operator must first consolidate the inputs to remove
+    /// potential negations.
+    pub must_consolidate: bool,
 }
 
 impl RustType<ProtoMonotonicTop1Plan> for MonotonicTop1Plan {
@@ -145,6 +151,7 @@ impl RustType<ProtoMonotonicTop1Plan> for MonotonicTop1Plan {
         ProtoMonotonicTop1Plan {
             group_key: self.group_key.into_proto(),
             order_key: self.order_key.into_proto(),
+            must_consolidate: self.must_consolidate.into_proto(),
         }
     }
 
@@ -152,6 +159,7 @@ impl RustType<ProtoMonotonicTop1Plan> for MonotonicTop1Plan {
         Ok(MonotonicTop1Plan {
             group_key: proto.group_key.into_rust()?,
             order_key: proto.order_key.into_rust()?,
+            must_consolidate: proto.must_consolidate.into_rust()?,
         })
     }
 }
@@ -168,6 +176,10 @@ pub struct MonotonicTopKPlan {
     pub limit: Option<usize>,
     /// The number of columns in the input and output.
     pub arity: usize,
+    /// True if the input is logically but not physically monotonic,
+    /// and the operator must first consolidate the inputs to remove
+    /// potential negations.
+    pub must_consolidate: bool,
 }
 
 impl RustType<ProtoMonotonicTopKPlan> for MonotonicTopKPlan {
@@ -177,6 +189,7 @@ impl RustType<ProtoMonotonicTopKPlan> for MonotonicTopKPlan {
             order_key: self.order_key.into_proto(),
             limit: self.limit.into_proto(),
             arity: self.arity.into_proto(),
+            must_consolidate: self.must_consolidate.into_proto(),
         }
     }
 
@@ -186,6 +199,7 @@ impl RustType<ProtoMonotonicTopKPlan> for MonotonicTopKPlan {
             order_key: proto.order_key.into_rust()?,
             limit: proto.limit.into_rust()?,
             arity: proto.arity.into_rust()?,
+            must_consolidate: proto.must_consolidate.into_rust()?,
         })
     }
 }

--- a/src/compute-client/src/plan/top_k.rs
+++ b/src/compute-client/src/plan/top_k.rs
@@ -92,6 +92,30 @@ impl TopKPlan {
             })
         }
     }
+    /// Informs the plan that it will apply to a single time, and therefore
+    /// may upgrade from a basic topk plan to a monotonic plan with mandatory
+    /// consolidation.
+    pub fn flag_snapshot(&mut self) {
+        if let TopKPlan::Basic(plan) = self {
+            if plan.offset == 0 {
+                *self = if plan.limit == Some(1) {
+                    TopKPlan::MonotonicTop1(MonotonicTop1Plan {
+                        group_key: plan.group_key.clone(),
+                        order_key: plan.order_key.clone(),
+                        must_consolidate: true,
+                    })
+                } else {
+                    TopKPlan::MonotonicTopK(MonotonicTopKPlan {
+                        group_key: plan.group_key.clone(),
+                        order_key: plan.order_key.clone(),
+                        limit: plan.limit,
+                        arity: plan.arity,
+                        must_consolidate: true,
+                    })
+                }
+            }
+        }
+    }
 }
 
 impl RustType<ProtoTopKPlan> for TopKPlan {

--- a/src/compute-client/src/types/dataflows.rs
+++ b/src/compute-client/src/types/dataflows.rs
@@ -68,6 +68,22 @@ pub struct DataflowDescription<P, S: 'static = (), T = mz_repr::Timestamp> {
     pub debug_name: String,
 }
 
+impl<T> DataflowDescription<Plan<T>, (), mz_repr::Timestamp> {
+    /// Tests if the dataflow refers to a single timestamp, namely
+    /// that both `as_of` and `until` have a single coordinate and that
+    /// the `until` value corresponds to the `as_of` value plus one.
+    pub fn is_single_time(&self) -> bool {
+        // TODO: this would be much easier to check if `until` was a strict lower bound,
+        // and we would be testing that `until == as_of`.
+        match (self.as_of.as_ref(), self.until.as_option()) {
+            (Some(as_of), Some(until)) => {
+                as_of.as_option().and_then(|as_of| as_of.checked_add(1)) == Some(*until)
+            }
+            _ => false,
+        }
+    }
+}
+
 impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
     /// Creates a new dataflow description with a human-readable name.
     pub fn new(name: String) -> Self {

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -914,14 +914,18 @@ where
     fn build_monotonic<S>(
         &self,
         collection: Collection<S, (Row, Row), Diff>,
-        MonotonicPlan { aggr_funcs, skips }: MonotonicPlan,
+        MonotonicPlan {
+            aggr_funcs,
+            skips,
+            must_consolidate,
+        }: MonotonicPlan,
     ) -> (Arrangement<S, Row>, Collection<S, DataflowError, Diff>)
     where
         S: Scope<Timestamp = G::Timestamp>,
     {
         // Gather the relevant values into a vec of rows ordered by aggregation_index
         let mut row_buf = Row::default();
-        let collection = collection.map(move |(key, row)| {
+        let mut collection = collection.map(move |(key, row)| {
             let mut values = Vec::with_capacity(skips.len());
             let mut row_iter = row.iter();
             for skip in skips.iter() {
@@ -932,12 +936,14 @@ where
             (key, values)
         });
 
-        // We arrange the inputs ourself to force it into a leaner structure because we know we
-        // won't care about values.
-        let consolidated = collection
-            .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated ReduceMonotonic input");
+        // Consolidate if required to do so.
+        if must_consolidate {
+            collection = collection
+                .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated ReduceMonotonic input");
+        }
+
         let error_logger = self.error_logger();
-        let (partial, errs) = consolidated.ensure_monotonic(move |data, diff| {
+        let (partial, errs) = collection.ensure_monotonic(move |data, diff| {
             error_logger.log(
                 "Non-monotonic input to ReduceMonotonic",
                 &format!("data={data:?}, diff={diff}"),

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2457,7 +2457,7 @@ impl ExplainStage {
             ExplainStage::RawPlan => "optimize/raw",
             ExplainStage::DecorrelatedPlan => "optimize/hir_to_mir",
             ExplainStage::OptimizedPlan => "optimize/global",
-            ExplainStage::PhysicalPlan => "optimize/mir_to_lir",
+            ExplainStage::PhysicalPlan => "optimize/finalize_dataflow",
             ExplainStage::Trace => unreachable!(),
             ExplainStage::Timestamp => unreachable!(),
         }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -643,6 +643,16 @@ static ENABLE_WITH_MUTUALLY_RECURSIVE: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
+/// Feature flag indicating whether monotonic evaluation of one-shot SELECT queries is enabled.
+static ENABLE_MONOTONIC_ONESHOT_SELECTS: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_monotonic_oneshot_selects"),
+    value: &false,
+    description: "Feature flag indicating whether monotonic evaluation of one-shot SELECT queries \
+                  is enabled (Materialize).",
+    internal: true,
+    safe: true,
+};
+
 /// Feature flag indicating whether real time recency is enabled.
 static REAL_TIME_RECENCY: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("real_time_recency"),
@@ -1444,6 +1454,7 @@ impl Default for SystemVars {
             .with_var(&METRICS_RETENTION)
             .with_var(&MOCK_AUDIT_EVENT_TIMESTAMP)
             .with_var(&ENABLE_WITH_MUTUALLY_RECURSIVE)
+            .with_var(&ENABLE_MONOTONIC_ONESHOT_SELECTS)
             .with_var(&ENABLE_LD_RBAC_CHECKS)
             .with_var(&ENABLE_RBAC_CHECKS)
             .with_var(&PG_REPLICATION_CONNECT_TIMEOUT)
@@ -1767,6 +1778,11 @@ impl SystemVars {
             .expect("var known to exist")
             .set(VarInput::Flat(value.format().as_str()))
             .expect("valid parameter value")
+    }
+
+    /// Returns the `enable_monotonic_oneshot_selects` configuration parameter.
+    pub fn enable_monotonic_oneshot_selects(&self) -> bool {
+        *self.expect_value(&ENABLE_MONOTONIC_ONESHOT_SELECTS)
     }
 
     /// Returns the `enable_ld_rbac_checks` configuration parameter.

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -553,24 +553,28 @@ def workflow_test_github_15496(c: Composition) -> None:
                     WORKERS 2
                 )
             );
+            -- Set data for test up.
+            SET cluster = cluster1;
+            CREATE TABLE base (data bigint, diff bigint);
+            CREATE MATERIALIZED VIEW data AS SELECT data FROM base, repeat_row(diff);
+            INSERT INTO base VALUES (1, 1);
+            INSERT INTO base VALUES (1, -1), (1, -1);
+
+            -- Create a materialized view to ensure non-monotonic rendering.
+            -- Note that we employ below a query hint to hit the case of not yet
+            -- generating a SQL-level error, given the partial fix to bucketed
+            -- aggregates introduced in PR #17918.
+            CREATE MATERIALIZED VIEW sum_and_max AS
+            SELECT SUM(data), MAX(data) FROM data OPTIONS (EXPECTED GROUP SIZE = 1);
             """
         )
         c.testdrive(
             dedent(
                 f"""
-            # Set data for test up
             > SET cluster = cluster1;
 
-            > CREATE TABLE base (data bigint, diff bigint);
-
-            > CREATE MATERIALIZED VIEW data AS SELECT data FROM base, repeat_row(diff);
-
-            > INSERT INTO base VALUES (1, 1);
-
-            > INSERT INTO base VALUES (1, -1), (1, -1);
-
             # Run a query that would generate a panic before the fix.
-            ! SELECT SUM(data), MAX(data) FROM data OPTIONS (EXPECTED GROUP SIZE = 1);
+            ! SELECT * FROM sum_and_max;
             contains:Non-positive accumulation in ReduceMinsMaxes
             """
             )
@@ -578,7 +582,7 @@ def workflow_test_github_15496(c: Composition) -> None:
 
         # ensure that an error was put into the logs
         c1 = c.invoke("logs", "clusterd_nopanic", capture=True)
-        assert "Mismatched aggregates for key in ReduceCollation" in c1.stdout
+        assert "Non-positive accumulation in ReduceMinsMaxes" in c1.stdout
 
 
 def workflow_test_github_17177(c: Composition) -> None:
@@ -840,36 +844,39 @@ def workflow_test_github_17509(c: Composition) -> None:
                     WORKERS 2
                 )
             );
+            -- Set data for test up.
+            SET cluster = cluster1;
+            CREATE TABLE base (data bigint, diff bigint);
+            CREATE MATERIALIZED VIEW data AS SELECT data FROM base, repeat_row(diff);
+            INSERT INTO base VALUES (1, 1);
+            INSERT INTO base VALUES (1, -1), (1, -1);
+
+            -- Create materialized views to ensure non-monotonic rendering.
+            CREATE MATERIALIZED VIEW max_data AS
+            SELECT MAX(data) FROM data;
+            CREATE MATERIALIZED VIEW max_group_by_data AS
+            SELECT data, MAX(data) FROM data GROUP BY data;
             """
         )
         c.testdrive(
             dedent(
                 f"""
-            # Set data for test up
             > SET cluster = cluster1;
 
-            > CREATE TABLE base (data bigint, diff bigint);
-
-            > CREATE MATERIALIZED VIEW data AS SELECT data FROM base, repeat_row(diff);
-
-            > INSERT INTO base VALUES (1, 1);
-
-            > INSERT INTO base VALUES (1, -1), (1, -1);
-
             # The query below would return a null previously, but now fails cleanly.
-            ! SELECT MAX(data) FROM data;
+            ! SELECT * FROM max_data;
             contains:Invalid data in source, saw non-positive accumulation for key
 
-            ! SELECT data, MAX(data) FROM data GROUP BY data;
+            ! SELECT * FROM max_group_by_data;
             contains:Invalid data in source, saw non-positive accumulation for key
 
             # Repairing the error must be possible.
             > INSERT INTO base VALUES (1, 2), (2, 1);
 
-            > SELECT MAX(data) FROM data;
+            > SELECT * FROM max_data;
             2
 
-            > SELECT data, MAX(data) FROM data GROUP BY data;
+            > SELECT * FROM max_group_by_data;
             1 1
             2 2
             """

--- a/test/testdrive/negative-multiplicities.td
+++ b/test/testdrive/negative-multiplicities.td
@@ -66,15 +66,20 @@ contains:Invalid data in source, saw non-positive accumulation
 
 # verify that some reduction in a collation plan catches a negative
 # multiplicity.
-! SELECT
-    data,
-    COUNT(DISTINCT data),
-    STRING_AGG(data::text || '1',  ','),
-    MIN(data),
-    MAX(DISTINCT data),
-    SUM(data),
-    STRING_AGG(data::text || '2',  ',')
-  FROM data
-  GROUP BY data
+> CREATE VIEW collation AS
+  SELECT
+      data,
+      COUNT(DISTINCT data),
+      STRING_AGG(data::text || '1',  ',') AS data_1,
+      MIN(data),
+      MAX(DISTINCT data),
+      SUM(data),
+      STRING_AGG(data::text || '2',  ',') AS data_2
+    FROM data
+    GROUP BY data;
+
+> CREATE DEFAULT INDEX ON collation;
+
+! SELECT * FROM collation;
 # Case-insensitive match for both 'Non' and 'non'
 contains:on-positive accumulation

--- a/test/testdrive/negative-multiplicities.td
+++ b/test/testdrive/negative-multiplicities.td
@@ -30,12 +30,17 @@ contains:Invalid data in source, saw retractions (1) for row that does not exist
 ! SELECT * FROM data
 contains:Invalid data in source, saw retractions (2) for row that does not exist: [Int64(1)]
 
-# regression scenario per #17963
-! SELECT grp.id, count(t.data) AS top_2_count,
-         (SELECT COUNT(d.data) FROM data d WHERE d.data % 2 = grp.id) AS total_count
-  FROM (SELECT generate_series(0,1) id) grp,
-         LATERAL (SELECT data FROM data WHERE data % 2 = grp.id ORDER BY data LIMIT 2) t
-  GROUP BY grp.id;
+# regression scenario per #17963, with non-monotonic rendering
+> CREATE VIEW topk AS
+  SELECT grp.id, count(t.data) AS top_2_count,
+           (SELECT COUNT(d.data) FROM data d WHERE d.data % 2 = grp.id) AS total_count
+    FROM (SELECT generate_series(0,1) id) grp,
+           LATERAL (SELECT data FROM data WHERE data % 2 = grp.id ORDER BY data LIMIT 2) t
+    GROUP BY grp.id;
+
+> CREATE DEFAULT INDEX ON topk;
+
+! SELECT * from topk;
 contains:Negative multiplicities in TopK
 
 # regression scenario per #17908
@@ -50,8 +55,13 @@ contains:Non-positive accumulation in ReduceInaccumulable DISTINCT
 ! SELECT list_agg(data)[1] FROM data;
 contains:Non-positive accumulation in ReduceInaccumulable
 
-# regression scenario per #17509
-! SELECT MAX(data) FROM data;
+# regression scenario per #17509, with non-monotonic rendering
+> CREATE VIEW max_data AS
+  SELECT MAX(data) FROM data;
+
+> CREATE DEFAULT INDEX ON max_data;
+
+! SELECT * FROM max_data;
 contains:Invalid data in source, saw non-positive accumulation
 
 # verify that some reduction in a collation plan catches a negative


### PR DESCRIPTION
Demonstration of one approach to introducing monotonicity for SELECT queries, by informing LIR plans of consolidation that when performed should result in collections with non-negative updates.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
