### PR TITLE
platform checks: Enable RBAC checks

### DIFF
--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -58,6 +58,7 @@ class Initialize(Action):
             print(f"Running initialize() from {check}")
             check.start_initialize(e)
 
+    def join(self, e: Executor) -> None:
         for check in self.checks:
             check.join_initialize(e)
 
@@ -80,6 +81,8 @@ class Manipulate(Action):
             print(f"Running manipulate() from {check}")
             check.start_manipulate(e, self.phase)
 
+    def join(self, e: Executor) -> None:
+        assert self.phase is not None
         for check in self.checks:
             check.join_manipulate(e, self.phase)
 
@@ -93,5 +96,6 @@ class Validate(Action):
             print(f"Running validate() from {check}")
             check.start_validate(e)
 
+    def join(self, e: Executor) -> None:
         for check in self.checks:
             check.join_validate(e)

--- a/misc/python/materialize/checks/alter_index.py
+++ b/misc/python/materialize/checks/alter_index.py
@@ -11,6 +11,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.util import MzVersion
 
 
 def schema() -> str:
@@ -66,8 +67,7 @@ class AlterIndex(Check):
 
     def manipulate(self) -> List[Testdrive]:
         fix_ownership = (
-            dedent(
-                """
+            """
                 # When upgrading from old version without roles the indexes are
                 # owned by default_role, thus we have to change the owner
                 # before altering them:
@@ -75,7 +75,6 @@ class AlterIndex(Check):
                 ALTER INDEX alter_index_table_primary_idx OWNER TO materialize;
                 ALTER INDEX alter_index_source_primary_idx OWNER TO materialize;
                 """
-            )
             if self.base_version >= MzVersion.parse("0.46.0-dev")
             else ""
         )

--- a/misc/python/materialize/checks/alter_index.py
+++ b/misc/python/materialize/checks/alter_index.py
@@ -65,6 +65,20 @@ class AlterIndex(Check):
         )
 
     def manipulate(self) -> List[Testdrive]:
+        fix_ownership = (
+            dedent(
+                """
+                # When upgrading from old version without roles the indexes are
+                # owned by default_role, thus we have to change the owner
+                # before altering them:
+                $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                ALTER INDEX alter_index_table_primary_idx OWNER TO materialize;
+                ALTER INDEX alter_index_source_primary_idx OWNER TO materialize;
+                """
+            )
+            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            else ""
+        )
         return [
             Testdrive(schema() + dedent(s))
             for s in [
@@ -80,7 +94,8 @@ class AlterIndex(Check):
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "C${kafka-ingest.iteration}"}
                 """,
-                """
+                fix_ownership
+                + """
                 > INSERT INTO alter_index_table SELECT 'D' || generate_series FROM generate_series(1,10000);
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "D${kafka-ingest.iteration}"}

--- a/misc/python/materialize/checks/databases.py
+++ b/misc/python/materialize/checks/databases.py
@@ -67,6 +67,20 @@ class CheckDatabaseCreate(Check):
 
 class CheckDatabaseDrop(Check):
     def manipulate(self) -> List[Testdrive]:
+        fix_ownership = (
+            dedent(
+                """
+                # When upgrading from old version without roles the database is
+                # owned by default_role, thus we have to change the owner
+                # before dropping it:
+                $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                ALTER DATABASE to_be_dropped OWNER TO materialize;
+                """
+            )
+            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            else ""
+        )
+
         return [
             Testdrive(dedent(s))
             for s in [
@@ -75,7 +89,8 @@ class CheckDatabaseDrop(Check):
                 > SET DATABASE=to_be_dropped;
                 > CREATE TABLE t1 (f1 INTEGER);
                 """,
-                """
+                fix_ownership
+                + """
                 > DROP DATABASE to_be_dropped CASCADE;
                 """,
             ]

--- a/misc/python/materialize/checks/databases.py
+++ b/misc/python/materialize/checks/databases.py
@@ -11,6 +11,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.util import MzVersion
 
 
 class CheckDatabaseCreate(Check):
@@ -68,15 +69,13 @@ class CheckDatabaseCreate(Check):
 class CheckDatabaseDrop(Check):
     def manipulate(self) -> List[Testdrive]:
         fix_ownership = (
-            dedent(
-                """
+            """
                 # When upgrading from old version without roles the database is
                 # owned by default_role, thus we have to change the owner
                 # before dropping it:
                 $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
                 ALTER DATABASE to_be_dropped OWNER TO materialize;
                 """
-            )
             if self.base_version >= MzVersion.parse("0.46.0-dev")
             else ""
         )

--- a/misc/python/materialize/checks/drop_index.py
+++ b/misc/python/materialize/checks/drop_index.py
@@ -11,6 +11,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.util import MzVersion
 
 
 class DropIndex(Check):
@@ -31,8 +32,7 @@ class DropIndex(Check):
 
     def manipulate(self) -> List[Testdrive]:
         fix_ownership = (
-            dedent(
-                """
+            """
                 # When upgrading from old version without roles the indexes are
                 # owned by default_role, thus we have to change the owner
                 # before dropping them:
@@ -40,7 +40,6 @@ class DropIndex(Check):
                 ALTER INDEX drop_index_table_primary_idx OWNER TO materialize;
                 ALTER INDEX drop_index_index2 OWNER TO materialize;
                 """
-            )
             if self.base_version >= MzVersion.parse("0.46.0-dev")
             else ""
         )

--- a/misc/python/materialize/checks/drop_table.py
+++ b/misc/python/materialize/checks/drop_table.py
@@ -11,6 +11,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.util import MzVersion
 
 
 class DropTable(Check):
@@ -29,15 +30,13 @@ class DropTable(Check):
 
     def manipulate(self) -> List[Testdrive]:
         fix_ownership = (
-            dedent(
-                """
+            """
                 # When upgrading from old version without roles the table is
                 # owned by default_role, thus we have to change the owner
                 # before dropping it:
                 $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
                 ALTER TABLE drop_table2 OWNER TO materialize;
                 """
-            )
             if self.base_version >= MzVersion.parse("0.46.0-dev")
             else ""
         )

--- a/misc/python/materialize/checks/drop_table.py
+++ b/misc/python/materialize/checks/drop_table.py
@@ -28,13 +28,28 @@ class DropTable(Check):
         )
 
     def manipulate(self) -> List[Testdrive]:
+        fix_ownership = (
+            dedent(
+                """
+                # When upgrading from old version without roles the table is
+                # owned by default_role, thus we have to change the owner
+                # before dropping it:
+                $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                ALTER TABLE drop_table2 OWNER TO materialize;
+                """
+            )
+            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            else ""
+        )
+
         return [
             Testdrive(dedent(s))
             for s in [
                 """
                 > DROP TABLE drop_table1;
                 """,
-                """
+                fix_ownership
+                + """
                 > DROP TABLE drop_table2;
                 """,
             ]

--- a/misc/python/materialize/checks/rename_index.py
+++ b/misc/python/materialize/checks/rename_index.py
@@ -11,6 +11,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.util import MzVersion
 
 
 class RenameIndex(Check):
@@ -28,8 +29,7 @@ class RenameIndex(Check):
 
     def manipulate(self) -> List[Testdrive]:
         fix_ownership = (
-            dedent(
-                """
+            """
                 # When upgrading from old version without roles the indexes are
                 # owned by default_role, thus we have to change the owner
                 # before altering them:
@@ -37,7 +37,6 @@ class RenameIndex(Check):
                 ALTER INDEX rename_index_index1 OWNER TO materialize;
                 ALTER INDEX rename_index_index2 OWNER TO materialize;
                 """
-            )
             if self.base_version >= MzVersion.parse("0.46.0-dev")
             else ""
         )

--- a/misc/python/materialize/checks/rename_source.py
+++ b/misc/python/materialize/checks/rename_source.py
@@ -11,6 +11,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.util import MzVersion
 
 
 class RenameSource(Check):
@@ -59,15 +60,13 @@ class RenameSource(Check):
 
     def manipulate(self) -> List[Testdrive]:
         fix_ownership = (
-            dedent(
-                """
+            """
                 # When upgrading from old version without roles the source is
                 # owned by default_role, thus we have to change the owner
                 # before dropping it:
                 $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
                 ALTER SOURCE rename_source2 OWNER TO materialize;
                 """
-            )
             if self.base_version >= MzVersion.parse("0.46.0-dev")
             else ""
         )

--- a/misc/python/materialize/checks/rename_source.py
+++ b/misc/python/materialize/checks/rename_source.py
@@ -58,6 +58,20 @@ class RenameSource(Check):
         )
 
     def manipulate(self) -> List[Testdrive]:
+        fix_ownership = (
+            dedent(
+                """
+                # When upgrading from old version without roles the source is
+                # owned by default_role, thus we have to change the owner
+                # before dropping it:
+                $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                ALTER SOURCE rename_source2 OWNER TO materialize;
+                """
+            )
+            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            else ""
+        )
+
         return [
             Testdrive(self._source_schema() + dedent(s))
             for s in [
@@ -68,7 +82,8 @@ class RenameSource(Check):
                 $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema}
                 {"f1": "E"}
                 """,
-                """
+                fix_ownership
+                + """
                 $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema}
                 {"f1": "F"}
                 > ALTER SOURCE rename_source2 RENAME to rename_source3;

--- a/misc/python/materialize/checks/rename_table.py
+++ b/misc/python/materialize/checks/rename_table.py
@@ -11,6 +11,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.util import MzVersion
 
 
 class RenameTable(Check):
@@ -27,15 +28,13 @@ class RenameTable(Check):
 
     def manipulate(self) -> List[Testdrive]:
         fix_ownership = (
-            dedent(
-                """
+            """
                 # When upgrading from old version without roles the table is
                 # owned by default_role, thus we have to change the owner
                 # before dropping it:
                 $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
                 ALTER TABLE rename_table2 OWNER TO materialize;
                 """
-            )
             if self.base_version >= MzVersion.parse("0.46.0-dev")
             else ""
         )

--- a/misc/python/materialize/checks/rename_table.py
+++ b/misc/python/materialize/checks/rename_table.py
@@ -26,6 +26,20 @@ class RenameTable(Check):
         )
 
     def manipulate(self) -> List[Testdrive]:
