### PR TITLE
storage/surfaces: add non-populated disk_bytes to mz_cluster_replicas_metrics/sizes

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1692,7 +1692,8 @@ pub static MZ_CLUSTER_REPLICA_SIZES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTa
         .with_column("processes", ScalarType::UInt64.nullable(false))
         .with_column("workers", ScalarType::UInt64.nullable(false))
         .with_column("cpu_nano_cores", ScalarType::UInt64.nullable(false))
-        .with_column("memory_bytes", ScalarType::UInt64.nullable(false)),
+        .with_column("memory_bytes", ScalarType::UInt64.nullable(false))
+        .with_column("disk_bytes", ScalarType::UInt64.nullable(true)),
     is_retained_metrics_object: true,
 });
 
@@ -1821,7 +1822,8 @@ pub static MZ_CLUSTER_REPLICA_METRICS: Lazy<BuiltinTable> = Lazy::new(|| Builtin
         .with_column("replica_id", ScalarType::String.nullable(false))
         .with_column("process_id", ScalarType::UInt64.nullable(false))
         .with_column("cpu_nano_cores", ScalarType::UInt64.nullable(true))
-        .with_column("memory_bytes", ScalarType::UInt64.nullable(true)),
+        .with_column("memory_bytes", ScalarType::UInt64.nullable(true))
+        .with_column("disk_bytes", ScalarType::UInt64.nullable(true)),
     is_retained_metrics_object: true,
 });
 
@@ -2808,7 +2810,8 @@ SELECT
     r.id AS replica_id,
     m.process_id,
     m.cpu_nano_cores::float8 / s.cpu_nano_cores * 100 AS cpu_percent,
-    m.memory_bytes::float8 / s.memory_bytes * 100 AS memory_percent
+    m.memory_bytes::float8 / s.memory_bytes * 100 AS memory_percent,
+    m.disk_bytes::float8 / s.disk_bytes * 100 AS disk_percent
 FROM
     mz_cluster_replicas AS r
         JOIN mz_internal.mz_cluster_replica_sizes AS s ON r.size = s.size

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1084,6 +1084,8 @@ impl CatalogState {
                     u64::cast_from(process_id).into(),
                     (*cpu_nano_cores).into(),
                     (*memory_bytes).into(),
+                    // TODO(guswynn): disk usage will be filled in later.
+                    Datum::Null,
                 ])
             },
         );
@@ -1120,6 +1122,8 @@ impl CatalogState {
                         u64::cast_from(*workers).into(),
                         cpu_limit.as_nanocpus().into(),
                         memory_bytes.into(),
+                        // TODO(guswynn): disk size will be filled in later.
+                        Datum::Null,
                     ]);
                     BuiltinTableUpdate { id, row, diff: 1 }
                 },

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -232,10 +232,10 @@ Explained Query:
         ArrangeBy keys=[[#0]]
           Get mz_catalog.mz_clusters
         ArrangeBy keys=[[#0]]
-          Project (#0, #15)
+          Project (#0, #17)
             Filter (#3) IS NOT NULL
-              Map (((uint8_to_double(#14) / uint8_to_double(#10)) * 100))
-                Join on=(#0 = #11 AND #3 = #6) type=differential
+              Map (((uint8_to_double(#15) / uint8_to_double(#10)) * 100))
+                Join on=(#0 = #12 AND #3 = #6) type=differential
                   ArrangeBy keys=[[#0]]
                     Get mz_catalog.mz_cluster_replicas
                   ArrangeBy keys=[[#0]]

--- a/test/testdrive/metrics-cluster.td
+++ b/test/testdrive/metrics-cluster.td
@@ -16,7 +16,8 @@
       r.name,
       u.process_id,
       u.cpu_percent >= 0.0,
-      u.memory_percent > 0.0
+      u.memory_percent > 0.0,
+      u.disk_percent
   FROM
       mz_clusters AS c
           JOIN mz_cluster_replicas AS r ON r.cluster_id = c.id
@@ -25,11 +26,11 @@
               ON r.id = u.replica_id
   WHERE c.name IN ( 'foo', 'bar', 'xyzzy' )
   ORDER BY c.name, r.name, process_id
-foo size_1 0 true true
-foo size_2_2 0 true true
-foo size_2_2 1 true true
-foo size_32 0 true true
-xyzzy size_4 0 true true
+foo size_1 0 true true <null>
+foo size_2_2 0 true true <null>
+foo size_2_2 1 true true <null>
+foo size_32 0 true true <null>
+xyzzy size_4 0 true true <null>
 
 > DROP CLUSTER foo
 > DROP CLUSTER bar


### PR DESCRIPTION
As part of the `UPSERT` spill-to-disk project, we are adding access to disks on all replicas. To allow users to inspect their disk usage, we want people to be able to query the disk usage (and max disk size) for their replica. How we get this information has not yet been determined (k8s does not offer this information), but I want to adjust the schemas of the internal system objects before https://github.com/MaterializeInc/materialize/issues/18699 is resolved, as change of the relationdesc will clear any history the existing metrics tables has.

### Motivation

  * This PR adds a known-desirable feature.
https://github.com/MaterializeInc/materialize/issues/17067


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
