### PR TITLE
sqlancer: Use official version

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -620,7 +620,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
-          args: [--runtime=3300, --oracle=PQS]
+          args: [--runtime=3300, --oracle=PQS, --no-qpg]
 
   - id: sqlancer-norec
     label: "SQLancer NoREC"

--- a/test/sqlancer/Dockerfile
+++ b/test/sqlancer/Dockerfile
@@ -20,10 +20,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     maven
 
 # Rebuild since SQLancer repo might have changed
-ADD https://api.github.com/repos/def-/sqlancer/git/refs/heads/master version.json
+ADD https://api.github.com/repos/sqlancer/sqlancer/git/refs/heads/master version.json
 
 # Build SQLancer
-RUN git clone --depth=1 --single-branch https://github.com/def-/sqlancer \
+RUN git clone --depth=1 --single-branch https://github.com/sqlancer/sqlancer \
     && cd sqlancer \
     && mvn package -DskipTests
 

--- a/test/sqlancer/mzcompose.py
+++ b/test/sqlancer/mzcompose.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import argparse
 import random
 import time
 from threading import Thread
@@ -33,6 +34,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument("--num-tries", default=100000, type=int)
     parser.add_argument("--num-threads", default=4, type=int)
     parser.add_argument("--seed", default=None, type=int)
+    parser.add_argument("--qpg", default=True, action=argparse.BooleanOptionalAction)
     parser.add_argument("--oracle", default="NOREC", type=str)
     args = parser.parse_args()
 
@@ -72,9 +74,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         f"{args.num_tries}",
         "--num-threads",
         f"{args.num_threads}",
+        "--qpg-enable",
+        f"{args.qpg}",
         "--random-string-generation",
         "ALPHANUMERIC_SPECIALCHAR",
-        "postgres",
+        "materialize",
         "--oracle",
         args.oracle,
         capture=True,


### PR DESCRIPTION
Now that all my changes have been merged into it: https://github.com/sqlancer/sqlancer/pull/773

We will thus profit from new changes to the SQLancer repository.

I also plan to merge my upcoming improvements into sqlancer directly.

They are also running Materialize in CI now: https://github.com/sqlancer/sqlancer/actions/runs/4626101042/jobs/8182493757 & https://github.com/sqlancer/sqlancer/actions/runs/4626101042/jobs/8182494217 So they should catch if someone breaks the Mz backend.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
