### PR TITLE
github: Transfer ownership of postgres-util crate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,7 +59,7 @@
 /src/pgtest                         @MaterializeInc/surfaces
 /src/pgwire                         @MaterializeInc/surfaces
 /src/pid-file                       @benesch
-/src/postgres-util                  @MaterializeInc/surfaces
+/src/postgres-util                  @MaterializeInc/storage
 /src/prof                           @umanwizard
 /src/proto                          @aalexandrov
 /src/repr                           @MaterializeInc/storage @MaterializeInc/compute


### PR DESCRIPTION
This commit transfers the ownership of the postgres-util crate from surfaces to storage. This crate is used for postgres sources, and therefore belongs under the storage team.

### Motivation

Changes ownership of a crate.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
