### PR TITLE
platform checks: Fix version for enable_ld_rbac_checks

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -87,7 +87,7 @@ class ConfigureMz(MzcomposeAction):
         if self.base_version >= MzVersion(0, 47, 0):
             input += "ALTER SYSTEM SET enable_rbac_checks TO true;\n"
 
-        if self.base_version >= MzVersion(0, 50, 0):
+        if self.base_version >= MzVersion.parse("0.51.0-dev"):
             input += "ALTER SYSTEM SET enable_ld_rbac_checks TO true;\n"
 
         self.handle = e.testdrive(input=input)

--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -113,7 +113,7 @@ class Owners(Check):
                     + self._drop_objects("materialize", 3, success=False)
                     + self._drop_objects("materialize", 4, success=False)
                 )
-                if self.base_version >= MzVersion.parse("0.50.0-dev")
+                if self.base_version >= MzVersion.parse("0.51.0-dev")
                 else ""
             )
             + self._create_objects("owner_role_01", 5)


### PR DESCRIPTION
Was not yet part of 0.50, see https://materialize.com/docs/releases/v0.50/

I'll let the failed nightlies run against it.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
