### PR TITLE
Output buckets in physical `EXPLAIN` text, not skips

### DIFF
--- a/src/compute-client/src/explain/text.rs
+++ b/src/compute-client/src/explain/text.rs
@@ -599,7 +599,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for HierarchicalPlan {
                 writeln!(f, "{}aggr_funcs=[{}]", ctx.indent, aggr_funcs)?;
                 let skips = separated(", ", &plan.skips);
                 writeln!(f, "{}skips=[{}]", ctx.indent, skips)?;
-                let buckets = separated(", ", &plan.skips);
+                let buckets = separated(", ", &plan.buckets);
                 writeln!(f, "{}buckets=[{}]", ctx.indent, buckets)?;
             }
         }

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -390,7 +390,7 @@ Explained Query:
   Reduce::Hierarchical
     aggr_funcs=[min, max]
     skips=[0, 0]
-    buckets=[0, 0]
+    buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
     val_plan
       project=(#1, #1)
     key_plan
@@ -439,7 +439,7 @@ Explained Query:
       Reduce::Hierarchical
         aggr_funcs=[min, max]
         skips=[0, 0]
-        buckets=[0, 0]
+        buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
         val_plan
           project=(#0, #0)
         key_plan
@@ -557,7 +557,7 @@ Explained Query:
     hierarchical
       aggr_funcs=[min, max]
       skips=[2, 0]
-      buckets=[2, 0]
+      buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
     basic
       aggrs[0]=(1, string_agg(row(row((integer_to_text(#1) || "1"), ","))))
       aggrs[1]=(5, string_agg(row(row((integer_to_text(#1) || "2"), ","))))
@@ -619,7 +619,7 @@ Explained Query:
         hierarchical
           aggr_funcs=[min, max]
           skips=[2, 0]
-          buckets=[2, 0]
+          buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
         basic
           aggrs[0]=(1, string_agg(row(row((integer_to_text(#0) || "1"), ","))))
           aggrs[1]=(5, string_agg(row(row((integer_to_text(#0) || "2"), ","))))


### PR DESCRIPTION
This commit fixes the text output of `EXPLAIN PHYSICAL PLAN`, which was previously outputting the `skips` redundantly in the field dedicated to `buckets` in a hierarchical aggregation. After the commit, the buckets are produced in the output appropriately.

### Motivation

  * This PR fixes a previously unreported bug.

The text output of `EXPLAIN PHYSICAL PLAN` was duplicating the `skips` data in the `buckets` output instead of reporting the bucket values. An example of the difference can be seen in the fixed output of `test/sqllogictest/explain/physical_plan_as_text.slt` tests, where the relevant difference is:

```diff
    skips=[0, 0]
-    buckets=[0, 0]
+    buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
```
### Tips for reviewer

This is a minor change. I chanced upon the bug while working on #18546.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes to the `buckets` reported in the text output of `EXPLAIN PHYSICAL PLAN`.
