### PR TITLE
adapter: Reset table timer after system writes

### DIFF
--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -396,8 +396,8 @@ impl Coordinator {
         self.pending_writes
             .push(PendingWriteTxn::System { updates, source });
         self.group_commit_initiate(None).await;
-        // Avoid excessive `Message::GroupCommitInitiate` by resetting the periodic table
-        // advancement. The group commit triggered by above will already advance all tables.
+        // Avoid excessive group commits by resetting the periodic table advancement timer. The
+        // group commit triggered by above will already advance all tables.
         self.advance_timelines_interval.reset();
     }
 

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -396,6 +396,9 @@ impl Coordinator {
         self.pending_writes
             .push(PendingWriteTxn::System { updates, source });
         self.group_commit_initiate(None).await;
+        // Avoid excessive `Message::GroupCommitInitiate` by resetting the periodic table
+        // advancement. The group commit triggered by above will already advance all tables.
+        self.advance_timelines_interval.reset();
     }
 
     /// Defers executing `deferred` until the write lock becomes available; waiting


### PR DESCRIPTION
f324497810c19b85f2a01a5483ede8b7562d9db5, reduced the amount of group commits by resetting the table advancement timer after user writes. However, it forgot to reset the timer after system writes. This commit additionally resets the timer after system writes.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
