### PR TITLE
ci: Avoid starting agent for merge check when not in PR

### DIFF
--- a/ci/test/check-merge-with-target.sh
+++ b/ci/test/check-merge-with-target.sh
@@ -16,12 +16,6 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-# BUILDKITE_PULL_REQUEST will either contain the number of the PR or
-# the string "false".
-if [[ $BUILDKITE_PULL_REQUEST == "false" ]]; then
-    exit 0
-fi
-
 ci_collapsed_heading "Configure git"
 BUILDKITE_REPO_REF="buildkite-origin"
 run git remote add "$BUILDKITE_REPO_REF" "$BUILDKITE_REPO"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -48,6 +48,7 @@ steps:
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
+    if: "build.pull_request.id != null"
 
   - id: devel-docker-tags
     label: Tag development docker images


### PR DESCRIPTION
Follow up for https://github.com/MaterializeInc/materialize/issues/18320 to address comment https://github.com/MaterializeInc/materialize/pull/18585#issuecomment-1497211462:

> I think this should work: if: "build.pull_request.id != null". Then we don't have to start up an agent just for an if condition.