### PR TITLE
pg sources: configurable TCP keepalives

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6048,6 +6048,15 @@ impl Catalog {
                 .system_config()
                 .enable_multi_worker_storage_persist_sink(),
             persist: self.persist_config(),
+            pg_replication_timeouts: mz_postgres_util::ReplicationTimeouts {
+                connect_timeout: Some(self.system_config().pg_replication_connect_timeout()),
+                keepalives_retries: Some(self.system_config().pg_replication_keepalives_retries()),
+                keepalives_idle: Some(self.system_config().pg_replication_keepalives_idle()),
+                keepalives_interval: Some(
+                    self.system_config().pg_replication_keepalives_interval(),
+                ),
+                tcp_user_timeout: Some(self.system_config().pg_replication_tcp_user_timeout()),
+            },
         }
     }
 

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -17,4 +17,13 @@ package mz_storage_client.types.parameters;
 message ProtoStorageParameters {
     mz_persist_client.cfg.ProtoPersistParameters persist = 1;
     bool enable_multi_worker_storage_persist_sink = 2;
+    ProtoPgReplicationTimeouts pg_replication_timeouts = 3;
+}
+
+message ProtoPgReplicationTimeouts {
+    optional mz_proto.ProtoDuration connect_timeout = 1;
+    optional uint32 keepalives_retries = 2;
+    optional mz_proto.ProtoDuration keepalives_idle = 3;
+    optional mz_proto.ProtoDuration keepalives_interval = 4;
+    optional mz_proto.ProtoDuration tcp_user_timeout = 5;
 }

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -29,6 +29,8 @@ pub struct DataflowParameters {
     /// implementation in storage ingestions. Is applied only
     /// when a cluster or dataflow is restarted.
     pub enable_multi_worker_storage_persist_sink: bool,
+    /// Configured PG replication timeouts,
+    pub pg_replication_timeouts: mz_postgres_util::ReplicationTimeouts,
 }
 
 /// Internal commands that can be sent by individual operators/workers that will

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -33,7 +33,7 @@ use mz_timely_util::operator::CollectionExt;
 use crate::decode::{render_decode_cdcv2, render_decode_delimited};
 use crate::render::upsert::UpsertKey;
 use crate::source::types::{DecodeResult, SourceOutput};
-use crate::source::{self, RawSourceCreationConfig};
+use crate::source::{self, RawSourceCreationConfig, SourceCreationParams};
 
 /// A type-level enum that holds one of two types of sources depending on their message type
 ///
@@ -86,6 +86,14 @@ where
 
     let connection = description.desc.connection.clone();
     let source_name = format!("{}-{}", connection.name(), id);
+
+    let params = SourceCreationParams {
+        pg_replication_timeouts: storage_state
+            .dataflow_parameters
+            .pg_replication_timeouts
+            .clone(),
+    };
+
     let base_source_config = RawSourceCreationConfig {
         name: source_name,
         id,
@@ -109,6 +117,7 @@ where
         shared_remap_upper: Rc::clone(
             &storage_state.source_uppers[&description.remap_collection_id],
         ),
+        params,
     };
 
     // TODO(petrosagg): put the description as-is in the RawSourceCreationConfig instead of cloning

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -48,7 +48,7 @@ pub mod types;
 pub use kafka::KafkaSourceReader;
 pub use postgres::PostgresSourceReader;
 pub use source_reader_pipeline::create_raw_source;
