### PR TITLE
adapter: docs and followups from #18426

### DIFF
--- a/doc/user/content/integrations/http-api.md
+++ b/doc/user/content/integrations/http-api.md
@@ -73,7 +73,7 @@ You can optionally specify session variables for each request, as a URL-encoded 
 https://<MZ host address>/api/sql?options=<object>
 ```
 
-For example, this is how you could specify the the `application_name` session variable with Javascript:
+For example, this is how you could specify the `application_name` session variable with JavaScript:
 
 ```javascript
 // Create and encode our parameters object.

--- a/doc/user/content/integrations/http-api.md
+++ b/doc/user/content/integrations/http-api.md
@@ -34,6 +34,8 @@ The API:
     - `DECLARE`
     - `FETCH`
     - `SUBSCRIBE`
+- Supports specifying run-time configuration parameters ([session variables](https://www.postgresql.org/docs/current/sql-set.html))
+  via URL query parameters.
 
 ### Transactional semantics
 
@@ -62,6 +64,25 @@ Accessing the endpoint requires [basic authentication](https://developer.mozilla
 
 * **User ID:** Your email to access Materialize.
 * **Password:** Your app password.
+
+#### Query Parameters
+You can optionally specify session variables for each request, as a URL encoded JSON object, with the `options` query parameter:
+
+```
+https://<MZ host address>/api/sql?options=<object>
+```
+
+For example, this is how you could specify the the `application_name` session variable with Javascript:
+
+```javascript
+// Create and encode our parameters object.
+const options = { application_name: "my_app" };
+const encoded = encodeURIComponent(JSON.stringify(options));
+
+// Add the object to our URL as the "options" query parameter.
+const url = new URL(`https://${mzHostAddress}/api/sql`);
+url.searchParams.append("options", encoded);
+```
 
 ### Input format
 

--- a/doc/user/content/integrations/http-api.md
+++ b/doc/user/content/integrations/http-api.md
@@ -66,7 +66,8 @@ Accessing the endpoint requires [basic authentication](https://developer.mozilla
 * **Password:** Your app password.
 
 #### Query Parameters
-You can optionally specify session variables for each request, as a URL encoded JSON object, with the `options` query parameter:
+
+You can optionally specify session variables for each request, as a URL-encoded JSON object, with the `options` query parameter:
 
 ```
 https://<MZ host address>/api/sql?options=<object>

--- a/doc/user/content/integrations/websocket-api.md
+++ b/doc/user/content/integrations/websocket-api.md
@@ -31,6 +31,8 @@ The API:
     - `COPY`
     - `DECLARE`
     - `FETCH`
+- Supports specifying run-time configuration parameters ([session variables](https://www.postgresql.org/docs/current/sql-set.html))
+  via the initial authentication message.
 
 ### Transactional semantics
 
@@ -69,7 +71,7 @@ To authenticate using a token, send an initial text or binary message containing
 
 ```
 {
-	"token": "<Your access token>",
+    "token": "<Your access token>",
     "options": { <Optional map of session variables> }
 }
 ```
@@ -181,8 +183,8 @@ You can model these with the following TypeScript definitions:
 
 ```typescript
 type Auth =
-    | { user: string; password: string }
-    | { token: string }
+    | { user: string; password: string; options?: { [name: string]: string } }
+    | { token: string; options?: { [name: string]: string } }
     ;
 
 interface Simple {

--- a/src/sql/src/session/hint.rs
+++ b/src/sql/src/session/hint.rs
@@ -19,6 +19,8 @@ const PSQL_LABEL: &str = "psql";
 const DBT_LABEL: &str = "dbt";
 /// Prometheus label for [`ApplicationNameHint::WebConsole`].
 const WEB_CONSOLE_LABEL: &str = "web_console";
+/// Prometheus label for [`ApplicationNameHint::MzPsql`].
+const MZ_PSQL_LABEL: &str = "mz_psql";
 
 /// A hint for what application is making a request to the adapter.
 ///
@@ -41,6 +43,8 @@ pub enum ApplicationNameHint {
     Dbt(Private),
     /// Request came from our web console.
     WebConsole(Private),
+    /// Request came from the `psql` shell spawned by `mz`.
+    MzPsql(Private),
 }
 
 impl ApplicationNameHint {
@@ -49,6 +53,7 @@ impl ApplicationNameHint {
             "psql" => ApplicationNameHint::Psql(Private),
             "dbt" => ApplicationNameHint::Dbt(Private),
             "web_console" => ApplicationNameHint::WebConsole(Private),
+            "mz_psql" => ApplicationNameHint::MzPsql(Private),
             "" => ApplicationNameHint::Unspecified(Private),
             // TODO(parkertimmerman): We should keep some record of these "unrecognized"
             // names, and possibly support more popular ones in the future.
@@ -63,6 +68,7 @@ impl ApplicationNameHint {
             ApplicationNameHint::Psql(_) => PSQL_LABEL,
             ApplicationNameHint::Dbt(_) => DBT_LABEL,
             ApplicationNameHint::WebConsole(_) => WEB_CONSOLE_LABEL,
+            ApplicationNameHint::MzPsql(_) => MZ_PSQL_LABEL,
         }
     }
 }


### PR DESCRIPTION
### Motivation

* This PR are follow-ups from #18426

1. Update the public docs for the HTTP and WebSocket endpoints
2. Add `mz_psql` as an `ApplicationNameHint` which was introduced in #18511 

### Tips for reviewer

For the public docs I included a Javascript example of a "url-encoded JSON object" which users provide as a query param. This seemed complex enough to warrant an example, but I'm not sure if we want to provide an example like this, since maybe they can become out-of-date more easily?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
