### PR TITLE
platform-checks: Adjust the PgCdc check to match reality

### DIFF
--- a/misc/python/materialize/checks/pg_cdc.py
+++ b/misc/python/materialize/checks/pg_cdc.py
@@ -12,6 +12,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.util import MzVersion
 
 
 class PgCdc(Check):
@@ -149,18 +150,26 @@ class PgCdc(Check):
                 F 400 97350
                 G 300 97350
                 H 200 97350
-
-                > SELECT key FROM (SHOW INDEXES ON postgres_source_tableA);
-                {f1,f2}
-
-                ? EXPLAIN SELECT DISTINCT f1, f2 FROM postgres_source_tableA;
-                Explained Query (fast path):
-                  Project (#0, #1)
-                    ReadExistingIndex materialize.public.postgres_source_tablea_primary_idx
-
-                Used Indexes:
-                  - materialize.public.postgres_source_tablea_primary_idx
                 """
+            )
+            + (
+                dedent(
+                    """
+                    # Confirm that the primary key information has been propagated from Pg
+                    > SELECT key FROM (SHOW INDEXES ON postgres_source_tableA);
+                    {f1,f2}
+
+                    ? EXPLAIN SELECT DISTINCT f1, f2 FROM postgres_source_tableA;
+                    Explained Query (fast path):
+                      Project (#0, #1)
+                        ReadExistingIndex materialize.public.postgres_source_tablea_primary_idx
+
+                    Used Indexes:
+                      - materialize.public.postgres_source_tablea_primary_idx
+                    """
+                )
+                if self.base_version >= MzVersion.parse("0.50.0-dev")
+                else ""
             )
         )
 


### PR DESCRIPTION
The Check confirms that primary keys defined on the Pg side can also be used to efficiently answer SELECT DISTINCT queries on the Mz side. This functionality is however only available in v0.50.0 and later, so must be gated accordingly.

Closes: #18536

### Motivation

  * This PR fixes a recognized bug.

Nightly was failing because the PgCdc check had version-specific parts that were not gated properly.