### PR TITLE
repr: move Date to TodoDatumToPersist

### DIFF
--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -87,8 +87,8 @@ impl ColumnType {
             (true, Bool) => f.call::<Option<bool>>(),
             (false, Int16) => f.call::<i16>(),
             (true, Int16) => f.call::<Option<i16>>(),
-            (false, Int32 | Date) => f.call::<i32>(),
-            (true, Int32 | Date) => f.call::<Option<i32>>(),
+            (false, Int32) => f.call::<i32>(),
+            (true, Int32) => f.call::<Option<i32>>(),
             (false, Int64) => f.call::<i64>(),
             (true, Int64) => f.call::<Option<i64>>(),
             (false, UInt16) => f.call::<u16>(),
@@ -112,6 +112,7 @@ impl ColumnType {
             (
                 _,
                 Numeric { .. }
+                | Date
                 | Time
                 | Timestamp
                 | TimestampTz


### PR DESCRIPTION
It's not literally stored as a Datum::Int32, it's a Datum::Date. We can impl this using an i32 column, but for now move it to TodoDatumToPersist so it doesn't panic at runtime.


### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
