### PR TITLE
persist: add real implementation of Schema for Maelstrom{Key,Val}

### DIFF
--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -21,7 +21,6 @@ use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::cache::StateCache;
 use mz_persist_client::critical::SinceHandle;
 use mz_persist_client::metrics::Metrics;
-use mz_persist_types::codec_impls::TodoSchema;
 use timely::order::TotalOrder;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -40,6 +39,7 @@ use mz_persist_client::{PersistClient, ShardId};
 use crate::maelstrom::api::{Body, ErrorCode, MaelstromError, NodeId, ReqTxnOp, ResTxnOp};
 use crate::maelstrom::node::{Handle, Service};
 use crate::maelstrom::services::{CachingBlob, MaelstromBlob, MaelstromConsensus};
+use crate::maelstrom::txn::codec_impls::{MaelstromKeySchema, MaelstromValSchema};
 use crate::maelstrom::Args;
 use crate::BUILD_INFO;
 
@@ -140,8 +140,8 @@ impl Transactor {
             .open(
                 shard_id,
                 "maelstrom long-lived",
-                Arc::new(TodoSchema::<MaelstromKey>::default()),
-                Arc::new(TodoSchema::<MaelstromVal>::default()),
+                Arc::new(MaelstromKeySchema),
+                Arc::new(MaelstromValSchema),
             )
             .await?;
         // Use the CONTROLLER_CRITICAL_SINCE id for all nodes so we get coverage
@@ -270,8 +270,8 @@ impl Transactor {
                 .open_leased_reader(
                     self.shard_id,
                     "maelstrom short-lived",
-                    Arc::new(TodoSchema::<MaelstromKey>::default()),
-                    Arc::new(TodoSchema::<MaelstromVal>::default()),
+                    Arc::new(MaelstromKeySchema),
+                    Arc::new(MaelstromValSchema),
                 )
                 .await
                 .expect("codecs should match");
@@ -712,13 +712,16 @@ impl Service for TransactorService {
 }
 
 mod codec_impls {
-    use mz_persist_types::codec_impls::TodoSchema;
+    use mz_persist_types::codec_impls::{SimpleDecoder, SimpleEncoder, SimpleSchema};
+    use mz_persist_types::columnar::{ColumnPush, DataType, Schema};
+    use mz_persist_types::part::{ColumnsMut, ColumnsRef};
+    use mz_persist_types::stats::StatsFn;
     use mz_persist_types::Codec;
 
     use crate::maelstrom::txn::{MaelstromKey, MaelstromVal};
 
     impl Codec for MaelstromKey {
-        type Schema = TodoSchema<MaelstromKey>;
+        type Schema = MaelstromKeySchema;
 
         fn codec_name() -> String {
             "MaelstromKey".into()
@@ -739,8 +742,29 @@ mod codec_impls {
         }
     }
 
+    #[derive(Debug)]
+    pub struct MaelstromKeySchema;
+
+    impl Schema<MaelstromKey> for MaelstromKeySchema {
+        type Encoder<'a> = SimpleEncoder<'a, MaelstromKey, u64>;
+
+        type Decoder<'a> = SimpleDecoder<'a, MaelstromKey, u64>;
+
+        fn columns(&self) -> Vec<(String, DataType, StatsFn)> {
+            SimpleSchema::<MaelstromKey, u64>::columns()
+        }
+
+        fn decoder<'a>(&self, cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
+            SimpleSchema::<MaelstromKey, u64>::decoder(cols, |val, ret| ret.0 = val)
+        }
+
+        fn encoder<'a>(&self, cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
+            SimpleSchema::<MaelstromKey, u64>::encoder(cols, |val| val.0)
+        }
+    }
+
     impl Codec for MaelstromVal {
-        type Schema = TodoSchema<MaelstromVal>;
+        type Schema = MaelstromValSchema;
 
         fn codec_name() -> String {
             "MaelstromVal".into()
@@ -758,6 +782,33 @@ mod codec_impls {
             Ok(MaelstromVal(
                 serde_json::from_slice(buf).map_err(|err| err.to_string())?,
             ))
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct MaelstromValSchema;
+
+    impl Schema<MaelstromVal> for MaelstromValSchema {
+        type Encoder<'a> = SimpleEncoder<'a, MaelstromVal, Vec<u8>>;
+
+        type Decoder<'a> = SimpleDecoder<'a, MaelstromVal, Vec<u8>>;
+
+        fn columns(&self) -> Vec<(String, DataType, StatsFn)> {
+            SimpleSchema::<MaelstromVal, Vec<u8>>::columns()
+        }
+
+        fn decoder<'a>(&self, cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
+            SimpleSchema::<MaelstromVal, Vec<u8>>::decoder(cols, |val, ret| {
+                *ret = MaelstromVal::decode(val).expect("should be valid MaelstromVal")
+            })
+        }
+
+        fn encoder<'a>(&self, cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
+            SimpleSchema::<MaelstromVal, Vec<u8>>::push_encoder(cols, |col, val| {
+                let mut buf = Vec::new();
+                MaelstromVal::encode(val, &mut buf);
+                ColumnPush::<Vec<u8>>::push(col, &buf)
+            })
         }
     }
 }


### PR DESCRIPTION
Mostly just to we can turn the stats collection ff on in CI without getting failures.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
