### PR TITLE
#18121 use EXPECTED GROUP SIZE hint in basic top-K rendering

### DIFF
--- a/doc/user/content/sql/select.md
+++ b/doc/user/content/sql/select.md
@@ -107,7 +107,7 @@ The following query hints are valid within the `OPTION` clause.
 
 Hint | Value type | Description
 ------|------------|------------
-`EXPECTED GROUP SIZE` | `int` | How many rows will have the same group key. Materialize can render `min` and `max` expressions more efficiently with this information.
+`EXPECTED GROUP SIZE` | `int` | How many rows will have the same group key. Materialize can render `min` and `max` expressions, and some [Top K patterns](/guides/top-k), more efficiently with this information.
 
 For an example, see [Using query hints](#using-query-hints).
 

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1945,6 +1945,26 @@ impl<T> CollectionPlan for Plan<T> {
     }
 }
 
+/// Returns bucket sizes, descending, suitable for hierarchical decomposition of an operator, based
+/// on the expected number of rows that will have the same group key.
+fn bucketing_of_expected_group_size(expected_group_size: Option<u64>) -> Vec<u64> {
+    let mut buckets = vec![];
+    let mut current = 16;
+
+    // Plan for 4B records in the expected case if the user didn't specify a group size.
+    let limit = expected_group_size.unwrap_or(4_000_000_000);
+
+    // Distribute buckets in powers of 16, so that we can strike a balance between how many inputs
+    // each layer gets from the preceding layer, while also limiting the number of layers.
+    while current < limit {
+        buckets.push(current);
+        current = current.saturating_mul(16);
+    }
+
+    buckets.reverse();
+    buckets
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1329,6 +1329,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 limit,
                 offset,
                 monotonic,
+                expected_group_size,
             } => {
                 let arity = input.arity();
                 let (input, keys) = Self::from_mir_inner(input, arrangements, debug_info)?;
@@ -1340,6 +1341,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     *limit,
                     arity,
                     *monotonic,
+                    *expected_group_size,
                 );
 
                 // We don't have an MFP here -- install an operator to permute the

--- a/src/compute-client/src/plan/top_k.proto
+++ b/src/compute-client/src/plan/top_k.proto
@@ -29,6 +29,7 @@ message ProtoBasicTopKPlan {
     optional uint64 limit = 3;
     uint64 offset = 4;
     uint64 arity = 5;
+    optional uint64 expected_group_size = 6;
 }
 
 message ProtoMonotonicTop1Plan {

--- a/src/compute-client/src/plan/top_k.proto
+++ b/src/compute-client/src/plan/top_k.proto
@@ -29,7 +29,7 @@ message ProtoBasicTopKPlan {
     optional uint64 limit = 3;
     uint64 offset = 4;
     uint64 arity = 5;
-    optional uint64 expected_group_size = 6;
+    repeated uint64 buckets = 6;
 }
 
 message ProtoMonotonicTop1Plan {

--- a/src/compute-client/src/plan/top_k.rs
+++ b/src/compute-client/src/plan/top_k.rs
@@ -46,6 +46,7 @@ impl TopKPlan {
     /// * `limit` - An optional limit of how many rows should be revealed.
     /// * `arity` - The number of columns in the input and output.
     /// * `monotonic` - `true` if the input is monotonic.
+    /// * `expected_group_size` - A hint about how many rows will have the same group key.
     pub(crate) fn create_from(
         group_key: Vec<usize>,
         order_key: Vec<ColumnOrder>,
@@ -53,6 +54,7 @@ impl TopKPlan {
         limit: Option<usize>,
         arity: usize,
         monotonic: bool,
+        expected_group_size: Option<u64>,
     ) -> Self {
         if monotonic && offset == 0 && limit == Some(1) {
             TopKPlan::MonotonicTop1(MonotonicTop1Plan {
@@ -82,6 +84,7 @@ impl TopKPlan {
                 offset,
                 limit,
                 arity,
+                expected_group_size,
             })
         }
     }
@@ -202,6 +205,8 @@ pub struct BasicTopKPlan {
     pub offset: usize,
     /// The number of columns in the input and output.
     pub arity: usize,
+    /// Hint: how many rows will have the same group key.
+    pub expected_group_size: Option<u64>,
 }
 
 impl RustType<ProtoBasicTopKPlan> for BasicTopKPlan {
@@ -212,6 +217,7 @@ impl RustType<ProtoBasicTopKPlan> for BasicTopKPlan {
             limit: self.limit.into_proto(),
             offset: self.offset.into_proto(),
             arity: self.arity.into_proto(),
+            expected_group_size: self.expected_group_size.into_proto(),
         }
     }
 
@@ -222,6 +228,7 @@ impl RustType<ProtoBasicTopKPlan> for BasicTopKPlan {
             limit: proto.limit.into_rust()?,
             offset: proto.offset.into_rust()?,
             arity: proto.arity.into_rust()?,
+            expected_group_size: proto.expected_group_size.into_rust()?,
         })
     }
 }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -148,7 +148,7 @@ where
                     offset,
                     limit,
                     arity,
-                    expected_group_size,
+                    buckets,
                 }) => {
                     let (oks, errs) = build_topk(
                         ok_input,
@@ -157,7 +157,7 @@ where
                         offset,
                         limit,
                         arity,
-                        expected_group_size,
+                        buckets,
                         &self.debug_name,
                     );
                     err_collection = err_collection.concat(&errs);
@@ -178,7 +178,7 @@ where
             offset: usize,
             limit: Option<usize>,
             arity: usize,
-            expected_group_size: Option<u64>,
+            buckets: Vec<u64>,
             debug_name: &str,
         ) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
         where