+        fix_ownership = (
+            dedent(
+                """
+                # When upgrading from old version without roles the table is
+                # owned by default_role, thus we have to change the owner
+                # before dropping it:
+                $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                ALTER TABLE rename_table2 OWNER TO materialize;
+                """
+            )
+            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            else ""
+        )
+
         return [
             Testdrive(dedent(s))
             for s in [
@@ -34,7 +48,8 @@ class RenameTable(Check):
                 > ALTER TABLE rename_table1 RENAME TO rename_table2;
                 > INSERT INTO rename_table2 VALUES (3);
                 """,
-                """
+                fix_ownership
+                + """
                 > INSERT INTO rename_table2 VALUES (4);
                 > ALTER TABLE rename_table2 RENAME TO rename_table3;
                 > INSERT INTO rename_table3 VALUES (5);

--- a/misc/python/materialize/checks/rename_view.py
+++ b/misc/python/materialize/checks/rename_view.py
@@ -11,6 +11,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.util import MzVersion
 
 
 class RenameView(Check):
@@ -28,8 +29,7 @@ class RenameView(Check):
 
     def manipulate(self) -> List[Testdrive]:
         fix_ownership = (
-            dedent(
-                """
+            """
                 # When upgrading from old version without roles the views are
                 # owned by default_role, thus we have to change the owner
                 # before dropping them:
@@ -37,7 +37,6 @@ class RenameView(Check):
                 ALTER VIEW rename_view_viewB2 OWNER TO materialize;
                 ALTER VIEW rename_view_viewA2 OWNER TO materialize;
                 """
-            )
             if self.base_version >= MzVersion.parse("0.46.0-dev")
             else ""
         )

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -66,13 +66,11 @@ class Scenario:
 
     def run(self) -> None:
         actions = self.actions()
