### PR TITLE
*: make printing of error chain more explicit

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -940,7 +940,7 @@ impl Coordinator {
                                     .await
                                 })
                                 .await
-                                .map_err(StorageError::from)
+                                .map_err(StorageError::Generic)
                                 .map_err(AdapterError::from);
                             // It is not an error for sink connections to become ready after `internal_cmd_rx` is dropped.
                             let result = internal_cmd_tx.send(Message::SinkConnectionReady(

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -267,6 +267,9 @@ impl AdapterError {
                         .join("\n"))
                     .join("\n"))
             },
+            AdapterError::Storage(storage_error) => {
+                storage_error.source().map(|source_error| source_error.to_string_with_causes())
+            }
             _ => None,
         }
     }

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -19,6 +19,7 @@ use tokio::sync::oneshot;
 
 use mz_compute_client::controller::error as compute_error;
 use mz_expr::{EvalError, UnmaterializableFunc};
+use mz_ore::error::ErrorExt;
 use mz_ore::stack::RecursionLimitError;
 use mz_ore::str::StrExt;
 use mz_repr::explain::ExplainError;
@@ -460,7 +461,7 @@ impl fmt::Display for AdapterError {
                 write!(f, "cannot materialize call to {}", func)
             }
             AdapterError::Unsupported(features) => write!(f, "{} are not supported", features),
-            AdapterError::Unstructured(e) => write!(f, "{:#}", e),
+            AdapterError::Unstructured(e) => write!(f, "{}", e.display_with_causes()),
             AdapterError::WriteOnlyTransaction => f.write_str("transaction in write-only mode"),
             AdapterError::UnknownPreparedStatement(name) => {
                 write!(f, "prepared statement {} does not exist", name.quoted())

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -317,7 +317,9 @@ impl ShouldHalt for StorageError {
             StorageError::SourceIdReused(_)
             | StorageError::SinkIdReused(_)
             | StorageError::IdentifierMissing(_)
-            | StorageError::ClientError(_)
+            | StorageError::IngestionInstanceMissing { .. }
+            | StorageError::ExportInstanceMissing { .. }
+            | StorageError::Generic(_)
             | StorageError::DataflowError(_) => false,
             StorageError::IOError(e) => e.should_halt(),
         }

--- a/src/cluster/src/server.rs
+++ b/src/cluster/src/server.rs
@@ -24,6 +24,7 @@ use tracing::{info, warn};
 
 use mz_cluster_client::client::{ClusterStartupEpoch, TimelyConfig};
 use mz_ore::cast::CastFrom;
+use mz_ore::error::ErrorExt;
 use mz_ore::halt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_persist_client::cache::PersistClientCache;
@@ -226,7 +227,7 @@ where
                     Self::build_timely(worker_config, config, epoch, persist_clients, handle).await;
                 match build_timely_result {
                     Err(e) => {
-                        warn!("timely initialization failed: {e:#}");
+                        warn!("timely initialization failed: {}", e.display_with_causes());
                         return Err(e);
                     }
                     Ok(ok) => ok,

--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -91,6 +91,7 @@ use mz_cloud_resources::AwsExternalIdPrefix;
 use mz_compute_client::service::proto_compute_server::ProtoComputeServer;
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};
 use mz_ore::cli::{self, CliConfig};
+use mz_ore::error::ErrorExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::netio::{Listener, SocketAddr};
 use mz_ore::now::SYSTEM_TIME;
@@ -170,7 +171,7 @@ async fn main() {
         enable_version_flag: true,
     });
     if let Err(err) = run(args).await {
-        eprintln!("clusterd: fatal: {:#}", err);
+        eprintln!("clusterd: fatal: {}", err.display_with_causes());
         process::exit(1);
     }
 }

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -121,6 +121,7 @@ use mz_orchestrator_process::{
 };
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs, TracingOrchestrator};
 use mz_ore::cli::{self, CliConfig, KeyValueArg};
+use mz_ore::error::ErrorExt;
 use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
