### PR TITLE
adapter: peek refactor

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -275,6 +275,51 @@ impl RealTimeRecencyContext {
     }
 }
 
+#[derive(Debug)]
+pub enum PeekStage {
+    Validate(PeekStageValidate),
+    Timestamp(PeekStageTimestamp),
+    Finish(PeekStageFinish),
+}
+
+#[derive(Debug)]
+pub struct PeekStageValidate {
+    pub plan: mz_sql::plan::PeekPlan,
+}
+
+#[derive(Debug)]
+pub struct PeekStageTimestamp {
+    source: MirRelationExpr,
+    finishing: RowSetFinishing,
+    copy_to: Option<CopyFormat>,
+    view_id: GlobalId,
+    index_id: GlobalId,
+    source_ids: BTreeSet<GlobalId>,
+    cluster_id: ClusterId,
+    id_bundle: CollectionIdBundle,
+    when: QueryWhen,
+    target_replica: Option<ReplicaId>,
+    timeline_context: TimelineContext,
+    in_immediate_multi_stmt_txn: bool,
+}
+
+#[derive(Debug)]
+pub struct PeekStageFinish {
+    pub finishing: RowSetFinishing,
+    pub copy_to: Option<CopyFormat>,
+    pub source: MirRelationExpr,
+    pub cluster_id: ClusterId,
+    pub when: QueryWhen,
+    pub target_replica: Option<ReplicaId>,
+    pub view_id: GlobalId,
+    pub index_id: GlobalId,
+    pub timeline_context: TimelineContext,
+    pub source_ids: BTreeSet<GlobalId>,
+    pub id_bundle: CollectionIdBundle,
+    pub in_immediate_multi_stmt_txn: bool,
+    pub real_time_recency_ts: Option<mz_repr::Timestamp>,
+}
+
 /// Configures a coordinator.
 pub struct Config {
     pub dataflow_client: mz_controller::Controller,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1275,6 +1275,13 @@ impl Coordinator {
     fn catalog_and_controller_mut(&mut self) -> (&mut Catalog, &mut mz_controller::Controller) {
         (Arc::make_mut(&mut self.catalog), &mut self.controller)
     }
+
+    /// Publishes a notice message to all sessions.
+    pub(crate) fn broadcast_notice(&mut self, notice: AdapterNotice) {
+        for meta in self.active_conns.values() {
+            let _ = meta.notice_tx.send(notice.clone());
+        }
+    }
 }
 
 /// Serves the coordinator based on the provided configuration.

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -40,7 +40,7 @@ use mz_repr::{Diff, GlobalId, RelationType, Row};
 use crate::client::ConnectionId;
 use crate::coord::timestamp_selection::TimestampContext;
 use crate::util::{send_immediate_rows, ResultExt};
-use crate::{AdapterError, AdapterNotice};
+use crate::AdapterError;
 
 use super::id_bundle::CollectionIdBundle;
 
@@ -552,13 +552,6 @@ impl crate::coord::Coordinator {
             }
         }
         pending_peek
-    }
-
-    /// Publishes a notice message to all sessions.
-    pub(crate) fn broadcast_notice(&mut self, notice: AdapterNotice) {
-        for meta in self.active_conns.values() {
-            let _ = meta.notice_tx.send(notice.clone());
-        }
     }
 }
 


### PR DESCRIPTION
Move code around, no functional changes. See commits.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a