-        if isinstance(actions[0], StartMz):
-            # The first action is StartMz, configure it implicitly afterwards
-            actions.insert(1, ConfigureMz())
-        else:
-            actions.insert(0, ConfigureMz())
+        # The first action is StartMz, configure it implicitly afterwards
+        actions.insert(1 if isinstance(actions[0], StartMz) else 0, ConfigureMz(self))
         for action in actions:
             action.execute(self.executor)
+            action.join(self.executor)
 
 
 class NoRestartNoUpgrade(Scenario):

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -13,6 +13,7 @@ from typing import List, Optional, Type
 from materialize.checks.actions import Action, Initialize, Manipulate, Validate
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
+from materialize.checks.mzcompose_actions import ConfigureMz
 from materialize.checks.mzcompose_actions import (
     DropCreateDefaultReplica as DropCreateDefaultReplicaAction,
 )
@@ -64,7 +65,13 @@ class Scenario:
         return self._base_version
 
     def run(self) -> None:
-        for action in self.actions():
+        actions = self.actions()
+        if isinstance(actions[0], StartMz):
+            # The first action is StartMz, configure it implicitly afterwards
+            actions.insert(1, ConfigureMz())
+        else:
+            actions.insert(0, ConfigureMz())
+        for action in actions:
             action.execute(self.executor)
 
 

