### PR TITLE
persist: impl PersistSourceDataStats for all ScalarTypes

### DIFF
--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -53,7 +53,7 @@ use std::fmt::Debug;
 use crate::codec_impls::UnitSchema;
 use crate::columnar::sealed::ColumnRef;
 use crate::part::{ColumnsMut, ColumnsRef, PartBuilder};
-use crate::stats::{DynStats, StatsFn};
+use crate::stats::{ColumnStats, StatsFn};
 use crate::Codec;
 
 /// A type understood by persist.
@@ -92,7 +92,7 @@ pub trait Data: Debug + Send + Sync + Sized + 'static {
     type Mut: ColumnPush<Self> + Default;
 
     /// The statistics type of columns of this type of data.
-    type Stats: DynStats + for<'a> From<&'a Self::Col>;
+    type Stats: ColumnStats<Self> + for<'a> From<&'a Self::Col>;
 }
 
 /// A type that may be retrieved from a column of `[T]`.

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -115,7 +115,9 @@ pub use crate::relation::{
     ColumnName, ColumnType, NotNullViolation, ProtoColumnName, ProtoColumnType, ProtoRelationDesc,
     ProtoRelationType, RelationDesc, RelationType,
 };
-pub use crate::row::encoding::{DatumDecoderT, DatumEncoderT, RowDecoder, RowEncoder};
+pub use crate::row::encoding::{
+    DatumDecoderT, DatumEncoderT, DatumToPersist, DatumToPersistFn, RowDecoder, RowEncoder,
+};
 pub use crate::row::{
     datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, ProtoRow, Row,
     RowArena, RowPacker, RowRef,

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -9,7 +9,7 @@
 
 use std::borrow::Borrow;
 
-use mz_persist_types::columnar::Data;
+use mz_persist_types::columnar::{ColumnGet, Data};
 use mz_persist_types::stats::{JsonStats, PrimitiveStats};
 use prost::Message;
 
@@ -95,7 +95,7 @@ pub(crate) fn proto_datum_min_max_nulls(col: &<Vec<u8> as Data>::Col) -> (Vec<u8
 
     let mut buf = Row::default();
     for idx in 0..col.len() {
-        ProtoDatumToPersist::decode(col, idx, &mut buf.packer());
+        ProtoDatumToPersist::decode(ColumnGet::<Vec<u8>>::get(col, idx), &mut buf.packer());
         let datum = as_optional_datum(&buf).expect("not enough datums");
         if datum == Datum::Null {
             null_count += 1;
@@ -127,7 +127,7 @@ pub(crate) fn jsonb_stats_nulls(
 
     let mut buf = Row::default();
     for idx in 0..col.len() {
-        ProtoDatumToPersist::decode(col, idx, &mut buf.packer());
+        ProtoDatumToPersist::decode(ColumnGet::<Vec<u8>>::get(col, idx), &mut buf.packer());
         let datum = as_optional_datum(&buf).expect("not enough datums");
         // Datum::Null only shows up at the top level of Jsonb, so we handle it
         // here instead of in the recursing function.


### PR DESCRIPTION
Do this by introducing a `ColumnStats` trait that allows pulling out a lower and upper using `T::Ref` (also a none_count).

Schemaless Jsonb is more complicated because we potentially want to retrieve stats for some `->` operation.

Touches #12684

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
