### PR TITLE
test: Fix broken sqllogictest

### DIFF
--- a/test/sqllogictest/introspection/cluster_log_compaction.slt
+++ b/test/sqllogictest/introspection/cluster_log_compaction.slt
@@ -20,6 +20,9 @@ SET CLUSTER TO c1;
 statement ok
 BEGIN
 
+statement ok
+SET auto_route_introspection_queries = false;
+
 # Transaction will force a read hold on this index.
 query TT rowsort
 SELECT * FROM mz_internal.mz_arrangement_batches_raw;


### PR DESCRIPTION
### Motivation
Fixes #18613 

The sqllogictest defined in `cluster_log_compaction.slt` needs the query to run a specific cluster, thus we disable auto routing introspection queries to the mz_introspection cluster.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
