### PR TITLE
persist: introduce filter pushdown audit

### DIFF
--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -38,7 +38,7 @@ differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-
 futures = "0.3.25"
 futures-util = "0.3"
 mz-build-info = { path = "../build-info" }
-mz-ore = { path = "../ore", features = ["bytes_", "tracing_"] }
+mz-ore = { path = "../ore", features = ["bytes_", "test", "tracing_"] }
 mz-persist = { path = "../persist" }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -729,6 +729,7 @@ where
             stats: part.stats,
             encoded_size_bytes: part.encoded_size_bytes,
             leased_seqno: Some(self.lease_seqno()),
+            filter_pushdown_audit: false,
         })
     }
 


### PR DESCRIPTION
This is a way to verify the ongoing end-to-end correctness of filter pushdown via "audit". When the filter rejects a part as completely unnecessary, we sometimes mark it with an audit bit. This means we fetch the part like normal and if the MFP keeps anything from it, then something has gone horribly wrong.

Touches #12684

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

I manually tested this with bin/environmentd and a bug in the impl of should_fetch

```diff
diff --git a/src/storage-client/src/source/persist_source.rs b/src/storage-client/src/source/persist_source.rs
index f518cd5bb..b8164dae7 100644
--- a/src/storage-client/src/source/persist_source.rs
+++ b/src/storage-client/src/source/persist_source.rs
@@ -140,7 +140,7 @@ where
         move |stats| {
             mfp_pushdown.as_ref().map_or(true, |x| {
                 x.should_fetch(&PersistSourceDataStatsImpl { desc: &desc, stats })
-            })
+            }) && false
         },
     );
     let rows = decode_and_mfp(&fetched, &name, until, map_filter_project, yield_fn);
```

```
thread 'timely:work-0' panicked at 'persist filter pushdown correctness violation! u1 val=Ok((Row{[String("b"), UInt64(3), String("c")]}, 1680806140498, 1)) mfp=Some(MfpPlan { mfp: SafeMfpPlan { mfp: MapFilterProject { expressions: [], predicates: [(2, CallBinary { func: Gt, expr1: CallUnary { func: CastUint64ToNumeric(CastUint64ToNumeric(None)), expr: Column(1) }, expr2: Literal(Ok(Row{[Numeric(OrderedDecimal(2))]}), ColumnType { scalar_type: Numeric { max_scale: None }, nullable: false }) })], projection: [0, 1, 2], input_arity: 3 } }, lower_bounds: [], upper_bounds: [] })', ...
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
