### PR TITLE
storage: never call `block_on` on a timely worker

### DIFF
--- a/src/storage/src/decode/avro.rs
+++ b/src/storage/src/decode/avro.rs
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use tokio::runtime::Handle as TokioHandle;
-
 use mz_interchange::avro::Decoder;
 use mz_repr::Row;
 use mz_storage_client::types::connections::CsrClient;
@@ -16,7 +14,6 @@ use mz_storage_client::types::errors::DecodeErrorKind;
 
 #[derive(Debug)]
 pub struct AvroDecoderState {
-    tokio_handle: TokioHandle,
     decoder: Decoder<CsrClient>,
     events_success: i64,
 }
@@ -29,14 +26,13 @@ impl AvroDecoderState {
         confluent_wire_format: bool,
     ) -> Result<Self, anyhow::Error> {
         Ok(AvroDecoderState {
-            tokio_handle: TokioHandle::current(),
             decoder: Decoder::new(value_schema, ccsr_client, debug_name, confluent_wire_format)?,
             events_success: 0,
         })
     }
 
-    pub fn decode(&mut self, bytes: &mut &[u8]) -> Result<Option<Row>, DecodeErrorKind> {
-        match self.tokio_handle.block_on(self.decoder.decode(bytes)) {
+    pub async fn decode(&mut self, bytes: &mut &[u8]) -> Result<Option<Row>, DecodeErrorKind> {
+        match self.decoder.decode(bytes).await {
             Ok(row) => {
                 self.events_success += 1;
                 Ok(Some(row))

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -29,7 +29,6 @@ use timely::dataflow::operators::to_stream::Event;
 use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
-use tokio::runtime::Handle as TokioHandle;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio_postgres::error::DbError;
 use tokio_postgres::replication::LogicalReplicationStream;
@@ -295,8 +294,10 @@ impl SourceRender for PostgresSourceConnection {
 
             let resume_lsn = Arc::new(AtomicU64::new(start_offset.offset));
 
-            let connection_config = TokioHandle::current()
-                .block_on(self.connection.config(&*connection_context.secrets_reader))
+            let connection_config = self
+                .connection
+                .config(&*connection_context.secrets_reader)
+                .await
                 .expect("Postgres connection unexpectedly missing secrets");
 
             let mut source_tables = BTreeMap::new();


### PR DESCRIPTION
### Motivation

We are now in a position to properly call async functions during operator initialization so the previous workaround of blocking on tokio can be removed.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

* The diff is much smaller if viewed with whitespace hidden.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
