### PR TITLE
ci: add rocksdb as a dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +920,17 @@ name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "camino"
@@ -2996,6 +3027,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "librocksdb-sys"
+version = "0.10.0+7.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe4d5874f5ff2bc616e55e8c6086d478fcda13faf9495768a4aa1c22042d30b"
+dependencies = [
+ "bindgen 0.64.0",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,7 +3307,7 @@ checksum = "9006c95034ccf7b903d955f210469119f6c3477fc9c9e7a7845ce38a3e665c2a"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal",
- "bindgen",
+ "bindgen 0.59.2",
  "bitflags",
  "bitvec",
  "byteorder",
@@ -4813,6 +4858,7 @@ dependencies = [
  "rdkafka",
  "ref-cast",
  "regex",
+ "rocksdb",
  "serde",
  "serde_json",
  "sha2",
@@ -6329,6 +6375,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7278a1ec8bfd4a4e07515c589f5ff7b309a373f987393aef44813d9dcf87aa3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015439787fce1e75d55f279078d33ff14b4af5d93d995e8838ee4631301c8a99"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -91,6 +91,7 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
     git \
     gnupg2 \
     jq \
+    libclang-dev \
     libpq-dev \
     lld \
     make \
@@ -151,13 +152,13 @@ RUN mkdir rust \
         ;; \
     esac \
     && rm -rf rust \
-    && cargo install --root /usr/local --version "=0.5.2" cargo-about \
-    && cargo install --root /usr/local --version "=1.40.5" cargo-deb \
-    && cargo install --root /usr/local --version "=0.12.2" cargo-deny \
-    && cargo install --root /usr/local --version ="0.9.18" cargo-hakari \
-    && cargo install --root /usr/local --version "=0.9.44" cargo-nextest \
+    && cargo install --root /usr/local --version "=0.5.2" --locked cargo-about \
+    && cargo install --root /usr/local --version "=1.40.5" --locked cargo-deb \
+    && cargo install --root /usr/local --version "=0.12.2" --locked cargo-deny \
+    && cargo install --root /usr/local --version ="0.9.18" --locked cargo-hakari \
+    && cargo install --root /usr/local --version "=0.9.44" --locked cargo-nextest \
     && `: Until https://github.com/est31/cargo-udeps/pull/147 is released in cargo-udeps` \
-    && cargo install --root /usr/local --git https://github.com/est31/cargo-udeps --rev=b84d478ef3efd7264dba8c15c31a50c6399dc5bb --locked  cargo-udeps --features=vendored-openssl \
+    && cargo install --root /usr/local --git https://github.com/est31/cargo-udeps --rev=b84d478ef3efd7264dba8c15c31a50c6399dc5bb --locked cargo-udeps --features=vendored-openssl \
     && cargo install --root /usr/local --version "=0.2.15" --no-default-features --features=s3,openssl/vendored sccache \
     && cargo install --root /usr/local --version "=0.3.6" cargo-binutils
 

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,10 @@ skip = [
     # up.
     { name = "socket2", version = "0.4.9" },
     { name = "windows-sys", version = "0.42.0" },
+
+    # Waiting for <https://github.com/blackbeam/rust_mysql_common/commit/2a6419aef2ff609cd35a5ce41a9eb48253a8214d>
+    # to be released.
+    { name = "bindgen", version = "0.59.2" },
 ]
 
 # Use `tracing` instead.

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -12,12 +12,14 @@ Kubernetes to orchestrate interactions with other systems, like [Apache Kafka].
 ### C components
 
 Materialize depends on several components that are written in C and C++, so
-you'll need a working C and C++ toolchain. You'll also need to install the
-[CMake] build system.
+you'll need a working C and C++ toolchain. You'll also need to install:
+* The [CMake] build system
+* libclang
+* PostgreSQL
 
 On macOS, if you install [Homebrew], you'll be guided through the process of
-installing Apple's developer tools, which includes a C compiler. Then it's a
-cinch to install CMake:
+installing Apple's developer tools, which includes a C compiler and libclang.
+Then it's a cinch to install CMake and PostgreSQL.
 
 ```
 brew install cmake postgresql
@@ -27,7 +29,7 @@ On Debian-based Linux variants, it's even easier:
 
 ```shell
 sudo apt update
-sudo apt install build-essential cmake postgresql-client
+sudo apt install build-essential cmake postgresql-client libclang-dev
 ```
 
 On other platforms, you'll have to figure out how to get these tools yourself.

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -72,9 +72,11 @@ tonic-build = "0.8.2"
 
 [dev-dependencies]
 datadriven = { version = "0.6.0", features = ["async"] }
+rocksdb = { version = "0.20.1", default-features = false, features = ["snappy"] }
 itertools = "0.10.5"
 tokio = { version = "1.24.2", features = ["test-util"] }
 
 [package.metadata.cargo-udeps.ignore]
 # only used on linux
 normal = ["inotify", "workspace-hack"]
+development = ["rocksdb"]


### PR DESCRIPTION
In preparation for merging https://github.com/MaterializeInc/materialize/pull/18364, and the fact that we are going to being adding `rocksdb` to `mz_storage` soon. This pr adds `rocksdb` as a `dev-dependency` for now (so only `--all-targets` will build it), and adds documentation on what package needs to be installed on linux, which will be announced in `#eng-announce` as this merges

We also need to allow a new duplicate (`bindgen`), until `mysql_common` has a new release. I asked in the rust-mysql glitter chat about when this will happen.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
