### PR TITLE
doc/user: add 3xsmall option to CREATE CLUSTER REPLICA

### DIFF
--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -60,6 +60,7 @@ the [`select * from mz_cluster_replicas`](/sql/system-catalog/mz_catalog/#mz_clu
 
 Valid `size` options are:
 
+- `3xsmall`
 - `2xsmall`
 - `xsmall`
 - `small`


### PR DESCRIPTION
Post cluster unification, the `3xsmall` option became available for cluster replicas, rather than just sources and sinks. Add the missing documentation.

### Motivation

  * This PR fixes a previously unreported docs bug. (h/t @RobinClowers)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
