### PR TITLE
storage-client: don't panic if reading Kafka secret fails

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -22,12 +22,15 @@ use tracing::{event, warn};
 use mz_audit_log::VersionedEvent;
 use mz_compute_client::protocol::response::PeekResponse;
 use mz_controller::clusters::{ClusterId, ReplicaId};
+use mz_ore::error::ErrorExt;
 use mz_ore::retry::Retry;
 use mz_ore::task;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::names::{ObjectId, ResolvedDatabaseSpecifier};
 use mz_sql::session::vars::{self, SystemVars, Var};
-use mz_storage_client::controller::{CreateExportToken, ExportDescription, ReadPolicy};
+use mz_storage_client::controller::{
+    CreateExportToken, ExportDescription, ReadPolicy, StorageError,
+};
 use mz_storage_client::types::sinks::{SinkAsOf, StorageSinkConnection};
 use mz_storage_client::types::sources::{GenericSourceConnection, Timeline};
 
@@ -116,9 +119,16 @@ impl Coordinator {
                                             .connection
                                             .config(&*self.connection_context.secrets_reader)
                                             .await
-                                            .unwrap_or_else(|e| {
-                                                panic!("Postgres source {id} missing secrets: {e}")
-                                            });
+                                            .map_err(|e| {
+                                                AdapterError::Storage(StorageError::Generic(
+                                                    anyhow::anyhow!(
+                                                        "error creating Postgres client for \
+                                                        dropping acquired slots: {}",
+                                                        e.display_with_causes()
+                                                    ),
+                                                ))
+                                            })?;
+
                                         replication_slots_to_drop
                                             .push((config, conn.publication_details.slot.clone()));
                                     }

