### PR TITLE
storage: consolidate how we handle kafka errors

### DIFF
--- a/src/storage-client/src/sink.rs
+++ b/src/storage-client/src/sink.rs
@@ -14,7 +14,7 @@ use anyhow::{anyhow, Context};
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, ResourceSpecifier, TopicReplication};
 use rdkafka::ClientContext;
 
-use mz_kafka_util::client::MzClientContext;
+use mz_kafka_util::client::{MzClientContext, DEFAULT_FETCH_METADATA_TIMEOUT};
 use mz_ore::collections::CollectionExt;
 
 use crate::types::connections::ConnectionContext;
@@ -53,7 +53,7 @@ where
     if partition_count == -1 || replication_factor == -1 {
         let metadata = client
             .inner()
-            .fetch_metadata(None, Duration::from_secs(5))
+            .fetch_metadata(None, DEFAULT_FETCH_METADATA_TIMEOUT)
             .with_context(|| {
                 format!(
                     "error fetching metadata when creating new topic {} for sink",

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -31,10 +31,10 @@ def test_secrets(mz: MaterializeApplication) -> None:
               );
 
             # Our Redpanda instance is not configured for SASL, so we can not
-            # really establish a successful connection. Hence the expectation for an SSL error
+            # really establish a successful connection.
             ! CREATE SOURCE secrets_source
               FROM KAFKA CONNECTION secrets_conn (TOPIC 'foo_bar');
-            contains: SSL handshake failed
+            contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
             """
         )
     )

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -79,4 +79,4 @@ $ kafka-verify-data format=avro sink=materialize.public.data_snk sort-messages=t
 ! CREATE SOURCE connector_source
   FROM KAFKA CONNECTION kafka_sasl_no_ca (TOPIC 'testdrive-data-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_sasl
-contains: broker certificate could not be verified
+contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -150,4 +150,4 @@ a
   FROM KAFKA CONNECTION kafka_sasl_no_ca (TOPIC 'testdrive-data-${testdrive.seed}')
     FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl_no_ca
-contains: broker certificate could not be verified
+contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)

--- a/test/testdrive/kafka-source-errors.td
+++ b/test/testdrive/kafka-source-errors.td
@@ -32,7 +32,7 @@ contains:KAFKA CONNECTION without TOPIC
 
 ! CREATE SOURCE fawlty_broker_source
   FROM KAFKA CONNECTION fawlty_kafka_conn (TOPIC 'testdrive-fawlty-broker-source-${testdrive.seed}')
-contains: non-existent-broker:9092
+contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
 
 > CREATE CONNECTION IF NOT EXISTS fawlty_csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL 'http://non-existent-csr:8081'

--- a/test/testdrive/kafka-time-offset.td
+++ b/test/testdrive/kafka-time-offset.td
@@ -27,7 +27,7 @@ $ kafka-create-topic topic=t0
   FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1, TOPIC 'missing_topic')
   FORMAT TEXT
   INCLUDE OFFSET
-contains:topic missing_topic does not exist
+contains:UnknownTopicOrPartition (Broker: Unknown topic or partition)
 
 ! CREATE SOURCE pick_one
   FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1, START OFFSET=[1], TOPIC 'testdrive-t0-${testdrive.seed}')


### PR DESCRIPTION
Broken out of https://github.com/MaterializeInc/materialize/pull/18616

part of https://github.com/MaterializeInc/materialize/issues/18490

### Motivation

   * This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

