### PR TITLE
Mark ReductionPushdown and ReduceElision WMR-safe

### DIFF
--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -23,6 +23,10 @@ use mz_expr::MirRelationExpr;
 pub struct ReduceElision;
 
 impl crate::Transform for ReduceElision {
+    fn recursion_safe(&self) -> bool {
+        true
+    }
+
     #[tracing::instrument(
         target = "optimizer"
         level = "trace",

--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -59,6 +59,10 @@ use mz_expr::{AggregateExpr, JoinInputMapper, MirRelationExpr, MirScalarExpr};
 pub struct ReductionPushdown;
 
 impl crate::Transform for ReductionPushdown {
+    fn recursion_safe(&self) -> bool {
+        true
+    }
+
     #[tracing::instrument(
         target = "optimizer"
         level = "trace",

--- a/src/transform/tests/testdata/partial-reduction-pushdown
+++ b/src/transform/tests/testdata/partial-reduction-pushdown
@@ -15,7 +15,7 @@
 # decided that we need to spend more time on formalizing the proposed
 # approach, to ensure it is actually correct. Until we have done so,
 # the tests here only exercise the non-partial reduction pushdown
-# optimizationand are mostly equivalent to the tests in
+# optimization and are mostly equivalent to the tests in
 # `reduction-pushdown`.
 
 cat

--- a/test/sqllogictest/transform/reduce_elision.slt
+++ b/test/sqllogictest/transform/reduce_elision.slt
@@ -16,3 +16,114 @@ query T
 select (select jsonb_agg(1) from (select c) group by c) from (select 1 as c)
 ----
 [1]
+
+statement ok
+CREATE TABLE x (f0 int4, f1 string);
+
+statement ok
+CREATE TABLE y (f0 int2, f1 string primary key);
+
+# `ReductionPushdown` pushes the Distinct from after the Join into both join inputs.
+# Then, `ReduceElision` eliminates the Distinct from the 2nd join input.
+query T multiline
+EXPLAIN WITH(arity, join_impls, keys)
+SELECT DISTINCT *
+FROM x, y
+WHERE x.f1 = y.f1
+----
+Explained Query:
+  Project (#0..=#2, #1) // { arity: 4, keys: "([0, 1])" }
+    Join on=(#1 = #3) type=differential // { arity: 4, keys: "([0, 1])" }
+      implementation
+        %1:y[#1]UK » %0[#1]K
+      ArrangeBy keys=[[#1]] // { arity: 2, keys: "([0, 1])" }
+        Distinct group_by=[#0, #1] // { arity: 2, keys: "([0, 1])" }
+          Filter (#1) IS NOT NULL // { arity: 2, keys: "()" }
+            Get materialize.public.x // { arity: 2, keys: "()" }
+      ArrangeBy keys=[[#1]] // { arity: 2, keys: "([1])" }
+        Get materialize.public.y // { arity: 2, keys: "([1])" }
+
+Source materialize.public.x
+  filter=((#1) IS NOT NULL)
+
+EOF
+
+## -------------------- Tests for WITH MUTUALLY RECURSIVE --------------------
+
+# `ReductionPushdown` pushes the Distinct from after the Join into both join inputs.
+# Then, `ReduceElision` eliminates the Distinct from the 2nd join input.
+query T multiline
+EXPLAIN WITH(arity, join_impls, keys)
+WITH MUTUALLY RECURSIVE
+  c0(f0 int4, f1 string, f2 int2, f3 string) AS (
+    (SELECT DISTINCT *
+     FROM x, y
+     WHERE x.f1 = y.f1)
+    UNION ALL
+    (SELECT *
+     FROM c0)
+  )
+SELECT * FROM c0;
+----
+Explained Query:
+  Return // { arity: 4, keys: "()" }
+    Get l0 // { arity: 4, keys: "()" }
+  With Mutually Recursive
+    cte l0 =
+      Union // { arity: 4, keys: "()" }
+        Join on=(#1 = #3) type=differential // { arity: 4, keys: "([0, 1])" }
+          implementation
+            %1:y[#1]UK » %0[#1]K
+          ArrangeBy keys=[[#1]] // { arity: 2, keys: "([0, 1])" }
+            Distinct group_by=[#0, #1] // { arity: 2, keys: "([0, 1])" }
+              Filter (#1) IS NOT NULL // { arity: 2, keys: "()" }
+                Get materialize.public.x // { arity: 2, keys: "()" }
+          ArrangeBy keys=[[#1]] // { arity: 2, keys: "([1])" }
+            Get materialize.public.y // { arity: 2, keys: "([1])" }
+        Get l0 // { arity: 4, keys: "()" }
+
+Source materialize.public.x
+  filter=((#1) IS NOT NULL)
+
+EOF
+
+# Similar to the previous test, but
+#  - Has UNION instead of UNION ALL. This means that there is a Distinct at the root of l0.
+#  - The second input of the UNION has a DISTINCT. This should be eliminated later by `ReduceElision` after we make the
+#    unique key inference smarter for `LetRec`.
+query T multiline
+EXPLAIN WITH(arity, join_impls, keys)
+WITH MUTUALLY RECURSIVE
+  c0(f0 int4, f1 string, f2 int2, f3 string) AS (
+    (SELECT DISTINCT *
+     FROM x, y
+     WHERE x.f1 = y.f1)
+    UNION
+    (SELECT DISTINCT *
+     FROM c0)
+  )
+SELECT * FROM c0;
+----
+Explained Query:
+  Return // { arity: 4, keys: "([0, 1, 2, 3])" }
+    Get l0 // { arity: 4, keys: "([0, 1, 2, 3])" }
+  With Mutually Recursive
+    cte l0 =
+      Distinct group_by=[#0..=#3] // { arity: 4, keys: "([0, 1, 2, 3])" }
+        Union // { arity: 4, keys: "()" }
+          Join on=(#1 = #3) type=differential // { arity: 4, keys: "([0, 1])" }
+            implementation
+              %1:y[#1]UK » %0[#1]K
+            ArrangeBy keys=[[#1]] // { arity: 2, keys: "([0, 1])" }
+              Distinct group_by=[#0, #1] // { arity: 2, keys: "([0, 1])" }
+                Filter (#1) IS NOT NULL // { arity: 2, keys: "()" }
+                  Get materialize.public.x // { arity: 2, keys: "()" }
+            ArrangeBy keys=[[#1]] // { arity: 2, keys: "([1])" }
+              Get materialize.public.y // { arity: 2, keys: "([1])" }
+          Distinct group_by=[#0..=#3] // { arity: 4, keys: "([0, 1, 2, 3])" }
+            Get l0 // { arity: 4, keys: "()" }
+
+Source materialize.public.x
+  filter=((#1) IS NOT NULL)
+
+EOF

--- a/test/sqllogictest/transform/reduction_pushdown.slt
+++ b/test/sqllogictest/transform/reduction_pushdown.slt
@@ -1,0 +1,85 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+statement ok
+CREATE TABLE x (f0 int4, f1 string);
+
+statement ok
+CREATE TABLE y (f0 int2, f1 string);
+
+# `ReductionPushdown` pushes the Distinct from after the Join into both join inputs.
+query T multiline
+EXPLAIN WITH(arity, join_impls)
+SELECT DISTINCT *
+FROM x, y
+WHERE x.f1 = y.f1
+----
+Explained Query:
+  Project (#0, #1, #3, #1) // { arity: 4 }
+    Join on=(#1 = #2) type=differential // { arity: 4 }
+      implementation
+        %0[#1]K » %1[#0]K
+      ArrangeBy keys=[[#1]] // { arity: 2 }
+        Distinct group_by=[#0, #1] // { arity: 2 }
+          Filter (#1) IS NOT NULL // { arity: 2 }
+            Get materialize.public.x // { arity: 2 }
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Distinct group_by=[#1, #0] // { arity: 2 }
+          Filter (#1) IS NOT NULL // { arity: 2 }
+            Get materialize.public.y // { arity: 2 }
+
+Source materialize.public.x
+  filter=((#1) IS NOT NULL)
+Source materialize.public.y
+  filter=((#1) IS NOT NULL)
+
+EOF
+
+## -------------------- Tests for WITH MUTUALLY RECURSIVE --------------------
+
+# `ReductionPushdown` pushes the Distinct from after the Join into both join inputs.
+query T multiline
+EXPLAIN WITH(arity, join_impls)
+WITH MUTUALLY RECURSIVE
+  c0(f0 int4, f1 string, f2 int2, f3 string) AS (
+    (SELECT DISTINCT *
+     FROM x, y
+     WHERE x.f1 = y.f1)
+    UNION ALL
+    (SELECT *
+     FROM c0)
+  )
+SELECT * FROM c0;
+----
+Explained Query:
+  Return // { arity: 4 }
+    Get l0 // { arity: 4 }
+  With Mutually Recursive
+    cte l0 =
+      Union // { arity: 4 }
+        Project (#0, #1, #3, #2) // { arity: 4 }
+          Join on=(#1 = #2) type=differential // { arity: 4 }
+            implementation
+              %0[#1]K » %1[#0]K
+            ArrangeBy keys=[[#1]] // { arity: 2 }
+              Distinct group_by=[#0, #1] // { arity: 2 }
+                Filter (#1) IS NOT NULL // { arity: 2 }
+                  Get materialize.public.x // { arity: 2 }
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Distinct group_by=[#1, #0] // { arity: 2 }
+                Filter (#1) IS NOT NULL // { arity: 2 }
+                  Get materialize.public.y // { arity: 2 }
+        Get l0 // { arity: 4 }
+
+Source materialize.public.x
+  filter=((#1) IS NOT NULL)
+Source materialize.public.y
+  filter=((#1) IS NOT NULL)
+
+EOF


### PR DESCRIPTION
This just marks `ReductionPushdown` and `ReduceElision` to be WMR-safe, and adds slts for both. 

Note that unique key inference is not very smart yet for WMR, which is affecting `ReduceElision`, as shown by the last test in `reduce_elision.slt`. [I opened a separate issue for that](https://github.com/MaterializeInc/materialize/issues/18553), and will work on this next. But there are already some situations when both `ReductionPushdown` and `ReduceElision` kick in, so we can merge this PR in itself.

### Motivation

  * This PR adds a known-desirable feature:
    * #18170,
    * #18171

### Tips for reviewer

I suggest reviewing the test for pushdown before elision, because the elision tests are similar, but more complicated.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
