### PR TITLE
ssh-util: configure frequent SSH keepalives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4757,6 +4757,7 @@ dependencies = [
  "anyhow",
  "mz-ore",
  "openssh",
+ "openssh-mux-client",
  "openssl",
  "rand",
  "scopeguard",

--- a/src/ssh-util/Cargo.toml
+++ b/src/ssh-util/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 anyhow = { version = "1.0.66" }
 mz-ore = { path = "../ore" }
 openssh = { version = "0.9.8", default-features = false, features = ["native-mux"] }
+openssh-mux-client = "0.15.5"
 openssl = { version = "0.10.48", features = ["vendored"] }
 rand = "0.8.5"
 scopeguard = "1.1.0"

--- a/src/ssh-util/src/tunnel.rs
+++ b/src/ssh-util/src/tunnel.rs
@@ -203,8 +203,8 @@ async fn connect(
         {
             Ok(_) => return Ok((session, local_port)),
             Err(err) => match err {
-                openssh::Error::SshMux(err)
-                    if err.to_string().contains("forwarding request failed") =>
+                openssh::Error::SshMux(openssh_mux_client::Error::RequestFailure(e))
+                    if &*e == "Port forwarding failed" =>
                 {
                     info!("port {local_port} already in use; testing another port");
                 }


### PR DESCRIPTION
One of our customers has a 30s idle timeout for SSH connections at the TCP layer. Add a fairly aggressive SSH keepalive policy (10s,, to match our PostgreSQL TCP keepalive idle timeout), which should comfortably keep these SSH connections alive.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug: some SSH tunnels in production are unexpectedly recycled.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improve the reliability of SSH tunnels in the presence of short idle TCP connection timeouts.
