### PR TITLE
adapter: Rename *Object* structs to *Item*

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6923,7 +6923,7 @@ mod tests {
     use mz_sql::catalog::CatalogDatabase;
     use mz_sql::names;
     use mz_sql::names::{
-        DatabaseId, ItemQuali         , PartialItemName, QualifiedItemName,
+        DatabaseId, ItemQualifiers, PartialItemName, QualifiedItemName,
         ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier,
     };
     use mz_sql::plan::StatementContext;

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -60,7 +60,7 @@ use mz_sql::catalog::{
 };
 use mz_sql::func::OP_IMPLS;
 use mz_sql::names::{
-    Aug, DatabaseId, FullItemName, FullSchemaName, ObjectId, ItemQualifiers, PartialItemName,
+    Aug, DatabaseId, FullItemName, FullSchemaName, ItemQualifiers, ObjectId, PartialItemName,
     QualifiedItemName, QualifiedSchemaName, RawDatabaseSpecifier, ResolvedDatabaseSpecifier,
     RoleId, SchemaId, SchemaSpecifier, PUBLIC_ROLE_NAME,
 };
@@ -2509,8 +2509,7 @@ impl Catalog {
             for (builtin, id) in builtin_non_indexes {
                 let schema_id = catalog.state.ambient_schemas_by_name[builtin.schema()];
                 let name = QualifiedItemName {
-                    qualifiers: ItemQualifiers
- {
+                    qualifiers: ItemQualifiers {
                         database_spec: ResolvedDatabaseSpecifier::Ambient,
                         schema_spec: SchemaSpecifier::Id(schema_id),
                     },
@@ -3108,8 +3107,7 @@ impl Catalog {
                 element_id,
                 typ.oid,
                 QualifiedItemName {
-                    qualifiers: ItemQualifiers
- {
+                    qualifiers: ItemQualifiers {
                         database_spec: ResolvedDatabaseSpecifier::Ambient,
                         schema_spec: SchemaSpecifier::Id(pg_catalog_schema_id),
                     },
@@ -6475,8 +6473,7 @@ impl ExprHumanizer for ConnCatalog<'_> {
                     // If PG_CATALOG_SCHEMA is not in search path, you need
                     // qualified object name to refer to type.
                     let name = QualifiedItemName {
-                        qualifiers: ItemQualifiers
-     {
+                        qualifiers: ItemQualifiers {
                             database_spec: ResolvedDatabaseSpecifier::Ambient,
                             schema_spec: pg_catalog_schema,
                         },
@@ -6923,8 +6920,8 @@ mod tests {
     use mz_sql::catalog::CatalogDatabase;
     use mz_sql::names;
     use mz_sql::names::{
-        DatabaseId, ItemQualifiers, PartialItemName, QualifiedItemName,
-        ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier,
+        DatabaseId, ItemQualifiers, PartialItemName, QualifiedItemName, ResolvedDatabaseSpecifier,
+        SchemaId, SchemaSpecifier,
     };
     use mz_sql::plan::StatementContext;
     use mz_sql::session::vars::VarInput;
@@ -6956,8 +6953,7 @@ mod tests {
             let test_cases = vec![
                 TestCase {
                     input: QualifiedItemName {
-                        qualifiers: ItemQualifiers
-     {
+                        qualifiers: ItemQualifiers {
                             database_spec: ResolvedDatabaseSpecifier::Ambient,
                             schema_spec: SchemaSpecifier::Id(
                                 catalog.get_pg_catalog_schema_id().clone(),
@@ -6978,8 +6974,7 @@ mod tests {
                 },
                 TestCase {
                     input: QualifiedItemName {
-                        qualifiers: ItemQualifiers
-     {
+                        qualifiers: ItemQualifiers {
                             database_spec: ResolvedDatabaseSpecifier::Ambient,
                             schema_spec: SchemaSpecifier::Id(
                                 catalog.get_mz_catalog_schema_id().clone(),
@@ -7311,8 +7306,7 @@ mod tests {
                         id,
                         oid,
                         name: QualifiedItemName {
-                            qualifiers: ItemQualifiers
-         {
+                            qualifiers: ItemQualifiers {
                                 database_spec,
                                 schema_spec,
                             },
@@ -7897,8 +7891,7 @@ mod tests {
                     vec![Op::CreateItem {
                         item,
                         name: QualifiedItemName {
-                            qualifiers: ItemQualifiers
-         {
+                            qualifiers: ItemQualifiers {
                                 database_spec: ResolvedDatabaseSpecifier::Id(DatabaseId::new(1)),
                                 schema_spec: SchemaSpecifier::Id(SchemaId::new(3)),
                             },

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -132,7 +132,7 @@ pub const LINKED_CLUSTER_REPLICA_NAME: &str = "linked";
 ///
 /// To the outside world, databases, schemas, and items are all identified by
 /// name. Items can be referred to by their [`FullItemName`], which fully and
-/// unambiguously specifies the item, or a [`PartialObjectName`], which can omit the
+/// unambiguously specifies the item, or a [`PartialItemName`], which can omit the
 /// database name and/or the schema name. Partial names can be converted into
 /// full names via a complicated resolution process documented by the
 /// [`CatalogState::resolve`] method.
@@ -1072,7 +1072,7 @@ impl CatalogState {
             .expect("failed to lookup BuiltinCluster by ID")
     }
 
-    /// Resolves [`PartialObjectName`] into a [`CatalogEntry`].
+    /// Resolves [`PartialItemName`] into a [`CatalogEntry`].
     ///
     /// If `name` does not specify a database, the `current_database` is used.
     /// If `name` does not specify a schema, then the schemas in `search_path`
@@ -6359,7 +6359,7 @@ impl ConnCatalog<'_> {
         self.resolve_item(name).map(|entry| entry.name())
     }
 
-    /// returns a `PartialObjectName` with the minimum amount of qualifiers to unambiguously resolve
+    /// returns a `PartialItemName` with the minimum amount of qualifiers to unambiguously resolve
     /// the object.
     fn minimal_qualification(&self, qualified_name: &QualifiedItemName) -> PartialItemName {
         let database_id = match &qualified_name.qualifiers.database_spec {

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -3688,7 +3688,7 @@ mod tests {
     use mz_pgrepr::oid::{FIRST_MATERIALIZE_OID, FIRST_UNPINNED_OID};
     use mz_sql::catalog::{CatalogSchema, SessionCatalog};
     use mz_sql::func::OP_IMPLS;
-    use mz_sql::names::{PartialObjectName, ResolvedDatabaseSpecifier};
+    use mz_sql::names::{PartialItemName, ResolvedDatabaseSpecifier};
 
     use crate::catalog::{Catalog, CatalogItem, SYSTEM_CONN_ID};
 
@@ -3799,7 +3799,7 @@ mod tests {
             let conn_catalog = catalog.for_system_session();
             let resolve_type_oid = |item: &str| {
                 conn_catalog
-                    .resolve_item(&PartialObjectName {
+                    .resolve_item(&PartialItemName {
                         database: None,
                         // All functions we check exist in PG, so the types must, as
                         // well
@@ -3894,7 +3894,7 @@ mod tests {
                             .resolve_entry(
                                 None,
                                 &vec![(ResolvedDatabaseSpecifier::Ambient, schema.id().clone())],
-                                &PartialObjectName {
+                                &PartialItemName {
                                     database: None,
                                     schema: Some(schema.name().schema.clone()),
                                     item: ty.name.to_string(),
@@ -4031,7 +4031,7 @@ mod tests {
                 view.schema == PG_CATALOG_SCHEMA || view.schema == INFORMATION_SCHEMA
             }) {
                 let item = conn_catalog
-                    .resolve_item(&PartialObjectName {
+                    .resolve_item(&PartialItemName {
                         database: None,
                         schema: Some(view.schema.to_string()),
                         item: view.name.to_string(),

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -29,7 +29,7 @@ use mz_sql::catalog::{
     CatalogSchema, RoleAttributes,
 };
 use mz_sql::names::{
-    DatabaseId, ItemQualifiers, QualifiedObjectName, ResolvedDatabaseSpecifier, RoleId, SchemaId,
+    DatabaseId, ItemQualifiers, QualifiedItemName, ResolvedDatabaseSpecifier, RoleId, SchemaId,
     SchemaSpecifier, PUBLIC_ROLE_NAME,
 };
 use mz_stash::{AppendBatch, Stash, StashError, TableTransaction, TypedCollection};
@@ -1337,7 +1337,7 @@ pub struct Transaction<'a> {
 impl<'a> Transaction<'a> {
     pub fn loaded_items(
         &self,
-    ) -> Vec<(GlobalId, QualifiedObjectName, SerializedCatalogItem, RoleId)> {
+    ) -> Vec<(GlobalId, QualifiedItemName, SerializedCatalogItem, RoleId)> {
         let databases = self.databases.items();
         let schemas = self.schemas.items();
         let mut items = Vec::new();
@@ -1364,7 +1364,7 @@ impl<'a> Transaction<'a> {
             };
             items.push((
                 k.gid,
-                QualifiedObjectName {
+                QualifiedItemName {
                     qualifiers: ItemQualifiers {
                         database_spec,
                         schema_spec: SchemaSpecifier::from(v.schema_id),

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -29,7 +29,7 @@ use mz_sql::catalog::{
     CatalogSchema, RoleAttributes,
 };
 use mz_sql::names::{
-    DatabaseId, ObjectQualifiers, QualifiedObjectName, ResolvedDatabaseSpecifier, RoleId, SchemaId,
+    DatabaseId, ItemQualifiers, QualifiedObjectName, ResolvedDatabaseSpecifier, RoleId, SchemaId,
     SchemaSpecifier, PUBLIC_ROLE_NAME,
 };
 use mz_stash::{AppendBatch, Stash, StashError, TableTransaction, TypedCollection};
@@ -1365,7 +1365,7 @@ impl<'a> Transaction<'a> {
             items.push((
                 k.gid,
                 QualifiedObjectName {
-                    qualifiers: ObjectQualifiers {
+                    qualifiers: ItemQualifiers {
                         database_spec,
                         schema_spec: SchemaSpecifier::from(v.schema_id),
                     },

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -46,7 +46,7 @@ use mz_sql::catalog::{
     CatalogTypeDetails,
 };
 use mz_sql::catalog::{CatalogItem as SqlCatalogItem, CatalogRole};
-use mz_sql::names::{QualifiedObjectName, RoleId};
+use mz_sql::names::{QualifiedItemName, RoleId};
 use mz_sql::plan::{
     AlterIndexResetOptionsPlan, AlterIndexSetOptionsPlan, AlterItemRenamePlan,
     AlterOptionParameter, AlterOwnerPlan, AlterRolePlan, AlterSecretPlan, AlterSinkPlan,
@@ -1103,7 +1103,7 @@ impl Coordinator {
     async fn generate_view_ops(
         &mut self,
         session: &Session,
-        name: QualifiedObjectName,
+        name: QualifiedItemName,
         view: View,
         replace: Option<GlobalId>,
         depends_on: Vec<GlobalId>,
@@ -3720,7 +3720,7 @@ impl Coordinator {
     async fn create_linked_cluster_ops(
         &mut self,
         linked_object_id: GlobalId,
-        name: &QualifiedObjectName,
+        name: &QualifiedItemName,
         config: &SourceSinkClusterConfig,
         ops: &mut Vec<catalog::Op>,
         session: &Session,

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -19,7 +19,7 @@ use mz_controller::clusters::ClusterId;
 use mz_ore::halt;
 use mz_ore::soft_assert;
 use mz_repr::{GlobalId, RelationDesc, Row, ScalarType};
-use mz_sql::names::FullObjectName;
+use mz_sql::names::FullItemName;
 use mz_sql::plan::StatementDesc;
 use mz_sql::session::vars::Var;
 use mz_sql_parser::ast::display::AstDisplay;
@@ -188,7 +188,7 @@ pub(crate) fn send_immediate_rows(rows: Vec<Row>) -> ExecuteResponse {
 pub fn index_sql(
     index_name: String,
     cluster_id: ClusterId,
-    view_name: FullObjectName,
+    view_name: FullItemName,
     view_desc: &RelationDesc,
     keys: &[usize],
 ) -> String {

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -24,7 +24,7 @@ use mz_sql::plan::StatementDesc;
 use mz_sql::session::vars::Var;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
-    CreateIndexStatement, FetchStatement, Ident, Raw, RawClusterName, RawObjectName, Statement,
+    CreateIndexStatement, FetchStatement, Ident, Raw, RawClusterName, RawItemName, Statement,
 };
 use mz_stash::StashError;
 use mz_storage_client::controller::StorageError;
@@ -196,7 +196,7 @@ pub fn index_sql(
 
     CreateIndexStatement::<Raw> {
         name: Some(Ident::new(index_name)),
-        on_name: RawObjectName::Name(mz_sql::normalize::unresolve(view_name)),
+        on_name: RawItemName::Name(mz_sql::normalize::unresolve(view_name)),
         in_cluster: Some(RawClusterName::Resolved(cluster_id.to_string())),
         key_parts: Some(
             keys.iter()

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -97,7 +97,7 @@ use mz_ore::now::NOW_ZERO;
 use mz_repr::RelationDesc;
 use mz_sql::ast::{Expr, Statement};
 use mz_sql::catalog::CatalogDatabase;
-use mz_sql::names::{self, ItemQualifiers, QualifiedObjectName, ResolvedDatabaseSpecifier};
+use mz_sql::names::{self, ItemQualifiers, QualifiedItemName, ResolvedDatabaseSpecifier};
 use mz_sql::plan::{PlanContext, QueryContext, QueryLifetime, StatementContext};
 use mz_sql::DEFAULT_SCHEMA;
 
@@ -146,7 +146,7 @@ async fn datadriven() {
                                     vec![Op::CreateItem {
                                         id,
                                         oid,
-                                        name: QualifiedObjectName {
+                                        name: QualifiedItemName {
                                             qualifiers: ItemQualifiers {
                                                 database_spec,
                                                 schema_spec,

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -97,7 +97,7 @@ use mz_ore::now::NOW_ZERO;
 use mz_repr::RelationDesc;
 use mz_sql::ast::{Expr, Statement};
 use mz_sql::catalog::CatalogDatabase;
-use mz_sql::names::{self, ObjectQualifiers, QualifiedObjectName, ResolvedDatabaseSpecifier};
+use mz_sql::names::{self, ItemQualifiers, QualifiedObjectName, ResolvedDatabaseSpecifier};
 use mz_sql::plan::{PlanContext, QueryContext, QueryLifetime, StatementContext};
 use mz_sql::DEFAULT_SCHEMA;
 
@@ -147,7 +147,7 @@ async fn datadriven() {
                                         id,
                                         oid,
                                         name: QualifiedObjectName {
-                                            qualifiers: ObjectQualifiers {
+                                            qualifiers: ItemQualifiers {
                                                 database_spec,
                                                 schema_spec,
                                             },

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -24,7 +24,7 @@
 use std::fmt;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
-use crate::ast::{AstInfo, Expr, Ident, UnresolvedObjectName, WithOptionValue};
+use crate::ast::{AstInfo, Expr, Ident, UnresolvedItemName, WithOptionValue};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Schema {
@@ -171,7 +171,7 @@ impl_display_t!(CsrConfigOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CsrConnection<T: AstInfo> {
-    pub connection: T::ObjectName,
+    pub connection: T::ItemName,
     pub options: Vec<CsrConfigOption<T>>,
 }
 
@@ -526,7 +526,7 @@ impl_display!(DbzMode);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum DbzTxMetadataOption<T: AstInfo> {
-    Source(T::ObjectName),
+    Source(T::ItemName),
     Collection(WithOptionValue<T>),
 }
 impl<T: AstInfo> AstDisplay for DbzTxMetadataOption<T> {
@@ -931,7 +931,7 @@ impl_display_t!(KafkaConfigOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KafkaConnection<T: AstInfo> {
-    pub connection: T::ObjectName,
+    pub connection: T::ItemName,
     pub options: Vec<KafkaConfigOption<T>>,
 }
 
@@ -998,7 +998,7 @@ pub enum CreateSourceConnection<T: AstInfo> {
     Kafka(KafkaSourceConnection<T>),
     Postgres {
         /// The postgres connection.
-        connection: T::ObjectName,
+        connection: T::ItemName,
         options: Vec<PgConfigOption<T>>,
     },
     LoadGenerator {
@@ -1154,9 +1154,9 @@ impl AstDisplay for KafkaSinkKey {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PgTable<T: AstInfo> {
     /// The name of the table to sync
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     /// The name for the table in Materialize
-    pub alias: T::ObjectName,
+    pub alias: T::ItemName,
     /// The expected column schema of the synced table
     pub columns: Vec<ColumnDef<T>>,
 }
@@ -1221,7 +1221,7 @@ pub enum TableConstraint<T: AstInfo> {
     ForeignKey {
         name: Option<Ident>,
         columns: Vec<Ident>,
-        foreign_table: T::ObjectName,
+        foreign_table: T::ItemName,
         referred_columns: Vec<Ident>,
     },
     /// `[ CONSTRAINT <name> ] CHECK (<expr>)`
@@ -1344,7 +1344,7 @@ impl_display_t!(CreateSourceOption);
 pub struct ColumnDef<T: AstInfo> {
     pub name: Ident,
     pub data_type: T::DataType,
-    pub collation: Option<UnresolvedObjectName>,
+    pub collation: Option<UnresolvedItemName>,
     pub options: Vec<ColumnOptionDef<T>>,
 }
 
@@ -1412,7 +1412,7 @@ pub enum ColumnOption<T: AstInfo> {
     /// A referential integrity constraint (`[FOREIGN KEY REFERENCES
     /// <foreign_table> (<referred_columns>)`).
     ForeignKey {
-        foreign_table: UnresolvedObjectName,
+        foreign_table: UnresolvedItemName,
         referred_columns: Vec<Ident>,
     },
     // `CHECK (<expr>)`

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -22,7 +22,7 @@ use std::fmt;
 use std::mem;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
-use crate::ast::{AstInfo, Ident, OrderByExpr, Query, UnresolvedObjectName, Value};
+use crate::ast::{AstInfo, Ident, OrderByExpr, Query, UnresolvedItemName, Value};
 
 /// An SQL expression of any type.
 ///
@@ -110,7 +110,7 @@ pub enum Expr<T: AstInfo> {
     /// `expr COLLATE collation`
     Collate {
         expr: Box<Expr<T>>,
-        collation: UnresolvedObjectName,
+        collation: UnresolvedItemName,
     },
     /// `COALESCE(<expr>, ...)` or `GREATEST(<expr>, ...)` or `LEAST(<expr>`, ...)
     ///
@@ -587,7 +587,7 @@ impl<T: AstInfo> Expr<T> {
 
     pub fn call(name: Vec<&str>, args: Vec<Expr<T>>) -> Expr<T> {
         Expr::Function(Function {
-            name: UnresolvedObjectName(name.into_iter().map(Into::into).collect()),
+            name: UnresolvedItemName(name.into_iter().map(Into::into).collect()),
             args: FunctionArgs::args(args),
             filter: None,
             over: None,
@@ -796,7 +796,7 @@ impl_display!(WindowFrameBound);
 /// A function call
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Function<T: AstInfo> {
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     pub args: FunctionArgs<T>,
     // aggregate functions may specify e.g. `COUNT(DISTINCT X) FILTER (WHERE ...)`
     pub filter: Option<Box<Expr<T>>>,

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -107,18 +107,18 @@ impl_display!(Ident);
 pub struct UnresolvedItemName(pub Vec<Ident>);
 
 pub enum CatalogName {
-    ObjectName(Vec<Ident>),
+    ItemName(Vec<Ident>),
     FuncName(Vec<Ident>),
 }
 
 impl UnresolvedItemName {
-    /// Creates an `ObjectName` with a single [`Ident`], i.e. it appears as
+    /// Creates an `ItemName` with a single [`Ident`], i.e. it appears as
     /// "unqualified".
     pub fn unqualified(n: &str) -> UnresolvedItemName {
         UnresolvedItemName(vec![Ident::new(n)])
     }
 
-    /// Creates an `ObjectName` with an [`Ident`] for each element of `n`.
+    /// Creates an `ItemName` with an [`Ident`] for each element of `n`.
     ///
     /// Panics if passed an in ineligible `&[&str]` whose length is 0 or greater
     /// than 3.

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -102,44 +102,40 @@ impl AstDisplay for Ident {
 }
 impl_display!(Ident);
 
-/// A name of a table, view, custom type, etc., possibly multi-part, i.e. db.schema.obj
-/// TODO(jkosh44) There still seems to be some confusion as to what the definition of "Object" is
-///  in the parser and planner. This struct is only used for items that live in a schema, which in
-///  other parts of the code we refer to as "Item" or "Entry". "Object" tends to include clusters,
-///  replicas, databases, and schemas, which have their own struct for names.
+/// A name of a table, view, custom type, etc. that lives in a schema, possibly multi-part, i.e. db.schema.obj
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct UnresolvedObjectName(pub Vec<Ident>);
+pub struct UnresolvedItemName(pub Vec<Ident>);
 
 pub enum CatalogName {
     ObjectName(Vec<Ident>),
     FuncName(Vec<Ident>),
 }
 
-impl UnresolvedObjectName {
+impl UnresolvedItemName {
     /// Creates an `ObjectName` with a single [`Ident`], i.e. it appears as
     /// "unqualified".
-    pub fn unqualified(n: &str) -> UnresolvedObjectName {
-        UnresolvedObjectName(vec![Ident::new(n)])
+    pub fn unqualified(n: &str) -> UnresolvedItemName {
+        UnresolvedItemName(vec![Ident::new(n)])
     }
 
     /// Creates an `ObjectName` with an [`Ident`] for each element of `n`.
     ///
     /// Panics if passed an in ineligible `&[&str]` whose length is 0 or greater
     /// than 3.
-    pub fn qualified(n: &[&str]) -> UnresolvedObjectName {
+    pub fn qualified(n: &[&str]) -> UnresolvedItemName {
         assert!(n.len() <= 3 && n.len() > 0);
-        UnresolvedObjectName(n.iter().map(|n| (*n).into()).collect::<Vec<_>>())
+        UnresolvedItemName(n.iter().map(|n| (*n).into()).collect::<Vec<_>>())
     }
 }
 
-impl AstDisplay for UnresolvedObjectName {
+impl AstDisplay for UnresolvedItemName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         display::separated(&self.0, ".").fmt(f);
     }
 }
-impl_display!(UnresolvedObjectName);
+impl_display!(UnresolvedItemName);
 
-impl AstDisplay for &UnresolvedObjectName {
+impl AstDisplay for &UnresolvedItemName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         display::separated(&self.0, ".").fmt(f);
     }
@@ -171,8 +167,8 @@ impl_display!(UnresolvedDatabaseName);
 // resolveable as an object name later.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum DeferredObjectName<T: AstInfo> {
-    Named(T::ObjectName),
-    Deferred(UnresolvedObjectName),
+    Named(T::ItemName),
+    Deferred(UnresolvedItemName),
 }
 
 impl<T: AstInfo> AstDisplay for DeferredObjectName<T> {
@@ -191,7 +187,7 @@ pub enum UnresolvedName {
     ClusterReplica(QualifiedReplica),
     Database(UnresolvedDatabaseName),
     Schema(UnresolvedSchemaName),
-    Item(UnresolvedObjectName),
+    Item(UnresolvedItemName),
 }
 
 impl AstDisplay for UnresolvedName {

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -163,23 +163,23 @@ impl AstDisplay for UnresolvedDatabaseName {
 }
 impl_display!(UnresolvedDatabaseName);
 
-// The name of an object not yet created during name resolution, which should be
-// resolveable as an object name later.
+// The name of an item not yet created during name resolution, which should be
+// resolveable as an item name later.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub enum DeferredObjectName<T: AstInfo> {
+pub enum DeferredItemName<T: AstInfo> {
     Named(T::ItemName),
     Deferred(UnresolvedItemName),
 }
 
-impl<T: AstInfo> AstDisplay for DeferredObjectName<T> {
+impl<T: AstInfo> AstDisplay for DeferredItemName<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            DeferredObjectName::Named(o) => f.write_node(o),
-            DeferredObjectName::Deferred(o) => f.write_node(o),
+            DeferredItemName::Named(o) => f.write_node(o),
+            DeferredItemName::Deferred(o) => f.write_node(o),
         }
     }
 }
-impl_display_t!(DeferredObjectName);
+impl_display_t!(DeferredItemName);
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum UnresolvedName {

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -24,7 +24,7 @@ use std::mem;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{
-    AstInfo, Expr, FunctionArgs, Ident, ShowStatement, UnresolvedObjectName, WithOptionValue,
+    AstInfo, Expr, FunctionArgs, Ident, ShowStatement, UnresolvedItemName, WithOptionValue,
 };
 
 /// The most complete variant of a `SELECT` query expression, optionally
@@ -484,7 +484,7 @@ impl<T: AstInfo> TableWithJoins<T> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum TableFactor<T: AstInfo> {
     Table {
-        name: T::ObjectName,
+        name: T::ItemName,
         alias: Option<TableAlias>,
     },
     Function {
@@ -584,7 +584,7 @@ impl_display_t!(TableFactor);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TableFunction<T: AstInfo> {
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     pub args: FunctionArgs<T>,
 }
 impl<T: AstInfo> AstDisplay for TableFunction<T> {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -29,7 +29,7 @@ use enum_kinds::EnumKind;
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{
     AstInfo, ColumnDef, CreateConnection, CreateSinkConnection, CreateSourceConnection,
-    CreateSourceFormat, CreateSourceOption, CreateSourceOptionName, DeferredObjectName, Envelope,
+    CreateSourceFormat, CreateSourceOption, CreateSourceOptionName, DeferredItemName, Envelope,
     Expr, Format, Ident, KeyConstraint, Query, SelectItem, SourceIncludeMetadata, TableAlias,
     TableConstraint, TableWithJoins, UnresolvedDatabaseName, UnresolvedName, UnresolvedItemName,
     UnresolvedSchemaName, Value,
@@ -568,7 +568,7 @@ pub struct CreateSourceStatement<T: AstInfo> {
     pub key_constraint: Option<KeyConstraint>,
     pub with_options: Vec<CreateSourceOption<T>>,
     pub referenced_subsources: Option<ReferencedSubsources<T>>,
-    pub progress_subsource: Option<DeferredObjectName<T>>,
+    pub progress_subsource: Option<DeferredItemName<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for CreateSourceStatement<T> {
@@ -631,7 +631,7 @@ impl_display_t!(CreateSourceStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateSourceSubsource<T: AstInfo> {
     pub reference: UnresolvedItemName,
-    pub subsource: Option<DeferredObjectName<T>>,
+    pub subsource: Option<DeferredItemName<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for CreateSourceSubsource<T> {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -31,7 +31,7 @@ use crate::ast::{
     AstInfo, ColumnDef, CreateConnection, CreateSinkConnection, CreateSourceConnection,
     CreateSourceFormat, CreateSourceOption, CreateSourceOptionName, DeferredItemName, Envelope,
     Expr, Format, Ident, KeyConstraint, Query, SelectItem, SourceIncludeMetadata, TableAlias,
-    TableConstraint, TableWithJoins, UnresolvedDatabaseName, UnresolvedName, UnresolvedItemName,
+    TableConstraint, TableWithJoins, UnresolvedDatabaseName, UnresolvedItemName, UnresolvedName,
     UnresolvedSchemaName, Value,
 };
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2373,8 +2373,8 @@ pub enum WithOptionValue<T: AstInfo> {
     Ident(Ident),
     DataType(T::DataType),
     Secret(T::ItemName),
-    Object(T::ItemName),
-    UnresolvedObjectName(UnresolvedItemName),
+    Item(T::ItemName),
+    UnresolvedItemName(UnresolvedItemName),
     Sequence(Vec<WithOptionValue<T>>),
     // Special cases.
     ClusterReplicas(Vec<ReplicaDefinition<T>>),
@@ -2396,8 +2396,8 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
                 f.write_str("SECRET ");
                 f.write_node(name)
             }
-            WithOptionValue::Object(obj) => f.write_node(obj),
-            WithOptionValue::UnresolvedObjectName(r) => f.write_node(r),
+            WithOptionValue::Item(obj) => f.write_node(obj),
+            WithOptionValue::UnresolvedItemName(r) => f.write_node(r),
             WithOptionValue::ClusterReplicas(replicas) => {
                 f.write_str("(");
                 f.write_node(&display::comma_separated(replicas));

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -31,7 +31,7 @@ use crate::ast::{
     AstInfo, ColumnDef, CreateConnection, CreateSinkConnection, CreateSourceConnection,
     CreateSourceFormat, CreateSourceOption, CreateSourceOptionName, DeferredObjectName, Envelope,
     Expr, Format, Ident, KeyConstraint, Query, SelectItem, SourceIncludeMetadata, TableAlias,
-    TableConstraint, TableWithJoins, UnresolvedDatabaseName, UnresolvedName, UnresolvedObjectName,
+    TableConstraint, TableWithJoins, UnresolvedDatabaseName, UnresolvedName, UnresolvedItemName,
     UnresolvedSchemaName, Value,
 };
 
@@ -184,7 +184,7 @@ impl_display_t!(SelectStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InsertStatement<T: AstInfo> {
     /// TABLE
-    pub table_name: T::ObjectName,
+    pub table_name: T::ItemName,
     /// COLUMNS
     pub columns: Vec<Ident>,
     /// A SQL query that specifies what to insert.
@@ -215,7 +215,7 @@ impl_display_t!(InsertStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CopyRelation<T: AstInfo> {
     Table {
-        name: T::ObjectName,
+        name: T::ItemName,
         columns: Vec<Ident>,
     },
     Select(SelectStatement<T>),
@@ -346,7 +346,7 @@ impl_display_t!(CopyStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UpdateStatement<T: AstInfo> {
     /// `FROM`
-    pub table_name: T::ObjectName,
+    pub table_name: T::ItemName,
     /// Column assignments
     pub assignments: Vec<Assignment<T>>,
     /// WHERE
@@ -373,7 +373,7 @@ impl_display_t!(UpdateStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DeleteStatement<T: AstInfo> {
     /// `FROM`
-    pub table_name: T::ObjectName,
+    pub table_name: T::ItemName,
     /// `AS`
     pub alias: Option<TableAlias>,
     /// `USING`
@@ -459,7 +459,7 @@ impl_display_t!(KafkaBroker);
 pub enum KafkaBrokerTunnel<T: AstInfo> {
     Direct,
     AwsPrivatelink(KafkaBrokerAwsPrivatelink<T>),
-    SshTunnel(T::ObjectName),
+    SshTunnel(T::ItemName),
 }
 
 impl<T: AstInfo> AstDisplay for KafkaBrokerTunnel<T> {
@@ -516,7 +516,7 @@ impl_display_t!(KafkaBrokerAwsPrivatelinkOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct KafkaBrokerAwsPrivatelink<T: AstInfo> {
-    pub connection: T::ObjectName,
+    pub connection: T::ItemName,
     pub options: Vec<KafkaBrokerAwsPrivatelinkOption<T>>,
 }
 
@@ -536,7 +536,7 @@ impl_display_t!(KafkaBrokerAwsPrivatelink);
 /// `CREATE CONNECTION`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateConnectionStatement<T: AstInfo> {
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     pub connection: CreateConnection<T>,
     pub if_not_exists: bool,
 }
@@ -557,7 +557,7 @@ impl_display_t!(CreateConnectionStatement);
 /// `CREATE SOURCE`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateSourceStatement<T: AstInfo> {
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     pub in_cluster: Option<T::ClusterName>,
     pub col_names: Vec<Ident>,
     pub connection: CreateSourceConnection<T>,
@@ -630,7 +630,7 @@ impl_display_t!(CreateSourceStatement);
 /// A selected subsource in a FOR TABLES (..) statement
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateSourceSubsource<T: AstInfo> {
-    pub reference: UnresolvedObjectName,
+    pub reference: UnresolvedItemName,
     pub subsource: Option<DeferredObjectName<T>>,
 }
 
@@ -706,7 +706,7 @@ impl<T: AstInfo> AstDisplay for CreateSubsourceOption<T> {
 /// `CREATE SUBSOURCE`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateSubsourceStatement<T: AstInfo> {
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     pub columns: Vec<ColumnDef<T>>,
     pub constraints: Vec<TableConstraint<T>>,
     pub if_not_exists: bool,
@@ -776,10 +776,10 @@ impl<T: AstInfo> AstDisplay for CreateSinkOption<T> {
 /// `CREATE SINK`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateSinkStatement<T: AstInfo> {
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     pub in_cluster: Option<T::ClusterName>,
     pub if_not_exists: bool,
-    pub from: T::ObjectName,
+    pub from: T::ItemName,
     pub connection: CreateSinkConnection<T>,
     pub format: Option<Format<T>>,
     pub envelope: Option<Envelope>,
@@ -822,7 +822,7 @@ impl_display_t!(CreateSinkStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ViewDefinition<T: AstInfo> {
     /// View name
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     pub columns: Vec<Ident>,
     pub query: Query<T>,
 }
@@ -877,7 +877,7 @@ impl_display_t!(CreateViewStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateMaterializedViewStatement<T: AstInfo> {
     pub if_exists: IfExistsBehavior,
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     pub columns: Vec<Ident>,
     pub in_cluster: Option<T::ClusterName>,
     pub query: Query<T>,
@@ -920,7 +920,7 @@ impl_display_t!(CreateMaterializedViewStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateTableStatement<T: AstInfo> {
     /// Table name
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     /// Optional schema
     pub columns: Vec<ColumnDef<T>>,
     pub constraints: Vec<TableConstraint<T>>,
@@ -957,7 +957,7 @@ pub struct CreateIndexStatement<T: AstInfo> {
     pub name: Option<Ident>,
     pub in_cluster: Option<T::ClusterName>,
     /// `ON` table or view name
-    pub on_name: T::ObjectName,
+    pub on_name: T::ItemName,
     /// Expressions that form part of the index key. If not included, the
     /// key_parts will be inferred from the named object.
     pub key_parts: Option<Vec<Expr<T>>>,
@@ -1104,7 +1104,7 @@ impl_display!(RoleAttribute);
 /// A `CREATE SECRET` statement.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateSecretStatement<T: AstInfo> {
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     pub if_not_exists: bool,
     pub value: Expr<T>,
 }
@@ -1126,7 +1126,7 @@ impl_display_t!(CreateSecretStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateTypeStatement<T: AstInfo> {
     /// Name of the created type.
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     /// The new type's "base type".
     pub as_type: CreateTypeAs<T>,
 }
@@ -1432,7 +1432,7 @@ impl_display_t!(AlterOwnerStatement);
 pub struct AlterObjectRenameStatement {
     pub object_type: ObjectType,
     pub if_exists: bool,
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     pub to_item_name: Ident,
 }
 
@@ -1460,7 +1460,7 @@ pub enum AlterIndexAction<T: AstInfo> {
 /// `ALTER INDEX ... {RESET, SET}`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlterIndexStatement<T: AstInfo> {
-    pub index_name: UnresolvedObjectName,
+    pub index_name: UnresolvedItemName,
     pub if_exists: bool,
     pub action: AlterIndexAction<T>,
 }
@@ -1499,7 +1499,7 @@ pub enum AlterSinkAction<T: AstInfo> {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlterSinkStatement<T: AstInfo> {
-    pub sink_name: UnresolvedObjectName,
+    pub sink_name: UnresolvedItemName,
     pub if_exists: bool,
     pub action: AlterSinkAction<T>,
 }
@@ -1536,7 +1536,7 @@ pub enum AlterSourceAction<T: AstInfo> {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlterSourceStatement<T: AstInfo> {
-    pub source_name: UnresolvedObjectName,
+    pub source_name: UnresolvedItemName,
     pub if_exists: bool,
     pub action: AlterSourceAction<T>,
 }
@@ -1570,7 +1570,7 @@ impl_display_t!(AlterSourceStatement);
 /// `ALTER SECRET ... AS`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlterSecretStatement<T: AstInfo> {
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     pub if_exists: bool,
     pub value: Expr<T>,
 }
@@ -1592,7 +1592,7 @@ impl_display_t!(AlterSecretStatement);
 /// `ALTER CONNECTION ... ROTATE KEYS`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlterConnectionStatement {
-    pub name: UnresolvedObjectName,
+    pub name: UnresolvedItemName,
     pub if_exists: bool,
 }
 
@@ -1713,7 +1713,7 @@ pub struct DropObjectsStatement {
     /// An optional `IF EXISTS` clause. (Non-standard.)
     pub if_exists: bool,
     /// One or more objects to drop. (ANSI SQL requires exactly one.)
-    pub names: Vec<UnresolvedObjectName>,
+    pub names: Vec<UnresolvedItemName>,
     /// Whether `CASCADE` was specified. This will be `false` when
     /// `RESTRICT` or no drop behavior at all was specified.
     pub cascade: bool,
@@ -1740,7 +1740,7 @@ pub struct DropRolesStatement {
     /// An optional `IF EXISTS` clause. (Non-standard.)
     pub if_exists: bool,
     /// One or more objects to drop. (ANSI SQL requires exactly one.)
-    pub names: Vec<UnresolvedObjectName>,
+    pub names: Vec<UnresolvedItemName>,
 }
 
 impl AstDisplay for DropRolesStatement {
@@ -1759,7 +1759,7 @@ pub struct DropClustersStatement {
     /// An optional `IF EXISTS` clause. (Non-standard.)
     pub if_exists: bool,
     /// One or more objects to drop. (ANSI SQL requires exactly one.)
-    pub names: Vec<UnresolvedObjectName>,
+    pub names: Vec<UnresolvedItemName>,
     /// Whether `CASCADE` was specified. This will be `false` when
     /// `RESTRICT` or no drop behavior at all was specified.
     pub cascade: bool,
@@ -1876,7 +1876,7 @@ pub enum ShowObjectType<T: AstInfo> {
     },
     Index {
         in_cluster: Option<T::ClusterName>,
-        on_object: Option<T::ObjectName>,
+        on_object: Option<T::ItemName>,
     },
     Table,
     View,
@@ -1972,7 +1972,7 @@ impl_display_t!(ShowObjectsStatement);
 /// Note: this is a MySQL-specific statement.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowColumnsStatement<T: AstInfo> {
-    pub table_name: T::ObjectName,
+    pub table_name: T::ItemName,
     pub filter: Option<ShowStatementFilter<T>>,
 }
 
@@ -1992,7 +1992,7 @@ impl_display_t!(ShowColumnsStatement);
 /// `SHOW CREATE VIEW <view>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateViewStatement<T: AstInfo> {
-    pub view_name: T::ObjectName,
+    pub view_name: T::ItemName,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateViewStatement<T> {
@@ -2006,7 +2006,7 @@ impl_display_t!(ShowCreateViewStatement);
 /// `SHOW CREATE MATERIALIZED VIEW <name>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateMaterializedViewStatement<T: AstInfo> {
-    pub materialized_view_name: T::ObjectName,
+    pub materialized_view_name: T::ItemName,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateMaterializedViewStatement<T> {
@@ -2020,7 +2020,7 @@ impl_display_t!(ShowCreateMaterializedViewStatement);
 /// `SHOW CREATE SOURCE <source>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateSourceStatement<T: AstInfo> {
-    pub source_name: T::ObjectName,
+    pub source_name: T::ItemName,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateSourceStatement<T> {
@@ -2034,7 +2034,7 @@ impl_display_t!(ShowCreateSourceStatement);
 /// `SHOW CREATE TABLE <table>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateTableStatement<T: AstInfo> {
-    pub table_name: T::ObjectName,
+    pub table_name: T::ItemName,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateTableStatement<T> {
@@ -2048,7 +2048,7 @@ impl_display_t!(ShowCreateTableStatement);
 /// `SHOW CREATE SINK <sink>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateSinkStatement<T: AstInfo> {
-    pub sink_name: T::ObjectName,
+    pub sink_name: T::ItemName,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateSinkStatement<T> {
@@ -2062,7 +2062,7 @@ impl_display_t!(ShowCreateSinkStatement);
 /// `SHOW CREATE INDEX <index>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateIndexStatement<T: AstInfo> {
-    pub index_name: T::ObjectName,
+    pub index_name: T::ItemName,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateIndexStatement<T> {
@@ -2075,7 +2075,7 @@ impl_display_t!(ShowCreateIndexStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateConnectionStatement<T: AstInfo> {
-    pub connection_name: T::ObjectName,
+    pub connection_name: T::ItemName,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateConnectionStatement<T> {
@@ -2216,7 +2216,7 @@ impl_display_t!(SubscribeStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SubscribeRelation<T: AstInfo> {
-    Name(T::ObjectName),
+    Name(T::ItemName),
     Query(Query<T>),
 }
 
@@ -2372,9 +2372,9 @@ pub enum WithOptionValue<T: AstInfo> {
     Value(Value),
     Ident(Ident),
     DataType(T::DataType),
-    Secret(T::ObjectName),
-    Object(T::ObjectName),
-    UnresolvedObjectName(UnresolvedObjectName),
+    Secret(T::ItemName),
+    Object(T::ItemName),
+    UnresolvedObjectName(UnresolvedItemName),
     Sequence(Vec<WithOptionValue<T>>),
     // Special cases.
     ClusterReplicas(Vec<ReplicaDefinition<T>>),
@@ -2582,8 +2582,8 @@ impl_display!(ExplainStage);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Explainee<T: AstInfo> {
-    View(T::ObjectName),
-    MaterializedView(T::ObjectName),
+    View(T::ItemName),
+    MaterializedView(T::ItemName),
     Query(Query<T>),
 }
 

--- a/src/sql-parser/src/ast/fold.rs
+++ b/src/sql-parser/src/ast/fold.rs
@@ -26,7 +26,7 @@
 //! by invoking the right folder method on each of its fields.
 //!
 //! ```
-//! # use mz_sql_parser::ast::{Expr, Function, FunctionArgs, UnresolvedObjectName, WindowSpec, Raw, AstInfo};
+//! # use mz_sql_parser::ast::{Expr, Function, FunctionArgs, UnresolvedItemName, WindowSpec, Raw, AstInfo};
 //! #
 //! pub trait Fold<T: AstInfo, T2: AstInfo> {
 //!     /* ... */
@@ -36,7 +36,7 @@
 //!     }
 //!
 //!     /* ... */
-//!     # fn fold_unresolved_object_name(&mut self, node: UnresolvedObjectName) -> UnresolvedObjectName;
+//!     # fn fold_unresolved_item_name(&mut self, node: UnresolvedItemName) -> UnresolvedItemName;
 //!     # fn fold_function_args(&mut self, node: FunctionArgs<T>) -> FunctionArgs<T2>;
 //!     # fn fold_expr(&mut self, node: Expr<T>) -> Expr<T2>;
 //!     # fn fold_window_spec(&mut self, node: WindowSpec<T>) -> WindowSpec<T2>;
@@ -47,7 +47,7 @@
 //!     F: Fold<T, T2> + ?Sized,
 //! {
 //!     Function {
-//!         name: folder.fold_unresolved_object_name(node.name),
+//!         name: folder.fold_unresolved_item_name(node.name),
 //!         args: folder.fold_function_args(node.args),
 //!         filter: node.filter.map(|filter| Box::new(folder.fold_expr(*filter))),
 //!         over: node.over.map(|over| folder.fold_window_spec(over)),

--- a/src/sql-parser/src/ast/visit.rs
+++ b/src/sql-parser/src/ast/visit.rs
@@ -26,7 +26,7 @@
 //! by invoking the right visitor method of each of its fields.
 //!
 //! ```
-//! # use mz_sql_parser::ast::{Expr, Function, FunctionArgs, UnresolvedObjectName, WindowSpec, Raw, AstInfo};
+//! # use mz_sql_parser::ast::{Expr, Function, FunctionArgs, UnresolvedItemName, WindowSpec, Raw, AstInfo};
 //! #
 //! pub trait Visit<'ast, T: AstInfo> {
 //!     /* ... */
@@ -36,7 +36,7 @@
 //!     }
 //!
 //!     /* ... */
-//!     # fn visit_unresolved_object_name(&mut self, node: &'ast UnresolvedObjectName);
+//!     # fn visit_unresolved_item_name(&mut self, node: &'ast UnresolvedItemName);
 //!     # fn visit_function_args(&mut self, node: &'ast FunctionArgs<T>);
 //!     # fn visit_expr(&mut self, node: &'ast Expr<T>);
 //!     # fn visit_window_spec(&mut self, node: &'ast WindowSpec<T>);
@@ -46,7 +46,7 @@
 //! where
 //!     V: Visit<'ast, T> + ?Sized,
 //! {
-//!     visitor.visit_unresolved_object_name(&node.name);
+//!     visitor.visit_unresolved_item_name(&node.name);
 //!     visitor.visit_function_args(&node.args);
 //!     if let Some(filter) = &node.filter {
 //!         visitor.visit_expr(&*filter);
@@ -105,7 +105,7 @@
 //! ```
 //! use std::error::Error;
 //!
-//! use mz_sql_parser::ast::{Ident, Raw, AstInfo, RawObjectName};
+//! use mz_sql_parser::ast::{Ident, Raw, AstInfo, RawItemName};
 //! use mz_sql_parser::ast::visit::{self, Visit};
 //!
 //! struct IdentCollector<'ast> {
@@ -117,9 +117,9 @@
 //!         self.idents.push(node);
 //!         visit::visit_ident(self, node);
 //!     }
-//!     fn visit_object_name(&mut self, name: &'ast <Raw as AstInfo>::ObjectName) {
+//!     fn visit_item_name(&mut self, name: &'ast <Raw as AstInfo>::ItemName) {
 //!         match name {
-//!             RawObjectName::Name(n) | RawObjectName::Id(_, n) => {
+//!             RawItemName::Name(n) | RawItemName::Id(_, n) => {
 //!                 for node in &n.0 {
 //!                     self.idents.push(node);
 //!                     visit::visit_ident(self, node);

--- a/src/sql-parser/src/ast/visit_mut.rs
+++ b/src/sql-parser/src/ast/visit_mut.rs
@@ -25,7 +25,7 @@
 //! invoking the right visitor method of each of its fields.
 //!
 //! ```
-//! # use mz_sql_parser::ast::{Expr, Function, FunctionArgs, UnresolvedObjectName, WindowSpec, AstInfo};
+//! # use mz_sql_parser::ast::{Expr, Function, FunctionArgs, UnresolvedItemName, WindowSpec, AstInfo};
 //! #
 //! pub trait VisitMut<'ast, T: AstInfo> {
 //!     /* ... */
@@ -35,7 +35,7 @@
 //!     }
 //!
 //!     /* ... */
-//!     # fn visit_unresolved_object_name_mut(&mut self, node: &'ast mut UnresolvedObjectName);
+//!     # fn visit_unresolved_item_name_mut(&mut self, node: &'ast mut UnresolvedItemName);
 //!     # fn visit_function_args_mut(&mut self, node: &'ast mut FunctionArgs<T>);
 //!     # fn visit_expr_mut(&mut self, node: &'ast mut Expr<T>);
 //!     # fn visit_window_spec_mut(&mut self, node: &'ast mut WindowSpec<T>);
@@ -45,7 +45,7 @@
 //! where
 //!     V: VisitMut<'ast, T> + ?Sized,
 //! {
-//!     visitor.visit_unresolved_object_name_mut(&mut node.name);
+//!     visitor.visit_unresolved_item_name_mut(&mut node.name);
 //!     visitor.visit_function_args_mut(&mut node.args);
 //!     if let Some(filter) = &mut node.filter {
 //!         visitor.visit_expr_mut(&mut *filter);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4378,10 +4378,10 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_deferred_object_name(&mut self) -> Result<DeferredObjectName<Raw>, ParserError> {
+    fn parse_deferred_object_name(&mut self) -> Result<DeferredItemName<Raw>, ParserError> {
         Ok(match self.parse_raw_name()? {
-            named @ RawItemName::Id(..) => DeferredObjectName::Named(named),
-            RawItemName::Name(name) => DeferredObjectName::Deferred(name),
+            named @ RawItemName::Id(..) => DeferredItemName::Named(named),
+            RawItemName::Name(name) => DeferredItemName::Deferred(name),
         })
     }
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2736,7 +2736,7 @@ impl<'a> Parser<'a> {
                         WithOptionValue::Sequence(
                             inner
                                 .into_iter()
-                                .map(WithOptionValue::UnresolvedObjectName)
+                                .map(WithOptionValue::UnresolvedItemName)
                                 .collect_vec(),
                         )
                     });
@@ -3529,7 +3529,7 @@ impl<'a> Parser<'a> {
 
     fn parse_object_option_value(&mut self) -> Result<WithOptionValue<Raw>, ParserError> {
         let _ = self.consume_token(&Token::Eq);
-        Ok(WithOptionValue::Object(self.parse_raw_name()?))
+        Ok(WithOptionValue::Item(self.parse_raw_name()?))
     }
 
     fn parse_optional_option_value(&mut self) -> Result<Option<WithOptionValue<Raw>>, ParserError> {

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -97,7 +97,7 @@ use mz_ore::fmt::FormatBuffer;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::visit::Visit;
 use mz_sql_parser::ast::visit_mut::{self, VisitMut};
-use mz_sql_parser::ast::{AstInfo, Expr, Ident, Raw, RawDataType, RawObjectName};
+use mz_sql_parser::ast::{AstInfo, Expr, Ident, Raw, RawDataType, RawItemName};
 use mz_sql_parser::parser::{
     self, parse_statements, parse_statements_with_limit, ParserError, MAX_STATEMENT_BATCH_SIZE,
 };
@@ -261,8 +261,8 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
         fn visit_ident(&mut self, ident: &'a Ident) {
             self.seen_idents.push(ident.as_str());
         }
-        fn visit_object_name(&mut self, object_name: &'a <Raw as AstInfo>::ObjectName) {
-            if let RawObjectName::Name(name) = object_name {
+        fn visit_object_name(&mut self, object_name: &'a <Raw as AstInfo>::ItemName) {
+            if let RawItemName::Name(name) = object_name {
                 for ident in &name.0 {
                     self.seen_idents.push(ident.as_str());
                 }

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -270,7 +270,7 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
         }
         fn visit_data_type(&mut self, data_type: &'a <Raw as AstInfo>::DataType) {
             if let RawDataType::Other { name, .. } = data_type {
-                self.visit_object_name(name)
+                self.visit_item_name(name)
             }
         }
     }

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -261,8 +261,8 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
         fn visit_ident(&mut self, ident: &'a Ident) {
             self.seen_idents.push(ident.as_str());
         }
-        fn visit_object_name(&mut self, object_name: &'a <Raw as AstInfo>::ItemName) {
-            if let RawItemName::Name(name) = object_name {
+        fn visit_item_name(&mut self, item_name: &'a <Raw as AstInfo>::ItemName) {
+            if let RawItemName::Name(name) = item_name {
                 for ident in &name.0 {
                     self.seen_idents.push(ident.as_str());
                 }

--- a/src/sql-parser/tests/testdata/alias
+++ b/src/sql-parser/tests/testdata/alias
@@ -67,4 +67,4 @@ SELECT year FROM year
 ----
 SELECT "year" FROM "year"
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("year")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("year")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("year")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("year")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -18,14 +18,14 @@ COPY t(a, b) FROM STDIN
 ----
 COPY t(a, b) FROM STDIN
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [Ident("a"), Ident("b")] }, direction: From, target: Stdin, options: [] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [Ident("a"), Ident("b")] }, direction: From, target: Stdin, options: [] })
 
 parse-statement
 COPY t FROM STDIN
 ----
 COPY t FROM STDIN
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [] })
 
 parse-statement
 COPY (select 1) TO STDOUT
@@ -39,28 +39,28 @@ COPY t(a, b) TO STDOUT
 ----
 COPY t(a, b) TO STDOUT
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [Ident("a"), Ident("b")] }, direction: To, target: Stdout, options: [] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [Ident("a"), Ident("b")] }, direction: To, target: Stdout, options: [] })
 
 parse-statement
 COPY t TO STDOUT WITH (FORMAT TEXT)
 ----
 COPY t TO STDOUT WITH (FORMAT = text)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Ident(Ident("text"))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Ident(Ident("text"))) }] })
 
 parse-statement
 COPY t FROM STDIN WITH (FORMAT CSV, DELIMITER '|')
 ----
 COPY t FROM STDIN WITH (FORMAT = csv, DELIMITER = '|')
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [CopyOption { name: Format, value: Some(Ident(Ident("csv"))) }, CopyOption { name: Delimiter, value: Some(Value(String("|"))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [CopyOption { name: Format, value: Some(Ident(Ident("csv"))) }, CopyOption { name: Delimiter, value: Some(Value(String("|"))) }] })
 
 parse-statement
 COPY t TO STDOUT (format = text)
 ----
 COPY t TO STDOUT WITH (FORMAT = text)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Ident(Ident("text"))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Ident(Ident("text"))) }] })
 
 parse-statement
 COPY t TO STDOUT ()

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -18,28 +18,28 @@ CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool)
 ----
 CREATE TYPE custom AS MAP ( KEY TYPE = text, VALUE TYPE = bool )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { options: [CreateTypeMapOption { name: KeyType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, CreateTypeMapOption { name: ValueType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("custom")]), as_type: Map { options: [CreateTypeMapOption { name: KeyType, value: Some(DataType(Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] })) }, CreateTypeMapOption { name: ValueType, value: Some(DataType(Other { name: Name(UnresolvedItemName([Ident("bool")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = custom_type)
 ----
 CREATE TYPE custom AS MAP ( KEY TYPE = text, VALUE TYPE = custom_type )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { options: [CreateTypeMapOption { name: KeyType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, CreateTypeMapOption { name: ValueType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("custom_type")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("custom")]), as_type: Map { options: [CreateTypeMapOption { name: KeyType, value: Some(DataType(Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] })) }, CreateTypeMapOption { name: ValueType, value: Some(DataType(Other { name: Name(UnresolvedItemName([Ident("custom_type")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (KEY TYPE = text)
 ----
 CREATE TYPE custom AS MAP ( KEY TYPE = text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { options: [CreateTypeMapOption { name: KeyType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("custom")]), as_type: Map { options: [CreateTypeMapOption { name: KeyType, value: Some(DataType(Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (VALUE TYPE = bool)
 ----
 CREATE TYPE custom AS MAP ( VALUE TYPE = bool )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { options: [CreateTypeMapOption { name: ValueType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("custom")]), as_type: Map { options: [CreateTypeMapOption { name: ValueType, value: Some(DataType(Other { name: Name(UnresolvedItemName([Ident("bool")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool, random_type=int)
@@ -60,63 +60,63 @@ CREATE TYPE custom AS LIST (ELEMENT TYPE=text)
 ----
 CREATE TYPE custom AS LIST ( ELEMENT TYPE = text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("custom")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS LIST (ELEMENT TYPE=x)
 ----
 CREATE TYPE custom AS LIST ( ELEMENT TYPE = x )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("x")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("custom")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedItemName([Ident("x")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS LIST (ELEMENT TYPE=_text)
 ----
 CREATE TYPE custom AS LIST ( ELEMENT TYPE = _text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("_text")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("custom")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedItemName([Ident("_text")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE schema.t2 AS LIST (ELEMENT TYPE=schema.t1)
 ----
 CREATE TYPE schema.t2 AS LIST ( ELEMENT TYPE = schema.t1 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("schema"), Ident("t2")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("schema"), Ident("t1")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("schema"), Ident("t2")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedItemName([Ident("schema"), Ident("t1")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE db2.schema2.t2 AS LIST (ELEMENT TYPE=db1.schema1.t1)
 ----
 CREATE TYPE db2.schema2.t2 AS LIST ( ELEMENT TYPE = db1.schema1.t1 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("db2"), Ident("schema2"), Ident("t2")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("db1"), Ident("schema1"), Ident("t1")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("db2"), Ident("schema2"), Ident("t2")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedItemName([Ident("db1"), Ident("schema1"), Ident("t1")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE numeric_list AS LIST (ELEMENT TYPE=numeric(100,100,100))
 ----
 CREATE TYPE numeric_list AS LIST ( ELEMENT TYPE = numeric(100, 100, 100) )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("numeric_list")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("numeric")])), typ_mod: [100, 100, 100] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("numeric_list")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedItemName([Ident("numeric")])), typ_mod: [100, 100, 100] })) }] } })
 
 parse-statement
 CREATE TYPE named_composite AS (a int, b text, c float8);
 ----
 CREATE TYPE named_composite AS ( a int4, b text, c float8 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("named_composite")]), as_type: Record { column_defs: [ColumnDef { name: Ident("a"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("b"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("named_composite")]), as_type: Record { column_defs: [ColumnDef { name: Ident("a"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("b"), data_type: Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }] } })
 
 parse-statement
 CREATE TYPE named_composite AS (a InT,     b text, c flOAt8   );
 ----
 CREATE TYPE named_composite AS ( a int4, b text, c float8 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("named_composite")]), as_type: Record { column_defs: [ColumnDef { name: Ident("a"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("b"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("named_composite")]), as_type: Record { column_defs: [ColumnDef { name: Ident("a"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("b"), data_type: Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }] } })
 
 parse-statement
 CREATE TYPE named_composite AS (a int, b other_type, c yet_another_type);
 ----
 CREATE TYPE named_composite AS ( a int4, b other_type, c yet_another_type )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("named_composite")]), as_type: Record { column_defs: [ColumnDef { name: Ident("a"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("b"), data_type: Other { name: Name(UnresolvedObjectName([Ident("other_type")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("yet_another_type")])), typ_mod: [] }, collation: None, options: [] }] } })
+CreateType(CreateTypeStatement { name: UnresolvedItemName([Ident("named_composite")]), as_type: Record { column_defs: [ColumnDef { name: Ident("a"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("b"), data_type: Other { name: Name(UnresolvedItemName([Ident("other_type")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("yet_another_type")])), typ_mod: [] }, collation: None, options: [] }] } })
 
 parse-statement
 CREATE ROLE arjun
@@ -207,35 +207,35 @@ DROP ROLE IF EXISTS usr
 ----
 DROP ROLE IF EXISTS usr
 =>
-DropRoles(DropRolesStatement { if_exists: true, names: [UnresolvedObjectName([Ident("usr")])] })
+DropRoles(DropRolesStatement { if_exists: true, names: [UnresolvedItemName([Ident("usr")])] })
 
 parse-statement
 DROP ROLE a, b, c
 ----
 DROP ROLE a, b, c
 =>
-DropRoles(DropRolesStatement { if_exists: false, names: [UnresolvedObjectName([Ident("a")]), UnresolvedObjectName([Ident("b")]), UnresolvedObjectName([Ident("c")])] })
+DropRoles(DropRolesStatement { if_exists: false, names: [UnresolvedItemName([Ident("a")]), UnresolvedItemName([Ident("b")]), UnresolvedItemName([Ident("c")])] })
 
 parse-statement
 DROP USER usr
 ----
 DROP ROLE usr
 =>
-DropRoles(DropRolesStatement { if_exists: false, names: [UnresolvedObjectName([Ident("usr")])] })
+DropRoles(DropRolesStatement { if_exists: false, names: [UnresolvedItemName([Ident("usr")])] })
 
 parse-statement
 CREATE TABLE "table_name" (col_name int)
 ----
 CREATE TABLE table_name (col_name int4)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("table_name")]), columns: [ColumnDef { name: Ident("col_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("table_name")]), columns: [ColumnDef { name: Ident("col_name"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE schema_name.table_name (col_name int)
 ----
 CREATE TABLE schema_name.table_name (col_name int4)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("schema_name"), Ident("table_name")]), columns: [ColumnDef { name: Ident("col_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("schema_name"), Ident("table_name")]), columns: [ColumnDef { name: Ident("col_name"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE "" (col_name int)

--- a/src/sql-parser/tests/testdata/cursor
+++ b/src/sql-parser/tests/testdata/cursor
@@ -18,14 +18,14 @@ DECLARE "c" CURSOR WITHOUT HOLD FOR SELECT * FROM t
 ----
 DECLARE c CURSOR FOR SELECT * FROM t
 =>
-Declare(DeclareStatement { name: Ident("c"), stmt: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }) })
+Declare(DeclareStatement { name: Ident("c"), stmt: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }) })
 
 parse-statement
 DECLARE c CURSOR FOR SUBSCRIBE t
 ----
 DECLARE c CURSOR FOR SUBSCRIBE t
 =>
-Declare(DeclareStatement { name: Ident("c"), stmt: Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("t")]))), options: [], as_of: None, up_to: None }) })
+Declare(DeclareStatement { name: Ident("c"), stmt: Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("t")]))), options: [], as_of: None, up_to: None }) })
 
 parse-statement
 CLOSE c

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -29,7 +29,7 @@ CREATE TABLE uk_cities (
 ----
 CREATE TABLE uk_cities (name varchar(100) NOT NULL, lat float8 NULL, lng float8, constrained int4 NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0), ref int4 REFERENCES othertable (a, b))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("uk_cities")]), columns: [ColumnDef { name: Ident("name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [100] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("lat"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }] }, ColumnDef { name: Ident("lng"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("constrained"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }, ColumnOptionDef { name: Some(Ident("pkey")), option: Unique { is_primary: true } }, ColumnOptionDef { name: None, option: NotNull }, ColumnOptionDef { name: None, option: Unique { is_primary: false } }, ColumnOptionDef { name: None, option: Check(Op { op: Op { namespace: [], op: ">" }, expr1: Identifier([Ident("constrained")]), expr2: Some(Value(Number("0"))) }) }] }, ColumnDef { name: Ident("ref"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: ForeignKey { foreign_table: UnresolvedObjectName([Ident("othertable")]), referred_columns: [Ident("a"), Ident("b")] } }] }], constraints: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("uk_cities")]), columns: [ColumnDef { name: Ident("name"), data_type: Other { name: Name(UnresolvedItemName([Ident("varchar")])), typ_mod: [100] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("lat"), data_type: Other { name: Name(UnresolvedItemName([Ident("float8")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }] }, ColumnDef { name: Ident("lng"), data_type: Other { name: Name(UnresolvedItemName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("constrained"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }, ColumnOptionDef { name: Some(Ident("pkey")), option: Unique { is_primary: true } }, ColumnOptionDef { name: None, option: NotNull }, ColumnOptionDef { name: None, option: Unique { is_primary: false } }, ColumnOptionDef { name: None, option: Check(Op { op: Op { namespace: [], op: ">" }, expr1: Identifier([Ident("constrained")]), expr2: Some(Value(Number("0"))) }) }] }, ColumnDef { name: Ident("ref"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: ForeignKey { foreign_table: UnresolvedItemName([Ident("othertable")]), referred_columns: [Ident("a"), Ident("b")] } }] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (a int NOT NULL GARBAGE)
@@ -50,7 +50,7 @@ CREATE TABLE types_table (char_col char, bpchar_col bpchar, text_col text, bool_
 ----
 CREATE TABLE types_table (char_col bpchar, bpchar_col bpchar, text_col text, bool_col bool, date_col date, time_col time, timestamp_col timestamp, uuid_col uuid, double_col float8)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("types_table")]), columns: [ColumnDef { name: Ident("char_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bpchar")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("bpchar_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bpchar")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("text_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("bool_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("date_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("date")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("time_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("time")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("timestamp_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("uuid_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("uuid")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("double_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("types_table")]), columns: [ColumnDef { name: Ident("char_col"), data_type: Other { name: Name(UnresolvedItemName([Ident("bpchar")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("bpchar_col"), data_type: Other { name: Name(UnresolvedItemName([Ident("bpchar")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("text_col"), data_type: Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("bool_col"), data_type: Other { name: Name(UnresolvedItemName([Ident("bool")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("date_col"), data_type: Other { name: Name(UnresolvedItemName([Ident("date")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("time_col"), data_type: Other { name: Name(UnresolvedItemName([Ident("time")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("timestamp_col"), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamp")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("uuid_col"), data_type: Other { name: Name(UnresolvedItemName([Ident("uuid")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("double_col"), data_type: Other { name: Name(UnresolvedItemName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t
@@ -64,14 +64,14 @@ CREATE TABLE t ()
 ----
 CREATE TABLE t ()
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [], constraints: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TEMP TABLE t ()
 ----
 CREATE TEMPORARY TABLE t ()
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [], constraints: [], if_not_exists: false, temporary: true })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [], constraints: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE foo (bar int,)
@@ -85,14 +85,14 @@ CREATE TABLE foo (bar int list)
 ----
 CREATE TABLE foo (bar int4 list)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }), collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }), collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (bar int list list)
 ----
 CREATE TABLE foo (bar int4 list list)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(List(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] })), collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(List(Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] })), collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE tab (foo int,
@@ -106,112 +106,112 @@ CREATE TABLE foo (id int, CONSTRAINT address_pkey PRIMARY KEY (address_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT address_pkey PRIMARY KEY (address_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("address_pkey")), columns: [Ident("address_id")], is_primary: true, nulls_not_distinct: false }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("address_pkey")), columns: [Ident("address_id")], is_primary: true, nulls_not_distinct: false }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT uk_task UNIQUE (report_date, task_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT uk_task UNIQUE (report_date, task_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false, nulls_not_distinct: false }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false, nulls_not_distinct: false }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT uk_task UNIQUE NULLS NOT DISTINCT (report_date, task_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT uk_task UNIQUE NULLS NOT DISTINCT (report_date, task_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false, nulls_not_distinct: true }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false, nulls_not_distinct: true }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: Some(Ident("customer_address_id_fkey")), columns: [Ident("address_id")], foreign_table: Name(UnresolvedObjectName([Ident("public"), Ident("address")])), referred_columns: [Ident("address_id")] }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: Some(Ident("customer_address_id_fkey")), columns: [Ident("address_id")], foreign_table: Name(UnresolvedItemName([Ident("public"), Ident("address")])), referred_columns: [Ident("address_id")] }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TEMPORARY TABLE foo (id int, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
 ----
 CREATE TEMPORARY TABLE foo (id int4, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: Some(Ident("ck")), expr: Op { op: Op { namespace: [], op: "<>" }, expr1: Function(Function { name: UnresolvedObjectName([Ident("rtrim")]), args: Args { args: [Function(Function { name: UnresolvedObjectName([Ident("ltrim")]), args: Args { args: [Identifier([Ident("ref_code")])], order_by: [] }, filter: None, over: None, distinct: false })], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(String(""))) } }], if_not_exists: false, temporary: true })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: Some(Ident("ck")), expr: Op { op: Op { namespace: [], op: "<>" }, expr1: Function(Function { name: UnresolvedItemName([Ident("rtrim")]), args: Args { args: [Function(Function { name: UnresolvedItemName([Ident("ltrim")]), args: Args { args: [Identifier([Ident("ref_code")])], order_by: [] }, filter: None, over: None, distinct: false })], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(String(""))) } }], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE foo (id int, PRIMARY KEY (foo, bar))
 ----
 CREATE TABLE foo (id int4, PRIMARY KEY (foo, bar))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("foo"), Ident("bar")], is_primary: true, nulls_not_distinct: false }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("foo"), Ident("bar")], is_primary: true, nulls_not_distinct: false }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, UNIQUE (id))
 ----
 CREATE TABLE foo (id int4, UNIQUE (id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false, nulls_not_distinct: false }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false, nulls_not_distinct: false }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar))
 ----
 CREATE TABLE foo (id int4, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: None, columns: [Ident("foo"), Ident("bar")], foreign_table: Name(UnresolvedObjectName([Ident("anothertable")])), referred_columns: [Ident("foo"), Ident("bar")] }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: None, columns: [Ident("foo"), Ident("bar")], foreign_table: Name(UnresolvedItemName([Ident("anothertable")])), referred_columns: [Ident("foo"), Ident("bar")] }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CHECK (end_date > start_date OR end_date IS NULL))
 ----
 CREATE TABLE foo (id int4, CHECK (end_date > start_date OR end_date IS NULL))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: Or { left: Op { op: Op { namespace: [], op: ">" }, expr1: Identifier([Ident("end_date")]), expr2: Some(Identifier([Ident("start_date")])) }, right: IsExpr { expr: Identifier([Ident("end_date")]), construct: Null, negated: false } } }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: Or { left: Op { op: Op { namespace: [], op: ">" }, expr1: Identifier([Ident("end_date")]), expr2: Some(Identifier([Ident("start_date")])) }, right: IsExpr { expr: Identifier([Ident("end_date")]), construct: Null, negated: false } } }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CHECK (end_date > start_date OR end_date IS UNKNOWN))
 ----
 CREATE TABLE foo (id int4, CHECK (end_date > start_date OR end_date IS UNKNOWN))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: Or { left: Op { op: Op { namespace: [], op: ">" }, expr1: Identifier([Ident("end_date")]), expr2: Some(Identifier([Ident("start_date")])) }, right: IsExpr { expr: Identifier([Ident("end_date")]), construct: Unknown, negated: false } } }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: Or { left: Op { op: Op { namespace: [], op: ">" }, expr1: Identifier([Ident("end_date")]), expr2: Some(Identifier([Ident("start_date")])) }, right: IsExpr { expr: Identifier([Ident("end_date")]), construct: Unknown, negated: false } } }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CHECK (start_date IS TRUE))
 ----
 CREATE TABLE foo (id int4, CHECK (start_date IS TRUE))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: IsExpr { expr: Identifier([Ident("start_date")]), construct: True, negated: false } }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: IsExpr { expr: Identifier([Ident("start_date")]), construct: True, negated: false } }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TEMP TABLE t (c schema.type)
 ----
 CREATE TEMPORARY TABLE t (c schema.type)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: true })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE t (c db.schema.type)
 ----
 CREATE TABLE t (c db.schema.type)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (c "db"."schema"."type")
 ----
 CREATE TABLE t (c db.schema.type)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (c something.db.schema.type)
 ----
 CREATE TABLE t (c something.db.schema.type)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("something"), Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("something"), Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TEMP TABLE t (c db.schema.type(0,1,100))
 ----
 CREATE TEMPORARY TABLE t (c db.schema.type(0, 1, 100))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [0, 1, 100] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: true })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [0, 1, 100] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE t (c time with time zone (0,1,100))
@@ -239,14 +239,14 @@ CREATE TABLE t (c "type"(1))
 ----
 CREATE TABLE t (c type(1))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("type")])), typ_mod: [1] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("type")])), typ_mod: [1] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (c "type"(1) list list)
 ----
 CREATE TABLE t (c type(1) list list)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: List(List(Other { name: Name(UnresolvedObjectName([Ident("type")])), typ_mod: [1] })), collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: List(List(Other { name: Name(UnresolvedItemName([Ident("type")])), typ_mod: [1] })), collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE DATABASE IF EXISTS foo
@@ -288,35 +288,35 @@ CREATE VIEW myschema.myview AS SELECT foo FROM bar
 ----
 CREATE VIEW myschema.myview AS SELECT foo FROM bar
 =>
-CreateView(CreateViewStatement { if_exists: Error, temporary: false, definition: ViewDefinition { name: UnresolvedObjectName([Ident("myschema"), Ident("myview")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
+CreateView(CreateViewStatement { if_exists: Error, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("myschema"), Ident("myview")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
 
 parse-statement
 CREATE TEMPORARY VIEW myview AS SELECT foo FROM bar
 ----
 CREATE TEMPORARY VIEW myview AS SELECT foo FROM bar
 =>
-CreateView(CreateViewStatement { if_exists: Error, temporary: true, definition: ViewDefinition { name: UnresolvedObjectName([Ident("myview")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
+CreateView(CreateViewStatement { if_exists: Error, temporary: true, definition: ViewDefinition { name: UnresolvedItemName([Ident("myview")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
 
 parse-statement
 CREATE TEMP VIEW myview AS SELECT foo FROM bar
 ----
 CREATE TEMPORARY VIEW myview AS SELECT foo FROM bar
 =>
-CreateView(CreateViewStatement { if_exists: Error, temporary: true, definition: ViewDefinition { name: UnresolvedObjectName([Ident("myview")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
+CreateView(CreateViewStatement { if_exists: Error, temporary: true, definition: ViewDefinition { name: UnresolvedItemName([Ident("myview")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
 
 parse-statement
 CREATE OR REPLACE VIEW v AS SELECT 1
 ----
 CREATE OR REPLACE VIEW v AS SELECT 1
 =>
-CreateView(CreateViewStatement { if_exists: Replace, temporary: false, definition: ViewDefinition { name: UnresolvedObjectName([Ident("v")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
+CreateView(CreateViewStatement { if_exists: Replace, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("v")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
 
 parse-statement
 CREATE VIEW IF NOT EXISTS v AS SELECT 1
 ----
 CREATE VIEW IF NOT EXISTS v AS SELECT 1
 =>
-CreateView(CreateViewStatement { if_exists: Skip, temporary: false, definition: ViewDefinition { name: UnresolvedObjectName([Ident("v")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
+CreateView(CreateViewStatement { if_exists: Skip, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("v")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
 
 parse-statement
 CREATE OR REPLACE VIEW IF NOT EXISTS v AS SELECT 1
@@ -330,91 +330,91 @@ CREATE VIEW v (has, cols) AS SELECT 1, 2
 ----
 CREATE VIEW v (has, cols) AS SELECT 1, 2
 =>
-CreateView(CreateViewStatement { if_exists: Error, temporary: false, definition: ViewDefinition { name: UnresolvedObjectName([Ident("v")]), columns: [Ident("has"), Ident("cols")], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }, Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
+CreateView(CreateViewStatement { if_exists: Error, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("v")]), columns: [Ident("has"), Ident("cols")], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }, Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
 
 parse-statement
 CREATE VIEW IF NOT EXISTS myschema.myview AS SELECT foo FROM bar
 ----
 CREATE VIEW IF NOT EXISTS myschema.myview AS SELECT foo FROM bar
 =>
-CreateView(CreateViewStatement { if_exists: Skip, temporary: false, definition: ViewDefinition { name: UnresolvedObjectName([Ident("myschema"), Ident("myview")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
+CreateView(CreateViewStatement { if_exists: Skip, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("myschema"), Ident("myview")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
 
 parse-statement
 CREATE MATERIALIZED VIEW myschema.myview AS SELECT foo FROM bar
 ----
 CREATE MATERIALIZED VIEW myschema.myview AS SELECT foo FROM bar
 =>
-CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedObjectName([Ident("myschema"), Ident("myview")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } })
+CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("myschema"), Ident("myview")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } })
 
 parse-statement
 CREATE OR REPLACE MATERIALIZED VIEW v AS SELECT 1
 ----
 CREATE OR REPLACE MATERIALIZED VIEW v AS SELECT 1
 =>
-CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Replace, name: UnresolvedObjectName([Ident("v")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } })
+CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Replace, name: UnresolvedItemName([Ident("v")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } })
 
 parse-statement
 CREATE MATERIALIZED VIEW IF NOT EXISTS v AS SELECT 1
 ----
 CREATE MATERIALIZED VIEW IF NOT EXISTS v AS SELECT 1
 =>
-CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Skip, name: UnresolvedObjectName([Ident("v")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } })
+CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Skip, name: UnresolvedItemName([Ident("v")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } })
 
 parse-statement
 CREATE MATERIALIZED VIEW v (has, cols) AS SELECT 1, 2
 ----
 CREATE MATERIALIZED VIEW v (has, cols) AS SELECT 1, 2
 =>
-CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedObjectName([Ident("v")]), columns: [Ident("has"), Ident("cols")], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }, Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } })
+CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("v")]), columns: [Ident("has"), Ident("cols")], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }, Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } })
 
 parse-statement
 CREATE MATERIALIZED VIEW v IN CLUSTER bar AS SELECT 1
 ----
 CREATE MATERIALIZED VIEW v IN CLUSTER bar AS SELECT 1
 =>
-CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedObjectName([Ident("v")]), columns: [], in_cluster: Some(Unresolved(Ident("bar"))), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } })
+CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("v")]), columns: [], in_cluster: Some(Unresolved(Ident("bar"))), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } })
 
 parse-statement
 CREATE MATERIALIZED VIEW v IN CLUSTER [1] AS SELECT 1
 ----
 CREATE MATERIALIZED VIEW v IN CLUSTER [1] AS SELECT 1
 =>
-CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedObjectName([Ident("v")]), columns: [], in_cluster: Some(Resolved("1")), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } })
+CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("v")]), columns: [], in_cluster: Some(Resolved("1")), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } })
 
 parse-statement
 CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES ('use1-az1', 'use1-az4'))
 ----
 CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME = 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES = ('use1-az1', 'use1-az4'))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("privatelinkconn")]), connection: AwsPrivatelink { with_options: [AwsPrivatelinkConnectionOption { name: ServiceName, value: Some(Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc"))) }, AwsPrivatelinkConnectionOption { name: AvailabilityZones, value: Some(Sequence([Value(String("use1-az1")), Value(String("use1-az4"))])) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("privatelinkconn")]), connection: AwsPrivatelink { with_options: [AwsPrivatelinkConnectionOption { name: ServiceName, value: Some(Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc"))) }, AwsPrivatelinkConnectionOption { name: AvailabilityZones, value: Some(Sequence([Value(String("use1-az1")), Value(String("use1-az4"))])) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CONNECTION privatelinkconn FOR AWS PRIVATELINK SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES ('use1-az1', 'use1-az4')
 ----
 CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME = 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES = ('use1-az1', 'use1-az4'))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("privatelinkconn")]), connection: AwsPrivatelink { with_options: [AwsPrivatelinkConnectionOption { name: ServiceName, value: Some(Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc"))) }, AwsPrivatelinkConnectionOption { name: AvailabilityZones, value: Some(Sequence([Value(String("use1-az1")), Value(String("use1-az4"))])) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("privatelinkconn")]), connection: AwsPrivatelink { with_options: [AwsPrivatelinkConnectionOption { name: ServiceName, value: Some(Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc"))) }, AwsPrivatelinkConnectionOption { name: AvailabilityZones, value: Some(Sequence([Value(String("use1-az1")), Value(String("use1-az4"))])) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CONNECTION pgconn FOR postgres HOST foo, PORT 1234, SSL CERTIFICATE AUTHORITY 'foo', SSH TUNNEL tun
 ----
 CREATE CONNECTION pgconn TO POSTGRES (HOST = foo, PORT = 1234, SSL CERTIFICATE AUTHORITY = 'foo', SSH TUNNEL = tun)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, PostgresConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, PostgresConnectionOption { name: SshTunnel, value: Some(Object(Name(UnresolvedObjectName([Ident("tun")])))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, PostgresConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, PostgresConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("tun")])))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK db.schema.item, PORT 1234)
 ----
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK = db.schema.item, PORT = 1234)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: AwsPrivatelink, value: Some(Object(Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("item")])))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK db.schema.item, PORT 1234, HOST foo)
 ----
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK = db.schema.item, PORT = 1234, HOST = foo)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: AwsPrivatelink, value: Some(Object(Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("item")])))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, PostgresConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, PostgresConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }] }, if_not_exists: false })
 
 
 parse-statement
@@ -422,42 +422,42 @@ CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red');
 ----
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (REPLICATION FACTOR = 7, RETENTION MS = 10000, RETENTION BYTES = 10000000000, TOPIC 'topic') FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (REPLICATION FACTOR = 7, RETENTION MS = 10000, RETENTION BYTES = 10000000000, TOPIC = 'topic') FORMAT BYTES
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: ReplicationFactor, value: Some(Value(Number("7"))) }, KafkaConfigOption { name: RetentionMs, value: Some(Value(Number("10000"))) }, KafkaConfigOption { name: RetentionBytes, value: Some(Value(Number("10000000000"))) }, KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [] })
+CreateSink(CreateSinkStatement { name: UnresolvedItemName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaConfigOption { name: ReplicationFactor, value: Some(Value(Number("7"))) }, KafkaConfigOption { name: RetentionMs, value: Some(Value(Number("10000"))) }, KafkaConfigOption { name: RetentionBytes, value: Some(Value(Number("10000000000"))) }, KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [] })
 
 parse-statement
 CREATE SOURCE psychic IN CLUSTER c FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red');
 ----
 CREATE SOURCE psychic IN CLUSTER c FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), in_cluster: Some(Unresolved(Ident("c"))), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: Some(Unresolved(Ident("c"))), col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') KEY (a, b) FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') KEY (a, b) FORMAT BYTES
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }) }, format: Some(Bytes), envelope: None, with_options: [] })
+CreateSink(CreateSinkStatement { name: UnresolvedItemName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }) }, format: Some(Bytes), envelope: None, with_options: [] })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') KEY (a, b) NOT ENFORCED FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') KEY (a, b) NOT ENFORCED FORMAT BYTES
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: true }) }, format: Some(Bytes), envelope: None, with_options: [] })
+CreateSink(CreateSinkStatement { name: UnresolvedItemName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: true }) }, format: Some(Bytes), envelope: None, with_options: [] })
 
 parse-statement
 CREATE SINK foo IN CLUSTER c FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') KEY (a, b) NOT ENFORCED FORMAT BYTES
 ----
 CREATE SINK foo IN CLUSTER c FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') KEY (a, b) NOT ENFORCED FORMAT BYTES
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: Some(Unresolved(Ident("c"))), if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: true }) }, format: Some(Bytes), envelope: None, with_options: [] })
+CreateSink(CreateSinkStatement { name: UnresolvedItemName([Ident("foo")]), in_cluster: Some(Unresolved(Ident("c"))), if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: true }) }, format: Some(Bytes), envelope: None, with_options: [] })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT BYTES) FORMAT BYTES
@@ -485,105 +485,105 @@ CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT BYTES 
 ----
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT BYTES WITH (SNAPSHOT = true)
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(true))) }] })
+CreateSink(CreateSinkStatement { name: UnresolvedItemName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(true))) }] })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT BYTES WITH (SNAPSHOT = false)
 ----
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT BYTES WITH (SNAPSHOT = false)
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(false))) }] })
+CreateSink(CreateSinkStatement { name: UnresolvedItemName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(false))) }] })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT BYTES WITH (SIZE = 'xlarge')
 ----
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT BYTES WITH (SIZE = 'xlarge')
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Size, value: Some(Value(String("xlarge"))) }] })
+CreateSink(CreateSinkStatement { name: UnresolvedItemName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Size, value: Some(Value(String("xlarge"))) }] })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT BYTES WITH (SIZE = 'xlarge', SNAPSHOT = true)
 ----
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT BYTES WITH (SIZE = 'xlarge', SNAPSHOT = true)
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Size, value: Some(Value(String("xlarge"))) }, CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(true))) }] })
+CreateSink(CreateSinkStatement { name: UnresolvedItemName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Size, value: Some(Value(String("xlarge"))) }, CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(true))) }] })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT BYTES WITH (SIZE = 'xlarge', SNAPSHOT = true)
 ----
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT BYTES WITH (SIZE = 'xlarge', SNAPSHOT = true)
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Size, value: Some(Value(String("xlarge"))) }, CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(true))) }] })
+CreateSink(CreateSinkStatement { name: UnresolvedItemName([Ident("foo")]), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Size, value: Some(Value(String("xlarge"))) }, CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(true))) }] })
 
 parse-statement
 CREATE INDEX foo ON myschema.bar (a, b)
 ----
 CREATE INDEX foo ON myschema.bar (a, b)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX foo ON myschema.bar USING arrangement (a, b)
 ----
 CREATE INDEX foo ON myschema.bar (a, b)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX foo ON myschema.bar (a, b) WITH (LOGICAL COMPACTION WINDOW = 0)
 ----
 CREATE INDEX foo ON myschema.bar (a, b) WITH (LOGICAL COMPACTION WINDOW = 0)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [IndexOption { name: LogicalCompactionWindow, value: Some(Value(Number("0"))) }], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [IndexOption { name: LogicalCompactionWindow, value: Some(Value(Number("0"))) }], if_not_exists: false })
 
 parse-statement
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
 ----
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("fizz")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("baz")])), key_parts: Some([Function(Function { name: UnresolvedObjectName([Ident("ascii")]), args: Args { args: [Identifier([Ident("x")])], order_by: [] }, filter: None, over: None, distinct: false }), IsExpr { expr: Identifier([Ident("a")]), construct: Null, negated: true }, Nested(Exists(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("y")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("boop")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("boop"), Ident("z")]), expr2: Some(Identifier([Ident("z")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None })), Identifier([Ident("delta")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("fizz")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("baz")])), key_parts: Some([Function(Function { name: UnresolvedItemName([Ident("ascii")]), args: Args { args: [Identifier([Ident("x")])], order_by: [] }, filter: None, over: None, distinct: false }), IsExpr { expr: Identifier([Ident("a")]), construct: Null, negated: true }, Nested(Exists(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("y")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("boop")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("boop"), Ident("z")]), expr2: Some(Identifier([Ident("z")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None })), Identifier([Ident("delta")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX ind ON tab ((col + 1))
 ----
 CREATE INDEX ind ON tab ((col + 1))
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("ind")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("tab")])), key_parts: Some([Nested(Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("col")]), expr2: Some(Value(Number("1"))) })]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("ind")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("tab")])), key_parts: Some([Nested(Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("col")]), expr2: Some(Value(Number("1"))) })]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX qualifiers ON no_parentheses (alpha.omega)
 ----
 CREATE INDEX qualifiers ON no_parentheses (alpha.omega)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("qualifiers")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("no_parentheses")])), key_parts: Some([Identifier([Ident("alpha"), Ident("omega")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("qualifiers")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("no_parentheses")])), key_parts: Some([Identifier([Ident("alpha"), Ident("omega")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX foo IN CLUSTER bar ON myschema.bar (a, b)
 ----
 CREATE INDEX foo IN CLUSTER bar ON myschema.bar (a, b)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: Some(Unresolved(Ident("bar"))), on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: Some(Unresolved(Ident("bar"))), on_name: Name(UnresolvedItemName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX foo IN CLUSTER [1] ON myschema.bar (a, b)
 ----
 CREATE INDEX foo IN CLUSTER [1] ON myschema.bar (a, b)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: Some(Resolved("1")), on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: Some(Resolved("1")), on_name: Name(UnresolvedItemName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE DEFAULT INDEX ON tab
 ----
 CREATE DEFAULT INDEX ON tab
 =>
-CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("tab")])), key_parts: None, with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedItemName([Ident("tab")])), key_parts: None, with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE DEFAULT INDEX IF NOT EXISTS ON tab
 ----
 CREATE DEFAULT INDEX IF NOT EXISTS ON tab
 =>
-CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("tab")])), key_parts: None, with_options: [], if_not_exists: true })
+CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedItemName([Ident("tab")])), key_parts: None, with_options: [], if_not_exists: true })
 
 parse-statement
 CREATE DEFAULT INDEX ON tab (a, b)
@@ -604,7 +604,7 @@ CREATE INDEX ON tab (a, b)
 ----
 CREATE INDEX ON tab (a, b)
 =>
-CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("tab")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedItemName([Ident("tab")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX IF NOT EXISTS ON tab (a, b)
@@ -695,14 +695,14 @@ DROP TABLE foo
 ----
 DROP TABLE foo
 =>
-DropObjects(DropObjectsStatement { object_type: Table, if_exists: false, names: [UnresolvedObjectName([Ident("foo")])], cascade: false })
+DropObjects(DropObjectsStatement { object_type: Table, if_exists: false, names: [UnresolvedItemName([Ident("foo")])], cascade: false })
 
 parse-statement
 DROP TABLE IF EXISTS foo, bar CASCADE
 ----
 DROP TABLE IF EXISTS foo, bar CASCADE
 =>
-DropObjects(DropObjectsStatement { object_type: Table, if_exists: true, names: [UnresolvedObjectName([Ident("foo")]), UnresolvedObjectName([Ident("bar")])], cascade: true })
+DropObjects(DropObjectsStatement { object_type: Table, if_exists: true, names: [UnresolvedItemName([Ident("foo")]), UnresolvedItemName([Ident("bar")])], cascade: true })
 
 parse-statement
 DROP TABLE
@@ -723,63 +723,63 @@ DROP VIEW myschema.myview
 ----
 DROP VIEW myschema.myview
 =>
-DropObjects(DropObjectsStatement { object_type: View, if_exists: false, names: [UnresolvedObjectName([Ident("myschema"), Ident("myview")])], cascade: false })
+DropObjects(DropObjectsStatement { object_type: View, if_exists: false, names: [UnresolvedItemName([Ident("myschema"), Ident("myview")])], cascade: false })
 
 parse-statement
 DROP MATERIALIZED VIEW myschema.myview
 ----
 DROP MATERIALIZED VIEW myschema.myview
 =>
-DropObjects(DropObjectsStatement { object_type: MaterializedView, if_exists: false, names: [UnresolvedObjectName([Ident("myschema"), Ident("myview")])], cascade: false })
+DropObjects(DropObjectsStatement { object_type: MaterializedView, if_exists: false, names: [UnresolvedItemName([Ident("myschema"), Ident("myview")])], cascade: false })
 
 parse-statement
 DROP SOURCE myschema.mydatasource
 ----
 DROP SOURCE myschema.mydatasource
 =>
-DropObjects(DropObjectsStatement { object_type: Source, if_exists: false, names: [UnresolvedObjectName([Ident("myschema"), Ident("mydatasource")])], cascade: false })
+DropObjects(DropObjectsStatement { object_type: Source, if_exists: false, names: [UnresolvedItemName([Ident("myschema"), Ident("mydatasource")])], cascade: false })
 
 parse-statement
 DROP INDEX IF EXISTS myschema.myindex
 ----
 DROP INDEX IF EXISTS myschema.myindex
 =>
-DropObjects(DropObjectsStatement { object_type: Index, if_exists: true, names: [UnresolvedObjectName([Ident("myschema"), Ident("myindex")])], cascade: false })
+DropObjects(DropObjectsStatement { object_type: Index, if_exists: true, names: [UnresolvedItemName([Ident("myschema"), Ident("myindex")])], cascade: false })
 
 parse-statement
 SUBSCRIBE foo.bar
 ----
 SUBSCRIBE foo.bar
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: None, up_to: None })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: None, up_to: None })
 
 parse-statement
 SUBSCRIBE TO foo.bar
 ----
 SUBSCRIBE foo.bar
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: None, up_to: None })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: None, up_to: None })
 
 parse-statement
 SUBSCRIBE foo.bar AS OF 123
 ----
 SUBSCRIBE foo.bar AS OF 123
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Value(Number("123")))), up_to: None })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Value(Number("123")))), up_to: None })
 
 parse-statement
 SUBSCRIBE foo.bar AS OF now()
 ----
 SUBSCRIBE foo.bar AS OF now()
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: None })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: None })
 
 parse-statement
 SUBSCRIBE foo.bar WITH (SNAPSHOT) AS OF now()
 ----
 SUBSCRIBE foo.bar WITH (SNAPSHOT) AS OF now()
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [SubscribeOption { name: Snapshot, value: None }], as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: None })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [SubscribeOption { name: Snapshot, value: None }], as_of: Some(At(Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: None })
 
 parse-statement
 SUBSCRIBE foo.bar WITH (SNAPSHOT = false, TIMESTAMPS) AS OF now()
