### PR TITLE
cbrt tests: Don't expect too many digits

### DIFF
--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -387,29 +387,34 @@ SELECT cbrt(NULL)
 NULL
 
 query R
-SELECT cbrt(1.23783::float)
+SELECT cbrt(1.23783::float)::float4
 ----
-1.0737100084353584
+1.07371
 
 query R
-SELECT cbrt(1.23783::double)
+SELECT cbrt(1.23783::double)::float4
 ----
-1.0737100084353584
+1.07371
 
 query R
-SELECT cbrt(1.23783::decimal(15,5))
+SELECT cbrt(1.23783::decimal(15,5))::float4
 ----
-1.0737100084353584
+1.07371
 
 query R
-SELECT cbrt(-8::double)
+SELECT cbrt(-8::double)::float4
 ----
 -2
 
 query R
-SELECT cbrt(3::int)
+SELECT cbrt(3::int)::float4
 ----
-1.4422495703074083
+1.4422495
+
+query R
+SELECT cbrt(27::int)::float4
+----
+3
 
 # Test coalesce.
 query I


### PR DESCRIPTION
Because of architecture and libm's cbrt differences results are not guaranteed to be that exact.

Fixes #18746

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
