### PR TITLE
adapter: move peeks optimization off coordinator thread

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -78,6 +78,7 @@ use derivative::Derivative;
 use fail::fail_point;
 use futures::StreamExt;
 use itertools::Itertools;
+use mz_compute_client::types::dataflows::DataflowDescription;
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, watch, OwnedMutexGuard};
@@ -87,7 +88,7 @@ use uuid::Uuid;
 use mz_build_info::BuildInfo;
 use mz_cloud_resources::{CloudResourceController, VpcEndpointConfig};
 use mz_controller::clusters::{ClusterConfig, ClusterEvent, ClusterId, ReplicaId};
-use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr, RowSetFinishing};
+use mz_expr::{MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_orchestrator::ServiceProcessMetrics;
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
@@ -99,7 +100,7 @@ use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{stack, task};
 use mz_persist_client::usage::{ShardsUsage, StorageUsageClient};
 use mz_repr::explain::ExplainFormat;
-use mz_repr::{Datum, GlobalId, Row, Timestamp};
+use mz_repr::{Datum, GlobalId, RelationType, Row, Timestamp};
 use mz_secrets::SecretsController;
 use mz_sql::ast::{CreateSourceStatement, CreateSubsourceStatement, Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
@@ -249,9 +250,9 @@ pub enum RealTimeRecencyContext {
     },
     Peek {
         tx: ClientTransmitter<ExecuteResponse>,
+        dataflow: DataflowDescription<OptimizedMirRelationExpr>,
         finishing: RowSetFinishing,
         copy_to: Option<CopyFormat>,
-        source: MirRelationExpr,
         session: Session,
         cluster_id: ClusterId,
         when: QueryWhen,
@@ -262,6 +263,8 @@ pub enum RealTimeRecencyContext {
         source_ids: BTreeSet<GlobalId>,
         id_bundle: CollectionIdBundle,
         in_immediate_multi_stmt_txn: bool,
+        key: Vec<MirScalarExpr>,
+        typ: RelationType,
     },
 }
 
@@ -277,6 +280,7 @@ impl RealTimeRecencyContext {
 #[derive(Debug)]
 pub enum PeekStage {
     Validate(PeekStageValidate),
+    Optimize(PeekStageOptimize),
     Timestamp(PeekStageTimestamp),
     Finish(PeekStageFinish),
 }
@@ -287,7 +291,7 @@ pub struct PeekStageValidate {
 }
 
 #[derive(Debug)]
-pub struct PeekStageTimestamp {
+pub struct PeekStageOptimize {
     source: MirRelationExpr,
     finishing: RowSetFinishing,
     copy_to: Option<CopyFormat>,
@@ -303,10 +307,28 @@ pub struct PeekStageTimestamp {
 }
 
 #[derive(Debug)]
+pub struct PeekStageTimestamp {
+    dataflow: DataflowDescription<OptimizedMirRelationExpr>,
+    finishing: RowSetFinishing,
+    copy_to: Option<CopyFormat>,
+    view_id: GlobalId,
+    index_id: GlobalId,
+    source_ids: BTreeSet<GlobalId>,
+    cluster_id: ClusterId,
+    id_bundle: CollectionIdBundle,
+    when: QueryWhen,
+    target_replica: Option<ReplicaId>,
+    timeline_context: TimelineContext,
+    in_immediate_multi_stmt_txn: bool,
+    key: Vec<MirScalarExpr>,
+    typ: RelationType,
+}
+
+#[derive(Debug)]
 pub struct PeekStageFinish {
+    pub dataflow: DataflowDescription<OptimizedMirRelationExpr>,
     pub finishing: RowSetFinishing,
     pub copy_to: Option<CopyFormat>,
-    pub source: MirRelationExpr,
     pub cluster_id: ClusterId,
     pub when: QueryWhen,
     pub target_replica: Option<ReplicaId>,
@@ -317,6 +339,8 @@ pub struct PeekStageFinish {
     pub id_bundle: CollectionIdBundle,
     pub in_immediate_multi_stmt_txn: bool,
     pub real_time_recency_ts: Option<mz_repr::Timestamp>,
+    pub key: Vec<MirScalarExpr>,
+    pub typ: RelationType,
 }
 
 /// Configures a coordinator.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -206,6 +206,11 @@ pub enum Message<T = mz_repr::Timestamp> {
         transient_revision: u64,
         real_time_recency_ts: Timestamp,
     },
+    PeekStageReady {
+        tx: ClientTransmitter<ExecuteResponse>,
+        session: Session,
+        stage: PeekStage,
+    },
 }
 
 #[derive(Derivative)]

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -83,11 +83,7 @@ impl Coordinator {
             .compute
             .instance_snapshot(instance)
             .expect("compute instance does not exist");
-        DataflowBuilder {
-            catalog: self.catalog().state(),
-            compute,
-            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
-        }
+        DataflowBuilder::new(self.catalog().state(), compute)
     }
 
     /// Finalizes a dataflow and then broadcasts it to all workers.
@@ -271,15 +267,19 @@ impl CatalogTxn<'_, mz_repr::Timestamp> {
             .compute
             .instance_snapshot(instance)
             .expect("compute instance does not exist");
-        DataflowBuilder {
-            catalog: self.catalog,
-            compute,
-            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
-        }
+        DataflowBuilder::new(self.catalog, compute)
     }
 }
 
 impl<'a> DataflowBuilder<'a> {
+    pub fn new(catalog: &'a CatalogState, compute: ComputeInstanceSnapshot) -> Self {
+        Self {
+            catalog,
+            compute,
+            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
+        }
+    }
+
     /// Imports the view, source, or table with `id` into the provided
     /// dataflow description.
     fn import_into_dataflow(

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -692,9 +692,9 @@ impl Coordinator {
             ),
             RealTimeRecencyContext::Peek {
                 tx,
+                dataflow,
                 finishing,
                 copy_to,
-                source,
                 session,
                 cluster_id,
                 when,
@@ -705,14 +705,16 @@ impl Coordinator {
                 source_ids,
                 id_bundle,
                 in_immediate_multi_stmt_txn,
+                key,
+                typ,
             } => {
                 self.sequence_peek_stage(
                     tx,
                     session,
                     PeekStage::Finish(PeekStageFinish {
+                        dataflow,
                         finishing,
                         copy_to,
-                        source,
                         cluster_id,
                         when,
                         target_replica,
@@ -723,6 +725,8 @@ impl Coordinator {
                         id_bundle,
                         in_immediate_multi_stmt_txn,
                         real_time_recency_ts: Some(real_time_recency_ts),
+                        key,
+                        typ,
                     }),
                 )
                 .await;

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -99,6 +99,9 @@ impl Coordinator {
                 )
                 .await;
             }
+            Message::PeekStageReady { tx, session, stage } => {
+                self.sequence_peek_stage(tx, session, stage).await;
+            }
         }
     }
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -216,6 +216,17 @@ impl<T> ComputeController<T> {
         })
     }
 
+    /// Return a reference-less snapshot to the indicated compute instance.
+    pub fn instance_snapshot(
+        &self,
+        id: ComputeInstanceId,
+    ) -> Result<ComputeInstanceSnapshot, InstanceMissing> {
+        self.instance(id).map(|instance| ComputeInstanceSnapshot {
+            instance_id: id,
+            collections: BTreeSet::from_iter(instance.collections_iter().map(|(id, _state)| *id)),
+        })
+    }
+
     /// Return a read-only handle to the indicated collection.
     pub fn collection(
         &self,
@@ -634,6 +645,25 @@ impl<T> ComputeInstanceRef<'_, T> {
     /// Return a read-only handle to the indicated collection.
     pub fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, CollectionMissing> {
         self.instance.collection(id)
+    }
+}
+
+/// A reference-less snapshot of a compute instance.
+#[derive(Debug, Clone)]
+pub struct ComputeInstanceSnapshot {
+    instance_id: ComputeInstanceId,
+    collections: BTreeSet<GlobalId>,
+}
+
+impl ComputeInstanceSnapshot {
+    /// Return the ID of this compute instance.
+    pub fn instance_id(&self) -> ComputeInstanceId {
+        self.instance_id
+    }
+
+    /// Reports whether the instance contains the indicated collection.
+    pub fn contains_collection(&self, id: &GlobalId) -> bool {
+        self.collections.contains(id)
     }
 }
 


### PR DESCRIPTION
Remove all references and self access from the optimization phase so it can be moved to another task.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
