### PR TITLE
persist: collect schemaless stats for Jsonb

### DIFF
--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -33,13 +33,9 @@ impl PartStats {
             len: part.len(),
             cols: Default::default(),
         };
-        // TODO(mfp): We only need to plumb the schemas here if we end up
-        // allowing them to specify arbitrary min/max logic for complex types.
-        // If we don't end up doing that, consider pulling the schemas out of
-        // here.
         let mut key_cols = part.key_ref();
-        for (name, _typ) in schemas.key.columns() {
-            let col_stats = key_cols.stats(&name)?;
+        for (name, _typ, stats_fn) in schemas.key.columns() {
+            let col_stats = key_cols.stats(&name, stats_fn)?;
             key.cols.insert(name, col_stats);
         }
         key_cols.finish()?;

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -28,7 +28,7 @@ use crate::columnar::{
     ColumnFormat, ColumnGet, ColumnPush, Data, DataType, PartDecoder, PartEncoder, Schema,
 };
 use crate::part::{ColumnsMut, ColumnsRef};
-use crate::stats::{OptionStats, PrimitiveStats};
+use crate::stats::{BytesStats, OptionStats, PrimitiveStats, StatsFn};
 use crate::{Codec, Codec64, Opaque};
 
 /// An implementation of [Schema] for [()].
@@ -47,7 +47,7 @@ impl Schema<()> for UnitSchema {
     type Encoder<'a> = Self;
     type Decoder<'a> = Self;
 
-    fn columns(&self) -> Vec<(String, DataType)> {
+    fn columns(&self) -> Vec<(String, DataType, StatsFn)> {
         Vec::new()
     }
 
@@ -121,12 +121,12 @@ impl Schema<String> for StringSchema {
 
     type Decoder<'a> = SimpleDecoder<'a, String>;
 
-    fn columns(&self) -> Vec<(String, DataType)> {
+    fn columns(&self) -> Vec<(String, DataType, StatsFn)> {
         let data_type = DataType {
             optional: false,
             format: ColumnFormat::String,
         };
-        vec![("".to_owned(), data_type)]
+        vec![("".to_owned(), data_type, StatsFn::Default)]
     }
 
     fn decoder<'a>(&self, mut cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
@@ -181,12 +181,12 @@ impl Schema<Vec<u8>> for VecU8Schema {
 
     type Decoder<'a> = SimpleDecoder<'a, Vec<u8>>;
 
-    fn columns(&self) -> Vec<(String, DataType)> {
+    fn columns(&self) -> Vec<(String, DataType, StatsFn)> {
         let data_type = DataType {
             optional: false,
             format: ColumnFormat::Bytes,
         };
-        vec![("".to_owned(), data_type)]
+        vec![("".to_owned(), data_type, StatsFn::Default)]
     }
 
     fn decoder<'a>(&self, mut cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
@@ -342,7 +342,7 @@ impl Data for Vec<u8> {
     // TODO: Something that more obviously isn't optional.
     type Col = BinaryArray<i32>;
     type Mut = MutableBinaryArray<i32>;
-    type Stats = PrimitiveStats<Vec<u8>>;
+    type Stats = BytesStats;
 }
 
 impl Data for Option<Vec<u8>> {
@@ -353,7 +353,7 @@ impl Data for Option<Vec<u8>> {
     type Ref<'a> = Option<&'a [u8]>;
     type Col = BinaryArray<i32>;
     type Mut = MutableBinaryArray<i32>;
-    type Stats = OptionStats<PrimitiveStats<Vec<u8>>>;
+    type Stats = OptionStats<BytesStats>;
 }
 
 impl Data for String {
@@ -655,7 +655,7 @@ impl<T: Debug + Send + Sync> Schema<T> for TodoSchema<T> {
     type Encoder<'a> = Self;
     type Decoder<'a> = Self;
 
-    fn columns(&self) -> Vec<(String, DataType)> {
+    fn columns(&self) -> Vec<(String, DataType, StatsFn)> {
         panic!("TODO")
     }
 

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -53,7 +53,7 @@ use std::fmt::Debug;
 use crate::codec_impls::UnitSchema;
 use crate::columnar::sealed::ColumnRef;
 use crate::part::{ColumnsMut, ColumnsRef, PartBuilder};
-use crate::stats::DynStats;
+use crate::stats::{DynStats, StatsFn};
 use crate::Codec;
 
 /// A type understood by persist.
@@ -216,7 +216,7 @@ pub trait Schema<T>: Debug + Send + Sync {
     /// object with a method like `fn add<T: Data>(name: String)`. If we decide
     /// to support struct columns, a hypothetical StructSchemaBuilder would look
     /// very much like this. Decide if this is better/worth it.
-    fn columns(&self) -> Vec<(String, DataType)>;
+    fn columns(&self) -> Vec<(String, DataType, StatsFn)>;
 
     /// Returns a [Self::Decoder<'a>] for the given columns.
     fn decoder<'a>(&self, cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String>;

--- a/src/persist-types/src/stats.proto
+++ b/src/persist-types/src/stats.proto
@@ -26,6 +26,7 @@ message ProtoDynStats {
     oneof kind {
         ProtoStructStats struct = 2;
         ProtoPrimitiveStats primitive = 3;
+        ProtoBytesStats bytes = 4;
     }
 }
 
@@ -63,5 +64,21 @@ message ProtoPrimitiveStats {
         double upper_f64 = 24;
         bytes upper_bytes = 25;
         string upper_string = 26;
+    }
+}
+
+message ProtoJsonStats {
+    uint64 json_nulls = 1;
+    ProtoPrimitiveStats bools = 2;
+    ProtoPrimitiveStats string = 3;
+    ProtoPrimitiveStats numeric = 4;
+    uint64 list = 5;
+    map<string, ProtoJsonStats> map = 6;
+}
+
+message ProtoBytesStats {
+    oneof kind {
+        ProtoPrimitiveStats primitive = 1;
+        ProtoJsonStats json = 2;
     }
 }

--- a/src/persist-types/src/stats.proto
+++ b/src/persist-types/src/stats.proto
@@ -78,6 +78,7 @@ message ProtoJsonStats {
 
 message ProtoBytesStats {
     oneof kind {
+        // TODO(mfp): Pull bytes out of ProtoPrimitiveStats and inline it here?
         ProtoPrimitiveStats primitive = 1;
         ProtoJsonStats json = 2;
     }

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -18,7 +18,8 @@ use enum_dispatch::enum_dispatch;
 use mz_persist_types::columnar::{
     ColumnGet, ColumnPush, Data, DataType, PartDecoder, PartEncoder, Schema,
 };
-use mz_persist_types::part::{ColumnsMut, ColumnsRef};
+use mz_persist_types::part::{ColumnsMut, ColumnsRef, DynColumnRef};
+use mz_persist_types::stats::{BytesStats, DynStats, OptionStats, PrimitiveStats, StatsFn};
 use mz_persist_types::Codec;
 use prost::Message;
 use uuid::Uuid;
@@ -27,6 +28,7 @@ use mz_ore::cast::CastFrom;
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 
 use crate::adt::array::ArrayDimension;
+use crate::adt::jsonb::Jsonb;
 use crate::adt::numeric::Numeric;
 use crate::adt::range::{Range, RangeInner, RangeLowerBound, RangeUpperBound};
 use crate::chrono::ProtoNaiveTime;
@@ -35,6 +37,7 @@ use crate::row::{
     ProtoArray, ProtoArrayDimension, ProtoDatum, ProtoDatumOther, ProtoDict, ProtoDictElement,
     ProtoNumeric, ProtoRange, ProtoRangeInner, ProtoRow,
 };
+use crate::stats::{jsonb_stats_nulls, proto_datum_min_max_nulls};
 use crate::{ColumnType, Datum, RelationDesc, Row, RowPacker, ScalarType};
 
 impl Codec for Row {
@@ -109,6 +112,8 @@ impl ColumnType {
             (true, String | Char { .. } | VarChar { .. }) => {
                 f.call::<Option<std::string::String>>()
             }
+            (false, Jsonb) => f.call::<crate::adt::jsonb::Jsonb>(),
+            (true, Jsonb) => f.call::<Option<crate::adt::jsonb::Jsonb>>(),
             (
                 _,
                 Numeric { .. }
@@ -117,7 +122,6 @@ impl ColumnType {
                 | Timestamp
                 | TimestampTz
                 | Interval
-                | Jsonb
                 | Uuid
                 | Array(..)
                 | List { .. }
@@ -127,7 +131,13 @@ impl ColumnType {
                 | MzTimestamp
                 | Range { .. }
                 | MzAclItem,
-            ) => f.call::<TodoDatumToPersist>(),
+            ) => {
+                if *nullable {
+                    f.call::<NullableProtoDatumToPersist>()
+                } else {
+                    f.call::<ProtoDatumToPersist>()
+                }
+            }
         }
     }
 }
@@ -143,11 +153,12 @@ impl ColumnType {
 /// correspondence between DatumToPersist impls and ColumnTypes because a number
 /// of ScalarTypes map to the same set of `Datum`s (e.g. `String` and
 /// `VarChar`).
-///
-/// TODO: Specify stats fn so we can override it.
 pub trait DatumToPersist {
     /// The persist columnar type we're mapping to/from.
     type Data: Data;
+
+    /// Which logic to use for computing aggregate stats.
+    const STATS_FN: StatsFn;
 
     /// Encodes and pushes the given Datum into the persist column.
     ///
@@ -173,6 +184,7 @@ macro_rules! data_to_persist_primitive {
     ($data:ty, $unwrap:ident) => {
         impl DatumToPersist for $data {
             type Data = $data;
+            const STATS_FN: StatsFn = StatsFn::Default;
             fn encode(col: &mut <Self::Data as Data>::Mut, datum: Datum) {
                 ColumnPush::<Self::Data>::push(col, datum.$unwrap());
             }
@@ -182,6 +194,7 @@ macro_rules! data_to_persist_primitive {
         }
         impl DatumToPersist for Option<$data> {
             type Data = Option<$data>;
+            const STATS_FN: StatsFn = StatsFn::Default;
             fn encode(col: &mut <Self::Data as Data>::Mut, datum: Datum) {
                 if datum.is_null() {
                     ColumnPush::<Self::Data>::push(col, None);
@@ -209,13 +222,15 @@ data_to_persist_primitive!(f64, unwrap_float64);
 data_to_persist_primitive!(Vec<u8>, unwrap_bytes);
 data_to_persist_primitive!(String, unwrap_str);
 
-/// An implementation of [DatumToPersist] that maps to/from all Datum types
-/// using the ProtoDatum representation.
-#[derive(Debug)]
-pub struct TodoDatumToPersist;
+/// A specification for which StatsFn to use with DatumToPersist impls that
+/// encode and decode via ProtoDatum.
+trait ProtoDatumStats {
+    const STATS_FN: StatsFn;
+}
 
-impl DatumToPersist for TodoDatumToPersist {
+impl<T: ProtoDatumStats> DatumToPersist for T {
     type Data = Vec<u8>;
+    const STATS_FN: StatsFn = T::STATS_FN;
     fn encode(col: &mut <Self::Data as Data>::Mut, datum: Datum) {
         let proto = ProtoDatum::from(datum);
         let buf = proto.encode_to_vec();
@@ -227,6 +242,56 @@ impl DatumToPersist for TodoDatumToPersist {
         row.try_push_proto(&proto)
             .expect("ProtoDatum should be valid Datum");
     }
+}
+
+/// An implementation of [DatumToPersist] that maps to/from all non-nullable
+/// Datum types using the ProtoDatum representation.
+#[derive(Debug)]
+pub struct ProtoDatumToPersist;
+
+impl ProtoDatumStats for ProtoDatumToPersist {
+    const STATS_FN: StatsFn =
+        StatsFn::Custom(|col: &DynColumnRef| -> Result<Box<dyn DynStats>, String> {
+            let (lower, upper, null_count) = proto_datum_min_max_nulls(col.downcast::<Vec<u8>>()?);
+            assert_eq!(null_count, 0);
+            Ok(Box::new(PrimitiveStats { lower, upper }))
+        });
+}
+
+/// An implementation of [DatumToPersist] that maps to/from all nullable Datum
+/// types using the ProtoDatum representation.
+#[derive(Debug)]
+pub struct NullableProtoDatumToPersist;
+
+impl ProtoDatumStats for NullableProtoDatumToPersist {
+    const STATS_FN: StatsFn =
+        StatsFn::Custom(|col: &DynColumnRef| -> Result<Box<dyn DynStats>, String> {
+            let (lower, upper, null_count) = proto_datum_min_max_nulls(col.downcast::<Vec<u8>>()?);
+            Ok(Box::new(OptionStats {
+                none: null_count,
+                some: PrimitiveStats { lower, upper },
+            }))
+        });
+}
+
+impl ProtoDatumStats for Jsonb {
+    const STATS_FN: StatsFn =
+        StatsFn::Custom(|col: &DynColumnRef| -> Result<Box<dyn DynStats>, String> {
+            let (stats, null_count) = jsonb_stats_nulls(col.downcast::<Vec<u8>>()?)?;
+            assert_eq!(null_count, 0);
+            Ok(Box::new(BytesStats::Json(stats)))
+        });
+}
+
+impl ProtoDatumStats for Option<Jsonb> {
+    const STATS_FN: StatsFn =
+        StatsFn::Custom(|col: &DynColumnRef| -> Result<Box<dyn DynStats>, String> {
+            let (stats, null_count) = jsonb_stats_nulls(col.downcast::<Vec<u8>>()?)?;
+            Ok(Box::new(OptionStats {
+                some: BytesStats::Json(stats),
+                none: null_count,
+            }))
+        });
 }
 
 /// A helper for adapting mz's [Datum] to persist's columnar [Data].
@@ -257,7 +322,10 @@ pub enum DatumEncoder<'a> {
     OptBytes(DataMut<'a, Option<Vec<u8>>>),
     String(DataMut<'a, String>),
     OptString(DataMut<'a, Option<String>>),
-    Todo(DataMut<'a, TodoDatumToPersist>),
+    Jsonb(DataMut<'a, Jsonb>),
+    OptJsonb(DataMut<'a, Option<Jsonb>>),
+    Todo(DataMut<'a, ProtoDatumToPersist>),
+    OptTodo(DataMut<'a, NullableProtoDatumToPersist>),
 }
 
 /// An `enum_dispatch` companion for `DatumEncoder`.
@@ -338,7 +406,10 @@ pub enum DatumDecoder<'a> {
     OptBytes(DataRef<'a, Option<Vec<u8>>>),
     String(DataRef<'a, String>),
     OptString(DataRef<'a, Option<String>>),
-    Todo(DataRef<'a, TodoDatumToPersist>),
+    Jsonb(DataRef<'a, Jsonb>),
+    OptJsonb(DataRef<'a, Option<Jsonb>>),
+    Todo(DataRef<'a, ProtoDatumToPersist>),
+    OptTodo(DataRef<'a, NullableProtoDatumToPersist>),
 }
 
 /// An `enum_dispatch` companion for `DatumDecoder`.
@@ -396,16 +467,19 @@ impl Schema<Row> for RelationDesc {
     type Encoder<'a> = RowEncoder<'a>;
     type Decoder<'a> = RowDecoder<'a>;
 
-    fn columns(&self) -> Vec<(String, DataType)> {
-        struct ToDataType;
-        impl DatumToPersistFn<DataType> for ToDataType {
-            fn call<T: DatumToPersist>(self) -> DataType {
-                <T::Data as Data>::TYPE
+    fn columns(&self) -> Vec<(String, DataType, StatsFn)> {
+        struct ToPersist;
+        impl DatumToPersistFn<(DataType, StatsFn)> for ToPersist {
+            fn call<T: DatumToPersist>(self) -> (DataType, StatsFn) {
+                (<T::Data as Data>::TYPE, T::STATS_FN)
             }
         }
 
         self.iter()
-            .map(|(name, typ)| (name.0.clone(), typ.to_persist(ToDataType)))
+            .map(|(name, typ)| {
+                let (data_type, stats_fn) = typ.to_persist(ToPersist);
+                (name.0.clone(), data_type, stats_fn)
+            })
             .collect()
     }
 

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -7,6 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Borrow;
+
+use mz_persist_types::columnar::Data;
+use mz_persist_types::stats::{JsonStats, PrimitiveStats};
+use prost::Message;
+
+use crate::row::encoding::{DatumToPersist, ProtoDatumToPersist};
+use crate::row::ProtoDatum;
 use crate::{Datum, Row, RowArena};
 
 /// Provides access to statistics about SourceData stored in a Persist part (S3
@@ -64,4 +72,116 @@ pub trait PersistSourceDataStats: std::fmt::Debug {
     fn row_max(&self, _row: &mut Row) -> Option<usize> {
         None
     }
+}
+
+fn as_optional_datum<'a>(row: &'a Row) -> Option<Datum<'a>> {
+    let mut datums = row.iter();
+    let datum = datums.next()?;
+    if let Some(_) = datums.next() {
+        panic!("too many datums in: {}", row);
+    }
+    Some(datum)
+}
+
+/// Returns the min, max, and null_count for the column of Datums.
+///
+/// Each entry in the column is a single Datum encoded as a ProtoDatum. The min
+/// and max and similarly returned encoded via ProtoDatum. If the column is
+/// empty, the returned min and max will be Datum::Null, otherwise they will
+/// never be null.
+pub(crate) fn proto_datum_min_max_nulls(col: &<Vec<u8> as Data>::Col) -> (Vec<u8>, Vec<u8>, usize) {
+    let (mut min, mut max) = (Row::default(), Row::default());
+    let mut null_count = 0;
+
+    let mut buf = Row::default();
+    for idx in 0..col.len() {
+        ProtoDatumToPersist::decode(col, idx, &mut buf.packer());
+        let datum = as_optional_datum(&buf).expect("not enough datums");
+        if datum == Datum::Null {
+            null_count += 1;
+            continue;
+        }
+        if as_optional_datum(&min).map_or(true, |min| datum < min) {
+            min.packer().push(datum);
+        }
+        if as_optional_datum(&max).map_or(true, |max| datum > max) {
+            max.packer().push(datum);
+        }
+    }
+
+    let min = as_optional_datum(&min).unwrap_or(Datum::Null);
+    let max = as_optional_datum(&max).unwrap_or(Datum::Null);
+    let min = ProtoDatum::from(min).encode_to_vec();
+    let max = ProtoDatum::from(max).encode_to_vec();
+    (min, max, null_count)
+}
+
+/// Returns the JsonStats and null_count for the column of `ScalarType::Jsonb`.
+///
+/// Each entry in the column is a single Datum encoded as a ProtoDatum.
+pub(crate) fn jsonb_stats_nulls(
+    col: &<Vec<u8> as Data>::Col,
+) -> Result<(JsonStats, usize), String> {
+    let mut stats = JsonStats::default();
+    let mut null_count = 0;
+
+    let mut buf = Row::default();
+    for idx in 0..col.len() {
+        ProtoDatumToPersist::decode(col, idx, &mut buf.packer());
+        let datum = as_optional_datum(&buf).expect("not enough datums");
+        // Datum::Null only shows up at the top level of Jsonb, so we handle it
+        // here instead of in the recursing function.
+        if let Datum::Null = datum {
+            null_count += 1;
+        } else {
+            let () = jsonb_stats_datum(&mut stats, datum)?;
+        }
+    }
+    Ok((stats, null_count))
+}
+
+fn jsonb_stats_datum(stats: &mut JsonStats, datum: Datum<'_>) -> Result<(), String> {
+    fn update_stats<T: PartialOrd + ToOwned + ?Sized>(
+        stats: &mut Option<PrimitiveStats<T::Owned>>,
+        val: &T,
+    ) {
+        let stats = stats.get_or_insert_with(|| PrimitiveStats {
+            lower: val.to_owned(),
+            upper: val.to_owned(),
+        });
+        if val < stats.lower.borrow() {
+            stats.lower = val.to_owned();
+        }
+        if val > stats.upper.borrow() {
+            stats.upper = val.to_owned();
+        }
+    }
+
+    match datum {
+        Datum::JsonNull => stats.json_nulls += 1,
+        Datum::False => update_stats(&mut stats.bools, &false),
+        Datum::True => update_stats(&mut stats.bools, &true),
+        Datum::String(x) => update_stats(&mut stats.string, x),
+        Datum::Numeric(x) => {
+            let x = f64::try_from(x.0)
+                .map_err(|_| format!("TODO: Could not collect stats for decimal: {}", x))?;
+            update_stats(&mut stats.numeric, &x);
+        }
+        Datum::List(_) => {
+            stats.list += 1;
+        }
+        Datum::Map(x) => {
+            for (k, v) in x.iter() {
+                let key_stats = stats.map.entry(k.to_owned()).or_default();
+                let () = jsonb_stats_datum(key_stats, v)?;
+            }
+        }
+        _ => {
+            return Err(format!(
+                "invalid Datum type for ScalarType::Jsonb: {}",
+                datum
+            ))
+        }
+    }
+    Ok(())
 }

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -22,6 +22,7 @@ use bytes::BufMut;
 use dec::OrderedDecimal;
 use differential_dataflow::lattice::Lattice;
 use itertools::Itertools;
+use mz_persist_types::stats::StatsFn;
 use once_cell::sync::Lazy;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
@@ -2566,7 +2567,7 @@ impl Schema<SourceData> for RelationDesc {
 
     type Decoder<'a> = TodoSchema<SourceData>;
 
-    fn columns(&self) -> Vec<(String, DataType)> {
+    fn columns(&self) -> Vec<(String, DataType, StatsFn)> {
         // Constructing the fake RelationDesc is wasteful, but this only gets
         // called when the feature flag is on.
         Schema::<Row>::columns(&fake_relation_desc(self))


### PR DESCRIPTION
Do this by allowing Schema impls to supply arbitrary logic for computing stats.

It's a little gross, but to take advantage of this, we change the associated `Stats` type of the `Data` impl for `Vec<u8>` to be a new `BytesStats` enum. It has one variant for normal SQL bytes columns and a Json variant for the new stats.

Given the new stats_fn override, use it in `TodoDatumToPersist` to generate real mins and maxes by delegating the Datum's `Ord` impl.

Touches #12684

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