@@ -793,28 +793,28 @@ SUBSCRIBE foo.bar WITH (SNAPSHOT false)
 ----
 SUBSCRIBE foo.bar WITH (SNAPSHOT = false)
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [SubscribeOption { name: Snapshot, value: Some(Value(Boolean(false))) }], as_of: None, up_to: None })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [SubscribeOption { name: Snapshot, value: Some(Value(Boolean(false))) }], as_of: None, up_to: None })
 
 parse-statement
 SUBSCRIBE (SELECT * FROM a)
 ----
 SUBSCRIBE (SELECT * FROM a)
 =>
-Subscribe(SubscribeStatement { relation: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: [], as_of: None, up_to: None })
+Subscribe(SubscribeStatement { relation: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: [], as_of: None, up_to: None })
 
 parse-statement
 SUBSCRIBE foo.bar AS OF now() UP TO now() + interval '1' day
 ----
 SUBSCRIBE foo.bar AS OF now() UP TO now() + INTERVAL '1' DAY
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: Some(Op { op: Op { namespace: [], op: "+" }, expr1: Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(Interval(IntervalValue { value: "1", precision_high: Year, precision_low: Day, fsec_max_precision: None }))) }) })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: Some(Op { op: Op { namespace: [], op: "+" }, expr1: Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(Interval(IntervalValue { value: "1", precision_high: Year, precision_low: Day, fsec_max_precision: None }))) }) })
 
 parse-statement
 SUBSCRIBE foo.bar UP TO now() + interval '1' day
 ----
 SUBSCRIBE foo.bar UP TO now() + INTERVAL '1' DAY
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: None, up_to: Some(Op { op: Op { namespace: [], op: "+" }, expr1: Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(Interval(IntervalValue { value: "1", precision_high: Year, precision_low: Day, fsec_max_precision: None }))) }) })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: None, up_to: Some(Op { op: Op { namespace: [], op: "+" }, expr1: Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(Interval(IntervalValue { value: "1", precision_high: Year, precision_low: Day, fsec_max_precision: None }))) }) })
 
 parse-statement
 CREATE TABLE public.customer (
@@ -928,14 +928,14 @@ ALTER SOURCE name SET (SIZE LARGE)
 ----
 ALTER SOURCE name SET (SIZE = large)
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }]) })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("name")]), if_exists: false, action: SetOptions([CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }]) })
 
 parse-statement
 ALTER SOURCE name RESET (SIZE)
 ----
 ALTER SOURCE name RESET (SIZE)
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: ResetOptions([Size]) })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("name")]), if_exists: false, action: ResetOptions([Size]) })
 
 
 parse-statement
