### PR TITLE
platform-checks: Set enable_ld_rbac_checks only on versions that supp…

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -85,8 +85,10 @@ class ConfigureMz(MzcomposeAction):
         )
 
         if self.base_version >= MzVersion(0, 47, 0):
-            input += "ALTER SYSTEM SET enable_ld_rbac_checks TO true;\n"
             input += "ALTER SYSTEM SET enable_rbac_checks TO true;\n"
+
+        if self.base_version >= MzVersion(0, 50, 0):
+            input += "ALTER SYSTEM SET enable_ld_rbac_checks TO true;\n"
 
         self.handle = e.testdrive(input=input)
 

--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -105,10 +105,17 @@ class Owners(Check):
         return Testdrive(
             # materialize role is not allowed to drop the objects since it is
             # not the owner, verify this:
-            self._drop_objects("materialize", 1, success=False, expensive=True)
-            + self._drop_objects("materialize", 2, success=False)
-            + self._drop_objects("materialize", 3, success=False)
-            + self._drop_objects("materialize", 4, success=False)
+            (
+                # Requires enable_ld_rbac_checks
+                (
+                    self._drop_objects("materialize", 1, success=False, expensive=True)
+                    + self._drop_objects("materialize", 2, success=False)
+                    + self._drop_objects("materialize", 3, success=False)
+                    + self._drop_objects("materialize", 4, success=False)
+                )
+                if self.base_version >= MzVersion.parse("0.50.0-dev")
+                else ""
+            )
             + self._create_objects("owner_role_01", 5)
             + self._create_objects("owner_role_02", 6)
             + self._create_objects("owner_role_03", 7)


### PR DESCRIPTION
…ort it

`ALTER SYSTEM SET enable_ld_rbac_checks` is only supported on v0.50+, so must not be issued against older versions.
### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI was failing.

@jkosh44 FYI