@@ -204,30 +204,18 @@ where
             let mut validating = true;
             let mut err_collection: Option<Collection<G, _, _>> = None;
 
-            // This sequence of numbers defines the shifts that happen to the 64 bit hash
-            // of the record, and has the properties that 1. there are not too many of them,
-            // and 2. each has a modest difference to the next.
-            //
-            // These two properties mean that there should be no reductions on groups that
-            // are substantially larger than `offset + limit` (the largest factor should be
-            // bounded by two raised to the difference between subsequent numbers);
             if let Some(limit) = limit {
-                for log_modulus in
-                    [60, 56, 52, 48, 44, 40, 36, 32, 28, 24, 20, 16, 12, 8, 4u64].iter()
-                {
-                    // Avoid building stages larger than the expected group size, if we were given
-                    // that hint.
-                    if expected_group_size.map_or(false, |g| g <= 1 << log_modulus) {
-                        continue;
-                    }
-
+                // These bucket values define the shifts that happen to the 64 bit hash of the
+                // record, and should have the properties that 1. there are not too many of them,
+                // and 2. each has a modest difference to the next.
+                for bucket in buckets.into_iter() {
                     // here we do not apply `offset`, but instead restrict ourself with a limit
                     // that includes the offset. We cannot apply `offset` until we perform the
                     // final, complete reduction.
                     let (oks, errs) = build_topk_stage(
                         collection,
                         order_key.clone(),
-                        1u64 << log_modulus,
+                        bucket,
                         0,
                         Some(offset + limit),
                         arity,
@@ -258,10 +246,10 @@ where
             )
         }
 
-        // To provide a robust incremental orderby-limit experience, we want to avoid grouping
-        // *all* records (or even large groups) and then applying the ordering and limit. Instead,
-        // a more robust approach forms groups of bounded size (here, 16) and applies the offset
-        // and limit to each, and then increases the sizes of the groups.
+        // To provide a robust incremental orderby-limit experience, we want to avoid grouping *all*
+        // records (or even large groups) and then applying the ordering and limit. Instead, a more
+        // robust approach forms groups of bounded size and applies the offset and limit to each,
+        // and then increases the sizes of the groups.
 
         // Builds a "stage", which uses a finer grouping than is required to reduce the volume of
         // updates, and to reduce the amount of work on the critical path for updates. The cost is

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -178,7 +178,7 @@ where
             offset: usize,
             limit: Option<usize>,
             arity: usize,
-            _expected_group_size: Option<u64>,
+            expected_group_size: Option<u64>,
             debug_name: &str,
         ) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
         where
@@ -215,6 +215,12 @@ where
                 for log_modulus in
                     [60, 56, 52, 48, 44, 40, 36, 32, 28, 24, 20, 16, 12, 8, 4u64].iter()
                 {
+                    // Avoid building stages larger than the expected group size, if we were given
+                    // that hint.
+                    if expected_group_size.map_or(false, |g| g <= 1 << log_modulus) {
+                        continue;
+                    }
+
                     // here we do not apply `offset`, but instead restrict ourself with a limit
                     // that includes the offset. We cannot apply `offset` until we perform the
                     // final, complete reduction.

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -148,6 +148,7 @@ where
                     offset,
                     limit,
                     arity,
+                    expected_group_size,
                 }) => {
                     let (oks, errs) = build_topk(
                         ok_input,
@@ -156,6 +157,7 @@ where
                         offset,
                         limit,
                         arity,
+                        expected_group_size,
                         &self.debug_name,
                     );
                     err_collection = err_collection.concat(&errs);
@@ -176,6 +178,7 @@ where
             offset: usize,
             limit: Option<usize>,
             arity: usize,
+            _expected_group_size: Option<u64>,
             debug_name: &str,
         ) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
         where

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -589,6 +589,7 @@ impl MirRelationExpr {
                 offset,
                 monotonic,
                 input,
+                expected_group_size,
             } => {
                 FmtNode {
                     fmt_root: |f, ctx| {
@@ -608,6 +609,9 @@ impl MirRelationExpr {
                             write!(f, " offset={}", offset)?
                         }
                         write!(f, " monotonic={}", monotonic)?;
+                        if let Some(expected_group_size) = expected_group_size {
+                            write!(f, " expected_group_size={}", expected_group_size)?;
+                        }
                         self.fmt_attributes(f, ctx)
                     },
                     fmt_children: |f, ctx| input.fmt_text(f, ctx),

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -242,6 +242,9 @@ pub enum MirRelationExpr {
         /// True iff the input is known to monotonically increase (only addition of records).
         #[serde(default)]
         monotonic: bool,
+        /// User-supplied hint: how many rows will have the same group key.
+        #[serde(default)]
+        expected_group_size: Option<u64>,
     },
     /// Return a dataflow where the row counts are negated
     ///
@@ -1216,6 +1219,7 @@ impl MirRelationExpr {
         order_key: Vec<ColumnOrder>,
         limit: Option<usize>,
         offset: usize,
+        expected_group_size: Option<u64>,
     ) -> Self {
         MirRelationExpr::TopK {
             input: Box::new(self),
@@ -1223,6 +1227,7 @@ impl MirRelationExpr {
             order_key,
             limit,
             offset,
+            expected_group_size,
             monotonic: false,
         }
     }

--- a/src/sql/src/plan/explain/text.rs
+++ b/src/sql/src/plan/explain/text.rs
@@ -212,6 +212,7 @@ impl HirRelationExpr {
                 limit,
                 offset,
                 input,
+                expected_group_size,
             } => {
                 write!(f, "{}TopK", ctx.indent)?;
                 if group_key.len() > 0 {
@@ -227,6 +228,9 @@ impl HirRelationExpr {
                 }
                 if offset > &0 {
                     write!(f, " offset={}", offset)?
+                }
+                if let Some(expected_group_size) = expected_group_size {
+                    write!(f, " expected_group_size={}", expected_group_size)?;
                 }
                 writeln!(f)?;
                 ctx.indented(|ctx| input.fmt_text(f, ctx))?;

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -166,6 +166,8 @@ pub enum HirRelationExpr {
         limit: Option<usize>,
         /// Number of records to skip
         offset: usize,
+        /// User-supplied hint: how many rows will have the same group key.
+        expected_group_size: Option<u64>,
     },
     Negate {
         input: Box<HirRelationExpr>,
@@ -1211,6 +1213,7 @@ impl HirRelationExpr {
         order_key: Vec<ColumnOrder>,
         limit: Option<usize>,
         offset: usize,
+        expected_group_size: Option<u64>,
     ) -> Self {
         HirRelationExpr::TopK {
             input: Box::new(self),
@@ -1218,6 +1221,7 @@ impl HirRelationExpr {
             order_key,
             limit,
             offset,
+            expected_group_size,
         }
     }
 
@@ -1640,6 +1644,7 @@ impl HirRelationExpr {
                     order_key: finishing.order_by,
                     limit: finishing.limit,
                     offset: finishing.offset,
+                    expected_group_size: None,
                 }),
                 outputs: finishing.project,
             }
@@ -1716,6 +1721,7 @@ impl VisitChildren<Self> for HirRelationExpr {
                 order_key: _,
                 limit: _,
                 offset: _,
+                expected_group_size: _,
             }
             | Negate { input }
             | Threshold { input } => {
@@ -1798,6 +1804,7 @@ impl VisitChildren<Self> for HirRelationExpr {
                 order_key: _,
                 limit: _,
                 offset: _,
+                expected_group_size: _,
             }
             | Negate { input }
             | Threshold { input } => {
@@ -1880,6 +1887,7 @@ impl VisitChildren<Self> for HirRelationExpr {
                 order_key: _,
                 limit: _,
                 offset: _,
+                expected_group_size: _,
             }
             | Negate { input }
             | Threshold { input } => {
@@ -1963,6 +1971,7 @@ impl VisitChildren<Self> for HirRelationExpr {
                 order_key: _,
                 limit: _,
                 offset: _,
+                expected_group_size: _,
             }
             | Negate { input }
             | Threshold { input } => {
@@ -2043,6 +2052,7 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
                 order_key: _,
                 limit: _,
                 offset: _,
+                expected_group_size: _,
             }
             | Negate { input: _ }
             | Threshold { input: _ }
@@ -2113,6 +2123,7 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
                 order_key: _,
                 limit: _,
                 offset: _,
+                expected_group_size: _,
             }
             | Negate { input: _ }
             | Threshold { input: _ }
@@ -2184,6 +2195,7 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
                 order_key: _,
                 limit: _,
                 offset: _,
+                expected_group_size: _,
             }
             | Negate { input: _ }
             | Threshold { input: _ }
@@ -2256,6 +2268,7 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
                 order_key: _,
                 limit: _,
                 offset: _,
+                expected_group_size: _,
             }
             | Negate { input: _ }
             | Threshold { input: _ }

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -704,6 +704,7 @@ impl HirRelationExpr {
                     order_key,
                     limit,
                     offset,
+                    expected_group_size,
                 } => {
                     // TopK is uncomplicated, except that we must group by the columns of `get_outer` as well.
                     let input = input.applied_to(id_gen, get_outer.clone(), col_map, cte_map)?;
@@ -718,7 +719,13 @@ impl HirRelationExpr {
                             nulls_last: column_order.nulls_last,
                         })
                         .collect();
-                    input.top_k(applied_group_key, applied_order_key, limit, offset)
+                    input.top_k(
+                        applied_group_key,
+                        applied_order_key,
+                        limit,
+                        offset,
+                        expected_group_size,
+                    )
                 }
                 Negate { input } => {
                     // Negate is uncomplicated.

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -110,7 +110,7 @@ pub fn plan_root_query(
 ) -> Result<PlannedQuery<HirRelationExpr>, PlanError> {
     transform_ast::transform(scx, &mut query)?;
     let mut qcx = QueryContext::root(scx, lifetime);
-    let (mut expr, scope, mut finishing) = plan_query(&mut qcx, &query)?;
+    let (mut expr, scope, mut finishing, _) = plan_query(&mut qcx, &query)?;
 
     // Attempt to push the finishing's ordering past its projection. This allows
     // data to be projected down on the workers rather than the coordinator. It
@@ -1021,14 +1021,14 @@ fn check_col_index(name: &str, e: &Expr<Aug>, max: usize) -> Result<Option<usize
 fn plan_query(
     qcx: &mut QueryContext,
     q: &Query<Aug>,
-) -> Result<(HirRelationExpr, Scope, RowSetFinishing), PlanError> {
+) -> Result<(HirRelationExpr, Scope, RowSetFinishing, Option<u64>), PlanError> {
     qcx.checked_recur_mut(|qcx| plan_query_inner(qcx, q))
 }
 
 fn plan_query_inner(
     qcx: &mut QueryContext,
     q: &Query<Aug>,
-) -> Result<(HirRelationExpr, Scope, RowSetFinishing), PlanError> {
+) -> Result<(HirRelationExpr, Scope, RowSetFinishing, Option<u64>), PlanError> {
     // Plan CTEs and introduce bindings to `qcx.ctes`. Returns shadowed bindings
     // for the identifiers, so that they can be re-installed before returning.
     let cte_bindings = plan_ctes(qcx, q)?;
@@ -1054,8 +1054,14 @@ fn plan_query_inner(
         _ => sql_bail!("OFFSET must be an integer constant"),
     };
 
-    let (mut result, scope, finishing) = match &q.body {
+    let (mut result, scope, finishing, expected_group_size) = match &q.body {
         SetExpr::Select(s) => {
+            // Extract query options.
+            let SelectOptionExtracted {
+                expected_group_size,
+                seen: _,
+            } = SelectOptionExtracted::try_from(s.options.clone())?;
+
             let plan = plan_view_select(qcx, *s.clone(), q.order_by.clone())?;
             let finishing = RowSetFinishing {
                 order_by: plan.order_by,
@@ -1063,7 +1069,7 @@ fn plan_query_inner(
                 limit,
                 offset,
             };
-            Ok::<_, PlanError>((plan.expr, plan.scope, finishing))
+            Ok::<_, PlanError>((plan.expr, plan.scope, finishing, expected_group_size))
         }
         _ => {
             let (expr, scope) = plan_set_expr(qcx, &q.body)?;
@@ -1084,7 +1090,7 @@ fn plan_query_inner(
                 project: (0..ecx.relation_type.arity()).collect(),
                 offset,
             };
-            Ok((expr.map(map_exprs), scope, finishing))
+            Ok((expr.map(map_exprs), scope, finishing, None))
         }
     }?;
 
@@ -1124,7 +1130,7 @@ fn plan_query_inner(
         }
     }
 
-    Ok((result, scope, finishing))
+    Ok((result, scope, finishing, expected_group_size))
 }
 
 /// Creates plans for CTEs and introduces them to `qcx.ctes`.
@@ -1243,7 +1249,8 @@ pub fn plan_nested_query(
     qcx: &mut QueryContext,
     q: &Query<Aug>,
 ) -> Result<(HirRelationExpr, Scope), PlanError> {
-    let (mut expr, scope, finishing) = qcx.checked_recur_mut(|qcx| plan_query(qcx, q))?;
+    let (mut expr, scope, finishing, expected_group_size) =
+        qcx.checked_recur_mut(|qcx| plan_query(qcx, q))?;
     if finishing.limit.is_some() || finishing.offset > 0 {
         expr = HirRelationExpr::TopK {
             input: Box::new(expr),
@@ -1251,6 +1258,7 @@ pub fn plan_nested_query(
             order_key: finishing.order_by,
             limit: finishing.limit,
             offset: finishing.offset,
+            expected_group_size,
         };
     }
     Ok((expr.project(finishing.project), scope))
@@ -2041,6 +2049,7 @@ fn plan_view_select(
                     group_key: distinct_key,
                     limit: Some(1),
                     offset: 0,
+                    expected_group_size,
                 }
             }
         }
@@ -3783,7 +3792,7 @@ where
     }
 
     let mut qcx = ecx.derived_query_context();
-    let (mut expr, _scope, finishing) = plan_query(&mut qcx, query)?;
+    let (mut expr, _scope, finishing, expected_group_size) = plan_query(&mut qcx, query)?;
     if finishing.limit.is_some() || finishing.offset > 0 {
         expr = HirRelationExpr::TopK {
             input: Box::new(expr),
@@ -3791,6 +3800,7 @@ where
             order_key: finishing.order_by.clone(),
             limit: finishing.limit,
             offset: finishing.offset,
+            expected_group_size,
         };
     }
 

--- a/src/transform/src/canonicalization/topk_elision.rs
+++ b/src/transform/src/canonicalization/topk_elision.rs
@@ -49,6 +49,7 @@ impl TopKElision {
             limit,
             offset,
             monotonic: _,
+            expected_group_size: _,
         } = relation
         {
             if limit.is_none() && *offset == 0 {

--- a/src/transform/src/fusion/top_k.rs
+++ b/src/transform/src/fusion/top_k.rs
@@ -50,6 +50,7 @@ impl TopK {
             limit,
             offset,
             monotonic,
+            expected_group_size,
         } = relation
         {
             while let MirRelationExpr::TopK {
@@ -59,6 +60,7 @@ impl TopK {
                 limit: inner_limit,
                 offset: inner_offset,
                 monotonic: inner_monotonic,
+                expected_group_size: inner_expected_group_size,
             } = &mut **input
             {
                 // We can fuse two chained TopK operators as long as they share the
@@ -92,6 +94,17 @@ impl TopK {
 
                     *offset += *inner_offset;
                     *monotonic = *inner_monotonic;
+
+                    // Expected group size is only a hint, and setting it small when the group size
+                    // might actually be large would be bad.
+                    //
+                    // rust-lang/rust#70086 would allow a.zip_with(b, max) here.
+                    *inner_expected_group_size =
+                        match (&expected_group_size, &inner_expected_group_size) {
+                            (Some(a), Some(b)) => Some(std::cmp::max(*a, *b)),
+                            _ => None,
+                        };
+
                     **input = inner_input.take_dangerous();
                 } else {
                     break;

--- a/src/transform/src/literal_lifting.rs
+++ b/src/transform/src/literal_lifting.rs
@@ -615,6 +615,7 @@ impl LiteralLifting {
                     limit: _,
                     offset: _,
                     monotonic: _,
+                    expected_group_size: _,
                 } => {
                     let literals = self.action(input, gets)?;
                     if !literals.is_empty() {

--- a/src/transform/src/movement/projection_lifting.rs
+++ b/src/transform/src/movement/projection_lifting.rs
@@ -274,6 +274,7 @@ impl ProjectionLifting {
                     limit,
                     offset,
                     monotonic: _,
+                    expected_group_size,
                 } => {
                     self.action(input, gets)?;
                     if let MirRelationExpr::Project {
@@ -294,6 +295,7 @@ impl ProjectionLifting {
                                 order_key.clone(),
                                 limit.clone(),
                                 offset.clone(),
+                                expected_group_size.clone(),
                             )
                             .project(outputs.clone());
                     }

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -349,6 +349,7 @@ impl PredicatePushdown {
                             limit: _,
                             offset: _,
                             monotonic: _,
+                            expected_group_size: _,
                         } => {
                             let mut retain = Vec::new();
                             let mut push_down = Vec::new();

--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -1177,7 +1177,8 @@ VIEW ov
             ],
             "limit": 5,
             "offset": 0,
-            "monotonic": false
+            "monotonic": false,
+            "expected_group_size": null
           }
         },
         "outputs": [
@@ -2976,7 +2977,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                         "order_key": [],
                                                         "limit": 1,
                                                         "offset": 0,
-                                                        "monotonic": false
+                                                        "monotonic": false,
+                                                        "expected_group_size": null
                                                       }
                                                     },
                                                     "outputs": [
@@ -3529,7 +3531,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                         "order_key": [],
                                                         "limit": 1,
                                                         "offset": 0,
-                                                        "monotonic": false
+                                                        "monotonic": false,
+                                                        "expected_group_size": null
                                                       }
                                                     },
                                                     "outputs": [

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -906,7 +906,8 @@ VIEW ov
           ],
           "limit": 5,
           "offset": 0,
-          "monotonic": false
+          "monotonic": false,
+          "expected_group_size": null
         }
       }
     }
@@ -2136,7 +2137,8 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                           "order_key": [],
                           "limit": 1,
                           "offset": 0,
-                          "monotonic": false
+                          "monotonic": false,
+                          "expected_group_size": null
                         }
                       },
                       "body": {
@@ -2321,7 +2323,8 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                               "order_key": [],
                               "limit": 1,
                               "offset": 0,
-                              "monotonic": false
+                              "monotonic": false,
+                              "expected_group_size": null
                             }
                           },
                           "body": {

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -456,7 +456,15 @@ SELECT * FROM ov
               "limit": 5,
               "offset": 0,
               "arity": 2,
-              "expected_group_size": null
+              "buckets": [
+                268435456,
+                16777216,
+                1048576,
+                65536,
+                4096,
+                256,
+                16
+              ]
             }
           }
         }
@@ -700,7 +708,15 @@ VIEW ov
               "limit": 5,
               "offset": 0,
               "arity": 2,
-              "expected_group_size": null
+              "buckets": [
+                268435456,
+                16777216,
+                1048576,
+                65536,
+                4096,
+                256,
+                16
+              ]
             }
           }
         }

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -455,7 +455,8 @@ SELECT * FROM ov
               ],
               "limit": 5,
               "offset": 0,