@@ -964,21 +964,21 @@ ALTER SINK name SET (SIZE LARGE)
 ----
 ALTER SINK name SET (SIZE = large)
 =>
-AlterSink(AlterSinkStatement { sink_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([CreateSinkOption { name: Size, value: Some(Ident(Ident("large"))) }]) })
+AlterSink(AlterSinkStatement { sink_name: UnresolvedItemName([Ident("name")]), if_exists: false, action: SetOptions([CreateSinkOption { name: Size, value: Some(Ident(Ident("large"))) }]) })
 
 parse-statement
 ALTER SINK name RESET (SIZE)
 ----
 ALTER SINK name RESET (SIZE)
 =>
-AlterSink(AlterSinkStatement { sink_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: ResetOptions([Size]) })
+AlterSink(AlterSinkStatement { sink_name: UnresolvedItemName([Ident("name")]), if_exists: false, action: ResetOptions([Size]) })
 
 parse-statement
 ALTER INDEX name RENAME TO name2
 ----
 ALTER INDEX name RENAME TO name2
 =>
-AlterObjectRename(AlterObjectRenameStatement { object_type: Index, if_exists: false, name: UnresolvedObjectName([Ident("name")]), to_item_name: Ident("name2") })
+AlterObjectRename(AlterObjectRenameStatement { object_type: Index, if_exists: false, name: UnresolvedItemName([Ident("name")]), to_item_name: Ident("name2") })
 
 parse-statement
 ALTER INDEX i1 misplaced
@@ -999,14 +999,14 @@ ALTER VIEW name RENAME TO name2
 ----
 ALTER VIEW name RENAME TO name2
 =>
-AlterObjectRename(AlterObjectRenameStatement { object_type: View, if_exists: false, name: UnresolvedObjectName([Ident("name")]), to_item_name: Ident("name2") })
+AlterObjectRename(AlterObjectRenameStatement { object_type: View, if_exists: false, name: UnresolvedItemName([Ident("name")]), to_item_name: Ident("name2") })
 
 parse-statement
 ALTER MATERIALIZED VIEW name RENAME TO name2
 ----
 ALTER MATERIALIZED VIEW name RENAME TO name2
 =>
-AlterObjectRename(AlterObjectRenameStatement { object_type: MaterializedView, if_exists: false, name: UnresolvedObjectName([Ident("name")]), to_item_name: Ident("name2") })
+AlterObjectRename(AlterObjectRenameStatement { object_type: MaterializedView, if_exists: false, name: UnresolvedItemName([Ident("name")]), to_item_name: Ident("name2") })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS ()
@@ -1154,21 +1154,21 @@ DROP CLUSTER cluster
 ----
 DROP CLUSTER cluster
 =>
