### PR TITLE
bump nightly to one past 1.68.2

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-NIGHTLY_RUST_DATE=2023-01-03
+NIGHTLY_RUST_DATE=2023-04-04
 
 cd "$(dirname "$0")/.."
 


### PR DESCRIPTION
The bump to 1.68.2 didnt actually test any nightly tests, and now they fail: https://buildkite.com/materialize/tests/builds/53095#01875362-564d-42c3-b68e-587017a29602

I verified that this nightly builds mz correctly, locally