### PR TITLE
adapter: Log application_name with Segment logging

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -437,7 +437,11 @@ impl Coordinator {
                     event.object_type.as_title_case(),
                     event.event_type.as_title_case()
                 );
-                let application_name = session.map(|s| s.application_name()).unwrap_or("");
+                // Note: when there is no Session, that means something internal to
+                // environmentd initiated the transaction, hence the default name.
+                let application_name = session
+                    .map(|s| s.application_name())
+                    .unwrap_or("environmentd");
                 segment_client.environment_track(
                     &self.catalog().config().environment_id,
                     application_name,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -437,8 +437,10 @@ impl Coordinator {
                     event.object_type.as_title_case(),
                     event.event_type.as_title_case()
                 );
+                let application_name = session.map(|s| s.application_name()).unwrap_or("");
                 segment_client.environment_track(
                     &self.catalog().config().environment_id,
+                    application_name,
                     user_metadata.user_id,
                     event_type,
                     json!({ "details": event.details.as_json() }),

--- a/src/adapter/src/telemetry.rs
+++ b/src/adapter/src/telemetry.rs
@@ -63,13 +63,12 @@ impl SegmentClientExt for mz_segment::Client {
                 "cloud_provider_region".into(),
                 json!(environment_id.cloud_provider_region()),
             );
+            properties.insert("application_name".into(), json!(app_name));
         }
-        let app = json!({ "name": app_name });
 
         // "Context" is a defined dictionary of extra information related to a datapoint. Please
         // consult the docs before adding anything here: https://segment.com/docs/connections/spec/common/#context
         let context = json!({
-            "app": app,
             "group_id": environment_id.organization_id()
         });
 

--- a/src/environmentd/src/telemetry.rs
+++ b/src/environmentd/src/telemetry.rs
@@ -216,6 +216,7 @@ async fn report_loop(
                 .extend(traits.as_object().unwrap().clone());
             segment_client.environment_track(
                 &environment_id,
+                "environmentd",
                 // We use the organization ID as the user ID for events
                 // that are not associated with a particular user.
                 environment_id.organization_id(),


### PR DESCRIPTION
### Motivation
* This PR adds a known-desirable feature: #18094 

Currently we log the postgres `application_name` parameter just to Prometheus, but it would be great for analytics if we could also log it to Segment. This PR adds the application name to our existing `environmentd` Segment logging, specifically it adds `application_name` to the `properties` dictionary.

cc @ggnall 

### Tips for reviewer

I didn't see any testing for our Segment logging, but if there is some I'd be more than happy to update it to assert we pass the application name.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No user facing changes
