### PR TITLE
Make EXPECTED GROUP SIZE changes more consistent

### DIFF
--- a/src/compute-client/src/plan/reduce.rs
+++ b/src/compute-client/src/plan/reduce.rs
@@ -71,7 +71,7 @@ use mz_expr::permutation_for_arrangement;
 use mz_expr::AggregateExpr;
 use mz_expr::AggregateFunc;
 use mz_expr::MirScalarExpr;
-use mz_ore::{cast::CastFrom, soft_assert_or_log};
+use mz_ore::soft_assert_or_log;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 
 use super::{bucketing_of_expected_group_size, AvailableCollections};
@@ -173,15 +173,15 @@ pub enum ReducePlan {
 }
 
 proptest::prop_compose! {
-    /// `expected_group_size` is a usize, but instead of a uniform distribution,
+    /// `expected_group_size` is a u64, but instead of a uniform distribution,
     /// we want a logarithmic distribution so that we have an even distribution
     /// in the number of layers of buckets that a hierarchical plan would have.
     fn any_group_size()
-        (bits in 0..usize::BITS)
-        (integer in (((1_usize) << bits) - 1)
-            ..(if bits == (usize::BITS - 1){ usize::MAX }
-                else { (1_usize) << (bits + 1) - 1 }))
-    -> usize {
+        (bits in 0..u64::BITS)
+        (integer in (((1_u64) << bits) - 1)
+            ..(if bits == (u64::BITS - 1){ u64::MAX }
+                else { (1_u64) << (bits + 1) - 1 }))
+    -> u64 {
         integer
     }
 }
@@ -546,7 +546,7 @@ impl ReducePlan {
     pub fn create_from(
         aggregates: Vec<AggregateExpr>,
         monotonic: bool,
-        expected_group_size: Option<usize>,
+        expected_group_size: Option<u64>,
     ) -> Self {
         // If we don't have any aggregations we are just computing a distinct.
         if aggregates.is_empty() {
@@ -627,7 +627,7 @@ impl ReducePlan {
         typ: ReductionType,
         aggregates_list: Vec<(usize, AggregateExpr)>,
         monotonic: bool,
-        expected_group_size: Option<usize>,
+        expected_group_size: Option<u64>,
     ) -> Self {
         assert!(
             aggregates_list.len() > 0,
@@ -680,8 +680,7 @@ impl ReducePlan {
                     let monotonic = MonotonicPlan { aggr_funcs, skips };
                     ReducePlan::Hierarchical(HierarchicalPlan::Monotonic(monotonic))
                 } else {
-                    let buckets =
-                        bucketing_of_expected_group_size(expected_group_size.map(u64::cast_from));
+                    let buckets = bucketing_of_expected_group_size(expected_group_size);
                     let bucketed = BucketedPlan {
                         aggr_funcs,
                         skips,

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -611,7 +611,7 @@ impl MirRelationExpr {
                         }
                         write!(f, " monotonic={}", monotonic)?;
                         if let Some(expected_group_size) = expected_group_size {
-                            write!(f, " expected_group_size={}", expected_group_size)?;
+                            write!(f, " exp_group_size={}", expected_group_size)?;
                         }
                         self.fmt_attributes(f, ctx)
                     },

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -221,7 +221,7 @@ pub enum MirRelationExpr {
         monotonic: bool,
         /// User hint: expected number of values per group key. Used to optimize physical rendering.
         #[serde(default)]
-        expected_group_size: Option<usize>,
+        expected_group_size: Option<u64>,
     },
     /// Groups and orders within each group, limiting output.
     ///
@@ -1234,7 +1234,7 @@ impl MirRelationExpr {
         self,
         group_key: Vec<usize>,
         aggregates: Vec<AggregateExpr>,
-        expected_group_size: Option<usize>,
+        expected_group_size: Option<u64>,
     ) -> Self {
         MirRelationExpr::Reduce {
             input: Box::new(self),

--- a/src/sql/src/plan/explain/text.rs
+++ b/src/sql/src/plan/explain/text.rs
@@ -230,7 +230,7 @@ impl HirRelationExpr {
                     write!(f, " offset={}", offset)?
                 }
                 if let Some(expected_group_size) = expected_group_size {
-                    write!(f, " expected_group_size={}", expected_group_size)?;
+                    write!(f, " exp_group_size={}", expected_group_size)?;
                 }
                 writeln!(f)?;
                 ctx.indented(|ctx| input.fmt_text(f, ctx))?;

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -149,7 +149,7 @@ pub enum HirRelationExpr {
         input: Box<HirRelationExpr>,
         group_key: Vec<usize>,
         aggregates: Vec<AggregateExpr>,
-        expected_group_size: Option<usize>,
+        expected_group_size: Option<u64>,
     },
     Distinct {
         input: Box<HirRelationExpr>,
@@ -1196,7 +1196,7 @@ impl HirRelationExpr {
         self,
         group_key: Vec<usize>,
         aggregates: Vec<AggregateExpr>,
-        expected_group_size: Option<usize>,
+        expected_group_size: Option<u64>,
     ) -> Self {
         HirRelationExpr::Reduce {
             input: Box::new(self),

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -44,7 +44,6 @@ use uuid::Uuid;
 
 use mz_expr::virtual_syntax::AlgExcept;
 use mz_expr::{func as expr_func, Id, LocalId, MirScalarExpr, RowSetFinishing};
-use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 use mz_ore::str::StrExt;
@@ -1846,7 +1845,7 @@ fn plan_view_select(
             relation_expr = relation_expr.map(group_hir_exprs).reduce(
                 group_key,
                 agg_exprs,
-                expected_group_size.map(usize::cast_from),
+                expected_group_size,
             );
             (group_scope, select_all_mapping)
         } else {

--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -167,7 +167,7 @@ fn try_push_reduce_through_join(
     group_key: &Vec<MirScalarExpr>,
     aggregates: &Vec<AggregateExpr>,
     monotonic: bool,
-    expected_group_size: Option<usize>,
+    expected_group_size: Option<u64>,
 ) -> Option<MirRelationExpr> {
     // Variable name details:
     // The goal is to turn `old` (`Reduce { Join { <inputs> }}`) into
@@ -457,7 +457,7 @@ impl ReduceBuilder {
     fn construct_reduce(
         self,
         monotonic: bool,
-        expected_group_size: Option<usize>,
+        expected_group_size: Option<u64>,
     ) -> MirRelationExpr {
         MirRelationExpr::Reduce {
             input: Box::new(self.input),

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -161,7 +161,7 @@ EXPLAIN WITH(arity, join_impls) SELECT state, name FROM
 ----
 Explained Query:
   Project (#1, #0) // { arity: 2 }
-    TopK group_by=[#1] order_by=[#2 desc nulls_last] limit=3 monotonic=false expected_group_size=1 // { arity: 3 }
+    TopK group_by=[#1] order_by=[#2 desc nulls_last] limit=3 monotonic=false exp_group_size=1 // { arity: 3 }
       Get materialize.public.cities // { arity: 3 }
 
 EOF


### PR DESCRIPTION
In PR #18606, I had meant to note that Reduce's use of usize seems incorrect, and it's more obviously so now that we look at the shared bucketing code.  We might as well correct that now.

Additionally, I hadn't noticed that Reduce explains this option as `exp_group_size`; we might as well make that consistent.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

 - This PR refactors existing code.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
