### PR TITLE
Remove a reference to the binary distribution from the dev guide

### DIFF
--- a/doc/developer/guide-changes.md
+++ b/doc/developer/guide-changes.md
@@ -28,8 +28,7 @@ goals of code review are threefold:
 3. To socialize changes with other engineers on the team.
 
 Once a PR is approved and merged to the `main` branch, CI will automatically
-deploy a new `materialized` binary to <https://binaries.materialize.com> and the
-[materialized Docker image][docker].
+deploy a new [materialized Docker image][docker].
 
 While we encourage customers to use the latest stable release in production,
 many of our prospective customers run their proofs-of-concept (POCs) off these


### PR DESCRIPTION
As we no longer release the binary off `main`, remove the reference from the changes developer guide.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
  * This PR fixes a previously unreported bug.

I think mentioning the binary here could result in a confusion from engineers who are just getting started with Materialize. Additionally, the referenced URL was broken.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]



    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user facing behavior changes
