### PR TITLE
platform-checks: Add privileges validation to owners check

### DIFF
--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -223,6 +223,22 @@ class Owners(Check):
                 > SELECT mz_cluster_replicas.name, mz_roles.name FROM mz_cluster_replicas JOIN mz_roles ON mz_cluster_replicas.owner_id = mz_roles.id WHERE mz_cluster_replicas.name LIKE 'owner_cluster_r%'
                 owner_cluster_r1 owner_role_01
 
+                > SELECT mz_connections.name, mz_roles.name FROM mz_connections JOIN mz_roles ON mz_connections.owner_id = mz_roles.id WHERE mz_connections.name LIKE 'owner_%'
+                owner_csr_conn1 owner_role_01
+                owner_csr_conn2 owner_role_01
+                owner_csr_conn3 owner_role_01
+                owner_csr_conn4 owner_role_02
+                owner_csr_conn5 owner_role_01
+                owner_csr_conn6 owner_role_02
+                owner_csr_conn7 owner_role_03
+                owner_kafka_conn1 owner_role_01
+                owner_kafka_conn2 owner_role_01
+                owner_kafka_conn3 owner_role_01
+                owner_kafka_conn4 owner_role_02
+                owner_kafka_conn5 owner_role_01
+                owner_kafka_conn6 owner_role_02
+                owner_kafka_conn7 owner_role_03
+
                 > SELECT name, unnest(privileges)::text FROM mz_databases WHERE name LIKE 'owner_db%'
                 owner_db1 owner_role_01=UC/owner_role_01
                 owner_db2 owner_role_01=UC/owner_role_01
@@ -302,6 +318,21 @@ class Owners(Check):
                 > SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name LIKE 'owner_cluster%'
                 owner_cluster1 owner_role_01=UC/owner_role_01
 
