### PR TITLE
testdrive: Fortify negative-multiplicities.td

### DIFF
--- a/test/testdrive/negative-multiplicities.td
+++ b/test/testdrive/negative-multiplicities.td
@@ -66,4 +66,5 @@ contains:Invalid data in source, saw non-positive accumulation
     STRING_AGG(data::text || '2',  ',')
   FROM data
   GROUP BY data
-contains:Non-positive accumulation in ReduceInaccumulable
+# Case-insensitive match for both 'Non' and 'non'
+contains:on-positive accumulation


### PR DESCRIPTION
A SELECT query was returning different error messages when run on clusters of different sizes, I assume because of timing differences as to which operator had the chance to execute first.

Accept any message that speaks of non-positive accumulations regardless of capitalization and the operator that is being referenced.

### Motivation

  * This PR fixes a previously unreported bug.

Nightly was failing due to the error message being different

### Tips for reviewer

@vmarcos the query was failing like this:

```
testdrive/negative-multiplicities.td:59:1: error: expected error containing "Non-positive accumulation in ReduceInaccumulable", got "Invalid data in source errors, saw retractions (1) for row that does not exist: Evaluation error: internal error: Invalid data in source, saw non-positive accumulation for key Row{[Int64(1)]} in hierarchical mins-maxes aggregate"
```

so I made the test less sensitive to the specific error text.

@nrainer-materialize, some context:

This is an example of a more general, hm, situation that we have in our CI -- rather than have a separate test for e.g. very small or very large clusters, we leverage the same tests, in this case testdrive files in testdrive, and simply run them verbatim against large and small clusters. The same approach is used elsewhere in the CI -- for example, the queries that are used to test upgrades are the same that are used to test our ability to survive Postgres or Cockroach restarts.

The benefit is that as soon as some feature is added to an existing body of tests, it will automatically get exercised in all those contexts, without having to devote dedicated QA resources to write a matrix and then write additional tests that test every possible interaction of everything with everything else. The downside is that:
- most of the additional contexts run in Nightly, so if a new addition to the body of tests is not compatible with any of them, this causes Nightly to fail and then things need to be fixed after-the-fact, as in this PR
- having to write queries and tests in a general way that makes them runnable in different contexts imposes a burden on the test writer. For example, for a test to be usable in upgrade testing, it needs to be explicitly tagged whether it requires a particular version (and is therefore skipped if any older Mz version is involved in the particular context the test is being executed in).
