### PR TITLE
ci: Use ci_..._heading consistently

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -39,5 +39,5 @@ ci_collapsed_heading "kind: Purging state from previous builds..."
 bin/ci-builder run stable test/cloudtest/reset
 rm -f kubectl-*.log
 
-ci_uncollapsed_heading "+++ cloudtest: Running \`bin/pytest ${run_args[*]}\`"
+ci_uncollapsed_heading "cloudtest: Running \`bin/pytest ${run_args[*]}\`"
 bin/ci-builder run stable bin/pytest "${run_args[@]}" |& tee run.log

--- a/ci/plugins/scratch-aws-access/hooks/pre-command
+++ b/ci/plugins/scratch-aws-access/hooks/pre-command
@@ -11,7 +11,9 @@
 
 set -euo pipefail
 
-echo "~~~ Assuming scratch AWS role"
+. misc/shlib/shlib.bash
+
+ci_unimportant_heading "Assuming scratch AWS role"
 
 creds=$(aws sts assume-role --role-arn "$AWS_SCRATCH_ROLE_ARN" --duration-seconds 43200 --role-session-name ci)
 


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