-DropClusters(DropClustersStatement { if_exists: false, names: [UnresolvedObjectName([Ident("cluster")])], cascade: false })
+DropClusters(DropClustersStatement { if_exists: false, names: [UnresolvedItemName([Ident("cluster")])], cascade: false })
 
 parse-statement
 DROP CLUSTER IF EXISTS cluster
 ----
 DROP CLUSTER IF EXISTS cluster
 =>
-DropClusters(DropClustersStatement { if_exists: true, names: [UnresolvedObjectName([Ident("cluster")])], cascade: false })
+DropClusters(DropClustersStatement { if_exists: true, names: [UnresolvedItemName([Ident("cluster")])], cascade: false })
 
 parse-statement
 DROP CLUSTER IF EXISTS cluster RESTRICT
 ----
 DROP CLUSTER IF EXISTS cluster
 =>
-DropClusters(DropClustersStatement { if_exists: true, names: [UnresolvedObjectName([Ident("cluster")])], cascade: false })
+DropClusters(DropClustersStatement { if_exists: true, names: [UnresolvedItemName([Ident("cluster")])], cascade: false })
 
 parse-statement
 DROP CLUSTER REPLICA r1, r2
@@ -1196,35 +1196,35 @@ DROP CLUSTER IF EXISTS cluster CASCADE
 ----
 DROP CLUSTER IF EXISTS cluster CASCADE
 =>
-DropClusters(DropClustersStatement { if_exists: true, names: [UnresolvedObjectName([Ident("cluster")])], cascade: true })
+DropClusters(DropClustersStatement { if_exists: true, names: [UnresolvedItemName([Ident("cluster")])], cascade: true })
 
 parse-statement
 CREATE SECRET secret AS decode('c2VjcmV0Cg==', 'base64')
 ----
 CREATE SECRET secret AS decode('c2VjcmV0Cg==', 'base64')
 =>
-CreateSecret(CreateSecretStatement { name: UnresolvedObjectName([Ident("secret")]), if_not_exists: false, value: Function(Function { name: UnresolvedObjectName([Ident("decode")]), args: Args { args: [Value(String("c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
+CreateSecret(CreateSecretStatement { name: UnresolvedItemName([Ident("secret")]), if_not_exists: false, value: Function(Function { name: UnresolvedItemName([Ident("decode")]), args: Args { args: [Value(String("c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
 
 parse-statement
 CREATE SECRET IF NOT EXISTS secret AS decode('c2VjcmV0Cg==', 'base64')
 ----
 CREATE SECRET IF NOT EXISTS secret AS decode('c2VjcmV0Cg==', 'base64')
 =>
-CreateSecret(CreateSecretStatement { name: UnresolvedObjectName([Ident("secret")]), if_not_exists: true, value: Function(Function { name: UnresolvedObjectName([Ident("decode")]), args: Args { args: [Value(String("c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
+CreateSecret(CreateSecretStatement { name: UnresolvedItemName([Ident("secret")]), if_not_exists: true, value: Function(Function { name: UnresolvedItemName([Ident("decode")]), args: Args { args: [Value(String("c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
 
 parse-statement
 DROP SECRET secret
 ----
 DROP SECRET secret
 =>
-DropObjects(DropObjectsStatement { object_type: Secret, if_exists: false, names: [UnresolvedObjectName([Ident("secret")])], cascade: false })
+DropObjects(DropObjectsStatement { object_type: Secret, if_exists: false, names: [UnresolvedItemName([Ident("secret")])], cascade: false })
 
 parse-statement
 DROP SECRET IF EXISTS secret
 ----
 DROP SECRET IF EXISTS secret
 =>
-DropObjects(DropObjectsStatement { object_type: Secret, if_exists: true, names: [UnresolvedObjectName([Ident("secret")])], cascade: false })
+DropObjects(DropObjectsStatement { object_type: Secret, if_exists: true, names: [UnresolvedItemName([Ident("secret")])], cascade: false })
 
 parse-statement
 SHOW SECRETS
@@ -1238,21 +1238,21 @@ ALTER SECRET secret RENAME TO secret2
 ----
 ALTER SECRET secret RENAME TO secret2
 =>
-AlterObjectRename(AlterObjectRenameStatement { object_type: Secret, if_exists: false, name: UnresolvedObjectName([Ident("secret")]), to_item_name: Ident("secret2") })
+AlterObjectRename(AlterObjectRenameStatement { object_type: Secret, if_exists: false, name: UnresolvedItemName([Ident("secret")]), to_item_name: Ident("secret2") })
 
 parse-statement
 ALTER SECRET secret AS decode('new c2VjcmV0Cg==', 'base64')
 ----
 ALTER SECRET secret AS decode('new c2VjcmV0Cg==', 'base64')
 =>
-AlterSecret(AlterSecretStatement { name: UnresolvedObjectName([Ident("secret")]), if_exists: false, value: Function(Function { name: UnresolvedObjectName([Ident("decode")]), args: Args { args: [Value(String("new c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
+AlterSecret(AlterSecretStatement { name: UnresolvedItemName([Ident("secret")]), if_exists: false, value: Function(Function { name: UnresolvedItemName([Ident("decode")]), args: Args { args: [Value(String("new c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
 
 parse-statement
 CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux';
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKER = 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: Direct })) }, KafkaConnectionOption { name: SslKey, value: Some(Value(String("foo"))) }, KafkaConnectionOption { name: SslCertificate, value: Some(Value(String("qux"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: Direct })) }, KafkaConnectionOption { name: SslKey, value: Some(Value(String("foo"))) }, KafkaConnectionOption { name: SslCertificate, value: Some(Value(String("qux"))) }] }, if_not_exists: false })
 
 parse-statement roundtrip
 CREATE CONNECTION conn1 TO KAFKA (BROKER 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux');
@@ -1264,21 +1264,21 @@ CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234', PROGRESS TOPIC 'my-materi
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKER = 'kafka:1234', PROGRESS TOPIC = 'my-materialize-progress-topic')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: Direct })) }, KafkaConnectionOption { name: ProgressTopic, value: Some(Value(String("my-materialize-progress-topic"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: Direct })) }, KafkaConnectionOption { name: ProgressTopic, value: Some(Value(String("my-materialize-progress-topic"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CONNECTION conn1 TO KAFKA (BROKER 'kafka:1234' USING AWS PRIVATELINK aws.privatelink.c1);
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKER = 'kafka:1234' USING AWS PRIVATELINK aws.privatelink.c1)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedObjectName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CONNECTION conn1 TO KAFKA (BROKER 'kafka:1234' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9093));
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKER = 'kafka:1234' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9093))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedObjectName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) })) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) })) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CONNECTION conn1 TO KAFKA (
@@ -1291,7 +1291,7 @@ CREATE CONNECTION conn1 TO KAFKA (
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKERS = ('kafka:9092' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9092), 'kafka:9093' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9093), 'kafka:9094' USING AWS PRIVATELINK aws.privatelink.c1))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedObjectName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9092"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedObjectName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9094", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedObjectName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })])) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9092"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9094", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })])) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CONNECTION conn1 TO KAFKA (
@@ -1304,7 +1304,7 @@ CREATE CONNECTION conn1 TO KAFKA (
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKERS = ('kafka:9092' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9092), 'kafka:9093' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9093), 'kafka:9094' USING AWS PRIVATELINK aws.privatelink.c1))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedObjectName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9092"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedObjectName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9094", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedObjectName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })])) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9092"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9094", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })])) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CONNECTION conn1 TO KAFKA (
@@ -1327,28 +1327,28 @@ CREATE CONNECTION conn1 TO KAFKA (
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKERS = ('kafka:9092'USING SSH TUNNEL tunn, 'kafka:9093'USING SSH TUNNEL tunn))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: SshTunnel(Name(UnresolvedObjectName([Ident("tunn")]))) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: SshTunnel(Name(UnresolvedObjectName([Ident("tunn")]))) })])) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: SshTunnel(Name(UnresolvedItemName([Ident("tunn")]))) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: SshTunnel(Name(UnresolvedItemName([Ident("tunn")]))) })])) }] }, if_not_exists: false })
 
 parse-statement
 DROP CONNECTION conn1
 ----
 DROP CONNECTION conn1
 =>
-DropObjects(DropObjectsStatement { object_type: Connection, if_exists: false, names: [UnresolvedObjectName([Ident("conn1")])], cascade: false })
+DropObjects(DropObjectsStatement { object_type: Connection, if_exists: false, names: [UnresolvedItemName([Ident("conn1")])], cascade: false })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT BYTES
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY URL 'http://localhost:8081', USERNAME 'user', PASSWORD 'word'
 ----
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (URL = 'http://localhost:8081', USERNAME = 'user', PASSWORD = 'word')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }, CsrConnectionOption { name: Username, value: Some(Value(String("user"))) }, CsrConnectionOption { name: Password, value: Some(Value(String("word"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }, CsrConnectionOption { name: Username, value: Some(Value(String("user"))) }, CsrConnectionOption { name: Password, value: Some(Value(String("word"))) }] }, if_not_exists: false })
 
 parse-statement roundtrip
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (URL = 'http://localhost:8081', USERNAME = 'user', PASSWORD = 'word')
@@ -1361,14 +1361,14 @@ CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (AWS PRIVATELINK db.schema.
 ----
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (AWS PRIVATELINK = db.schema.item, PORT = 8080)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: AwsPrivatelink, value: Some(Object(Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("item")])))) }, CsrConnectionOption { name: Port, value: Some(Value(Number("8080"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, CsrConnectionOption { name: Port, value: Some(Value(Number("8080"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (SSH TUNNEL ssh)
 ----
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (SSH TUNNEL = ssh)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: SshTunnel, value: Some(Object(Name(UnresolvedObjectName([Ident("ssh")])))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("ssh")])))) }] }, if_not_exists: false })
 
 
 parse-statement
@@ -1376,7 +1376,7 @@ CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (AWS PRIVATELINK db.schema.
 ----
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (AWS PRIVATELINK = db.schema.item, PORT = 8080, URL = 'http://localhost:8081')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: AwsPrivatelink, value: Some(Object(Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("item")])))) }, CsrConnectionOption { name: Port, value: Some(Value(Number("8080"))) }, CsrConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, CsrConnectionOption { name: Port, value: Some(Value(Number("8080"))) }, CsrConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }] }, if_not_exists: false })
 
 
 parse-statement
@@ -1384,7 +1384,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT AVRO USING C
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), include_metadata: [], format: Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedObjectName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } })), envelope: Some(Debezium(Plain)), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), include_metadata: [], format: Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } })), envelope: Some(Debezium(Plain)), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 
 parse-statement
@@ -1392,7 +1392,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT PROTOBUF USI
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), include_metadata: [], format: Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedObjectName([Ident("conn2")])), options: [] }, seed: None } })), envelope: Some(Debezium(Plain)), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), include_metadata: [], format: Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, seed: None } })), envelope: Some(Debezium(Plain)), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
@@ -1436,7 +1436,7 @@ CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST 'ssh-bastion', PORT 1234, US
 ----
 CREATE CONNECTION my_ssh_tunnel TO SSH TUNNEL (HOST = 'ssh-bastion', PORT = 1234, USER = 'blah')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("my_ssh_tunnel")]), connection: Ssh { with_options: [SshConnectionOption { name: Host, value: Some(Value(String("ssh-bastion"))) }, SshConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, SshConnectionOption { name: User, value: Some(Value(String("blah"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("my_ssh_tunnel")]), connection: Ssh { with_options: [SshConnectionOption { name: Host, value: Some(Value(String("ssh-bastion"))) }, SshConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, SshConnectionOption { name: User, value: Some(Value(String("blah"))) }] }, if_not_exists: false })
 
 parse-statement roundtrip
 CREATE CONNECTION my_ssh_tunnel TO SSH TUNNEL (HOST 'ssh-bastion', PORT 1234, USER 'blah')
@@ -1448,21 +1448,21 @@ CREATE SOURCE lg FROM LOAD GENERATOR COUNTER
 ----
 CREATE SOURCE lg FROM LOAD GENERATOR COUNTER
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE lg FROM LOAD GENERATOR COUNTER (TICK INTERVAL '1s')
 ----
 CREATE SOURCE lg FROM LOAD GENERATOR COUNTER (TICK INTERVAL = '1s')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1s"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1s"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red') with (SIZE 'small');
 ----
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') WITH (SIZE = 'small')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 ALTER SYSTEM SET wal_level TO logical
@@ -1588,28 +1588,28 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FO
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR ALL TABLES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR ALL TABLES WITH (SIZE = 'small');
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR ALL TABLES WITH (SIZE = 'small')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(All), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(All), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (TEXT COLUMNS = [foo, foo.bar, foo.bar.qux, foo.bar.qux.qax, foo.bar.qux.qax.baz]) FOR ALL TABLES WITH (SIZE = 'small');
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (TEXT COLUMNS = (foo, foo.bar, foo.bar.qux, foo.bar.qux.qax, foo.bar.qux.qax.baz)) FOR ALL TABLES WITH (SIZE = 'small')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pg")])), options: [PgConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedObjectName(UnresolvedObjectName([Ident("foo")])), UnresolvedObjectName(UnresolvedObjectName([Ident("foo"), Ident("bar")])), UnresolvedObjectName(UnresolvedObjectName([Ident("foo"), Ident("bar"), Ident("qux")])), UnresolvedObjectName(UnresolvedObjectName([Ident("foo"), Ident("bar"), Ident("qux"), Ident("qax")])), UnresolvedObjectName(UnresolvedObjectName([Ident("foo"), Ident("bar"), Ident("qux"), Ident("qax"), Ident("baz")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(All), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("foo")])), UnresolvedItemName(UnresolvedItemName([Ident("foo"), Ident("bar")])), UnresolvedItemName(UnresolvedItemName([Ident("foo"), Ident("bar"), Ident("qux")])), UnresolvedItemName(UnresolvedItemName([Ident("foo"), Ident("bar"), Ident("qux"), Ident("qax")])), UnresolvedItemName(UnresolvedItemName([Ident("foo"), Ident("bar"), Ident("qux"), Ident("qax"), Ident("baz")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(All), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES (foo, bar as qux, baz into zop) WITH (SIZE = 'small');
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR TABLES (foo, bar AS qux, baz AS zop) WITH (SIZE = 'small')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(Subset([CreateSourceSubsource { reference: UnresolvedObjectName([Ident("foo")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedObjectName([Ident("bar")]), subsource: Some(Deferred(UnresolvedObjectName([Ident("qux")]))) }, CreateSourceSubsource { reference: UnresolvedObjectName([Ident("baz")]), subsource: Some(Deferred(UnresolvedObjectName([Ident("zop")]))) }])), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(Subset([CreateSourceSubsource { reference: UnresolvedItemName([Ident("foo")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("bar")]), subsource: Some(Deferred(UnresolvedItemName([Ident("qux")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(Deferred(UnresolvedItemName([Ident("zop")]))) }])), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES ([s1 AS foo.bar]) WITH (SIZE = 'small');
@@ -1623,7 +1623,7 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FO
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR TABLES (baz AS [s1 AS foo.bar]) WITH (SIZE = 'small')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(Subset([CreateSourceSubsource { reference: UnresolvedObjectName([Ident("baz")]), subsource: Some(Named(Id("s1", UnresolvedObjectName([Ident("foo"), Ident("bar")])))) }])), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(Subset([CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(Named(Id("s1", UnresolvedItemName([Ident("foo"), Ident("bar")])))) }])), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES ([s1 AS foo.bar] AS baz) WITH (SIZE = 'small');
@@ -1644,7 +1644,7 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FO
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR ALL TABLES EXPOSE PROGRESS AS foo.bar WITH (SIZE = 'small')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(All), progress_subsource: Some(Deferred(UnresolvedObjectName([Ident("foo"), Ident("bar")]))) })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(All), progress_subsource: Some(Deferred(UnresolvedItemName([Ident("foo"), Ident("bar")]))) })
 
 parse-statement
 GRANT admin TO joe
@@ -1777,109 +1777,109 @@ ALTER TABLE foo OWNER TO joe
 ----
 ALTER TABLE foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: Table, if_exists: false, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: Table, if_exists: false, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER TABLE IF EXISTS foo OWNER TO joe
 ----
 ALTER TABLE IF EXISTS foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: Table, if_exists: true, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: Table, if_exists: true, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER SINK foo OWNER TO joe
 ----
 ALTER SINK foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: Sink, if_exists: false, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: Sink, if_exists: false, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER SINK IF EXISTS foo OWNER TO joe
 ----
 ALTER SINK IF EXISTS foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: Sink, if_exists: true, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: Sink, if_exists: true, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER SOURCE foo OWNER TO joe
 ----
 ALTER SOURCE foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: Source, if_exists: false, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: Source, if_exists: false, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER SOURCE IF EXISTS foo OWNER TO joe
 ----
 ALTER SOURCE IF EXISTS foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: Source, if_exists: true, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: Source, if_exists: true, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER INDEX foo OWNER TO joe
 ----
 ALTER INDEX foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: Index, if_exists: false, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: Index, if_exists: false, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER INDEX IF EXISTS foo OWNER TO joe
 ----
 ALTER INDEX IF EXISTS foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: Index, if_exists: true, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: Index, if_exists: true, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER SECRET foo OWNER TO joe
 ----
 ALTER SECRET foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: Secret, if_exists: false, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: Secret, if_exists: false, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER SECRET IF EXISTS foo OWNER TO joe
 ----
 ALTER SECRET IF EXISTS foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: Secret, if_exists: true, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: Secret, if_exists: true, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER CONNECTION foo OWNER TO joe
 ----
 ALTER CONNECTION foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: Connection, if_exists: false, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: Connection, if_exists: false, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER CONNECTION IF EXISTS foo OWNER TO joe
 ----
 ALTER CONNECTION IF EXISTS foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: Connection, if_exists: true, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: Connection, if_exists: true, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER VIEW foo OWNER TO joe
 ----
 ALTER VIEW foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: View, if_exists: false, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: View, if_exists: false, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER VIEW IF EXISTS foo OWNER TO joe
 ----
 ALTER VIEW IF EXISTS foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: View, if_exists: true, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: View, if_exists: true, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER MATERIALIZED VIEW foo OWNER TO joe
 ----
 ALTER MATERIALIZED VIEW foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: MaterializedView, if_exists: false, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: MaterializedView, if_exists: false, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })
 
 parse-statement
 ALTER MATERIALIZED VIEW IF EXISTS foo OWNER TO joe
 ----
 ALTER MATERIALIZED VIEW IF EXISTS foo OWNER TO joe
 =>
-AlterOwner(AlterOwnerStatement { object_type: MaterializedView, if_exists: true, name: Item(UnresolvedObjectName([Ident("foo")])), new_owner: Ident("joe") })
+AlterOwner(AlterOwnerStatement { object_type: MaterializedView, if_exists: true, name: Item(UnresolvedItemName([Ident("foo")])), new_owner: Ident("joe") })

--- a/src/sql-parser/tests/testdata/delete
+++ b/src/sql-parser/tests/testdata/delete
@@ -28,7 +28,7 @@ DELETE FROM table
 ----
 DELETE FROM table
 =>
-Delete(DeleteStatement { table_name: Name(UnresolvedObjectName([Ident("table")])), alias: None, using: [], selection: None })
+Delete(DeleteStatement { table_name: Name(UnresolvedItemName([Ident("table")])), alias: None, using: [], selection: None })
 
 parse-statement roundtrip
 DELETE FROM foo WHERE name = 5
@@ -40,4 +40,4 @@ DELETE FROM foo WHERE name = 5
 ----
 DELETE FROM foo WHERE name = 5
 =>
-Delete(DeleteStatement { table_name: Name(UnresolvedObjectName([Ident("foo")])), alias: None, using: [], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("name")]), expr2: Some(Value(Number("5"))) }) })
+Delete(DeleteStatement { table_name: Name(UnresolvedItemName([Ident("foo")])), alias: None, using: [], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("name")]), expr2: Some(Value(Number("5"))) }) })

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -58,21 +58,21 @@ EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))) })
+Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN WITH(types) FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN WITH(types) AS TEXT FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [Ident("types")], format: Text, no_errors: false, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))) })
+Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [Ident("types")], format: Text, no_errors: false, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN WITH(arity, typed) FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN WITH(arity, typed) AS TEXT FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [Ident("arity"), Ident("typed")], format: Text, no_errors: false, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))) })
+Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [Ident("arity"), Ident("typed")], format: Text, no_errors: false, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN ((SELECT 1))
@@ -86,7 +86,7 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
 
 # regression test for #16029
 parse-statement
@@ -94,7 +94,7 @@ EXPLAIN WITH a AS (SELECT 1) SELECT * FROM a
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
 
 parse-statement
 EXPLAIN TIMESTAMP FOR SELECT 1
@@ -108,7 +108,7 @@ EXPLAIN AS JSON SELECT * FROM foo
 ----
 EXPLAIN OPTIMIZED PLAN AS JSON FOR SELECT * FROM foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [], format: Json, no_errors: false, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [], format: Json, no_errors: false, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
 
 parse-statement
 EXPLAIN OPTIMIZER TRACE WITH (est_cost) AS TEXT FOR BROKEN SELECT 1 + 1

--- a/src/sql-parser/tests/testdata/id
+++ b/src/sql-parser/tests/testdata/id
@@ -18,7 +18,7 @@ SELECT * FROM [u123 AS materialize.public.foo]
 ----
 SELECT * FROM [u123 AS materialize.public.foo]
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Id("u123", UnresolvedObjectName([Ident("materialize"), Ident("public"), Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Id("u123", UnresolvedItemName([Ident("materialize"), Ident("public"), Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM [u123 AS foo]

--- a/src/sql-parser/tests/testdata/insert
+++ b/src/sql-parser/tests/testdata/insert
@@ -23,49 +23,49 @@ INSERT INTO customer VALUES (1, 2, 3)
 ----
 INSERT INTO customer VALUES (1, 2, 3)
 =>
-Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("customer")])), columns: [], source: Query(Query { ctes: Simple([]), body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }), returning: [] })
+Insert(InsertStatement { table_name: Name(UnresolvedItemName([Ident("customer")])), columns: [], source: Query(Query { ctes: Simple([]), body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }), returning: [] })
 
 parse-statement
 INSERT INTO customer VALUES (1, 2, 3), (1, 2, 3)
 ----
 INSERT INTO customer VALUES (1, 2, 3), (1, 2, 3)
 =>
-Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("customer")])), columns: [], source: Query(Query { ctes: Simple([]), body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))], [Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }), returning: [] })
+Insert(InsertStatement { table_name: Name(UnresolvedItemName([Ident("customer")])), columns: [], source: Query(Query { ctes: Simple([]), body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))], [Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }), returning: [] })
 
 parse-statement
 INSERT INTO public.customer VALUES (1, 2, 3)
 ----
 INSERT INTO public.customer VALUES (1, 2, 3)
 =>
-Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("public"), Ident("customer")])), columns: [], source: Query(Query { ctes: Simple([]), body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }), returning: [] })
+Insert(InsertStatement { table_name: Name(UnresolvedItemName([Ident("public"), Ident("customer")])), columns: [], source: Query(Query { ctes: Simple([]), body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }), returning: [] })
 
 parse-statement
 INSERT INTO db.public.customer VALUES (1, 2, 3)
 ----
 INSERT INTO db.public.customer VALUES (1, 2, 3)
 =>
-Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("db"), Ident("public"), Ident("customer")])), columns: [], source: Query(Query { ctes: Simple([]), body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }), returning: [] })
+Insert(InsertStatement { table_name: Name(UnresolvedItemName([Ident("db"), Ident("public"), Ident("customer")])), columns: [], source: Query(Query { ctes: Simple([]), body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }), returning: [] })
 
 parse-statement
 INSERT INTO public.customer (id, name, active) VALUES (1, 2, 3)
 ----
 INSERT INTO public.customer (id, name, active) VALUES (1, 2, 3)
 =>
-Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("public"), Ident("customer")])), columns: [Ident("id"), Ident("name"), Ident("active")], source: Query(Query { ctes: Simple([]), body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }), returning: [] })
+Insert(InsertStatement { table_name: Name(UnresolvedItemName([Ident("public"), Ident("customer")])), columns: [Ident("id"), Ident("name"), Ident("active")], source: Query(Query { ctes: Simple([]), body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }), returning: [] })
 
 parse-statement
 INSERT INTO customer WITH foo AS (SELECT 1) SELECT * FROM foo UNION VALUES (1)
 ----
 INSERT INTO customer WITH foo AS (SELECT 1) SELECT * FROM foo UNION VALUES (1)
 =>
-Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("customer")])), columns: [], source: Query(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("foo"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: SetOperation { op: Union, all: false, left: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), right: Values(Values([[Value(Number("1"))]])) }, order_by: [], limit: None, offset: None }), returning: [] })
+Insert(InsertStatement { table_name: Name(UnresolvedItemName([Ident("customer")])), columns: [], source: Query(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("foo"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: SetOperation { op: Union, all: false, left: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), right: Values(Values([[Value(Number("1"))]])) }, order_by: [], limit: None, offset: None }), returning: [] })
 
 parse-statement
 INSERT INTO customer DEFAULT VALUES
 ----
 INSERT INTO customer DEFAULT VALUES
 =>
-Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("customer")])), columns: [], source: DefaultValues, returning: [] })
+Insert(InsertStatement { table_name: Name(UnresolvedItemName([Ident("customer")])), columns: [], source: DefaultValues, returning: [] })
 
 parse-statement
 INSERT INTO customer DEFAULT VALUES, DEFAULT VALUES
@@ -79,7 +79,7 @@ INSERT INTO t DEFAULT VALUES RETURNING *, *, i, a AS x
 ----
 INSERT INTO t DEFAULT VALUES RETURNING *, *, i, a AS x
 =>
-Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("t")])), columns: [], source: DefaultValues, returning: [Wildcard, Wildcard, Expr { expr: Identifier([Ident("i")]), alias: None }, Expr { expr: Identifier([Ident("a")]), alias: Some(Ident("x")) }] })
+Insert(InsertStatement { table_name: Name(UnresolvedItemName([Ident("t")])), columns: [], source: DefaultValues, returning: [Wildcard, Wildcard, Expr { expr: Identifier([Ident("i")]), alias: None }, Expr { expr: Identifier([Ident("a")]), alias: Some(Ident("x")) }] })
 
 parse-statement
 INSERT INTO t DEFAULT VALUES RETURNING * as x

--- a/src/sql-parser/tests/testdata/literal
+++ b/src/sql-parser/tests/testdata/literal
@@ -103,62 +103,62 @@ Value(HexString("deadBEEF"))
 parse-scalar
 DATE '1999-01-01'
 ----
-Cast { expr: Value(String("1999-01-01")), data_type: Other { name: Name(UnresolvedObjectName([Ident("date")])), typ_mod: [] } }
+Cast { expr: Value(String("1999-01-01")), data_type: Other { name: Name(UnresolvedItemName([Ident("date")])), typ_mod: [] } }
 
 parse-scalar
 DATE 'invalid date'
 ----
-Cast { expr: Value(String("invalid date")), data_type: Other { name: Name(UnresolvedObjectName([Ident("date")])), typ_mod: [] } }
+Cast { expr: Value(String("invalid date")), data_type: Other { name: Name(UnresolvedItemName([Ident("date")])), typ_mod: [] } }
 
 parse-scalar
 TIME '01:23:34'
 ----
-Cast { expr: Value(String("01:23:34")), data_type: Other { name: Name(UnresolvedObjectName([Ident("time")])), typ_mod: [] } }
+Cast { expr: Value(String("01:23:34")), data_type: Other { name: Name(UnresolvedItemName([Ident("time")])), typ_mod: [] } }
 
 parse-scalar
 TIME 'invalid time'
 ----
-Cast { expr: Value(String("invalid time")), data_type: Other { name: Name(UnresolvedObjectName([Ident("time")])), typ_mod: [] } }
+Cast { expr: Value(String("invalid time")), data_type: Other { name: Name(UnresolvedItemName([Ident("time")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMP '1999-01-01 01:23:34.555'
 ----
-Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] } }
+Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamp")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMPTZ '1999-01-01 01:23:34.555'
 ----
-Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] } }
+Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamptz")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMP WITH TIME ZONE '1999-01-01 01:23:34.555'
 ----
-Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] } }
+Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamptz")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMP WITHOUT TIME ZONE '1999-01-01 01:23:34.555'
 ----
-Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] } }
+Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamp")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMP 'invalid timestamptx'
 ----
-Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] } }
+Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamp")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMPTZ 'invalid timestamptx'
 ----
-Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] } }
+Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamptz")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMP WITH TIME ZONE 'invalid timestamptx'
 ----
-Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] } }
+Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamptz")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMP WITHOUT TIME ZONE 'invalid timestamptx'
 ----
-Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] } }
+Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamp")])), typ_mod: [] } }
 
 parse-scalar
 INTERVAL '1' YEAR

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -133,7 +133,7 @@ Op { op: Op { namespace: [], op: "!~*" }, expr1: Identifier([Ident("a")]), expr2
 parse-scalar
 a !x 'foo'
 ----
-Op { op: Op { namespace: [], op: "!" }, expr1: Identifier([Ident("a")]), expr2: Some(Cast { expr: Value(String("foo")), data_type: Other { name: Name(UnresolvedObjectName([Ident("x")])), typ_mod: [] } }) }
+Op { op: Op { namespace: [], op: "!" }, expr1: Identifier([Ident("a")]), expr2: Some(Cast { expr: Value(String("foo")), data_type: Other { name: Name(UnresolvedItemName([Ident("x")])), typ_mod: [] } }) }
 
 parse-scalar
 a !x
@@ -199,214 +199,214 @@ id::numeric
 parse-scalar
 EXTRACT(YEAR FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("year")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("year")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(MILLENIUM FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("millenium")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("millenium")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(CENTURY FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("century")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("century")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(YEAR FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("year")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("year")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(ISOYEAR FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("isoyear")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("isoyear")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(QUARTER FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("quarter")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("quarter")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(MONTH FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("month")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("month")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(DAY FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("day")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("day")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(HOUR FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("hour")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("hour")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(MINUTE FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("minute")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("minute")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(SECOND FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("second")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("second")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(MILLISECONDS FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("milliseconds")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("milliseconds")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(MICROSECONDS FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("microseconds")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("microseconds")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(TIMEZONE FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("timezone")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("timezone")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(TIMEZONE_HOUR FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("timezone_hour")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("timezone_hour")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(TIMEZONE_MINUTE FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("timezone_minute")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("timezone_minute")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(WEEK FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("week")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("week")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(DOY FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("doy")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("doy")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(DOW FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("dow")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("dow")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(ISODOW FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("isodow")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("isodow")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(EPOCH FROM d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("extract")]), args: Args { args: [Value(String("epoch")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("epoch")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 # date_part
 
 parse-scalar
 DATE_PART('YEAR', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("YEAR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("YEAR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('MILLENIUM', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("MILLENIUM")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("MILLENIUM")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('CENTURY', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("CENTURY")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("CENTURY")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('YEAR', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("YEAR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("YEAR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('ISOYEAR', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("ISOYEAR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("ISOYEAR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('QUARTER', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("QUARTER")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("QUARTER")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('MONTH', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("MONTH")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("MONTH")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('DAY', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("DAY")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("DAY")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('HOUR', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("HOUR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("HOUR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('MINUTE', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("MINUTE")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("MINUTE")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('SECOND', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("SECOND")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("SECOND")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('MILLISECONDS', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("MILLISECONDS")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("MILLISECONDS")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('MICROSECONDS', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("MICROSECONDS")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("MICROSECONDS")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('TIMEZONE', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("TIMEZONE")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("TIMEZONE")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('TIMEZONE_HOUR', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("TIMEZONE_HOUR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("TIMEZONE_HOUR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('TIMEZONE_MINUTE', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("TIMEZONE_MINUTE")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("TIMEZONE_MINUTE")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('WEEK', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("WEEK")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("WEEK")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('DOY', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("DOY")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("DOY")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('DOW', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("DOW")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("DOW")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('ISODOW', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("ISODOW")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("ISODOW")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('EPOCH', d)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("date_part")]), args: Args { args: [Value(String("EPOCH")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("EPOCH")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 COALESCE(foo, bar)
@@ -424,7 +424,7 @@ COALESCE()
 parse-scalar
 sqrt(id)
 ----
-Function(Function { name: UnresolvedObjectName([Ident("sqrt")]), args: Args { args: [Identifier([Ident("id")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("sqrt")]), args: Args { args: [Identifier([Ident("id")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar roundtrip
 (a + b) - (c + d)
@@ -454,7 +454,7 @@ AnySubquery { left: Value(Number("1")), op: Op { namespace: [], op: "<" }, right
 parse-scalar
 1 < ANY (fn())
 ----
-AnyExpr { left: Value(Number("1")), op: Op { namespace: [], op: "<" }, right: Function(Function { name: UnresolvedObjectName([Ident("fn")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }) }
+AnyExpr { left: Value(Number("1")), op: Op { namespace: [], op: "<" }, right: Function(Function { name: UnresolvedItemName([Ident("fn")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }) }
 
 parse-scalar
 LIST[]
@@ -529,17 +529,17 @@ address[1:list_length(address) - 1]
 parse-scalar
 ARRAY[]::int[]
 ----
-Cast { expr: Array([]), data_type: Array(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }) }
+Cast { expr: Array([]), data_type: Array(Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }) }
 
 parse-scalar
 ARRAY[]::int[][][][]
 ----
-Cast { expr: Array([]), data_type: Array(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }) }
+Cast { expr: Array([]), data_type: Array(Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }) }
 
 parse-scalar
 ARRAY[]::int[2][2]
 ----
-Cast { expr: Array([]), data_type: Array(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }) }
+Cast { expr: Array([]), data_type: Array(Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }) }
 
 parse-scalar
 a -> b
@@ -700,12 +700,12 @@ Nested(WildcardAccess(WildcardAccess(Nested(Identifier([Ident("x")])))))
 parse-scalar
 position('om' IN 'Thomas')
 ----
-Function(Function { name: UnresolvedObjectName([Ident("position")]), args: Args { args: [Value(String("om")), Value(String("Thomas"))], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("position")]), args: Args { args: [Value(String("om")), Value(String("Thomas"))], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 "position"('om', 'Thomas')
 ----
-Function(Function { name: UnresolvedObjectName([Ident("position")]), args: Args { args: [Value(String("om")), Value(String("Thomas"))], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: UnresolvedItemName([Ident("position")]), args: Args { args: [Value(String("om")), Value(String("Thomas"))], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 position('om', 'Thomas')

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -176,7 +176,7 @@ SELECT id, fname, lname FROM customer WHERE id = 1 LIMIT 5
 ----
 SELECT id, fname, lname FROM customer WHERE id = 1 LIMIT 5
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("id")]), expr2: Some(Value(Number("1"))) }), group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("5")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("id")]), expr2: Some(Value(Number("1"))) }), group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("5")) }), offset: None }, as_of: None })
 
 # LIMIT should not be parsed as an alias.
 
@@ -185,7 +185,7 @@ SELECT id FROM customer LIMIT 1
 ----
 SELECT id FROM customer LIMIT 1
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("1")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("1")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT 1 LIMIT 5
@@ -199,21 +199,21 @@ SELECT DISTINCT name FROM customer
 ----
 SELECT DISTINCT name FROM customer
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: Some(EntireRow), projection: [Expr { expr: Identifier([Ident("name")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: Some(EntireRow), projection: [Expr { expr: Identifier([Ident("name")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT DISTINCT ON (a, b) name, a, b FROM customer
 ----
 SELECT DISTINCT ON (a, b) name, a, b FROM customer
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: Some(On([Identifier([Ident("a")]), Identifier([Ident("b")])])), projection: [Expr { expr: Identifier([Ident("name")]), alias: None }, Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: Some(On([Identifier([Ident("a")]), Identifier([Ident("b")])])), projection: [Expr { expr: Identifier([Ident("name")]), alias: None }, Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT DISTINCT ON (a, b) name, a, b FROM customer
 ----
 SELECT DISTINCT ON (a, b) name, a, b FROM customer
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: Some(On([Identifier([Ident("a")]), Identifier([Ident("b")])])), projection: [Expr { expr: Identifier([Ident("name")]), alias: None }, Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: Some(On([Identifier([Ident("a")]), Identifier([Ident("b")])])), projection: [Expr { expr: Identifier([Ident("name")]), alias: None }, Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT DISTINCT ON (a, b) name, a, b FROM customer
@@ -225,7 +225,7 @@ SELECT DISTINCT ON (a + b, NOT c) a, b, c FROM customer
 ----
 SELECT DISTINCT ON (a + b, NOT c) a, b, c FROM customer
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: Some(On([Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("a")]), expr2: Some(Identifier([Ident("b")])) }, Not { expr: Identifier([Ident("c")]) }])), projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Identifier([Ident("c")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: Some(On([Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("a")]), expr2: Some(Identifier([Ident("b")])) }, Not { expr: Identifier([Ident("c")]) }])), projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Identifier([Ident("c")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT ALL name FROM customer
@@ -237,14 +237,14 @@ SELECT * FROM foo
 ----
 SELECT * FROM foo
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT foo.* FROM foo
 ----
 SELECT foo.* FROM foo
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: QualifiedWildcard([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: QualifiedWildcard([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT (x).a, (x).a.b.c
@@ -277,7 +277,7 @@ SELECT a.col + 1 AS newname FROM foo AS a
 ----
 SELECT a.col + 1 AS newname FROM foo AS a
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("a"), Ident("col")]), expr2: Some(Value(Number("1"))) }, alias: Some(Ident("newname")) }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: Some(TableAlias { name: Ident("a"), columns: [], strict: false }) }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("a"), Ident("col")]), expr2: Some(Value(Number("1"))) }, alias: Some(Ident("newname")) }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("foo")])), alias: Some(TableAlias { name: Ident("a"), columns: [], strict: false }) }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT a.col + 1 AS newname FROM foo AS a
@@ -319,14 +319,14 @@ SELECT count(*) FILTER (WHERE foo) FROM customer
 ----
 SELECT count(*) FILTER (WHERE foo) FROM customer
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("count")]), args: Star, filter: Some(Identifier([Ident("foo")])), over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: UnresolvedItemName([Ident("count")]), args: Star, filter: Some(Identifier([Ident("foo")])), over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT count(DISTINCT + x) FROM customer
 ----
 SELECT count(DISTINCT + x) FROM customer
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("count")]), args: Args { args: [Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("x")]), expr2: None }], order_by: [] }, filter: None, over: None, distinct: true }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: UnresolvedItemName([Ident("count")]), args: Args { args: [Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("x")]), expr2: None }], order_by: [] }, filter: None, over: None, distinct: true }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT count(ALL + x) FROM customer
@@ -358,7 +358,7 @@ SELECT array_agg(b ORDER BY a)
 ----
 SELECT array_agg(b ORDER BY a)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("array_agg")]), args: Args { args: [Identifier([Ident("b")])], order_by: [OrderByExpr { expr: Identifier([Ident("a")]), asc: None, nulls_last: None }] }, filter: None, over: None, distinct: false }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: UnresolvedItemName([Ident("array_agg")]), args: Args { args: [Identifier([Ident("b")])], order_by: [OrderByExpr { expr: Identifier([Ident("a")]), asc: None, nulls_last: None }] }, filter: None, over: None, distinct: false }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 
 # Parameters
@@ -413,42 +413,42 @@ SELECT * FROM customers WHERE segment IN (SELECT segm FROM bar)
 ----
 SELECT * FROM customers WHERE segment IN (SELECT segm FROM bar)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customers")])), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("segment")]), subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("segm")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, negated: false }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customers")])), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("segment")]), subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("segm")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, negated: false }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t WHERE x IN (VALUES (1))
 ----
 SELECT * FROM t WHERE x IN (VALUES (1))
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("x")]), subquery: Query { ctes: Simple([]), body: Values(Values([[Value(Number("1"))]])), order_by: [], limit: None, offset: None }, negated: false }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("x")]), subquery: Query { ctes: Simple([]), body: Values(Values([[Value(Number("1"))]])), order_by: [], limit: None, offset: None }, negated: false }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM customers WHERE age BETWEEN 25 AND 32
 ----
 SELECT * FROM customers WHERE age BETWEEN 25 AND 32
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customers")])), alias: None }, joins: [] }], selection: Some(Between { expr: Identifier([Ident("age")]), negated: false, low: Value(Number("25")), high: Value(Number("32")) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customers")])), alias: None }, joins: [] }], selection: Some(Between { expr: Identifier([Ident("age")]), negated: false, low: Value(Number("25")), high: Value(Number("32")) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM customers WHERE age NOT BETWEEN 25 AND 32
 ----
 SELECT * FROM customers WHERE age NOT BETWEEN 25 AND 32
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customers")])), alias: None }, joins: [] }], selection: Some(Between { expr: Identifier([Ident("age")]), negated: true, low: Value(Number("25")), high: Value(Number("32")) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customers")])), alias: None }, joins: [] }], selection: Some(Between { expr: Identifier([Ident("age")]), negated: true, low: Value(Number("25")), high: Value(Number("32")) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t WHERE 1 BETWEEN 1 + 2 AND 3 + 4 IS NULL
 ----
 SELECT * FROM t WHERE 1 BETWEEN 1 + 2 AND 3 + 4 IS NULL
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), alias: None }, joins: [] }], selection: Some(IsExpr { expr: Between { expr: Value(Number("1")), negated: false, low: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }, high: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("3")), expr2: Some(Value(Number("4"))) } }, construct: Null, negated: false }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: Some(IsExpr { expr: Between { expr: Value(Number("1")), negated: false, low: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }, high: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("3")), expr2: Some(Value(Number("4"))) } }, construct: Null, negated: false }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t WHERE 1 BETWEEN 1 + 2 AND 3 + 4 IS NOT FALSE
 ----
 SELECT * FROM t WHERE 1 BETWEEN 1 + 2 AND 3 + 4 IS NOT FALSE
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), alias: None }, joins: [] }], selection: Some(IsExpr { expr: Between { expr: Value(Number("1")), negated: false, low: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }, high: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("3")), expr2: Some(Value(Number("4"))) } }, construct: False, negated: true }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: Some(IsExpr { expr: Between { expr: Value(Number("1")), negated: false, low: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }, high: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("3")), expr2: Some(Value(Number("4"))) } }, construct: False, negated: true }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 
 parse-statement
@@ -456,35 +456,35 @@ SELECT * FROM t WHERE 1 = 1 AND 1 + x BETWEEN 1 AND 2
 ----
 SELECT * FROM t WHERE 1 = 1 AND 1 + x BETWEEN 1 AND 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), alias: None }, joins: [] }], selection: Some(And { left: Op { op: Op { namespace: [], op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, right: Between { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Identifier([Ident("x")])) }, negated: false, low: Value(Number("1")), high: Value(Number("2")) } }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: Some(And { left: Op { op: Op { namespace: [], op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, right: Between { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Identifier([Ident("x")])) }, negated: false, low: Value(Number("1")), high: Value(Number("2")) } }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t WHERE 1 = 1 AND 1 + x BETWEEN 1 AND 2
 ----
 SELECT * FROM t WHERE 1 = 1 AND 1 + x BETWEEN 1 AND 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), alias: None }, joins: [] }], selection: Some(And { left: Op { op: Op { namespace: [], op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, right: Between { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Identifier([Ident("x")])) }, negated: false, low: Value(Number("1")), high: Value(Number("2")) } }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: Some(And { left: Op { op: Op { namespace: [], op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, right: Between { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Identifier([Ident("x")])) }, negated: false, low: Value(Number("1")), high: Value(Number("2")) } }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT id, fname, lname FROM customer WHERE id < 5 ORDER BY lname ASC, fname DESC, id
 ----
 SELECT id, fname, lname FROM customer WHERE id < 5 ORDER BY lname ASC, fname DESC, id
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "<" }, expr1: Identifier([Ident("id")]), expr2: Some(Value(Number("5"))) }), group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("id")]), asc: None, nulls_last: None }], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "<" }, expr1: Identifier([Ident("id")]), expr2: Some(Value(Number("5"))) }), group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("id")]), asc: None, nulls_last: None }], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT id, fname, lname FROM customer ORDER BY lname ASC, fname DESC, id
 ----
 SELECT id, fname, lname FROM customer ORDER BY lname ASC, fname DESC, id
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("id")]), asc: None, nulls_last: None }], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("id")]), asc: None, nulls_last: None }], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT id, fname, lname FROM customer ORDER BY lname ASC, fname DESC, id NULLS FIRST
 ----
 SELECT id, fname, lname FROM customer ORDER BY lname ASC, fname DESC, id NULLS FIRST
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("id")]), asc: None, nulls_last: Some(false) }], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("id")]), asc: None, nulls_last: Some(false) }], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT id, fname, lname FROM customer WHERE id < 5
@@ -492,35 +492,35 @@ ORDER BY lname ASC, fname DESC NULLS LAST LIMIT 2
 ----
 SELECT id, fname, lname FROM customer WHERE id < 5 ORDER BY lname ASC, fname DESC NULLS LAST LIMIT 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "<" }, expr1: Identifier([Ident("id")]), expr2: Some(Value(Number("5"))) }), group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false), nulls_last: Some(true) }], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "<" }, expr1: Identifier([Ident("id")]), expr2: Some(Value(Number("5"))) }), group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true), nulls_last: None }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false), nulls_last: Some(true) }], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT id, fname, lname FROM customer GROUP BY lname, fname
 ----
 SELECT id, fname, lname FROM customer GROUP BY lname, fname
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("lname")]), Identifier([Ident("fname")])], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("lname")]), Identifier([Ident("fname")])], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1
 ----
 SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(Op { op: Op { namespace: [], op: ">" }, expr1: Function(Function { name: UnresolvedObjectName([Ident("count")]), args: Star, filter: None, over: None, distinct: false }), expr2: Some(Value(Number("1"))) }), options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(Op { op: Op { namespace: [], op: ">" }, expr1: Function(Function { name: UnresolvedItemName([Ident("count")]), args: Star, filter: None, over: None, distinct: false }), expr2: Some(Value(Number("1"))) }), options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1
 ----
 SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(Op { op: Op { namespace: [], op: ">" }, expr1: Function(Function { name: UnresolvedObjectName([Ident("count")]), args: Star, filter: None, over: None, distinct: false }), expr2: Some(Value(Number("1"))) }), options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(Op { op: Op { namespace: [], op: ">" }, expr1: Function(Function { name: UnresolvedItemName([Ident("count")]), args: Star, filter: None, over: None, distinct: false }), expr2: Some(Value(Number("1"))) }), options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar GROUP BY foo HAVING 1 = 1
 ----
 SELECT foo FROM bar GROUP BY foo HAVING 1 = 1
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }), options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }), options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT id, fname, lname FROM customer WHERE id = 1 LIMIT ALL
@@ -576,63 +576,63 @@ SELECT * FROM t1, t2
 ----
 SELECT * FROM t1, t2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1a NATURAL JOIN t1b, t2a NATURAL JOIN t2b
 ----
 SELECT * FROM t1a NATURAL JOIN t1b, t2a NATURAL JOIN t2b
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1a")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t1b")])), alias: None }, join_operator: Inner(Natural) }] }, TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t2a")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2b")])), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1a")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t1b")])), alias: None }, join_operator: Inner(Natural) }] }, TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t2a")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2b")])), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 CROSS JOIN t2
 ----
 SELECT * FROM t1 CROSS JOIN t2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: None }, join_operator: CrossJoin }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: CrossJoin }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 JOIN t2 AS foo USING (c1)
 ----
 SELECT * FROM t1 JOIN t2 AS foo USING (c1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: Some(TableAlias { name: Ident("foo"), columns: [], strict: false }) }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: Some(TableAlias { name: Ident("foo"), columns: [], strict: false }) }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 JOIN t2 foo USING (c1)
 ----
 SELECT * FROM t1 JOIN t2 AS foo USING (c1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: Some(TableAlias { name: Ident("foo"), columns: [], strict: false }) }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: Some(TableAlias { name: Ident("foo"), columns: [], strict: false }) }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 NATURAL JOIN t2
 ----
 SELECT * FROM t1 NATURAL JOIN t2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 NATURAL LEFT JOIN t2
 ----
 SELECT * FROM t1 NATURAL LEFT JOIN t2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: None }, join_operator: LeftOuter(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: LeftOuter(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 NATURAL RIGHT JOIN t2
 ----
 SELECT * FROM t1 NATURAL RIGHT JOIN t2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: None }, join_operator: RightOuter(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: RightOuter(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 NATURAL FULL JOIN t2
 ----
 SELECT * FROM t1 NATURAL FULL JOIN t2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: None }, join_operator: FullOuter(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: FullOuter(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 natural
@@ -646,42 +646,42 @@ SELECT c1, c2 FROM t1, t4 JOIN t2 ON t2.c = t1.c LEFT JOIN t3 USING (q, c) WHERE
 ----
 SELECT c1, c2 FROM t1, t4 JOIN t2 ON t2.c = t1.c LEFT JOIN t3 USING (q, c) WHERE t4.c = t1.c
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }, Expr { expr: Identifier([Ident("c2")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t4")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: None }, join_operator: Inner(On(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("t2"), Ident("c")]), expr2: Some(Identifier([Ident("t1"), Ident("c")])) })) }, Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t3")])), alias: None }, join_operator: LeftOuter(Using([Ident("q"), Ident("c")])) }] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("t4"), Ident("c")]), expr2: Some(Identifier([Ident("t1"), Ident("c")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }, Expr { expr: Identifier([Ident("c2")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t4")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: Inner(On(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("t2"), Ident("c")]), expr2: Some(Identifier([Ident("t1"), Ident("c")])) })) }, Join { relation: Table { name: Name(UnresolvedItemName([Ident("t3")])), alias: None }, join_operator: LeftOuter(Using([Ident("q"), Ident("c")])) }] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("t4"), Ident("c")]), expr2: Some(Identifier([Ident("t1"), Ident("c")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM a NATURAL JOIN (b NATURAL JOIN (c NATURAL JOIN d NATURAL JOIN e)) NATURAL JOIN (f NATURAL JOIN (g NATURAL JOIN h))
 ----
 SELECT * FROM a NATURAL JOIN (b NATURAL JOIN (c NATURAL JOIN d NATURAL JOIN e)) NATURAL JOIN (f NATURAL JOIN (g NATURAL JOIN h))
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("b")])), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("c")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("d")])), alias: None }, join_operator: Inner(Natural) }, Join { relation: Table { name: Name(UnresolvedObjectName([Ident("e")])), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }, Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("f")])), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("g")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("h")])), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("b")])), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("c")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("d")])), alias: None }, join_operator: Inner(Natural) }, Join { relation: Table { name: Name(UnresolvedItemName([Ident("e")])), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }, Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("f")])), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("g")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("h")])), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM (a NATURAL JOIN b) NATURAL JOIN c
 ----
 SELECT * FROM (a NATURAL JOIN b) NATURAL JOIN c
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("b")])), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("c")])), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("b")])), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("c")])), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM (a NATURAL JOIN b) c NATURAL JOIN d
 ----
 SELECT * FROM (a NATURAL JOIN b) AS c NATURAL JOIN d
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("b")])), alias: None }, join_operator: Inner(Natural) }] }, alias: Some(TableAlias { name: Ident("c"), columns: [], strict: false }) }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("d")])), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("b")])), alias: None }, join_operator: Inner(Natural) }] }, alias: Some(TableAlias { name: Ident("c"), columns: [], strict: false }) }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("d")])), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM (((a NATURAL JOIN b)))
 ----
 SELECT * FROM (((a NATURAL JOIN b)))
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("b")])), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [] }, alias: None }, joins: [] }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("b")])), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [] }, alias: None }, joins: [] }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM a NATURAL JOIN (((b NATURAL JOIN c)))
 ----
 SELECT * FROM a NATURAL JOIN (((b NATURAL JOIN c)))
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("b")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("c")])), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [] }, alias: None }, joins: [] }, alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("b")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("c")])), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [] }, alias: None }, joins: [] }, alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM (a NATURAL JOIN (b))
@@ -695,28 +695,28 @@ SELECT c1 FROM t1 INNER JOIN t2 USING (c1)
 ----
 SELECT c1 FROM t1 JOIN t2 USING (c1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: None }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT c1 FROM t1 LEFT OUTER JOIN t2 USING (c1)
 ----
 SELECT c1 FROM t1 LEFT JOIN t2 USING (c1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: None }, join_operator: LeftOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: LeftOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT c1 FROM t1 RIGHT OUTER JOIN t2 USING (c1)
 ----
 SELECT c1 FROM t1 RIGHT JOIN t2 USING (c1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: None }, join_operator: RightOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: RightOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT c1 FROM t1 FULL OUTER JOIN t2 USING (c1)
 ----
 SELECT c1 FROM t1 FULL JOIN t2 USING (c1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("t2")])), alias: None }, join_operator: FullOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: FullOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM a OUTER JOIN b ON 1
@@ -733,7 +733,7 @@ SELECT foo + bar FROM a, b
 ----
 WITH a AS (SELECT 1 AS foo), b AS (SELECT 2 AS bar) SELECT foo + bar FROM a, b
 =>
-Select(SelectStatement { query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: Some(Ident("foo")) }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }, Cte { alias: TableAlias { name: Ident("b"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: Some(Ident("bar")) }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("foo")]), expr2: Some(Identifier([Ident("bar")])) }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("b")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: Some(Ident("foo")) }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }, Cte { alias: TableAlias { name: Ident("b"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: Some(Ident("bar")) }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("foo")]), expr2: Some(Identifier([Ident("bar")])) }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("b")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 CREATE VIEW v AS
@@ -744,7 +744,7 @@ CREATE VIEW v AS
 ----
 CREATE VIEW v AS WITH a AS (SELECT 1 AS foo), b AS (SELECT 2 AS bar) SELECT foo + bar FROM a, b
 =>
-CreateView(CreateViewStatement { if_exists: Error, temporary: false, definition: ViewDefinition { name: UnresolvedObjectName([Ident("v")]), columns: [], query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: Some(Ident("foo")) }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }, Cte { alias: TableAlias { name: Ident("b"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: Some(Ident("bar")) }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("foo")]), expr2: Some(Identifier([Ident("bar")])) }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("b")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
+CreateView(CreateViewStatement { if_exists: Error, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("v")]), columns: [], query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: Some(Ident("foo")) }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }, Cte { alias: TableAlias { name: Ident("b"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: Some(Ident("bar")) }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("foo")]), expr2: Some(Identifier([Ident("bar")])) }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("b")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
 
 parse-statement roundtrip
 WITH cte (col1, col2) AS (SELECT foo, bar FROM baz) SELECT * FROM cte
@@ -823,42 +823,42 @@ SELECT foo FROM bar OFFSET 2 ROWS
 ----
 SELECT foo FROM bar OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 OFFSET 2 ROWS
 ----
 SELECT foo FROM bar WHERE foo = 4 OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar ORDER BY baz OFFSET 2 ROWS
 ----
 SELECT foo FROM bar ORDER BY baz OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2 ROWS
 ----
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS) OFFSET 2 ROWS
 ----
 SELECT foo FROM (SELECT * FROM bar OFFSET 2) OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM LATERAL bar(1)
 ----
 SELECT foo FROM bar(1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { function: TableFunction { name: UnresolvedObjectName([Ident("bar")]), args: Args { args: [Value(Number("1"))], order_by: [] } }, alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { function: TableFunction { name: UnresolvedItemName([Ident("bar")]), args: Args { args: [Value(Number("1"))], order_by: [] } }, alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM LATERAL bar
@@ -879,49 +879,49 @@ SELECT foo FROM bar OFFSET 2
 ----
 SELECT foo FROM bar OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 OFFSET 2
 ----
 SELECT foo FROM bar WHERE foo = 4 OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar ORDER BY baz OFFSET 2
 ----
 SELECT foo FROM bar ORDER BY baz OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2
 ----
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM (SELECT * FROM bar OFFSET 2) OFFSET 2
 ----
 SELECT foo FROM (SELECT * FROM bar OFFSET 2) OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS) OFFSET 2
 ----
 SELECT foo FROM (SELECT * FROM bar OFFSET 2) OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM (SELECT * FROM bar OFFSET 2) OFFSET 2 ROWS
 ----
 SELECT foo FROM (SELECT * FROM bar OFFSET 2) OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT 'foo' OFFSET 0
@@ -940,7 +940,7 @@ SELECT foo FROM bar FETCH FIRST 2 ROWS ONLY
 ----
 SELECT foo FROM bar LIMIT 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT 'foo' FETCH FIRST 2 ROWS ONLY
@@ -954,28 +954,28 @@ SELECT foo FROM bar FETCH FIRST ROWS ONLY
 ----
 SELECT foo FROM bar LIMIT 1
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("1")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("1")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 FETCH FIRST 2 ROWS ONLY
 ----
 SELECT foo FROM bar WHERE foo = 4 LIMIT 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar ORDER BY baz FETCH FIRST 2 ROWS ONLY
 ----
 SELECT foo FROM bar ORDER BY baz LIMIT 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz FETCH FIRST 2 ROWS WITH TIES
 ----
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz FETCH FIRST 2 ROWS WITH TIES
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: Some(Limit { with_ties: true, quantity: Value(Number("2")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: Some(Limit { with_ties: true, quantity: Value(Number("2")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY
@@ -989,98 +989,98 @@ SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2 ROWS FETCH FIRST 2 ROWS 
 ----
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz LIMIT 2 OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("foo")]), expr2: Some(Value(Number("4"))) }), group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None, nulls_last: None }], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM (SELECT * FROM bar FETCH FIRST 2 ROWS ONLY) FETCH FIRST 2 ROWS ONLY
 ----
 SELECT foo FROM (SELECT * FROM bar LIMIT 2) LIMIT 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY) OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY
 ----
 SELECT foo FROM (SELECT * FROM bar LIMIT 2 OFFSET 2) LIMIT 2 OFFSET 2
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: Some(Value(Number("2"))) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: Some(Value(Number("2"))) }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: Some(Value(Number("2"))) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("2")) }), offset: Some(Value(Number("2"))) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH FIRST 10 ROW ONLY
 ----
 SELECT foo FROM bar LIMIT 10
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("10")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("10")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH NEXT 10 ROW ONLY
 ----
 SELECT foo FROM bar LIMIT 10
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("10")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("10")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH NEXT 10 ROWS WITH TIES
 ----
 SELECT foo FROM bar FETCH FIRST 10 ROWS WITH TIES
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: true, quantity: Value(Number("10")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: true, quantity: Value(Number("10")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH NEXT ROWS WITH TIES
 ----
 SELECT foo FROM bar FETCH FIRST 1 ROWS WITH TIES
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: true, quantity: Value(Number("1")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: true, quantity: Value(Number("1")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH FIRST ROWS ONLY
 ----
 SELECT foo FROM bar LIMIT 1
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("1")) }), offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("1")) }), offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM customer LEFT JOIN (SELECT * FROM "order" WHERE "order".customer = customer.id LIMIT 3) AS "order" ON true
 ----
 SELECT * FROM customer LEFT JOIN (SELECT * FROM "order" WHERE "order".customer = customer.id LIMIT 3) AS "order" ON true
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [Join { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("order")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("order"), Ident("customer")]), expr2: Some(Identifier([Ident("customer"), Ident("id")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("3")) }), offset: None }, alias: Some(TableAlias { name: Ident("order"), columns: [], strict: false }) }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Derived { lateral: false, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("order")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("order"), Ident("customer")]), expr2: Some(Identifier([Ident("customer"), Ident("id")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("3")) }), offset: None }, alias: Some(TableAlias { name: Ident("order"), columns: [], strict: false }) }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM customer LEFT JOIN LATERAL (SELECT * FROM "order" WHERE "order".customer = customer.id LIMIT 3) AS "order" ON true
 ----
 SELECT * FROM customer LEFT JOIN LATERAL (SELECT * FROM "order" WHERE "order".customer = customer.id LIMIT 3) AS "order" ON true
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [Join { relation: Derived { lateral: true, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("order")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("order"), Ident("customer")]), expr2: Some(Identifier([Ident("customer"), Ident("id")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("3")) }), offset: None }, alias: Some(TableAlias { name: Ident("order"), columns: [], strict: false }) }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Derived { lateral: true, subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("order")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("order"), Ident("customer")]), expr2: Some(Identifier([Ident("customer"), Ident("id")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("3")) }), offset: None }, alias: Some(TableAlias { name: Ident("order"), columns: [], strict: false }) }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM customer LEFT JOIN LATERAL generate_series(1, customer.id) ON true
 ----
 SELECT * FROM customer LEFT JOIN generate_series(1, customer.id) ON true
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { function: TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] } }, alias: None, with_ordinality: false }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { function: TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] } }, alias: None, with_ordinality: false }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS alias
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS alias
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM generate_series(1, 2) WITH ORDINALITY
 ----
 SELECT * FROM generate_series(1, 2) WITH ORDINALITY
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Function { function: TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Function { function: TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM ROWS FROM (generate_series(1, 2) WITH ORDINALITY)
@@ -1094,14 +1094,14 @@ SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDI
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 # Ensure parsing AS OF is case-insensitive
 parse-statement
@@ -1109,14 +1109,14 @@ SELECT * FROM data as of now()
 ----
 SELECT * FROM data AS OF now()
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("data")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("data")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
 
 parse-statement
 SELECT * FROM data AS OF now()
 ----
 SELECT * FROM data AS OF now()
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("data")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("data")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
 
 
 parse-statement
@@ -1124,7 +1124,7 @@ SELECT * FROM data AS OF AT LEAST 5
 ----
 SELECT * FROM data AS OF AT LEAST 5
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("data")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(AtLeast(Value(Number("5")))) })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("data")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(AtLeast(Value(Number("5")))) })
 
 # Query hints
 parse-statement
