### PR TITLE
Update design document instructions

### DIFF
--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -52,6 +52,7 @@ Err on the side of writing a design document.
 
 ## Creation
 1. Copy the [template](./00000000_template.md) to a new date-prefixed file in `doc/developer/design` and fill it in.
+   The template contains a skeleton that you can use as a guideline to write the design document, but it is fine to diverge from the structure.
 2. Submit a pull request---this makes it easy for others to add written comments.
 3. Announce that the design doc is ready for review in #eng-announce.
 
@@ -60,13 +61,18 @@ Err on the side of writing a design document.
 5. Gather explicit approvals from relevant stakeholders.
    Typically, there is a small set of people who have a vested interest in the area the design touches.
    If it's not clear who that is, ask a TL, EM, or in #eng-general.
-6. Keep the design doc open while working on the feature and keep it updated as you're refining the design.
 
 ## Finalization
 6. Announce the intent to close commenting on the design document in #eng-announce.
    Tag people that should be aware of the design and ask for their feedback.
 7. Allow two business days for any final comments.
 8. If no comments have raised new issues or if no one has asked for additional time to review, merge the design document.
+
+# Maintaining a design document
+
+Design documents capture a moment in time and thus should not receive regular updates such as documentation.
+Therefore, it represents the current agreed on state, or the state once the feature's work is complete.
+We recommend updating the design as part of implementation changes, to keep both in sync.
 
 # How should you push back on aspects of a design document?
 


### PR DESCRIPTION
This changes the following:
* Drop the instruction to keep the design doc PR open while the feature is under development. This allows us to merge design docs before the feature work is complete to capture approvals early on.
* Mention that the template is a recommendation and not a hard requirement.
* Add a section on how to maintain a design document, i.e., capture points in time, and update as the feature work progresses, but don't expect updates after landing the feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
