### PR TITLE
adapter: Maintain max dataflows per cluster

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -931,7 +931,7 @@ impl Coordinator {
                             vec![self.must_finalize_dataflow(dataflow, idx.cluster_id)];
                         self.controller
                             .active_compute()
-                            .create_dataflows(idx.cluster_id, dataflow_plan)
+                            .create_dataflows(idx.cluster_id, None, dataflow_plan)
                             .unwrap_or_terminate("cannot fail to create dataflows");
                     }
                 }

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -329,7 +329,8 @@ impl ShouldHalt for StorageError {
 impl ShouldHalt for DataflowCreationError {
     fn should_halt(&self) -> bool {
         match self {
-            DataflowCreationError::SinceViolation(_) => true,
+            DataflowCreationError::SinceViolation(_)
+            | DataflowCreationError::ResourceExhaustion { .. } => true,
             DataflowCreationError::InstanceMissing(_)
             | DataflowCreationError::CollectionMissing(_)
             | DataflowCreationError::MissingAsOf => false,

--- a/src/compute-client/src/controller/error.rs
+++ b/src/compute-client/src/controller/error.rs
@@ -121,6 +121,13 @@ pub enum DataflowCreationError {
     MissingAsOf,
     #[error("dataflow has an as_of not beyond the since of collection: {0}")]
     SinceViolation(GlobalId),
+    #[error("dataflow tried to create more resources than is allowed in the system configuration. {resource_type} resource limit of {limit} cannot be exceeded. Current amount is {current_amount} instance, tried to create {new_instances} new instances.")]
+    ResourceExhaustion {
+        resource_type: String,
+        limit: u32,
+        current_amount: usize,
+        new_instances: i32,
+    },
 }
 
 impl From<InstanceMissing> for DataflowCreationError {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -732,6 +732,14 @@ pub const AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
+pub const MAX_DATAFLOWS_PER_CLUSTER: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_dataflows_per_cluster"),
+    value: &500,
+    description: "The maximum number of concurrent dataflows on a single cluster (Materialize).",
+    internal: false,
+    safe: true,
+};
+
 /// Represents the input to a variable.
 ///
 /// Each variable has different rules for how it handles each style of input.
@@ -1467,6 +1475,7 @@ impl Default for SystemVars {
             .with_var(&PG_REPLICATION_KEEPALIVES_INTERVAL)
             .with_var(&PG_REPLICATION_KEEPALIVES_RETRIES)
             .with_var(&PG_REPLICATION_TCP_USER_TIMEOUT)
+            .with_var(&MAX_DATAFLOWS_PER_CLUSTER)
     }
 }
 
@@ -1800,6 +1809,11 @@ impl SystemVars {
     /// Note: this is generally intended to be set via LaunchDarkly
     pub fn enable_auto_route_introspection_queries(&self) -> bool {
         *self.expect_value(&ENABLE_AUTO_ROUTE_INTROSPECTION_QUERIES)
+    }
+
+    /// Returns the `max_dataflows_per_cluster` configuration parameter.
+    pub fn max_dataflows_per_cluster(&self) -> u32 {
+        *self.expect_value(&MAX_DATAFLOWS_PER_CLUSTER)
     }
 }
 

--- a/test/cluster/resources/resource-limits.td
+++ b/test/cluster/resources/resource-limits.td
@@ -285,6 +285,30 @@ ALTER SYSTEM RESET ALL
 > DROP TABLE t4;
 
 $ postgres-execute connection=mz_system
+ALTER SYSTEM SET max_dataflows_per_cluster = 21
+
+> SHOW max_dataflows_per_cluster
+21
+
+> CREATE TABLE subscribe_table(a int)
+
+$ postgres-execute connection=mz_system
+BEGIN
+$ postgres-execute connection=mz_system
+DECLARE c CURSOR FOR SUBSCRIBE (SELECT * FROM subscribe_table);
+$ postgres-execute connection=mz_system
+FETCH 1 c WITH (TIMEOUT='0s')
+
+! SUBSCRIBE (SELECT * FROM subscribe_table)
+contains: Max dataflows per cluster resource limit of 21 cannot be exceeded
+
+$ postgres-execute connection=mz_system
+ROLLBACK
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM RESET max_dataflows_per_cluster
+
+$ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_sources = 2
 
 # Insert Postgres data


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Proposed fix for #18341. Looking for feedback, I don't love the approach: the number of dataflows is the number of internal dataflows which doesn't correspond 1:1 with selects + subscribes. On the other hand it may map more closely to cluster usage.

I also don't like how `total_collections_after_dataflows` has to really reflect the behavior of `create_dataflows`

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
