### PR TITLE
platform checks: Fix the UpgradeEntireMzFourVersions scenario

### DIFF
--- a/misc/python/materialize/checks/alter_index.py
+++ b/misc/python/materialize/checks/alter_index.py
@@ -75,7 +75,7 @@ class AlterIndex(Check):
                 ALTER INDEX alter_index_table_primary_idx OWNER TO materialize;
                 ALTER INDEX alter_index_source_primary_idx OWNER TO materialize;
                 """
-            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            if self.base_version >= MzVersion.parse("0.47.0")
             else ""
         )
         return [

--- a/misc/python/materialize/checks/databases.py
+++ b/misc/python/materialize/checks/databases.py
@@ -76,7 +76,7 @@ class CheckDatabaseDrop(Check):
                 $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
                 ALTER DATABASE to_be_dropped OWNER TO materialize;
                 """
-            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            if self.base_version >= MzVersion.parse("0.47.0")
             else ""
         )
 

--- a/misc/python/materialize/checks/drop_index.py
+++ b/misc/python/materialize/checks/drop_index.py
@@ -40,7 +40,7 @@ class DropIndex(Check):
                 ALTER INDEX drop_index_table_primary_idx OWNER TO materialize;
                 ALTER INDEX drop_index_index2 OWNER TO materialize;
                 """
-            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            if self.base_version >= MzVersion.parse("0.47.0")
             else ""
         )
 

--- a/misc/python/materialize/checks/drop_table.py
+++ b/misc/python/materialize/checks/drop_table.py
@@ -37,7 +37,7 @@ class DropTable(Check):
                 $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
                 ALTER TABLE drop_table2 OWNER TO materialize;
                 """
-            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            if self.base_version >= MzVersion.parse("0.47.0")
             else ""
         )
 

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -84,7 +84,7 @@ class ConfigureMz(MzcomposeAction):
             """
         )
 
-        if self.base_version >= MzVersion(0, 46, 0):
+        if self.base_version >= MzVersion(0, 47, 0):
             input += "ALTER SYSTEM SET enable_rbac_checks TO true;\n"
 
         self.handle = e.testdrive(input=input)

--- a/misc/python/materialize/checks/rename_index.py
+++ b/misc/python/materialize/checks/rename_index.py
@@ -37,7 +37,7 @@ class RenameIndex(Check):
                 ALTER INDEX rename_index_index1 OWNER TO materialize;
                 ALTER INDEX rename_index_index2 OWNER TO materialize;
                 """
-            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            if self.base_version >= MzVersion.parse("0.47.0")
             else ""
         )
 

--- a/misc/python/materialize/checks/rename_source.py
+++ b/misc/python/materialize/checks/rename_source.py
@@ -67,7 +67,7 @@ class RenameSource(Check):
                 $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
                 ALTER SOURCE rename_source2 OWNER TO materialize;
                 """
-            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            if self.base_version >= MzVersion.parse("0.47.0")
             else ""
         )
 

--- a/misc/python/materialize/checks/rename_table.py
+++ b/misc/python/materialize/checks/rename_table.py
@@ -35,7 +35,7 @@ class RenameTable(Check):
                 $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
                 ALTER TABLE rename_table2 OWNER TO materialize;
                 """
-            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            if self.base_version >= MzVersion.parse("0.47.0")
             else ""
         )
 

--- a/misc/python/materialize/checks/rename_view.py
+++ b/misc/python/materialize/checks/rename_view.py
@@ -37,7 +37,7 @@ class RenameView(Check):
                 ALTER VIEW rename_view_viewB2 OWNER TO materialize;
                 ALTER VIEW rename_view_viewA2 OWNER TO materialize;
                 """
-            if self.base_version >= MzVersion.parse("0.46.0-dev")
+            if self.base_version >= MzVersion.parse("0.47.0")
             else ""
         )
 


### PR DESCRIPTION
The `ALTER SYSTEM SET enable_rbac_checks TO true;` statement was being run against Mz versions that did not support it.

### Motivation


  * This PR fixes a previously unreported bug.
Nightly CI is failing.

### Tips for reviewer

@def-  I am pushing this fix without a review today as to make the Friday release cut-off deadline.

I still intend to review the entire framework and figure out if there is a better way to express tests that could avoid the pain you experienced with RBAC from being repeated in the future.