### PR TITLE
adapter: Fix mz_sessions retractions

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -22,7 +22,7 @@ use mz_expr::MirScalarExpr;
 use mz_orchestrator::{CpuLimit, MemoryLimit, ServiceProcessMetrics};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
-use mz_ore::now::SYSTEM_TIME;
+use mz_ore::now::EpochMillis;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::jsonb::Jsonb;
 use mz_repr::role_id::RoleId;
@@ -1186,13 +1186,10 @@ impl CatalogState {
         &self,
         id: ConnectionId,
         role_id: RoleId,
+        connect_time: EpochMillis,
         diff: Diff,
     ) -> BuiltinTableUpdate {
-        // We use the system clock to determine when a session
-        // connected to Materialize. This is not intended to be 100%
-        // accurate and correct, so we don't burden the timestamp
-        // oracle with generating a more correct timestamp.
-        let connect_dt = mz_ore::now::to_datetime(SYSTEM_TIME());
+        let connect_dt = mz_ore::now::to_datetime(connect_time);
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_SESSIONS),
             row: Row::pack_slice(&[

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -171,7 +171,10 @@ impl ConnClient {
     ///
     /// It is the caller's responsibility to have authenticated the user.
     pub fn new_session(&self, user: User) -> Session {
-        Session::new(self.build_info, self.conn_id, user)
+        // We use the system clock to determine when a session connected to Materialize. This is not
+        // intended to be 100% accurate and correct, so we don't burden the timestamp oracle with
+        // generating a more correct timestamp.
+        Session::new(self.build_info, self.conn_id, user, (self.inner.now)())
     }
 
     /// Returns the ID of the connection associated with this client.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -92,7 +92,7 @@ use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_orchestrator::ServiceProcessMetrics;
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::now::NowFn;
+use mz_ore::now::{EpochMillis, NowFn};
 use mz_ore::retry::Retry;
 use mz_ore::task::spawn;
 use mz_ore::thread::JoinHandleExt;
@@ -333,6 +333,9 @@ struct ConnMeta {
 
     /// Channel on which to send notices to a session.
     notice_tx: mpsc::UnboundedSender<AdapterNotice>,
+
+    /// The time when the connection was established.
+    connect_time: EpochMillis,
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -92,7 +92,7 @@ use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_orchestrator::ServiceProcessMetrics;
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::now::{EpochMillis, NowFn};
+use mz_ore::now::NowFn;
 use mz_ore::retry::Retry;
 use mz_ore::task::spawn;
 use mz_ore::thread::JoinHandleExt;
@@ -333,9 +333,6 @@ struct ConnMeta {
 
     /// Channel on which to send notices to a session.
     notice_tx: mpsc::UnboundedSender<AdapterNotice>,
-
-    /// The time when the connection was established.
-    connect_time: EpochMillis,
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -640,7 +640,7 @@ impl Coordinator {
             .dec();
         self.active_conns.remove(&session.conn_id());
         self.cancel_pending_peeks(&session.conn_id());
-        let update = self.catalog().state().pack_session_update(&session, -1);
+        let update = self.catalog().state().pack_session_update(session, -1);
         self.send_builtin_table_updates(vec![update], BuiltinTableUpdateSource::DDL)
             .await;
     }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -269,12 +269,7 @@ impl Coordinator {
                 drop_sinks: Vec::new(),
             },
         );
-        let update = self.catalog().state().pack_session_update(
-            session.conn_id(),
-            *session.role_id(),
-            session.connect_time(),
-            1,
-        );
+        let update = self.catalog().state().pack_session_update(&session, 1);
         self.send_builtin_table_updates(vec![update], BuiltinTableUpdateSource::DDL)
             .await;
 
@@ -645,12 +640,7 @@ impl Coordinator {
             .dec();
         self.active_conns.remove(&session.conn_id());
         self.cancel_pending_peeks(&session.conn_id());
-        let update = self.catalog().state().pack_session_update(
-            session.conn_id(),
-            *session.role_id(),
-            session.connect_time(),
-            -1,
-        );
+        let update = self.catalog().state().pack_session_update(&session, -1);
         self.send_builtin_table_updates(vec![update], BuiltinTableUpdateSource::DDL)
             .await;
     }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -260,6 +260,7 @@ impl Coordinator {
             .active_sessions
             .with_label_values(&[session_type])
             .inc();
+        let connect_time = self.now();
         self.active_conns.insert(
             session.conn_id(),
             ConnMeta {
@@ -267,12 +268,19 @@ impl Coordinator {
                 secret_key: session.secret_key(),
                 notice_tx: session.retain_notice_transmitter(),
                 drop_sinks: Vec::new(),
+                // We use the system clock to determine when a connection
+                // connected to Materialize. This is not intended to be 100%
+                // accurate and correct, so we don't burden the timestamp
+                // oracle with generating a more correct timestamp.
+                connect_time: connect_time.clone(),
             },
         );
-        let update =
-            self.catalog()
-                .state()
-                .pack_session_update(session.conn_id(), *session.role_id(), 1);
+        let update = self.catalog().state().pack_session_update(
+            session.conn_id(),
+            *session.role_id(),
+            connect_time,
+            1,
+        );
         self.send_builtin_table_updates(vec![update], BuiltinTableUpdateSource::DDL)
             .await;
 
@@ -641,12 +649,17 @@ impl Coordinator {
             .active_sessions
             .with_label_values(&[session_type])
             .dec();
-        self.active_conns.remove(&session.conn_id());
+        let conn_meta = self
+            .active_conns
+            .remove(&session.conn_id())
+            .expect("session metadata out of sync");
         self.cancel_pending_peeks(&session.conn_id());
-        let update =
-            self.catalog()
-                .state()
-                .pack_session_update(session.conn_id(), *session.role_id(), -1);
+        let update = self.catalog().state().pack_session_update(
+            session.conn_id(),
+            *session.role_id(),
+            conn_meta.connect_time,
+            -1,
+        );
         self.send_builtin_table_updates(vec![update], BuiltinTableUpdateSource::DDL)
             .await;
     }


### PR DESCRIPTION
One of the columns in the `mz_sessions` system table is the time at which the session connected. We were generating this timestamp at the same time that we generated the update to the table. As a consequence the addition update and the retraction update would have different timestamps causing invalid retractions.

This commit fixes this issue by saving the timestamp as metadata with each connection and passing in the timestamp to the row update function. It also switches to using deterministic timestamps instead of hard-coding in the system clock.

Fixes #18607

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
