### PR TITLE
adapter: Buffer updates to metrics system tables

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -122,7 +122,7 @@ use crate::catalog::{
 use crate::client::{Client, ConnectionId, Handle};
 use crate::command::{Canceled, Command, ExecuteResponse};
 use crate::config::SystemParameterFrontend;
-use crate::coord::appends::{BuiltinTableUpdateSource, Deferred, PendingWriteTxn};
+use crate::coord::appends::{Deferred, PendingWriteTxn};
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::peek::PendingPeek;
 use crate::coord::read_policy::ReadCapability;
@@ -1128,8 +1128,7 @@ impl Coordinator {
         }
 
         info!("coordinator init: sending builtin table updates");
-        self.send_builtin_table_updates(builtin_table_updates, BuiltinTableUpdateSource::DDL)
-            .await;
+        self.send_builtin_table_updates(builtin_table_updates).await;
 
         // Signal to the storage controller that it is now free to reconcile its
         // state with what it has learned from the adapter.

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -381,8 +381,8 @@ impl Coordinator {
         self.trigger_group_commit();
     }
 
-    /// Submit a write to a system be executed during the next group commit. This method does not
-    /// trigger a group commit.
+    /// Submit a write to a system table be executed during the next group commit. This method does
+    /// not trigger a group commit.
     ///
     /// This is useful for non-critical writes like metric updates because it allows us to piggy
     /// back off the next group commit instead of triggering a potentially expensive group commit.

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -375,27 +375,42 @@ impl Coordinator {
             .expect("sending to self.internal_cmd_tx cannot fail");
     }
 
-    /// Submit a write to be executed during the next group commit.
+    /// Submit a write to be executed during the next group commit and trigger a group commit.
     pub(crate) fn submit_write(&mut self, pending_write_txn: PendingWriteTxn) {
-        self.trigger_group_commit();
         self.pending_writes.push(pending_write_txn);
+        self.trigger_group_commit();
     }
 
+    /// Submit a write to a system be executed during the next group commit. This method does not
+    /// trigger a group commit.
+    ///
+    /// This is useful for non-critical writes like metric updates because it allows us to piggy
+    /// back off the next group commit instead of triggering a potentially expensive group commit.
+    ///
+    /// DO NOT call this for DDL which needs the system tables updated immediately.
     #[tracing::instrument(level = "debug", skip_all, fields(updates = updates.len()))]
-    pub(crate) async fn send_builtin_table_updates(
-        &mut self,
-        updates: Vec<BuiltinTableUpdate>,
-        source: BuiltinTableUpdateSource,
-    ) {
+    pub(crate) fn buffer_builtin_table_updates(&mut self, updates: Vec<BuiltinTableUpdate>) {
+        self.pending_writes.push(PendingWriteTxn::System {
+            updates,
+            source: BuiltinTableUpdateSource::Background,
+        });
+    }
+
+    /// Submit a write to a system table. This method will block until the write has been applied.
+    #[tracing::instrument(level = "debug", skip_all, fields(updates = updates.len()))]
+    pub(crate) async fn send_builtin_table_updates(&mut self, updates: Vec<BuiltinTableUpdate>) {
         // Most DDL queries cause writes to system tables. Unlike writes to user tables, system
         // table writes do not wait for a group commit, they explicitly trigger one. There is a
         // possibility that if a user is executing DDL at a rate faster than 1 query per
         // millisecond, then the global timeline will unboundedly advance past the system clock.
         // This can cause future queries to block, but will not affect correctness. Since this
         // rate of DDL is unlikely, we allow DDL to explicitly trigger group commit.
-        self.pending_writes
-            .push(PendingWriteTxn::System { updates, source });
+        self.pending_writes.push(PendingWriteTxn::System {
+            updates,
+            source: BuiltinTableUpdateSource::DDL,
+        });
         self.group_commit_initiate(None).await;
+        self.advance_timelines_interval.reset();
     }
 
     /// Defers executing `deferred` until the write lock becomes available; waiting

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -34,7 +34,7 @@ use crate::client::ConnectionId;
 use crate::command::{
     Canceled, Command, ExecuteResponse, Response, StartupMessage, StartupResponse,
 };
-use crate::coord::appends::{BuiltinTableUpdateSource, Deferred, PendingWriteTxn};
+use crate::coord::appends::{Deferred, PendingWriteTxn};
 use crate::coord::peek::PendingPeek;
 use crate::coord::{ConnMeta, Coordinator, CreateSourceStatementReady, Message, PendingTxn};
 use crate::error::AdapterError;
@@ -270,8 +270,7 @@ impl Coordinator {
             },
         );
         let update = self.catalog().state().pack_session_update(&session, 1);
-        self.send_builtin_table_updates(vec![update], BuiltinTableUpdateSource::DDL)
-            .await;
+        self.send_builtin_table_updates(vec![update]).await;
 
         ClientTransmitter::new(tx, self.internal_cmd_tx.clone())
             .send(Ok(StartupResponse { messages }), session)
@@ -641,7 +640,6 @@ impl Coordinator {
         self.active_conns.remove(&session.conn_id());
         self.cancel_pending_peeks(&session.conn_id());
         let update = self.catalog().state().pack_session_update(session, -1);
-        self.send_builtin_table_updates(vec![update], BuiltinTableUpdateSource::DDL)
-            .await;
+        self.send_builtin_table_updates(vec![update]).await;
     }
 }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -29,7 +29,7 @@ use mz_storage_client::controller::CollectionMetadata;
 
 use crate::client::ConnectionId;
 use crate::command::{Command, ExecuteResponse};
