### PR TITLE
sql: add translate func

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -364,6 +364,11 @@
     description: Substring starting at `start_pos` of length `l`
     url: substring
 
+  - signature: "translate(s: str, from: str, to: str) -> str"
+    description: >- 
+      Any character in `s` that matches a character in `from` is replaced by the corresponding character in the `to`.
+      If `from` is longer than `to`, occurrences of the extra characters in `from` are removed.
+
   - signature: "trim([BOTH | LEADING | TRAILING]? ['c'? FROM]? 's') -> str"
     description: "Trims any character in `c` from `s` on the specified side.<br/><br/>Defaults:<br/>
       &bull; Side: `BOTH`<br/>

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -366,7 +366,7 @@
 
   - signature: "translate(s: str, from: str, to: str) -> str"
     description: >- 
-      Any character in `s` that matches a character in `from` is replaced by the corresponding character in the `to`.
+      Any character in `s` that matches a character in `from` is replaced by the corresponding character in `to`.
       If `from` is longer than `to`, occurrences of the extra characters in `from` are removed.
 
   - signature: "trim([BOTH | LEADING | TRAILING]? ['c'? FROM]? 's') -> str"

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -365,7 +365,7 @@
     url: substring
 
   - signature: "translate(s: str, from: str, to: str) -> str"
-    description: >- 
+    description: >-
       Any character in `s` that matches a character in `from` is replaced by the corresponding character in `to`.
       If `from` is longer than `to`, occurrences of the extra characters in `from` are removed.
 

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -643,6 +643,7 @@ message ProtoVariadicFunc {
         google.protobuf.Empty or = 26;
         mz_repr.relation_and_scalar.ProtoScalarType range_create = 27;
         google.protobuf.Empty make_mz_acl_item = 28;
+        google.protobuf.Empty translate = 29;
     }
 }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -5720,16 +5720,7 @@ fn translate<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a> 
         temp_storage.push_string(
             string
                 .chars()
-                .map(|c| {
-                    match from.find(c) {
-                        Some(m) => {
-                            to.chars().nth(m)
-                        },
-                        None => {
-                            Some(c)
-                        },
-                    }
-                })
+                .map(|c| from.find(c).map_or(Some(c), |m| to.chars().nth(m)))
                 .filter_map(identity)
                 .collect()
         )

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::cmp::{self, Ordering};
-use std::convert::{TryFrom, TryInto, identity};
+use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::iter;
 use std::ops::{BitOrAssign, Deref};
@@ -5720,10 +5720,9 @@ fn translate<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a> 
         temp_storage.push_string(
             string
                 .chars()
-                .map(|c| from.find(c).map_or(Some(c), |m| to.chars().nth(m)))
-                .filter_map(identity)
-                .collect()
-        )
+                .filter_map(|c| from.find(c).map_or(Some(c), |m| to.chars().nth(m)))
+                .collect(),
+        ),
     )
 }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::cmp::{self, Ordering};
-use std::convert::{TryFrom, TryInto};
+use std::convert::{TryFrom, TryInto, identity};
 use std::fmt;
 use std::iter;
 use std::ops::{BitOrAssign, Deref};
@@ -5711,6 +5711,31 @@ fn replace<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a> {
     )
 }
 
