### PR TITLE
storage-usage-test: Fix expected storage usage for simplest materiali…

### DIFF
--- a/test/storage-usage/mzcompose.py
+++ b/test/storage-usage/mzcompose.py
@@ -154,7 +154,7 @@ database_objects = [
             > CREATE MATERIALIZED VIEW obj AS SELECT COUNT(*) FROM t1;
             """
         ),
-        expected_size=7 * 1024,
+        expected_size=4 * 1024,
     ),
     # The pg-cdc source is expected to be empty. The data is in the sub-source
     DatabaseObject(
@@ -247,7 +247,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 $ set-regex match=\d+ replacement=<SIZE>
 
                 # Select the raw size as well, so if this errors in testdrive, its easier to debug.
-                > SELECT size_bytes, size_bytes BETWEEN {database_object.expected_size//2} AND {database_object.expected_size*3}
+                > SELECT size_bytes, size_bytes BETWEEN {database_object.expected_size//3} AND {database_object.expected_size*3}
                   FROM mz_storage_usage
                   WHERE collection_timestamp = ( SELECT MAX(collection_timestamp) FROM mz_storage_usage )
                   AND object_id = ( SELECT id FROM mz_objects WHERE name = 'obj' );


### PR DESCRIPTION
…zed views

A SELECT COUNT(*) materialized view now takes less storage than it did before.

Furthermore, make the test more lenient when less storage usage than expected is being reported.


### Motivation


  * This PR fixes a previously unreported bug.
Sporadic failures in CI

### Tips for reviewer


@nrainer-materialize the context here is that we have an introspection table that records the S3 usage of various sources and materialized views. This is then used for customer billing purposes.

The test creates such objects and then checks if the recorded storage usage is within the same ballpark of the expected storage usage, with a wide berth, given that there is garbage collection and other background activity going on. The test has been flaky since the storage usage consumption of small objects is measured in kilobytes, but goes up and down a few KB here and there because of random code changes and optimizations.