### PR TITLE
User/system replica IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3673,6 +3673,7 @@ dependencies = [
  "itertools",
  "mz-ore",
  "mz-proto",
+ "mz-stash",
  "once_cell",
  "prometheus",
  "proptest",

--- a/doc/developer/cloudtest.md
+++ b/doc/developer/cloudtest.md
@@ -153,7 +153,7 @@ is instantiated once per `pytest` invocation
 ```
 from materialize.cloudtest.util.wait import wait
 
-wait(condition="condition=Ready", resource="pod/compute-cluster-1-replica-1-0")
+wait(condition="condition=Ready", resource="pod/compute-cluster-u1-replica-u1-0")
 ```
 
 `wait` uses `kubectl wait` behind the scenes. Here is what the `kubectl wait`

--- a/doc/developer/guide-tokio-console.md
+++ b/doc/developer/guide-tokio-console.md
@@ -25,9 +25,9 @@ different processes, e.g.:
 
 ```text
 environmentd: [...]  INFO mz_ore::tracing: starting tokio console on http://127.0.0.1:6669
-compute-cluster-u1-replica-1: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]3ee9
-compute-cluster-s1-replica-2: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]f5b6
-compute-cluster-s2-replica-3: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]7af2
+compute-cluster-u1-replica-u1: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]3ee9
+compute-cluster-s1-replica-s1: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]f5b6
+compute-cluster-s2-replica-s2: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]7af2
 ```
 
 Then, in a different tmux pane/terminal, run the `tokio-console` command with the listen address of

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -130,7 +130,7 @@ each replica, including the times at which it was created and dropped
 <!-- RELATION_SPEC mz_internal.mz_cluster_replica_history -->
 | Field                 | Type                         | Meaning                                                                                                                                   |
 |-----------------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| `internal_replica_id` | [`text`]                     | An internal identifier of a cluster replica. Guaranteed to be unique, but not guaranteed to correspond to any user-facing replica ID.     |
+| `replica_id`          | [`text`]                     | The ID of a cluster replica.                                                                                                              |
 | `size`                | [`text`]                     | The size of the cluster replica. Corresponds to [`mz_cluster_replica_sizes.size`](#mz_cluster_replica_sizes).                             |
 | `cluster_name`        | [`text`]                     | The name of the cluster associated with the replica.                                                                                      |
 | `replica_name`        | [`text`]                     | The name of the replica.                                                                                                                  |

--- a/misc/python/materialize/checks/replica.py
+++ b/misc/python/materialize/checks/replica.py
@@ -11,6 +11,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.util import MzVersion
 
 
 class CreateReplica(Check):
@@ -46,7 +47,40 @@ class CreateReplica(Check):
                 123
                 > SELECT * FROM create_replica_view;
                 123
-           """
+
+                # Confirm that all replica_ids have been migrated to the uXXX/sXXX format
+                > SELECT COUNT(*)
+                  FROM mz_cluster_replicas
+                  WHERE id NOT LIKE 's%'
+                  AND id NOT LIKE 'u%';
+                0
+
+                # Confirm that there are CREATE events for all replicas with new-format IDs
+                # resultset should not contain any NULLs.
+                # System and unmanaged replicas have no audit log entries, so we need to exclude
+                # those.
+                > SELECT DISTINCT event_type
+                  FROM mz_cluster_replicas
+                  LEFT JOIN mz_audit_events ON (
+                    mz_cluster_replicas.id = mz_audit_events.details->>'replica_id'
+                    AND mz_audit_events.event_type = 'create'
+                  )
+                  WHERE
+                    mz_cluster_replicas.id LIKE 'u%'
+                    AND mz_cluster_replicas.size IS NOT NULL;
+                create
+                """
+                + """
+                # Confirm that there are DROP events for replicas with old-format IDs
+                > SELECT COUNT(*) >= 2 FROM mz_audit_events
+                  WHERE object_type = 'cluster-replica'
+                  AND event_type = 'drop'
+                  AND details->>'replica_id' NOT LIKE 's%'
+                  AND details->>'replica_id' NOT LIKE 'u%';
+                true
+                """
+                if self.base_version < MzVersion.parse("0.66.0-dev")
+                else ""
             )
         )
 

--- a/misc/python/materialize/cloudtest/app/materialize_application.py
+++ b/misc/python/materialize/cloudtest/app/materialize_application.py
@@ -111,15 +111,15 @@ class MaterializeApplication(CloudtestApplicationBase):
         )
 
     def wait_resource_creation_completed(self) -> None:
-        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
+        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
 
     def wait_replicas(self) -> None:
         # NOTE[btv] - This will need to change if the order of
         # creating clusters/replicas changes, but it seemed fine to
         # assume this order, since we already assume it in `create`.
-        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
-        wait(condition="condition=Ready", resource="pod/cluster-s1-replica-2-0")
-        wait(condition="condition=Ready", resource="pod/cluster-s2-replica-3-0")
+        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
+        wait(condition="condition=Ready", resource="pod/cluster-s1-replica-s1-0")
+        wait(condition="condition=Ready", resource="pod/cluster-s2-replica-s2-0")
 
     def wait_for_sql(self) -> None:
         """Wait until environmentd pod is ready and can accept SQL connections"""

--- a/misc/python/materialize/cloudtest/app/materialize_application.py
+++ b/misc/python/materialize/cloudtest/app/materialize_application.py
@@ -111,15 +111,19 @@ class MaterializeApplication(CloudtestApplicationBase):
         )
 
     def wait_resource_creation_completed(self) -> None:
-        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
+        wait(
+            condition="condition=Ready",
+            resource="pod",
+            label="cluster.environmentd.materialize.cloud/cluster-id=u1",
+        )
 
     def wait_replicas(self) -> None:
-        # NOTE[btv] - This will need to change if the order of
-        # creating clusters/replicas changes, but it seemed fine to
-        # assume this order, since we already assume it in `create`.
-        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
-        wait(condition="condition=Ready", resource="pod/cluster-s1-replica-s1-0")
-        wait(condition="condition=Ready", resource="pod/cluster-s2-replica-s2-0")
+        for cluster_id in ("u1", "s1", "s2"):
+            wait(
+                condition="condition=Ready",
+                resource="pod",
+                label=f"cluster.environmentd.materialize.cloud/cluster-id={cluster_id}",
+            )
 
     def wait_for_sql(self) -> None:
         """Wait until environmentd pod is ready and can accept SQL connections"""

--- a/misc/python/materialize/cloudtest/util/cluster.py
+++ b/misc/python/materialize/cloudtest/util/cluster.py
@@ -9,18 +9,8 @@
 
 
 def cluster_pod_name(cluster_id: str, replica_id: str, process: int = 0) -> str:
-    # Replica IDs now appear as `GlobalId`s in `mz_cluster_replicas`, while
-    # the pod names still contain only the numeric ID.
-    # TODO(teskje): Change pod names to contain the replica `GlobalId`.
-    replica_id = replica_id.lstrip("u")
-
     return f"pod/cluster-{cluster_id}-replica-{replica_id}-{process}"
 
 
 def cluster_service_name(cluster_id: str, replica_id: str) -> str:
-    # Replica IDs now appear as `GlobalId`s in `mz_cluster_replicas`, while
-    # the pod names still contain only the numeric ID.
-    # TODO(teskje): Change pod names to contain the replica `GlobalId`.
-    replica_id = replica_id.lstrip("u")
-
     return f"service/cluster-{cluster_id}-replica-{replica_id}"

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4825,8 +4825,8 @@ impl Catalog {
         self.storage().await.allocate_user_cluster_id().await
     }
 
