### PR TITLE
doc/user document reserved disk_bytes fields in usage tables

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -33,9 +33,10 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 | Field               | Type         | Meaning                                              |
 | ------------------- | ------------ | --------                                             |
 | `replica_id`        | [`text`]     | The ID of a cluster replica.                         |
-| `process_id`        | [`bigint`]   | An identifier of a compute process within a replica. |
-| `cpu_nano_cores`    | [`bigint`]   | Approximate CPU usage, in billionths of a vCPU core. |
-| `memory_bytes`      | [`bigint`]   | Approximate RAM usage, in bytes.                     |
+| `process_id`        | [`uint8`]    | An identifier of a compute process within a replica. |
+| `cpu_nano_cores`    | [`uint8`]    | Approximate CPU usage, in billionths of a vCPU core. |
+| `memory_bytes`      | [`uint8`]    | Approximate RAM usage, in bytes.                     |
+| `disk_bytes`        | [`uint8`]    | Currently null. Reserved for later use.              |
 
 ### `mz_cluster_replica_sizes`
 
@@ -54,6 +55,7 @@ them for any kind of capacity planning.
 | `workers`        | [`uint8`] | The number of Timely Dataflow workers per process.            |
 | `cpu_nano_cores` | [`uint8`] | The CPU allocation per process, in billionths of a vCPU core. |
 | `memory_bytes`   | [`uint8`] | The RAM allocation per process, in billionths of a vCPU core. |
+| `disk_bytes`     | [`uint8`] | Currently null. Reserved for later use.                       |
 
 
 ### `mz_cluster_links`
@@ -100,6 +102,7 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 | `process_id`     | [`uint8`] | An identifier of a compute process within a replica.       |
 | `cpu_percent`    | [`uint8`] | Approximate CPU usage, in percent of the total allocation. |
 | `memory_percent` | [`uint8`] | Approximate RAM usage, in percent of the total allocation. |
+| `disk_percent`   | [`uint8`] | Currently null. Reserved for later use.                    |
 
 ### `mz_cluster_replica_frontiers`
 


### PR DESCRIPTION
Documenting https://github.com/MaterializeInc/materialize/pull/18717, should merge after that pr is released

### Motivation
docs

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