@@ -1189,7 +1189,7 @@ SELECT LIST(SELECT customer.id FROM customer JOIN user on customer.id = user.id 
 ----
 SELECT LIST(SELECT customer.id FROM customer JOIN user ON customer.id = user.id LIMIT 12)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ListSubquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("customer"), Ident("id")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("user")])), alias: None }, join_operator: Inner(On(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("customer"), Ident("id")]), expr2: Some(Identifier([Ident("user"), Ident("id")])) })) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("12")) }), offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ListSubquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("customer"), Ident("id")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("user")])), alias: None }, join_operator: Inner(On(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("customer"), Ident("id")]), expr2: Some(Identifier([Ident("user"), Ident("id")])) })) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("12")) }), offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT LIST(
@@ -1205,7 +1205,7 @@ SELECT LIST(
 ----
 SELECT LIST(WITH usps AS (SELECT 42) SELECT LIST[customer.id, LIST[customer.first_name, customer.last_name], LIST[LIST[customer.zip]]] FROM customer JOIN user ON customer.id = user.id LIMIT 12)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ListSubquery(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("usps"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("42")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Expr { expr: List([Identifier([Ident("customer"), Ident("id")]), List([Identifier([Ident("customer"), Ident("first_name")]), Identifier([Ident("customer"), Ident("last_name")])]), List([List([Identifier([Ident("customer"), Ident("zip")])])])]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("user")])), alias: None }, join_operator: Inner(On(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("customer"), Ident("id")]), expr2: Some(Identifier([Ident("user"), Ident("id")])) })) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("12")) }), offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ListSubquery(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("usps"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("42")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Expr { expr: List([Identifier([Ident("customer"), Ident("id")]), List([Identifier([Ident("customer"), Ident("first_name")]), Identifier([Ident("customer"), Ident("last_name")])]), List([List([Identifier([Ident("customer"), Ident("zip")])])])]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("user")])), alias: None }, join_operator: Inner(On(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("customer"), Ident("id")]), expr2: Some(Identifier([Ident("user"), Ident("id")])) })) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("12")) }), offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT LIST(
@@ -1215,7 +1215,7 @@ SELECT LIST(
 ----
 SELECT LIST(WITH usps AS (SELECT 42) SELECT * FROM usps)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ListSubquery(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("usps"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("42")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("usps")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ListSubquery(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("usps"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("42")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("usps")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 # Array subqueries
 parse-statement
@@ -1244,7 +1244,7 @@ SELECT ARRAY(SELECT customer.id FROM customer JOIN user on customer.id = user.id
 ----
 SELECT ARRAY(SELECT customer.id FROM customer JOIN user ON customer.id = user.id LIMIT 12)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ArraySubquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("customer"), Ident("id")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("user")])), alias: None }, join_operator: Inner(On(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("customer"), Ident("id")]), expr2: Some(Identifier([Ident("user"), Ident("id")])) })) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("12")) }), offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ArraySubquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("customer"), Ident("id")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("user")])), alias: None }, join_operator: Inner(On(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("customer"), Ident("id")]), expr2: Some(Identifier([Ident("user"), Ident("id")])) })) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("12")) }), offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT ARRAY(
@@ -1260,7 +1260,7 @@ SELECT ARRAY(
 ----
 SELECT ARRAY(WITH usps AS (SELECT 42) SELECT ARRAY[customer.id, ARRAY[customer.first_name, customer.last_name], ARRAY[ARRAY[customer.zip]]] FROM customer JOIN user ON customer.id = user.id LIMIT 12)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ArraySubquery(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("usps"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("42")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Expr { expr: Array([Identifier([Ident("customer"), Ident("id")]), Array([Identifier([Ident("customer"), Ident("first_name")]), Identifier([Ident("customer"), Ident("last_name")])]), Array([Array([Identifier([Ident("customer"), Ident("zip")])])])]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("user")])), alias: None }, join_operator: Inner(On(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("customer"), Ident("id")]), expr2: Some(Identifier([Ident("user"), Ident("id")])) })) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("12")) }), offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ArraySubquery(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("usps"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("42")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Expr { expr: Array([Identifier([Ident("customer"), Ident("id")]), Array([Identifier([Ident("customer"), Ident("first_name")]), Identifier([Ident("customer"), Ident("last_name")])]), Array([Array([Identifier([Ident("customer"), Ident("zip")])])])]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("user")])), alias: None }, join_operator: Inner(On(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("customer"), Ident("id")]), expr2: Some(Identifier([Ident("user"), Ident("id")])) })) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("12")) }), offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT ARRAY(
@@ -1270,7 +1270,7 @@ SELECT ARRAY(
 ----
 SELECT ARRAY(WITH usps AS (SELECT 42) SELECT * FROM usps)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ArraySubquery(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("usps"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("42")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("usps")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ArraySubquery(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("usps"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("42")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("usps")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT count(DISTINCT *) FROM foo

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -219,7 +219,7 @@ SHOW INDEXES ON foo
 ----
 SHOW INDEXES ON foo
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Index { in_cluster: None, on_object: Some(Name(UnresolvedObjectName([Ident("foo")]))) }, from: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Index { in_cluster: None, on_object: Some(Name(UnresolvedItemName([Ident("foo")]))) }, from: None, filter: None }))
 
 parse-statement
 SHOW INDEXES
@@ -240,7 +240,7 @@ SHOW INDEXES ON t IN CLUSTER c
 ----
 SHOW INDEXES ON t IN CLUSTER c
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Index { in_cluster: Some(Unresolved(Ident("c"))), on_object: Some(Name(UnresolvedObjectName([Ident("t")]))) }, from: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Index { in_cluster: Some(Unresolved(Ident("c"))), on_object: Some(Name(UnresolvedItemName([Ident("t")]))) }, from: None, filter: None }))
 
 parse-statement
 SHOW INDEXES FROM s
@@ -275,77 +275,77 @@ SHOW CREATE VIEW foo
 ----
 SHOW CREATE VIEW foo
 =>
-Show(ShowCreateView(ShowCreateViewStatement { view_name: Name(UnresolvedObjectName([Ident("foo")])) }))
+Show(ShowCreateView(ShowCreateViewStatement { view_name: Name(UnresolvedItemName([Ident("foo")])) }))
 
 parse-statement
 SHOW CREATE MATERIALIZED VIEW foo
 ----
 SHOW CREATE MATERIALIZED VIEW foo
 =>
-Show(ShowCreateMaterializedView(ShowCreateMaterializedViewStatement { materialized_view_name: Name(UnresolvedObjectName([Ident("foo")])) }))
+Show(ShowCreateMaterializedView(ShowCreateMaterializedViewStatement { materialized_view_name: Name(UnresolvedItemName([Ident("foo")])) }))
 
 parse-statement
 SHOW CREATE SINK foo
 ----
 SHOW CREATE SINK foo
 =>
-Show(ShowCreateSink(ShowCreateSinkStatement { sink_name: Name(UnresolvedObjectName([Ident("foo")])) }))
+Show(ShowCreateSink(ShowCreateSinkStatement { sink_name: Name(UnresolvedItemName([Ident("foo")])) }))
 
 parse-statement
 SHOW CREATE INDEX foo
 ----
 SHOW CREATE INDEX foo
 =>
-Show(ShowCreateIndex(ShowCreateIndexStatement { index_name: Name(UnresolvedObjectName([Ident("foo")])) }))
+Show(ShowCreateIndex(ShowCreateIndexStatement { index_name: Name(UnresolvedItemName([Ident("foo")])) }))
 
 parse-statement
 SHOW COLUMNS FROM mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedItemName([Ident("mytable")])), filter: None }))
 
 parse-statement
 SHOW COLUMNS FROM mydb.mytable
 ----
 SHOW COLUMNS FROM mydb.mytable
 =>
-Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mydb"), Ident("mytable")])), filter: None }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedItemName([Ident("mydb"), Ident("mytable")])), filter: None }))
 
 parse-statement
 SHOW COLUMNS FROM mytable LIKE 'pattern'
 ----
 SHOW COLUMNS FROM mytable LIKE 'pattern'
 =>
-Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: Some(Like("pattern")) }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedItemName([Ident("mytable")])), filter: Some(Like("pattern")) }))
 
 parse-statement
 SHOW COLUMNS FROM mytable WHERE 1 = 2
 ----
 SHOW COLUMNS FROM mytable WHERE 1 = 2
 =>
-Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: Some(Where(Op { op: Op { namespace: [], op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) })) }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedItemName([Ident("mytable")])), filter: Some(Where(Op { op: Op { namespace: [], op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) })) }))
 
 parse-statement
 SHOW FIELDS FROM mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedItemName([Ident("mytable")])), filter: None }))
 
 parse-statement
 SHOW COLUMNS IN mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedItemName([Ident("mytable")])), filter: None }))
 
 parse-statement
 SHOW FIELDS IN mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedItemName([Ident("mytable")])), filter: None }))
 
 parse-statement
 SHOW a

--- a/src/sql-parser/tests/testdata/update
+++ b/src/sql-parser/tests/testdata/update
@@ -28,4 +28,4 @@ UPDATE t SET a = 1, b = 2, c = 3 WHERE d
 ----
 UPDATE t SET a = 1, b = 2, c = 3 WHERE d
 =>
-Update(UpdateStatement { table_name: Name(UnresolvedObjectName([Ident("t")])), assignments: [Assignment { id: Ident("a"), value: Value(Number("1")) }, Assignment { id: Ident("b"), value: Value(Number("2")) }, Assignment { id: Ident("c"), value: Value(Number("3")) }], selection: Some(Identifier([Ident("d")])) })
+Update(UpdateStatement { table_name: Name(UnresolvedItemName([Ident("t")])), assignments: [Assignment { id: Ident("a"), value: Value(Number("1")) }, Assignment { id: Ident("b"), value: Value(Number("2")) }, Assignment { id: Ident("c"), value: Value(Number("3")) }], selection: Some(Identifier([Ident("d")])) })

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -256,8 +256,8 @@ impl<'a, 'ast> Visit<'ast, Raw> for QueryIdentAgg<'a> {
         }
     }
 
