### PR TITLE
optbench: replace deprecated `pkg_resources` package

### DIFF
--- a/misc/python/materialize/optbench/__init__.py
+++ b/misc/python/materialize/optbench/__init__.py
@@ -7,14 +7,13 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from pathlib import Path
+from importlib import resources
+from importlib.abc import Traversable
 from typing import List
 
-from pkg_resources import resource_filename
 
-
-def resource_path(name: str) -> Path:
-    return Path(resource_filename(__name__, name))
+def resource_path(name: str) -> Traversable:
+    return resources.files(__package__) / name
 
 
 def scenarios() -> List[str]:
@@ -23,14 +22,14 @@ def scenarios() -> List[str]:
     of files located in both the `schema` and `workload` resource paths.
     """
     schema_files = {
-        p.stem
+        p.name.removesuffix(".sql")
         for p in resource_path("schema").iterdir()
-        if p.is_file() and p.suffix == ".sql"
+        if p.is_file() and p.name.endswith(".sql")
     }
     workload_files = {
-        p.stem
+        p.name.removesuffix(".sql")
         for p in resource_path("workload").iterdir()
-        if p.is_file() and p.suffix == ".sql"
+        if p.is_file() and p.name.endswith(".sql")
     }
 
     return sorted(schema_files.intersection(workload_files))
@@ -40,10 +39,10 @@ class Scenario:
     def __init__(self, value: str) -> None:
         self.value = value
 
-    def schema_path(self) -> Path:
+    def schema_path(self) -> Traversable:
         return resource_path(f"schema/{self}.sql")
 
-    def workload_path(self) -> Path:
+    def workload_path(self) -> Traversable:
         return resource_path(f"workload/{self}.sql")
 
     def __str__(self) -> str:

--- a/misc/python/materialize/optbench/sql.py
+++ b/misc/python/materialize/optbench/sql.py
@@ -11,7 +11,7 @@ import logging
 import re
 import ssl
 from enum import Enum
-from pathlib import Path
+from importlib.abc import Traversable
 from typing import Any, Dict, List, Optional, cast
 
 import numpy as np
@@ -154,6 +154,6 @@ class Database:
 # -----------------
 
 
-def parse_from_file(path: Path) -> List[str]:
+def parse_from_file(path: Traversable) -> List[str]:
     """Parses a *.sql file to a list of queries."""
     return sqlparse.split(path.read_text())


### PR DESCRIPTION
Fixes #18527.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

I followed [the `pkg_resources` migration guide to `importlib.resources`](https://docs.python.org/3/library/importlib.resources.html#module-importlib.resources). @jkosh44 feel to auto-allow "rebase and merge" after approval.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
