### PR TITLE
sql: Clarify parsing errors for role id

### DIFF
--- a/src/repr/src/role_id.rs
+++ b/src/repr/src/role_id.rs
@@ -17,7 +17,6 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
-
 use mz_proto::{RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.role_id.rs"));
@@ -111,29 +110,30 @@ impl FromStr for RoleId {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let err = || anyhow!("couldn't parse role id '{s}'");
         match s.chars().next() {
             Some(SYSTEM_CHAR) => {
                 if s.len() < 2 {
-                    return Err(anyhow!("couldn't parse role id {}", s));
+                    return Err(err());
                 }
-                let val: u64 = s[1..].parse()?;
+                let val: u64 = s[1..].parse().map_err(|_| err())?;
                 Ok(Self::System(val))
             }
             Some(USER_CHAR) => {
                 if s.len() < 2 {
-                    return Err(anyhow!("couldn't parse role id {}", s));
+                    return Err(err());
                 }
-                let val: u64 = s[1..].parse()?;
+                let val: u64 = s[1..].parse().map_err(|_| err())?;
                 Ok(Self::User(val))
             }
             Some(PUBLIC_CHAR) => {
                 if s.len() == 1 {
                     Ok(Self::Public)
                 } else {
-                    Err(anyhow!("couldn't parse role id {s}"))
+                    Err(err())
                 }
             }
-            _ => Err(anyhow!("couldn't parse role id {s}")),
+            _ => Err(err()),
         }
     }
 }

--- a/test/sqllogictest/privileges.slt
+++ b/test/sqllogictest/privileges.slt
@@ -135,3 +135,14 @@ query T
 SELECT mz_internal.make_mz_aclitem('u3251', 's345', 'CREATE')::text
 ----
 u3251=C/s345
+
+# Test parsing errors
+
+query error couldn't parse role id 'uasdf7890ad'
+SELECT mz_internal.make_mz_aclitem('u1', 'uasdf7890ad', 'CREATE')
+
+query error couldn't parse role id 'sd98fas9df8'
+SELECT mz_internal.make_mz_aclitem('sd98fas9df8', 's1', 'CREATE')
+
+query error unrecognized privilege type: "asdfa ljefioj"
+SELECT mz_internal.make_mz_aclitem('u1', 's1', 'asdfa ljefioj')


### PR DESCRIPTION
This commit makes the errors returned from parsing a role id more consistent and clear.

Fixes #18706


### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
