### PR TITLE
upgrade-matrix: Comprehensive upgrade testing

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -21,6 +21,8 @@ kubernetes==25.3.0
 kubernetes-stubs==22.6.0.post1
 launchdarkly-api==11.0.0
 mypy==0.991
+networkx==3.0
+networkx-stubs==0.0.1
 numpy==1.24.2
 pandas==1.5.2
 parameterized==0.8.1

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -51,6 +51,7 @@ steps:
           - { value: checks-upgrade-entire-mz-four-versions }
           - { value: checks-upgrade-clusterd-compute-first }
           - { value: checks-upgrade-clusterd-compute-last }
+          - { value: checks-upgrade-matrix }
           - { value: cloudtest-upgrade }
           - { value: persist-maelstrom-single-node }
           - { value: persist-maelstrom-multi-node }
@@ -481,6 +482,17 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=UpgradeClusterdComputeLast]
+
+  - id: checks-upgrade-matrix
+    label: "Random upgrades over the entire matrix"
+    timeout_in_minutes: 120
+    agents:
+      queue: linux-x86_64
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: upgrade-matrix
+          args: ["--seed=$BUILDKITE_JOB_ID"]
 
   - id: cloudtest-upgrade
     label: "Platform checks upgrade in Cloudtest/K8s"

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -65,6 +65,7 @@ class Materialized(Service):
         restart: Optional[str] = None,
         use_default_volumes: bool = True,
         ports: Optional[List[str]] = None,
+        bootstrap_system_parameters: Optional[List[str]] = None,
     ) -> None:
         depends_on: Dict[str, ServiceDependency] = {
             s: {"condition": "service_started"} for s in depends_on
@@ -76,6 +77,10 @@ class Materialized(Service):
             # after v0.38 ships, since these environment variables will be
             # baked into the Docker image.
             "MZ_ORCHESTRATOR=process",
+            # The following settings can not be baked in the default image, as they
+            # are enabled for testing purposes only
+            "ORCHESTRATOR_PROCESS_TCP_PROXY_LISTEN_ADDR=0.0.0.0",
+            "ORCHESTRATOR_PROCESS_PROMETHEUS_SERVICE_DISCOVERY_DIRECTORY=/mzdata/prometheus",
             # Please think twice before forwarding additional environment
             # variables from the host, as it's easy to write tests that are
             # then accidentally dependent on the state of the host machine.
@@ -86,6 +91,18 @@ class Materialized(Service):
             "CLUSTERD_LOG_FILTER",
             *environment_extra,
         ]
+
+        if bootstrap_system_parameters is None:
+            bootstrap_system_parameters = [
+                "persist_sink_minimum_batch_updates=128",
+                "enable_multi_worker_storage_persist_sink=true",
+                "storage_persist_sink_minimum_batch_updates=100",
+            ]
+
+        if len(bootstrap_system_parameters) > 0:
+            environment += [
+                "MZ_BOOTSTRAP_SYSTEM_PARAMETER=" + ";".join(bootstrap_system_parameters)
+            ]
 
         command = []
 
@@ -116,11 +133,6 @@ class Materialized(Service):
             # f"--bootstrap-builtin-cluster-replica-size={self.default_replica_size}",
             f"--bootstrap-default-cluster-replica-size={self.default_replica_size}",
             f"--default-storage-host-size={self.default_storage_size}",
-            "--bootstrap-system-parameter=persist_sink_minimum_batch_updates=128",
-            # We wish to test the new implementation as its the canonical one, but
-            # want to control the rollout to production.
-            "--bootstrap-system-parameter=enable_multi_worker_storage_persist_sink=true",
-            "--bootstrap-system-parameter=storage_persist_sink_minimum_batch_updates=100",
         ]
 
         if external_cockroach:

