### PR TITLE
sql: fix function call for eqaulity functions on ranges

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3565,7 +3565,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(ArrayAny, ArrayAny) => BinaryFunc::Lt => Bool, 1072;
             params!(RecordAny, RecordAny) => BinaryFunc::Lt => Bool, 2990;
             params!(MzTimestamp, MzTimestamp)=>BinaryFunc::Lt =>Bool, oid::FUNC_MZ_TIMESTAMP_LT_MZ_TIMESTAMP_OID;
-            params!(RangeAny, RangeAny) => BinaryFunc::Eq => Bool, 3884;
+            params!(RangeAny, RangeAny) => BinaryFunc::Lt => Bool, 3884;
         },
         "<=" => Scalar {
             params!(Numeric, Numeric) => BinaryFunc::Lte => Bool, 1755;
@@ -3593,7 +3593,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(ArrayAny, ArrayAny) => BinaryFunc::Lte => Bool, 1074;
             params!(RecordAny, RecordAny) => BinaryFunc::Lte => Bool, 2992;
             params!(MzTimestamp, MzTimestamp)=>BinaryFunc::Lte =>Bool, oid::FUNC_MZ_TIMESTAMP_LTE_MZ_TIMESTAMP_OID;
-            params!(RangeAny, RangeAny) => BinaryFunc::Eq => Bool, 3885;
+            params!(RangeAny, RangeAny) => BinaryFunc::Lte => Bool, 3885;
         },
         ">" => Scalar {
             params!(Numeric, Numeric) => BinaryFunc::Gt => Bool, 1756;
@@ -3621,7 +3621,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(ArrayAny, ArrayAny) => BinaryFunc::Gt => Bool, 1073;
             params!(RecordAny, RecordAny) => BinaryFunc::Gt => Bool, 2991;
             params!(MzTimestamp, MzTimestamp)=>BinaryFunc::Gt =>Bool, oid::FUNC_MZ_TIMESTAMP_GT_MZ_TIMESTAMP_OID;
-            params!(RangeAny, RangeAny) => BinaryFunc::Eq => Bool, 3887;
+            params!(RangeAny, RangeAny) => BinaryFunc::Gt => Bool, 3887;
         },
         ">=" => Scalar {
             params!(Numeric, Numeric) => BinaryFunc::Gte => Bool, 1757;
@@ -3649,7 +3649,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(ArrayAny, ArrayAny) => BinaryFunc::Gte => Bool, 1075;
             params!(RecordAny, RecordAny) => BinaryFunc::Gte => Bool, 2993;
             params!(MzTimestamp, MzTimestamp)=>BinaryFunc::Gte =>Bool, oid::FUNC_MZ_TIMESTAMP_GTE_MZ_TIMESTAMP_OID;
-            params!(RangeAny, RangeAny) => BinaryFunc::Eq => Bool, 3886;
+            params!(RangeAny, RangeAny) => BinaryFunc::Gte => Bool, 3886;
         },
         // Warning!
         // - If you are writing functions here that do not simply use

--- a/test/pgtest/range.pt
+++ b/test/pgtest/range.pt
@@ -82,6 +82,9 @@ Execute
 Parse {"query": "SELECT a t, array_agg(v ORDER BY v) FROM ( SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL ) int4range_values(a), int4range_test_values WHERE a -|- v GROUP BY a ORDER BY a;"}
 Bind
 Execute
+Parse {"query": "SELECT DISTINCT l.v, r.v, l.v < r.v, l.v <= r.v, l.v > r.v, l.v >= r.v, l.v = r.v, l.v <> r.v FROM int4range_test_values AS l, int4range_test_values AS r;"}
+Bind
+Execute
 Sync
 ----
 
@@ -172,6 +175,58 @@ ParseComplete
 BindComplete
 DataRow {"fields":["[1,)","{(,1),[-1,1)}"]}
 CommandComplete {"tag":"SELECT 1"}
