### PR TITLE
storage: broadcast ssh tunnel errors to sources and sinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4763,7 +4763,9 @@ dependencies = [
  "serde_json",
  "ssh-key",
  "tempfile",
+ "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "workspace-hack",
  "zeroize",
@@ -7572,9 +7574,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -61,7 +61,7 @@ serde_json = "1.0.89"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["rt", "time"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
-tokio-stream = "0.1.11"
+tokio-stream = "0.1.12"
 tracing = "0.1.37"
 tracing-opentelemetry = { git = "https://github.com/MaterializeInc/tracing.git", branch = "v0.1.x" }
 tracing-subscriber = "0.3.16"

--- a/src/cluster-client/Cargo.toml
+++ b/src/cluster-client/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 tokio = "1.24.2"
-tokio-stream = "0.1.11"
+tokio-stream = "0.1.12"
 tonic = "0.8.2"
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -41,7 +41,7 @@ serde_json = "1.0.89"
 thiserror = "1.0.37"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.24.2"
-tokio-stream = "0.1.11"
+tokio-stream = "0.1.12"
 tonic = "0.8.2"
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -27,7 +27,7 @@ regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.24.2"
-tokio-stream = "0.1.11"
+tokio-stream = "0.1.12"
 tracing = "0.1.37"
 uuid = { version = "1.2.2" }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -78,7 +78,7 @@ thiserror = "1.0.37"
 tokio = { version = "1.24.2", features = ["sync"] }
 tokio-openssl = "0.6.3"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
-tokio-stream = { version = "0.1.11", features = ["net"] }
+tokio-stream = { version = "0.1.12", features = ["net"] }
 tower-http = { version = "0.3.5", features = ["cors"] }
 tracing = "0.1.37"
 tracing-core = "0.1.30"

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -19,7 +19,7 @@ use mz_ore::collections::CollectionExt;
 use rdkafka::client::{BrokerAddr, Client, NativeClient, OAuthToken};
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
 use rdkafka::consumer::{ConsumerContext, Rebalance};
-use rdkafka::error::{KafkaError, KafkaResult};
+use rdkafka::error::{KafkaError, KafkaResult, RDKafkaErrorCode};
 use rdkafka::producer::{DefaultProducerContext, DeliveryResult, ProducerContext};
 use rdkafka::types::RDKafkaRespErr;
 use rdkafka::util::Timeout;
@@ -217,12 +217,15 @@ where
     }
 }
 
