### PR TITLE
adapter: Refactor cluster replica dependents

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3770,10 +3770,12 @@ impl Coordinator {
             }
             Some(linked_cluster) => {
                 for id in linked_cluster.replicas_by_id.keys() {
-                    ops.push(Op::DropObject(ObjectId::ClusterReplica((
-                        linked_cluster.id(),
-                        *id,
-                    ))));
+                    ops.extend(
+                        self.catalog()
+                            .cluster_replica_dependents(linked_cluster.id(), *id)
+                            .into_iter()
+                            .map(catalog::Op::DropObject),
+                    );
                 }
                 let size = match config {
                     SourceSinkClusterConfig::Linked { size } => size.clone(),


### PR DESCRIPTION
Previously, the assumption that cluster replicas had no dependents was
sprinkled throughout the code in multiple places. This commit
centralizes that assumption to the `cluster_replica_dependents` method.

This assumption hasn't changed, but moving it to a single place makes
the assumption more future-proof and easier to change, should it change
in the future.

### Motivation
This PR refactors existing code.


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
