### PR TITLE
#18215: expose errors in ReduceCollation as query-level errors

### DIFF
--- a/test/testdrive/negative-multiplicities.td
+++ b/test/testdrive/negative-multiplicities.td
@@ -53,3 +53,17 @@ contains:Non-positive accumulation in ReduceInaccumulable
 # regression scenario per #17509
 ! SELECT MAX(data) FROM data;
 contains:Invalid data in source, saw non-positive accumulation
+
+# verify that some reduction in a collation plan catches a negative
+# multiplicity.
+! SELECT
+    data,
+    COUNT(DISTINCT data),
+    STRING_AGG(data::text || '1',  ','),
+    MIN(data),
+    MAX(DISTINCT data),
+    SUM(data),
+    STRING_AGG(data::text || '2',  ',')
+  FROM data
+  GROUP BY data
+contains:Non-positive accumulation in ReduceInaccumulable


### PR DESCRIPTION
These are the final immediately-actionable pieces of #17178.  I spent a while trying to find an alternative to this approach, but with the mechanisms we have available presently, it seems to be the only reasonable way.

I'm not sure about strategies for provoking these errors in tests, but I'd like to add a testdrive test that gives us more coverage on ReduceCollation in general.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

 * This PR fixes recognized bugs: #18215, #18216.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
