### PR TITLE
ore: add helpers for timing out Result-returning futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chrono"
 version = "0.4.24"
-source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#4e2c2b4ad23d6822445718ee536b45d5d649040f"
+source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#311d52eb91d360bf8877e37a074ec7693f797daa"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -4225,6 +4225,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-openssl",
+ "tokio-test",
  "tonic",
  "tracing",
  "tracing-opentelemetry",
@@ -7587,6 +7588,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -64,6 +64,7 @@ yansi = { version = "0.5.1", optional = true }
 anyhow = { version = "1.0.66" }
 scopeguard = "1.1.0"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio-test = "0.4.2"
 
 [features]
 default = ["workspace-hack"]


### PR DESCRIPTION
The new `mz_ore::future::{timeout, timeout_at}` functions are like `tokio::time::{timeout, timeout_at}`, but specialized for futures that return `Result`s. Whether the deadline elapsed is indicated by the error return type, rather than by wrapping a new `Result` around the output.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