--- a/test/upgrade-matrix/README.md
+++ b/test/upgrade-matrix/README.md
@@ -1,0 +1,59 @@
+# Introduction
+
+Existing upgrade tests, both the legacy ones in `test/upgrade` and the hard-coded upgrade
+scenarios in `misc/python/materialize/checks/scenarios_upgrade.py` fail to capture all
+the possible events that could happen over the lifetime of a Mz instance.
+
+For example, the previously-mentioned test frameworks only use the several most-recent
+Mz versions. This means that those tests will not attempt to upgrade an Mz instance
+that contains database objects, catalog entries or other data that was created in
+a very old Mz version.
+
+At the same time, involving all possible old Mz versions in a test would cause a
+combinatorial explosion, as we want to both create very old database objects *and*
+for those objects be modified, referenced or otherwise exercised on other, more
+recent versions.
+
+# Design
+
+To combat the combinatorial explosion, we will be randomly testing some upgrade
+scenarios out of the space of all upgrade scenarios. To do that, we construct a
+directed acyclic graph that represents all the states the Mz cluster could be in.
+
+The graph contains nodes for states such as starting a particular Mz version or
+stopping said version. It also contains nodes that represent the possible places
+of execution of SQL statements. A valid upgrade path may go from version X to
+version X+1 to X+2 without running any SQL, but another valid upgrade path would
+run some DDLs on any of those versions.
+
+We leverage the Platform Checks framework to provide the statements to run.
+Therefore, we need to place the initialize() , manipulate #1
+and manipulate #2 phases of Platform Checks framework in the graph as well, in
+all places where they could legitimately run sucessfully.
+
+We then walk the graph randomly in order to construct an upgrade scenario that starts
+at some old Mz version and proceeds across valid actions all the way to the
+latest HEAD. From the initial list of random walks, we prune those that are not valid:
+ - a Mz version must first be shut down before another one can be started
+ - the initialize phase must have run at some point prior to manipulate #1 and
+   identically for the manipulate #2 phase.
+
+From the first X (default = 20) walks, we construct a Platform Checks Scenario
+and pass it to the Platform Checks framework for execution.
+
+# Debugging
+
+The framework uses a PRNG with a known random seed. The CI output will contain lines such as:
+
+```
+--- Random seed is 123456789
+--- Checks to use: [<class 'materialize.checks.pg_cdc.PgCdc'>, <class 'materialize.checks.sink.SinkUpsert'>]
+```
+--- Testing upgrade scenario with id 1234: [BeginUpgradeSequence, BeginVersion(v0.42.4), ...
+```
+
+From this information, we can exactly the same upgrade scenario:
+
+```
+bin/mzcompose --find upgrade-matrix run default --seed=123456789 --scenario-id=1234 --check=SinkUpsert
+```

--- a/test/upgrade-matrix/mzcompose
+++ b/test/upgrade-matrix/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/upgrade-matrix/mzcompose.py
+++ b/test/upgrade-matrix/mzcompose.py
@@ -1,0 +1,326 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import os
+import random
+import sys
+import time
+from typing import Generator, List
+
+import networkx as nx
+
+# mzcompose may start this script from the root of the Mz repository,
+# so we need to explicitly add this directory to the Python module search path
+sys.path.append(os.path.dirname(__file__))
+
+from nodes import (
+    BeginUpgradeScenario,
+    BeginVersion,
+    ChecksInitialize,
+    ChecksManipulate1,
+    ChecksManipulate2,
+    ChecksValidate,
+    EndUpgradeScenario,
+    EndVersion,
+    Node,
+)
+
+from materialize.checks.actions import Action
+from materialize.checks.all_checks import *  # noqa: F401 F403
+from materialize.checks.checks import Check
+from materialize.checks.executors import MzcomposeExecutor
+from materialize.checks.scenarios import *  # noqa: F401 F403
+from materialize.checks.scenarios import Scenario
+from materialize.mzcompose import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services import (
+    Cockroach,
+    Debezium,
+    Materialized,
+    Postgres,
+    Redpanda,
+)
+from materialize.mzcompose.services import Testdrive as TestdriveService
+from materialize.util import MzVersion, released_materialize_versions
+
+# All released Materialize versions, in order from most to least recent.
+all_versions = released_materialize_versions()
+
+SERVICES = [
+    Cockroach(setup_materialize=True),
+    Postgres(),
+    Redpanda(auto_create_topics=True),
+    Debezium(redpanda=True),
+    Materialized(),  # Overriden inside Platform Checks
+    TestdriveService(
+        default_timeout="300s",
+        no_reset=True,
+        seed=1,
+        entrypoint_extra=[
+            "--var=replicas=1",
+            f"--var=default-replica-size={Materialized.Size.DEFAULT_SIZE}-{Materialized.Size.DEFAULT_SIZE}",
+            f"--var=default-storage-size={Materialized.Size.DEFAULT_SIZE}",
+        ],
+    ),
+]
+
+
+def setup(c: Composition) -> None:
+    c.up("testdrive", persistent=True)
+    c.up("cockroach", "redpanda", "postgres", "debezium")
+
+
+def teardown(c: Composition) -> None:
+    c.down(destroy_volumes=True)
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    """Test sequences of upgrades across the entire possible matrix of upgrade scenarios.
+
+    Thie framework works by building a graph that contains the Mz versions and Checks actions
+    to perform as nodes, as well as the allowed upgrade paths and other required dependencies
+    (as edges). All valid simple paths within the graph are upgrade scenarios that need to be
+    exercised and we pick a subset of them to run.
+    """
+
+    c.silent = True
+    parser.add_argument(
+        "--check",
+        metavar="CHECK",
+        type=str,
+        action="append",
+        help="Check(s) to run.",
+        default=["PgCdc", "SinkUpsert"],
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Just print the upgrade paths that will be tested.",
+    )
+
+    parser.add_argument(
+        "--min-version",
+        metavar="VERSION",
+        type=MzVersion.parse,
+        default=MzVersion.parse("0.39.0"),
+        help="Minimum Mz version to involve.",
+    )
+
+    parser.add_argument(
+        "--max-version-gap",
+        type=int,
+        default=1,
+        help="Maximum number of versions to skip",
+    )
+
+    parser.add_argument(
+        "--num-scenarios",
+        type=int,
+        default=50,
+        help="Number of upgrade scenarios to test",
+    )
+
+    parser.add_argument("--seed", metavar="SEED", type=str, default=str(time.time()))
+
+    parser.add_argument("--scenario-id", type=int, default=None)
+
+    args = parser.parse_args()
+
+    print(f"--- Random seed is {args.seed}")
+    random.seed(args.seed)
+
+    checks = (
+        [globals()[check] for check in args.check]
+        if args.check
+        else Check.__subclasses__()
+    )
+
+    print(f"--- Checks to use: {checks}")
+
+    executor = MzcomposeExecutor(composition=c)
+
+    versions = list(reversed([v for v in all_versions if v >= args.min_version]))
+    print(
+        "--- Testing upgrade scenarios involving the following versions: "
+        + " ".join([str(v) for v in versions])
+    )
+
+    for id, upgrade_scenario in enumerate(
+        get_upgrade_scenarios(
+            versions=versions,
+            max_version_gap=args.max_version_gap,
+            num_scenarios=args.num_scenarios,
+        )
+    ):
+        if args.scenario_id is not None and id != args.scenario_id:
+            continue
+
+        print(f"--- Testing upgrade scenario with id {id}: {upgrade_scenario}")
+
+        class GeneratedUpgradeScenario(Scenario):
+            # The minimum version referenced in the upgrade scenario
+            def base_version(self) -> MzVersion:
+                return min(
+                    [
+                        node.version
+                        for node in upgrade_scenario
+                        if isinstance(node, BeginVersion) and node.version is not None
+                    ]
+                )
+
+            # Convert the Nodes from the path into Checks Actions
+            def actions(self) -> List[Action]:
+                actions = []
+                for node in upgrade_scenario:
+                    actions.extend(node.actions(self))
+                return actions
+
+        scenario = GeneratedUpgradeScenario(checks=checks, executor=executor)
+        if not args.dry_run:
+            teardown(c)
+            setup(c)
+            scenario.run()
+            teardown(c)
+
+
+def random_simple_paths(
+    G: nx.DiGraph, source: Node, target: Node
+) -> Generator[List[Node], None, None]:
+    current: Node = source
+    path: List[Node] = [source]
+
+    def reset() -> None:
+        nonlocal current, path
+        current = source
+        path = [source]
+
+    reset()
+    while True:
+        all_out_neighbours = [e[1] for e in G.out_edges(current)]
+        new_out_neighbours = [n for n in all_out_neighbours if n not in path]
+        if len(new_out_neighbours) == 0:
+            # Dead end, start from the beginning
+            reset()
+            continue
+
+        next = random.choice(new_out_neighbours)
+
+        path = path + [next]
+        if next == target:
+            yield path
+            reset()
+        else:
+            current = next
+
+
+def get_upgrade_scenarios(
+    versions: List[MzVersion], max_version_gap: int, num_scenarios: int
+) -> List[List[Node]]:
+    g = nx.DiGraph()
+
+    # Nodes for the start and end of the upgrade scenario
+    scenario_begin = BeginUpgradeScenario()
+    scenario_end = EndUpgradeScenario()
+    g.add_nodes_from([scenario_begin, scenario_end])
+
+    # Nodes for starting and stopping a particular version
+    # We also add a node that starts the HEAD version,
+    # without a node to stop it.
+    versions_begin = [BeginVersion(version=v) for v in versions] + [
+        BeginVersion(version=None)
+    ]
+    g.add_nodes_from(versions_begin)
+
+    versions_end = [EndVersion(version=v) for v in versions]
+    g.add_nodes_from(versions_end)
+
+    # Nodes for the individual phases of the Check framework
+    checks_initialize = ChecksInitialize()
+    checks_manipulate1 = ChecksManipulate1()
+    checks_manipulate2 = ChecksManipulate2()
+    checks_validate = ChecksValidate()
+    checks_phases = [
+        checks_initialize,
+        checks_manipulate1,
+        checks_manipulate2,
+        checks_validate,
+    ]
+    g.add_nodes_from(checks_phases)
+
+    # Now that we have specified all the available operations in terms of Nodes,
+    # we define the allowed sequences of events in terms of Edges between them.
+
+    # Allow starting and stopping the same version with no action required in-between
+    for i in range(len(versions_end)):
+        g.add_edge(versions_begin[i], versions_end[i])
+
+    # Allow upgrades from X-N to X for N >= 1 ... max_version_gap
+    for skipped_count in range(1, max_version_gap + 1):
+        if len(versions_begin) >= skipped_count:
+            for v in range(len(versions_begin) - skipped_count):
+                g.add_edge(versions_end[v], versions_begin[v + skipped_count])
+
+    # Allow multiple Check phases to run within the same version
+    for i in range(0, len(checks_phases) - 2):
+        g.add_edge(checks_phases[i], checks_phases[i + 1])
+
+    # Allow a Check phase to run immediately after upgrading to version X
+    for i in range(len(versions_begin)):
+        for checks_phase in checks_phases[:-1]:
+            g.add_edge(versions_begin[i], checks_phase)
+
+    # Allow a Check phase to run immediately before stopping version X
+    for i in range(len(versions_end)):
+        for checks_phase in checks_phases[:-1]:
+            g.add_edge(checks_phase, versions_end[i])
+
+    # Allow the test to start at any previous version:
+    for i in range(len(versions_begin) - 1):
+        g.add_edge(scenario_begin, versions_begin[i])
+
+    # Validate will run only after the HEAD version has started
+    g.add_edge(versions_begin[-1], checks_validate)
+
+    # And the test can only end after Validate has run
+    g.add_edge(checks_validate, scenario_end)
+
+    # Now the Nodes are properly connected, so walk the graph.
+    # Some of the paths will not valid upgrade scenarios,
+    # so perform additional validation
+    valid_paths = []
+    for potential_path in random_simple_paths(g, scenario_begin, scenario_end):
+        # Verify that all Check phases are present
+        checks_phases_present = [
+            phase for phase in potential_path if phase in checks_phases
+        ]
+        if checks_phases_present != checks_phases:
+            continue
+
+        # Check that BeginVersion and EndVersion are properly matched
+        consistent_restarts = True
+        last_started_version = None
+        for phase in potential_path:
+            if isinstance(phase, BeginVersion):
+                last_started_version = phase.version
+            elif isinstance(phase, EndVersion):
+                assert (
+                    last_started_version is not None
+                ), f"last_started_version: {last_started_version}"
+                assert phase.version is not None
+                if last_started_version != phase.version:
+                    # Path jumps from version to version without a EndVersion
+                    consistent_restarts = False
+
+        if consistent_restarts:
+            valid_paths.append(potential_path)
+
+        if len(valid_paths) >= num_scenarios:
+            break
+
+    return valid_paths

--- a/test/upgrade-matrix/nodes.py
+++ b/test/upgrade-matrix/nodes.py
@@ -1,0 +1,86 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import List, Optional
+
+from materialize.checks.actions import Action, Initialize, Manipulate, Validate
+from materialize.checks.mzcompose_actions import KillMz, StartMz
+from materialize.checks.scenarios import Scenario
+from materialize.util import MzVersion
+
+
+class Node:
+    def actions(self, scenario: Scenario) -> List[Action]:
+        return []
+
+
+class BeginUpgradeScenario(Node):
+    def __repr__(self) -> str:
+        return "BeginUpgradeScenario"
+
+
+class EndUpgradeScenario(Node):
+    def __repr__(self) -> str:
+        return "EndUpgradeScenario"
+
+
+class BeginVersion(Node):
+    def __init__(self, version: Optional[MzVersion]):
+        self.version = version
+
+    def __repr__(self) -> str:
+        return f"BeginVersion({self.version})"
+
+    def actions(self, scenario: Scenario) -> List[Action]:
+        # As this action may need start very old Mz versions,
+        # we do not use any bootstrap_systme_parameters
+        return [StartMz(tag=self.version, bootstrap_system_parameters=[])]
+
+
+class EndVersion(Node):
+    def __init__(self, version: Optional[MzVersion]):
+        self.version = version
+
+    def __repr__(self) -> str:
+        return f"EndVersion({self.version})"
+
+    def actions(self, scenario: Scenario) -> List[Action]:
+        return [KillMz()]
+
+
+class ChecksInitialize(Node):
+    def __repr__(self) -> str:
+        return "ChecksInitialize"
+
+    def actions(self, scenario: Scenario) -> List[Action]:
+        return [Initialize(scenario)]
+
+
+class ChecksManipulate1(Node):
+    def __repr__(self) -> str:
+        return "ChecksManipulate(#1)"
+
+    def actions(self, scenario: Scenario) -> List[Action]:
+        return [Manipulate(scenario, phase=1)]
+
+
+class ChecksManipulate2(Node):
+    def __repr__(self) -> str:
+        return "ChecksManipulate(#2)"
+
+    def actions(self, scenario: Scenario) -> List[Action]:
+        return [Manipulate(scenario, phase=2)]
+
+
+class ChecksValidate(Node):
+    def __repr__(self) -> str:
+        return "ChecksValidate"
+
+    def actions(self, scenario: Scenario) -> List[Action]:
+        return [Validate(scenario)]


### PR DESCRIPTION
Test upgrade by constructing a graph of all allowed upgrade paths and then placing the Platform Check phases at all possible places within the graph.

### Motivation

A recent regression in upgrade has exposed a hole in our upgrade testing whereby we were not exercising an upgrade chain that was long enough to be impacted by a particular bug.

So, a need arose to:
- test upgrade with longer chains of versions than we currently do (we were testing upgrade from the last 2 versions, currently we upgrade from the last 4 versions)
- create the database objects at different times along the chain of upgrades, so that there are very old objects and then newer ones based on them.
- we need to test upgrades that bypass individual versions . While our current scripting around the cloud guarantees that upgrades are made in sequential fashion, I think it will be difficult for this to continue to be true especially in the case of emergencies / manual K8s manipulations / restores from backup / other out-of-the-ordinary events.

So I tried to model the allowed upgrades and the allowed statements that can run (because the prerequisite Checks statements have also run) as a graph and then walk along the graph to obtain **all** valid upgrade scenarios.

### Tips for reviewer

To give it a try:

```
cd test/upgrade-matrix
./mzcompose run default --dry-run
```

This will print out in symbolic form the actions that the framework intends to perform. If actual DDLs were run, one of those lines would be 5+ minutes of execution time :-(

```
--- Testing upgrade sequence: [BeginUpgradeSequence, BeginVersion(v0.47.1), ChecksInitialize, ChecksManipulate(#1), EndVersion(v0.47.1), BeginVersion(v0.48.3), ChecksManipulate(#2), EndVersion(v0.48.3), BeginVersion(None), ChecksValidate, EndUpgradeSequence]
--- Testing upgrade sequence: [BeginUpgradeSequence, BeginVersion(v0.47.1), ChecksInitialize, EndVersion(v0.47.1), BeginVersion(v0.48.3), ChecksManipulate(#1), ChecksManipulate(#2), EndVersion(v0.48.3), BeginVersion(None), ChecksValidate, EndUpgradeSequence]
--- Testing upgrade sequence: [BeginUpgradeSequence, BeginVersion(v0.48.3), ChecksInitialize, ChecksManipulate(#1), ChecksManipulate(#2), EndVersion(v0.48.3), BeginVersion(None), ChecksValidate, EndUpgradeSequence]
```