### PR TITLE
Fix assignment of AZs

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -78,7 +78,6 @@ use derivative::Derivative;
 use fail::fail_point;
 use futures::StreamExt;
 use itertools::Itertools;
-use rand::seq::SliceRandom;
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, watch, OwnedMutexGuard};

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1382,9 +1382,6 @@ pub async fn serve(
     if availability_zones.is_empty() {
         availability_zones.push(DUMMY_AVAILABILITY_ZONE.into());
     }
-    // Shuffle availability zones for unbiased selection in
-    // Coordinator::sequence_create_compute_replica.
-    availability_zones.shuffle(&mut rand::thread_rng());
 
     let aws_principal_context = if aws_account_id.is_some()
         && connection_context.aws_external_id_prefix.is_some()

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -92,6 +92,7 @@ use std::time::Duration;
 
 use anyhow::{bail, Context};
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
+use rand::seq::SliceRandom;
 use tokio::sync::oneshot;
 use tower_http::cors::AllowOrigin;
 
@@ -314,7 +315,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
             // availability zone installed.
             default_availability_zone: config
                 .availability_zones
-                .first()
+                .choose(&mut rand::thread_rng())
                 .cloned()
                 .unwrap_or_else(|| mz_adapter::DUMMY_AVAILABILITY_ZONE.into()),
         },


### PR DESCRIPTION
We had been shuffling the list of AZs on environmentd boot in an attempt to make sure they were assigned randomly. However, we later pick the AZ from a `BTreeMap`, which sorts its elements by key.

Instead of shuffling on boot, just randomly select one at the time when the AZ is chosen.

### Motivation

  * This PR fixes a previously unreported bug.

Replicas of new clusters are assigned to the first known AZ in alphabetical order, rather than randomly.