--- a/misc/python/materialize/zippy/replica_actions.py
+++ b/misc/python/materialize/zippy/replica_actions.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import random
+from textwrap import dedent
 from typing import List, Optional, Set, Type
 
 from materialize.mzcompose import Composition
@@ -24,7 +25,16 @@ class DropDefaultReplica(Action):
         return {MzIsRunning}
 
     def run(self, c: Composition) -> None:
-        c.testdrive("> DROP CLUSTER REPLICA default.r1;")
+        # Default cluster is not owned by materialize, thus can't be dropped by
+        # it if enable_rbac_checks is on.
+        c.testdrive(
+            dedent(
+                """
+            $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+            DROP CLUSTER REPLICA default.r1
+            """
+            )
+        )
 
 
 class CreateReplica(Action):

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from textwrap import dedent
 from typing import List, Optional
 
 import pytest
@@ -46,25 +45,6 @@ class ReplaceEnvironmentdStatefulSet(Action):
         stateful_set.replace()
 
 
-class LiftClusterLimits(Action):
-    def execute(self, e: Executor) -> None:
-        e.testdrive(
-            input=dedent(
-                """
-                $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
-                $ postgres-execute connection=mz_system
-                ALTER SYSTEM SET max_tables = 1000;
-
-                ALTER SYSTEM SET max_sources = 1000;
-
-                ALTER SYSTEM SET max_materialized_views = 1000;
-                ALTER SYSTEM SET max_objects_per_schema = 1000;
-                """
-            )
-        )
-
-
 class CloudtestUpgrade(Scenario):
     """A Platform Checks scenario that performs an upgrade in cloudtest/K8s"""
 
@@ -73,7 +53,6 @@ class CloudtestUpgrade(Scenario):
 
     def actions(self) -> List[Action]:
         return [
-            LiftClusterLimits(),
             Initialize(self),
             Manipulate(self, phase=1),
             ReplaceEnvironmentdStatefulSet(new_tag=None),

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -44,6 +44,10 @@ class ReplaceEnvironmentdStatefulSet(Action):
         stateful_set.tag = self.new_tag
         stateful_set.replace()
 
+    def join(self, e: Executor) -> None:
+        # execute is blocking already
+        pass
+
 
 class CloudtestUpgrade(Scenario):
     """A Platform Checks scenario that performs an upgrade in cloudtest/K8s"""


### PR DESCRIPTION
As suggested in https://github.com/MaterializeInc/materialize/pull/18477#discussion_r1152885371

Part of https://github.com/MaterializeInc/materialize/issues/17983

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
