### PR TITLE
doc/user: bump to v0.48.4

### DIFF
--- a/doc/user/content/releases/v0.48.md
+++ b/doc/user/content/releases/v0.48.md
@@ -2,7 +2,7 @@
 title: "Materialize v0.48"
 date: 2023-03-29
 released: true
-patch: 3
+patch: 4
 ---
 
 ## v0.48.0


### PR DESCRIPTION
An additional patch version was rolled out for v0.48. Updating `patch` to support QA automated testing.

See [this thread](https://materializeinc.slack.com/archives/CTESPM7FU/p1680300294527559) for details.