### PR TITLE
.github: Add affected pages textarea for docs issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/03-documentation.yml
@@ -20,6 +20,14 @@ body:
       label: Documentation request
   - type: textarea
     attributes:
+      label: Affected Pages
+      description: |
+          Link to the pages relevant to your documentation change request.
+      value:
+    validations:
+      required: false
+  - type: textarea
+    attributes:
       label: Related work
       description: |
         If relevant, link to related work that can provide more context (e.g. design documents, tracking issues).

--- a/.github/ISSUE_TEMPLATE/03-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/03-documentation.yml
@@ -22,7 +22,7 @@ body:
     attributes:
       label: Affected Pages
       description: |
-          Link to the pages relevant to your documentation change request.
+        If available, link any pages relevant to your documentation change request.
       value:
     validations:
       required: false


### PR DESCRIPTION
Adding a new text area for affected pages. Could consider making this a requirement.