### PR TITLE
[skunkworks] persist: Don't copy into a single Vec for S3 Blob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4216,6 +4216,7 @@ dependencies = [
  "paste",
  "pin-project",
  "prometheus",
+ "proptest",
  "scopeguard",
  "sentry",
  "sentry-tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,9 +539,8 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29dcab29afbea7726f5c10c7be0c38666d7eb07db551580b3b26ed7cfb5d1935"
+version = "0.53.2"
+source = "git+https://github.com/parker-timmerman/smithy-rs.git?branch=v0.53.2#2865b0455f363646976cdcd419baa4701b24e3e8"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,3 +115,4 @@ postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 vte = { git = "https://github.com/alacritty/vte" }
+aws-smithy-http = { git = "https://github.com/parker-timmerman/smithy-rs.git", branch = "v0.53.2" }

--- a/deny.toml
+++ b/deny.toml
@@ -210,4 +210,8 @@ allow-git = [
     # Waiting on https://github.com/launchdarkly/rust-server-sdk/pull/20 to make
     # it into a release.
     "https://github.com/MaterializeInc/rust-server-sdk",
+
+    # Waiting on https://github.com/awslabs/smithy-rs/pull/2525 to make it into a
+    # release.
+    "https://github.com/parker-timmerman/smithy-rs.git",
 ]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -63,12 +63,14 @@ yansi = { version = "0.5.1", optional = true }
 [dev-dependencies]
 anyhow = { version = "1.0.66" }
 scopeguard = "1.1.0"
+proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 tokio-test = "0.4.2"
 
 [features]
 default = ["workspace-hack"]
 async = ["async-trait", "futures", "openssl", "tokio-openssl", "tokio"]