@@ -526,7 +527,7 @@ fn main() {
         enable_version_flag: true,
     });
     if let Err(err) = run(args) {
-        eprintln!("environmentd: {:#}", err);
+        eprintln!("environmentd: {}", err.display_with_causes());
         process::exit(1);
     }
 }

--- a/src/environmentd/src/server.rs
+++ b/src/environmentd/src/server.rs
@@ -23,6 +23,7 @@ use tokio::sync::oneshot;
 use tokio_stream::wrappers::TcpListenerStream;
 use tracing::{debug, error};
 
+use mz_ore::error::ErrorExt;
 use mz_ore::task;
 
 /// TCP keepalive settings. The idle time and interval match CockroachDB [0].
@@ -123,7 +124,11 @@ where
         let fut = server.handle_connection(conn);
         task::spawn(|| &task_name, async {
             if let Err(e) = fut.await {
-                debug!("error handling connection in {}: {:#}", S::NAME, e);
+                debug!(
+                    "error handling connection in {}: {}",
+                    S::NAME,
+                    e.display_with_causes()
+                );
             }
         });
     }

--- a/src/interchange/src/bin/avro-decode.rs
+++ b/src/interchange/src/bin/avro-decode.rs
@@ -85,6 +85,7 @@ use mz_interchange::avro::Decoder;
 use mz_interchange::confluent;
 use mz_ore::cli;
 use mz_ore::cli::CliConfig;
+use mz_ore::error::ErrorExt;
 
 /// Decode a single Avro row using Materialize's Avro decoder.
 #[derive(clap::Parser)]
@@ -102,7 +103,7 @@ struct Args {
 async fn main() {
     let args: Args = cli::parse_args(CliConfig::default());
     if let Err(e) = run(args).await {
-        println!("{e:#}");
+        println!("{}", e.display_with_causes());
         process::exit(1);
     }
 }

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -116,6 +116,7 @@ use mz_orchestrator::{
     ServiceProcessMetrics, ServiceStatus,
 };
 use mz_ore::cast::{CastFrom, ReinterpretCast, TryCastFrom};
+use mz_ore::error::ErrorExt;
 use mz_ore::netio::UnixSocketAddr;
 use mz_ore::result::ResultExt;
 use mz_ore::task::{AbortOnDropHandle, JoinHandleExt};
@@ -609,8 +610,9 @@ impl NamespacedProcessOrchestrator {
         let contents = serde_json::to_vec_pretty(&static_configs).expect("valid json");
         if let Err(e) = fs::write(&path, &contents).await {
             warn!(
-                "{}: failed to write prometheus service discovery file: {e:#}",
-                self.namespace
+                "{}: failed to write prometheus service discovery file: {}",
+                self.namespace,
+                e.display_with_causes()
             );
         }
     }
@@ -746,7 +748,7 @@ async fn tcp_proxy(
             }
             res = conns.try_next() => {
                 if let Err(e) = res {
-                    warn!("{name}: tcp proxy connection failed: {e:#}");
+                    warn!("{name}: tcp proxy connection failed: {}", e.display_with_causes());
                 }
             }
         }

