### PR TITLE
adapter: Limit number of outstanding connections and subscribes

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -28,7 +28,7 @@ use mz_sql::plan::{
     AbortTransactionPlan, CommitTransactionPlan, CopyRowsPlan, CreateRolePlan, Params, Plan,
     TransactionType,
 };
-use mz_sql::session::vars::{EndTransactionAction, OwnedVarInput};
+use mz_sql::session::vars::{EndTransactionAction, OwnedVarInput, SystemVars};
 
 use crate::client::ConnectionId;
 use crate::command::{
@@ -205,6 +205,19 @@ impl Coordinator {
         cancel_tx: Arc<watch::Sender<Canceled>>,
         tx: oneshot::Sender<Response<StartupResponse>>,
     ) {
+        if let Err(e) = self.validate_resource_limit(
+            self.active_conns.len(),
+            1,
+            SystemVars::max_connections,
+            "Max Connections",
+        ) {
+            let _ = tx.send(Response {
+                result: Err(e),
+                session,
+            });
+            return;
+        }
+
         if self
             .catalog()
             .try_get_role_by_name(&session.user().name)

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1076,7 +1076,7 @@ impl Coordinator {
     }
 
     /// Validate a specific type of resource limit and return an error if that limit is exceeded.
-    fn validate_resource_limit<F>(
+    pub(crate) fn validate_resource_limit<F>(
         &self,
         current_amount: usize,
         new_instances: i32,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -62,8 +62,8 @@ use mz_sql::plan::{
 };
 use mz_sql::session::user::SYSTEM_USER;
 use mz_sql::session::vars::{
-    IsolationLevel, OwnedVarInput, VarError, VarInput, CLUSTER_VAR_NAME, DATABASE_VAR_NAME,
-    TRANSACTION_ISOLATION_VAR_NAME,
+    IsolationLevel, OwnedVarInput, SystemVars, VarError, VarInput, CLUSTER_VAR_NAME,
+    DATABASE_VAR_NAME, TRANSACTION_ISOLATION_VAR_NAME,
 };
 use mz_sql::session::vars::{Var, ENABLE_RBAC_CHECKS};
 use mz_ssh_util::keys::SshKeyPairSet;
@@ -2261,6 +2261,13 @@ impl Coordinator {
         plan: SubscribePlan,
         depends_on: Vec<GlobalId>,
     ) -> Result<ExecuteResponse, AdapterError> {
+        self.validate_resource_limit(
+            self.active_subscribes.len(),
+            1,
+            SystemVars::max_subscribes,
+            "Max Subscribes",
+        )?;
+
         let SubscribePlan {
             from,
             with_snapshot,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -648,6 +648,22 @@ pub const AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
+pub const MAX_SUBSCRIBES: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_subscribes"),
+    value: &100,
+    description: "The maximum number of concurrent subscribes on a single cluster (Materialize).",
+    internal: false,
+    safe: true,
+};
+
+pub const MAX_CONNECTIONS: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_connections"),
+    value: &500,
+    description: "The maximum number of concurrent cpmmectopms on a single cluster (Materialize).",
+    internal: false,
+    safe: true,
+};
+
 /// Represents the input to a variable.
 ///
 /// Each variable has different rules for how it handles each style of input.
@@ -1360,6 +1376,8 @@ impl Default for SystemVars {
             .with_var(&ENABLE_WITH_MUTUALLY_RECURSIVE)
             .with_var(&ENABLE_RBAC_CHECKS)
             .with_var(&ENABLE_AUTO_ROUTE_INTROSPECTION_QUERIES)
+            .with_var(&MAX_SUBSCRIBES)
+            .with_var(&MAX_CONNECTIONS)
     }
 }
 
@@ -1658,6 +1676,16 @@ impl SystemVars {
     /// Note: this is generally intended to be set via LaunchDarkly
     pub fn enable_auto_route_introspection_queries(&self) -> bool {
         *self.expect_value(&ENABLE_AUTO_ROUTE_INTROSPECTION_QUERIES)
+    }
+
+    /// Returns the `max_subscribes` configuration parameter.
+    pub fn max_subscribes(&self) -> u32 {
+        *self.expect_value(&MAX_SUBSCRIBES)
+    }
+
+    /// Returns the `max_connections` configuration parameter.
+    pub fn max_connections(&self) -> u32 {
+        *self.expect_value(&MAX_CONNECTIONS)
     }
 }
 

--- a/test/cluster/resources/resource-limits.td
+++ b/test/cluster/resources/resource-limits.td
@@ -285,6 +285,30 @@ ALTER SYSTEM RESET ALL
 > DROP TABLE t4;
 
 $ postgres-execute connection=mz_system
+ALTER SYSTEM SET max_subscribes = 1
+
+> SHOW max_subscribes
+1
+
+> CREATE TABLE subscribe_table(a int)
+
+$ postgres-execute connection=mz_system
+BEGIN
+$ postgres-execute connection=mz_system
+DECLARE c CURSOR FOR SUBSCRIBE (SELECT * FROM subscribe_table);
+$ postgres-execute connection=mz_system
+FETCH 1 c WITH (TIMEOUT='0s')
+
+! SUBSCRIBE (SELECT * FROM subscribe_table)
+contains: Max Subscribes resource limit of 1 cannot be exceeded
+
+$ postgres-execute connection=mz_system
+ROLLBACK
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM RESET max_subscribes
+
+$ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_sources = 2
 
 # Insert Postgres data


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Fixes #18341. I dont think I can use testdriver to test the number of connections: I was able to get it to fail but it happens in postgres-connect and I can't assert anything on the error I get from it

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