+                > SELECT name, unnest(privileges)::text FROM mz_connections WHERE name LIKE 'owner_%'
+                owner_csr_conn1 owner_role_01=U/owner_role_01
+                owner_csr_conn2 owner_role_01=U/owner_role_01
+                owner_csr_conn3 owner_role_01=U/owner_role_01
+                owner_csr_conn4 owner_role_02=U/owner_role_02
+                owner_csr_conn5 owner_role_01=U/owner_role_01
+                owner_csr_conn6 owner_role_02=U/owner_role_02
+                owner_csr_conn7 owner_role_03=U/owner_role_03
+                owner_kafka_conn1 owner_role_01=U/owner_role_01
+                owner_kafka_conn2 owner_role_01=U/owner_role_01
+                owner_kafka_conn3 owner_role_01=U/owner_role_01
+                owner_kafka_conn4 owner_role_02=U/owner_role_02
+                owner_kafka_conn5 owner_role_01=U/owner_role_01
+                owner_kafka_conn6 owner_role_02=U/owner_role_02
+                owner_kafka_conn7 owner_role_03=U/owner_role_03
                 """
             )
             + self._drop_objects("owner_role_01", 5)

--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -222,6 +222,86 @@ class Owners(Check):
 
                 > SELECT mz_cluster_replicas.name, mz_roles.name FROM mz_cluster_replicas JOIN mz_roles ON mz_cluster_replicas.owner_id = mz_roles.id WHERE mz_cluster_replicas.name LIKE 'owner_cluster_r%'
                 owner_cluster_r1 owner_role_01
+
+                > SELECT name, unnest(privileges)::text FROM mz_databases WHERE name LIKE 'owner_db%'
+                owner_db1 owner_role_01=UC/owner_role_01
+                owner_db2 owner_role_01=UC/owner_role_01
+                owner_db3 owner_role_01=UC/owner_role_01
+                owner_db4 owner_role_02=UC/owner_role_02
+                owner_db5 owner_role_01=UC/owner_role_01
+                owner_db6 owner_role_02=UC/owner_role_02
+                owner_db7 owner_role_03=UC/owner_role_03
+
+                > SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name LIKE 'owner_schema%'
+                owner_schema1 owner_role_01=UC/owner_role_01
+                owner_schema2 owner_role_01=UC/owner_role_01
+                owner_schema3 owner_role_01=UC/owner_role_01
+                owner_schema4 owner_role_02=UC/owner_role_02
+                owner_schema5 owner_role_01=UC/owner_role_01
+                owner_schema6 owner_role_02=UC/owner_role_02
+                owner_schema7 owner_role_03=UC/owner_role_03
+
+                > SELECT name, unnest(privileges)::text FROM mz_tables WHERE name LIKE 'owner_t%'
+                owner_t1 owner_role_01=arwd/owner_role_01
+                owner_t2 owner_role_01=arwd/owner_role_01
+                owner_t3 owner_role_01=arwd/owner_role_01
+                owner_t4 owner_role_02=arwd/owner_role_02
+                owner_t5 owner_role_01=arwd/owner_role_01
+                owner_t6 owner_role_02=arwd/owner_role_02
+                owner_t7 owner_role_03=arwd/owner_role_03
+
+                > SELECT name, unnest(privileges)::text FROM mz_views WHERE name LIKE 'owner_v%'
+                owner_v1 owner_role_01=r/owner_role_01
+                owner_v2 owner_role_01=r/owner_role_01
+                owner_v3 owner_role_01=r/owner_role_01
+                owner_v4 owner_role_02=r/owner_role_02
+                owner_v5 owner_role_01=r/owner_role_01
+                owner_v6 owner_role_02=r/owner_role_02
+                owner_v7 owner_role_03=r/owner_role_03
+
+                > SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name LIKE 'owner_mv%'
+                owner_mv1 owner_role_01=r/owner_role_01
+                owner_mv2 owner_role_01=r/owner_role_01
+                owner_mv3 owner_role_01=r/owner_role_01
+                owner_mv4 owner_role_02=r/owner_role_02
+                owner_mv5 owner_role_01=r/owner_role_01
+                owner_mv6 owner_role_02=r/owner_role_02
+                owner_mv7 owner_role_03=r/owner_role_03
+
+                > SELECT name, unnest(privileges)::text FROM mz_types WHERE name LIKE 'owner_type%'
+                owner_type1 =U/owner_role_01
+                owner_type1 owner_role_01=U/owner_role_01
+                owner_type2 =U/owner_role_01
+                owner_type2 owner_role_01=U/owner_role_01
+                owner_type3 =U/owner_role_01
+                owner_type3 owner_role_01=U/owner_role_01
+                owner_type4 =U/owner_role_02
+                owner_type4 owner_role_02=U/owner_role_02
+                owner_type5 =U/owner_role_01
+                owner_type5 owner_role_01=U/owner_role_01
+                owner_type6 =U/owner_role_02
+                owner_type6 owner_role_02=U/owner_role_02
+                owner_type7 =U/owner_role_03
+                owner_type7 owner_role_03=U/owner_role_03
+
+                > SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name LIKE 'owner_secret%'
+                owner_secret1 owner_role_01=U/owner_role_01
+                owner_secret2 owner_role_01=U/owner_role_01
+                owner_secret3 owner_role_01=U/owner_role_01
+                owner_secret4 owner_role_02=U/owner_role_02
+                owner_secret5 owner_role_01=U/owner_role_01
+                owner_secret6 owner_role_02=U/owner_role_02
+                owner_secret7 owner_role_03=U/owner_role_03
+
+                > SELECT name, unnest(privileges)::text FROM mz_sources WHERE name LIKE 'owner_source%' AND type = 'load-generator'
+                owner_source1 owner_role_01=r/owner_role_01
+
+                ! SELECT name, unnest(privileges)::text FROM mz_sinks WHERE name LIKE 'owner_sink%'
+                contains: column "privileges" does not exist
+
+                > SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name LIKE 'owner_cluster%'
+                owner_cluster1 owner_role_01=UC/owner_role_01
+
                 """
             )
             + self._drop_objects("owner_role_01", 5)

--- a/misc/python/materialize/checks/roles.py
+++ b/misc/python/materialize/checks/roles.py
@@ -57,11 +57,14 @@ class CreateRole(Check):
                 create_role1
                 create_role2
                 """
+                # TODO(def-) Grantor information is currently not stable during
+                # upgrades due to https://github.com/MaterializeInc/materialize/pull/18780
+                # Reenable on next release
                 + self._if_can_grant_revoke(
                     """
-                > SELECT role.name, member.name, grantor.name from mz_role_members JOIN mz_roles role ON mz_role_members.role_id = role.id JOIN mz_roles member ON mz_role_members.member = member.id JOIN mz_roles grantor ON mz_role_members.grantor = grantor.id WHERE role.name LIKE 'create_role%';
-                create_role1 materialize mz_system
-                create_role2 materialize mz_system
+                > SELECT role.name, member.name from mz_role_members JOIN mz_roles role ON mz_role_members.role_id = role.id JOIN mz_roles member ON mz_role_members.member = member.id JOIN mz_roles grantor ON mz_role_members.grantor = grantor.id WHERE role.name LIKE 'create_role%';
+                create_role1 materialize
+                create_role2 materialize
                 """
                 )
             )

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -122,7 +122,9 @@ class UpgradeEntireMzFourVersions(Scenario):
         return released_versions[3]
 
     def actions(self) -> List[Action]:
-        print(f"Upgrading going through {released_versions[:3]}")
+        print(
+            f"Upgrading going through {released_versions[3]} -> {released_versions[2]} -> {released_versions[1]} -> {released_versions[0]}"
+        )
         return [
             StartMz(tag=released_versions[3]),
             Initialize(self),


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/17983

Depends on https://github.com/MaterializeInc/materialize/pull/18700

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