--- a/src/ore/src/error.rs
+++ b/src/ore/src/error.rs
@@ -1,0 +1,139 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Error utilities.
+
+use std::error::Error;
+use std::fmt::{self, Debug, Display};
+
+/// Extension methods for [`std::error::Error`].
+pub trait ErrorExt: Error {
+    /// Returns a type that displays the error, along with the chain of _source_ errors or
+    /// causes, if there are any.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use anyhow::anyhow;
+    /// use mz_ore::error::ErrorExt;
+    ///
+    /// let error = anyhow!("inner");
+    /// let error = error.context("context");
+    /// assert_eq!(format!("error: ({})", error.display_with_causes()), "error: (context: inner)");
+    /// ```
+    fn display_with_causes(&self) -> ErrorChainFormatter<&Self> {
+        ErrorChainFormatter(self)
+    }
+
+    /// Converts `self` to a string `String`, along with the chain of _source_ errors or
+    /// causes, if there are any.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use anyhow::anyhow;
+    /// use mz_ore::error::ErrorExt;
+    ///
+    /// let error = anyhow!("inner");
+    /// let error = error.context("context");
+    /// assert_eq!(error.to_string_with_causes(), "context: inner");
+    /// ```
+    fn to_string_with_causes(&self) -> String {
+        format!("{}", self.display_with_causes())
+    }
+}
+
+impl<E: Error + ?Sized> ErrorExt for E {}
+
+/// Formats an error with its full chain of causes.
+pub struct ErrorChainFormatter<E>(E);
+
+impl<E: Error> Display for ErrorChainFormatter<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)?;
+
+        let mut maybe_cause = self.0.source();
+
+        while let Some(cause) = maybe_cause {
+            write!(f, ": {}", cause)?;
+            maybe_cause = cause.source();
+        }
+
+        Ok(())
+    }
+}
+
+impl<E: Error> Debug for ErrorChainFormatter<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use anyhow::anyhow;
+
+    use super::*;
+
+    #[test]
+    fn basic_usage() {
+        let error = anyhow!("root");
+        let error = error.context("context");
+        assert_eq!(error.to_string_with_causes(), "context: root");
+    }
+
+    #[test]
+    fn basic_usage_with_arc() {
+        // The reason for this signature is that our Plan errors have a `cause` field like this:
+        // ```
+        // cause: Arc<dyn Error + Send + Sync>
+        // ```
+        fn verify(dyn_error: Arc<dyn Error + Send + Sync>) {
+            assert_eq!(
+                dyn_error.to_string_with_causes(),
+                "test error: context: root"
+            );
+        }
+
+        let error = anyhow!("root");
+        let error = error.context("context");
+        let error = TestError { inner: error };
+        let arc_error = Arc::new(error);
+        verify(arc_error);
+    }
+
+    #[derive(Debug)]
+    struct TestError {
+        inner: anyhow::Error,
+    }
+
+    impl Display for TestError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            // We don't print our causes.
+            write!(f, "test error")?;
+            Ok(())
+        }
+    }
+
+    impl std::error::Error for TestError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            Some(self.inner.as_ref())
+        }
+    }
+}

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -102,6 +102,7 @@ pub mod codegen;
 pub mod collections;
 pub mod display;
 pub mod env;
+pub mod error;
 pub mod fmt;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "async")))]
 #[cfg(feature = "async")]

--- a/src/ore/src/result.rs
+++ b/src/ore/src/result.rs
@@ -59,6 +59,7 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
     where
         E: std::fmt::Display,
     {
+        // WIP: Do we want to change these as well?
         self.as_ref().err().map(DisplayExt::to_string_alt)
     }
 

--- a/src/persist-client/examples/persistcli.rs
+++ b/src/persist-client/examples/persistcli.rs
@@ -86,6 +86,7 @@
 use mz_build_info::{build_info, BuildInfo};
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};
 use mz_ore::cli::{self, CliConfig};
+use mz_ore::error::ErrorExt;
 use mz_ore::task::RuntimeExt;
 use tokio::runtime::Handle;
 use tracing::{info_span, Instrument};
@@ -164,7 +165,7 @@ fn main() {
     };
 
     if let Err(err) = res {
-        eprintln!("error: {:#}", err);
+        eprintln!("error: {}", err.display_with_causes());
         std::process::exit(1);
     }
 }

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -20,6 +20,7 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use futures_util::TryFutureExt;
 use mz_ore::cast::CastFrom;
+use mz_ore::error::ErrorExt;
 use mz_ore::task::spawn;
 use mz_persist::location::Blob;
 use mz_persist_types::codec_impls::VecU8Schema;
@@ -371,7 +372,11 @@ where
             }
             Ok(Err(err)) | Err(err) => {
                 metrics.compaction.failed.inc();
-                debug!("compaction for {} failed: {:#}", machine.shard_id(), err);
+                debug!(
+                    "compaction for {} failed: {}",
+                    machine.shard_id(),
+                    err.display_with_causes()
+                );
                 Err(err)
             }
         }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -22,6 +22,7 @@ use timely::PartialOrder;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