+/// Id of a partition in a topic.
+pub type PartitionId = i32;
+
 /// Retrieve number of partitions for a given `topic` using the given `client`
 pub fn get_partitions<C: ClientContext>(
     client: &Client<C>,
     topic: &str,
     timeout: Duration,
-) -> Result<Vec<i32>, anyhow::Error> {
+) -> Result<Vec<PartitionId>, anyhow::Error> {
     let meta = client.fetch_metadata(Some(topic), timeout)?;
     if meta.topics().len() != 1 {
         bail!(
@@ -231,7 +234,17 @@ pub fn get_partitions<C: ClientContext>(
             meta.topics().len()
         );
     }
+
+    fn check_err(err: Option<RDKafkaRespErr>) -> anyhow::Result<()> {
+        if let Some(err) = err {
+            Err(RDKafkaErrorCode::from(err))?
+        }
+        Ok(())
+    }
+
     let meta_topic = meta.topics().into_element();
+    check_err(meta_topic.error())?;
+
     if meta_topic.name() != topic {
         bail!(
             "got results for wrong topic {} (expected {})",
@@ -240,11 +253,18 @@ pub fn get_partitions<C: ClientContext>(
         );
     }
 
-    if meta_topic.partitions().len() == 0 {
+    let mut partition_ids = Vec::with_capacity(meta_topic.partitions().len());
+    for partition_meta in meta_topic.partitions() {
+        check_err(partition_meta.error())?;
+
+        partition_ids.push(partition_meta.id());
+    }
+
+    if partition_ids.len() == 0 {
         bail!("topic {} does not exist", topic);
     }
 
-    Ok(meta_topic.partitions().iter().map(|x| x.id()).collect())
+    Ok(partition_ids)
 }
 
 /// A simpler version of [`create_new_client_config`] that defaults

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -105,7 +105,7 @@ pub enum PostgresError {
     Generic(#[from] anyhow::Error),
     /// Error using ssh.
     #[error(transparent)]
-    Ssh(#[from] openssh::Error),
+    Ssh(#[from] mz_ssh_util::tunnel::SshTunnelError),
     /// Error doing io to setup an ssh connection.
     #[error(transparent)]
     SshIo(#[from] std::io::Error),

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -28,7 +28,7 @@ semver = "1.0.16"
 sysinfo = "0.27.2"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.24.2"
-tokio-stream = "0.1.11"
+tokio-stream = "0.1.12"
 tonic = "0.8.2"
 tower = "0.4.13"
 tracing = "0.1.37"

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -10,7 +10,7 @@
 //! Provides parsing and convenience functions for working with Kafka from the `sql` package.
 
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use anyhow::bail;
 use mz_ore::error::ErrorExt;
@@ -355,45 +355,3 @@ where
         .map_err(|e| sql_err!("{}", e))?;
     Ok(high)
 }
-
-/// Gets error strings from `rdkafka` when creating test consumers.
-#[derive(Default, Debug, Clone)]
-pub struct KafkaErrCheckContext {
-    pub error: Arc<Mutex<Option<String>>>,
-}
-
-/*
-impl ConsumerContext for KafkaErrCheckContext {}
-
-impl ClientContext for KafkaErrCheckContext {
-    // `librdkafka` doesn't seem to propagate all errors up the stack, but does
-    // log them, so we are currently relying on the `log` callback for error
-    // handling in some situations.
-    fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
-        use rdkafka::config::RDKafkaLogLevel::*;
-        // `INFO` messages with a `fac` of `FAIL` occur when e.g. connecting to
-        // an SSL-authed broker without credentials.
-        if fac == "FAIL" || matches!(level, Emerg | Alert | Critical | Error) {
-            let mut error = self.error.lock().expect("lock poisoned");
-            // Do not allow logging to overwrite other values if
-            // present.
-            if error.is_none() {
-                *error = Some(format!("error logged: {}", log_message));
-            }
-        }
-        MzClientContext.log(level, fac, log_message)
-    }
-    // Refer to the comment on the `log` callback.
-    fn error(&self, error: rdkafka::error::KafkaError, reason: &str) {
-        // Allow error to overwrite value irrespective of other conditions
-        // (i.e. logging).
-
-        *self.error.lock().expect("lock poisoned") = Some(format!(
-            "{}: reason: {}",
-            error.display_with_causes(),
-            reason
-        ));
-        MzClientContext.error(error, reason)
-    }
-}
-*/

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -226,9 +226,10 @@ pub async fn purify_create_source(
                 .topic
                 .ok_or_else(|| sql_err!("KAFKA CONNECTION without TOPIC"))?;
 
-            let consumer = kafka_util::create_consumer(&connection_context, &connection, &topic)
-                .await
-                .map_err(|e| anyhow!("Failed to create and connect Kafka consumer: {}", e))?;
+            let (consumer, _) =
+                kafka_util::create_consumer(&connection_context, &connection, &topic)
+                    .await
+                    .map_err(|e| anyhow!("Failed to create and connect Kafka consumer: {}", e))?;
 
             if let Some(offset_type) = offset_type {
                 // Translate `START TIMESTAMP` to a start offset

--- a/src/ssh-util/Cargo.toml
+++ b/src/ssh-util/Cargo.toml
@@ -17,7 +17,9 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 ssh-key = { version = "0.4.3" }
 tempfile = "3.3.0"
+thiserror = { version = "1.0.37" }
 tokio = "1.24.2"
+tokio-stream = "0.1.12"
 tracing = "0.1.37"
 zeroize = { version = "1.5.7", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/ssh-util/src/tunnel.rs
+++ b/src/ssh-util/src/tunnel.rs
@@ -89,6 +89,7 @@ impl SshTunnelConfig {
         remote_host: &str,
         remote_port: u16,
     ) -> Result<SshTunnelHandle, SshTunnelError> {
+        // `broadcast` channels can be re-subscribed to obtain receivers.
         let (error_broadcaster, _) = channel(1000);
 
         let (mut session, local_port) = match connect(self, remote_host, remote_port).await {

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -54,7 +54,7 @@ thiserror = "1.0.37"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde"] }
-tokio-stream = "0.1.11"
+tokio-stream = "0.1.12"
 tonic = "0.8.2"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"

--- a/src/storage-client/src/sink.rs
+++ b/src/storage-client/src/sink.rs
@@ -196,7 +196,10 @@ async fn build_kafka(
     connection_context: ConnectionContext,
 ) -> Result<StorageSinkConnection, anyhow::Error> {
     // Create Kafka topic.
-    let client: AdminClient<_> = builder
+    //
+    // We don't inspect the error stream, as this method is used in
+    // the adapter only.
+    let (client, _): (AdminClient<_>, _) = builder
         .connection
         .create_with_context(&connection_context, MzClientContext, &BTreeMap::new())
         .await

--- a/src/storage-client/src/ssh_tunnels.rs
+++ b/src/storage-client/src/ssh_tunnels.rs
@@ -172,11 +172,11 @@ impl SshTunnelManager {
 }
 
 /// Identifies a connection to a remote host via an SSH tunnel.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
-struct SshTunnelKey {
-    connection_id: GlobalId,
-    remote_host: String,
-    remote_port: u16,
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct SshTunnelKey {
+    pub connection_id: GlobalId,
+    pub remote_host: String,
+    pub remote_port: u16,
 }
 
 /// The state of an SSH tunnel connection.

--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -275,7 +275,6 @@ pub struct KafkaConnectionErrorSubscription {
 }
 
 impl KafkaConnectionErrorSubscription {
-    // Must be cancel-safe.
     async fn next(
         &mut self,
     ) -> Option<(
@@ -332,11 +331,6 @@ impl KafkaConnectionErrorSubscription {
 
     /// A future that returns if at least one underlying connection breaks. The return
     /// type can be waited on until recovery occurs.
-    ///
-    /// This method is cancel-safe.
-    // The cancel-safety of this method is non-trivial to reason about. Note that in both
-    // `check_connection_statuses` AND `Self::next`, there are no intermediate values held
-    // across await points. This behavior MUST be preserved.
     pub async fn check_connection_statuses(&mut self) -> BrokenKafkaConnection<'_> {
         let (tunnel, error) = loop {
             match self.next().await {

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -57,7 +57,7 @@ sha2 = "0.10.6"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde"] }
-tokio-stream = "0.1.11"
+tokio-stream = "0.1.12"
 tokio-util = { version = "0.7.4", features = ["io"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -36,7 +36,7 @@ use timely::dataflow::operators::{Enter, Leave, Map};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp as _};
 use timely::PartialOrder;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
 use mz_interchange::avro::{AvroEncoder, AvroSchemaGenerator};
@@ -224,7 +224,6 @@ impl KafkaSinkSendRetryManager {
 #[derive(Clone)]
 pub struct SinkProducerContext {
     metrics: Arc<SinkMetrics>,
-    status_tx: mpsc::Sender<SinkStatus>,
     retry_manager: Arc<Mutex<KafkaSinkSendRetryManager>>,
 }
 
@@ -235,11 +234,6 @@ impl ClientContext for SinkProducerContext {
         MzClientContext.log(level, fac, log_message)
     }
     fn error(&self, error: KafkaError, reason: &str) {
-        let status = SinkStatus::Stalled {
-            error: error.to_string(),
-            hint: None,
-        };
-        let _ = self.status_tx.try_send(status);
         MzClientContext.error(error, reason)
     }
 }
@@ -386,7 +380,7 @@ struct KafkaSinkState {
 
     progress_topic: String,
     progress_key: String,
-    progress_client: Option<Arc<BaseConsumer<BrokerRewritingClientContext<SinkConsumerContext>>>>,
+    progress_client: Option<Arc<BaseConsumer<BrokerRewritingClientContext<MzClientContext>>>>,
 
     healthchecker: Arc<Mutex<Option<Healthchecker>>>,
     internal_cmd_tx: Rc<RefCell<dyn InternalCommandSender>>,
@@ -405,27 +399,6 @@ struct KafkaSinkState {
     /// exactly-once guarantees.
     write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
 }
-
-#[derive(Clone)]
-struct SinkConsumerContext {
-    status_tx: mpsc::Sender<SinkStatus>,
-}
-
-impl ClientContext for SinkConsumerContext {
-    fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
-        MzClientContext.log(level, fac, log_message)
-    }
-    fn error(&self, error: KafkaError, reason: &str) {
-        let status = SinkStatus::Stalled {
-            error: error.to_string(),
-            hint: None,
-        };
-        let _ = self.status_tx.try_send(status);
-        MzClientContext.error(error, reason)
-    }
-}
-
-impl ConsumerContext for SinkConsumerContext {}
 
 impl KafkaSinkState {
     async fn new(
@@ -448,26 +421,12 @@ impl KafkaSinkState {
 
         let retry_manager = Arc::new(Mutex::new(KafkaSinkSendRetryManager::new()));
 
-        let (status_tx, mut status_rx) = mpsc::channel(16);
-
         let producer_context = SinkProducerContext {
             metrics: Arc::clone(&metrics),
-            status_tx: status_tx.clone(),
             retry_manager: Arc::clone(&retry_manager),
         };
 
         let healthchecker: Arc<Mutex<Option<Healthchecker>>> = Arc::new(Mutex::new(None));
-
-        {
-            let healthchecker = Arc::clone(&healthchecker);
-            task::spawn(|| "producer-error-report", async move {
-                while let Some(status) = status_rx.recv().await {
-                    if let Some(hc) = healthchecker.lock().await.as_mut() {
-                        hc.update_status(status).await;
-                    }
-                }
-            });
-        }
 
         let producer = connection
             .connection
@@ -514,7 +473,7 @@ impl KafkaSinkState {
             .connection
             .create_with_context(
                 connection_context,
-                SinkConsumerContext { status_tx },
+                MzClientContext,
                 &btreemap! {
                     "group.id" => format!("materialize-bootstrap-sink-{sink_id}"),
                     "isolation.level" => "read_committed".into(),

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use anyhow::Context;
 use std::any::Any;
 use std::collections::BTreeMap;
 use std::convert::Infallible;
@@ -21,11 +20,10 @@ use futures::StreamExt;
 use maplit::btreemap;
 use rdkafka::consumer::base_consumer::PartitionQueue;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
-use rdkafka::error::{KafkaError, RDKafkaErrorCode};
+use rdkafka::error::KafkaError;
 use rdkafka::message::{BorrowedMessage, Headers};
 use rdkafka::statistics::Statistics;
 use rdkafka::topic_partition_list::Offset;
-use rdkafka::types::RDKafkaRespErr;
 use rdkafka::{ClientContext, Message, TopicPartitionList};
 use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, Stream};
@@ -33,7 +31,9 @@ use timely::progress::Antichain;
 use tokio::sync::Notify;
 use tracing::{error, info, trace, warn};
 
-use mz_kafka_util::client::{BrokerRewritingClientContext, MzClientContext};
+use mz_kafka_util::client::{
+    get_partitions, BrokerRewritingClientContext, MzClientContext, PartitionId,
+};
 use mz_ore::error::ErrorExt;
 use mz_ore::thread::{JoinHandleExt, UnparkOnDropHandle};
 use mz_repr::{adt::jsonb::Jsonb, Diff, GlobalId};
@@ -48,8 +48,6 @@ use crate::source::types::{HealthStatus, HealthStatusUpdate, SourceReaderMetrics
 use crate::source::{RawSourceCreationConfig, SourceMessage, SourceReaderError};
 
 mod metrics;
-
-type PartitionId = i32;
 
 /// Contains all information necessary to ingest data from Kafka
 pub struct KafkaSourceReader {
@@ -140,7 +138,7 @@ impl SourceRender for KafkaSourceConnection {
             let (stats_tx, stats_rx) = crossbeam_channel::unbounded();
             let health_status = Arc::new(Mutex::new(None));
             let notificator = Arc::new(Notify::new());
-            let consumer = connection
+            let consumer: Result<BaseConsumer<_>, _> = connection
                 .create_with_context(
                     &connection_context,
                     GlueConsumerContext {
@@ -308,7 +306,7 @@ impl SourceRender for KafkaSourceConnection {
                         );
                         while let Some(partition_info) = partition_info.upgrade() {
                             let result =
-                                get_kafka_partitions(&consumer, &topic, Duration::from_secs(30));
+                                get_partitions(consumer.client(), &topic, Duration::from_secs(30));
                             trace!(
                                 source_id = config.id.to_string(),
                                 worker_id = config.worker_id,
@@ -925,39 +923,6 @@ impl GlueConsumerContext {
 }
 
 impl ConsumerContext for GlueConsumerContext {}
-
-/// Return the list of partition ids associated with a specific topic
-fn get_kafka_partitions<C>(
-    consumer: &BaseConsumer<C>,
-    topic: &str,
-    timeout: Duration,
-) -> Result<Vec<PartitionId>, anyhow::Error>
-where
-    C: ConsumerContext,
-{
-    let metadata = consumer.fetch_metadata(Some(topic), timeout)?;
-    let topic_meta = metadata
-        .topics()
-        .get(0)
-        .context("expected a topic in the metadata result")?;
-
-    fn check_err(err: Option<RDKafkaRespErr>) -> anyhow::Result<()> {
-        if let Some(err) = err {
-            Err(RDKafkaErrorCode::from(err))?
-        }
-        Ok(())
-    }
-
-    check_err(topic_meta.error())?;
-
-    let mut partition_ids = Vec::with_capacity(topic_meta.partitions().len());
-    for partition_meta in topic_meta.partitions() {
-        check_err(partition_meta.error())?;
-
-        partition_ids.push(partition_meta.id());
-    }
-    Ok(partition_ids)
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -64,7 +64,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 tokio = { version = "1.24.2", features = ["process"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-serde_json-1"] }
-tokio-stream = "0.1.11"
+tokio-stream = "0.1.12"
 tokio-util = { version = "0.7.4", features = ["compat"] }
 url = "2.3.1"
 uuid = "1.2.2"

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -96,7 +96,7 @@ textwrap = { version = "0.15.0", default-features = false, features = ["terminal
 time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
 tokio = { version = "1.27.0", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
-tokio-stream = { version = "0.1.11", features = ["net", "sync"] }
+tokio-stream = { version = "0.1.12", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
 tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "retry", "timeout", "util"] }
 tower-http = { version = "0.3.5", features = ["auth", "cors", "map-response-body", "trace", "util"] }
@@ -194,7 +194,7 @@ time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-kno
 time-macros = { version = "0.2.6", default-features = false, features = ["formatting", "parsing", "serde"] }
 tokio = { version = "1.27.0", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
-tokio-stream = { version = "0.1.11", features = ["net", "sync"] }
+tokio-stream = { version = "0.1.12", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
 tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "retry", "timeout", "util"] }
 tower-http = { version = "0.3.5", features = ["auth", "cors", "map-response-body", "trace", "util"] }

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -31,10 +31,10 @@ def test_secrets(mz: MaterializeApplication) -> None:
               );
 
             # Our Redpanda instance is not configured for SASL, so we can not
-            # really establish a successful connection. Hence the expectation for an SSL error
+            # really establish a successful connection.
             ! CREATE SOURCE secrets_source
               FROM KAFKA CONNECTION secrets_conn (TOPIC 'foo_bar');
-            contains: SSL handshake failed
+            contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
             """
         )
     )

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -79,4 +79,4 @@ $ kafka-verify-data format=avro sink=materialize.public.data_snk sort-messages=t
 ! CREATE SOURCE connector_source
   FROM KAFKA CONNECTION kafka_sasl_no_ca (TOPIC 'testdrive-data-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_sasl
-contains: broker certificate could not be verified
+contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -150,4 +150,4 @@ a
   FROM KAFKA CONNECTION kafka_sasl_no_ca (TOPIC 'testdrive-data-${testdrive.seed}')
     FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl_no_ca
-contains: broker certificate could not be verified
+contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)

--- a/test/ssh-connection/kafka-source-after-ssh-failure.td
+++ b/test/ssh-connection/kafka-source-after-ssh-failure.td
@@ -13,7 +13,11 @@
 # This error comes from the Kafka source's metadata fetch loop.
 > SELECT status FROM mz_internal.mz_source_statuses st
   JOIN mz_sources s ON st.id = s.id
-  WHERE s.name = 'mz_source' AND error LIKE '%Meta data fetch error%'
+  WHERE s.name = 'mz_source' AND error LIKE '%Could not resolve hostname ssh-bastion-host: Name or service not known%'
+stalled
+> SELECT status FROM mz_internal.mz_source_statuses st
+  JOIN mz_sources s ON st.id = s.id
+  WHERE s.name = 'csr_source' AND error LIKE '%Could not resolve hostname ssh-bastion-host: Name or service not known%'
 stalled
 
 # Drop and recreate the source cluster's replica so we can test behavior after
@@ -25,5 +29,5 @@ stalled
 # unable to connect.
 > SELECT status FROM mz_internal.mz_source_statuses st
   JOIN mz_sources s ON st.id = s.id
-  WHERE s.name = 'mz_source' AND error LIKE '%failed creating kafka consumer: creating ssh tunnel: failed to connect to the remote host%'
+  WHERE s.name = 'mz_source' AND error LIKE '%failed creating kafka consumer: creating ssh tunnel: ssh tunnel: failed to connect to the remote host%'
 stalled

--- a/test/ssh-connection/kafka-source-after-ssh-restart.td
+++ b/test/ssh-connection/kafka-source-after-ssh-restart.td
@@ -26,3 +26,8 @@ three
   JOIN mz_sources s ON st.id = s.id
   WHERE s.name = 'mz_source'
 running
+
+> SELECT status FROM mz_internal.mz_source_statuses st
+  JOIN mz_sources s ON st.id = s.id
+  WHERE s.name = 'csr_source'
+running

--- a/test/testdrive/kafka-source-errors.td
+++ b/test/testdrive/kafka-source-errors.td
@@ -32,7 +32,7 @@ contains:KAFKA CONNECTION without TOPIC
 
 ! CREATE SOURCE fawlty_broker_source
   FROM KAFKA CONNECTION fawlty_kafka_conn (TOPIC 'testdrive-fawlty-broker-source-${testdrive.seed}')
-contains: non-existent-broker:9092
+contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
 
 > CREATE CONNECTION IF NOT EXISTS fawlty_csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL 'http://non-existent-csr:8081'

--- a/test/testdrive/kafka-time-offset.td
+++ b/test/testdrive/kafka-time-offset.td
@@ -27,7 +27,7 @@ $ kafka-create-topic topic=t0
   FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1, TOPIC 'missing_topic')
   FORMAT TEXT
   INCLUDE OFFSET
-contains:topic missing_topic does not exist
+contains:UnknownTopicOrPartition (Broker: Unknown topic or partition)
 
 ! CREATE SOURCE pick_one
   FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1, START OFFSET=[1], TOPIC 'testdrive-t0-${testdrive.seed}')


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/18490


This pr consolidates and improves the way we handle kafka errors. There are 2 main commits:

- The bottom commit makes an opinionated choice about how we report `rdkafka` errors, namely, we no longer trust `rdkafka` `log` or `error` callbacks to report meaningful errors to users, instead relying on metadata fetch errors (for sources) or producer errors (for sinks).
  - additionally, this commit merges some similar codepaths between adapter and storage
- The second commit allows sources and sinks to subscribe to errors in their underlying ssh tunnels. The api for this is meant to be simple: `create_with_context` additionally returns an object that can be polled to watch for ssh tunnel errors, and when errors occur
  - In practice the implementation is a bit complex. Tunnels can be shared across many workers, so tunnels need to use a `tokio::sync::broadcast` channel to communicate errors. Additionally, there is 1 ssh tunnel per broker, so users (sources and sinks) need to poll multiple `broadcast` channels to watch the health of ALL tunnels they use. Note that this pr adds the ability to dynamically add ssh tunnels that need to be watched (no removal of brokers is supported right now), which will be required when we add top-level `SSH TUNNEL` support to kafka sources.

### Motivation

   * This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