-    fn visit_unresolved_object_name(&mut self, unresolved_object_name: &'ast UnresolvedItemName) {
-        let names = &unresolved_object_name.0;
+    fn visit_unresolved_item_name(&mut self, unresolved_item_name: &'ast UnresolvedItemName) {
+        let names = &unresolved_item_name.0;
         self.check_failure(names);
         // Every item is used as an `ObjectName` at least once, which
         // lets use track all items named `self.name`.
@@ -276,8 +276,8 @@ impl<'a, 'ast> Visit<'ast, Raw> for QueryIdentAgg<'a> {
         }
     }
 
-    fn visit_object_name(&mut self, object_name: &'ast <Raw as AstInfo>::ItemName) {
-        match object_name {
+    fn visit_item_name(&mut self, item_name: &'ast <Raw as AstInfo>::ItemName) {
+        match item_name {
             RawItemName::Name(n) | RawItemName::Id(_, n) => {
                 self.visit_unresolved_object_name(n)
             }
@@ -333,17 +333,17 @@ impl<'ast> VisitMut<'ast, Raw> for CreateSqlRewriter {
             _ => visit_mut::visit_expr_mut(self, e),
         }
     }
-    fn visit_unresolved_object_name_mut(
+    fn visit_unresolved_item_name_mut(
         &mut self,
-        unresolved_object_name: &'ast mut UnresolvedItemName,
+        unresolved_item_name: &'ast mut UnresolvedItemName,
     ) {
-        self.maybe_rewrite_idents(&mut unresolved_object_name.0);
+        self.maybe_rewrite_idents(&mut unresolved_item_name.0);
     }
-    fn visit_object_name_mut(
+    fn visit_item_name_mut(
         &mut self,
-        object_name: &'ast mut <mz_sql_parser::ast::Raw as AstInfo>::ItemName,
+        item_name: &'ast mut <mz_sql_parser::ast::Raw as AstInfo>::ItemName,
     ) {
-        match object_name {
+        match item_name {
             RawItemName::Name(n) | RawItemName::Id(_, n) => self.maybe_rewrite_idents(&mut n.0),
         }
     }
@@ -363,11 +363,11 @@ struct CreateSqlIdReplacer<'a> {
 }
 
 impl<'ast> VisitMut<'ast, Raw> for CreateSqlIdReplacer<'_> {
-    fn visit_object_name_mut(
+    fn visit_item_name_mut(
         &mut self,
-        object_name: &'ast mut <mz_sql_parser::ast::Raw as AstInfo>::ItemName,
+        item_name: &'ast mut <mz_sql_parser::ast::Raw as AstInfo>::ItemName,
     ) {
-        match object_name {
+        match item_name {
             RawItemName::Id(id, _) => {
                 let old_id = match id.parse() {
                     Ok(old_id) => old_id,

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -41,19 +41,19 @@ pub fn create_stmt_rename(create_stmt: &mut Statement<Raw>, to_item_name: String
         })
         | Statement::CreateMaterializedView(CreateMaterializedViewStatement { name, .. })
         | Statement::CreateTable(CreateTableStatement { name, .. }) => {
-            // The last name in an ObjectName is the item name. The item name
+            // The last name in an ItemName is the item name. The item name
             // does not have a fixed index.
             // TODO: https://github.com/MaterializeInc/materialize/issues/5591
-            let object_name_len = name.0.len() - 1;
-            name.0[object_name_len] = Ident::new(to_item_name);
+            let item_name_len = name.0.len() - 1;
+            name.0[item_name_len] = Ident::new(to_item_name);
         }
         Statement::CreateSecret(CreateSecretStatement { name, .. }) => {
-            let object_name_len = name.0.len() - 1;
-            name.0[object_name_len] = Ident::new(to_item_name);
+            let item_name_len = name.0.len() - 1;
+            name.0[item_name_len] = Ident::new(to_item_name);
         }
         Statement::CreateConnection(CreateConnectionStatement { name, .. }) => {
-            let object_name_len = name.0.len() - 1;
-            name.0[object_name_len] = Ident::new(to_item_name);
+            let item_name_len = name.0.len() - 1;
+            name.0[item_name_len] = Ident::new(to_item_name);
         }
         _ => unreachable!("Internal error: only catalog items can be renamed"),
     }
@@ -77,13 +77,13 @@ pub fn create_stmt_rename_refs(
     to_item_name: String,
 ) -> Result<(), String> {
     let from_object = UnresolvedItemName::from(from_name.clone());
-    let maybe_update_object_name = |object_name: &mut UnresolvedItemName| {
-        if object_name.0 == from_object.0 {
+    let maybe_update_object_name = |item_name: &mut UnresolvedItemName| {
+        if item_name.0 == from_object.0 {
             // The last name in an ObjectName is the item name. The item name
             // does not have a fixed index.
             // TODO: https://github.com/MaterializeInc/materialize/issues/5591
-            let object_name_len = object_name.0.len() - 1;
-            object_name.0[object_name_len] = Ident::new(to_item_name.clone());
+            let item_name_len = item_name.0.len() - 1;
+            item_name.0[item_name_len] = Ident::new(to_item_name.clone());
         }
     };
 

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -279,7 +279,7 @@ impl<'a, 'ast> Visit<'ast, Raw> for QueryIdentAgg<'a> {
     fn visit_item_name(&mut self, item_name: &'ast <Raw as AstInfo>::ItemName) {
         match item_name {
             RawItemName::Name(n) | RawItemName::Id(_, n) => {
-                self.visit_unresolved_object_name(n)
+                self.visit_unresolved_item_name(n)
             }
         }
     }

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -76,10 +76,10 @@ pub fn create_stmt_rename_refs(
     from_name: FullItemName,
     to_item_name: String,
 ) -> Result<(), String> {
-    let from_object = UnresolvedItemName::from(from_name.clone());
-    let maybe_update_object_name = |item_name: &mut UnresolvedItemName| {
-        if item_name.0 == from_object.0 {
-            // The last name in an ObjectName is the item name. The item name
+    let from_item = UnresolvedItemName::from(from_name.clone());
+    let maybe_update_item_name = |item_name: &mut UnresolvedItemName| {
+        if item_name.0 == from_item.0 {
+            // The last name in an ItemName is the item name. The item name
             // does not have a fixed index.
             // TODO: https://github.com/MaterializeInc/materialize/issues/5591
             let item_name_len = item_name.0.len() - 1;
@@ -90,10 +90,10 @@ pub fn create_stmt_rename_refs(
     // TODO(sploiselle): Support renaming schemas and databases.
     match create_stmt {
         Statement::CreateIndex(CreateIndexStatement { on_name, .. }) => {
-            maybe_update_object_name(on_name.name_mut());
+            maybe_update_item_name(on_name.name_mut());
         }
         Statement::CreateSink(CreateSinkStatement { from, .. }) => {
-            maybe_update_object_name(from.name_mut());
+            maybe_update_item_name(from.name_mut());
         }
         Statement::CreateView(CreateViewStatement {
             definition: ViewDefinition { query, .. },
@@ -259,7 +259,7 @@ impl<'a, 'ast> Visit<'ast, Raw> for QueryIdentAgg<'a> {
     fn visit_unresolved_item_name(&mut self, unresolved_item_name: &'ast UnresolvedItemName) {
         let names = &unresolved_item_name.0;
         self.check_failure(names);
-        // Every item is used as an `ObjectName` at least once, which
+        // Every item is used as an `ItemName` at least once, which
         // lets use track all items named `self.name`.
         if let Some(p) = names.iter().rposition(|e| e == self.name) {
             // Name used as last element of `<db>.<schema>.<item>`

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -22,7 +22,7 @@ use crate::ast::{
     CreateViewStatement, Expr, Ident, Query, Raw, RawObjectName, Statement, UnresolvedObjectName,
     ViewDefinition,
 };
-use crate::names::FullObjectName;
+use crate::names::FullItemName;
 
 /// Changes the `name` used in an item's `CREATE` statement. To complete a
 /// rename operation, you must also call `create_stmt_rename_refs` on all dependent
@@ -73,7 +73,7 @@ pub fn create_stmt_rename(create_stmt: &mut Statement<Raw>, to_item_name: String
 ///   check, but will be more meaningful once the first restriction is lifted.
 pub fn create_stmt_rename_refs(
     create_stmt: &mut Statement<Raw>,
-    from_name: FullObjectName,
+    from_name: FullItemName,
     to_item_name: String,
 ) -> Result<(), String> {
     let from_object = UnresolvedObjectName::from(from_name.clone());
@@ -113,7 +113,7 @@ pub fn create_stmt_rename_refs(
 }
 
 /// Rewrites `query`'s references of `from` to `to` or errors if too ambiguous.
-fn rewrite_query(from: FullObjectName, to: String, query: &mut Query<Raw>) -> Result<(), String> {
+fn rewrite_query(from: FullItemName, to: String, query: &mut Query<Raw>) -> Result<(), String> {
     let from_ident = Ident::new(from.item.clone());
     let to_ident = Ident::new(to);
     let qual_depth =
@@ -292,7 +292,7 @@ struct CreateSqlRewriter {
 
 impl CreateSqlRewriter {
     fn rewrite_query_with_qual_depth(
-        from_name: FullObjectName,
+        from_name: FullItemName,
         to_name: Ident,
         qual_depth: usize,
         query: &mut Query<Raw>,

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -278,9 +278,7 @@ impl<'a, 'ast> Visit<'ast, Raw> for QueryIdentAgg<'a> {
 
     fn visit_item_name(&mut self, item_name: &'ast <Raw as AstInfo>::ItemName) {
         match item_name {
-            RawItemName::Name(n) | RawItemName::Id(_, n) => {
-                self.visit_unresolved_item_name(n)
-            }
+            RawItemName::Name(n) | RawItemName::Id(_, n) => self.visit_unresolved_item_name(n),
         }
     }
 }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -1022,7 +1022,7 @@ impl<'a, T> ErsatzCatalog<'a, T> {
         &self,
         item: UnresolvedItemName,
     ) -> Result<(UnresolvedItemName, &'a T), PlanError> {
-        let name = normalize::unresolved_object_name(item)?;
+        let name = normalize::unresolved_item_name(item)?;
 
         let schemas = match self.0.get(&name.item) {
             Some(schemas) => schemas,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -39,8 +39,8 @@ use mz_storage_client::types::sources::SourceDesc;
 
 use crate::func::Func;
 use crate::names::{
-    Aug, DatabaseId, FullItemName, FullSchemaName, ObjectId, PartialObjectName,
-    QualifiedObjectName, QualifiedSchemaName, ResolvedDatabaseSpecifier, RoleId, SchemaSpecifier,
+    Aug, DatabaseId, FullItemName, FullSchemaName, ObjectId, PartialItemName,
+    QualifiedItemName, QualifiedSchemaName, ResolvedDatabaseSpecifier, RoleId, SchemaSpecifier,
 };
 use crate::normalize;
 use crate::plan::statement::ddl::PlannedRoleAttributes;
@@ -174,14 +174,14 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     ///
     /// Note that it is not an error if the named item appears in more than one
     /// of the search schemas. The catalog implementation must choose one.
-    fn resolve_item(&self, item_name: &PartialObjectName)
+    fn resolve_item(&self, item_name: &PartialItemName)
         -> Result<&dyn CatalogItem, CatalogError>;
 
     /// Performs the same operation as [`SessionCatalog::resolve_item`] but for
     /// functions within the catalog.
     fn resolve_function(
         &self,
-        item_name: &PartialObjectName,
+        item_name: &PartialItemName,
     ) -> Result<&dyn CatalogItem, CatalogError>;
 
     /// Gets an item by its ID.
@@ -193,7 +193,7 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     fn get_item(&self, id: &GlobalId) -> &dyn CatalogItem;
 
     /// Reports whether the specified type exists in the catalog.
-    fn item_exists(&self, name: &QualifiedObjectName) -> bool;
+    fn item_exists(&self, name: &QualifiedItemName) -> bool;
 
     /// Gets a cluster by ID.
     fn get_cluster(&self, id: ClusterId) -> &dyn CatalogCluster;
@@ -208,10 +208,10 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// Finds a name like `name` that is not already in use.
     ///
     /// If `name` itself is available, it is returned unchanged.
-    fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName;
+    fn find_available_name(&self, name: QualifiedItemName) -> QualifiedItemName;
 
     /// Returns a fully qualified human readable name from fully qualified non-human readable name
-    fn resolve_full_name(&self, name: &QualifiedObjectName) -> FullItemName;
+    fn resolve_full_name(&self, name: &QualifiedItemName) -> FullItemName;
 
     /// Returns a fully qualified human readable schema name from fully qualified non-human
     /// readable schema name
@@ -478,7 +478,7 @@ pub trait CatalogClusterReplica<'a> {
 /// catalog, and refers to the various entities that belong to a schema.
 pub trait CatalogItem {
     /// Returns the fully qualified name of the catalog item.
-    fn name(&self) -> &QualifiedObjectName;
+    fn name(&self) -> &QualifiedItemName;
 
     /// Returns a stable ID for the catalog item.
     fn id(&self) -> GlobalId;

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -1015,8 +1015,8 @@ impl<'a, T> ErsatzCatalog<'a, T> {
     /// describes.
     ///
     /// # Errors
-    /// - If `item` cannot be normalized to a [`PartialObjectName`]
-    /// - If the normalized `PartialObjectName` does not resolve to an item in
+    /// - If `item` cannot be normalized to a [`PartialItemName`]
+    /// - If the normalized `PartialItemName` does not resolve to an item in
     ///   `self.0`.
     pub fn resolve(
         &self,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -32,7 +32,7 @@ use mz_expr::MirScalarExpr;
 use mz_ore::now::{EpochMillis, NowFn};
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::{ColumnName, GlobalId, RelationDesc};
-use mz_sql_parser::ast::UnresolvedObjectName;
+use mz_sql_parser::ast::UnresolvedItemName;
 use mz_sql_parser::ast::{Expr, ObjectType};
 use mz_storage_client::types::connections::Connection;
 use mz_storage_client::types::sources::SourceDesc;
@@ -1020,8 +1020,8 @@ impl<'a, T> ErsatzCatalog<'a, T> {
     ///   `self.0`.
     pub fn resolve(
         &self,
-        item: UnresolvedObjectName,
-    ) -> Result<(UnresolvedObjectName, &'a T), PlanError> {
+        item: UnresolvedItemName,
+    ) -> Result<(UnresolvedItemName, &'a T), PlanError> {
         let name = normalize::unresolved_object_name(item)?;
 
         let schemas = match self.0.get(&name.item) {
@@ -1060,7 +1060,7 @@ impl<'a, T> ErsatzCatalog<'a, T> {
         };
 
         Ok((
-            UnresolvedObjectName::qualified(&[database, schema, &name.item]),
+            UnresolvedItemName::qualified(&[database, schema, &name.item]),
             desc,
         ))
     }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -39,7 +39,7 @@ use mz_storage_client::types::sources::SourceDesc;
 
 use crate::func::Func;
 use crate::names::{
-    Aug, DatabaseId, FullObjectName, FullSchemaName, ObjectId, PartialObjectName,
+    Aug, DatabaseId, FullItemName, FullSchemaName, ObjectId, PartialObjectName,
     QualifiedObjectName, QualifiedSchemaName, ResolvedDatabaseSpecifier, RoleId, SchemaSpecifier,
 };
 use crate::normalize;
@@ -211,7 +211,7 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName;
 
     /// Returns a fully qualified human readable name from fully qualified non-human readable name
-    fn resolve_full_name(&self, name: &QualifiedObjectName) -> FullObjectName;
+    fn resolve_full_name(&self, name: &QualifiedObjectName) -> FullItemName;
 
     /// Returns a fully qualified human readable schema name from fully qualified non-human
     /// readable schema name
@@ -490,7 +490,7 @@ pub trait CatalogItem {
     ///
     /// If the catalog item is not of a type that produces data (i.e., a sink or
     /// an index), it returns an error.
-    fn desc(&self, name: &FullObjectName) -> Result<Cow<RelationDesc>, CatalogError>;
+    fn desc(&self, name: &FullItemName) -> Result<Cow<RelationDesc>, CatalogError>;
 
     /// Returns the resolved function.
     ///

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -39,8 +39,8 @@ use mz_storage_client::types::sources::SourceDesc;
 
 use crate::func::Func;
 use crate::names::{
-    Aug, DatabaseId, FullItemName, FullSchemaName, ObjectId, PartialItemName,
-    QualifiedItemName, QualifiedSchemaName, ResolvedDatabaseSpecifier, RoleId, SchemaSpecifier,
+    Aug, DatabaseId, FullItemName, FullSchemaName, ObjectId, PartialItemName, QualifiedItemName,
+    QualifiedSchemaName, ResolvedDatabaseSpecifier, RoleId, SchemaSpecifier,
 };
 use crate::normalize;
 use crate::plan::statement::ddl::PlannedRoleAttributes;
@@ -174,8 +174,7 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     ///
     /// Note that it is not an error if the named item appears in more than one
     /// of the search schemas. The catalog implementation must choose one.
-    fn resolve_item(&self, item_name: &PartialItemName)
-        -> Result<&dyn CatalogItem, CatalogError>;
+    fn resolve_item(&self, item_name: &PartialItemName) -> Result<&dyn CatalogItem, CatalogError>;
 
     /// Performs the same operation as [`SessionCatalog::resolve_item`] but for
     /// functions within the catalog.

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -24,7 +24,7 @@ use mz_repr::{ColumnName, ColumnType, Datum, RelationType, Row, ScalarBaseType, 
 
 use crate::ast::{SelectStatement, Statement};
 use crate::catalog::{CatalogType, TypeCategory, TypeReference};
-use crate::names::{self, PartialObjectName};
+use crate::names::{self, PartialItemName};
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
     AggregateFunc, BinaryFunc, CoercibleScalarExpr, ColumnOrder, HirRelationExpr, HirScalarExpr,
@@ -39,7 +39,7 @@ use crate::plan::typeconv::{self, CastContext};
 #[derive(Clone, Copy, Debug)]
 pub enum FuncSpec<'a> {
     /// A function name.
-    Func(&'a PartialObjectName),
+    Func(&'a PartialItemName),
     /// An operator name.
     Op(&'a str),
 }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1207,9 +1207,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 }
                 Item(item_name)
             }
-            UnresolvedItemName(name) => {
-                UnresolvedItemName(self.fold_unresolved_item_name(name))
-            }
+            UnresolvedItemName(name) => UnresolvedItemName(self.fold_unresolved_item_name(name)),
             ClusterReplicas(replicas) => ClusterReplicas(
                 replicas
                     .into_iter()

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -39,11 +39,11 @@ use crate::plan::PlanError;
 /// A fully-qualified human readable name of an item in the catalog.
 ///
 /// Catalog names compare case sensitively. Use
-/// [`normalize::unresolved_object_name`] to
-/// perform proper case folding if converting an [`UnresolvedObjectName`] to a
+/// [`normalize::unresolved_item_name`] to
+/// perform proper case folding if converting an [`UnresolvedItemName`] to a
 /// `FullItemName`.
 ///
-/// [`normalize::unresolved_object_name`]: crate::normalize::unresolved_object_name
+/// [`normalize::unresolved_item_name`]: crate::normalize::unresolved_item_name
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct FullItemName {
     /// The database name.
@@ -829,7 +829,7 @@ impl<'a> NameResolver<'a> {
             RawDataType::Other { name, typ_mod } => {
                 let (full_name, item) = match name {
                     RawItemName::Name(name) => {
-                        let name = normalize::unresolved_object_name(name)?;
+                        let name = normalize::unresolved_item_name(name)?;
                         let item = self.catalog.resolve_item(&name)?;
                         let full_name = self.catalog.resolve_full_name(item.name());
                         (full_name, item)
@@ -967,7 +967,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
     ) -> <Aug as AstInfo>::ItemName {
         match item_name {
             RawItemName::Name(raw_name) => {
-                let raw_name = match normalize::unresolved_object_name(raw_name) {
+                let raw_name = match normalize::unresolved_item_name(raw_name) {
                     Ok(raw_name) => raw_name,
                     Err(e) => {
                         if self.status.is_ok() {

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -78,12 +78,12 @@ impl From<FullItemName> for UnresolvedItemName {
 /// A fully-qualified non-human readable name of an item in the catalog using IDs for the database
 /// and schema.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct QualifiedObjectName {
+pub struct QualifiedItemName {
     pub qualifiers: ItemQualifiers,
     pub item: String,
 }
 
-impl fmt::Display for QualifiedObjectName {
+impl fmt::Display for QualifiedItemName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let ResolvedDatabaseSpecifier::Id(id) = &self.qualifiers.database_spec {
             write!(f, "{}.", id)?;
@@ -94,16 +94,16 @@ impl fmt::Display for QualifiedObjectName {
 
 /// An optionally-qualified human-readable name of an item in the catalog.
 ///
-/// This is like a [`FullObjectName`], but either the database or schema name may be
+/// This is like a [`FullItemName`], but either the database or schema name may be
 /// omitted.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PartialObjectName {
+pub struct PartialItemName {
     pub database: Option<String>,
     pub schema: Option<String>,
     pub item: String,
 }
 
-impl PartialObjectName {
+impl PartialItemName {
     // Whether either self or other might be a (possibly differently qualified)
     // version of the other.
     pub fn matches(&self, other: &Self) -> bool {
@@ -119,7 +119,7 @@ impl PartialObjectName {
     }
 }
 
-impl fmt::Display for PartialObjectName {
+impl fmt::Display for PartialItemName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(database) = &self.database {
             write!(f, "{}.", database)?;
@@ -131,13 +131,13 @@ impl fmt::Display for PartialObjectName {
     }
 }
 
-impl From<FullItemName> for PartialObjectName {
-    fn from(n: FullItemName) -> PartialObjectName {
+impl From<FullItemName> for PartialItemName {
+    fn from(n: FullItemName) -> PartialItemName {
         let database = match n.database {
             RawDatabaseSpecifier::Ambient => None,
             RawDatabaseSpecifier::Name(name) => Some(name),
         };
-        PartialObjectName {
+        PartialItemName {
             database,
             schema: Some(n.schema),
             item: n.item,
@@ -145,9 +145,9 @@ impl From<FullItemName> for PartialObjectName {
     }
 }
 
-impl From<String> for PartialObjectName {
+impl From<String> for PartialItemName {
     fn from(item: String) -> Self {
-        PartialObjectName {
+        PartialItemName {
             database: None,
             schema: None,
             item,
@@ -155,8 +155,8 @@ impl From<String> for PartialObjectName {
     }
 }
 
-impl From<PartialObjectName> for UnresolvedItemName {
-    fn from(partial_name: PartialObjectName) -> UnresolvedItemName {
+impl From<PartialItemName> for UnresolvedItemName {
+    fn from(partial_name: PartialItemName) -> UnresolvedItemName {
         let mut name_parts = Vec::new();
         if let Some(database) = partial_name.database {
             name_parts.push(Ident::new(database));

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1196,7 +1196,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 }
                 Secret(item_name)
             }
-            Object(obj) => {
+            Item(obj) => {
                 let item_name = self.fold_item_name(obj);
                 match &item_name {
                     ResolvedItemName::Item { .. } => {}
@@ -1205,10 +1205,10 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                     }
                     ResolvedItemName::Error => {}
                 }
-                Object(item_name)
+                Item(item_name)
             }
-            UnresolvedObjectName(name) => {
-                UnresolvedObjectName(self.fold_unresolved_item_name(name))
+            UnresolvedItemName(name) => {
+                UnresolvedItemName(self.fold_unresolved_item_name(name))
             }
             ClusterReplicas(replicas) => ClusterReplicas(
                 replicas

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -272,7 +272,7 @@ pub fn create_statement(
         fn visit_table_factor_mut(&mut self, table_factor: &'ast mut TableFactor<Aug>) {
             match table_factor {
                 TableFactor::Table { name, alias, .. } => {
-                    self.visit_object_name_mut(name);
+                    self.visit_item_name_mut(name);
                     if let Some(alias) = alias {
                         self.visit_table_alias_mut(alias);
                     }

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -30,7 +30,7 @@ use mz_sql_parser::ast::{
 };
 
 use crate::names::{
-    Aug, FullItemName, PartialObjectName, PartialSchemaName, RawDatabaseSpecifier,
+    Aug, FullItemName, PartialItemName, PartialSchemaName, RawDatabaseSpecifier,
 };
 use crate::plan::error::PlanError;
 use crate::plan::statement::StatementContext;
@@ -53,11 +53,11 @@ pub fn column_name(id: Ident) -> ColumnName {
 /// Normalizes an unresolved object name.
 pub fn unresolved_object_name(
     mut name: UnresolvedItemName,
-) -> Result<PartialObjectName, PlanError> {
+) -> Result<PartialItemName, PlanError> {
     if name.0.len() < 1 || name.0.len() > 3 {
         return Err(PlanError::MisqualifiedName(name.to_string()));
     }
-    let out = PartialObjectName {
+    let out = PartialItemName {
         item: ident(
             name.0
                 .pop()

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -29,9 +29,7 @@ use mz_sql_parser::ast::{
     UnresolvedItemName, UnresolvedSchemaName, Value, ViewDefinition,
 };
 
-use crate::names::{
-    Aug, FullItemName, PartialItemName, PartialSchemaName, RawDatabaseSpecifier,
-};
+use crate::names::{Aug, FullItemName, PartialItemName, PartialSchemaName, RawDatabaseSpecifier};
 use crate::plan::error::PlanError;
 use crate::plan::statement::StatementContext;
 
@@ -51,9 +49,7 @@ pub fn column_name(id: Ident) -> ColumnName {
 }
 
 /// Normalizes an unresolved object name.
-pub fn unresolved_item_name(
-    mut name: UnresolvedItemName,
-) -> Result<PartialItemName, PlanError> {
+pub fn unresolved_item_name(mut name: UnresolvedItemName) -> Result<PartialItemName, PlanError> {
     if name.0.len() < 1 || name.0.len() > 3 {
         return Err(PlanError::MisqualifiedName(name.to_string()));
     }
@@ -173,9 +169,9 @@ pub fn create_statement(
     mut stmt: Statement<Aug>,
 ) -> Result<String, PlanError> {
     let allocate_name = |name: &UnresolvedItemName| -> Result<_, PlanError> {
-        Ok(unresolve(scx.allocate_full_name(
-            unresolved_item_name(name.clone())?,
-        )?))
+        Ok(unresolve(
+            scx.allocate_full_name(unresolved_item_name(name.clone())?)?,
+        ))
     };
 
     let allocate_temporary_name = |name: &UnresolvedItemName| -> Result<_, PlanError> {

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -51,7 +51,7 @@ pub fn column_name(id: Ident) -> ColumnName {
 }
 
 /// Normalizes an unresolved object name.
-pub fn unresolved_object_name(
+pub fn unresolved_item_name(
     mut name: UnresolvedItemName,
 ) -> Result<PartialItemName, PlanError> {
     if name.0.len() < 1 || name.0.len() > 3 {
@@ -129,9 +129,9 @@ impl From<SqlValueOrSecret> for Option<Value> {
     }
 }
 
-/// Unnormalizes an object name.
+/// Unnormalizes an item name.
 ///
-/// This is the inverse of the [`unresolved_object_name`] function.
+/// This is the inverse of the [`unresolved_item_name`] function.
 pub fn unresolve(name: FullItemName) -> UnresolvedItemName {
     let mut out = vec![];
     if let RawDatabaseSpecifier::Name(n) = name.database {
@@ -142,8 +142,8 @@ pub fn unresolve(name: FullItemName) -> UnresolvedItemName {
     UnresolvedItemName(out)
 }
 
-/// Converts an `UnresolvedObjectName` to a `FullObjectName` if the
-/// `UnresolvedObjectName` is fully specified. Otherwise returns an error.
+/// Converts an `UnresolvedItemName` to a `FullItemName` if the
+/// `UnresolvedItemName` is fully specified. Otherwise returns an error.
 pub fn full_name(mut raw_name: UnresolvedItemName) -> Result<FullItemName, PlanError> {
     match raw_name.0.len() {
         3 => Ok(FullItemName {
@@ -165,22 +165,22 @@ pub fn full_name(mut raw_name: UnresolvedItemName) -> Result<FullItemName, PlanE
 /// The resulting statement will not depend upon any session parameters, nor
 /// specify any non-default options (like `TEMPORARY`, `IF NOT EXISTS`, etc).
 ///
-/// The goal is to construct a backwards-compatible description of the object.
+/// The goal is to construct a backwards-compatible description of the item.
 /// SQL is the most stable part of Materialize, so SQL is used to describe the
-/// objects that are persisted in the catalog.
+/// items that are persisted in the catalog.
 pub fn create_statement(
     scx: &StatementContext,
     mut stmt: Statement<Aug>,
 ) -> Result<String, PlanError> {
     let allocate_name = |name: &UnresolvedItemName| -> Result<_, PlanError> {
         Ok(unresolve(scx.allocate_full_name(
-            unresolved_object_name(name.clone())?,
+            unresolved_item_name(name.clone())?,
         )?))
     };
 
     let allocate_temporary_name = |name: &UnresolvedItemName| -> Result<_, PlanError> {
         Ok(unresolve(scx.allocate_temporary_full_name(
-            unresolved_object_name(name.clone())?,
+            unresolved_item_name(name.clone())?,
         )))
     };
 

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -30,7 +30,7 @@ use mz_sql_parser::ast::{
 };
 
 use crate::names::{
-    Aug, FullObjectName, PartialObjectName, PartialSchemaName, RawDatabaseSpecifier,
+    Aug, FullItemName, PartialObjectName, PartialSchemaName, RawDatabaseSpecifier,
 };
 use crate::plan::error::PlanError;
 use crate::plan::statement::StatementContext;
@@ -132,7 +132,7 @@ impl From<SqlValueOrSecret> for Option<Value> {
 /// Unnormalizes an object name.
 ///
 /// This is the inverse of the [`unresolved_object_name`] function.
-pub fn unresolve(name: FullObjectName) -> UnresolvedObjectName {
+pub fn unresolve(name: FullItemName) -> UnresolvedObjectName {
     let mut out = vec![];
     if let RawDatabaseSpecifier::Name(n) = name.database {
         out.push(Ident::new(n));
@@ -144,14 +144,14 @@ pub fn unresolve(name: FullObjectName) -> UnresolvedObjectName {
 
 /// Converts an `UnresolvedObjectName` to a `FullObjectName` if the
 /// `UnresolvedObjectName` is fully specified. Otherwise returns an error.
-pub fn full_name(mut raw_name: UnresolvedObjectName) -> Result<FullObjectName, PlanError> {
+pub fn full_name(mut raw_name: UnresolvedObjectName) -> Result<FullItemName, PlanError> {
     match raw_name.0.len() {
-        3 => Ok(FullObjectName {
+        3 => Ok(FullItemName {
             item: ident(raw_name.0.pop().unwrap()),
             schema: ident(raw_name.0.pop().unwrap()),
             database: RawDatabaseSpecifier::Name(ident(raw_name.0.pop().unwrap())),
         }),
-        2 => Ok(FullObjectName {
+        2 => Ok(FullItemName {
             item: ident(raw_name.0.pop().unwrap()),
             schema: ident(raw_name.0.pop().unwrap()),
             database: RawDatabaseSpecifier::Ambient,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -60,8 +60,8 @@ use crate::ast::{
 };
 use crate::catalog::{CatalogType, IdReference, RoleAttributes};
 use crate::names::{
-    Aug, DatabaseId, FullItemName, ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier,
-    RoleId, SchemaId,
+    Aug, DatabaseId, FullItemName, ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier, RoleId,
+    SchemaId,
 };
 
 pub use self::expr::{

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -60,7 +60,7 @@ use crate::ast::{
 };
 use crate::catalog::{CatalogType, IdReference, RoleAttributes};
 use crate::names::{
-    Aug, DatabaseId, FullItemName, ObjectId, QualifiedObjectName, ResolvedDatabaseSpecifier,
+    Aug, DatabaseId, FullItemName, ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier,
     RoleId, SchemaId,
 };
 
@@ -450,7 +450,7 @@ pub enum ReplicaConfig {
 
 #[derive(Debug)]
 pub struct CreateSourcePlan {
-    pub name: QualifiedObjectName,
+    pub name: QualifiedItemName,
     pub source: Source,
     pub if_not_exists: bool,
     pub timeline: Timeline,
@@ -502,21 +502,21 @@ pub enum SourceSinkClusterConfig {
 
 #[derive(Debug)]
 pub struct CreateConnectionPlan {
-    pub name: QualifiedObjectName,
+    pub name: QualifiedItemName,
     pub if_not_exists: bool,
     pub connection: Connection,
 }
 
 #[derive(Debug)]
 pub struct CreateSecretPlan {
-    pub name: QualifiedObjectName,
+    pub name: QualifiedItemName,
     pub secret: Secret,
     pub if_not_exists: bool,
 }
 
 #[derive(Debug)]
 pub struct CreateSinkPlan {
-    pub name: QualifiedObjectName,
+    pub name: QualifiedItemName,
     pub sink: Sink,
     pub with_snapshot: bool,
     pub if_not_exists: bool,
@@ -525,14 +525,14 @@ pub struct CreateSinkPlan {
 
 #[derive(Debug)]
 pub struct CreateTablePlan {
-    pub name: QualifiedObjectName,
+    pub name: QualifiedItemName,
     pub table: Table,
     pub if_not_exists: bool,
 }
 
 #[derive(Debug)]
 pub struct CreateViewPlan {
-    pub name: QualifiedObjectName,
+    pub name: QualifiedItemName,
     pub view: View,
     /// The ID of the object that this view is replacing, if any.
     pub replace: Option<GlobalId>,
@@ -544,7 +544,7 @@ pub struct CreateViewPlan {
 
 #[derive(Debug)]
 pub struct CreateMaterializedViewPlan {
-    pub name: QualifiedObjectName,
+    pub name: QualifiedItemName,
     pub materialized_view: MaterializedView,
     /// The ID of the object that this view is replacing, if any.
     pub replace: Option<GlobalId>,
@@ -556,7 +556,7 @@ pub struct CreateMaterializedViewPlan {
 
 #[derive(Debug)]
 pub struct CreateIndexPlan {
-    pub name: QualifiedObjectName,
+    pub name: QualifiedItemName,
     pub index: Index,
     pub options: Vec<IndexOption>,
     pub if_not_exists: bool,
@@ -564,7 +564,7 @@ pub struct CreateIndexPlan {
 
 #[derive(Debug)]
 pub struct CreateTypePlan {
-    pub name: QualifiedObjectName,
+    pub name: QualifiedItemName,
     pub typ: Type,
 }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -60,7 +60,7 @@ use crate::ast::{
 };
 use crate::catalog::{CatalogType, IdReference, RoleAttributes};
 use crate::names::{
-    Aug, DatabaseId, FullObjectName, ObjectId, QualifiedObjectName, ResolvedDatabaseSpecifier,
+    Aug, DatabaseId, FullItemName, ObjectId, QualifiedObjectName, ResolvedDatabaseSpecifier,
     RoleId, SchemaId,
 };
 
@@ -746,7 +746,7 @@ pub struct AlterSourcePlan {
 #[derive(Debug)]
 pub struct AlterItemRenamePlan {
     pub id: GlobalId,
-    pub current_full_name: FullObjectName,
+    pub current_full_name: FullItemName,
     pub to_name: String,
     pub object_type: ObjectType,
 }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -31,7 +31,7 @@ use mz_sql_parser::ast::UnresolvedItemName;
 use mz_sql_parser::parser::ParserError;
 
 use crate::catalog::{CatalogError, CatalogItemType};
-use crate::names::PartialObjectName;
+use crate::names::PartialItemName;
 use crate::names::ResolvedItemName;
 use crate::plan::plan_utils::JoinSide;
 use crate::plan::scope::ScopeItem;
@@ -49,19 +49,19 @@ pub enum PlanError {
         documentation_link: String,
     },
     UnknownColumn {
-        table: Option<PartialObjectName>,
+        table: Option<PartialItemName>,
         column: ColumnName,
     },
     UngroupedColumn {
-        table: Option<PartialObjectName>,
+        table: Option<PartialItemName>,
         column: ColumnName,
     },
     WrongJoinTypeForLateralColumn {
-        table: Option<PartialObjectName>,
+        table: Option<PartialItemName>,
         column: ColumnName,
     },
     AmbiguousColumn(ColumnName),
-    AmbiguousTable(PartialObjectName),
+    AmbiguousTable(PartialItemName),
     UnknownColumnInUsingClause {
         column: ColumnName,
         join_side: JoinSide,
@@ -466,7 +466,7 @@ impl From<ParserError> for PlanError {
 }
 
 struct ColumnDisplay<'a> {
-    table: &'a Option<PartialObjectName>,
+    table: &'a Option<PartialItemName>,
     column: &'a ColumnName,
 }
 

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -27,7 +27,7 @@ use mz_repr::strconv;
 use mz_repr::ColumnName;
 use mz_repr::GlobalId;
 use mz_sql_parser::ast::display::AstDisplay;
-use mz_sql_parser::ast::UnresolvedObjectName;
+use mz_sql_parser::ast::UnresolvedItemName;
 use mz_sql_parser::parser::ParserError;
 
 use crate::catalog::{CatalogError, CatalogItemType};
@@ -119,7 +119,7 @@ pub enum PlanError {
         err: Box<PlanError>,
     },
     UnexpectedDuplicateReference {
-        name: UnresolvedObjectName,
+        name: UnresolvedItemName,
     },
     /// Declaration of a recursive type did not match the inferred type.
     RecursiveTypeMismatch(String, Vec<String>, Vec<String>),

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -32,7 +32,7 @@ use mz_sql_parser::parser::ParserError;
 
 use crate::catalog::{CatalogError, CatalogItemType};
 use crate::names::PartialObjectName;
-use crate::names::ResolvedObjectName;
+use crate::names::ResolvedItemName;
 use crate::plan::plan_utils::JoinSide;
 use crate::plan::scope::ScopeItem;
 
@@ -85,9 +85,9 @@ pub enum PlanError {
     InvalidNumericMaxScale(InvalidNumericMaxScaleError),
     InvalidCharLength(InvalidCharLengthError),
     InvalidId(GlobalId),
-    InvalidObject(Box<ResolvedObjectName>),
+    InvalidObject(Box<ResolvedItemName>),
     InvalidVarCharMaxLength(InvalidVarCharMaxLengthError),
-    InvalidSecret(Box<ResolvedObjectName>),
+    InvalidSecret(Box<ResolvedItemName>),
     InvalidTemporarySchema,
     Parser(ParserError),
     DropViewOnMaterializedView(String),

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -319,7 +319,7 @@ pub fn plan_insert_query(
     }
 
     let returning = {
-        let (scope, typ) = if let ResolvedItemName::Object { full_name, .. } = table_name {
+        let (scope, typ) = if let ResolvedItemName::Item { full_name, .. } = table_name {
             let desc = table.desc(&full_name)?;
             let scope = Scope::from_source(Some(full_name.clone().into()), desc.iter_names());
             let typ = desc.typ().clone();
@@ -566,7 +566,7 @@ pub fn plan_mutation_query_inner(
 ) -> Result<ReadThenWritePlan, PlanError> {
     // Get global ID.
     let id = match table_name {
-        ResolvedItemName::Object { id, .. } => id,
+        ResolvedItemName::Item { id, .. } => id,
         _ => sql_bail!("cannot mutate non-user table"),
     };
 
@@ -5238,7 +5238,7 @@ impl<'a> QueryContext<'a> {
         object: ResolvedItemName,
     ) -> Result<(HirRelationExpr, Scope), PlanError> {
         match object {
-            ResolvedItemName::Object { id, full_name, .. } => {
+            ResolvedItemName::Item { id, full_name, .. } => {
                 let name = full_name.into();
                 let item = self.scx.get_item(&id);
                 let desc = item

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2588,9 +2588,9 @@ fn plan_table_function_internal(
             plan_exprs(ecx, args)?
         }
     };
-    let resolved_name = normalize::unresolved_object_name(name.clone())?;
+    let resolved_name = normalize::unresolved_item_name(name.clone())?;
     let table_name = match table_name {
-        Some(table_name) => normalize::unresolved_object_name(table_name.clone())?.item,
+        Some(table_name) => normalize::unresolved_item_name(table_name.clone())?.item,
         None => resolved_name.item.clone(),
     };
     let scope_name = Some(PartialItemName {
@@ -2747,7 +2747,7 @@ fn invent_column_name(
                 _ => None,
             },
             Expr::Function(func) => {
-                let name = normalize::unresolved_object_name(func.name.clone()).ok()?;
+                let name = normalize::unresolved_item_name(func.name.clone()).ok()?;
                 if name.schema.as_deref() == Some("mz_internal") {
                     None
                 } else {
@@ -2825,7 +2825,7 @@ fn expand_select_item<'a>(
         } => {
             *ecx.qcx.scx.ambiguous_columns.borrow_mut() = true;
             let table_name =
-                normalize::unresolved_object_name(UnresolvedItemName(table_name.clone()))?;
+                normalize::unresolved_item_name(UnresolvedItemName(table_name.clone()))?;
             let out: Vec<_> = ecx
                 .scope
                 .items
@@ -4134,7 +4134,7 @@ fn plan_aggregate(
         bail_unsupported!("aggregate window functions");
     }
 
-    let name = normalize::unresolved_object_name(name.clone())?;
+    let name = normalize::unresolved_item_name(name.clone())?;
 
     // We follow PostgreSQL's rule here for mapping `count(*)` into the
     // generalized function selection framework. The rule is simple: the user
@@ -4224,7 +4224,7 @@ fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<HirScalarExpr, 
 
     // If the name is qualified, it must refer to a column in a table.
     if !names.is_empty() {
-        let table_name = normalize::unresolved_object_name(UnresolvedItemName(names))?;
+        let table_name = normalize::unresolved_item_name(UnresolvedItemName(names))?;
         let i = ecx
             .scope
             .resolve_table_column(&ecx.qcx.outer_scopes, &table_name, &col_name)?;
@@ -4325,7 +4325,7 @@ fn plan_function<'a>(
         distinct,
     }: &'a Function<Aug>,
 ) -> Result<HirScalarExpr, PlanError> {
-    let unresolved_name = normalize::unresolved_object_name(name.clone())?;
+    let unresolved_name = normalize::unresolved_item_name(name.clone())?;
 
     let impls = match resolve_func(ecx, name, args)? {
         Func::Aggregate(_) if ecx.allow_aggregates => {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -68,7 +68,7 @@ use mz_sql_parser::ast::{
 
 use crate::catalog::{CatalogItemType, CatalogType, SessionCatalog};
 use crate::func::{self, Func, FuncSpec};
-use crate::names::{Aug, PartialObjectName, ResolvedDataType, ResolvedItemName};
+use crate::names::{Aug, PartialItemName, ResolvedDataType, ResolvedItemName};
 use crate::normalize;
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
@@ -2084,7 +2084,7 @@ fn plan_scalar_table_funcs(
         // A single table-function might return several columns as a record
         let num_cols = scope.len();
         for i in 0..scope.len() {
-            scope.items[i].table_name = Some(PartialObjectName {
+            scope.items[i].table_name = Some(PartialItemName {
                 database: None,
                 schema: None,
                 item: id.clone(),
@@ -2102,7 +2102,7 @@ fn plan_scalar_table_funcs(
     let mut i = 0;
     for (id, num_cols) in table_funcs.values().zip(num_cols) {
         for _ in 0..num_cols {
-            scope.items[i].table_name = Some(PartialObjectName {
+            scope.items[i].table_name = Some(PartialItemName {
                 database: None,
                 schema: None,
                 item: id.clone(),
@@ -2114,7 +2114,7 @@ fn plan_scalar_table_funcs(
         // Ordinality column. This doubles as the
         // `is_exists_column_for_a_table_function_that_was_in_the_target_list` later on
         // because it only needs to be NULL or not.
-        scope.items[i].table_name = Some(PartialObjectName {
+        scope.items[i].table_name = Some(PartialItemName {
             database: None,
             schema: None,
             item: id.clone(),
@@ -2593,7 +2593,7 @@ fn plan_table_function_internal(
         Some(table_name) => normalize::unresolved_object_name(table_name.clone())?.item,
         None => resolved_name.item.clone(),
     };
-    let scope_name = Some(PartialObjectName {
+    let scope_name = Some(PartialItemName {
         database: None,
         schema: None,
         item: table_name,
@@ -2650,7 +2650,7 @@ fn plan_table_alias(mut scope: Scope, alias: Option<&TableAlias>) -> Result<Scop
         let table_name = normalize::ident(name.to_owned());
         for (i, item) in scope.items.iter_mut().enumerate() {
             item.table_name = if item.allow_unqualified_references {
-                Some(PartialObjectName {
+                Some(PartialItemName {
                     database: None,
                     schema: None,
                     item: table_name.clone(),
@@ -2862,7 +2862,7 @@ fn expand_select_item<'a>(
                 if let [name] = ident.as_slice() {
                     if let Ok(items) = ecx.scope.items_from_table(
                         &[],
-                        &PartialObjectName {
+                        &PartialItemName {
                             database: None,
                             schema: None,
                             item: name.as_str().to_string(),
@@ -4242,7 +4242,7 @@ fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<HirScalarExpr, 
     // to a table.
     let items = ecx.scope.items_from_table(
         &ecx.qcx.outer_scopes,
-        &PartialObjectName {
+        &PartialItemName {
             database: None,
             schema: None,
             item: col_name.as_str().to_owned(),

--- a/src/sql/src/plan/scope.rs
+++ b/src/sql/src/plan/scope.rs
@@ -48,7 +48,7 @@ use mz_ore::iter::IteratorExt;
 use mz_repr::ColumnName;
 
 use crate::ast::Expr;
-use crate::names::{Aug, PartialObjectName};
+use crate::names::{Aug, PartialItemName};
 use crate::plan::error::PlanError;
 use crate::plan::expr::ColumnRef;
 use crate::plan::plan_utils::JoinSide;
@@ -56,7 +56,7 @@ use crate::plan::plan_utils::JoinSide;
 #[derive(Debug, Clone)]
 pub struct ScopeItem {
     /// The name of the table that produced this scope item, if any.
-    pub table_name: Option<PartialObjectName>,
+    pub table_name: Option<PartialItemName>,
     /// The name of the column.
     pub column_name: ColumnName,
     /// The expressions from which this scope item is derived. Used by `GROUP
@@ -145,7 +145,7 @@ impl ScopeItem {
     }
 
     /// Constructs a new scope item from a name.
-    pub fn from_name<N>(table_name: Option<PartialObjectName>, column_name: N) -> ScopeItem
+    pub fn from_name<N>(table_name: Option<PartialItemName>, column_name: N) -> ScopeItem
     where
         N: Into<ColumnName>,
     {
@@ -164,7 +164,7 @@ impl ScopeItem {
         item
     }
 
-    pub fn is_from_table(&self, table_name: &PartialObjectName) -> bool {
+    pub fn is_from_table(&self, table_name: &PartialItemName) -> bool {
         match &self.table_name {
             None => false,
             Some(n) => n.matches(table_name),
@@ -180,7 +180,7 @@ impl Scope {
         }
     }
 
-    pub fn from_source<I, N>(table_name: Option<PartialObjectName>, column_names: I) -> Self
+    pub fn from_source<I, N>(table_name: Option<PartialItemName>, column_names: I) -> Self
     where
         I: IntoIterator<Item = N>,
         N: Into<ColumnName>,
@@ -253,7 +253,7 @@ impl Scope {
     pub fn items_from_table<'a>(
         &'a self,
         outer_scopes: &'a [Scope],
-        table: &PartialObjectName,
+        table: &PartialItemName,
     ) -> Result<Vec<(ColumnRef, &'a ScopeItem)>, PlanError> {
         let mut seen_level = None;
         let items: Vec<_> = self
@@ -273,7 +273,7 @@ impl Scope {
         &'a self,
         outer_scopes: &[Scope],
         mut matches: M,
-        table_name: Option<&PartialObjectName>,
+        table_name: Option<&PartialItemName>,
         column_name: &ColumnName,
     ) -> Result<ColumnRef, PlanError>
     where
@@ -351,7 +351,7 @@ impl Scope {
     pub fn resolve_table_column<'a>(
         &'a self,
         outer_scopes: &[Scope],
-        table_name: &PartialObjectName,
+        table_name: &PartialItemName,
         column_name: &ColumnName,
     ) -> Result<ColumnRef, PlanError> {
         let mut seen_at_level = None;
@@ -381,7 +381,7 @@ impl Scope {
     pub fn resolve<'a>(
         &'a self,
         outer_scopes: &[Scope],
-        table_name: Option<&PartialObjectName>,
+        table_name: Option<&PartialItemName>,
         column_name: &ColumnName,
     ) -> Result<ColumnRef, PlanError> {
         match table_name {
@@ -432,10 +432,10 @@ impl Scope {
         }
     }
 
-    fn table_names(&self) -> BTreeSet<&PartialObjectName> {
+    fn table_names(&self) -> BTreeSet<&PartialItemName> {
         self.items
             .iter()
             .filter_map(|name| name.table_name.as_ref())
-            .collect::<BTreeSet<&PartialObjectName>>()
+            .collect::<BTreeSet<&PartialItemName>>()
     }
 }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -540,9 +540,9 @@ impl<'a> StatementContext<'a> {
         })
     }
 
-    // Creates a `ResolvedObjectName::Object` from a `GlobalId` and an
-    // `UnresolvedObjectName`.
-    pub fn allocate_resolved_object_name(
+    // Creates a `ResolvedItemName::Item` from a `GlobalId` and an
+    // `UnresolvedItemName`.
+    pub fn allocate_resolved_item_name(
         &self,
         id: GlobalId,
         name: UnresolvedItemName,

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -26,9 +26,9 @@ use crate::catalog::{
     CatalogCluster, CatalogDatabase, CatalogItem, CatalogItemType, CatalogSchema, SessionCatalog,
 };
 use crate::names::{
-    self, Aug, DatabaseId, FullItemName, ItemQualifiers, PartialItemName,
-    QualifiedItemName, RawDatabaseSpecifier, ResolvedDataType, ResolvedDatabaseSpecifier,
-    ResolvedItemName, ResolvedSchemaName, SchemaSpecifier,
+    self, Aug, DatabaseId, FullItemName, ItemQualifiers, PartialItemName, QualifiedItemName,
+    RawDatabaseSpecifier, ResolvedDataType, ResolvedDatabaseSpecifier, ResolvedItemName,
+    ResolvedSchemaName, SchemaSpecifier,
 };
 use crate::normalize;
 use crate::plan::error::PlanError;

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -547,7 +547,7 @@ impl<'a> StatementContext<'a> {
         id: GlobalId,
         name: UnresolvedItemName,
     ) -> Result<ResolvedItemName, PlanError> {
-        let partial = normalize::unresolved_object_name(name)?;
+        let partial = normalize::unresolved_item_name(name)?;
         let qualified = self.allocate_qualified_name(partial.clone())?;
         let full_name = self.allocate_full_name(partial)?;
         Ok(ResolvedItemName::Item {
@@ -630,7 +630,7 @@ impl<'a> StatementContext<'a> {
     pub fn resolve_item(&self, name: RawItemName) -> Result<&dyn CatalogItem, PlanError> {
         match name {
             RawItemName::Name(name) => {
-                let name = normalize::unresolved_object_name(name)?;
+                let name = normalize::unresolved_item_name(name)?;
                 Ok(self.catalog.resolve_item(&name)?)
             }
             RawItemName::Id(id, _) => {
@@ -659,7 +659,7 @@ impl<'a> StatementContext<'a> {
         &self,
         name: UnresolvedItemName,
     ) -> Result<&dyn CatalogItem, PlanError> {
-        let name = normalize::unresolved_object_name(name)?;
+        let name = normalize::unresolved_item_name(name)?;
         Ok(self.catalog.resolve_function(&name)?)
     }
 

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -28,7 +28,7 @@ use crate::catalog::{
 use crate::names::{
     self, Aug, DatabaseId, FullObjectName, ObjectQualifiers, PartialObjectName,
     QualifiedObjectName, RawDatabaseSpecifier, ResolvedDataType, ResolvedDatabaseSpecifier,
-    ResolvedObjectName, ResolvedSchemaName, SchemaSpecifier,
+    ResolvedItemName, ResolvedSchemaName, SchemaSpecifier,
 };
 use crate::normalize;
 use crate::plan::error::PlanError;
@@ -546,11 +546,11 @@ impl<'a> StatementContext<'a> {
         &self,
         id: GlobalId,
         name: UnresolvedObjectName,
-    ) -> Result<ResolvedObjectName, PlanError> {
+    ) -> Result<ResolvedItemName, PlanError> {
         let partial = normalize::unresolved_object_name(name)?;
         let qualified = self.allocate_qualified_name(partial.clone())?;
         let full_name = self.allocate_full_name(partial)?;
-        Ok(ResolvedObjectName::Object {
+        Ok(ResolvedItemName::Object {
             id,
             qualifiers: qualified.qualifiers,
             full_name,
@@ -646,12 +646,12 @@ impl<'a> StatementContext<'a> {
 
     pub fn get_item_by_resolved_name(
         &self,
-        name: &ResolvedObjectName,
+        name: &ResolvedItemName,
     ) -> Result<&dyn CatalogItem, PlanError> {
         match name {
-            ResolvedObjectName::Object { id, .. } => Ok(self.get_item(id)),
-            ResolvedObjectName::Cte { .. } => sql_bail!("non-user item"),
-            ResolvedObjectName::Error => unreachable!("should have been caught in name resolution"),
+            ResolvedItemName::Object { id, .. } => Ok(self.get_item(id)),
+            ResolvedItemName::Cte { .. } => sql_bail!("non-user item"),
+            ResolvedItemName::Error => unreachable!("should have been caught in name resolution"),
         }
     }
 

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -16,12 +16,12 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use mz_repr::{ColumnType, GlobalId, RelationDesc, ScalarType};
 use mz_sql_parser::ast::{
-    ColumnDef, RawObjectName, ShowStatement, TableConstraint, UnresolvedDatabaseName,
+    ColumnDef, RawItemName, ShowStatement, TableConstraint, UnresolvedDatabaseName,
     UnresolvedSchemaName,
 };
 use mz_storage_client::types::connections::{AwsPrivatelink, Connection, SshTunnel, Tunnel};
 
-use crate::ast::{Ident, ObjectType, Statement, UnresolvedObjectName};
+use crate::ast::{Ident, ObjectType, Statement, UnresolvedItemName};
 use crate::catalog::{
     CatalogCluster, CatalogDatabase, CatalogItem, CatalogItemType, CatalogSchema, SessionCatalog,
 };
@@ -545,7 +545,7 @@ impl<'a> StatementContext<'a> {
     pub fn allocate_resolved_object_name(
         &self,
         id: GlobalId,
-        name: UnresolvedObjectName,
+        name: UnresolvedItemName,
     ) -> Result<ResolvedItemName, PlanError> {
         let partial = normalize::unresolved_object_name(name)?;
         let qualified = self.allocate_qualified_name(partial.clone())?;
@@ -627,13 +627,13 @@ impl<'a> StatementContext<'a> {
         self.catalog.item_exists(name)
     }
 
-    pub fn resolve_item(&self, name: RawObjectName) -> Result<&dyn CatalogItem, PlanError> {
+    pub fn resolve_item(&self, name: RawItemName) -> Result<&dyn CatalogItem, PlanError> {
         match name {
-            RawObjectName::Name(name) => {
+            RawItemName::Name(name) => {
                 let name = normalize::unresolved_object_name(name)?;
                 Ok(self.catalog.resolve_item(&name)?)
             }
-            RawObjectName::Id(id, _) => {
+            RawItemName::Id(id, _) => {
                 let gid = id.parse()?;
                 Ok(self.catalog.get_item(&gid))
             }
@@ -657,7 +657,7 @@ impl<'a> StatementContext<'a> {
 
     pub fn resolve_function(
         &self,
-        name: UnresolvedObjectName,
+        name: UnresolvedItemName,
     ) -> Result<&dyn CatalogItem, PlanError> {
         let name = normalize::unresolved_object_name(name)?;
         Ok(self.catalog.resolve_function(&name)?)

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -36,7 +36,7 @@ use mz_sql_parser::ast::{
     AlterOwnerStatement, AlterRoleStatement, AlterSinkAction, AlterSinkStatement,
     AlterSourceAction, AlterSourceStatement, AlterSystemResetAllStatement,
     AlterSystemResetStatement, AlterSystemSetStatement, CreateTypeListOption,
-    CreateTypeListOptionName, CreateTypeMapOption, CreateTypeMapOptionName, DeferredObjectName,
+    CreateTypeListOptionName, CreateTypeMapOption, CreateTypeMapOptionName, DeferredItemName,
     GrantRoleStatement, RevokeRoleStatement, SshConnectionOption, UnresolvedName,
     UnresolvedItemName, UnresolvedSchemaName, Value,
 };
@@ -821,7 +821,7 @@ pub fn plan_create_source(
                 let name = subsource.reference.clone();
 
                 let target = match &subsource.subsource {
-                    Some(DeferredObjectName::Named(target)) => target.clone(),
+                    Some(DeferredItemName::Named(target)) => target.clone(),
                     _ => {
                         sql_bail!("[internal error] subsources must be named during purification")
                     }
@@ -1007,13 +1007,13 @@ pub fn plan_create_source(
     let progress_subsource = progress_subsource
         .as_ref()
         .map(|name| match name {
-            DeferredObjectName::Named(name) => match name {
+            DeferredItemName::Named(name) => match name {
                 ResolvedItemName::Item { id, .. } => Ok(*id),
                 ResolvedItemName::Cte { .. } | ResolvedItemName::Error => {
                     sql_bail!("[internal error] invalid target id")
                 }
             },
-            DeferredObjectName::Deferred(_) => {
+            DeferredItemName::Deferred(_) => {
                 sql_bail!("[internal error] progress subsource must be named during purification")
             }
         })

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -37,8 +37,8 @@ use mz_sql_parser::ast::{
     AlterSourceAction, AlterSourceStatement, AlterSystemResetAllStatement,
     AlterSystemResetStatement, AlterSystemSetStatement, CreateTypeListOption,
     CreateTypeListOptionName, CreateTypeMapOption, CreateTypeMapOptionName, DeferredItemName,
-    GrantRoleStatement, RevokeRoleStatement, SshConnectionOption, UnresolvedName,
-    UnresolvedItemName, UnresolvedSchemaName, Value,
+    GrantRoleStatement, RevokeRoleStatement, SshConnectionOption, UnresolvedItemName,
+    UnresolvedName, UnresolvedSchemaName, Value,
 };
 use mz_storage_client::types::connections::aws::{AwsAssumeRole, AwsConfig, AwsCredentials};
 use mz_storage_client::types::connections::{
@@ -112,9 +112,9 @@ use crate::plan::{
     CreateMaterializedViewPlan, CreateRolePlan, CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan,
     CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan, DataSourceDesc,
     DropClusterReplicasPlan, DropClustersPlan, DropDatabasePlan, DropItemsPlan, DropRolesPlan,
-    DropSchemaPlan, FullItemName, GrantRolePlan, HirScalarExpr, Index, Ingestion,
-    MaterializedView, Params, Plan, QueryContext, ReplicaConfig, RevokeRolePlan, RotateKeysPlan,
-    Secret, Sink, Source, SourceSinkClusterConfig, Table, Type, View,
+    DropSchemaPlan, FullItemName, GrantRolePlan, HirScalarExpr, Index, Ingestion, MaterializedView,
+    Params, Plan, QueryContext, ReplicaConfig, RevokeRolePlan, RotateKeysPlan, Secret, Sink,
+    Source, SourceSinkClusterConfig, Table, Type, View,
 };
 
 pub fn describe_create_database(
@@ -589,10 +589,7 @@ pub fn plan_create_source(
             for name in text_columns {
                 let (qual, col) = match name.0.split_last().expect("must have at least one element")
                 {
-                    (col, qual) => (
-                        UnresolvedItemName(qual.to_vec()),
-                        col.as_str().to_string(),
-                    ),
+                    (col, qual) => (UnresolvedItemName(qual.to_vec()), col.as_str().to_string()),
                 };
 
                 let (_name, table_desc) = publication_catalog

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -91,7 +91,7 @@ use crate::catalog::{
 };
 use crate::kafka_util::{self, KafkaConfigOptionExtracted, KafkaStartOffsetType};
 use crate::names::{
-    Aug, DatabaseId, FullSchemaName, ObjectId, PartialObjectName, QualifiedObjectName,
+    Aug, DatabaseId, FullSchemaName, ObjectId, PartialItemName, QualifiedItemName,
     RawDatabaseSpecifier, ResolvedClusterName, ResolvedDataType, ResolvedDatabaseSpecifier,
     ResolvedItemName, RoleId, SchemaId, SchemaSpecifier,
 };
@@ -320,7 +320,7 @@ pub fn plan_create_table(
 
     // Check for an object in the catalog with this same name
     let full_name = scx.catalog.resolve_full_name(&name);
-    let partial_name = PartialObjectName::from(full_name.clone());
+    let partial_name = PartialItemName::from(full_name.clone());
     if let (false, Ok(item)) = (if_not_exists, scx.catalog.resolve_item(&partial_name)) {
         return Err(PlanError::ItemAlreadyExists {
             name: full_name.to_string(),
@@ -1024,7 +1024,7 @@ pub fn plan_create_source(
 
     // Check for an object in the catalog with this same name
     let full_name = scx.catalog.resolve_full_name(&name);
-    let partial_name = PartialObjectName::from(full_name.clone());
+    let partial_name = PartialItemName::from(full_name.clone());
     if let (false, Ok(item)) = (if_not_exists, scx.catalog.resolve_item(&partial_name)) {
         return Err(PlanError::ItemAlreadyExists {
             name: full_name.to_string(),
@@ -1654,7 +1654,7 @@ pub fn plan_view(
     def: &mut ViewDefinition<Aug>,
     params: &Params,
     temporary: bool,
-) -> Result<(QualifiedObjectName, View), PlanError> {
+) -> Result<(QualifiedItemName, View), PlanError> {
     let create_sql = normalize::create_statement(
         scx,
         Statement::CreateView(CreateViewStatement {
@@ -1736,7 +1736,7 @@ pub fn plan_create_view(
 
     // Check for an object in the catalog with this same name
     let full_name = scx.catalog.resolve_full_name(&name);
-    let partial_name = PartialObjectName::from(full_name.clone());
+    let partial_name = PartialItemName::from(full_name.clone());
     if let (IfExistsBehavior::Error, Ok(item)) =
         (*if_exists, scx.catalog.resolve_item(&partial_name))
     {
@@ -1824,7 +1824,7 @@ pub fn plan_create_materialized_view(
 
     // Check for an object in the catalog with this same name
     let full_name = scx.catalog.resolve_full_name(&name);
-    let partial_name = PartialObjectName::from(full_name.clone());
+    let partial_name = PartialItemName::from(full_name.clone());
     if let (IfExistsBehavior::Error, Ok(item)) =
         (stmt.if_exists, scx.catalog.resolve_item(&partial_name))
     {
@@ -1897,7 +1897,7 @@ pub fn plan_create_sink(
 
     // Check for an object in the catalog with this same name
     let full_name = scx.catalog.resolve_full_name(&name);
-    let partial_name = PartialObjectName::from(full_name.clone());
+    let partial_name = PartialItemName::from(full_name.clone());
     if let (false, Ok(item)) = (if_not_exists, scx.catalog.resolve_item(&partial_name)) {
         return Err(PlanError::ItemAlreadyExists {
             name: full_name.to_string(),
@@ -2292,12 +2292,12 @@ pub fn plan_create_index(
     let keys = query::plan_index_exprs(scx, &on_desc, filled_key_parts.clone())?;
 
     let index_name = if let Some(name) = name {
-        QualifiedObjectName {
+        QualifiedItemName {
             qualifiers: on.name().qualifiers.clone(),
             item: normalize::ident(name.clone()),
         }
     } else {
-        let mut idx_name = QualifiedObjectName {
+        let mut idx_name = QualifiedItemName {
             qualifiers: on.name().qualifiers.clone(),
             item: on.name().item.clone(),
         };
@@ -2331,7 +2331,7 @@ pub fn plan_create_index(
 
     // Check for an object in the catalog with this same name
     let full_name = scx.catalog.resolve_full_name(&index_name);
-    let partial_name = PartialObjectName::from(full_name.clone());
+    let partial_name = PartialItemName::from(full_name.clone());
     if let (false, Ok(item)) = (*if_not_exists, scx.catalog.resolve_item(&partial_name)) {
         return Err(PlanError::ItemAlreadyExists {
             name: full_name.to_string(),
@@ -2476,7 +2476,7 @@ pub fn plan_create_type(
 
     // Check for an object in the catalog with this same name
     let full_name = scx.catalog.resolve_full_name(&name);
-    let partial_name = PartialObjectName::from(full_name.clone());
+    let partial_name = PartialItemName::from(full_name.clone());
     if let Ok(item) = scx.catalog.resolve_item(&partial_name) {
         return Err(PlanError::ItemAlreadyExists {
             name: full_name.to_string(),
@@ -3281,7 +3281,7 @@ pub fn plan_create_connection(
 
     // Check for an object in the catalog with this same name
     let full_name = scx.catalog.resolve_full_name(&name);
-    let partial_name = PartialObjectName::from(full_name.clone());
+    let partial_name = PartialItemName::from(full_name.clone());
     if let (false, Ok(item)) = (if_not_exists, scx.catalog.resolve_item(&partial_name)) {
         return Err(PlanError::ItemAlreadyExists {
             name: full_name.to_string(),
@@ -3887,7 +3887,7 @@ pub fn plan_alter_object_rename(
                     format!("{object_type}").to_lowercase()
                 )
             }
-            let proposed_name = QualifiedObjectName {
+            let proposed_name = QualifiedItemName {
                 qualifiers: entry.name().qualifiers.clone(),
                 item: to_item_name.clone().into_string(),
             };

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -38,7 +38,7 @@ use mz_sql_parser::ast::{
     AlterSystemResetStatement, AlterSystemSetStatement, CreateTypeListOption,
     CreateTypeListOptionName, CreateTypeMapOption, CreateTypeMapOptionName, DeferredObjectName,
     GrantRoleStatement, RevokeRoleStatement, SshConnectionOption, UnresolvedName,
-    UnresolvedObjectName, UnresolvedSchemaName, Value,
+    UnresolvedItemName, UnresolvedSchemaName, Value,
 };
 use mz_storage_client::types::connections::aws::{AwsAssumeRole, AwsConfig, AwsCredentials};
 use mz_storage_client::types::connections::{
@@ -370,7 +370,7 @@ generate_extracted_config!(
     PgConfigOption,
     (Details, String),
     (Publication, String),
-    (TextColumns, Vec::<UnresolvedObjectName>, Default(vec![]))
+    (TextColumns, Vec::<UnresolvedItemName>, Default(vec![]))
 );
 
 pub fn plan_create_source(
@@ -590,7 +590,7 @@ pub fn plan_create_source(
                 let (qual, col) = match name.0.split_last().expect("must have at least one element")
                 {
                     (col, qual) => (
-                        UnresolvedObjectName(qual.to_vec()),
+                        UnresolvedItemName(qual.to_vec()),
                         col.as_str().to_string(),
                     ),
                 };
@@ -3815,7 +3815,7 @@ fn plan_alter_item_owner(
     scx: &StatementContext,
     object_type: ObjectType,
     if_exists: bool,
-    name: UnresolvedObjectName,
+    name: UnresolvedItemName,
     new_owner: RoleId,
 ) -> Result<Plan, PlanError> {
     match resolve_object(scx, name, if_exists)? {
@@ -4334,7 +4334,7 @@ fn resolve_schema<'a>(
 
 fn resolve_object<'a>(
     scx: &'a StatementContext,
-    name: UnresolvedObjectName,
+    name: UnresolvedItemName,
     if_exists: bool,
 ) -> Result<Option<&'a dyn CatalogItem>, PlanError> {
     let name = normalize::unresolved_object_name(name)?;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -93,7 +93,7 @@ use crate::kafka_util::{self, KafkaConfigOptionExtracted, KafkaStartOffsetType};
 use crate::names::{
     Aug, DatabaseId, FullSchemaName, ObjectId, PartialObjectName, QualifiedObjectName,
     RawDatabaseSpecifier, ResolvedClusterName, ResolvedDataType, ResolvedDatabaseSpecifier,
-    ResolvedObjectName, RoleId, SchemaId, SchemaSpecifier,
+    ResolvedItemName, RoleId, SchemaId, SchemaSpecifier,
 };
 use crate::normalize::{self, ident};
 use crate::plan::error::PlanError;
@@ -850,8 +850,8 @@ pub fn plan_create_source(
         };
 
         let target_id = match target {
-            ResolvedObjectName::Object { id, .. } => id,
-            ResolvedObjectName::Cte { .. } | ResolvedObjectName::Error => {
+            ResolvedItemName::Object { id, .. } => id,
+            ResolvedItemName::Cte { .. } | ResolvedItemName::Error => {
                 sql_bail!("[internal error] invalid target id")
             }
         };
@@ -1008,8 +1008,8 @@ pub fn plan_create_source(
         .as_ref()
         .map(|name| match name {
             DeferredObjectName::Named(name) => match name {
-                ResolvedObjectName::Object { id, .. } => Ok(*id),
-                ResolvedObjectName::Cte { .. } | ResolvedObjectName::Error => {
+                ResolvedItemName::Object { id, .. } => Ok(*id),
+                ResolvedItemName::Cte { .. } | ResolvedItemName::Error => {
                     sql_bail!("[internal error] invalid target id")
                 }
             },
@@ -2353,7 +2353,7 @@ pub fn plan_create_index(
     *name = Some(Ident::new(index_name.item.clone()));
     *key_parts = Some(filled_key_parts);
     let if_not_exists = *if_not_exists;
-    if let ResolvedObjectName::Object { print_id, .. } = &mut stmt.on_name {
+    if let ResolvedItemName::Object { print_id, .. } = &mut stmt.on_name {
         *print_id = false;
     }
     let create_sql = normalize::create_statement(scx, Statement::CreateIndex(stmt))?;
@@ -2867,7 +2867,7 @@ Instead, specify BROKERS using multiple strings, e.g. BROKERS ('kafka:9092', 'ka
                     )?;
 
                     let id = match &aws_privatelink.connection {
-                        ResolvedObjectName::Object { id, .. } => id,
+                        ResolvedItemName::Object { id, .. } => id,
                         _ => sql_bail!(
                             "internal error: Kafka PrivateLink connection was not resolved"
                         ),
@@ -2896,7 +2896,7 @@ Instead, specify BROKERS using multiple strings, e.g. BROKERS ('kafka:9092', 'ka
                 }
                 KafkaBrokerTunnel::SshTunnel(ssh) => {
                     let id = match &ssh {
-                        ResolvedObjectName::Object { id, .. } => id,
+                        ResolvedItemName::Object { id, .. } => id,
                         _ => sql_bail!(
                             "internal error: Kafka SSH tunnel connection was not resolved"
                         ),

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -478,7 +478,7 @@ pub fn plan_subscribe(
 
 pub fn describe_table(
     scx: &StatementContext,
-    table_name: <Aug as AstInfo>::ObjectName,
+    table_name: <Aug as AstInfo>::ItemName,
     columns: Vec<Ident>,
 ) -> Result<StatementDesc, PlanError> {
     let (_, desc, _) = query::plan_copy_from(scx, table_name, columns)?;

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -31,7 +31,7 @@ use crate::ast::{
     ViewDefinition,
 };
 use crate::catalog::CatalogItemType;
-use crate::names::{self, Aug, ResolvedObjectName};
+use crate::names::{self, Aug, ResolvedItemName};
 use crate::plan::query::{plan_up_to, QueryLifetime};
 use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::with_options::TryFromValue;
@@ -499,7 +499,7 @@ pub fn describe_copy(
 
 fn plan_copy_from(
     scx: &StatementContext,
-    table_name: ResolvedObjectName,
+    table_name: ResolvedItemName,
     columns: Vec<Ident>,
     format: CopyFormat,
     options: CopyOptionExtracted,

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -31,7 +31,7 @@ use crate::ast::{
 };
 use crate::catalog::{CatalogItemType, SessionCatalog};
 use crate::names::{
-    self, Aug, NameSimplifier, ResolvedClusterName, ResolvedDatabaseName, ResolvedObjectName,
+    self, Aug, NameSimplifier, ResolvedClusterName, ResolvedDatabaseName, ResolvedItemName,
     ResolvedSchemaName,
 };
 use crate::parse;
@@ -469,7 +469,7 @@ fn show_all_objects<'a>(
 pub fn show_indexes<'a>(
     scx: &'a StatementContext<'a>,
     from_schema: Option<ResolvedSchemaName>,
-    on_object: Option<ResolvedObjectName>,
+    on_object: Option<ResolvedItemName>,
     in_cluster: Option<ResolvedClusterName>,
     filter: Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -272,7 +272,7 @@ impl<'a> FuncRewriter<'a> {
                 distinct,
                 over: None,
             }) => {
-                let name = normalize::unresolved_object_name(name.clone()).ok()?;
+                let name = normalize::unresolved_item_name(name.clone()).ok()?;
                 if let Some(database) = &name.database {
                     // If a database name is provided, we need only verify that
                     // the database exists, as presently functions can only

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -19,7 +19,7 @@ use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 use mz_sql_parser::ast::visit_mut::{self, VisitMut, VisitMutNode};
 use mz_sql_parser::ast::{
     Expr, Function, FunctionArgs, Ident, Op, OrderByExpr, Query, Select, SelectItem, TableAlias,
-    TableFactor, TableFunction, TableWithJoins, UnresolvedObjectName, Value,
+    TableFactor, TableFunction, TableWithJoins, UnresolvedItemName, Value,
 };
 
 use crate::names::{Aug, PartialObjectName, ResolvedDataType};
@@ -108,7 +108,7 @@ impl<'a> FuncRewriter<'a> {
     }
 
     fn plan_agg(
-        name: UnresolvedObjectName,
+        name: UnresolvedItemName,
         expr: Expr<Aug>,
         order_by: Vec<OrderByExpr<Aug>>,
         filter: Option<Box<Expr<Aug>>>,
@@ -128,7 +128,7 @@ impl<'a> FuncRewriter<'a> {
 
     fn plan_avg(expr: Expr<Aug>, filter: Option<Box<Expr<Aug>>>, distinct: bool) -> Expr<Aug> {
         let sum = Self::plan_agg(
-            UnresolvedObjectName::qualified(&["pg_catalog", "sum"]),
+            UnresolvedItemName::qualified(&["pg_catalog", "sum"]),
             expr.clone(),
             vec![],
             filter.clone(),
@@ -136,7 +136,7 @@ impl<'a> FuncRewriter<'a> {
         )
         .call_unary(vec!["mz_internal", "mz_avg_promotion"]);
         let count = Self::plan_agg(
-            UnresolvedObjectName::qualified(&["pg_catalog", "count"]),
+            UnresolvedItemName::qualified(&["pg_catalog", "count"]),
             expr,
             vec![],
             filter,
@@ -168,14 +168,14 @@ impl<'a> FuncRewriter<'a> {
         let expr = expr.call_unary(vec!["mz_internal", "mz_avg_promotion"]);
         let expr_squared = expr.clone().multiply(expr.clone());
         let sum_squares = Self::plan_agg(
-            UnresolvedObjectName::qualified(&["pg_catalog", "sum"]),
+            UnresolvedItemName::qualified(&["pg_catalog", "sum"]),
             expr_squared,
             vec![],
             filter.clone(),
             distinct,
         );
         let sum = Self::plan_agg(
-            UnresolvedObjectName::qualified(&["pg_catalog", "sum"]),
+            UnresolvedItemName::qualified(&["pg_catalog", "sum"]),
             expr.clone(),
             vec![],
             filter.clone(),
@@ -183,7 +183,7 @@ impl<'a> FuncRewriter<'a> {
         );
         let sum_squared = sum.clone().multiply(sum);
         let count = Self::plan_agg(
-            UnresolvedObjectName::qualified(&["pg_catalog", "count"]),
+            UnresolvedItemName::qualified(&["pg_catalog", "count"]),
             expr,
             vec![],
             filter,
@@ -226,7 +226,7 @@ impl<'a> FuncRewriter<'a> {
         // would perform an explicit cast, and to match PostgreSQL we must
         // perform only an implicit cast.
         let sum = Self::plan_agg(
-            UnresolvedObjectName::qualified(&["pg_catalog", "sum"]),
+            UnresolvedItemName::qualified(&["pg_catalog", "sum"]),
             expr.negate().cast(self.int32_data_type()),
             vec![],
             filter,
@@ -253,7 +253,7 @@ impl<'a> FuncRewriter<'a> {
         // but that performs an explicit cast, and to match PostgreSQL we must
         // perform only an implicit cast.
         let sum = Self::plan_agg(
-            UnresolvedObjectName::qualified(&["pg_catalog", "sum"]),
+            UnresolvedItemName::qualified(&["pg_catalog", "sum"]),
             expr.or(Expr::Value(Value::Boolean(false)))
                 .cast(self.int32_data_type()),
             vec![],
@@ -459,7 +459,7 @@ impl Desugarer {
                     .from(TableWithJoins {
                         relation: TableFactor::Function {
                             function: TableFunction {
-                                name: UnresolvedObjectName(vec![
+                                name: UnresolvedItemName(vec![
                                     Ident::new("mz_catalog"),
                                     Ident::new("unnest"),
                                 ]),

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -22,7 +22,7 @@ use mz_sql_parser::ast::{
     TableFactor, TableFunction, TableWithJoins, UnresolvedItemName, Value,
 };
 
-use crate::names::{Aug, PartialObjectName, ResolvedDataType};
+use crate::names::{Aug, PartialItemName, ResolvedDataType};
 use crate::normalize;
 use crate::plan::{PlanError, StatementContext};
 
@@ -72,7 +72,7 @@ impl<'a> FuncRewriter<'a> {
         }
     }
 
-    fn resolve_known_valid_data_type(&self, name: &PartialObjectName) -> ResolvedDataType {
+    fn resolve_known_valid_data_type(&self, name: &PartialItemName) -> ResolvedDataType {
         let item = self
             .scx
             .catalog
@@ -89,7 +89,7 @@ impl<'a> FuncRewriter<'a> {
     }
 
     fn int32_data_type(&self) -> ResolvedDataType {
-        self.resolve_known_valid_data_type(&PartialObjectName {
+        self.resolve_known_valid_data_type(&PartialItemName {
             database: None,
             schema: Some("pg_catalog".into()),
             item: "int4".into(),

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -76,7 +76,7 @@ impl From<&Object> for GlobalId {
 impl TryFromValue<WithOptionValue<Aug>> for Object {
     fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
         Ok(match v {
-            WithOptionValue::Object(ResolvedItemName::Object { id, .. }) => Object(id),
+            WithOptionValue::Object(ResolvedItemName::Item { id, .. }) => Object(id),
             _ => sql_bail!("must provide an object"),
         })
     }
@@ -130,7 +130,7 @@ impl ImpliedValue for ResolvedDataType {
 impl TryFromValue<WithOptionValue<Aug>> for StringOrSecret {
     fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
         Ok(match v {
-            WithOptionValue::Secret(ResolvedItemName::Object { id, .. }) => {
+            WithOptionValue::Secret(ResolvedItemName::Item { id, .. }) => {
                 StringOrSecret::Secret(id)
             }
             v => StringOrSecret::String(String::try_from_value(v)?),

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -76,7 +76,7 @@ impl From<&Object> for GlobalId {
 impl TryFromValue<WithOptionValue<Aug>> for Object {
     fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
         Ok(match v {
-            WithOptionValue::Object(ResolvedItemName::Item { id, .. }) => Object(id),
+            WithOptionValue::Item(ResolvedItemName::Item { id, .. }) => Object(id),
             _ => sql_bail!("must provide an object"),
         })
     }
@@ -94,7 +94,7 @@ impl ImpliedValue for Object {
 impl TryFromValue<WithOptionValue<Aug>> for UnresolvedItemName {
     fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
         Ok(match v {
-            WithOptionValue::UnresolvedObjectName(name) => name,
+            WithOptionValue::UnresolvedItemName(name) => name,
             _ => sql_bail!("must provide an object name"),
         })
     }
@@ -408,8 +408,8 @@ impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOpti
             WithOptionValue::Value(v) => V::try_from_value(v),
             WithOptionValue::Ident(i) => V::try_from_value(Value::String(i.into_string())),
             WithOptionValue::Sequence(_)
-            | WithOptionValue::Object(_)
-            | WithOptionValue::UnresolvedObjectName(_)
+            | WithOptionValue::Item(_)
+            | WithOptionValue::UnresolvedItemName(_)
             | WithOptionValue::Secret(_)
             | WithOptionValue::DataType(_)
             | WithOptionValue::ClusterReplicas(_)
@@ -417,8 +417,8 @@ impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOpti
                 "incompatible value types: cannot convert {} to {}",
                 match v {
                     WithOptionValue::Sequence(_) => "sequences",
-                    WithOptionValue::Object(_) => "object references",
-                    WithOptionValue::UnresolvedObjectName(_) => "object names",
+                    WithOptionValue::Item(_) => "object references",
+                    WithOptionValue::UnresolvedItemName(_) => "object names",
                     WithOptionValue::Secret(_) => "secrets",
                     WithOptionValue::DataType(_) => "data types",
                     WithOptionValue::ClusterReplicas(_) => "cluster replicas",

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -18,7 +18,7 @@ use mz_repr::strconv;
 use mz_repr::GlobalId;
 use mz_storage_client::types::connections::StringOrSecret;
 
-use crate::ast::{AstInfo, IntervalValue, UnresolvedObjectName, Value, WithOptionValue};
+use crate::ast::{AstInfo, IntervalValue, UnresolvedItemName, Value, WithOptionValue};
 use crate::names::{ResolvedDataType, ResolvedItemName};
 use crate::plan::{Aug, PlanError};
 
@@ -91,7 +91,7 @@ impl ImpliedValue for Object {
     }
 }
 
-impl TryFromValue<WithOptionValue<Aug>> for UnresolvedObjectName {
+impl TryFromValue<WithOptionValue<Aug>> for UnresolvedItemName {
     fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
         Ok(match v {
             WithOptionValue::UnresolvedObjectName(name) => name,
@@ -103,7 +103,7 @@ impl TryFromValue<WithOptionValue<Aug>> for UnresolvedObjectName {
     }
 }
 
-impl ImpliedValue for UnresolvedObjectName {
+impl ImpliedValue for UnresolvedItemName {
     fn implied_value() -> Result<Self, PlanError> {
         sql_bail!("must provide an object name")
     }

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -19,7 +19,7 @@ use mz_repr::GlobalId;
 use mz_storage_client::types::connections::StringOrSecret;
 
 use crate::ast::{AstInfo, IntervalValue, UnresolvedObjectName, Value, WithOptionValue};
-use crate::names::{ResolvedDataType, ResolvedObjectName};
+use crate::names::{ResolvedDataType, ResolvedItemName};
 use crate::plan::{Aug, PlanError};
 
 pub trait TryFromValue<T>: Sized {
@@ -76,7 +76,7 @@ impl From<&Object> for GlobalId {
 impl TryFromValue<WithOptionValue<Aug>> for Object {
     fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
         Ok(match v {
-            WithOptionValue::Object(ResolvedObjectName::Object { id, .. }) => Object(id),
+            WithOptionValue::Object(ResolvedItemName::Object { id, .. }) => Object(id),
             _ => sql_bail!("must provide an object"),
         })
     }
@@ -130,7 +130,7 @@ impl ImpliedValue for ResolvedDataType {
 impl TryFromValue<WithOptionValue<Aug>> for StringOrSecret {
     fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
         Ok(match v {
-            WithOptionValue::Secret(ResolvedObjectName::Object { id, .. }) => {
+            WithOptionValue::Secret(ResolvedItemName::Object { id, .. }) => {
                 StringOrSecret::Secret(id)
             }
             v => StringOrSecret::String(String::try_from_value(v)?),

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -64,7 +64,7 @@ fn subsource_gen<'a, T>(
         let subsource_name = match &subsource.subsource {
             Some(name) => match name {
                 DeferredObjectName::Deferred(name) => {
-                    let partial = normalize::unresolved_object_name(name.clone())?;
+                    let partial = normalize::unresolved_item_name(name.clone())?;
                     match partial.schema {
                         Some(_) => name.clone(),
                         // In cases when a prefix is not provided for the deferred name
@@ -83,7 +83,7 @@ fn subsource_gen<'a, T>(
                 // the schema of the reference.
                 subsource_name_gen(
                     source_name,
-                    &normalize::unresolved_object_name(subsource.reference.clone())?.item,
+                    &normalize::unresolved_item_name(subsource.reference.clone())?.item,
                 )?
             }
         };
@@ -104,7 +104,7 @@ fn subsource_name_gen(
     source_name: &UnresolvedItemName,
     subsource_name: &String,
 ) -> Result<UnresolvedItemName, PlanError> {
-    let mut partial = normalize::unresolved_object_name(source_name.clone())?;
+    let mut partial = normalize::unresolved_item_name(source_name.clone())?;
     partial.item = subsource_name.to_string();
     Ok(UnresolvedItemName::from(partial))
 }
@@ -380,7 +380,7 @@ pub async fn purify_create_source(
                         option_name: PgConfigOptionName::TextColumns.to_ast_string(),
                         err: Box::new(PlanError::UnknownColumn {
                             table: Some(
-                                normalize::unresolved_object_name(fully_qualified_name)
+                                normalize::unresolved_item_name(fully_qualified_name)
                                     .expect("known to be of valid len"),
                             ),
                             column: mz_repr::ColumnName::from(col),
@@ -673,7 +673,7 @@ pub async fn purify_create_source(
             let mut suggested_name = prefix.to_vec();
             suggested_name.push(format!("{}_progress", item).into());
 
-            let partial = normalize::unresolved_object_name(UnresolvedItemName(suggested_name))?;
+            let partial = normalize::unresolved_item_name(UnresolvedItemName(suggested_name))?;
             let qualified = scx.allocate_qualified_name(partial)?;
             let found_name = scx.catalog.find_available_name(qualified);
             let full_name = scx.catalog.resolve_full_name(&found_name);

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -680,7 +680,7 @@ pub async fn purify_create_source(
 
             (
                 UnresolvedObjectName::from(full_name.clone()),
-                crate::names::ResolvedItemName::Object {
+                crate::names::ResolvedItemName::Item {
                     id: transient_id,
                     qualifiers: found_name.qualifiers,
                     full_name,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -680,7 +680,7 @@ pub async fn purify_create_source(
 
             (
                 UnresolvedObjectName::from(full_name.clone()),
-                crate::names::ResolvedObjectName::Object {
+                crate::names::ResolvedItemName::Object {
                     id: transient_id,
                     qualifiers: found_name.qualifiers,
                     full_name,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -414,7 +414,7 @@ pub async fn purify_create_source(
             {
                 let seq = text_columns
                     .into_iter()
-                    .map(WithOptionValue::UnresolvedObjectName)
+                    .map(WithOptionValue::UnresolvedItemName)
                     .collect();
                 text_cols_option.value = Some(WithOptionValue::Sequence(seq));
             }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -79,7 +79,7 @@ use mz_secrets::SecretsController;
 use mz_sql::ast::{Expr, Raw, ShowStatement, Statement};
 use mz_sql::catalog::EnvironmentId;
 use mz_sql_parser::{
-    ast::{display::AstDisplay, CreateIndexStatement, RawObjectName, Statement as AstStatement},
+    ast::{display::AstDisplay, CreateIndexStatement, RawItemName, Statement as AstStatement},
     parser,
 };
 use mz_stash::StashFactory;
@@ -1704,7 +1704,7 @@ fn mutate(sql: &str) -> Vec<String> {
                 AstStatement::<Raw>::CreateIndex(CreateIndexStatement {
                     name: None,
                     in_cluster: None,
-                    on_name: RawObjectName::Name(stmt.name.clone()),
+                    on_name: RawItemName::Name(stmt.name.clone()),
                     key_parts: Some(
                         stmt.columns
                             .iter()

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -21,7 +21,7 @@ use mz_compute_client::sources::MzOffset;
 use mz_expr::PartitionId;
 use mz_ore::retry::Retry;
 use mz_sql::catalog::SessionCatalog;
-use mz_sql::names::PartialObjectName;
+use mz_sql::names::PartialItemName;
 use mz_stash::Stash;
 
 use crate::action::{ControlFlow, State};
@@ -40,7 +40,7 @@ async fn run_verify_timestamp_compaction_action(
     let item_id = state
         .with_catalog_copy(|catalog| {
             catalog
-                .resolve_item(&PartialObjectName {
+                .resolve_item(&PartialItemName {
                     database: None,
                     schema: None,
                     item: source.clone(),


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Progress on #18463. It seems that a lot of uses of Object should be Item, this is a bunch of renaming in that direction. I didn't change any of the logic on purpose, it's all a bunch of renaming

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