+use mz_ore::error::ErrorExt;
 #[allow(unused_imports)] // False positive.
 use mz_ore::fmt::FormatBuffer;
 use mz_persist::location::{ExternalError, Indeterminate, SeqNo};
@@ -935,17 +936,17 @@ where
             Err(err) => {
                 if retry.attempt() >= INFO_MIN_ATTEMPTS {
                     info!(
-                        "external operation {} failed, retrying in {:?}: {:#}",
+                        "external operation {} failed, retrying in {:?}: {}",
                         metrics.name,
                         retry.next_sleep(),
-                        err
+                        err.display_with_causes()
                     );
                 } else {
                     debug!(
-                        "external operation {} failed, retrying in {:?}: {:#}",
+                        "external operation {} failed, retrying in {:?}: {}",
                         metrics.name,
                         retry.next_sleep(),
-                        err
+                        err.display_with_causes()
                     );
                 }
                 retry = retry.sleep().await;
@@ -984,10 +985,10 @@ where
                 // helpful. As a result, this intentionally ignores
                 // INFO_MIN_ATTEMPTS and always logs at debug.
                 debug!(
-                    "external operation {} failed, retrying in {:?}: {:#}",
+                    "external operation {} failed, retrying in {:?}: {}",
                     metrics.name,
                     retry.next_sleep(),
-                    err
+                    err.display_with_causes()
                 );
                 retry = retry.sleep().await;
                 continue;

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -34,7 +34,6 @@ use chrono::{DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, 
 use dec::OrderedDecimal;
 use fast_float::FastFloat;
 use mz_lowertest::MzReflect;
-use mz_ore::display::DisplayExt;
 use mz_ore::result::ResultExt;
 use num_traits::Float as NumFloat;
 use once_cell::sync::Lazy;
@@ -45,6 +44,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use mz_ore::cast::ReinterpretCast;
+use mz_ore::error::ErrorExt;
 use mz_ore::fmt::FormatBuffer;
 use mz_ore::lex::LexBuf;
 use mz_ore::str::StrExt;
@@ -616,7 +616,7 @@ pub fn parse_bytes(s: &str) -> Result<Vec<u8>, ParseError> {
     // [1]: https://www.postgresql.org/docs/current/datatype-binary.html#id-1.5.7.12.10
     if let Some(remainder) = s.strip_prefix(r"\x") {
         parse_bytes_hex(remainder).map_err(|e| {
-            ParseError::invalid_input_syntax("bytea", s).with_details(e.to_string_alt())
+            ParseError::invalid_input_syntax("bytea", s).with_details(e.to_string_with_causes())
         })
     } else {
         parse_bytes_traditional(s)
@@ -1796,6 +1796,7 @@ pub enum ParseHexError {
     InvalidHexDigit(char),
     OddLength,
 }
+impl Error for ParseHexError {}
 
 impl fmt::Display for ParseHexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/s3-datagen/src/main.rs
+++ b/src/s3-datagen/src/main.rs
@@ -88,6 +88,7 @@ use tracing_subscriber::filter::EnvFilter;
 
 use mz_ore::cast::CastFrom;
 use mz_ore::cli::{self, CliConfig};
+use mz_ore::error::ErrorExt;
 
 /// Generate meaningless data in S3 to test download speeds
 #[derive(Parser)]
@@ -134,7 +135,7 @@ struct Args {
 #[tokio::main]
 async fn main() {
     if let Err(e) = run().await {
-        error!("{:#}", e);
+        error!("{}", e.display_with_causes());
         std::process::exit(1);
     }
 }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -440,25 +440,26 @@ impl From<InvalidVarCharMaxLengthError> for PlanError {
 
 impl From<anyhow::Error> for PlanError {
     fn from(e: anyhow::Error) -> PlanError {
-        sql_err!("{:#}", e)
+        // WIP: Do we maybe want to keep the alternate selector for these?
+        sql_err!("{}", e.display_with_causes())
     }
 }
 
 impl From<TryFromIntError> for PlanError {
     fn from(e: TryFromIntError) -> PlanError {
-        sql_err!("{:#}", e)
+        sql_err!("{}", e.display_with_causes())
     }
 }
 
 impl From<ParseIntError> for PlanError {
     fn from(e: ParseIntError) -> PlanError {
-        sql_err!("{:#}", e)
+        sql_err!("{}", e.display_with_causes())
     }
 }
 
 impl From<EvalError> for PlanError {
     fn from(e: EvalError) -> PlanError {
-        sql_err!("{:#}", e)
+        sql_err!("{}", e.display_with_causes())
     }
 }
 

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use mz_expr::EvalError;
+use mz_ore::error::ErrorExt;
 use mz_ore::stack::RecursionLimitError;
 use mz_ore::str::{separated, StrExt};
 use mz_repr::adt::char::InvalidCharLengthError;
@@ -163,9 +164,11 @@ impl PlanError {
 
     pub fn detail(&self) -> Option<String> {
         match self {
-            Self::FetchingCsrSchemaFailed { cause, .. } => Some(cause.to_string()),
-            Self::FetchingPostgresPublicationInfoFailed { cause } => Some(cause.to_string()),
-            Self::InvalidProtobufSchema { cause } => Some(cause.to_string()),
+            Self::FetchingCsrSchemaFailed { cause, .. } => Some(cause.to_string_with_causes()),
+            Self::FetchingPostgresPublicationInfoFailed { cause } => {
+                Some(cause.to_string_with_causes())
+            }
+            Self::InvalidProtobufSchema { cause } => Some(cause.to_string_with_causes()),
             Self::InvalidOptionValue { err, .. } => err.detail(),
             _ => None,
         }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -62,6 +62,7 @@ use uuid::Uuid;
 use mz_controller::ControllerConfig;
 use mz_orchestrator_process::{ProcessOrchestrator, ProcessOrchestratorConfig};
 use mz_ore::cast::ReinterpretCast;
+use mz_ore::error::ErrorExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::retry::Retry;
@@ -184,9 +185,19 @@ impl fmt::Display for Outcome<'_> {
         use Outcome::*;
         const INDENT: &str = "\n        ";
         match self {
-            Unsupported { error, location } => write!(f, "Unsupported:{}:\n{:#}", location, error),
+            Unsupported { error, location } => write!(
+                f,
+                "Unsupported:{}:\n{}",
+                location,
+                error.display_with_causes()
+            ),
             ParseFailure { error, location } => {
-                write!(f, "ParseFailure:{}:\n{:#}", location, error)
+                write!(
+                    f,
+                    "ParseFailure:{}:\n{}",
+                    location,
+                    error.display_with_causes()
+                )
             }
             PlanFailure { error, location } => write!(f, "PlanFailure:{}:\n{:#}", location, error),
             UnexpectedPlanSuccess {

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -100,6 +100,7 @@ use mz_adapter::{
 use mz_build_info::{build_info, BuildInfo};
 use mz_ore::{
     cli::{self, CliConfig},
+    error::ErrorExt,
     metrics::MetricsRegistry,
     now::SYSTEM_TIME,
 };
@@ -146,7 +147,7 @@ async fn main() {
         enable_version_flag: true,
     });
     if let Err(err) = run(args).await {
-        eprintln!("stash: {:#}", err);
+        eprintln!("stash: {}", err.display_with_causes());
         process::exit(1);
     }
 }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -32,6 +32,7 @@ use bytes::BufMut;
 use derivative::Derivative;
 use differential_dataflow::lattice::Lattice;
 use itertools::Itertools;
+use mz_ore::error::ErrorExt;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use prost::Message;
@@ -873,10 +874,22 @@ impl fmt::Display for StorageError {
                     id.iter().map(|id| id.to_string()).join(", ")
                 )
             }
-            Self::ClientError(err) => write!(f, "underlying client error: {:#}", err),
-            Self::IOError(err) => write!(f, "failed to read or write state: {err}"),
-            Self::DataflowError(err) => write!(f, "dataflow failed to process request: {err}"),
-            Self::InvalidUsage(err) => write!(f, "invalid usage: {err}"),
+            Self::ClientError(err) => {
+                // WIP: Should we even try and print the causes here? Feels like thats the
+                // responsibility of the caller now.
+                write!(f, "underlying client error: {}", err.display_with_causes())
+            }
+            Self::IOError(err) => write!(
+                f,
+                "failed to read or write state: {}",
+                err.display_with_causes()
+            ),
+            Self::DataflowError(err) => write!(
+                f,
+                "dataflow failed to process request: {}",
+                err.display_with_causes()
+            ),
+            Self::InvalidUsage(err) => write!(f, "invalid usage: {}", err),
         }
     }
 }

--- a/src/storage/src/decode/avro.rs
+++ b/src/storage/src/decode/avro.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use mz_interchange::avro::Decoder;
+use mz_ore::error::ErrorExt;
 use mz_repr::Row;
 use mz_storage_client::types::errors::DecodeErrorKind;
 
@@ -37,8 +38,8 @@ impl AvroDecoderState {
                 Ok(Some(row))
             }
             Err(err) => Err(DecodeErrorKind::Text(format!(
-                "avro deserialization error: {:#}",
-                err
+                "avro deserialization error: {}",
+                err.display_with_causes()
             ))),
         }
     }

--- a/src/storage/src/decode/protobuf.rs
+++ b/src/storage/src/decode/protobuf.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use mz_interchange::protobuf::{DecodedDescriptors, Decoder};
+use mz_ore::error::ErrorExt;
 use mz_repr::Row;
 use mz_storage_client::types::errors::DecodeErrorKind;
 use mz_storage_client::types::sources::encoding::ProtobufEncoding;
@@ -51,8 +52,8 @@ impl ProtobufDecoderState {
             Err(err) => {
                 self.events_error += 1;
                 Some(Err(DecodeErrorKind::Text(format!(
-                    "protobuf deserialization error: {:#}",
-                    err
+                    "protobuf deserialization error: {}",
+                    err.display_with_causes()
                 ))))
             }
         }

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -45,6 +45,7 @@ use mz_interchange::json::JsonEncoder;
 use mz_kafka_util::client::{BrokerRewritingClientContext, MzClientContext};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
+use mz_ore::error::ErrorExt;
 use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use mz_ore::retry::{Retry, RetryResult};
 use mz_ore::task;
@@ -942,7 +943,7 @@ impl KafkaSinkState {
                         });
 
                 self.update_status(SinkStatus::Stalled {
-                    error: format!("{:#}", error),
+                    error: format!("{}", error.display_with_causes()),
                     hint,
                 })
                 .await;

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -56,6 +56,7 @@ use tracing::{info, trace, warn};
 use mz_expr::PartitionId;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
+use mz_ore::error::ErrorExt;
 use mz_ore::now::NowFn;
 use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
@@ -553,7 +554,7 @@ where
             remap_relation_desc,
         )
         .await
-        .unwrap_or_else(|e| panic!("Failed to create remap handle for source {}: {:#}", name, e));
+        .unwrap_or_else(|e| panic!("Failed to create remap handle for source {}: {}", name, e.display_with_causes()));
         let clock = RemapClock::new(now.clone(), timestamp_interval);
         let (mut timestamper, mut initial_batch) = ReclockOperator::new(remap_handle, clock).await;
 

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -34,7 +34,7 @@ use rdkafka::ClientConfig;
 use regex::{Captures, Regex};
 use url::Url;
 
-use mz_ore::display::DisplayExt;
+use mz_ore::error::ErrorExt;
 use mz_ore::retry::Retry;
 use mz_ore::task;
 use mz_postgres_util::make_tls;
@@ -424,7 +424,10 @@ impl State {
             bail!(
                 "deleting Kafka topics: {} errors: {}",
                 errors.len(),
-                errors.into_iter().map(|e| e.to_string_alt()).join("\n")
+                errors
+                    .into_iter()
+                    .map(|e| e.to_string_with_causes())
+                    .join("\n")
             );
         }
     }

