### PR TITLE
adapter: handle publications specified as identifiers

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -126,7 +126,7 @@ pub(crate) async fn migrate(
 // they were not used to generate the DDL for the subsources and it is now too
 // late to apply them.
 //
-// TODO(migration): delete in version v.51 (released in v0.49 + 1 additional
+// TODO(migration): delete in version v.52 (released in v0.50 + 1 additional
 // release)
 async fn pg_source_table_metadata_rewrite(
     catalog: &ConnCatalog<'_>,
@@ -212,8 +212,9 @@ async fn pg_source_table_metadata_rewrite(
 
         let publication = match publication {
             mz_sql::ast::WithOptionValue::Value(mz_sql::ast::Value::String(publication)) => {
-                publication
+                &*publication
             }
+            mz_sql::ast::WithOptionValue::Ident(ident) => ident.as_str(),
             _ => unreachable!("corrupt catalog"),
         };
 


### PR DESCRIPTION


<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

The parser currently accepts specifying the publication for a postgres source with both single and double quotes which are parsed as strings and identifiers respectively.

The catalog migration patched in this PR was making the assumption that only strings are accepted, leading to a crash during environmentd bootstrap when the catalog contained publication specified as idents.

Independently of this PR we should think about whether or not we want to make a technically breaking change and disallow idents completely from parser positions that expect a string.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
