### PR TITLE
Fix broken index migration

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2145,7 +2145,7 @@ impl CatalogItem {
             | CatalogItem::Type(_)
             | CatalogItem::Func(_)
             | CatalogItem::Secret(_)
-            | CatalogItem::Connection(_) => return None,
+            | CatalogItem::Connection(_) => None,
         }
     }
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2133,6 +2133,11 @@ impl CatalogItem {
         }
     }
 
+    /// The custom compaction window, if any has been set.
+    /// Note[btv]: As of 2023-04-10, this is only set
+    /// for objects with `is_retained_metrics_object`. That
+    /// may not always be true in the future, if we enable user-settable
+    /// compaction windows.
     pub fn custom_logical_compaction_window(&self) -> Option<Duration> {
         match self {
             CatalogItem::Table(table) => table.custom_logical_compaction_window,
@@ -2149,6 +2154,14 @@ impl CatalogItem {
         }
     }
 
+    /// The initial compaction window, for objects that have one; that is,
+    /// tables, sources, indexes, and MVs.
+    ///
+    /// If `custom_logical_compaction_window()` returns something, use
+    /// that.  Otherwise, use a sensible default (currently 1s).
+    ///
+    /// For objects that do not have the concept of compaction window,
+    /// return nothing.
     pub fn initial_logical_compaction_window(&self) -> Option<Duration> {
         let custom_logical_compaction_window = match self {
             CatalogItem::Table(_)

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2134,10 +2134,10 @@ impl CatalogItem {
     }
 
     /// The custom compaction window, if any has been set.
-    /// Note[btv]: As of 2023-04-10, this is only set
-    /// for objects with `is_retained_metrics_object`. That
-    /// may not always be true in the future, if we enable user-settable
-    /// compaction windows.
+    // Note[btv]: As of 2023-04-10, this is only set
+    // for objects with `is_retained_metrics_object`. That
+    // may not always be true in the future, if we enable user-settable
+    // compaction windows.
     pub fn custom_logical_compaction_window(&self) -> Option<Duration> {
         match self {
             CatalogItem::Table(table) => table.custom_logical_compaction_window,


### PR DESCRIPTION
Migrating indexes involves loading their stored SQL and re-parsing it. However, `is_retained_metrics_relation` and `custom_logical_compaction_window` are not expressed in SQL, and were being filled in as `false`/`None` by default. This was causing the retained metrics indexes to be created with 1s retention time, thus losing us the ability to show historical data.

I'm not sure if there's a good way to test this -- do we have a framework that will let us spin up an environment on v0.48.5, upgrade it to v0.49.2 (to observe the bad behavior), then upgrade it to this PR (to observe that the indexes are now retained) ?

If not, we will have to rely on the "I tried it and it works" method of testing.

### Motivation
  * This PR fixes a recognized bug.
https://github.com/MaterializeInc/materialize/issues/18699

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix lack of historical data in cluster replica metrics