--- a/src/testdrive/src/error.rs
+++ b/src/testdrive/src/error.rs
@@ -23,6 +23,8 @@ use std::path::{Path, PathBuf};
 use atty::Stream;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
+use mz_ore::error::ErrorExt;
+
 /// An error produced when parsing or executing a testdrive script.
 ///
 /// Errors are optionally associated with a location in a testdrive script. When
@@ -65,7 +67,7 @@ impl Error {
                     write!(&mut stderr, "{}:{}: ", location.line, location.col)?;
                 }
                 write_error_heading(&mut stderr, &color_spec)?;
-                writeln!(&mut stderr, "{:#}", self.source)?;
+                writeln!(&mut stderr, "{}", self.source.display_with_causes())?;
                 color_spec.set_bold(false);
                 stderr.set_color(&color_spec)?;
                 write!(&mut stderr, "{}", location.snippet)?;
@@ -74,7 +76,7 @@ impl Error {
             None => {
                 let color_spec = ColorSpec::new();
                 write_error_heading(&mut stderr, &color_spec)?;
-                writeln!(&mut stderr, "{:#}", self.source)?;
+                writeln!(&mut stderr, "{}", self.source.display_with_causes())?;
                 Ok(())
             }
         }
@@ -83,7 +85,7 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:#}", self.source)
+        write!(f, "{}", self.source.display_with_causes())
     }
 }
 

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -86,7 +86,7 @@ use std::path::Path;
 use action::Run;
 use anyhow::{anyhow, Context};
 