-pub use source_reader_pipeline::RawSourceCreationConfig;
+pub use source_reader_pipeline::{RawSourceCreationConfig, SourceCreationParams};
 
 /// Returns true if the given source id/worker id is responsible for handling the given
 /// partition.

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -298,7 +298,8 @@ impl SourceRender for PostgresSourceConnection {
                 .connection
                 .config(&*connection_context.secrets_reader)
                 .await
-                .expect("Postgres connection unexpectedly missing secrets");
+                .expect("Postgres connection unexpectedly missing secrets")
+                .replication_timeouts(config.params.pg_replication_timeouts);
 
             let mut source_tables = BTreeMap::new();
             let tables_iter = self.publication_details.tables.iter();

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -1025,6 +1025,14 @@ async fn produce_replication<'a>(
 
             // The inner loop
             loop {
+                use LogicalReplicationMessage::*;
+                metrics.total.inc();
+
+                // Wait no longer than `FEEDBACK_INTERVAL` on the stream; if we exceed the deadline,
+                // we should let the upstream PG source know we're still here. This also gives us an
+                // opportunity to check that it's still alive.
+                let res = tokio::time::timeout(FEEDBACK_INTERVAL, stream.as_mut().next()).await;
+
                 // The upstream will periodically request status updates by setting the keepalive's
                 // reply field to 1. However, we cannot rely on these messages arriving on time. For
                 // example, when the upstream is sending a big transaction its keepalive messages are
@@ -1036,9 +1044,7 @@ async fn produce_replication<'a>(
                 // See: https://www.postgresql.org/message-id/CAMsr+YE2dSfHVr7iEv1GSPZihitWX-PMkD9QALEGcTYa+sdsgg@mail.gmail.com
                 let mut needs_status_update = last_feedback.elapsed() > FEEDBACK_INTERVAL;
 
-                metrics.total.inc();
-                use LogicalReplicationMessage::*;
-                match stream.as_mut().next().await {
+                match res.ok().flatten() {
                     Some(Ok(XLogData(xlog_data))) => match xlog_data.data() {
                         Begin(_) => {
                             last_data_message = Instant::now();

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -127,6 +127,14 @@ pub struct RawSourceCreationConfig {
     pub source_statistics: StorageStatistics<SourceStatisticsUpdate, SourceStatisticsMetrics>,
     /// Enables reporting the remap operator's write frontier.
     pub shared_remap_upper: Rc<RefCell<Antichain<mz_repr::Timestamp>>>,
+    /// Configuration parameters, possibly from LaunchDarkly
+    pub params: SourceCreationParams,
+}
+
+#[derive(Clone)]
+pub struct SourceCreationParams {
+    /// Sets timeouts specific to PG replication streams
+    pub pg_replication_timeouts: mz_postgres_util::ReplicationTimeouts,
 }
 
 /// Creates a source dataflow operator graph from a source connection. The type of SourceConnection
@@ -519,6 +527,7 @@ where
         persist_clients,
         source_statistics: _,
         shared_remap_upper,
+        params: _,
     } = config;
 
     let chosen_worker = usize::cast_from(id.hashed() % u64::cast_from(worker_count));
@@ -673,6 +682,7 @@ where
         persist_clients: _,
         source_statistics: _,
         shared_remap_upper: _,
+        params: _,
     } = config;
 
     let bytes_read_counter = base_metrics.bytes_read.clone();

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1073,6 +1073,7 @@ impl StorageState {
                         DataflowParameters {
                             enable_multi_worker_storage_persist_sink: params
                                 .enable_multi_worker_storage_persist_sink,
+                            pg_replication_timeouts: params.pg_replication_timeouts,
                         },
                     ))
                 }

--- a/test/pg-cdc-resumption/configure-materalize.td
+++ b/test/pg-cdc-resumption/configure-materalize.td
@@ -12,7 +12,7 @@
 
 > CREATE SECRET pgpass AS 'postgres'
 > CREATE CONNECTION pg TO POSTGRES (
-    HOST postgres,
+    HOST toxiproxy,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass

--- a/test/pg-cdc-resumption/mzcompose.py
+++ b/test/pg-cdc-resumption/mzcompose.py
@@ -106,6 +106,7 @@ def disconnect_pg_during_replication(c: Composition) -> None:
         "delete-rows-t2.td",
         "alter-table.td",
         "toxiproxy-close-connection.td",
+        "validate-toxiproxy-disco.td",
         "toxiproxy-restore-connection.td",
     )
 

--- a/test/pg-cdc-resumption/toxiproxy-close-connection.td
+++ b/test/pg-cdc-resumption/toxiproxy-close-connection.td
@@ -13,8 +13,8 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies/postgres/toxics content-type=application/json
 {
   "name": "postgres",
-  "type": "limit_data",
-  "attributes": { "bytes": 65535 }
+  "type": "timeout",
+  "timeout": 0
 }
 
 > SELECT mz_internal.mz_sleep(5);

--- a/test/pg-cdc-resumption/validate-toxiproxy-disco.td
+++ b/test/pg-cdc-resumption/validate-toxiproxy-disco.td
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT DISTINCT error FROM mz_internal.mz_source_statuses;
+"connection closed"


### PR DESCRIPTION
Based on https://github.com/MaterializeInc/materialize/issues/17598#issuecomment-1498500020, we want to add TCP keepalives to notice when the connection has failed more eagerly than we were before.

@pH14 could you PTAL?

@MaterializeInc/qa Is there an existing pattern for only running `mzcompose` tests only on nightly? Glad to make a pattern but assumed there was something that I just couldn't find, so didn't want to make something needlessly duplicative.

### Motivation

This PR adds a known-desirable feature. https://github.com/MaterializeInc/materialize/issues/17598#issuecomment-1498500020

Note that this PR also fixes a bug; `pg-cdc-resumption` was not previously using the toxiproxy connection whatsoever, so was not successfully testing that we were resilient to interruption. Ran locally and it worked still, but this should likely get fixed quickly––will break this off into its own PR if things drag.

### Tips for reviewer

Note that these new tests only test the previous timeout setting and do not meaningfully test the TCP keepalives; this is moreso just substantiating that we have, in fact, experienced a network interruption where we previously were not.

I am not marking this as draft because it improves our situation here, but maybe it could be even more improved.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
