### PR TITLE
Introduce Row::kind_iter

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -34,7 +34,7 @@ use mz_compute_client::plan::reduce::{
 use mz_expr::{AggregateExpr, AggregateFunc, EvalError, MirScalarExpr};
 use mz_ore::soft_assert_or_log;
 use mz_repr::adt::numeric::{self, Numeric, NumericAgg};
-use mz_repr::{Datum, DatumList, DatumVec, Diff, Row, RowArena};
+use mz_repr::{Datum, DatumKindList, DatumList, DatumVec, Diff, Row, RowArena};
 use mz_storage_client::types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
 use mz_timely_util::reduce::ReduceExt;
@@ -399,14 +399,14 @@ where
                     return;
                 }
 
-                let mut accumulable = DatumList::empty().iter();
-                let mut hierarchical = DatumList::empty().iter();
-                let mut basic = DatumList::empty().iter();
+                let mut accumulable = DatumKindList::empty().iter();
+                let mut hierarchical = DatumKindList::empty().iter();
+                let mut basic = DatumKindList::empty().iter();
                 for ((reduction_type, row), _) in input.iter() {
                     match reduction_type {
-                        ReductionType::Accumulable => accumulable = row.iter(),
-                        ReductionType::Hierarchical => hierarchical = row.iter(),
-                        ReductionType::Basic => basic = row.iter(),
+                        ReductionType::Accumulable => accumulable = row.kind_iter(),
+                        ReductionType::Hierarchical => hierarchical = row.kind_iter(),
+                        ReductionType::Basic => basic = row.kind_iter(),
                     }
                 }
 

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -119,8 +119,8 @@ pub use crate::row::encoding::{
     DatumDecoderT, DatumEncoderT, DatumToPersist, DatumToPersistFn, RowDecoder, RowEncoder,
 };
 pub use crate::row::{
-    datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, ProtoRow, Row,
-    RowArena, RowPacker, RowRef,
+    datum_list_size, datum_size, datums_size, row_size, DatumKindList, DatumList, DatumMap,
+    ProtoRow, Row, RowArena, RowPacker, RowRef,
 };
 pub use crate::scalar::{
     arb_datum, arb_range_type, AsColumnType, Datum, DatumType, PropArray, PropDatum, PropDict,

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -30,6 +30,7 @@ use crate::adt::numeric::Numeric;
     Default,
     Arbitrary,
 )]
+#[repr(transparent)]
 pub struct Timestamp {
     /// note no `pub`.
     internal: u64,
@@ -277,11 +278,11 @@ impl mz_persist_types::Codec64 for Timestamp {
         u64::codec_name()
     }
 
-    fn encode(&self) -> [u8; 8] {
+    fn encode(&self) -> [u8; std::mem::size_of::<Self>()] {
         self.internal.encode()
     }
 
-    fn decode(buf: [u8; 8]) -> Self {
+    fn decode(buf: [u8; std::mem::size_of::<Self>()]) -> Self {
         Self {
             internal: u64::decode(buf),
         }


### PR DESCRIPTION
Introduces an iterator over the datum kinds within a Row, which can be used instead of full datum decoding where merely the type or existence of a datum is important.

Decoding the datum's kind requires reading tag values and length data for variable-sized kinds, but can skip over actual data.

The implementation of `read_datum_kind` needs to be kept in sync with `read_datum`, which is somewhat unfortunate. However, it seems this might be an acceptable trade-off if we can justify it with a performance gain.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