+bytes_ = ["bytes", "smallvec", "smallvec/const_generics"]
 network = ["async", "bytes", "hyper", "smallvec", "tonic"]
 tracing_ = [
   "anyhow",

--- a/src/ore/src/bytes.rs
+++ b/src/ore/src/bytes.rs
@@ -1,0 +1,682 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! One bytes type to rule them all!
+//!
+//! TODO(parkertimmerman): Ideally we don't implement this "bytes type" on our own
+//! and use something else, e.g. `SegmentedBuf` from the `bytes-utils` crate. Currently
+//! that type, nor anything else, implement std::io::Read and std::io::Seek, which
+//! we need. We have an open issue with the `bytes-utils` crate, <https://github.com/vorner/bytes-utils/issues/16>
+//! to add these trait impls.
+//!
+
+use bytes::{Buf, Bytes};
+use smallvec::SmallVec;
+
+use internal::SegmentedReader;
+
+/// A cheaply clonable collection of possibly non-contiguous bytes.
+///
+/// `Vec<u8>` or `Bytes` are contiguous chunks of memory, which are fast (e.g. better cache
+/// locality) and easier to work with (e.g. can take a slice), but can cause problems (e.g.
+/// memory fragmentation) if you try to allocate a single very large chunk. Depending on the
+/// application, you probably don't need a contiguous chunk of memory, just a way to store and
+/// iterate over a collection of bytes.
+/// 
+/// Note: [`SegmentedBytes`] is generic over a `const N: usize`. Internally we use a 
+/// [`smallvec::SmallVec`] to store our [`Bytes`] segments, and `N` is how many `Bytes` we'll
+/// store inline before spilling to the heap. We default `N = 1`, so in the case of a single
+/// `Bytes` segment, we avoid one layer of indirection. 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SegmentedBytes<const N: usize = 1> {
+    /// Collection of non-contiguous segments.
+    segments: SmallVec<[Bytes; N]>,
+    /// Pre-computed length of all the segments.
+    len: usize,
+}
+
+impl Default for SegmentedBytes {
+    fn default() -> Self {
+        SegmentedBytes {
+            segments: SmallVec::new(),
+            len: 0,
+        }
+    }
+}
+
+impl SegmentedBytes {
+    /// Creates a new empty [`SegmentedBytes`], reserving space inline for `N` **segments**.
+    ///
+    /// Note: If you don't know how many segments you have, you should use [`SegmentedBytes::default`].
+    pub fn new<const N: usize>() -> SegmentedBytes<N> {
+        SegmentedBytes {
+            segments: SmallVec::new(),
+            len: 0,
+        }
+    }
+}
+
+impl<const N: usize> SegmentedBytes<N> {
+    /// Returns the number of bytes contained in this [`SegmentedBytes`].
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns if this [`SegmentedBytes`] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Consumes `self` returning an [`Iterator`] over all of the non-contiguous segments
+    /// that make up this buffer.
+    pub fn into_segments(self) -> impl Iterator<Item = Bytes> {
+        self.segments.into_iter()
+    }
+
+    /// Copies all of the bytes from `self` returning one contiguous blob.
+    pub fn into_contiguous(mut self) -> Vec<u8> {
+        self.copy_to_bytes(self.remaining()).into()
+    }
+
+    /// Extends the buffer by one more segment of [`Bytes`]
+    pub fn push(&mut self, b: Bytes) {
+        self.len += b.len();
+        self.segments.push(b);
+    }
+
+    /// Consumes `self` returning a type that implements [`io::Read`] and [`io::Seek`].
+    ///
+    /// Note: [`Clone`]-ing a [`SegmentedBytes`] is cheap, so if you need to retain the original
+    /// [`SegmentedBytes`] you should clone it.
+    ///
+    /// [`io::Read`]: std::io::Read
+    /// [`io::Seek`]: std::io::Seek
+    pub fn reader(self) -> SegmentedReader {
+        SegmentedReader::new(self.segments)
+    }
+}
+
+impl<const N: usize> Buf for SegmentedBytes<N> {
+    fn remaining(&self) -> usize {
+        self.len()
+    }
+
+    fn chunk(&self) -> &[u8] {
+        // Return the first non-empty segment.
+        self.segments
+            .iter()
+            .filter(|c| !c.is_empty())
+            .map(Buf::chunk)
+            .next()
+            .unwrap_or_default()
+    }
+
+    fn advance(&mut self, mut cnt: usize) {
+        assert!(cnt <= self.len, "Advance past the end of buffer");
+        self.len -= cnt;
+
+        while cnt > 0 {
+            if let Some(seg) = self.segments.first_mut() {
+                if seg.remaining() > cnt {
+                    seg.advance(cnt);
+                    // We advanced `cnt` bytes, so no more need to advance.
+                    cnt = 0;
+                } else {
+                    // Remove the whole first buffer.
+                    cnt = cnt.saturating_sub(seg.remaining());
+                    self.segments.remove(0);
+                }
+            }
+        }
+    }
+}
+
+impl From<Bytes> for SegmentedBytes {
+    fn from(value: Bytes) -> Self {
+        let len = value.len();
+        let mut segments = SmallVec::new();
+        segments.push(value);
+
+        SegmentedBytes { segments, len }
+    }
+}
+
+impl From<Vec<Bytes>> for SegmentedBytes {
+    fn from(value: Vec<Bytes>) -> Self {
+        let mut len = 0;
+        let mut segments = SmallVec::with_capacity(value.len());
+
+        for segment in value {
+            len += segment.len();
+            segments.push(segment);
+        }
+
+        SegmentedBytes { segments, len }
+    }
+}
+
+impl From<Vec<u8>> for SegmentedBytes {
+    fn from(value: Vec<u8>) -> Self {
+        let bytes = Bytes::from(value);
+        SegmentedBytes::from(bytes)
+    }
+}
+
+impl<const N: usize> FromIterator<Bytes> for SegmentedBytes<N> {
+    fn from_iter<T: IntoIterator<Item = Bytes>>(iter: T) -> Self {
+        let mut len = 0;
+        let mut segments = SmallVec::new();
+
+        for segment in iter {
+            len += segment.len();
+            segments.push(segment);
+        }
+
+        SegmentedBytes { segments, len }
+    }
+}
+
+impl<const N: usize> FromIterator<Vec<u8>> for SegmentedBytes<N> {
+    fn from_iter<T: IntoIterator<Item = Vec<u8>>>(iter: T) -> Self {
+        iter.into_iter().map(Bytes::from).collect()
+    }
+}
+
+mod internal {
+    use bytes::Bytes;
+    use std::collections::BTreeMap;
+    use std::io;
+    use std::ops::Bound;
+
+    use crate::cast::CastFrom;
+
+    /// Provides efficient reading and seeking across a collection of segmented bytes.
+    #[derive(Debug)]
+    pub struct SegmentedReader {
+        segments: BTreeMap<usize, Bytes>,
+        len: usize,
+        pointer: u64,
+    }
+
+    impl SegmentedReader {
+        pub fn new(segments: impl IntoIterator<Item = Bytes>) -> Self {
+            let mut map = BTreeMap::new();
+            let mut total_len = 0;
+
+            let non_empty_segments = segments.into_iter().filter(|s| !s.is_empty());
+            for segment in non_empty_segments {
+                total_len += segment.len();
+                map.insert(total_len, segment);
+            }
+
+            SegmentedReader {
+                segments: map,
+                len: total_len,
+                pointer: 0,
+            }
+        }
+
+        /// The total number of bytes this [`SegmentedReader`] is mapped over.
+        pub fn len(&self) -> usize {
+            self.len
+        }
+
+        /// The current position of the internal cursor for this [`SegmentedReader`].
+        ///
+        /// Note: It's possible for the current position to be greater than the length,
+        /// as [`std::io::Seek`] allows you to seek past the end of the stream.
+        pub fn position(&self) -> u64 {
+            self.pointer
+        }
+    }
+
+    impl io::Read for SegmentedReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let pointer = usize::cast_from(self.pointer);
+
+            // We've seeked past the end, return nothing.
+            if pointer > self.len {
+                return Ok(0);
+            }
+
+            if let Some((accum_len, segment)) = self
+                .segments
+                .range((Bound::Excluded(&pointer), Bound::Included(&self.len)))
+                .next()
+            {
+                // How many bytes we have left in this segment.
+                let remaining_len = accum_len - pointer;
+                // Position within the segment to being reading.
+                let segment_pos = segment.len() - remaining_len;
+
+                // How many bytes we'll read.
+                let len = core::cmp::min(remaining_len, buf.len());
+                // Copy bytes from the current segment into the buffer.
+                buf[..len].copy_from_slice(&segment[segment_pos..segment_pos + len]);
+                // Advance our pointer.
+                self.pointer += u64::cast_from(len);
+
+                Ok(len)
+            } else {
+                Ok(0)
+            }
+        }
+    }
+
+    impl io::Seek for SegmentedReader {
+        fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+            use io::SeekFrom;
+
+            // Get a base to seek from, and an offset to seek to.
+            let (base, offset) = match pos {
+                SeekFrom::Start(n) => {
+                    self.pointer = n;
+                    return Ok(n);
+                }
+                SeekFrom::End(n) => (u64::cast_from(self.len), n),
+                SeekFrom::Current(n) => (self.pointer, n),
+            };
+
+            // Check for integer overflow, but we don't check our bounds!
+            //
+            // The contract for io::Seek denotes that seeking beyond the end
+            // of the stream is allowed. If we're beyond the end of the stream
+            // then we won't read back any bytes, but it won't be an error.
+            match base.checked_add_signed(offset) {
+                Some(n) => {
+                    self.pointer = n;
+                    Ok(self.pointer)
+                }
+                None => {
+                    let err = io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "Invalid seek to an overflowing position",
+                    );
+                    Err(err)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::{
+        Buf,
+        Bytes,
+    };
+    use std::io::{Read, Seek, SeekFrom};
+    use proptest::prelude::*;
+
+    use super::SegmentedBytes;
+
+    #[test]
+    fn test_empty() {
+        let s = SegmentedBytes::default();
+
+        // We should report as empty.
+        assert!(s.is_empty());
+        assert_eq!(s.len(), 0);
+
+        // An iterator of segments should return nothing.
+        let mut i = s.clone().into_segments();
+        assert_eq!(i.next(), None);
+
+        // bytes::Buf shouldn't report anything as remaining.
+        assert_eq!(s.remaining(), 0);
+        // We should get back an empty chunk if we try to read anything.
+        assert!(s.chunk().is_empty());
+
+        // Turn ourselves into a type that impls io::Read.
+        let mut reader = s.reader();
+
+        // We shouldn't panic, but we shouldn't get back any bytes.
+        let mut buf = Vec::new();
+        let bytes_read = reader.read(&mut buf[..]).unwrap();
+        assert_eq!(bytes_read, 0);
+
+        // We should be able to seek past the end without panicking.
+        reader.seek(SeekFrom::Current(20)).unwrap();
+        let bytes_read = reader.read(&mut buf[..]).unwrap();
+        assert_eq!(bytes_read, 0);
+    }
+
+    #[test]
+    fn test_bytes_buf() {
+        let mut s = SegmentedBytes::from(vec![0, 1, 2, 3, 4, 5, 6, 7]);
+
+        assert_eq!(s.len(), 8);
+        assert_eq!(s.len(), s.remaining());
+        assert_eq!(s.chunk(), &[0, 1, 2, 3, 4, 5, 6, 7]);
+
+        // Advance far into the buffer.
+        s.advance(6);
+        assert_eq!(s.len(), 2);
+        assert_eq!(s.len(), s.remaining());
+        assert_eq!(s.chunk(), &[6, 7]);
+    }
+
+    #[test]
+    fn test_bytes_buf_multi() {
+        let segments = vec![vec![0, 1, 2, 3], vec![4, 5, 6, 7], vec![8, 9, 10, 11]];
+        let mut s: SegmentedBytes<2> = segments.into_iter().collect();
+
+        assert_eq!(s.len(), 12);
+        assert_eq!(s.len(), s.remaining());
+
+        // Chunk should return the entirety of the first segment.
+        assert_eq!(s.chunk(), &[0, 1, 2, 3]);
+
+        // Advance into the middle segment
+        s.advance(6);
+        assert_eq!(s.len(), 6);
+        assert_eq!(s.len(), s.remaining());
+
+        // Chunk should return the rest of the second segment.
+        assert_eq!(s.chunk(), &[6, 7]);
+
+        // Read across two segments.
+        let x = s.get_u32();
+        assert_eq!(x, u32::from_be_bytes([6, 7, 8, 9]));
+
+        // Only two bytes remaining.
+        assert_eq!(s.len(), 2);
+        assert_eq!(s.len(), s.remaining());
+
+        let mut s = s.chain(&[12, 13, 14, 15][..]);
+
+        // Should have 6 bytes total now.
+        assert_eq!(s.remaining(), 6);
+        // We'll read out the last two bytes from the last segment.
+        assert_eq!(s.chunk(), &[10, 11]);
+
+        // Advance into the chained segment.
+        s.advance(3);
+        // Read the remaining bytes.
+        assert_eq!(s.chunk(), &[13, 14, 15]);
+    }
+
+    #[test]
+    fn test_io_read() {
+        let s = SegmentedBytes::from(vec![0, 1, 2, 3, 4, 5, 6, 7]);
+        let mut reader = s.reader();
+
+        assert_eq!(reader.len(), 8);
+        assert_eq!(reader.position(), 0);
+
+        // Read a small amount.
+        let mut buf = [0; 4];
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 4);
+        assert_eq!(buf, [0, 1, 2, 3]);
+
+        // We should still report our original length.
+        assert_eq!(reader.len(), 8);
+        // But our position has moved.
+        assert_eq!(reader.position(), 4);
+
+        // We can seek forwards and read bytes.
+        reader.seek(SeekFrom::Current(1)).unwrap();
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 3);
+        assert_eq!(buf, [5, 6, 7, 3]);
+
+        assert_eq!(reader.len(), 8);
+        // We've read to the end!
+        assert_eq!(reader.position(), 8);
+
+        // We shouldn't read any bytes
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 0);
+        // Buffer shouldn't change from what it was last.
+        assert_eq!(buf, [5, 6, 7, 3]);
+
+        // Seek backwards and re-read bytes.
+        reader.seek(SeekFrom::Start(2)).unwrap();
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 4);
+        assert_eq!(buf, [2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_io_read_multi() {
+        let segments = vec![vec![0, 1, 2, 3], vec![4, 5, 6, 7, 8, 9], vec![10, 11]];
+        let s: SegmentedBytes<2> = segments.into_iter().collect();
+        let mut reader = s.reader();
+
+        assert_eq!(reader.len(), 12);
+        assert_eq!(reader.position(), 0);
+
+        // Read up to the first segment.
+        let mut buf = [0; 6];
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 4);
+        assert_eq!(buf, [0, 1, 2, 3, 0, 0]);
+
+        // Read 5 bytes, which should come from the second segment.
+        let bytes_read = reader.read(&mut buf[1..]).unwrap();
+        assert_eq!(bytes_read, 5);
+        assert_eq!(buf, [0, 4, 5, 6, 7, 8]);
+
+        // Seek backwards to the middle of the first segment.
+        reader.seek(SeekFrom::Start(2)).unwrap();
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 2);
+        assert_eq!(buf, [2, 3, 5, 6, 7, 8]);
+
+        // Seek past the end.
+        reader.seek(SeekFrom::Start(1000)).unwrap();
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 0);
+
+        assert_eq!(reader.len(), 12);
+        assert_eq!(reader.position(), 1000);
+
+        // Seek back to the middle.
+        reader.seek(SeekFrom::Start(6)).unwrap();
+        // Read the entire bufffer.
+        let mut buf = Vec::new();
+        let bytes_read = reader.read_to_end(&mut buf).unwrap();
+        assert_eq!(bytes_read, 6);
+        assert_eq!(buf, &[6, 7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn test_multi() {
+        let segments = vec![vec![0, 1, 2, 3], vec![4, 5, 6, 7, 8, 9], vec![10, 11]];
+        let mut s: SegmentedBytes<2> = segments.into_iter().collect();
+
+        assert_eq!(s.len(), 12);
+        assert_eq!(s.remaining(), 12);
+
+        // Read the first chunk.
+        assert_eq!(s.chunk(), [0, 1, 2, 3]);
+
+        // Advance to the middle.
+        s.advance(6);
+        assert_eq!(s.remaining(), 6);
+
+        // Convert to a reader.
+        let mut reader = s.reader();
+        // We should be at the beginning, and only see the remaining 6 bytes.
+        assert_eq!(reader.len(), 6);
+        assert_eq!(reader.position(), 0);
+
+        // Read to the end of the second segment.
+        let mut buf = [0; 8];
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 4);
+        assert_eq!(buf, [6, 7, 8, 9, 0, 0, 0, 0]);
+
+        // Read again to get the final segment.
+        let bytes_read = reader.read(&mut buf[4..]).unwrap();
+        assert_eq!(bytes_read, 2);
+        assert_eq!(buf, [6, 7, 8, 9, 10, 11, 0, 0]);
+
+        // Seek back to the beginning.
+        reader.seek(SeekFrom::Start(0)).unwrap();
+        // Read everything.
+        reader.read_exact(&mut buf[..6]).unwrap();
+        assert_eq!(buf, [6, 7, 8, 9, 10, 11, 0, 0]);
+    }
+
+    #[test]
+    fn test_single_empty_segment() {
+        let s = SegmentedBytes::from(Vec::<u8>::new());
+
+        // Everything should comeback empty.
+        assert_eq!(s.len(), 0);
+        assert_eq!(s.remaining(), 0);
+        assert!(s.chunk().is_empty());
+
+        let mut reader = s.reader();
+
+        // Reading shouldn't fail, but it also shouldn't yield any bytes.
+        let mut buf = [0; 4];
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 0);
+        assert_eq!(buf, [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_middle_segment_empty() {
+        let segments = vec![vec![1, 2], vec![], vec![3, 4, 5, 6]];
+        let mut s: SegmentedBytes = segments.clone().into_iter().collect();
+
+        assert_eq!(s.len(), 6);
+        assert_eq!(s.remaining(), 6);
+
+        // Read and advanced past the first chunk.
+        let first_chunk = s.chunk();
+        assert_eq!(first_chunk, [1, 2]);
+        s.advance(first_chunk.len());
+
+        assert_eq!(s.remaining(), 4);
+
+        // We should skip the empty segment and continue to the next.
+        let second_chunk = s.chunk();
+        assert_eq!(second_chunk, [3, 4, 5, 6]);
+
+        // Recreate SegmentedBytes.
+        let s: SegmentedBytes = segments.into_iter().collect();
+        let mut reader = s.reader();
+
+        // We should be able to read the first chunk.
+        let mut buf = [0; 4];
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 2);
+        assert_eq!(buf, [1, 2, 0, 0]);
+
+        // And we should be able to read the second chunk without issue.
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 4);
+        assert_eq!(buf, [3, 4, 5, 6]);
+
+        // Seek backwards and read again.
+        reader.seek(SeekFrom::Current(-2)).unwrap();
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 2);
+        assert_eq!(buf, [5, 6, 5, 6]);
+    }
+
+    #[test]
+    fn test_last_segment_empty() {
+        let segments = vec![vec![1, 2], vec![3, 4, 5, 6], vec![]];
+        let mut s: SegmentedBytes = segments.clone().into_iter().collect();
+
+        assert_eq!(s.len(), 6);
+        assert_eq!(s.remaining(), 6);
+
+        // Read and advanced past the first chunk.
+        let first_chunk = s.chunk();
+        assert_eq!(first_chunk, [1, 2]);
+        s.advance(first_chunk.len());
+
+        assert_eq!(s.remaining(), 4);
+
+        // Read and advance past the second chunk.
+        let second_chunk = s.chunk();
+        assert_eq!(second_chunk, [3, 4, 5, 6]);
+        s.advance(second_chunk.len());
+
+        // No bytes should remain.
+        assert_eq!(s.remaining(), 0);
+        assert!(s.chunk().is_empty());
+
+        // Recreate SegmentedBytes.
+        let s: SegmentedBytes = segments.into_iter().collect();
+        let mut reader = s.reader();
+
+        // We should be able to read the first chunk.
+        let mut buf = [0; 4];
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 2);
+        assert_eq!(buf, [1, 2, 0, 0]);
+
+        // And we should be able to read the second chunk without issue.
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 4);
+        assert_eq!(buf, [3, 4, 5, 6]);
+
+        // Reading again shouldn't provide any bytes.
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 0);
+        // Buffer shouldn't change.
+        assert_eq!(buf, [3, 4, 5, 6]);
+
+        // Seek backwards and read again.
+        reader.seek(SeekFrom::Current(-2)).unwrap();
+        let bytes_read = reader.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 2);
+        assert_eq!(buf, [5, 6, 5, 6]);
+    }
+
+    proptest! {
+        #[test]
+        #[cfg_attr(miri, ignore)] // slow
+        fn proptest_copy_to_bytes(segments: Vec<Vec<u8>>, num_bytes: usize) {
+            let contiguous: Vec<u8> = segments.clone().into_iter().flatten().collect();
+            let mut contiguous = Bytes::from(contiguous);
+            let mut segmented: SegmentedBytes = segments.into_iter().map(Bytes::from).collect();
+
+            // Cap num_bytes at the size of contiguous.
+            let num_bytes = contiguous.len() % num_bytes;
+
+            let copied_c = contiguous.copy_to_bytes(num_bytes);
+            let copied_s = segmented.copy_to_bytes(num_bytes);
+
+            prop_assert_eq!(copied_c, copied_s);
+        }
+
+        #[test]
+        #[cfg_attr(miri, ignore)] // slow
+        fn proptest_read_to_end(segments: Vec<Vec<u8>>) {
+            let contiguous: Vec<u8> = segments.clone().into_iter().flatten().collect();
+            let contiguous = Bytes::from(contiguous);
+            let segmented: SegmentedBytes = segments.into_iter().map(Bytes::from).collect();
+
+            let mut reader_c = contiguous.reader();
+            let mut reader_s = segmented.reader();
+
+            let mut buf_c = Vec::new();
+            reader_c.read_to_end(&mut buf_c).unwrap();
+
+            let mut buf_s = Vec::new();
+            reader_s.read_to_end(&mut buf_s).unwrap();
+
+            assert_eq!(buf_s, buf_s);
+        }
+    }
+}

