### PR TITLE
deps: pick up crossbeam soundness fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.66"
 async-trait = "0.1.59"
 bytesize = "1.1.0"
 clap = { version = "3.2.20", features = ["derive", "env"] }
-crossbeam-channel = "0.5.6"
+crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3.25"

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.66"
 async-trait = "0.1.59"
 bytesize = "1.1.0"
 clap = { version = "3.2.20", features = ["derive", "env"] }
-crossbeam-channel = "0.5.6"
+crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.59"
 clap = { version = "3.2.20", features = ["env", "derive"] }
-crossbeam-channel = "0.5.6"
+crossbeam-channel = "0.5.8"
 futures = "0.3.25"
 http = "0.2.8"
 itertools = "0.10.5"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = "0.1.59"
 bytesize = "1.1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.20", features = ["derive", "env"] }
-crossbeam-channel = { version = "0.5.6" }
+crossbeam-channel = "0.5.8"
 csv-core = { version = "0.1.10" }
 dec = "0.4.8"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -28,7 +28,7 @@ bytes = { version = "1.3.0" }
 chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.20", features = ["derive", "env", "wrap_help"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
-crossbeam-channel = { version = "0.5.6" }
+crossbeam-channel = { version = "0.5.8" }
 crossbeam-deque = { version = "0.8.2" }
 crossbeam-epoch = { version = "0.9.13" }
 crossbeam-utils = { version = "0.8.7" }
@@ -125,7 +125,7 @@ cc = { version = "1.0.78", default-features = false, features = ["parallel"] }
 chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.20", features = ["derive", "env", "wrap_help"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
-crossbeam-channel = { version = "0.5.6" }
+crossbeam-channel = { version = "0.5.8" }
 crossbeam-deque = { version = "0.8.2" }
 crossbeam-epoch = { version = "0.9.13" }
 crossbeam-utils = { version = "0.8.7" }


### PR DESCRIPTION
### Motivation

Update to `v0.5.8` which includes https://github.com/crossbeam-rs/crossbeam/pull/972

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->



<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