-use mz_ore::display::DisplayExt;
+use mz_ore::error::ErrorExt;
 
 use self::action::ControlFlow;
 use self::error::{ErrorLocation, PosError};
@@ -198,7 +198,7 @@ pub(crate) async fn run_line_reader(
     if config.reset {
         drop(state);
         if let Err(e) = state_cleanup.await {
-            errors.push(anyhow!("cleanup failed: error: {}", e.to_string_alt()).into());
+            errors.push(anyhow!("cleanup failed: error: {}", e.to_string_with_causes()).into());
         }
     }
 


### PR DESCRIPTION
### Motivation

Before, we were using the alternate selector (`{:#}`) when printing errors in _some_ places. This was motivated by the fact that `anyhow::Error` prints the error along with the chain of underlying errors (what you get when you keep calling `Error::source()`). We didn't do this consistently, meaning we would not report the root causes to users for some errors. Additionally, most error types, for example those creates by `thiserror` _do not_ print the chain of errors when alternate printing is requested.

This introduces a new `ErrorExt`, with `ErrorExt::display_with_causes` and `ErrorExt:to_string_with_causes` (which yes, are a bit of a mouthful) that allow us to _explicitly_ request when the chain of errors should be printed along with the top-most error. This changes all (hopefully!) places where we previously used `{:#}` or `DisplayExt::to_string_alt` (a util that invokes the former). Plus I get rid of some places where we used `anyhow::anyhow!()` to get the chain-printing behaviour.

Initially motivated by https://github.com/MaterializeInc/materialize/issues/18490#issuecomment-1495385815, but this got bigger over time.

**Follow-ups**
 - document this in the style guide! But I'd like us to agree to this quickly and merge, because it touches quite some files.
 - change `ResultExt` to use this new, explicit way of printing error chains, and change `strconv.rs`, which needs some refactorings to make this work

### Tips for reviewer

Regarding the initial motivation:

With this PR, you will get
```
materialize=> CREATE SOURCE pg_source
  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
  FOR TABLES ("tablea", "tableb");
ERROR:  failed to fetch publication information from PostgreSQL database
DETAIL:  some more context: intermediate context: the root cause
```

Without the change you will only get:
```
materialize=> CREATE SOURCE pg_source
  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
  FOR TABLES ("tablea", "tableb");
ERROR:  failed to fetch publication information from PostgreSQL database
DETAIL:  some more context
```

Meaning we could only see the top-level error.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
