### PR TITLE
adapter: Add resource limit for cluster replicas

### DIFF
--- a/doc/user/content/sql/show.md
+++ b/doc/user/content/sql/show.md
@@ -32,6 +32,7 @@ max_clusters                                | `10`                              
 max_databases                               | `1000`                                                                | The maximum number of databases in the region.
 max_objects_per_schema                      | `1000`                                                                | The maximum number of objects in a schema.
 max_replicas_per_cluster                    | `5`                                                                   | The maximum number of replicas of a single cluster.
+max_cluster_replicas                        | `50`                                                                  | The maximum total number of replicas across all clusters.
 max_result_size                             | `1 GiB`                                                               | The maximum size in bytes for a single query's result.
 max_schemas_per_database                    | `1000`                                                                | The maximum number of schemas in a database.
 max_secrets                                 | `100`                                                                 | The maximum number of secrets in the region, across all schemas.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -374,6 +374,15 @@ const MAX_REPLICAS_PER_CLUSTER: ServerVar<u32> = ServerVar {
     safe: true,
 };
 
+const MAX_CLUSTER_REPLICAS: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_cluster_replicas"),
+    // MAX_CLUSTERS.value * MAX_REPLICAS_PER_CLUSTER.value
+    value: &50,
+    description: "The maximum number of replicas across all clusters (Materialize).",
+    internal: false,
+    safe: true,
+};
+
 const MAX_DATABASES: ServerVar<u32> = ServerVar {
     name: UncasedStr::new("max_databases"),
     value: &1000,
@@ -1437,6 +1446,7 @@ impl Default for SystemVars {
             .with_var(&MAX_MATERIALIZED_VIEWS)
             .with_var(&MAX_CLUSTERS)
             .with_var(&MAX_REPLICAS_PER_CLUSTER)
+            .with_var(&MAX_CLUSTER_REPLICAS)
             .with_var(&MAX_DATABASES)
             .with_var(&MAX_SCHEMAS_PER_DATABASE)
             .with_var(&MAX_OBJECTS_PER_SCHEMA)
@@ -1636,6 +1646,11 @@ impl SystemVars {
     /// Returns the value of the `max_replicas_per_cluster` configuration parameter.
     pub fn max_replicas_per_cluster(&self) -> u32 {
         *self.expect_value(&MAX_REPLICAS_PER_CLUSTER)
+    }
+
+    /// Returns the value of the `max_replicas` configuration parameter.
+    pub fn max_cluster_replicas(&self) -> u32 {
+        *self.expect_value(&MAX_CLUSTER_REPLICAS)
     }
 
     /// Returns the value of the `max_databases` configuration parameter.

--- a/test/cluster/resources/resource-limits.td
+++ b/test/cluster/resources/resource-limits.td
@@ -352,5 +352,40 @@ ALTER SYSTEM SET max_aws_privatelink_connections = 42
 > SHOW max_aws_privatelink_connections
 42
 
+> DROP SOURCE mz_source
+
+> DROP SOURCE mz_source2
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET max_replicas_per_cluster = 100
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET max_cluster_replicas = 3
+
+> SHOW max_cluster_replicas
+3
+
+> CREATE CLUSTER c1 REPLICAS (r1 (size '1'), r2 (size '1'))
+
+! CREATE CLUSTER REPLICA c1.r3 SIZE '1'
+contains:Cluster replicas resource limit of 3 cannot be exceeded. Current amount is 3 instances, tried to create 1 new instances.
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET max_cluster_replicas = 4
+
+> SHOW max_cluster_replicas
+4
+
+> CREATE CLUSTER REPLICA c1.r3 SIZE '1'
+
+! CREATE CLUSTER REPLICA c1.r4 SIZE '1'
+contains:Cluster replicas resource limit of 4 cannot be exceeded. Current amount is 4 instances, tried to create 1 new instances.
+
+> DROP CLUSTER REPLICA c1.r2
+
+> CREATE CLUSTER REPLICA c1.r4 SIZE '1'
+
+> DROP CLUSTER c1 CASCADE
+
 $ postgres-execute connection=mz_system
 ALTER SYSTEM RESET ALL

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1384,6 +1384,7 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
                     $ postgres-execute connection=mz_system
                     ALTER SYSTEM SET max_clusters = {args.clusters * 10}
                     ALTER SYSTEM SET max_replicas_per_cluster = {args.replicas * 10}
+                    ALTER SYSTEM SET max_cluster_replicas = {args.replicas * 10}
                     """
                 )
             )

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -31,7 +31,7 @@ IntervalStyle                           postgres               "Sets the display
 is_superuser                            off                    "Reports whether the current session is a superuser (PostgreSQL)."
 max_aws_privatelink_connections         0                      "The maximum number of AWS PrivateLink connections in the region, across all schemas (Materialize)."
 max_clusters                            10                     "The maximum number of clusters in the region (Materialize)."
-max_cluster_replicas                    50                     "The maximum number of total replicas across all clusters (Materialize)."
+max_cluster_replicas                    50                     "The maximum number of replicas across all clusters (Materialize)."
 max_databases                           1000                   "The maximum number of databases in the region (Materialize)."
 max_materialized_views                  100                    "The maximum number of materialized views in the region, across all schemas (Materialize)."
 max_objects_per_schema                  1000                   "The maximum number of objects in a schema (Materialize)."

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -31,6 +31,7 @@ IntervalStyle                           postgres               "Sets the display
 is_superuser                            off                    "Reports whether the current session is a superuser (PostgreSQL)."
 max_aws_privatelink_connections         0                      "The maximum number of AWS PrivateLink connections in the region, across all schemas (Materialize)."
 max_clusters                            10                     "The maximum number of clusters in the region (Materialize)."
+max_cluster_replicas                    50                     "The maximum number of total replicas across all clusters (Materialize)."
 max_databases                           1000                   "The maximum number of databases in the region (Materialize)."
 max_materialized_views                  100                    "The maximum number of materialized views in the region, across all schemas (Materialize)."
 max_objects_per_schema                  1000                   "The maximum number of objects in a schema (Materialize)."


### PR DESCRIPTION
Adds a resource limit for total cluster replicas.

### Motivation
  * This PR adds a feature that has not yet been specified.
 
### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release adds a resource limit for the total amount of cluster replicas.