--- a/src/ore/src/bytes.rs
+++ b/src/ore/src/bytes.rs
@@ -34,11 +34,11 @@ use internal::SegmentedReader;
 /// memory fragmentation) if you try to allocate a single very large chunk. Depending on the
 /// application, you probably don't need a contiguous chunk of memory, just a way to store and
 /// iterate over a collection of bytes.
-/// 
-/// Note: [`SegmentedBytes`] is generic over a `const N: usize`. Internally we use a 
+///
+/// Note: [`SegmentedBytes`] is generic over a `const N: usize`. Internally we use a
 /// [`smallvec::SmallVec`] to store our [`Bytes`] segments, and `N` is how many `Bytes` we'll
 /// store inline before spilling to the heap. We default `N = 1`, so in the case of a single
-/// `Bytes` segment, we avoid one layer of indirection. 
+/// `Bytes` segment, we avoid one layer of indirection.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SegmentedBytes<const N: usize = 1> {
     /// Collection of non-contiguous segments.
@@ -313,12 +313,9 @@ mod internal {
 
 #[cfg(test)]
 mod tests {
-    use bytes::{
-        Buf,
-        Bytes,
-    };
-    use std::io::{Read, Seek, SeekFrom};
+    use bytes::{Buf, Bytes};
     use proptest::prelude::*;
+    use std::io::{Read, Seek, SeekFrom};
 
     use super::SegmentedBytes;
 

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -92,6 +92,9 @@
 #[cfg(feature = "test")]
 pub mod assert;
 pub mod bits;
+#[cfg_attr(nightly_doc_features, doc(cfg(feature = "bytes_")))]
+#[cfg(feature = "bytes_")]
+pub mod bytes;
 pub mod cast;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "cli")))]
 #[cfg(feature = "cli")]

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -38,7 +38,7 @@ differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-
 futures = "0.3.25"
 futures-util = "0.3"
 mz-build-info = { path = "../build-info" }
