### PR TITLE
Fix a cast inversion bug in `LiteralConstraints`

### DIFF
--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -1014,6 +1014,7 @@ Used Indexes:
 EOF
 
 # Regression test for https://github.com/MaterializeInc/materialize/issues/15696
+# CREATE INDEX should call reduce on index expressions.
 
 statement ok
 CREATE TABLE bar(a BOOL, b BOOL);
@@ -1032,3 +1033,80 @@ Used Indexes:
   - materialize.public.bar_expr_idx
 
 EOF
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/18410
+# We should resist the temptation to do an index lookup in the following test; `preserves_uniqueness` should be checked
+# not just on the inverse cast, but on the original cast as well.
+
+statement ok
+CREATE TABLE t3 ( c0 FLOAT );
+
+statement ok
+INSERT INTO t3 VALUES (-0.1), (0.6), (1), (0);
+
+statement ok
+CREATE INDEX t3i0 ON t3 (c0);
+
+query T multiline
+EXPLAIN WITH(arity, join_impls)
+SELECT * FROM t3 WHERE NOT (((t3.c0)::INT != 0));
+----
+Explained Query (fast path):
+  Filter (0 = double_to_integer(#0))
+    ReadExistingIndex materialize.public.t3i0
+
+Used Indexes:
+  - materialize.public.t3i0
+
+EOF
+
+query R rowsort
+SELECT * FROM t3 WHERE NOT (((t3.c0)::INT != 0));
+----
+-0.1
+0
+
+# Float index lookup should work. (No casts in this test.)
+# Also tests that deduplication works between `t3.c0 != -0.1` and `-0.1 != t3.c0`:
+# `-0.1` should appear in lookup_values only once!
+
+query T multiline
+EXPLAIN WITH(arity, join_impls)
+SELECT * FROM t3 WHERE NOT ((t3.c0 != 0.6) AND (t3.c0 != -0.1) AND (t3.c0 != 0.1) AND (-0.1 != t3.c0));
+----
+Explained Query (fast path):
+  Project (#0)
+    ReadExistingIndex materialize.public.t3i0 lookup_values=[(0.6); (0.1); (-0.1)]
+
+Used Indexes:
+  - materialize.public.t3i0
+
+EOF
+
+query R rowsort
+SELECT * FROM t3 WHERE NOT ((t3.c0 != 0.6) AND (t3.c0 != -0.1) AND (t3.c0 != 0.1) AND (-0.1 != t3.c0));
+----
+-0.1
+0.6
+
+# The following (rounding) cast will be executed by the constant folding in `MirScalarExpr::reduce`. We should look up
+# the rounded value.
+
+query T multiline
+EXPLAIN WITH(arity, join_impls)
+SELECT * FROM t3 WHERE t3.c0 = 0.8::INT OR t3.c0 = -0.1;
+----
+Explained Query (fast path):
+  Project (#0)
+    ReadExistingIndex materialize.public.t3i0 lookup_values=[(1); (-0.1)]
+
+Used Indexes:
+  - materialize.public.t3i0
+
+EOF
+
+query R rowsort
+SELECT * FROM t3 WHERE t3.c0 = 0.8::INT OR t3.c0 = -0.1;
+----
+-0.1
+1


### PR DESCRIPTION
When looking for a literal equality to perform an index lookup, we try to match an equality in not just its original form, but also with a cast (and some other functions) removed from one side by inverse-casting both sides. However, we need to be careful with casts that don't preserve uniqueness, e.g., because they involve rounding. So far, we had a check that we don't try an inverse cast when the inverse cast doesn't `preserves_uniqueness`. This PR adds the same check for the original cast function, so that we don't lose rounding casts.

### Motivation

  * This PR fixes a recognized bug: #18410

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