--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -351,7 +351,7 @@ impl KafkaConnection {
                 k,
                 v.get_string(&*connection_context.secrets_reader)
                     .await
-                    .expect("reading kafka secret unexpectedly failed"),
+                    .context("reading kafka secret")?,
             );
         }
         for (k, v) in extra_options {

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -232,6 +232,17 @@ def test_missing_secret(mz: MaterializeApplication) -> None:
               WHERE name = 'source_with_deleted_secret';
             true
 
+            ! DROP CLUSTER to_be_killed CASCADE;
+            contains:error creating Postgres client for dropping acquired slots
+
+            # The cluster should still be there.
+            > SELECT name from mz_clusters where name = 'to_be_killed';
+            to_be_killed
+
+            # Try and put the secret in place again.
+            > ALTER SECRET to_be_deleted AS 'postgres';
+
+            # Cluster can now be deleted.
             > DROP CLUSTER to_be_killed CASCADE;
             """
         ),

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -13,6 +13,7 @@ import pytest
 from pg8000.exceptions import InterfaceError
 
 from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.k8s import cluster_pod_name
 from materialize.cloudtest.wait import wait
 
 
@@ -94,3 +95,145 @@ def test_orphaned_secrets(mz: MaterializeApplication) -> None:
 
     mz.wait_for_sql()
     wait(condition="delete", resource=f"secret/{secret}")
+
+
+def test_missing_secret(mz: MaterializeApplication) -> None:
+    """Test that Mz does not panic if a secret goes missing from K8s"""
+    mz.testdrive.run(
+        input=dedent(
+            """
+          > CREATE CLUSTER to_be_killed REPLICAS (to_be_killed (SIZE '1'));
+
+          > CREATE SECRET to_be_deleted AS 'postgres'
+
+          > CREATE CONNECTION kafka_conn_with_deleted_secret TO KAFKA (
+                BROKER '${testdrive.kafka-addr}',
+                SASL MECHANISMS 'PLAIN',
+                SASL USERNAME = SECRET to_be_deleted,
+                SASL PASSWORD = SECRET to_be_deleted
+              );
+
+          > CREATE CONNECTION pg_conn_with_deleted_secret TO POSTGRES (
+            HOST 'postgres',
+            DATABASE postgres,
+            USER postgres,
+            PASSWORD SECRET to_be_deleted
+            );
+
+          $ postgres-execute connection=postgres://postgres:postgres@postgres
+          ALTER USER postgres WITH replication;
+          DROP SCHEMA IF EXISTS public CASCADE;
+          DROP PUBLICATION IF EXISTS mz_source;
+          CREATE SCHEMA public;
+
+          CREATE TABLE t1 (f1 INTEGER);
+          ALTER TABLE t1 REPLICA IDENTITY FULL;
+          INSERT INTO t1 VALUES (1);
+
+          CREATE PUBLICATION mz_source FOR TABLE t1;
+
+          > CREATE SOURCE source_with_deleted_secret
+            IN CLUSTER to_be_killed
+            FROM POSTGRES CONNECTION pg_conn_with_deleted_secret
+            (PUBLICATION 'mz_source')
+            FOR ALL TABLES;
+     """
+        )
+    )
+
+    id = mz.environmentd.sql_query(
+        "SELECT id FROM mz_secrets WHERE name = 'to_be_deleted'"
+    )[0][0]
+    assert id is not None
+    secret = f"user-managed-{id}"
+
+    mz.kubectl("delete", "secret", secret)
+    wait(condition="delete", resource=f"secret/{secret}")
+
+    mz.testdrive.run(
+        input=dedent(
+            """
+            ! CREATE SOURCE some_pg_source
+              FROM POSTGRES CONNECTION pg_conn_with_deleted_secret
+              (PUBLICATION 'mz_source')
+              FOR ALL TABLES;
+            contains: NotFound
+
+            ! CREATE SOURCE some_kafka_source
+              FROM KAFKA CONNECTION kafka_conn_with_deleted_secret
+              (TOPIC 'foo')
+            contains: NotFound
+            """
+        ),
+        no_reset=True,
+    )
+
+    # Restart the storage computed and confirm that the source errors out properly
+
+    cluster_id, replica_id = mz.environmentd.sql_query(
+        f"SELECT cluster_id, id FROM mz_cluster_replicas WHERE name = 'to_be_killed'"
+    )[0]
+    pod_name = cluster_pod_name(cluster_id, replica_id, 0)
+
+    mz.kubectl("exec", pod_name, "--", "bash", "-c", f"kill -9 `pidof clusterd`")
+    wait(condition="condition=Ready", resource=f"{pod_name}")
+
+    mz.testdrive.run(
+        input=dedent(
+            """
+            ! CREATE SOURCE some_pg_source
+              FROM POSTGRES CONNECTION pg_conn_with_deleted_secret
+              (PUBLICATION 'mz_source')
+              FOR ALL TABLES;
+            contains: NotFound
+
+            ! CREATE SOURCE some_kafka_source
+              FROM KAFKA CONNECTION kafka_conn_with_deleted_secret
+              (TOPIC 'foo')
+            contains: NotFound
+
+            > SELECT error like '%NotFound%'
+              FROM mz_internal.mz_source_statuses
+              WHERE name = 'source_with_deleted_secret';
+            true
+            """
+        ),
+        no_reset=True,
+    )
+
+    # Kill the environmentd and confirm the same
+
+    mz.kubectl(
+        "exec",
+        "pod/environmentd-0",
+        "--",
+        "bash",
+        "-c",
+        f"kill -9 `pidof environmentd`",
+    )
+    wait(condition="condition=Ready", resource=f"pod/environmentd-0")
+
+    mz.testdrive.run(
+        input=dedent(
+            """
+            ! CREATE SOURCE some_pg_source
+              FROM POSTGRES CONNECTION pg_conn_with_deleted_secret
+              (PUBLICATION 'mz_source')
+              FOR ALL TABLES;
+            contains: NotFound
+
+            ! CREATE SOURCE some_kafka_source
+              FROM KAFKA CONNECTION kafka_conn_with_deleted_secret
+              (TOPIC 'foo')
+            contains: NotFound
+
+            > SELECT error like '%NotFound%'
+              FROM mz_internal.mz_source_statuses
+              WHERE name = 'source_with_deleted_secret';
+            true
+
+            > DROP CLUSTER to_be_killed CASCADE;
+            """
+        ),
+        no_reset=True,
+    )


### PR DESCRIPTION
The surrounding code paths have been sufficiently refactored such that it is now possible to gracefully return an error here.

Fix #18438.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Too small a bug to mention IMO.
