### PR TITLE
adapter: Refactor cascading delete statements

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -501,7 +501,12 @@ impl Coordinator {
             Err(e) => {
                 // Drop the placeholder sink if still present.
                 if self.catalog().try_get_entry(&id).is_some() {
-                    let ops = self.catalog().drop_items_ops(&[id], &mut BTreeSet::new());
+                    let ops = self
+                        .catalog()
+                        .item_dependents(id)
+                        .into_iter()
+                        .map(catalog::Op::DropObject)
+                        .collect();
                     self.catalog_transact(
                         session_and_tx.as_ref().map(|(ref session, _tx)| session),
                         ops,

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -89,11 +89,6 @@ pub enum AdapterError {
     },
     /// The selection value for a table mutation operation refers to an invalid object.
     InvalidTableMutationSelection,
-    /// An operation attempted to modify a linked cluster.
-    ModifyLinkedCluster {
-        cluster_name: String,
-        linked_object_name: String,
-    },
     /// An operation attempted to create an illegal item in a
     /// storage-only cluster
     BadItemInStorageCluster {
@@ -345,9 +340,6 @@ impl fmt::Display for AdapterError {
                     "cannot use wildcard expansions or NATURAL JOINs in a view that depends on \
                     system objects"
                 )
-            }
-            AdapterError::ModifyLinkedCluster { cluster_name, .. } => {
-                write!(f, "cannot modify linked cluster {}", cluster_name.quoted())
             }
             AdapterError::ChangedPlan => f.write_str("cached plan must not change result type"),
             AdapterError::Catalog(e) => e.fmt(f),

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -319,7 +319,6 @@ impl ErrorResponse {
             AdapterError::BadItemInStorageCluster { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::Catalog(_) => SqlState::INTERNAL_ERROR,
             AdapterError::ChangedPlan => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::ModifyLinkedCluster { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::DuplicateCursor(_) => SqlState::DUPLICATE_CURSOR,
             AdapterError::Eval(EvalError::CharacterNotValidForEncoding(_)) => {
                 SqlState::PROGRAM_LIMIT_EXCEEDED

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3264,8 +3264,8 @@ impl<'a> Parser<'a> {
                 );
                 Ok(Statement::DropObjects(DropObjectsStatement {
                     object_type: ObjectType::Schema,
-                    names: vec![name],
                     if_exists,
+                    names: vec![name],
                     cascade,
                 }))
             }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -141,6 +141,9 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// Returns true if `schema` is an internal system schema, false otherwise
     fn is_system_schema(&self, schema: &str) -> bool;
 
+    /// Returns true if `schema` is an internal system schema, false otherwise
+    fn is_system_schema_specifier(&self, schema: &SchemaSpecifier) -> bool;
+
     /// Resolves the named role.
     fn resolve_role(&self, role_name: &str) -> Result<&dyn CatalogRole, CatalogError>;
 
@@ -241,6 +244,20 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
 
     /// Returns the [`RoleId`] of the owner of an object by its ID.
     fn get_owner_id(&self, id: &ObjectId) -> Option<RoleId>;
+
+    /// Returns all the IDs of all objects that depend on `ids`, including `ids` themselves.
+    ///
+    /// The order is guaranteed to be in reverse dependency order, i.e. the leafs will appear
+    /// earlier in the list than the roots. This is particularly userful for the order to drop
+    /// objects.
+    fn object_dependents(&self, ids: Vec<ObjectId>) -> Vec<ObjectId>;
+
+    /// Returns all the IDs of all objects that depend on `id`, including `id` themselves.
+    ///
+    /// The order is guaranteed to be in reverse dependency order, i.e. the leafs will appear
+    /// earlier in the list than `id`. This is particularly userful for the order to drop
+    /// objects.
+    fn item_dependents(&self, id: GlobalId) -> Vec<ObjectId>;
 }
 
 /// Configuration associated with a catalog.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -517,8 +517,8 @@ pub struct CreateTablePlan {
 pub struct CreateViewPlan {
     pub name: QualifiedItemName,
     pub view: View,
-    /// The ID of the object that this view is replacing, if any.
-    pub replace: Option<GlobalId>,
+    /// The IDs of the objects that this view is replacing, if any.
+    pub replace: Vec<GlobalId>,
     pub if_not_exists: bool,
     /// True if the view contains an expression that can make the exact column list
     /// ambiguous. For example `NATURAL JOIN` or `SELECT *`.
@@ -529,8 +529,8 @@ pub struct CreateViewPlan {
 pub struct CreateMaterializedViewPlan {
     pub name: QualifiedItemName,
     pub materialized_view: MaterializedView,
-    /// The ID of the object that this view is replacing, if any.
-    pub replace: Option<GlobalId>,
+    /// The IDs of the objects that this view is replacing, if any.
+    pub replace: Vec<GlobalId>,
     pub if_not_exists: bool,
     /// True if the materialized view contains an expression that can make the exact column list
     /// ambiguous. For example `NATURAL JOIN` or `SELECT *`.

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -150,6 +150,10 @@ pub enum PlanError {
         name: String,
         item_type: CatalogItemType,
     },
+    ModifyLinkedCluster {
+        cluster_name: String,
+        linked_object_name: String,
+    },
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -396,6 +400,7 @@ impl fmt::Display for PlanError {
             Self::InvalidPrivatelinkAvailabilityZone { name, ..} => write!(f, "invalid AWS PrivateLink availability zone {}", name.quoted()),
             Self::InvalidSchemaName => write!(f, "no schema has been selected to create in"),
             Self::ItemAlreadyExists { name, item_type } => write!(f, "{item_type} {} already exists", name.quoted()),
+            Self::ModifyLinkedCluster {cluster_name, ..} => write!(f, "cannot modify linked cluster {}", cluster_name.quoted()),
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2796,13 +2796,13 @@ pub fn plan_create_cluster_replica(
     }: CreateClusterReplicaStatement<Aug>,
 ) -> Result<Plan, PlanError> {
     let cluster = scx.catalog.resolve_cluster(Some(&of_cluster.to_string()))?;
-    ensure_cluster_is_not_linked(scx, cluster.id())?;
     if is_storage_cluster(scx, cluster)
         && cluster.bound_objects().len() > 0
         && cluster.replicas().len() > 0
     {
         sql_bail!("cannot create more than one replica of a cluster containing sources or sinks");
     }
+    ensure_cluster_is_not_linked(scx, cluster.id())?;
     Ok(Plan::CreateClusterReplica(CreateClusterReplicaPlan {
         name: normalize::ident(name),
         cluster_id: cluster.id(),

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -697,7 +697,7 @@ SELECT mz_roles.name
 ----
 joe
 
-statement error must be owner of DATABASE jdb
+statement error must be owner of SCHEMA jdb.public, DATABASE jdb
 DROP DATABASE jdb
 
 statement error must be owner of DATABASE jdb
@@ -830,7 +830,7 @@ SELECT mz_roles.name
 ----
 joe
 
-statement error must be owner of CLUSTER jclus
+statement error must be owner of CLUSTER REPLICA jclus.jr1, CLUSTER jclus
 DROP CLUSTER jclus
 
 statement error must be owner of CLUSTER jclus
@@ -1280,6 +1280,76 @@ simple conn=mz_system,user=mz_system
 ALTER TABLE t OWNER TO group2;
 ----
 COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP TABLE t;
+----
+COMPLETE 0
+
+# Test that ownership is checked with cascading deletes
+
+statement ok
+CREATE TABLE t (a INT);
+
+simple conn=joe,user=joe
+CREATE VIEW v AS SELECT * FROM t;
+----
+COMPLETE 0
+
+statement error must be owner of VIEW materialize.public.v
+DROP TABLE t CASCADE;
+
+simple conn=mz_system,user=mz_system
+ALTER VIEW v OWNER TO materialize;
+----
+COMPLETE 0
+
+statement ok
+DROP TABLE t CASCADE;
+
+statement ok
+CREATE VIEW v AS SELECT 1 AS a;
+
+simple conn=joe,user=joe
+CREATE INDEX i ON v(a);
+----
+COMPLETE 0
+
+statement error must be owner of INDEX materialize.public.i
+CREATE OR REPLACE VIEW v AS SELECT 2 AS a;
+
+simple conn=mz_system,user=mz_system
+ALTER INDEX i OWNER TO materialize;
+----
+COMPLETE 0
+
+statement ok
+CREATE OR REPLACE VIEW v AS SELECT 2 AS a;
+
+statement ok
+DROP VIEW v;
+
+statement ok
+CREATE MATERIALIZED VIEW mv AS SELECT 1 AS a;
+
+simple conn=joe,user=joe
+CREATE INDEX i ON mv(a);
+----
+COMPLETE 0
+
+statement error must be owner of INDEX materialize.public.i
+CREATE OR REPLACE MATERIALIZED VIEW mv AS SELECT 2 AS a;
+
+simple conn=mz_system,user=mz_system
+ALTER INDEX i OWNER TO materialize;
+----
+COMPLETE 0
+
+statement ok
+CREATE OR REPLACE MATERIALIZED VIEW mv AS SELECT 2 AS a;
+
+statement ok
+DROP MATERIALIZED VIEW mv;
 
 # Disable rbac checks.
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
Previously, the adapter would collect all the IDs of objects to delete as part of a cascading delete during sequencing. This commit refactors this logic so the IDs are collected during planning. This allows us to include those IDs as part of RBAC checks.

Additionally, we had to move the validation that no user was directly modifying a linked cluster to the planner.

Fixes #18551

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