-use crate::coord::appends::{BuiltinTableUpdateSource, Deferred};
+use crate::coord::appends::Deferred;
 use crate::coord::timestamp_selection::TimestampContext;
 use crate::coord::{
     Coordinator, CreateSourceStatementReady, Message, PendingReadTxn, RealTimeRecencyContext,
@@ -297,8 +297,7 @@ impl Coordinator {
                     } else {
                         vec![insertion]
                     };
-                    self.send_builtin_table_updates(updates, BuiltinTableUpdateSource::Background)
-                        .await;
+                    self.buffer_builtin_table_updates(updates);
                 }
             }
             ControllerResponse::ComputeReplicaMetrics(replica_id, new) => {
@@ -330,8 +329,7 @@ impl Coordinator {
                     } else {
                         insertions
                     };
-                    self.send_builtin_table_updates(updates, BuiltinTableUpdateSource::Background)
-                        .await;
+                    self.buffer_builtin_table_updates(updates);
                 }
             }
             ControllerResponse::ComputeReplicaWriteFrontiers(updates) => {
@@ -362,11 +360,7 @@ impl Coordinator {
                     }
                 }
 
-                self.send_builtin_table_updates(
-                    builtin_updates,
-                    BuiltinTableUpdateSource::Background,
-                )
-                .await;
+                self.buffer_builtin_table_updates(builtin_updates);
             }
         }
     }

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -16,7 +16,6 @@ use mz_sql::plan::StatementDesc;
 use mz_sql_parser::ast::{Raw, Statement};
 
 use crate::catalog::Catalog;
-use crate::coord::appends::BuiltinTableUpdateSource;
 use crate::coord::Coordinator;
 use crate::session::{Session, TransactionStatus};
 use crate::subscribe::ActiveSubscribe;
@@ -203,8 +202,7 @@ impl Coordinator {
             .catalog()
             .state()
             .pack_subscribe_update(id, &active_subscribe, 1);
-        self.send_builtin_table_updates(vec![update], BuiltinTableUpdateSource::DDL)
-            .await;
+        self.send_builtin_table_updates(vec![update]).await;
 
         let session_type = metrics::session_type_label_value(&active_subscribe.user);
         self.metrics
@@ -222,8 +220,7 @@ impl Coordinator {
                 .catalog()
                 .state()
                 .pack_subscribe_update(id, &active_subscribe, -1);
-            self.send_builtin_table_updates(vec![update], BuiltinTableUpdateSource::DDL)
-                .await;
+            self.send_builtin_table_updates(vec![update]).await;
 
             let session_type = metrics::session_type_label_value(&active_subscribe.user);
             self.metrics


### PR DESCRIPTION
Previously whenever we needed to update a system table containing metrics, we would immediately trigger a potentially expensive group commit whenever a metric was updated. Metrics are not critical enough that we needed to update the system table immediately.

This commit update the append logic so the table updates for metrics are buffered but don't trigger a group commit. Instead, they will piggyback off the next group commit. This will hopefully allow multiple metrics updates to be coalesced into a single group commit.

This commit also restarts the table advancement timer whenever a system table is updated, which was left off of a previous commit. In the previous commit only user writes would reset the timer.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