-              "arity": 2
+              "arity": 2,
+              "expected_group_size": null
             }
           }
         }
@@ -698,7 +699,8 @@ VIEW ov
               ],
               "limit": 5,
               "offset": 0,
-              "arity": 2
+              "arity": 2,
+              "expected_group_size": null
             }
           }
         }

--- a/test/sqllogictest/explain/raw_plan_as_json.slt
+++ b/test/sqllogictest/explain/raw_plan_as_json.slt
@@ -352,7 +352,8 @@ VIEW ov
           }
         ],
         "limit": 5,
-        "offset": 0
+        "offset": 0,
+        "expected_group_size": null
       }
     },
     "outputs": [
@@ -827,7 +828,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                 "group_key": [],
                 "order_key": [],
                 "limit": 1,
-                "offset": 0
+                "offset": 0,
+                "expected_group_size": null
               }
             },
             "outputs": [
@@ -891,7 +893,8 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                     "group_key": [],
                     "order_key": [],
                     "limit": 1,
-                    "offset": 0
+                    "offset": 0,
+                    "expected_group_size": null
                   }
                 },
                 "outputs": [

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -60,6 +60,24 @@ TX  Houston
 TX  San_Antonio
 TX  Dallas
 
+# EXPECTED GROUP SIZE hint should not affect the results
+query TT rowsort
+SELECT state, name FROM
+    (SELECT DISTINCT state FROM cities) grp,
+    LATERAL (SELECT name FROM cities WHERE state = grp.state
+             OPTIONS (EXPECTED GROUP SIZE = 1)
+             ORDER BY pop DESC NULLS LAST LIMIT 3)
+----
+AZ  Phoenix
+CA  Los_Angeles
+CA  San_Francisco
+CA  San_Jose
+IL  Chicago
+NY  New_York
+TX  Dallas
+TX  Houston
+TX  San_Antonio
+
 mode standard
 
 query T multiline
@@ -131,5 +149,19 @@ Explained Query:
       TopK group_by=[#0] order_by=[#1 desc nulls_first] limit=1 monotonic=false // { arity: 2 }
         Project (#1, #2) // { arity: 2 }
           Get materialize.public.cities // { arity: 3 }
+
+EOF
+
+query T multiline
+EXPLAIN WITH(arity, join_impls) SELECT state, name FROM
+    (SELECT DISTINCT state FROM cities) grp,
+    LATERAL (SELECT name FROM cities WHERE state = grp.state
+             OPTIONS (EXPECTED GROUP SIZE = 1)
+             ORDER BY pop DESC NULLS LAST LIMIT 3)
+----
+Explained Query:
+  Project (#1, #0) // { arity: 2 }
+    TopK group_by=[#1] order_by=[#2 desc nulls_last] limit=3 monotonic=false expected_group_size=1 // { arity: 3 }
+      Get materialize.public.cities // { arity: 3 }
 
 EOF


### PR DESCRIPTION
Using TPC-H at scale factor 1 on a scratch instance, there's a significant observable performance difference when supplying `EXPECTED GROUP SIZE` -- 48 seconds without the option, 26 seconds with the option supplied as 7 (the largest number of items in a group) or 1 (which disables creation of all but the last stage), with the following query:

```
SELECT
    sum(revenue) AS revenue
FROM (
    SELECT l_orderkey,
           sum(l_extendedprice * (1 - l_discount)) AS revenue
    FROM lineitem
    GROUP BY l_orderkey
    OPTIONS (EXPECTED GROUP SIZE = 7)
    ORDER BY revenue DESC
    LIMIT 10
);
```

Note that unlike reduce's usage of this hint, we need to extend the BasicTopKPlan protobuf type, since the use of this hint happens in rendering instead of planning.

To consider:
 - whether we should supply a default just as the reduce code does (`expected_group_size.unwrap_or(4_000_000_000)` in `ReducePlan::create_inner`) -- this is probably safe and worthwhile.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

 - This PR adds a known-desirable feature: #18121.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow specifying the EXPECTED GROUP SIZE query hint for non-monotonic TopK queries. <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
