### PR TITLE
persist: columnar mapping tests and bug fixes

### DIFF
--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -29,16 +29,7 @@ impl PartStats {
         schemas: &Schemas<K, V>,
         part: &Part,
     ) -> Result<Self, String> {
-        let mut key = StructStats {
-            len: part.len(),
-            cols: Default::default(),
-        };
-        let mut key_cols = part.key_ref();
-        for (name, _typ, stats_fn) in schemas.key.columns() {
-            let col_stats = key_cols.stats(&name, stats_fn)?;
-            key.cols.insert(name, col_stats);
-        }
-        key_cols.finish()?;
+        let key = part.key_stats(schemas.key.as_ref())?;
         Ok(PartStats { key })
     }
 

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -346,10 +346,10 @@ mod impls {
 
     impl ColumnStats<Option<Vec<u8>>> for OptionStats<BytesStats> {
         fn lower<'a>(&'a self) -> Option<<Option<Vec<u8>> as Data>::Ref<'a>> {
-            Some(self.some.lower())
+            self.some.lower().map(Some)
         }
         fn upper<'a>(&'a self) -> Option<<Option<Vec<u8>> as Data>::Ref<'a>> {
-            Some(self.some.upper())
+            self.some.upper().map(Some)
         }
         fn none_count(&self) -> usize {
             self.none

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -13,7 +13,7 @@ use mz_persist_types::columnar::{ColumnGet, Data};
 use mz_persist_types::stats::{JsonStats, PrimitiveStats};
 use prost::Message;
 
-use crate::row::encoding::{DatumToPersist, ProtoDatumToPersist};
+use crate::row::encoding::{DatumToPersist, NullableProtoDatumToPersist};
 use crate::row::ProtoDatum;
 use crate::{Datum, Row, RowArena};
 
@@ -89,13 +89,22 @@ fn as_optional_datum<'a>(row: &'a Row) -> Option<Datum<'a>> {
 /// and max and similarly returned encoded via ProtoDatum. If the column is
 /// empty, the returned min and max will be Datum::Null, otherwise they will
 /// never be null.
-pub(crate) fn proto_datum_min_max_nulls(col: &<Vec<u8> as Data>::Col) -> (Vec<u8>, Vec<u8>, usize) {
+///
+/// NB: `Vec<u8>` and `Option<Vec<u8>>` happen to use the same type for Col.
+/// It's a bit odd to use the Option version for both, but it happens to work
+/// because the non-option version won't generate any Nulls.
+pub(crate) fn proto_datum_min_max_nulls(
+    col: &<Option<Vec<u8>> as Data>::Col,
+) -> (Vec<u8>, Vec<u8>, usize) {
     let (mut min, mut max) = (Row::default(), Row::default());
     let mut null_count = 0;
 
     let mut buf = Row::default();
     for idx in 0..col.len() {
-        ProtoDatumToPersist::decode(ColumnGet::<Vec<u8>>::get(col, idx), &mut buf.packer());
+        NullableProtoDatumToPersist::decode(
+            ColumnGet::<Option<Vec<u8>>>::get(col, idx),
+            &mut buf.packer(),
+        );
         let datum = as_optional_datum(&buf).expect("not enough datums");
         if datum == Datum::Null {
             null_count += 1;
@@ -119,15 +128,22 @@ pub(crate) fn proto_datum_min_max_nulls(col: &<Vec<u8> as Data>::Col) -> (Vec<u8
 /// Returns the JsonStats and null_count for the column of `ScalarType::Jsonb`.
 ///
 /// Each entry in the column is a single Datum encoded as a ProtoDatum.
+///
+/// NB: `Vec<u8>` and `Option<Vec<u8>>` happen to use the same type for Col.
+/// It's a bit odd to use the Option version for both, but it happens to work
+/// because the non-option version won't generate any Nulls.
 pub(crate) fn jsonb_stats_nulls(
-    col: &<Vec<u8> as Data>::Col,
+    col: &<Option<Vec<u8>> as Data>::Col,
 ) -> Result<(JsonStats, usize), String> {
     let mut stats = JsonStats::default();
     let mut null_count = 0;
 
     let mut buf = Row::default();
     for idx in 0..col.len() {
-        ProtoDatumToPersist::decode(ColumnGet::<Vec<u8>>::get(col, idx), &mut buf.packer());
+        NullableProtoDatumToPersist::decode(
+            ColumnGet::<Option<Vec<u8>>>::get(col, idx),
+            &mut buf.packer(),
+        );
         let datum = as_optional_datum(&buf).expect("not enough datums");
         // Datum::Null only shows up at the top level of Jsonb, so we handle it
         // here instead of in the recursing function.


### PR DESCRIPTION
This adds basic unit test coverage of roundtrip-ing Row and SourceData through persist's columnar format and well as basic test coverage of stats over each column type.

Also included are the  large number of bug fixes necessary to make the new tests pass.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