+fn translate<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a> {
+    let string = datums[0].unwrap_str();
+    let from = datums[1].unwrap_str();
+    let to = datums[2].unwrap_str();
+
+    Datum::String(
+        temp_storage.push_string(
+            string
+                .chars()
+                .map(|c| {
+                    match from.find(c) {
+                        Some(m) => {
+                            to.chars().nth(m)
+                        },
+                        None => {
+                            Some(c)
+                        },
+                    }
+                })
+                .filter_map(identity)
+                .collect()
+        )
+    )
+}
+
 fn jsonb_build_array<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a> {
     if datums.iter().any(|datum| datum.is_null()) {
         // the inputs should all be valid jsonb types, but a casting error might produce a Datum::Null that needs to be propagated
@@ -6609,6 +6634,7 @@ pub enum VariadicFunc {
         elem_type: ScalarType,
     },
     MakeMzAclItem,
+    Translate,
 }
 
 impl VariadicFunc {
@@ -6639,6 +6665,7 @@ impl VariadicFunc {
             VariadicFunc::PadLeading => eager!(pad_leading, temp_storage),
             VariadicFunc::Substr => eager!(substr),
             VariadicFunc::Replace => Ok(eager!(replace, temp_storage)),
+            VariadicFunc::Translate => Ok(eager!(translate, temp_storage)),
             VariadicFunc::JsonbBuildArray => Ok(eager!(jsonb_build_array, temp_storage)),
             VariadicFunc::JsonbBuildObject => Ok(eager!(jsonb_build_object, temp_storage)),
             VariadicFunc::ArrayCreate {
@@ -6690,6 +6717,7 @@ impl VariadicFunc {
             | VariadicFunc::PadLeading
             | VariadicFunc::Substr
             | VariadicFunc::Replace
+            | VariadicFunc::Translate
             | VariadicFunc::JsonbBuildArray
             | VariadicFunc::JsonbBuildObject
             | VariadicFunc::ArrayCreate { elem_type: _ }
@@ -6724,6 +6752,7 @@ impl VariadicFunc {
             PadLeading => ScalarType::String.nullable(in_nullable),
             Substr => ScalarType::String.nullable(in_nullable),
             Replace => ScalarType::String.nullable(in_nullable),
+            Translate => ScalarType::String.nullable(in_nullable),
             JsonbBuildArray | JsonbBuildObject => ScalarType::Jsonb.nullable(true),
             ArrayCreate { elem_type } => {
                 debug_assert!(
@@ -6819,6 +6848,7 @@ impl VariadicFunc {
             | PadLeading
             | Substr
             | Replace
+            | Translate
             | JsonbBuildArray
             | JsonbBuildObject
             | ArrayCreate { .. }
@@ -6899,6 +6929,7 @@ impl fmt::Display for VariadicFunc {
             VariadicFunc::PadLeading => f.write_str("lpad"),
             VariadicFunc::Substr => f.write_str("substr"),
             VariadicFunc::Replace => f.write_str("replace"),
+            VariadicFunc::Translate => f.write_str("translate"),
             VariadicFunc::JsonbBuildArray => f.write_str("jsonb_build_array"),
             VariadicFunc::JsonbBuildObject => f.write_str("jsonb_build_object"),
             VariadicFunc::ArrayCreate { .. } => f.write_str("array_create"),
@@ -7002,6 +7033,7 @@ impl RustType<ProtoVariadicFunc> for VariadicFunc {
             VariadicFunc::PadLeading => PadLeading(()),
             VariadicFunc::Substr => Substr(()),
             VariadicFunc::Replace => Replace(()),
+            VariadicFunc::Translate => Translate(()),
             VariadicFunc::JsonbBuildArray => JsonbBuildArray(()),
             VariadicFunc::JsonbBuildObject => JsonbBuildObject(()),
             VariadicFunc::ArrayCreate { elem_type } => ArrayCreate(elem_type.into_proto()),
@@ -7041,6 +7073,7 @@ impl RustType<ProtoVariadicFunc> for VariadicFunc {
                 PadLeading(()) => Ok(VariadicFunc::PadLeading),
                 Substr(()) => Ok(VariadicFunc::Substr),
                 Replace(()) => Ok(VariadicFunc::Replace),
+                Translate(()) => Ok(VariadicFunc::Translate),
                 JsonbBuildArray(()) => Ok(VariadicFunc::JsonbBuildArray),
                 JsonbBuildObject(()) => Ok(VariadicFunc::JsonbBuildObject),
                 ArrayCreate(elem_type) => Ok(VariadicFunc::ArrayCreate {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2374,6 +2374,9 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         "to_timestamp" => Scalar {
             params!(Float64) => UnaryFunc::ToTimestamp(func::ToTimestamp) => TimestampTz, 1158;
         },
+        "translate" => Scalar {
+            params!(String, String, String) => VariadicFunc::Translate => String, 878;
+        },
         "trunc" => Scalar {
             params!(Float32) => UnaryFunc::TruncFloat32(func::TruncFloat32) => Float32, oid::FUNC_TRUNC_F32_OID;
             params!(Float64) => UnaryFunc::TruncFloat64(func::TruncFloat64) => Float64, 1343;

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -1432,3 +1432,87 @@ INSERT INTO gh18095_1 VALUES('''%ꆔA?')
 query T
 SELECT FROM gh18095_1 JOIN gh18095_0 ON (gh18095_1.c0)LIKE((gh18095_1.c0)::VARCHAR(4));
 ----
+
+### translate ###
+
+# NULL inputs
+
+query I
+SELECT translate(NULL, 'one', 'two')
+----
+NULL
+
+query I
+SELECT translate('one', NULL, 'two')
+----
+NULL
+
+query I
+SELECT translate('one', 'two', NULL)
+----
+NULL
+
+query I
+SELECT translate('one', NULL, NULL)
+----
+NULL
+
+query I
+SELECT translate(NULL, 'one', NULL)
+----
+NULL
+
+query I
+SELECT translate(NULL, NULL, 'one')
+----
+NULL
+
+query I
+SELECT translate(NULL, NULL, NULL)
+----
+NULL
+
+# replace single occurrence of a single char
+
+query T
+SELECT translate('foe', 'f', 't')
+----
+toe
+
+# replace multiple occurrences of a single char
+
+query T
+SELECT translate('hello', 'l', 'x')
+----
+hexxo
+
+# remove extra occurrences when len(from) > len(to)
+
+query T
+SELECT translate('ffl', 'fl', 't')
+----
+tt
+
+query I
+SELECT translate('[1]', '[]', '')::numeric
+----
+1
+
+# ignore extra occurences when len(to) > len(from)
+
+query T
+SELECT translate('something', 'sth', 'xfvlg')
+----
+xomefving
+
+# ignore non-matching extra occurrences
+
+query T
+SELECT translate('ffl', 'fx', 't')
+----
+ttl
+
+query T
+SELECT translate('hello', 'fl', 'tx')
+----
+hexxo


### PR DESCRIPTION
This PR adds support for the `translate` function.

Solves #18041

### Motivation

* This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
            - Adds documentation for the `translate` string function