-mz-ore = { path = "../ore", features = ["tracing_"] }
+mz-ore = { path = "../ore", features = ["bytes_", "tracing_"] }
 mz-persist = { path = "../persist" }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -17,6 +17,7 @@ use std::time::Instant;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use bytes::Bytes;
+use mz_ore::bytes::SegmentedBytes;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist::cfg::{BlobConfig, ConsensusConfig};
@@ -287,7 +288,7 @@ struct ReadOnly<T>(T);
 
 #[async_trait]
 impl Blob for ReadOnly<Arc<dyn Blob + Sync + Send>> {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
+    async fn get(&self, key: &str) -> Result<Option<SegmentedBytes>, ExternalError> {
         self.0.get(key).await
     }
 

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -250,7 +250,7 @@ pub async fn fetch_state_rollup(
         .get(&rollup_key.complete(&shard_id))
         .await?
         .expect("fetching the specified state rollup");
-    let proto = ProtoStateRollup::decode(rollup_buf.as_slice()).expect("invalid encoded state");
+    let proto = ProtoStateRollup::decode(rollup_buf).expect("invalid encoded state");
     Ok(proto)
 }
 
@@ -283,8 +283,7 @@ pub async fn fetch_state_rollups(args: &StateArgs) -> Result<impl serde::Seriali
             .await
             .unwrap();
         if let Some(rollup_buf) = rollup_buf {
-            let proto =
-                ProtoStateRollup::decode(rollup_buf.as_slice()).expect("invalid encoded state");
+            let proto = ProtoStateRollup::decode(rollup_buf).expect("invalid encoded state");
             rollup_states.insert(key.to_string(), proto);
         }
     }
