### PR TITLE
persist: count all live diffs at start of gc

### DIFF
--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -873,6 +873,10 @@ impl<T: Timestamp + Lattice + Codec64> StateVersionsIter<T> {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.diffs.len()
+    }
+
     /// Advances first to some starting state (in practice, usually the first
     /// live state), and then through each successive state, for as many diffs
     /// as this iterator was initialized with.

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -307,6 +307,11 @@ impl StorageUsageClient {
             .inc_by(now.duration_since(start).as_secs_f64());
         start = now;
 
+        let shard_metrics = self.metrics.shards.shard(&shard_id);
+        shard_metrics
+            .gc_live_diffs
+            .set(u64::cast_from(states_iter.len()));
+
         let mut referenced_batches_bytes = BTreeMap::new();
         let mut referenced_other_bytes = 0;
         while let Some(_) = states_iter.next(|x| {
@@ -360,7 +365,6 @@ impl StorageUsageClient {
         // Sanity check that we didn't obviously do anything wrong.
         assert_eq!(ret.total_bytes(), blob_usage.total_bytes());
 
-        let shard_metrics = self.metrics.shards.shard(&shard_id);
         shard_metrics
             .usage_current_state_batches_bytes
             .set(ret.current_state_batches_bytes);


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Right now our `gc_live_diffs` metric counts the # of diffs with seqnos >= `seqno_since` after GC runs. However I think we've typically expected this to be the total # of live diffs encountered by GC, including ones that it truncates during its run. We additionally only get to see the # of live diffs after GC finishes, which could take a long time. 

This updates GC to update the live diff count as soon as it starts.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