+ParseComplete
+BindComplete
+DataRow {"fields":["empty","empty","f","t","f","t","t","f"]}
+DataRow {"fields":["empty","(,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["(,)","(,)","f","t","f","t","t","f"]}
+DataRow {"fields":["empty","(,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[0,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["(,1)","(,)","t","t","f","f","f","t"]}
+DataRow {"fields":["[0,)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[0,)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["(,)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["(,)","[0,)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[-99,-50)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["[50,99)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["(,1)","(,1)","f","t","f","t","t","f"]}
+DataRow {"fields":["(,1)","[0,)","t","t","f","f","f","t"]}
+DataRow {"fields":["[0,)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[0,)","[0,)","f","t","f","t","t","f"]}
+DataRow {"fields":["(,)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","[-99,-50)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["[50,99)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","[0,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","[0,)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-1,1)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","[0,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[-99,-50)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["[0,)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["[0,)","[-99,-50)","f","f","t","t","f","t"]}
+DataRow {"fields":["[0,)","[-1,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","[50,99)","f","t","f","t","t","f"]}
+DataRow {"fields":["[50,99)","[-99,-50)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","[-1,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-99,-50)","[-99,-50)","f","t","f","t","t","f"]}
+DataRow {"fields":["[-99,-50)","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-1,1)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-1,1)","[-99,-50)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","[-1,1)","f","t","f","t","t","f"]}
+CommandComplete {"tag":"SELECT 49"}
 ReadyForQuery {"status":"I"}
 
 send
@@ -197,6 +252,9 @@ Parse {"query": "SELECT a t, array_agg(v ORDER BY v) FROM ( SELECT DISTINCT a FR
 Bind
 Execute
 Parse {"query": "SELECT a t, array_agg(v ORDER BY v) FROM ( SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL ) numrange_values(a), numrange_test_values WHERE a -|- v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT DISTINCT l.v, r.v, l.v < r.v, l.v <= r.v, l.v > r.v, l.v >= r.v, l.v = r.v, l.v <> r.v FROM numrange_test_values AS l, numrange_test_values AS r;"}
 Bind
 Execute
 Sync
@@ -296,6 +354,58 @@ ParseComplete
 BindComplete
 DataRow {"fields":["[1,)","{(,1),[-1,1)}"]}
 CommandComplete {"tag":"SELECT 1"}
+ParseComplete
+BindComplete
+DataRow {"fields":["empty","empty","f","t","f","t","t","f"]}
+DataRow {"fields":["empty","(,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["(,)","(,)","f","t","f","t","t","f"]}
+DataRow {"fields":["empty","(,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","(-1,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["(,1)","(,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(-1,)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["(-1,)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["(,)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["(,)","(-1,)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[-99,-50)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-1,1)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["(,1)","(,1)","f","t","f","t","t","f"]}
+DataRow {"fields":["(,1)","(-1,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(-1,)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["(-1,)","(-1,)","f","t","f","t","t","f"]}
+DataRow {"fields":["(,)","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","[-99,-50)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-1,1)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","(-1,)","t","t","f","f","f","t"]}
+DataRow {"fields":["[50,99)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","(-1,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","(-1,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[-99,-50)","t","t","f","f","f","t"]}
+DataRow {"fields":["(-1,)","[-1,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["(-1,)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["(-1,)","[-99,-50)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","[-1,1)","f","t","f","t","t","f"]}
+DataRow {"fields":["[-1,1)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-1,1)","[-99,-50)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","[-1,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","[50,99)","f","t","f","t","t","f"]}
+DataRow {"fields":["[50,99)","[-99,-50)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-99,-50)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-99,-50)","[-99,-50)","f","t","f","t","t","f"]}
+CommandComplete {"tag":"SELECT 49"}
 ReadyForQuery {"status":"I"}
 
 # test range binary encodings

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -665,12 +665,12 @@ true
 query B
 select '(,)'::int4range > 'empty'::int4range;
 ----
-false
+true
 
 query B
 select '(,)'::int4range >= 'empty'::int4range;
 ----
-false
+true
 
 query B
 select '(,)'::int4range < 'empty'::int4range;
@@ -1817,12 +1817,12 @@ true
 query B
 select '(,)'::int8range > 'empty'::int8range;
 ----
-false
+true
 
 query B
 select '(,)'::int8range >= 'empty'::int8range;
 ----
-false
+true
 
 query B
 select '(,)'::int8range < 'empty'::int8range;
@@ -2904,12 +2904,12 @@ true
 query B
 select '(,)'::daterange > 'empty'::daterange;
 ----
-false
+true
 
 query B
 select '(,)'::daterange >= 'empty'::daterange;
 ----
-false
+true
 
 query B
 select '(,)'::daterange < 'empty'::daterange;
@@ -4067,12 +4067,12 @@ true
 query B
 select '(,)'::numrange > 'empty'::numrange;
 ----
-false
+true
 
 query B
 select '(,)'::numrange >= 'empty'::numrange;
 ----
-false
+true
 
 query B
 select '(,)'::numrange < 'empty'::numrange;
@@ -5806,12 +5806,12 @@ true
 query B
 select '(,)'::tsrange > 'empty'::tsrange;
 ----
-false
+true
 
 query B
 select '(,)'::tsrange >= 'empty'::tsrange;
 ----
-false
+true
 
 query B
 select '(,)'::tsrange < 'empty'::tsrange;
@@ -7532,12 +7532,12 @@ true
 query B
 select '(,)'::tstzrange > 'empty'::tstzrange;
 ----
-false
+true
 
 query B
 select '(,)'::tstzrange >= 'empty'::tstzrange;
 ----
-false
+true
 
 query B
 select '(,)'::tstzrange < 'empty'::tstzrange;


### PR DESCRIPTION
Fixes #18726

### Motivation

This PR fixes a recognized bug.

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Return the correct results when using `<`, `<=`, `>`, and `>=` on any range type. Previously all of these expressions return the evaluation for equality.