@@ -500,7 +499,7 @@ pub async fn shard_stats(blob_uri: &str) -> anyhow::Result<()> {
         };
 
         let state: State<u64> =
-            UntypedState::decode(&cfg.build_version, &rollup).check_ts_codec(&shard)?;
+            UntypedState::decode(&cfg.build_version, rollup).check_ts_codec(&shard)?;
 
         let leased_readers = state.collections.leased_readers.len();
         let critical_readers = state.collections.critical_readers.len();

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::metric;
 use mz_ore::metrics::{
@@ -1542,7 +1543,7 @@ impl MetricsBlob {
 
 #[async_trait]
 impl Blob for MetricsBlob {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
+    async fn get(&self, key: &str) -> Result<Option<SegmentedBytes>, ExternalError> {
         let res = self
             .metrics
             .blob

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -747,7 +747,7 @@ impl StateVersions {
             self.metrics
                 .codecs
                 .state
-                .decode(|| UntypedState::decode(&self.cfg.build_version, &buf))
+                .decode(|| UntypedState::decode(&self.cfg.build_version, buf))
         })
     }
 

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -35,7 +35,7 @@ futures-util = "0.3.25"
 once_cell = "1.16.0"
 md-5 = "0.10.5"
 mz-aws-s3-util = { path = "../aws-s3-util" }
-mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async"] }
+mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes_"] }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
 openssl = { version = "0.10.48", features = ["vendored"] }

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -16,6 +16,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use bytes::Bytes;
 use fail::fail_point;
+use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastFrom;
 use tokio::fs::{self, File, OpenOptions};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -75,7 +76,7 @@ impl FileBlob {
 
 #[async_trait]
 impl Blob for FileBlob {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
+    async fn get(&self, key: &str) -> Result<Option<SegmentedBytes>, ExternalError> {
         let file_path = self.blob_path(&FileBlob::replace_forward_slashes(key));
         let mut file = match File::open(file_path).await {
             Ok(file) => file,
@@ -84,7 +85,7 @@ impl Blob for FileBlob {
         };
         let mut buf = Vec::new();
         file.read_to_end(&mut buf).await?;
-        Ok(Some(buf))
+        Ok(Some(SegmentedBytes::from(buf)))
     }
 
     async fn list_keys_and_metadata(

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -14,11 +14,11 @@
 // structs.
 
 use std::fmt::{self, Debug};
-use std::io::Cursor;
 use std::marker::PhantomData;
 
 use bytes::BufMut;
 use differential_dataflow::trace::Description;
+use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastFrom;
 use mz_persist_types::Codec64;
 use prost::Message;
@@ -223,8 +223,8 @@ impl<T: Timestamp + Codec64> BlobTraceBatchPart<T> {
     }
 
     /// Decodes a BlobTraceBatchPart from the Parquet format.
-    pub fn decode<'a>(buf: &'a [u8]) -> Result<Self, Error> {
-        decode_trace_parquet(&mut Cursor::new(&buf))
+    pub fn decode(buf: &SegmentedBytes) -> Result<Self, Error> {
+        decode_trace_parquet(&mut buf.clone().reader())
     }
 }
 

--- a/src/persist/src/intercept.rs
+++ b/src/persist/src/intercept.rs
@@ -14,6 +14,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use mz_ore::bytes::SegmentedBytes;
 
 use crate::location::{Atomicity, Blob, BlobMetadata, ExternalError};
 
@@ -76,7 +77,7 @@ impl InterceptBlob {
 
 #[async_trait]
 impl Blob for InterceptBlob {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
+    async fn get(&self, key: &str) -> Result<Option<SegmentedBytes>, ExternalError> {
         self.blob.get(key).await
     }
 

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -15,6 +15,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use bytes::Bytes;
+use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastFrom;
 
 use crate::error::Error;
@@ -118,8 +119,9 @@ impl MemBlob {
 
 #[async_trait]
 impl Blob for MemBlob {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
-        self.core.lock().await.get(key)
+    async fn get(&self, key: &str) -> Result<Option<SegmentedBytes>, ExternalError> {
+        let maybe_bytes = self.core.lock().await.get(key)?;
+        Ok(maybe_bytes.map(SegmentedBytes::from))
     }
 
     async fn list_keys_and_metadata(

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -16,6 +16,7 @@ use std::time::{Instant, UNIX_EPOCH};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use bytes::Bytes;
+use mz_ore::bytes::SegmentedBytes;
 use rand::prelude::SmallRng;
 use rand::{Rng, SeedableRng};
 use tracing::trace;
@@ -140,7 +141,7 @@ impl UnreliableBlob {
 
 #[async_trait]
 impl Blob for UnreliableBlob {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
+    async fn get(&self, key: &str) -> Result<Option<SegmentedBytes>, ExternalError> {
         self.handle.run_op("get", || self.blob.get(key)).await
     }
 

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -19,7 +19,7 @@ aws-credential-types = { version = "0.53.0", default-features = false, features 
 aws-sdk-sts = { version = "0.23.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 aws-sig-auth = { version = "0.53.0", default-features = false, features = ["sign-eventstream"] }
 aws-sigv4 = { version = "0.53.0", features = ["sign-eventstream"] }
-aws-smithy-http = { version = "0.53.1", default-features = false, features = ["event-stream", "rt-tokio"] }
+aws-smithy-http = { git = "https://github.com/parker-timmerman/smithy-rs.git", branch = "v0.53.2", default-features = false, features = ["event-stream", "rt-tokio"] }
 axum = { version = "0.6.7", features = ["headers", "ws"] }
 base64 = { version = "0.13.1", features = ["alloc"] }
 bstr = { version = "0.2.14" }
@@ -90,7 +90,7 @@ semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.152", features = ["alloc", "derive"] }
 serde_json = { version = "1.0.89", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value"] }
 sha2 = { version = "0.10.6" }
-smallvec = { version = "1.10.0", default-features = false, features = ["serde", "union", "write"] }
+smallvec = { version = "1.10.0", default-features = false, features = ["const_generics", "serde", "union", "write"] }
 syn = { version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
 textwrap = { version = "0.15.0", default-features = false, features = ["terminal_size"] }
 time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
@@ -115,7 +115,7 @@ aws-credential-types = { version = "0.53.0", default-features = false, features 
 aws-sdk-sts = { version = "0.23.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 aws-sig-auth = { version = "0.53.0", default-features = false, features = ["sign-eventstream"] }
 aws-sigv4 = { version = "0.53.0", features = ["sign-eventstream"] }
-aws-smithy-http = { version = "0.53.1", default-features = false, features = ["event-stream", "rt-tokio"] }
+aws-smithy-http = { git = "https://github.com/parker-timmerman/smithy-rs.git", branch = "v0.53.2", default-features = false, features = ["event-stream", "rt-tokio"] }
 axum = { version = "0.6.7", features = ["headers", "ws"] }
 base64 = { version = "0.13.1", features = ["alloc"] }
 bstr = { version = "0.2.14" }
@@ -187,7 +187,7 @@ semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.152", features = ["alloc", "derive"] }
 serde_json = { version = "1.0.89", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value"] }
 sha2 = { version = "0.10.6" }
-smallvec = { version = "1.10.0", default-features = false, features = ["serde", "union", "write"] }
+smallvec = { version = "1.10.0", default-features = false, features = ["const_generics", "serde", "union", "write"] }
 syn = { version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
 textwrap = { version = "0.15.0", default-features = false, features = ["terminal_size"] }
 time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }


### PR DESCRIPTION
### Motivation

Today the implementation of [`Blob` for `S3`](https://github.com/MaterializeInc/materialize/blob/main/src/persist/src/s3.rs#L315) will [copy all of the multi-part responses into a single contiguous Vec](https://github.com/MaterializeInc/materialize/blob/main/src/persist/src/s3.rs#L495-L514). We need to do this because of the return type on `Blob::get`, but practically it's unnecessary because no consumers of `Blob::get` need the bytes to be in a single contiguous Vec. Ideally we don't do this copy, and the API specifies some return type that is an iterable, but possibly non-contiguous collection of bytes. There's a [TODO](https://github.com/MaterializeInc/materialize/blob/main/src/persist/src/s3.rs#L495-L501) that describes this!

This PR adds a new type to `ore` called `SegmentedBytes`, which is a collection of individual `Byte` segments. This new type implements `bytes::Buf` and `std::io::{Read, Seek}` which are the two APIs used by consumers of `Blob::get`. We then update the [`Blob::get`](https://github.com/MaterializeInc/materialize/blob/main/src/persist/src/location.rs#L397) method to return `SegmentedBytes` instead of `Vec<u8>`. Finally we update the S3 Blob impl to no longer copy bytes from the responses into a single Vec, and as part of this refactor, we also request each part's body immediately after receiving its header, instead of waiting for all the headers to come back first, which fixes another [TODO](https://github.com/MaterializeInc/materialize/blob/main/src/persist/src/s3.rs#L427-L431).

Note: Ideally we don't have to define our own "segmented bytes" type, but I couldn't find anything else that really gave us what we wanted. I tried the following:
1. Making the return type of `Blob::get` generic with `Box<dyn bytes::Buf>`, but it appears part of the returned blobs are encoded with arrow2, and the [decoder](https://github.com/MaterializeInc/materialize/blob/main/src/persist/src/indexed/columnar/parquet.rs#L52) requires the buffer to implement `std::io::Read` _and_ `std::io::Seek`, which `bytes::Buf` does not. I also couldn't find any other impls of arrow2 that used `bytes::Buf` instead of the `std::io` traits.
2. `bytes-utils` has a [`SegmentedBuf`](https://docs.rs/bytes-utils/latest/bytes_utils/struct.SegmentedBuf.html) type, but it similarly doesn't implement `Read` and `Seek`. So we'd also have to wrap this type.
3. `aws-smithy-http` has an [`AggregatedBytes`](https://docs.rs/aws-smithy-http/latest/aws_smithy_http/byte_stream/struct.AggregatedBytes.html) type, which is what the S3 client returns. But again, it doesn't implement `Read` and `Seek`, so we'd need to wrap the type ourselves.

So because we'd at least need to add a wrapper type to make any existing types work, I implemented our own "segmented bytes" type since it wasn't much more work, and we'd have total control over the impl.

Currently we depend on a personal fork of Amazon's [`smithy-rs`](https://github.com/parker-timmerman/smithy-rs) just because they have yet to release https://github.com/awslabs/smithy-rs/pull/2525. Also I'm more than happy to make a Materialize fork of `smithy-rs`, I didn't do that yet though because I wanted to get feedback on this change first.

### Tips for reviewer

There are multiple stacked changes in this PR, it's best if you view each of the commits independently. The changes are:
1. Create a new type called `SegmentedBytes` in the `ore` crate
2. Update the `trait Blob` in `persist` to use `SegmentedBytes`
3. Update the S3 client to no longer copy bytes into a single `Vec`

I see we have an [open loop benchmark](https://github.com/MaterializeInc/materialize/blob/main/src/persist-client/examples/open_loop.rs) for our persist-client, @danhhz would you know how to run this?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
