### PR TITLE
transform: refine `DatumKnowledge::meet_assign` type handing

### DIFF
--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -616,7 +616,7 @@ impl DatumKnowledge {
                 let nullable = self.nullable() || other.nullable();
                 *self = Any { nullable }
             } else if s_typ != o_typ {
-                // Same value but different base types - strip all modifiers!
+                // Same value but different concrete types - strip all modifiers!
                 // This is identical to what ColumnType::union is doing.
                 *s_typ = s_typ.without_modifiers();
             } else {
@@ -701,11 +701,16 @@ impl DatumKnowledge {
                 unreachable!();
             };
 
-            if s_typ != o_typ {
-                soft_panic_or_log!("Undefined meet of non-equal types {s_typ:?} != {o_typ:?}");
+            if !s_typ.base_eq(o_typ) {
+                soft_panic_or_log!("Undefined meet of non-equal base types {s_typ:?} != {o_typ:?}");
                 *self = Self::top(); // this really should be Nothing
             } else if s_val != o_val {
                 *self = Nothing;
+            } else if s_typ != o_typ {
+                // Same value but different concrete types - strip all
+                // modifiers! We should probably pick the more specific of the
+                // two types if they are ordered or return Nothing otherwise.
+                *s_typ = s_typ.without_modifiers();
             } else {
                 // Value and type coincide - do nothing!
             }

--- a/test/sqllogictest/github-18708.slt
+++ b/test/sqllogictest/github-18708.slt
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for #18708.
+
+statement ok
+CREATE TABLE t0(c0 FLOAT  DEFAULT (-1.77794611E9));
+
+statement ok
+CREATE TABLE t3(c0 smallint , c1 CHAR(111) , c2 REAL , c3 FLOAT );
+
+statement ok
+CREATE TABLE t5(c0 INT );
+
+statement ok
+CREATE VIEW v0(c0) AS (SELECT ALL (0.31161855206970124)::VARCHAR FROM t5 WHERE (t5.c0) BETWEEN (t5.c0) AND (t5.c0));
+
+query T multiline
+EXPLAIN SELECT
+  t3.c0, t3.c1, t3.c3, t3.c2
+FROM
+  t0,
+  v0
+  FULL OUTER JOIN t3 ON (((-6.2850675E8)>(0.56364256))) IS FALSE
+  RIGHT OUTER JOIN t5 ON ((- (t5.c0)) BETWEEN (t3.c2) AND (0.15850659265367217)) IS NOT UNKNOWN
+WHERE (t3.c1) IN (CAST(((t3.c1)LIKE(v0.c0)) AS VARCHAR));
+----
+Explained Query:
+  Project (#0, #1, #3, #2)
+    Filter (((integer_to_numeric(#5) <= 0.15850659265367217) AND (integer_to_real(#5) >= #2))) IS NOT NULL
+      Map (-(#4))
+        CrossJoin type=delta
+          ArrangeBy keys=[[]]
+            Project ()
+              Get materialize.public.t0
+          ArrangeBy keys=[[]]
+            Project ()
+              Filter (#0 <= #0) AND (#0 >= #0)
+                Get materialize.public.t5
+          ArrangeBy keys=[[]]
+            Filter (#1 = text_to_char(text_to_varchar(boolean_to_text("0.31161855206970124" ~~(padchar(#1))))))
+              Get materialize.public.t3
+          ArrangeBy keys=[[]]
+            Get materialize.public.t5
+
+Source materialize.public.t3
+  filter=((#1 = text_to_char(text_to_varchar(boolean_to_text("0.31161855206970124" ~~(padchar(#1)))))))
+
+EOF


### PR DESCRIPTION
Relax the `DatumKnowledge::meet_assign` handling of two `Lit` variants w.r.t. their types.
Fixes #18708.

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

I've asked @MaterializeInc/surfaces about a mechanism to use the greatest lower bound and not the least upper bound of the two types.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
