### PR TITLE
environmentd: allow TLS connections to the internal SQL port

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -110,7 +110,7 @@ use uuid::Uuid;
 use mz_adapter::catalog::ClusterReplicaSizeMap;
 use mz_cloud_resources::{AwsExternalIdPrefix, CloudResourceController};
 use mz_controller::ControllerConfig;
-use mz_environmentd::{TlsConfig, TlsMode, BUILD_INFO};
+use mz_environmentd::{TlsConfig, BUILD_INFO};
 use mz_frontegg_auth::{
     Authentication as FronteggAuthentication, AuthenticationConfig as FronteggConfig,
 };
@@ -594,13 +594,9 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         }
         None
     } else {
-        let mode = match args.tls_mode.as_str() {
-            "require" => TlsMode::Require,
-            _ => unreachable!(),
-        };
         let cert = args.tls_cert.unwrap();
         let key = args.tls_key.unwrap();
-        Some(TlsConfig { mode, cert, key })
+        Some(TlsConfig { cert, key })
     };
     let frontegg = match (
         args.frontegg_tenant,

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -83,7 +83,7 @@ pub struct TlsConfig {
 #[derive(Debug, Clone, Copy)]
 pub enum TlsMode {
     Disable,
-    Enable,
+    Require,
 }
 
 #[derive(Clone)]
@@ -396,8 +396,8 @@ async fn http_auth<B>(
     let cert_user = match (tls_mode, &conn_protocol) {
         (TlsMode::Disable, ConnProtocol::Http) => None,
         (TlsMode::Disable, ConnProtocol::Https { .. }) => unreachable!(),
-        (TlsMode::Enable, ConnProtocol::Http) => return Err(AuthError::HttpsRequired),
-        (TlsMode::Enable, ConnProtocol::Https { .. }) => None,
+        (TlsMode::Require, ConnProtocol::Http) => return Err(AuthError::HttpsRequired),
+        (TlsMode::Require, ConnProtocol::Https { .. }) => None,
     };
     let creds = match frontegg {
         // If no Frontegg authentication, we can use the cert's username if

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -219,20 +219,10 @@ pub struct Config {
 /// Configures TLS encryption for connections.
 #[derive(Debug, Clone)]
 pub struct TlsConfig {
-    /// The TLS mode to use.
-    pub mode: TlsMode,
     /// The path to the TLS certificate.
     pub cert: PathBuf,
     /// The path to the TLS key.
     pub key: PathBuf,
-}
-
-/// Configures how strictly to enforce TLS encryption and authentication.
-#[derive(Debug, Clone)]
-pub enum TlsMode {
-    /// Require that all clients connect with TLS, but do not require that they
-    /// present a client certificate.
-    Require,
 }
 
 /// Start an `environmentd` server.
@@ -265,15 +255,11 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
             };
             let pgwire_tls = mz_pgwire::TlsConfig {
                 context: context.clone(),
-                mode: match tls_config.mode {
-                    TlsMode::Require => mz_pgwire::TlsMode::Enable,
-                },
+                mode: mz_pgwire::TlsMode::Require,
             };
             let http_tls = http::TlsConfig {
                 context,
-                mode: match tls_config.mode {
-                    TlsMode::Require => http::TlsMode::Enable,
-                },
+                mode: http::TlsMode::Require,
             };
             (Some(pgwire_tls), Some(http_tls))
         }
@@ -411,7 +397,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     // Launch SQL server.
     task::spawn(|| "sql_server", {
         let sql_server = mz_pgwire::Server::new(mz_pgwire::Config {
-            tls: pgwire_tls,
+            tls: pgwire_tls.clone(),
             adapter_client: adapter_client.clone(),
             frontegg: config.frontegg.clone(),
             metrics: metrics.clone(),
@@ -423,7 +409,16 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     // Launch internal SQL server.
     task::spawn(|| "internal_sql_server", {
         let internal_sql_server = mz_pgwire::Server::new(mz_pgwire::Config {
-            tls: None,
+            tls: pgwire_tls.map(|mut pgwire_tls| {
+                // Allow, but do not require, TLS connections on the internal
+                // port. Some users of the internal SQL server do not support
+                // TLS, while others require it, so we allow both.
+                //
+                // TODO(benesch): migrate all internal applications to TLS and
+                // remove `TlsMode::Allow`.
+                pgwire_tls.mode = mz_pgwire::TlsMode::Allow;
+                pgwire_tls
+            }),
             adapter_client: adapter_client.clone(),
             frontegg: None,
             metrics,

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -119,7 +119,7 @@ use tungstenite::protocol::frame::coding::CloseCode;
 use tungstenite::Message;
 use uuid::Uuid;
 
-use mz_environmentd::{TlsMode, WebSocketAuth, WebSocketResponse};
+use mz_environmentd::{WebSocketAuth, WebSocketResponse};
 use mz_frontegg_auth::{
     ApiTokenArgs, ApiTokenResponse, Authentication as FronteggAuthentication,
     AuthenticationConfig as FronteggConfig, Claims, RefreshToken, REFRESH_SUFFIX,
@@ -829,7 +829,7 @@ fn test_auth_expiry() {
     let frontegg_password = &format!("mzp_{client_id}{secret}");
 
     let config = util::Config::default()
-        .with_tls(TlsMode::Require, server_cert, server_key)
+        .with_tls(server_cert, server_key)
         .with_frontegg(&frontegg_auth);
     let server = util::start_server(config).unwrap();
 
@@ -982,7 +982,7 @@ fn test_auth_base() {
     // Test connecting to a server that requires TLS and uses Materialize Cloud for
     // authentication.
     let config = util::Config::default()
-        .with_tls(TlsMode::Require, &server_cert, &server_key)
+        .with_tls(&server_cert, &server_key)
         .with_frontegg(&frontegg_auth);
     let server = util::start_server(config).unwrap();
     run_tests(
@@ -1368,7 +1368,7 @@ fn test_auth_base() {
     drop(server);
 
     // Test TLS modes with a server that requires TLS.
-    let config = util::Config::default().with_tls(TlsMode::Require, &server_cert, &server_key);
+    let config = util::Config::default().with_tls(&server_cert, &server_key);
     let server = util::start_server(config).unwrap();
     run_tests(
         "TlsMode::Require",
@@ -1480,7 +1480,7 @@ fn test_auth_intermediate_ca() {
 
     // When the server presents only its own certificate, without the
     // intermediary, the client should fail to verify the chain.
-    let config = util::Config::default().with_tls(TlsMode::Require, &server_cert, &server_key);
+    let config = util::Config::default().with_tls(&server_cert, &server_key);
     let server = util::start_server(config).unwrap();
     run_tests(
         "TlsMode::Require",
@@ -1512,7 +1512,7 @@ fn test_auth_intermediate_ca() {
     // When the server is configured to present the entire certificate chain,
     // the client should be able to verify the chain even though it only knows
     // about the root CA.
-    let config = util::Config::default().with_tls(TlsMode::Require, server_cert_chain, &server_key);
+    let config = util::Config::default().with_tls(server_cert_chain, &server_key);
     let server = util::start_server(config).unwrap();
     run_tests(
         "TlsMode::Require",
@@ -1615,7 +1615,7 @@ fn test_auth_admin() {
 
     {
         let config = util::Config::default()
-            .with_tls(TlsMode::Require, &server_cert, &server_key)
+            .with_tls(&server_cert, &server_key)
             .with_frontegg(&frontegg_auth);
         let server = util::start_server(config).unwrap();
 
@@ -1652,7 +1652,7 @@ fn test_auth_admin() {
 
     {
         let config = util::Config::default()
-            .with_tls(TlsMode::Require, &server_cert, &server_key)
+            .with_tls(&server_cert, &server_key)
             .with_frontegg(&frontegg_auth);
         let server = util::start_server(config).unwrap();
 
@@ -1689,7 +1689,7 @@ fn test_auth_admin() {
 
     {
         let config = util::Config::default()
-            .with_tls(TlsMode::Require, &server_cert, &server_key)
+            .with_tls(&server_cert, &server_key)
             .with_frontegg(&frontegg_auth);
         let server = util::start_server(config).unwrap();
 

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -97,7 +97,7 @@ use tokio_postgres::Client;
 use tower_http::cors::AllowOrigin;
 
 use mz_controller::ControllerConfig;
-use mz_environmentd::{TlsMode, WebSocketAuth, WebSocketResponse};
+use mz_environmentd::{WebSocketAuth, WebSocketResponse};
 use mz_frontegg_auth::Authentication as FronteggAuthentication;
 use mz_orchestrator_process::{ProcessOrchestrator, ProcessOrchestratorConfig};
 use mz_ore::metrics::MetricsRegistry;
@@ -165,14 +165,8 @@ impl Config {
         self
     }
 
-    pub fn with_tls(
-        mut self,
-        mode: TlsMode,
-        cert_path: impl Into<PathBuf>,
-        key_path: impl Into<PathBuf>,
-    ) -> Self {
+    pub fn with_tls(mut self, cert_path: impl Into<PathBuf>, key_path: impl Into<PathBuf>) -> Self {
         self.tls = Some(mz_environmentd::TlsConfig {
-            mode,
             cert: cert_path.into(),
             key: key_path.into(),
         });

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -59,12 +59,13 @@ pub struct TlsConfig {
     pub mode: TlsMode,
 }
 
-/// Specifies how strictly to enforce TLS encryption and authentication.
+/// Specifies how strictly to enforce TLS encryption.
 #[derive(Debug, Clone, Copy)]
 pub enum TlsMode {
-    Disable,
-    /// Clients must negotiate TLS encryption.
-    Enable,
+    /// Allow TLS encryption.
+    Allow,
+    /// Require that clients negotiate TLS encryption.
+    Require,
 }
 
 /// A server that communicates with clients via the pgwire protocol.
@@ -123,7 +124,7 @@ impl Server {
                     Some(FrontendStartupMessage::Startup { version, params }) => {
                         let mut conn = FramedConn::new(conn_id, conn);
                         protocol::run(protocol::RunParams {
-                            tls_mode: tls.as_ref().map(|tls| tls.mode).unwrap_or(TlsMode::Disable),
+                            tls_mode: tls.as_ref().map(|tls| tls.mode),
                             adapter_client,
                             conn: &mut conn,
                             version,


### PR DESCRIPTION
When the external SQL port requires TLS, allow TLS connections to the internal port as well. This allows tools like Teleport, which insist upon using TLS for all connections, to connect to the internal SQL port, without breaking existing users of the internal SQL port, which may need to be reconfigured to support TLS encryption.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

    Support for Teleport for internal access control: https://github.com/MaterializeInc/cloud/issues/4943.

### Tips for reviewer

There should be no user facing changes here, but I took the opportunity to cut out the `environmentd::TlsMode` enum (which had only one variant) to cut down on complexity.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Not a user facing change.