-    pub async fn allocate_replica_id(&self) -> Result<ReplicaId, Error> {
-        self.storage().await.allocate_replica_id().await
+    pub async fn allocate_user_replica_id(&self) -> Result<ReplicaId, Error> {
+        self.storage().await.allocate_user_replica_id().await
     }
 
     pub fn allocate_oid(&mut self) -> Result<u32, Error> {
@@ -4840,14 +4840,14 @@ impl Catalog {
         self.storage().await.get_all_persisted_timestamps().await
     }
 
-    /// Get the next user ID without allocating it.
-    pub async fn get_next_user_global_id(&self) -> Result<GlobalId, Error> {
-        self.storage().await.get_next_user_global_id().await
+    /// Get the next system replica id without allocating it.
+    pub async fn get_next_system_replica_id(&self) -> Result<u64, Error> {
+        self.storage().await.get_next_system_replica_id().await
     }
 
-    /// Get the next replica id without allocating it.
-    pub async fn get_next_replica_id(&self) -> Result<ReplicaId, Error> {
-        self.storage().await.get_next_replica_id().await
+    /// Get the next user replica id without allocating it.
+    pub async fn get_next_user_replica_id(&self) -> Result<u64, Error> {
+        self.storage().await.get_next_user_replica_id().await
     }
 
     /// Persist new global timestamp for a timeline to disk.
@@ -8882,7 +8882,7 @@ mod tests {
     use std::iter;
 
     use itertools::Itertools;
-    use mz_controller::clusters::ClusterId;
+    use mz_controller::clusters::{ClusterId, ReplicaId};
     use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
     use mz_ore::collections::CollectionExt;
     use mz_ore::now::{NOW_ZERO, SYSTEM_TIME};
@@ -10003,7 +10003,10 @@ mod tests {
 
         assert_eq!(
             mz_sql::catalog::ObjectType::ClusterReplica,
-            catalog.get_object_type(&ObjectId::ClusterReplica((ClusterId::User(1), 1)))
+            catalog.get_object_type(&ObjectId::ClusterReplica((
+                ClusterId::User(1),
+                ReplicaId::User(1)
+            )))
         );
         assert_eq!(
             mz_sql::catalog::ObjectType::Role,
@@ -10025,7 +10028,7 @@ mod tests {
             None,
             catalog.get_privileges(&SystemObjectId::Object(ObjectId::ClusterReplica((
                 ClusterId::User(1),
-                1
+                ReplicaId::User(1),
             ))))
         );
         assert_eq!(

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -4410,7 +4410,7 @@ pub const MZ_CLUSTER_REPLICA_HISTORY: BuiltinView = BuiltinView {
                 WHERE object_type = 'cluster-replica' AND event_type = 'drop'
             )
         SELECT
-            creates.replica_id AS internal_replica_id,
+            creates.replica_id,
             creates.size,
             creates.cluster_name,
             creates.replica_name,

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -12,7 +12,6 @@ use std::net::Ipv4Addr;
 use bytesize::ByteSize;
 use chrono::{DateTime, Utc};
 use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent, VersionedStorageUsage};
-use mz_compute_client::controller::NewReplicaId;
 use mz_controller::clusters::{
     ClusterId, ClusterStatus, ManagedReplicaAvailabilityZones, ManagedReplicaLocation, ProcessId,
     ReplicaAllocation, ReplicaId, ReplicaLocation,
@@ -256,9 +255,6 @@ impl CatalogState {
             _ => (None, None, None),
         };
 
-        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
-        let id = NewReplicaId::User(id);
-
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICAS),
             row: Row::pack_slice(&[
@@ -306,9 +302,6 @@ impl CatalogState {
             ClusterStatus::NotReady(None) => None,
             ClusterStatus::NotReady(Some(NotReadyReason::OomKilled)) => Some("oom-killed"),
         };
-
-        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
-        let replica_id = NewReplicaId::User(replica_id);
 
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_STATUSES),
@@ -1135,9 +1128,6 @@ impl CatalogState {
         last_heartbeat: DateTime<Utc>,
         diff: Diff,
     ) -> BuiltinTableUpdate {
-        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
-        let id = NewReplicaId::User(id);
-
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_HEARTBEATS),
             row: Row::pack_slice(&[
@@ -1179,10 +1169,6 @@ impl CatalogState {
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let id = self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_METRICS);
-
-        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
-        let replica_id = NewReplicaId::User(replica_id);
-
         let rows = updates.iter().enumerate().map(
             |(
                 process_id,

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -71,7 +71,8 @@ const SCHEMA_ID_ALLOC_KEY: &str = "schema";
 const USER_ROLE_ID_ALLOC_KEY: &str = "user_role";
 const USER_CLUSTER_ID_ALLOC_KEY: &str = "user_compute";
 const SYSTEM_CLUSTER_ID_ALLOC_KEY: &str = "system_compute";
-const REPLICA_ID_ALLOC_KEY: &str = "replica";
+const USER_REPLICA_ID_ALLOC_KEY: &str = "replica";
+const SYSTEM_REPLICA_ID_ALLOC_KEY: &str = "system_replica";
 pub(crate) const AUDIT_LOG_ID_ALLOC_KEY: &str = "auditlog";
 pub(crate) const STORAGE_USAGE_ID_ALLOC_KEY: &str = "storage_usage";
 
@@ -140,7 +141,8 @@ fn add_new_builtin_cluster_replicas_migration(
         if matches!(replica_names, None)
             || matches!(replica_names, Some(names) if !names.contains(builtin_replica.name))
         {
-            let replica_id = txn.get_and_increment_id(REPLICA_ID_ALLOC_KEY.to_string())?;
+            let replica_id = txn.get_and_increment_id(SYSTEM_REPLICA_ID_ALLOC_KEY.to_string())?;
+            let replica_id = ReplicaId::System(replica_id);
             let config = builtin_cluster_replica_config(bootstrap_args);
             txn.insert_cluster_replica(
                 *cluster_id,
@@ -758,19 +760,20 @@ impl Connection {
         Ok(ClusterId::User(id))
     }
 
-    pub async fn allocate_replica_id(&mut self) -> Result<ReplicaId, Error> {
-        let id = self.allocate_id(REPLICA_ID_ALLOC_KEY, 1).await?;
-        Ok(id.into_element())
+    pub async fn allocate_user_replica_id(&mut self) -> Result<ReplicaId, Error> {
+        let id = self.allocate_id(USER_REPLICA_ID_ALLOC_KEY, 1).await?;
+        let id = id.into_element();
+        Ok(ReplicaId::User(id))
     }
 
-    /// Get the next user id without allocating it.
-    pub async fn get_next_user_global_id(&mut self) -> Result<GlobalId, Error> {
-        self.get_next_id("user").await.map(GlobalId::User)
+    /// Get the next system replica id without allocating it.
+    pub async fn get_next_system_replica_id(&mut self) -> Result<u64, Error> {
+        self.get_next_id(SYSTEM_REPLICA_ID_ALLOC_KEY).await
     }
 
-    /// Get the next replica id without allocating it.
-    pub async fn get_next_replica_id(&mut self) -> Result<ReplicaId, Error> {
-        self.get_next_id(REPLICA_ID_ALLOC_KEY).await
+    /// Get the next user replica id without allocating it.
+    pub async fn get_next_user_replica_id(&mut self) -> Result<u64, Error> {
+        self.get_next_id(USER_REPLICA_ID_ALLOC_KEY).await
     }
 
     async fn get_next_id(&mut self, id_type: &str) -> Result<u64, Error> {

--- a/src/adapter/src/catalog/storage/objects.rs
+++ b/src/adapter/src/catalog/storage/objects.rs
@@ -213,16 +213,13 @@ impl RustType<proto::ClusterIntrospectionSourceIndexValue>
 impl RustType<proto::ClusterReplicaKey> for ClusterReplicaKey {
     fn into_proto(&self) -> proto::ClusterReplicaKey {
         proto::ClusterReplicaKey {
-            id: Some(proto::ReplicaId { value: self.id }),
+            id: Some(self.id.into_proto()),
         }
     }
 
     fn from_proto(proto: proto::ClusterReplicaKey) -> Result<Self, TryFromProtoError> {
         Ok(ClusterReplicaKey {
-            id: proto
-                .id
-                .map(|id| id.value)
-                .ok_or_else(|| TryFromProtoError::missing_field("ClusterReplicaKey::id"))?,
+            id: proto.id.into_rust_if_some("ClusterReplicaKey::id")?,
         })
     }
 }

--- a/src/adapter/src/catalog/storage/stash.rs
+++ b/src/adapter/src/catalog/storage/stash.rs
@@ -616,7 +616,7 @@ pub async fn initialize(
         proto::audit_log_event_v1::Details::CreateClusterReplicaV1(
             proto::audit_log_event_v1::CreateClusterReplicaV1 {
                 cluster_id: DEFAULT_USER_CLUSTER_ID.to_string(),
-                cluser_name: DEFAULT_USER_CLUSTER_NAME.to_string(),
+                cluster_name: DEFAULT_USER_CLUSTER_NAME.to_string(),
                 replica_name: DEFAULT_USER_REPLICA_NAME.to_string(),
                 replica_id: Some(DEFAULT_USER_REPLICA_ID.to_string().into()),
                 logical_size: options.default_cluster_replica_size.to_string(),

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2054,7 +2054,10 @@ pub async fn serve(
                     .await?;
                 coord
                     .controller
-                    .remove_orphaned_replicas(coord.catalog().get_next_replica_id().await?)
+                    .remove_orphaned_replicas(
+                        coord.catalog().get_next_user_replica_id().await?,
+                        coord.catalog().get_next_system_replica_id().await?,
+                    )
                     .await
                     .map_err(AdapterError::Orchestrator)?;
                 Ok(())

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -133,7 +133,7 @@ impl Coordinator {
         )?;
 
         for replica_name in (0..replication_factor).map(managed_cluster_replica_name) {
-            let id = self.catalog_mut().allocate_replica_id().await?;
+            let id = self.catalog_mut().allocate_user_replica_id().await?;
             self.create_managed_cluster_replica_op(
                 cluster_id,
                 id,
@@ -322,7 +322,7 @@ impl Coordinator {
 
             ops.push(catalog::Op::CreateClusterReplica {
                 cluster_id: id,
-                id: self.catalog_mut().allocate_replica_id().await?,
+                id: self.catalog_mut().allocate_user_replica_id().await?,
                 name: replica_name.clone(),
                 config,
                 owner_id: *session.current_role_id(),
@@ -447,7 +447,7 @@ impl Coordinator {
             },
         };
 
-        let id = self.catalog_mut().allocate_replica_id().await?;
+        let id = self.catalog_mut().allocate_user_replica_id().await?;
         // Replicas have the same owner as their cluster.
         let owner_id = self.catalog().get_cluster(cluster_id).owner_id();
         let op = catalog::Op::CreateClusterReplica {
@@ -731,7 +731,7 @@ impl Coordinator {
                 }
             }
             for name in (0..*new_replication_factor).map(managed_cluster_replica_name) {
-                let id = self.catalog_mut().allocate_replica_id().await?;
+                let id = self.catalog_mut().allocate_user_replica_id().await?;
                 self.create_managed_cluster_replica_op(
                     cluster_id,
                     id,
@@ -763,7 +763,7 @@ impl Coordinator {
             for name in
                 (*replication_factor..*new_replication_factor).map(managed_cluster_replica_name)
             {
-                let id = self.catalog_mut().allocate_replica_id().await?;
+                let id = self.catalog_mut().allocate_user_replica_id().await?;
                 self.create_managed_cluster_replica_op(
                     cluster_id,
                     id,

--- a/src/adapter/src/coord/sequencer/linked_cluster.rs
+++ b/src/adapter/src/coord/sequencer/linked_cluster.rs
@@ -105,7 +105,7 @@ impl Coordinator {
         };
         ops.push(catalog::Op::CreateClusterReplica {
             cluster_id,
-            id: self.catalog().allocate_replica_id().await?,
+            id: self.catalog().allocate_user_replica_id().await?,
             name: LINKED_CLUSTER_REPLICA_NAME.into(),
             config: ReplicaConfig {
                 location,

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -535,7 +535,7 @@ impl RustType<proto::audit_log_event_v1::CreateClusterReplicaV1> for CreateClust
     fn into_proto(&self) -> proto::audit_log_event_v1::CreateClusterReplicaV1 {
         proto::audit_log_event_v1::CreateClusterReplicaV1 {
             cluster_id: self.cluster_id.to_string(),
-            cluser_name: self.cluster_name.to_string(),
+            cluster_name: self.cluster_name.to_string(),
             replica_id: self.replica_id.as_ref().map(|id| proto::StringWrapper {
                 inner: id.to_string(),
             }),
@@ -550,7 +550,7 @@ impl RustType<proto::audit_log_event_v1::CreateClusterReplicaV1> for CreateClust
     ) -> Result<Self, TryFromProtoError> {
         Ok(CreateClusterReplicaV1 {
             cluster_id: proto.cluster_id,
-            cluster_name: proto.cluser_name,
+            cluster_name: proto.cluster_name,
             replica_id: proto.replica_id.map(|id| id.inner),
             replica_name: proto.replica_name,
             logical_size: proto.logical_size,

--- a/src/cluster-client/Cargo.toml
+++ b/src/cluster-client/Cargo.toml
@@ -15,6 +15,7 @@ http = "0.2.8"
 itertools = "0.10.5"
 mz-ore = { path = "../ore", features = ["tracing_"] }
 mz-proto = { path = "../proto" }
+mz-stash = { path = "../stash" }
 once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -75,10 +75,6 @@ pub type ComputeInstanceId = StorageInstanceId;
 /// Identifier of a replica.
 pub type ReplicaId = mz_cluster_client::ReplicaId;
 
-/// Identifier of a replica.
-// TODO(#18377): Replace `ReplicaId` with this type.
-pub type NewReplicaId = mz_cluster_client::NewReplicaId;
-
 /// Responses from the compute controller.
 #[derive(Debug)]
 pub enum ComputeControllerResponse<T> {

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1688,7 +1688,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                             // The ID is arbitrary here; we just need some dummy
                             // value to return.
                             cluster_id: ClusterId::System(0),
-                            replica_id: 0,
+                            replica_id: ReplicaId::System(0),
                         })
                     }
                 }

--- a/src/stash/build.rs
+++ b/src/stash/build.rs
@@ -204,6 +204,7 @@ fn main() -> anyhow::Result<()> {
         .enum_attribute("ClusterId.value", ATTR)
         .enum_attribute("DatabaseId.value", ATTR)
         .enum_attribute("SchemaId.value", ATTR)
+        .enum_attribute("ReplicaId.value", ATTR)
         .enum_attribute("RoleId.value", ATTR)
         .enum_attribute("ReplicaConfig.location", ATTR)
         .enum_attribute("AuditLogEventV1.details", ATTR)

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "f7d98ebfafc35c8704434e6b338a9ac1"
+    "md5": "5ad2ed8268532bc29eff108d6f0eb6d8"
   },
   {
     "name": "objects_v25.proto",
@@ -41,6 +41,6 @@
   },
   {
     "name": "objects_v34.proto",
-    "md5": "e99c9e18fd5c1d998f8cb89360cf8f53"
+    "md5": "cddbbfecec523eec8a9f685633fb5c7c"
   }
 ]

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "caeba871ee4c70243741bb5efa474b9e"
+    "md5": "f7d98ebfafc35c8704434e6b338a9ac1"
   },
   {
     "name": "objects_v25.proto",

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -38,5 +38,9 @@
   {
     "name": "objects_v33.proto",
     "md5": "b5f70889965589369efc18ec36e8cbd8"
+  },
+  {
+    "name": "objects_v34.proto",
+    "md5": "e99c9e18fd5c1d998f8cb89360cf8f53"
   }
 ]

--- a/src/stash/protos/objects.proto
+++ b/src/stash/protos/objects.proto
@@ -264,7 +264,10 @@ message SchemaId {
 }
 
 message ReplicaId {
-    uint64 value = 1;
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
 }
 
 message ReplicaLogging {

--- a/src/stash/protos/objects.proto
+++ b/src/stash/protos/objects.proto
@@ -461,7 +461,7 @@ message AuditLogEventV1 {
 
     message CreateClusterReplicaV1 {
         string cluster_id = 1;
-        string cluser_name = 2;
+        string cluster_name = 2;
         StringWrapper replica_id = 3;
         string replica_name = 4;
         string logical_size = 5;

--- a/src/stash/protos/objects_v34.proto
+++ b/src/stash/protos/objects_v34.proto
@@ -461,7 +461,7 @@ message AuditLogEventV1 {
 
     message CreateClusterReplicaV1 {
         string cluster_id = 1;
-        string cluser_name = 2;
+        string cluster_name = 2;
         StringWrapper replica_id = 3;
         string replica_name = 4;
         string logical_size = 5;

--- a/src/stash/protos/objects_v34.proto
+++ b/src/stash/protos/objects_v34.proto
@@ -1,0 +1,598 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// This protobuf file defines the types we store in the Stash.
+//
+// Before and after modifying this file, make sure you have a snapshot of the before version,
+// e.g. a copy of this file named 'objects_v{STASH_VERSION}.proto', and a snapshot of the file
+// after your modifications, e.g. 'objects_v{STASH_VERSION + 1}.proto'. Then you can write a
+// migration using these two files, and no matter how they types change in the future, we'll always
+// have these snapshots to facilitate the migration.
+
+
+syntax = "proto3";
+
+package objects_v34;
+
+message ConfigKey {
+    string key = 1;
+}
+
+message ConfigValue {
+    uint64 value = 1;
+}
+
+message SettingKey {
+    string name = 1;
+}
+
+message SettingValue {
+    string value = 1;
+}
+
+message IdAllocKey {
+    string name = 1;
+}
+
+message IdAllocValue {
+    uint64 next_id = 1;
+}
+
+message GidMappingKey {
+    string schema_name = 1;
+    CatalogItemType object_type = 2;
+    string object_name = 3;
+}
+
+message GidMappingValue {
+    uint64 id = 1;
+    string fingerprint = 2;
+}
+
+message ClusterKey {
+    ClusterId id = 1;
+}
+
+message ClusterValue {
+    string name = 1;
+    GlobalId linked_object_id = 2;
+    RoleId owner_id = 3;
+    repeated MzAclItem privileges = 4;
+    ClusterConfig config = 5;
+}
+
+message ClusterIntrospectionSourceIndexKey {
+    ClusterId cluster_id = 1;
+    string name = 2;
+}
+
+message ClusterIntrospectionSourceIndexValue {
+    uint64 index_id = 1;
+}
+
+message ClusterReplicaKey {
+    ReplicaId id = 1;
+}
+
+message ClusterReplicaValue {
+    ClusterId cluster_id = 1;
+    string name = 2;
+    ReplicaConfig config = 3;
+    RoleId owner_id = 4;
+}
+
+message DatabaseKey {
+    DatabaseId id = 1;
+}
+
+message DatabaseValue {
+    string name = 1;
+    RoleId owner_id = 2;
+    repeated MzAclItem privileges = 3;
+}
+
+message SchemaKey {
+    SchemaId id = 1;
+}
+
+message SchemaValue {
+    DatabaseId database_id = 1;
+    string name = 2;
+    RoleId owner_id = 3;
+    repeated MzAclItem privileges = 4;
+}
+
+message ItemKey {
+    GlobalId gid = 1;
+}
+
+message ItemValue {
+    SchemaId schema_id = 1;
+    string name = 2;
+    CatalogItem definition = 3;
+    RoleId owner_id = 4;
+    repeated MzAclItem privileges = 5;
+}
+
+message RoleKey {
+    RoleId id = 1;
+}
+
+message RoleValue {
+    string name = 1;
+    RoleAttributes attributes = 2;
+    RoleMembership membership = 3;
+}
+
+message TimestampKey {
+    string id = 1;
+}
+
+message TimestampValue {
+    Timestamp ts = 1;
+}
+
+message ServerConfigurationKey {
+    string name = 1;
+}
+
+message ServerConfigurationValue {
+    string value = 1;
+}
+
+message AuditLogKey {
+    oneof event {
+        AuditLogEventV1 v1 = 1;
+    }
+}
+
+message StorageUsageKey {
+    message StorageUsageV1 {
+        uint64 id = 1;
+        StringWrapper shard_id = 2;
+        uint64 size_bytes = 3;
+        EpochMillis collection_timestamp = 4;
+    }
+
+    oneof usage {
+        StorageUsageV1 v1 = 1;
+    }
+}
+
+message SinkAsOf {
+    TimestampAntichain frontier = 1;
+    bool strict = 2;
+}
+
+message DurableCollectionMetadata {
+    reserved 1;
+    reserved "remap_shard";
+
+    // StringWrapper remap_shard = 1;
+    string data_shard = 2;
+}
+
+message DurableExportMetadata {
+    SinkAsOf initial_as_of = 1;
+}
+
+// ---- Common Types
+//
+// Note: Normally types like this would go in some sort of `common.proto` file, but we want to keep
+// our proto definitions in a single file to make snapshotting easier, hence them living here.
+
+message Empty { /* purposefully empty */ }
+
+// In protobuf a "None" string is the same thing as an empty string. To get the same semantics of
+// an `Option<String>` from Rust, we need to wrap a string in a message.
+message StringWrapper {
+    string inner = 1;
+}
+
+message Duration {
+    uint64 secs = 1;
+    uint32 nanos = 2;
+}
+
+message EpochMillis {
+    uint64 millis = 1;
+}
+
+// Opaque timestamp type that is specific to Materialize.
+message Timestamp {
+    uint64 internal = 1;
+}
+
+enum CatalogItemType {
+    CATALOG_ITEM_TYPE_UNKNOWN = 0;
+    CATALOG_ITEM_TYPE_TABLE = 1;
+    CATALOG_ITEM_TYPE_SOURCE = 2;
+    CATALOG_ITEM_TYPE_SINK = 3;
+    CATALOG_ITEM_TYPE_VIEW = 4;
+    CATALOG_ITEM_TYPE_MATERIALIZED_VIEW = 5;
+    CATALOG_ITEM_TYPE_INDEX = 6;
+    CATALOG_ITEM_TYPE_TYPE = 7;
+    CATALOG_ITEM_TYPE_FUNC = 8;
+    CATALOG_ITEM_TYPE_SECRET = 9;
+    CATALOG_ITEM_TYPE_CONNECTION = 10;
+}
+
+message CatalogItem {
+    message V1 {
+        string create_sql = 1;
+    }
+
+    oneof value {
+        V1 v1 = 1;
+    }
+}
+
+message GlobalId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        uint64 transient = 3;
+        Empty explain = 4;
+    }
+}
+
+message ClusterId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message DatabaseId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message SchemaId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message ReplicaId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message ReplicaLogging {
+    bool log_logging = 1;
+    Duration interval = 2;
+}
+
+message ReplicaMergeEffort {
+    uint32 effort = 1;
+}
+
+message ClusterConfig {
+    message ManagedCluster {
+        string size = 1;
+        uint32 replication_factor = 2;
+        repeated string availability_zones = 3;
+        ReplicaLogging logging = 4;
+        ReplicaMergeEffort idle_arrangement_merge_effort = 5;
+        bool disk = 6;
+    }
+
+    oneof variant {
+        Empty unmanaged = 1;
+        ManagedCluster managed = 2;
+    }
+}
+
+message ReplicaConfig {
+    message UnmanagedLocation {
+        repeated string storagectl_addrs = 1;
+        repeated string storage_addrs = 2;
+        repeated string computectl_addrs = 3;
+        repeated string compute_addrs = 4;
+        uint64 workers = 5;
+    }
+
+    message ManagedLocation {
+        string size = 1;
+        optional string availability_zone = 2;
+        bool disk = 4;
+    }
+
+    oneof location {
+        UnmanagedLocation unmanaged = 1;
+        ManagedLocation managed = 2;
+    }
+    ReplicaLogging logging = 3;
+    ReplicaMergeEffort idle_arrangement_merge_effort = 4;
+}
+
+message RoleId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        Empty public = 3;
+    }
+}
+
+message RoleAttributes {
+    bool inherit = 1;
+}
+
+message RoleMembership {
+    message Entry {
+        RoleId key = 1;
+        RoleId value = 2;
+    }
+
+    repeated Entry map = 1;
+}
+
+message AclMode {
+    // A bit flag representing all the privileges that can be granted to a role.
+    uint64 bitflags = 1;
+}
+
+message MzAclItem {
+    RoleId grantee = 1;
+    RoleId grantor = 2;
+    AclMode acl_mode = 3;
+}
+
+message TimestampAntichain {
+    repeated Timestamp elements = 1;
+}
+
+enum ObjectType {
+    OBJECT_TYPE_UNKNOWN = 0;
+    OBJECT_TYPE_TABLE = 1;
+    OBJECT_TYPE_VIEW = 2;
+    OBJECT_TYPE_MATERIALIZED_VIEW = 3;
+    OBJECT_TYPE_SOURCE = 4;
+    OBJECT_TYPE_SINK = 5;
+    OBJECT_TYPE_INDEX = 6;
+    OBJECT_TYPE_TYPE = 7;
+    OBJECT_TYPE_ROLE = 8;
+    OBJECT_TYPE_CLUSTER = 9;
+    OBJECT_TYPE_CLUSTER_REPLICA = 10;
+    OBJECT_TYPE_SECRET = 11;
+    OBJECT_TYPE_CONNECTION = 12;
+    OBJECT_TYPE_DATABASE = 13;
+    OBJECT_TYPE_SCHEMA = 14;
+    OBJECT_TYPE_FUNC = 15;
+}
+
+message DefaultPrivilegesKey {
+    RoleId role_id = 1;
+    DatabaseId database_id = 2;
+    SchemaId schema_id = 3;
+    ObjectType object_type = 4;
+    RoleId grantee = 5;
+}
+
+message DefaultPrivilegesValue {
+    AclMode privileges = 1;
+}
+
+message SystemPrivilegesKey {
+    RoleId grantee = 1;
+    RoleId grantor = 2;
+}
+
+message SystemPrivilegesValue {
+    AclMode acl_mode = 1;
+}
+
+message AuditLogEventV1 {
+    enum EventType {
+        EVENT_TYPE_UNKNOWN = 0;
+        EVENT_TYPE_CREATE = 1;
+        EVENT_TYPE_DROP = 2;
+        EVENT_TYPE_ALTER = 3;
+        EVENT_TYPE_GRANT = 4;
+        EVENT_TYPE_REVOKE = 5;
+    }
+
+    enum ObjectType {
+        OBJECT_TYPE_UNKNOWN = 0;
+        OBJECT_TYPE_CLUSTER = 1;
+        OBJECT_TYPE_CLUSTER_REPLICA = 2;
+        OBJECT_TYPE_CONNECTION = 3;
+        OBJECT_TYPE_DATABASE = 4;
+        OBJECT_TYPE_FUNC = 5;
+        OBJECT_TYPE_INDEX = 6;
+        OBJECT_TYPE_MATERIALIZED_VIEW = 7;
+        OBJECT_TYPE_ROLE = 8;
+        OBJECT_TYPE_SECRET = 9;
+        OBJECT_TYPE_SCHEMA = 10;
+        OBJECT_TYPE_SINK = 11;
+        OBJECT_TYPE_SOURCE = 12;
+        OBJECT_TYPE_TABLE = 13;
+        OBJECT_TYPE_TYPE = 14;
+        OBJECT_TYPE_VIEW = 15;
+        OBJECT_TYPE_SYSTEM = 16;
+    }
+
+    message IdFullNameV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+    }
+
+    message FullNameV1 {
+        string database = 1;
+        string schema = 2;
+        string item = 3;
+    }
+
+    message IdNameV1 {
+        string id = 1;
+        string name = 2;
+    }
+
+    message RenameClusterV1 {
+        string id = 1;
+        string old_name = 2;
+        string new_name = 3;
+    }
+
+    message RenameClusterReplicaV1 {
+        string cluster_id = 1;
+        string replica_id = 2;
+        string old_name = 3;
+        string new_name = 4;
+    }
+
+    message RenameItemV1 {
+        string id = 1;
+        FullNameV1 old_name = 2;
+        FullNameV1 new_name = 3;
+    }
+
+    message CreateClusterReplicaV1 {
+        string cluster_id = 1;
+        string cluser_name = 2;
+        StringWrapper replica_id = 3;
+        string replica_name = 4;
+        string logical_size = 5;
+        bool disk = 6;
+    }
+
+    message DropClusterReplicaV1 {
+        string cluster_id = 1;
+        string cluster_name = 2;
+        StringWrapper replica_id = 3;
+        string replica_name = 4;
+    }
+
+    message CreateSourceSinkV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper size = 3;
+    }
+
+    message CreateSourceSinkV2 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper size = 3;
+        string external_type = 4;
+    }
+
+    message AlterSourceSinkV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper old_size = 3;
+        StringWrapper new_size = 4;
+    }
+
+    message AlterSetClusterV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper old_cluster = 3;
+        StringWrapper new_cluster = 4;
+    }
+
+    message GrantRoleV1 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+    }
+
+    message GrantRoleV2 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+        string executed_by = 4;
+    }
+
+    message RevokeRoleV1 {
+        string role_id = 1;
+        string member_id = 2;
+    }
+
+    message RevokeRoleV2 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+        string executed_by = 4;
+    }
+
+    message UpdatePrivilegeV1 {
+        string object_id = 1;
+        string grantee_id = 2;
+        string grantor_id = 3;
+        string privileges = 4;
+    }
+
+    message AlterDefaultPrivilegeV1 {
+        string role_id = 1;
+        StringWrapper database_id = 2;
+        StringWrapper schema_id = 3;
+        string grantee_id= 4;
+        string privileges = 5;
+    }
+
+    message UpdateOwnerV1 {
+        string object_id = 1;
+        string old_owner_id = 2;
+        string new_owner_id = 3;
+    }
+
+    message SchemaV1 {
+        string id = 1;
+        string name = 2;
+        string database_name = 3;
+    }
+
+    message SchemaV2 {
+        string id = 1;
+        string name = 2;
+        StringWrapper database_name = 3;
+    }
+
+    message UpdateItemV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+    }
+
+    uint64 id = 1;
+    EventType event_type = 2;
+    ObjectType object_type = 3;
+    StringWrapper user = 4;
+    EpochMillis occurred_at = 5;
+
+    // next-id: 27
+    oneof details {
+        CreateClusterReplicaV1 create_cluster_replica_v1 = 6;
+        DropClusterReplicaV1 drop_cluster_replica_v1 = 7;
+        CreateSourceSinkV1 create_source_sink_v1 = 8;
+        CreateSourceSinkV2 create_source_sink_v2 = 9;
+        AlterSourceSinkV1 alter_source_sink_v1 = 10;
+        AlterSetClusterV1 alter_set_cluster_v1 = 25;
+        GrantRoleV1 grant_role_v1 = 11;
+        GrantRoleV2 grant_role_v2 = 12;
+        RevokeRoleV1 revoke_role_v1 = 13;
+        RevokeRoleV2 revoke_role_v2 = 14;
+        UpdatePrivilegeV1 update_privilege_v1 = 22;
+        AlterDefaultPrivilegeV1 alter_default_privilege_v1 = 23;
+        UpdateOwnerV1 update_owner_v1 = 24;
+        IdFullNameV1 id_full_name_v1 = 15;
+        RenameClusterV1 rename_cluster_v1 = 20;
+        RenameClusterReplicaV1 rename_cluster_replica_v1 = 21;
+        RenameItemV1 rename_item_v1 = 16;
+        IdNameV1 id_name_v1 = 17;
+        SchemaV1 schema_v1 = 18;
+        SchemaV2 schema_v2 = 19;
+        UpdateItemV1 update_item_v1 = 26;
+    }
+}

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -107,7 +107,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 33;
+pub const STASH_VERSION: u64 = 34;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/objects.rs
+++ b/src/stash/src/objects.rs
@@ -190,6 +190,8 @@ pub unsafe trait WireCompatible<T: prost::Message>: prost::Message + Default {
     }
 }
 
+unsafe impl WireCompatible<()> for () {}
+
 /// Defines one protobuf type as wire compatible with another.
 ///
 /// ```text

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -916,6 +916,7 @@ impl Stash {
                             30 => upgrade::v30_to_v31::upgrade(),
                             31 => upgrade::v31_to_v32::upgrade(&mut tx).await?,
                             32 => upgrade::v32_to_v33::upgrade(&mut tx).await?,
+                            33 => upgrade::v33_to_v34::upgrade(&mut tx).await?,
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -54,6 +54,7 @@ pub(crate) mod v29_to_v30;
 pub(crate) mod v30_to_v31;
 pub(crate) mod v31_to_v32;
 pub(crate) mod v32_to_v33;
+pub(crate) mod v33_to_v34;
 
 pub(crate) enum MigrationAction<K1, K2, V2> {
     /// Deletes the provided key.

--- a/src/stash/src/upgrade/v33_to_v34.rs
+++ b/src/stash/src/upgrade/v33_to_v34.rs
@@ -1,0 +1,222 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::objects::{wire_compatible, WireCompatible};
+use crate::upgrade::MigrationAction;
+use crate::{StashError, Transaction, TypedCollection};
+
+pub mod v33 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v33.rs"));
+}
+
+pub mod v34 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v34.rs"));
+}
+
+wire_compatible!(v33::ClusterReplicaValue with v34::ClusterReplicaValue);
+wire_compatible!(v33::IdAllocKey with v34::IdAllocKey);
+wire_compatible!(v33::IdAllocValue with v34::IdAllocValue);
+
+const CLUSTER_REPLICA_COLLECTION: TypedCollection<
+    v33::ClusterReplicaKey,
+    v33::ClusterReplicaValue,
+> = TypedCollection::new("compute_replicas");
+
+const ID_ALLOCATOR_COLLECTION: TypedCollection<v33::IdAllocKey, v33::IdAllocValue> =
+    TypedCollection::new("id_alloc");
+
+const SYSTEM_REPLICA_ID_ALLOC_KEY: &str = "system_replica";
+
+/// Migrate replica IDs from 'NNN' to 'uNNN'/'sNNN' format.
+pub async fn upgrade(tx: &mut Transaction<'_>) -> Result<(), StashError> {
+    initialize_system_replica_id_allocator(tx).await?;
+    migrate_cluster_replicas(tx).await?;
+    Ok(())
+}
+
+/// Initialize the "system_replica" ID allocator.
+async fn initialize_system_replica_id_allocator(
+    tx: &mut Transaction<'_>,
+) -> Result<(), StashError> {
+    let coll = CLUSTER_REPLICA_COLLECTION.from_tx(tx).await?;
+    let mut max_system_id = 0;
+    for (_, value) in tx.peek_one(coll).await? {
+        let cluster_id = value.cluster_id.unwrap().value.unwrap();
+        if let v33::cluster_id::Value::System(id) = cluster_id {
+            max_system_id = std::cmp::max(max_system_id, id);
+        }
+    }
+    let next_id = max_system_id + 1;
+
+    ID_ALLOCATOR_COLLECTION
+        .migrate_compat(tx, |entries| {
+            let key = v34::IdAllocKey {
+                name: SYSTEM_REPLICA_ID_ALLOC_KEY.into(),
+            };
+            assert!(!entries.contains_key(&key));
+            let value = v34::IdAllocValue { next_id };
+            vec![MigrationAction::Insert(key, value)]
+        })
+        .await
+}
+
+/// Migrate replica IDs in the "cluster_replicas" collection.
+async fn migrate_cluster_replicas(tx: &mut Transaction<'_>) -> Result<(), StashError> {
+    let action = |(key, value): (&v33::ClusterReplicaKey, &v33::ClusterReplicaValue)| {
+        let old_id = key.id.as_ref().unwrap().value;
+        let cluster_id = value.cluster_id.as_ref().unwrap().value.as_ref().unwrap();
+
+        // Construct the new ID format based on the plain ID and the cluster type.
+        // System clusters currently always have a single replica, so we can set the replica ID to
+        // the cluster ID. This does not work for user clusters.
+        let new_id = match cluster_id {
+            v33::cluster_id::Value::User(_) => v34::replica_id::Value::User(old_id),
+            v33::cluster_id::Value::System(id) => v34::replica_id::Value::System(*id),
+        };
+
+        let new_key = v34::ClusterReplicaKey {
+            id: Some(v34::ReplicaId {
+                value: Some(new_id),
+            }),
+        };
+        let new_value = WireCompatible::convert(value.clone());
+        MigrationAction::Update(key.clone(), (new_key, new_value))
+    };
+
+    CLUSTER_REPLICA_COLLECTION
+        .migrate_to::<_, v34::ClusterReplicaValue>(tx, |entries| {
+            entries.iter().map(action).collect()
+        })
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::DebugStashFactory;
+
+    use super::*;
+
+    const CLUSTER_REPLICA_COLLECTION_V34: TypedCollection<
+        v34::ClusterReplicaKey,
+        v34::ClusterReplicaValue,
+    > = TypedCollection::new("compute_replicas");
+
+    const ID_ALLOCATOR_COLLECTION_V34: TypedCollection<v34::IdAllocKey, v34::IdAllocValue> =
+        TypedCollection::new("id_alloc");
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn smoke_test() {
+        let factory = DebugStashFactory::new().await;
+        let mut stash = factory.open_debug().await;
+
+        CLUSTER_REPLICA_COLLECTION
+            .insert_without_overwrite(
+                &mut stash,
+                vec![
+                    (
+                        v33::ClusterReplicaKey {
+                            id: Some(v33::ReplicaId { value: 100 }),
+                        },
+                        v33::ClusterReplicaValue {
+                            cluster_id: Some(v33::ClusterId {
+                                value: Some(v33::cluster_id::Value::System(5)),
+                            }),
+                            config: None,
+                            name: "system".into(),
+                            owner_id: None,
+                        },
+                    ),
+                    (
+                        v33::ClusterReplicaKey {
+                            id: Some(v33::ReplicaId { value: 200 }),
+                        },
+                        v33::ClusterReplicaValue {
+                            cluster_id: Some(v33::ClusterId {
+                                value: Some(v33::cluster_id::Value::User(7)),
+                            }),
+                            config: None,
+                            name: "user".into(),
+                            owner_id: None,
+                        },
+                    ),
+                ],
+            )
+            .await
+            .unwrap();
+
+        // Run the migration.
+        stash
+            .with_transaction(|mut tx| {
+                Box::pin(async move {
+                    upgrade(&mut tx).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+
+        let mut replicas: Vec<_> = CLUSTER_REPLICA_COLLECTION_V34
+            .peek_one(&mut stash)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+        replicas.sort();
+
+        assert_eq!(
+            replicas,
+            vec![
+                (
+                    v34::ClusterReplicaKey {
+                        id: Some(v34::ReplicaId {
+                            value: Some(v34::replica_id::Value::System(5))
+                        }),
+                    },
+                    v34::ClusterReplicaValue {
+                        cluster_id: Some(v34::ClusterId {
+                            value: Some(v34::cluster_id::Value::System(5)),
+                        }),
+                        config: None,
+                        name: "system".into(),
+                        owner_id: None,
+                    },
+                ),
+                (
+                    v34::ClusterReplicaKey {
+                        id: Some(v34::ReplicaId {
+                            value: Some(v34::replica_id::Value::User(200))
+                        }),
+                    },
+                    v34::ClusterReplicaValue {
+                        cluster_id: Some(v34::ClusterId {
+                            value: Some(v34::cluster_id::Value::User(7)),
+                        }),
+                        config: None,
+                        name: "user".into(),
+                        owner_id: None,
+                    },
+                ),
+            ]
+        );
+
+        let key = v34::IdAllocKey {
+            name: SYSTEM_REPLICA_ID_ALLOC_KEY.into(),
+        };
+        let next_system_replica_id = ID_ALLOCATOR_COLLECTION_V34
+            .peek_key_one(&mut stash, key)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            next_system_replica_id,
+            Some(v34::IdAllocValue { next_id: 6 })
+        );
+    }
+}

--- a/src/stash/src/upgrade/v33_to_v34.rs
+++ b/src/stash/src/upgrade/v33_to_v34.rs
@@ -186,7 +186,7 @@ async fn migrate_audit_log(tx: &mut Transaction<'_>, now: u64) -> Result<(), Sta
             details: Some(v34::audit_log_event_v1::Details::CreateClusterReplicaV1(
                 v34::audit_log_event_v1::CreateClusterReplicaV1 {
                     cluster_id: details.cluster_id,
-                    cluser_name: details.cluser_name,
+                    cluster_name: details.cluser_name,
                     replica_id: Some(v34::StringWrapper { inner: new_id }),
                     replica_name: details.replica_name,
                     logical_size: details.logical_size,
@@ -506,7 +506,7 @@ mod tests {
                                 v34::audit_log_event_v1::Details::CreateClusterReplicaV1(
                                     v34::audit_log_event_v1::CreateClusterReplicaV1 {
                                         cluster_id: "u1".into(),
-                                        cluser_name: "c1".into(),
+                                        cluster_name: "c1".into(),
                                         replica_id: Some(v34::StringWrapper { inner: "1".into() }),
                                         replica_name: "r1".into(),
                                         logical_size: "small".into(),
@@ -530,7 +530,7 @@ mod tests {
                                 v34::audit_log_event_v1::Details::CreateClusterReplicaV1(
                                     v34::audit_log_event_v1::CreateClusterReplicaV1 {
                                         cluster_id: "u2".into(),
-                                        cluser_name: "c2".into(),
+                                        cluster_name: "c2".into(),
                                         replica_id: Some(v34::StringWrapper { inner: "2".into() }),
                                         replica_name: "r2".into(),
                                         logical_size: "big".into(),
@@ -594,7 +594,7 @@ mod tests {
                                 v34::audit_log_event_v1::Details::CreateClusterReplicaV1(
                                     v34::audit_log_event_v1::CreateClusterReplicaV1 {
                                         cluster_id: "u2".into(),
-                                        cluser_name: "c2".into(),
+                                        cluster_name: "c2".into(),
                                         replica_id: Some(v34::StringWrapper { inner: "u2".into() }),
                                         replica_name: "r2".into(),
                                         logical_size: "big".into(),

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -33,7 +33,7 @@ use differential_dataflow::lattice::Lattice;
 use itertools::Itertools;
 use mz_build_info::BuildInfo;
 use mz_cluster_client::client::ClusterReplicaLocation;
-use mz_cluster_client::{NewReplicaId, ReplicaId};
+use mz_cluster_client::ReplicaId;
 use mz_ore::collections::HashSet;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
@@ -2517,10 +2517,7 @@ where
             };
             let object_id = object_id.to_string();
             let object_datum = Datum::String(&object_id);
-            let replica_id = replica_id.map(|id| {
-                // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
-                NewReplicaId::User(id).to_string()
-            });
+            let replica_id = replica_id.map(|id| id.to_string());
             let replica_datum = replica_id.as_deref().map_or(Datum::Null, Datum::String);
 
             let row = Row::pack_slice(&[object_datum, replica_datum, time_datum]);

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -113,8 +113,8 @@ def test_crash_environmentd(mz: MaterializeApplication) -> None:
 
     def get_replica() -> Tuple[V1Pod, V1StatefulSet]:
         """Find the stateful set for the replica of the default cluster"""
-        compute_pod_name = "cluster-u1-replica-1-0"
-        ss_name = "cluster-u1-replica-1"
+        compute_pod_name = "cluster-u1-replica-u1-0"
+        ss_name = "cluster-u1-replica-u1"
         compute_pod = mz.environmentd.api().read_namespaced_pod(
             compute_pod_name, mz.environmentd.namespace()
         )

--- a/test/cloudtest/test_smoke.py
+++ b/test/cloudtest/test_smoke.py
@@ -14,7 +14,11 @@ from materialize.cloudtest.util.wait import wait
 
 
 def test_wait(mz: MaterializeApplication) -> None:
-    wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
+    wait(
+        condition="condition=Ready",
+        resource="pod",
+        label="cluster.environmentd.materialize.cloud/cluster-id=u1",
+    )
 
 
 def test_sql(mz: MaterializeApplication) -> None:

--- a/test/cloudtest/test_smoke.py
+++ b/test/cloudtest/test_smoke.py
@@ -14,7 +14,7 @@ from materialize.cloudtest.util.wait import wait
 
 
 def test_wait(mz: MaterializeApplication) -> None:
-    wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
+    wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
 
 
 def test_sql(mz: MaterializeApplication) -> None:

--- a/test/cloudtest/test_system_clusters.py
+++ b/test/cloudtest/test_system_clusters.py
@@ -28,5 +28,5 @@ def test_system_clusters(mz: MaterializeApplication) -> None:
     """Confirm that the system clusters have the expected labels and selectors"""
     mz.wait_replicas()
 
-    assert_pod_properties(mz, "cluster-s1-replica-2-0")
-    assert_pod_properties(mz, "cluster-s2-replica-3-0")
+    assert_pod_properties(mz, "cluster-s1-replica-s1-0")
+    assert_pod_properties(mz, "cluster-s2-replica-s2-0")

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -56,7 +56,11 @@ def test_upgrade(
         log_filter=log_filter,
         release_mode=(not dev),
     )
-    wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
+    wait(
+        condition="condition=Ready",
+        resource="pod",
+        label="cluster.environmentd.materialize.cloud/cluster-id=u1",
+    )
 
     executor = CloudtestExecutor(application=mz, version=LAST_RELEASED_VERSION)
     scenario = CloudtestUpgrade(checks=Check.__subclasses__(), executor=executor)

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -56,7 +56,7 @@ def test_upgrade(
         log_filter=log_filter,
         release_mode=(not dev),
     )
-    wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
+    wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
 
     executor = CloudtestExecutor(application=mz, version=LAST_RELEASED_VERSION)
     scenario = CloudtestUpgrade(checks=Check.__subclasses__(), executor=executor)

--- a/test/legacy-upgrade/check-from-v0.27.0-kafka-sink.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-kafka-sink.td
@@ -13,8 +13,16 @@
 # Test that the "disk" option on the linked cluster defaults to false
 > SELECT cluster, replica FROM (SHOW CLUSTER REPLICAS) WHERE cluster = 'materialize_public_upgrade_kafka_sink'
 materialize_public_upgrade_kafka_sink  linked
+
+# NOTE: Due to the ('N' -> 'uN') migration of replica IDs in the audit log, we
+# currently see additional `drop` and `create` events for each replica that
+# existed before the migration. Those events don't have a user attached, so we
+# can recognize them and filter them out.
 > SELECT event_type, object_type, details - 'id' - 'cluster_id' - 'replica_id'
   FROM mz_audit_events
-  WHERE details->>'name' = 'materialize_public_upgrade_kafka_sink' OR details->>'cluster_name' = 'materialize_public_upgrade_kafka_sink'
+  WHERE (
+    details->>'name' = 'materialize_public_upgrade_kafka_sink' OR
+    details->>'cluster_name' = 'materialize_public_upgrade_kafka_sink'
+  ) AND user IS NOT NULL
 create  cluster          "{\"name\":\"materialize_public_upgrade_kafka_sink\"}"
 create  cluster-replica  "{\"cluster_name\":\"materialize_public_upgrade_kafka_sink\",\"disk\":false,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}"

--- a/test/legacy-upgrade/check-from-v0.27.0-kafka-source.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-kafka-source.td
@@ -42,8 +42,16 @@ SELECT user FROM linked_cluster_audit_event_user ORDER BY priority DESC LIMIT 1
 # Test that the "disk" option on the linked cluster defaults to false
 > SELECT cluster, replica FROM (SHOW CLUSTER REPLICAS) WHERE cluster = 'materialize_public_kafka_source'
 materialize_public_kafka_source  linked
+
+# NOTE: Due to the ('N' -> 'uN') migration of replica IDs in the audit log, we
+# currently see additional `drop` and `create` events for each replica that
+# existed before the migration. Those events don't have a user attached, so we
+# can recognize them and filter them out.
 > SELECT event_type, object_type, details - 'id' - 'cluster_id' - 'replica_id', user
   FROM mz_audit_events
-  WHERE details->>'name' = 'materialize_public_kafka_source' OR details->>'cluster_name' = 'materialize_public_kafka_source'
+  WHERE (
+    details->>'name' = 'materialize_public_kafka_source' OR
+    details->>'cluster_name' = 'materialize_public_kafka_source'
+  ) AND user IS NOT NULL
 create  cluster          "{\"name\":\"materialize_public_kafka_source\"}"  ${expected-user}
 create  cluster-replica  "{\"cluster_name\":\"materialize_public_kafka_source\",\"disk\":false,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}"  ${expected-user}

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -102,7 +102,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 11  create  cluster  {"id":"u1","name":"default"}  NULL
 12  grant  cluster  {"grantee_id":"p","grantor_id":"s1","object_id":"Cu1","privileges":"U"}  NULL
 13  grant  cluster  {"grantee_id":"u1","grantor_id":"s1","object_id":"Cu1","privileges":"UC"}  NULL
-14  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","disk":false,"logical_size":"1","replica_id":"1","replica_name":"r1"}  NULL
+14  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","disk":false,"logical_size":"1","replica_id":"u1","replica_name":"r1"}  NULL
 15  grant  system  {"grantee_id":"s1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
 16  grant  system  {"grantee_id":"u1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
 17  create  database  {"id":"u2","name":"test"}  materialize
@@ -116,7 +116,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 25  create  role  {"id":"u2","name":"foo"}  materialize
 26  drop  role  {"id":"u2","name":"foo"}  materialize
 27  create  cluster  {"id":"u2","name":"foo"}  materialize
-28  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","disk":false,"logical_size":"1","replica_id":"4","replica_name":"r"}  materialize
+28  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","disk":false,"logical_size":"1","replica_id":"u2","replica_name":"r"}  materialize
 29  create  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
 30  create  view  {"database":"materialize","id":"u2","item":"unmat","schema":"public"}  materialize
 31  create  table  {"database":"materialize","id":"u3","item":"t","schema":"public"}  materialize
@@ -129,14 +129,14 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 38  drop  view  {"database":"materialize","id":"u2","item":"renamed","schema":"public"}  materialize
 39  create  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public","size":null,"type":"progress"}  materialize
 40  create  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
-41  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"1","replica_id":"5","replica_name":"linked"}  materialize
+41  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"1","replica_id":"u3","replica_name":"linked"}  materialize
 42  create  source  {"database":"materialize","id":"u8","item":"s","schema":"public","size":"1","type":"load-generator"}  materialize
-43  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"5","replica_name":"linked"}  materialize
-44  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"2","replica_id":"6","replica_name":"linked"}  materialize
+43  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"u3","replica_name":"linked"}  materialize
+44  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"2","replica_id":"u4","replica_name":"linked"}  materialize
 45  alter  source  {"database":"materialize","id":"u8","item":"s","new_size":"2","old_size":"1","schema":"public"}  materialize
 46  drop  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public"}  materialize
 47  drop  source  {"database":"materialize","id":"u8","item":"s","schema":"public"}  materialize
-48  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"6","replica_name":"linked"}  materialize
+48  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"u4","replica_name":"linked"}  materialize
 49  drop  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
 50  create  source  {"database":"materialize","id":"u9","item":"accounts","schema":"public","size":null,"type":"subsource"}  materialize
 51  create  source  {"database":"materialize","id":"u10","item":"auctions","schema":"public","size":null,"type":"subsource"}  materialize
@@ -145,11 +145,11 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 54  create  source  {"database":"materialize","id":"u13","item":"users","schema":"public","size":null,"type":"subsource"}  materialize
 55  create  source  {"database":"materialize","id":"u14","item":"multiplex_progress","schema":"public","size":null,"type":"progress"}  materialize
 56  create  cluster  {"id":"u4","name":"materialize_public_multiplex"}  materialize
-57  create  cluster-replica  {"cluster_id":"u4","cluster_name":"materialize_public_multiplex","disk":false,"logical_size":"1","replica_id":"7","replica_name":"linked"}  materialize
+57  create  cluster-replica  {"cluster_id":"u4","cluster_name":"materialize_public_multiplex","disk":false,"logical_size":"1","replica_id":"u5","replica_name":"linked"}  materialize
 58  create  source  {"database":"materialize","id":"u15","item":"multiplex","schema":"public","size":"1","type":"load-generator"}  materialize
-59  alter  cluster-replica  {"cluster_id":"u2","new_name":"s","old_name":"r","replica_id":"4"}  materialize
+59  alter  cluster-replica  {"cluster_id":"u2","new_name":"s","old_name":"r","replica_id":"u2"}  materialize
 60  alter  cluster  {"id":"u2","new_name":"bar","old_name":"foo"}  materialize
-61  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"bar","replica_id":"4","replica_name":"s"}  materialize
+61  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"bar","replica_id":"u2","replica_name":"s"}  materialize
 62  drop  cluster  {"id":"u2","name":"bar"}  materialize
 
 simple conn=mz_system,user=mz_system
@@ -181,11 +181,11 @@ false
 query TTTTBBBT
 SELECT internal_replica_id, cluster_name, replica_name, size, created_at IS NOT NULL, dropped_at IS NOT NULL, created_at < dropped_at, credits_per_hour FROM mz_internal.mz_cluster_replica_history ORDER BY created_at
 ----
-1  default  r1  1  true  false  NULL  1
-4  foo  r  1  true  true  true  1
-5  materialize_public_s  linked  1  true  true  true  1
-6  materialize_public_s  linked  2  true  true  true  1
-7  materialize_public_multiplex  linked  1  true  false  NULL  1
+u1  default  r1  1  true  false  NULL  1
+u2  foo  r  1  true  true  true  1
+u3  materialize_public_s  linked  1  true  true  true  1
+u4  materialize_public_s  linked  2  true  true  true  1
+u5  materialize_public_multiplex  linked  1  true  false  NULL  1
 
 simple conn=mz_system,user=mz_system
 CREATE ROLE r1;

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -179,7 +179,7 @@ SELECT occurred_at::text = '1970-01-01 00:00:00.666+00' FROM mz_audit_events ORD
 false
 
 query TTTTBBBT
-SELECT internal_replica_id, cluster_name, replica_name, size, created_at IS NOT NULL, dropped_at IS NOT NULL, created_at < dropped_at, credits_per_hour FROM mz_internal.mz_cluster_replica_history ORDER BY created_at
+SELECT replica_id, cluster_name, replica_name, size, created_at IS NOT NULL, dropped_at IS NOT NULL, created_at < dropped_at, credits_per_hour FROM mz_internal.mz_cluster_replica_history ORDER BY created_at
 ----
 u1  default  r1  1  true  false  NULL  1
 u2  foo  r  1  true  true  true  1

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -82,7 +82,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_history' ORDER BY position
 ----
-1  internal_replica_id  text
+1  replica_id  text
 2  size  text
 3  cluster_name  text
 4  replica_name  text

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -198,11 +198,11 @@ query TTT
 SELECT mz_clusters.name, mz_cluster_replicas.name, mz_cluster_replicas.id FROM mz_cluster_replicas JOIN mz_clusters ON mz_cluster_replicas.cluster_id = mz_clusters.id ORDER BY 1, 2
 ----
 default  r1  u1
-foo  r1  u5
-foo  r2  u6
-foo  r3  u7
-mz_introspection  r1  u3
-mz_system  r1  u2
+foo  r1  u3
+foo  r2  u4
+foo  r3  u5
+mz_introspection  r1  s2
+mz_system  r1  s1
 
 statement error db error: ERROR: cannot modify managed cluster foo
 DROP CLUSTER REPLICA foo.r1

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -558,13 +558,13 @@ from
   (select
         ref_0."credits_per_hour" as c0,
         ref_0."credits_per_hour" as c1,
-        ref_0."internal_replica_id" as c2,
+        ref_0."replica_id" as c2,
         ref_0."cluster_name" as c3,
         (select "id" from mz_internal.mz_scheduling_elapsed_raw limit 1 offset 57)
            as c4
       from
         mz_internal.mz_cluster_replica_history as ref_0
-      where ref_0."internal_replica_id" is NULL
+      where ref_0."replica_id" is NULL
       limit 102) as subq_0
 where (~ (select "replication_factor" from mz_catalog.mz_clusters limit 1 offset 5)
       ) <= (~ case when (case when (((((select "details" from mz_internal.mz_sink_statuses limit 1 offset 4)

--- a/test/sqllogictest/web-console.slt
+++ b/test/sqllogictest/web-console.slt
@@ -110,9 +110,9 @@ FROM mz_clusters c
 LEFT OUTER JOIN mz_cluster_replicas r ON c.id = r.cluster_id
 ORDER BY r.id
 ----
+s1 mz_system s1 r1 1
+s2 mz_introspection s2 r1 1
 u1 default u1 r1 1
-s1 mz_system u2 r1 1
-s2 mz_introspection u3 r1 1
 
 
 # ---- useClusterUtilization.ts

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -355,7 +355,7 @@ def workflow_rocksdb_cleanup(c: Composition) -> None:
             where s.name ='{source_name}'"""
         )[0]
         prefix = "/scratch"
-        cluster_prefix = f"cluster-{cluster_id}-replica-{replica_id[1:]}"
+        cluster_prefix = f"cluster-{cluster_id}-replica-{replica_id}"
         return f"{prefix}/{cluster_prefix}", f"{prefix}/{cluster_prefix}/{source_id}"
 
     # Returns the number of files recursive in a given directory


### PR DESCRIPTION
In #18376 we introduced a new replica ID format that made it possible to differentiate between user and system replicas, like with clusters. That PR only made the minimal changes required to change the format in the system tables. This PR now makes the database code use the new replica ID format everywhere. It also changes the IDs of replicas within system clusters to system IDs.

The externally visible changes from this PR are:

1. Orchestrator service names now contain `s{n}`/`u{n}` replica IDs, rather than just `{n}`.
2. The format of replica IDs in `mz_audit_events` has changed.
3. System replicas now have `s{n}` IDs, rather than `u{n}` IDs.

I expect (1) and (2) to potentially require changes to the cloud code, which is why I added the blocker below.
[Relevant Slack thread.](https://materializeinc.slack.com/archives/CL68GT3AT/p1683901234330229)

### Blockers

* [ ] Test with cloud code and adjust if necessary. 

### Motivation

  * This PR adds a known-desirable feature.

Advances #18377.

### Tips for reviewer

Look at the commits and their descriptions separately!

I think most of the changes are straightforward, except maybe the catalog migration stuff. I initially tried to write a regular migration but [found out that that is not possible](https://materializeinc.slack.com/archives/C02FWJ94HME/p1681464979565619). @parker-timmerman pointed me to https://github.com/MaterializeInc/materialize/pull/18719, in which he makes a similar change using a backwards-compatible serialized format. However, I decided to use a different approach following https://github.com/MaterializeInc/materialize/pull/18719#discussion_r1166010915. This way, we won't end up with tech debt once the non-standard migration has been removed.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
