### PR TITLE
adapter: correct stash retraction migrations

### DIFF
--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -245,7 +245,7 @@ impl Usage {
         // there is no overlap between expected names.
         Self::verify_all_usages()?;
 
-        let names = stash.collections().await?;
+        let names = BTreeSet::from_iter(stash.collections().await?.into_values());
         for usage in Self::all_usages() {
             // Some TypedCollections exist before any entries have been written
             // to a collection, so `stash.collections()` won't return it, and we
@@ -273,7 +273,7 @@ impl Usage {
         stash: &mut Stash,
     ) -> Result<BTreeMap<&str, serde_json::Value>, anyhow::Error> {
         let mut collections = Vec::new();
-        let collection_names = stash.collections().await?;
+        let collection_names = BTreeSet::from_iter(stash.collections().await?.into_values());
         macro_rules! dump_col {
             ($col:expr) => {
                 // Collections might not yet exist.

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::num::NonZeroI64;
 use std::sync::{Arc, Mutex};
@@ -991,7 +991,7 @@ impl Stash {
             .await
     }
 
-    pub async fn collections(&mut self) -> Result<BTreeSet<String>, StashError> {
+    pub async fn collections(&mut self) -> Result<BTreeMap<Id, String>, StashError> {
         self.with_transaction(move |tx| Box::pin(async move { tx.collections().await }))
             .await
     }
@@ -1203,7 +1203,7 @@ impl Consolidator {
                     .collect::<Vec<_>>();
                 let deleted = rows.len();
                 // Perform the consolidation in Rust.
-                let rows = crate::consolidate(rows);
+                let rows = crate::consolidate(&rows);
                 // Then for any items that have a positive diff, INSERT them
                 // back into the database. Our current production stash usage
                 // will never have any results here (all consolidations sum to


### PR DESCRIPTION
When we add an Option field to an existing catalog struct, that gets deserialized from the on-disk JSON as None. If we write a migration that migrates all Nones to a Some, the storage transaction notices we changed something so it issues a retraction. However the row it's retracting has a "field: None" entry, but the row on disk has *no* entry, so the retraction doesn't have a matching row from JSON's point of view, thus never gets consolidated.

This oddly doesn't affect correctness because the Rust consolidation code knows these cancel each other out, because they both deserialize the same.

It does however affect us when we then remove the Optionness of the new field, because we believe everything on disk is now populated. When we try to read the row without the field at all into a Rust struct, the migration errors.

To fix: write a transaction method that is able to tell apart things that have JSON differences but are Rust-equivalent, and retract all the rows (additions or retractions) that need to be consolidated from disk. Use this function to cleanup all collections before running the stash migration (a pre-migration migration), which can be removed after one release. Prevent this from happening in the future by automatically running this in all migrations for any changed collection.

Fixes #18485

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a