### PR TITLE
compute: tokenize error logging

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -171,7 +171,7 @@ where
     }
 
     pub(super) fn error_logger(&self) -> ErrorLogger {
-        ErrorLogger::new(self.shutdown_token.clone())
+        ErrorLogger::new(self.shutdown_token.clone(), self.debug_name.clone())
     }
 }
 

--- a/src/compute/src/render/errors.rs
+++ b/src/compute/src/render/errors.rs
@@ -78,11 +78,15 @@ where
 #[derive(Clone)]
 pub(super) struct ErrorLogger {
     token: Option<Weak<()>>,
+    dataflow_name: String,
 }
 
 impl ErrorLogger {
-    pub fn new(token: Option<Weak<()>>) -> Self {
-        Self { token }
+    pub fn new(token: Option<Weak<()>>, dataflow_name: String) -> Self {
+        Self {
+            token,
+            dataflow_name,
+        }
     }
 
     fn token_alive(&self) -> bool {
@@ -118,7 +122,10 @@ impl ErrorLogger {
     ///
     /// Use this method to notify about errors that cannot be caused by dataflow shutdown.
     pub fn log_always(&self, message: &'static str, details: &str) {
-        tracing::warn!("[customer-data] {message} ({details})");
+        tracing::warn!(
+            dataflow = self.dataflow_name,
+            "[customer-data] {message} ({details})"
+        );
         tracing::error!(message);
     }
 
@@ -126,7 +133,10 @@ impl ErrorLogger {
     ///
     /// Use this method to notify about errors that are certainly caused by bugs in Materialize.
     pub fn soft_panic_or_log(&self, message: &'static str, details: &str) {
-        tracing::warn!("[customer-data] {message} ({details})");
+        tracing::warn!(
+            dataflow = self.dataflow_name,
+            "[customer-data] {message} ({details})"
+        );
         mz_ore::soft_panic_or_log!("{}", message);
     }
 }

--- a/src/compute/src/render/errors.rs
+++ b/src/compute/src/render/errors.rs
@@ -70,3 +70,63 @@ where
         Some(Err)
     }
 }
+
+/// Error logger to be used by rendering code.
+///
+/// Holds onto a token to ensure that no false-positive errors are logged while the dataflow is in
+/// the process of shutting down.
+#[derive(Clone)]
+pub(super) struct ErrorLogger {
+    token: Option<Weak<()>>,
+}
+
+impl ErrorLogger {
+    pub fn new(token: Option<Weak<()>>) -> Self {
+        Self { token }
+    }
+
+    fn token_alive(&self) -> bool {
+        match &self.token {
+            Some(t) => t.upgrade().is_some(),
+            None => true,
+        }
+    }
+
+    /// Log the given error, unless the dataflow is shutting down.
+    ///
+    /// The logging format is optimized for surfacing errors with Sentry:
+    ///  * `error` is logged at ERROR level and will appear as the error title in Sentry.
+    ///    We require it to be a static string, to ensure that Sentry always merges instances of
+    ///    the same error together.
+    ///  * `details` is logged at WARN level and will appear in the breadcrumbs.
+    ///    Put relevant dynamic information here.
+    ///
+    /// The message that's logged at WARN level has the format
+    ///   "[customer-data] {message} ({details})"
+    /// We include the [customer-data] tag out of the expectation that `details` will always
+    /// contain some sensitive customer data. We include the `message` to make it possible to match
+    /// the breadcrumbs to their associated error in Sentry.
+    ///
+    // TODO(#18214): Rethink or justify our error logging strategy.
+    pub fn log(&self, message: &'static str, details: &str) {
+        if self.token_alive() {
+            self.log_always(message, details);
+        }
+    }
+
+    /// Like [`Self::log`], but also logs errors when the dataflow is shutting down.
+    ///
+    /// Use this method to notify about errors that cannot be caused by dataflow shutdown.
+    pub fn log_always(&self, message: &'static str, details: &str) {
+        tracing::warn!("[customer-data] {message} ({details})");
+        tracing::error!(message);
+    }
+
+    /// Like [`Self::log_always`], but panics in debug mode.
+    ///
+    /// Use this method to notify about errors that are certainly caused by bugs in Materialize.
+    pub fn soft_panic_or_log(&self, message: &'static str, details: &str) {
+        tracing::warn!("[customer-data] {message} ({details})");
+        mz_ore::soft_panic_or_log!("{}", message);
+    }
+}

--- a/src/compute/src/render/errors.rs
+++ b/src/compute/src/render/errors.rs
@@ -1,0 +1,72 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Helpers for handling errors encountered by operators.
+
+use std::hash::Hash;
+use std::rc::Weak;
+
+use differential_dataflow::ExchangeData;
+use mz_repr::Row;
+use timely::container::columnation::Columnation;
+
+/// Used to make possibly-validating code generic: think of this as a kind of `MaybeResult`,
+/// specialized for use in compute.  Validation code will only run when the error constructor is
+/// Some.
+pub(super) trait MaybeValidatingRow<T, E>: ExchangeData + Columnation + Hash {
+    fn ok(t: T) -> Self;
+    fn into_error() -> Option<fn(E) -> Self>;
+}
+
+impl<E> MaybeValidatingRow<Row, E> for Row {
+    fn ok(t: Row) -> Self {
+        t
+    }
+
+    fn into_error() -> Option<fn(E) -> Self> {
+        None
+    }
+}
+
+impl<E> MaybeValidatingRow<(), E> for () {
+    fn ok(t: ()) -> Self {
+        t
+    }
+
+    fn into_error() -> Option<fn(E) -> Self> {
+        None
+    }
+}
+
+impl<E, R> MaybeValidatingRow<Vec<R>, E> for Vec<R>
+where
+    R: ExchangeData + Columnation + Hash,
+{
+    fn ok(t: Vec<R>) -> Self {
+        t
+    }
+
+    fn into_error() -> Option<fn(E) -> Self> {
+        None
+    }
+}
+
+impl<T, E> MaybeValidatingRow<T, E> for Result<T, E>
+where
+    T: ExchangeData + Columnation + Hash,
+    E: ExchangeData + Columnation + Hash,
+{
+    fn ok(row: T) -> Self {
+        Ok(row)
+    }
+
+    fn into_error() -> Option<fn(E) -> Self> {
+        Some(Err)
+    }
+}

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -280,16 +280,12 @@ where
         S: Scope<Timestamp = G::Timestamp>,
     {
         let error_logger = self.error_logger();
-        let debug_name = self.debug_name.to_string();
 
         // We must have more than one arrangement to collate.
         if arrangements.len() <= 1 {
             error_logger.soft_panic_or_log(
                 "Incorrect number of arrangements in reduce collation",
-                &format!(
-                    "len={len}, debug_name={debug_name}",
-                    len = arrangements.len(),
-                ),
+                &format!("len={}", arrangements.len()),
             );
         }
 
@@ -380,8 +376,7 @@ where
                         error_logger.log(
                             message,
                             &format!(
-                                "key={key:?}, debug_name={debug_name}, \
-                                 n_aggregates_requested={requested}, \
+                                "key={key:?}, n_aggregates_requested={requested}, \
                                  n_distinct_aggregate_types={n_distinct_aggregate_types}",
                                 requested = input.len(),
                             ),
@@ -414,10 +409,7 @@ where
                         // We cannot properly reconstruct a row if aggregates are missing.
                         // This situation is not expected, so we log an error if it occurs.
                         let message = "Missing value for key in ReduceCollation";
-                        error_logger.log(
-                            message,
-                            &format!("typ={typ:?}, key={key:?}, debug_name={debug_name}"),
-                        );
+                        error_logger.log(message, &format!("typ={typ:?}, key={key:?}"));
                         output.push((EvalError::Internal(message.to_string()).into(), 1));
                         return;
                     }
@@ -430,7 +422,7 @@ where
                     }
 
                     let message = "Rows too large for key in ReduceCollation";
-                    error_logger.log(message, &format!("key={key:?}, debug_name={debug_name}"));
+                    error_logger.log(message, &format!("key={key:?}"));
                     output.push((EvalError::Internal(message.to_string()).into(), 1));
                 },
             );
@@ -446,7 +438,6 @@ where
         S: Scope<Timestamp = G::Timestamp>,
     {
         let error_logger = self.error_logger();
-        let debug_name = self.debug_name.to_string();
 
         let (output, errors) = collection
             .arrange_named::<RowSpine<_, _, _, _>>("Arranged DistinctBy")
@@ -465,10 +456,7 @@ where
                             continue;
                         }
                         let message = "Non-positive multiplicity in DistinctBy";
-                        error_logger.log(
-                            message,
-                            &format!("row={row:?}, count={count}, debug_name={debug_name}"),
-                        );
+                        error_logger.log(message, &format!("row={row:?}, count={count}"));
                         output.push((EvalError::Internal(message.to_string()).into(), 1));
                         return;
                     }
@@ -488,7 +476,6 @@ where
         S: Scope<Timestamp = G::Timestamp>,
     {
         let error_logger = self.error_logger();
-        let debug_name = self.debug_name.to_string();
 
         let (negated_result, errs) = collection
             .arrange_named::<RowSpine<Row, _, _, _>>("Arranged DistinctBy Retractions input")
@@ -499,10 +486,7 @@ where
                             continue;
                         }
                         let message = "Non-positive multiplicity in DistinctBy Retractions";
-                        error_logger.log(
-                            message,
-                            &format!("row={row:?}, count={count}, debug_name={debug_name}"),
-                        );
+                        error_logger.log(message, &format!("row={row:?}, count={count}"));
                         output.push((Err(message.to_string()), 1));
                         return;
                     }
@@ -553,11 +537,7 @@ where
         if aggrs.len() <= 1 {
             self.error_logger().soft_panic_or_log(
                 "Too few aggregations when building basic aggregates",
-                &format!(
-                    "len={len}, debug_name={name}",
-                    len = aggrs.len(),
-                    name = self.debug_name,
-                ),
+                &format!("len={}", aggrs.len()),
             )
         }
         let mut err_output = None;
@@ -665,7 +645,6 @@ where
         // rationale around using a second reduction here.
         if validating && err_output.is_none() {
             let error_logger = self.error_logger();
-            let debug_name = self.debug_name.to_string();
 
             let errs = arranged.reduce_abelian::<_, ErrValSpine<_, _, _>>(
                 "ReduceInaccumulable Error Check",
@@ -679,10 +658,7 @@ where
                         }
 
                         let message = "Non-positive accumulation in ReduceInaccumulable";
-                        error_logger.log(
-                            message,
-                            &format!("value={value:?}, count={count}, debug_name={debug_name}"),
-                        );
+                        error_logger.log(message, &format!("value={value:?}, count={count}"));
                         target.push((EvalError::Internal(message.to_string()).into(), 1));
                         return;
                     }
@@ -703,7 +679,6 @@ where
         R: MaybeValidatingRow<(), String>,
     {
         let error_logger = self.error_logger();
-        let debug_name = self.debug_name.to_string();
 
         input
             .arrange_named::<RowSpine<(Row, Row), _, _, _>>("Arranged ReduceInaccumulable")
@@ -718,10 +693,7 @@ where
 
                             let message =
                                 "Non-positive accumulation in ReduceInaccumulable DISTINCT";
-                            error_logger.log(
-                                message,
-                                &format!("value={value:?}, count={count}, debug_name={debug_name}"),
-                            );
+                            error_logger.log(message, &format!("value={value:?}, count={count}"));
                             t.push((err(message.to_string()), 1));
                             return;
                         }
@@ -823,7 +795,6 @@ where
             // Build a series of stages for the reduction
             // Arrange the final result into (key, Row)
             let error_logger = self.error_logger();
-            let debug_name = self.debug_name.to_string();
             let arranged =
                 partial.arrange_named::<RowSpine<_, Vec<Row>, _, _>>("Arrange ReduceMinsMaxes");
             // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
@@ -843,10 +814,7 @@ where
                                 }
 
                                 let message = "Non-positive accumulation in ReduceMinsMaxes";
-                                error_logger.log(
-                                    message,
-                                    &format!("val={val:?}, count={count}, debug_name={debug_name}"),
-                                );
+                                error_logger.log(message, &format!("val={val:?}, count={count}"));
                                 target.push((EvalError::Internal(message.to_string()).into(), 1));
                                 return;
                             }
@@ -895,7 +863,6 @@ where
         R: MaybeValidatingRow<Vec<Row>, (Row, u64)>,
     {
         let error_logger = self.error_logger();
-        let debug_name = self.debug_name.to_string();
         let arranged_input = input
             .arrange_named::<RowSpine<_, Vec<Row>, _, _>>("Arranged MinsMaxesHierarchical input");
 
@@ -911,10 +878,7 @@ where
                             }
                             error_logger.log(
                                 "Non-positive accumulation in MinsMaxesHierarchical",
-                                &format!(
-                                    "key={key:?}, value={value:?}, count={count}, \
-                                     debug_name={debug_name}"
-                                ),
+                                &format!("key={key:?}, value={value:?}, count={count}"),
                             );
                             // After complaining, output an error here so that we can eventually
                             // report it in an error stream.
@@ -973,11 +937,10 @@ where
         let consolidated = collection
             .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated ReduceMonotonic input");
         let error_logger = self.error_logger();
-        let debug_name = self.debug_name.to_string();
         let (partial, errs) = consolidated.ensure_monotonic(move |data, diff| {
             error_logger.log(
                 "Non-monotonic input to ReduceMonotonic",
-                &format!("data={data:?}, diff={diff}, debug_name={debug_name}"),
+                &format!("data={data:?}, diff={diff}"),
             );
             let m = "tried to build a monotonic reduction on non-monotonic input".to_string();
             (EvalError::Internal(m).into(), 1)
@@ -1036,11 +999,10 @@ where
             self.error_logger().soft_panic_or_log(
                 "Incorrect numbers of aggregates in accummulable reduction rendering",
                 &format!(
-                    "full_aggrs={}, simple_aggrs={}, distinct_aggrs={}, debug_name={}",
+                    "full_aggrs={}, simple_aggrs={}, distinct_aggrs={}",
                     full_aggrs.len(),
                     simple_aggrs.len(),
                     distinct_aggrs.len(),
-                    self.debug_name,
                 ),
             );
         }
@@ -1294,7 +1256,6 @@ where
         };
 
         let error_logger = self.error_logger();
-        let debug_name = self.debug_name.to_string();
         let err_full_aggrs = full_aggrs.clone();
         let (arranged_output, arranged_errs) = collection
             .arrange_named::<RowKeySpine<_, _, (Vec<Accum>, Diff)>>("ArrangeAccumulable")
@@ -1506,7 +1467,7 @@ where
                         if total == 0 && !accum.is_zero() {
                             error_logger.log(
                                 "Net-zero records with non-zero accumulation in ReduceAccumulable",
-                                &format!("aggr={aggr:?}, accum={accum:?}, debug_name={debug_name}"),
+                                &format!("aggr={aggr:?}, accum={accum:?}"),
                             );
                             let message = format!(
                                 "Invalid data in source, saw net-zero records for key {key} \
@@ -1521,9 +1482,7 @@ where
                                 if accum.is_negative() {
                                     error_logger.log(
                                     "Invalid negative unsigned aggregation in ReduceAccumulable",
-                                    &format!(
-                                        "aggr={aggr:?}, accum={accum:?}, debug_name={debug_name}"
-                                    ),
+                                    &format!("aggr={aggr:?}, accum={accum:?}"),
                                 );
                                     let message = format!(
                                         "Invalid data in source, saw negative accumulation with \

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -44,146 +44,6 @@ use crate::render::reduce::monoids::ReductionMonoid;
 use crate::render::ArrangementFlavor;
 use crate::typedefs::{ErrValSpine, RowKeySpine, RowSpine};
 
-use super::errors::ErrorLogger;
-
-/// Render a dataflow based on the provided plan.
-///
-/// The output will be an arrangements that looks the same as if
-/// we just had a single reduce operator computing everything together, and
-/// this arrangement can also be re-used.
-fn render_reduce_plan<G, T>(
-    debug_name: &str,
-    plan: ReducePlan,
-    collection: Collection<G, (Row, Row), Diff>,
-    err_input: Collection<G, DataflowError, Diff>,
-    key_arity: usize,
-    error_logger: ErrorLogger,
-) -> CollectionBundle<G, Row, T>
-where
-    G: Scope,
-    G::Timestamp: Lattice + Refines<T>,
-    T: Timestamp + Lattice,
-{
-    // Note also the special case in `ReducePlan::keys()`.
-    if plan == ReducePlan::DistinctNegated {
-        let (output, errs) = build_distinct_retractions(debug_name, collection, error_logger);
-        return CollectionBundle::from_collections(output, err_input.concat(&errs));
-    }
-    let mut errors = Default::default();
-    let arrangement = render_reduce_plan_inner(
-        debug_name,
-        plan,
-        collection,
-        &mut errors,
-        key_arity,
-        error_logger,
-    );
-    CollectionBundle::from_columns(
-        0..key_arity,
-        ArrangementFlavor::Local(
-            arrangement,
-            err_input
-                .concatenate(errors)
-                .arrange_named("Arrange bundle err"),
-        ),
-    )
-}
-
-fn render_reduce_plan_inner<G, T>(
-    debug_name: &str,
-    plan: ReducePlan,
-    collection: Collection<G, (Row, Row), Diff>,
-    errors: &mut Vec<Collection<G, DataflowError, Diff>>,
-    key_arity: usize,
-    error_logger: ErrorLogger,
-) -> Arrangement<G, Row>
-where
-    G: Scope,
-    G::Timestamp: Lattice + Refines<T>,
-    T: Timestamp + Lattice,
-{
-    let arrangement: Arrangement<G, Row> = match plan {
-        // If we have no aggregations or just a single type of reduction, we
-        // can go ahead and render them directly.
-        ReducePlan::Distinct => {
-            let (arranged_output, errs) = build_distinct(debug_name, collection, error_logger);
-            errors.push(errs);
-            arranged_output
-        }
-        ReducePlan::DistinctNegated => panic!("should have been handled in render_reduce_plan()"),
-        ReducePlan::Accumulable(expr) => {
-            let (arranged_output, errs) =
-                build_accumulable(debug_name, collection, expr, error_logger);
-            errors.push(errs);
-            arranged_output
-        }
-        ReducePlan::Hierarchical(HierarchicalPlan::Monotonic(expr)) => {
-            let (output, errs) = build_monotonic(debug_name, collection, expr, error_logger);
-            errors.push(errs);
-            output
-        }
-        ReducePlan::Hierarchical(HierarchicalPlan::Bucketed(expr)) => {
-            let (output, errs) = build_bucketed(debug_name, collection, expr, error_logger);
-            if let Some(e) = errs {
-                errors.push(e);
-            }
-            output
-        }
-        ReducePlan::Basic(BasicPlan::Single(index, aggr)) => {
-            let (output, errs) =
-                build_basic_aggregate(debug_name, collection, index, &aggr, true, error_logger);
-            errors.push(errs.expect("validation should have occurred as it was requested"));
-            output
-        }
-        ReducePlan::Basic(BasicPlan::Multiple(aggrs)) => {
-            let (output, errs) =
-                build_basic_aggregates(debug_name, collection, aggrs, error_logger);
-            errors.push(errs);
-            output
-        }
-        // Otherwise, we need to render something different for each type of
-        // reduction, and then stitch them together.
-        ReducePlan::Collation(expr) => {
-            // First, we need to render our constituent aggregations.
-            let mut to_collate = vec![];
-
-            for plan in [
-                expr.hierarchical.map(ReducePlan::Hierarchical),
-                expr.accumulable.map(ReducePlan::Accumulable),
-                expr.basic.map(ReducePlan::Basic),
-            ]
-            .into_iter()
-            .flat_map(std::convert::identity)
-            {
-                let r#type = ReductionType::try_from(&plan)
-                    .expect("only representable reduction types were used above");
-
-                let arrangement = render_reduce_plan_inner(
-                    debug_name,
-                    plan,
-                    collection.clone(),
-                    errors,
-                    key_arity,
-                    error_logger.clone(),
-                );
-                to_collate.push((r#type, arrangement));
-            }
-
-            // Now we need to collate them together.
-            let (oks, errs) = build_collation(
-                debug_name,
-                to_collate,
-                expr.aggregate_types,
-                &mut collection.scope(),
-                error_logger,
-            );
-            errors.push(errs);
-            oks
-        }
-    };
-    arrangement
-}
-
 impl<G, T> Context<G, Row, T>
 where
     G: Scope,
@@ -285,95 +145,254 @@ where
             err = err.concat(&err_input);
 
             // Render the reduce plan
-            render_reduce_plan(
-                &self.debug_name,
-                reduce_plan,
-                ok,
-                err,
-                key_arity,
-                self.error_logger(),
-            )
-            .leave_region()
+            self.render_reduce_plan(reduce_plan, ok, err, key_arity)
+                .leave_region()
         })
     }
-}
 
-/// Build the dataflow to combine arrangements containing results of different
-/// aggregation types into a single arrangement.
-///
-/// This computes the same thing as a join on the group key followed by shuffling
-/// the values into the correct order. This implementation assumes that all input
-/// arrangements present values in a way that respects the desired output order,
-/// so we can do a linear merge to form the output.
-fn build_collation<G>(
-    debug_name: &str,
-    arrangements: Vec<(ReductionType, Arrangement<G, Row>)>,
-    aggregate_types: Vec<ReductionType>,
-    scope: &mut G,
-    error_logger: ErrorLogger,
-) -> (Arrangement<G, Row>, Collection<G, DataflowError, Diff>)
-where
-    G: Scope,
-    G::Timestamp: Lattice,
-{
-    // We must have more than one arrangement to collate.
-    if arrangements.len() <= 1 {
-        error_logger.soft_panic_or_log(
-            "Incorrect number of arrangements in reduce collation",
-            &format!(
-                "len={len}, debug_name={debug_name}",
-                len = arrangements.len(),
+    /// Render a dataflow based on the provided plan.
+    ///
+    /// The output will be an arrangements that looks the same as if
+    /// we just had a single reduce operator computing everything together, and
+    /// this arrangement can also be re-used.
+    fn render_reduce_plan<S>(
+        &self,
+        plan: ReducePlan,
+        collection: Collection<S, (Row, Row), Diff>,
+        err_input: Collection<S, DataflowError, Diff>,
+        key_arity: usize,
+    ) -> CollectionBundle<S, Row, T>
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        // Note also the special case in `ReducePlan::keys()`.
+        if plan == ReducePlan::DistinctNegated {
+            let (output, errs) = self.build_distinct_retractions(collection);
+            return CollectionBundle::from_collections(output, err_input.concat(&errs));
+        }
+        let mut errors = Default::default();
+        let arrangement = self.render_reduce_plan_inner(plan, collection, &mut errors, key_arity);
+        CollectionBundle::from_columns(
+            0..key_arity,
+            ArrangementFlavor::Local(
+                arrangement,
+                err_input
+                    .concatenate(errors)
+                    .arrange_named("Arrange bundle err"),
             ),
-        );
+        )
     }
 
-    let mut to_concat = vec![];
+    fn render_reduce_plan_inner<S>(
+        &self,
+        plan: ReducePlan,
+        collection: Collection<S, (Row, Row), Diff>,
+        errors: &mut Vec<Collection<S, DataflowError, Diff>>,
+        key_arity: usize,
+    ) -> Arrangement<S, Row>
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        let arrangement: Arrangement<S, Row> = match plan {
+            // If we have no aggregations or just a single type of reduction, we
+            // can go ahead and render them directly.
+            ReducePlan::Distinct => {
+                let (arranged_output, errs) = self.build_distinct(collection);
+                errors.push(errs);
+                arranged_output
+            }
+            ReducePlan::DistinctNegated => {
+                panic!("should have been handled in render_reduce_plan()")
+            }
+            ReducePlan::Accumulable(expr) => {
+                let (arranged_output, errs) = self.build_accumulable(collection, expr);
+                errors.push(errs);
+                arranged_output
+            }
+            ReducePlan::Hierarchical(HierarchicalPlan::Monotonic(expr)) => {
+                let (output, errs) = self.build_monotonic(collection, expr);
+                errors.push(errs);
+                output
+            }
+            ReducePlan::Hierarchical(HierarchicalPlan::Bucketed(expr)) => {
+                let (output, errs) = self.build_bucketed(collection, expr);
+                if let Some(e) = errs {
+                    errors.push(e);
+                }
+                output
+            }
+            ReducePlan::Basic(BasicPlan::Single(index, aggr)) => {
+                let (output, errs) = self.build_basic_aggregate(collection, index, &aggr, true);
+                errors.push(errs.expect("validation should have occurred as it was requested"));
+                output
+            }
+            ReducePlan::Basic(BasicPlan::Multiple(aggrs)) => {
+                let (output, errs) = self.build_basic_aggregates(collection, aggrs);
+                errors.push(errs);
+                output
+            }
+            // Otherwise, we need to render something different for each type of
+            // reduction, and then stitch them together.
+            ReducePlan::Collation(expr) => {
+                // First, we need to render our constituent aggregations.
+                let mut to_collate = vec![];
 
-    // First, lets collect all results into a single collection.
-    for (reduction_type, arrangement) in arrangements.into_iter() {
-        let collection =
-            arrangement.as_collection(move |key, val| (key.clone(), (reduction_type, val.clone())));
-        to_concat.push(collection);
+                for plan in [
+                    expr.hierarchical.map(ReducePlan::Hierarchical),
+                    expr.accumulable.map(ReducePlan::Accumulable),
+                    expr.basic.map(ReducePlan::Basic),
+                ]
+                .into_iter()
+                .flat_map(std::convert::identity)
+                {
+                    let r#type = ReductionType::try_from(&plan)
+                        .expect("only representable reduction types were used above");
+
+                    let arrangement =
+                        self.render_reduce_plan_inner(plan, collection.clone(), errors, key_arity);
+                    to_collate.push((r#type, arrangement));
+                }
+
+                // Now we need to collate them together.
+                let (oks, errs) =
+                    self.build_collation(to_collate, expr.aggregate_types, &mut collection.scope());
+                errors.push(errs);
+                oks
+            }
+        };
+        arrangement
     }
 
-    // For each key above, we need to have exactly as many rows as there are distinct
-    // reduction types required by `aggregate_types`. We thus prepare here a properly
-    // deduplicated version of `aggregate_types` for validation during processing below.
-    let mut distinct_aggregate_types = aggregate_types.clone();
-    distinct_aggregate_types.sort_unstable();
-    distinct_aggregate_types.dedup();
-    let n_distinct_aggregate_types = distinct_aggregate_types.len();
+    /// Build the dataflow to combine arrangements containing results of different
+    /// aggregation types into a single arrangement.
+    ///
+    /// This computes the same thing as a join on the group key followed by shuffling
+    /// the values into the correct order. This implementation assumes that all input
+    /// arrangements present values in a way that respects the desired output order,
+    /// so we can do a linear merge to form the output.
+    fn build_collation<S>(
+        &self,
+        arrangements: Vec<(ReductionType, Arrangement<S, Row>)>,
+        aggregate_types: Vec<ReductionType>,
+        scope: &mut S,
+    ) -> (Arrangement<S, Row>, Collection<S, DataflowError, Diff>)
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        let error_logger = self.error_logger();
+        let debug_name = self.debug_name.to_string();
 
-    let aggregate_types_err = aggregate_types.clone();
-    let debug_name = debug_name.to_string();
-    use differential_dataflow::collection::concatenate;
-    let (oks, errs) = concatenate(scope, to_concat)
-        .arrange_named::<RowSpine<_, _, _, _>>("Arrange ReduceCollation")
-        .reduce_pair::<_, RowSpine<_, _, _, _>, _, ErrValSpine<_, _, _>>(
-            "ReduceCollation",
-            "ReduceCollation Errors",
-            {
-                let mut row_buf = Row::default();
-                move |_key, input, output| {
-                    // The inputs are pairs of a reduction type, and a row consisting of densely
-                    // packed fused aggregate values.
-                    //
-                    // We need to reconstitute the final value by:
-                    // 1. Extracting out the fused rows by type
-                    // 2. For each aggregate, figure out what type it is, and grab the relevant
-                    //    value from the corresponding fused row.
-                    // 3. Stitch all the values together into one row.
-                    let mut accumulable = DatumList::empty().iter();
-                    let mut hierarchical = DatumList::empty().iter();
-                    let mut basic = DatumList::empty().iter();
+        // We must have more than one arrangement to collate.
+        if arrangements.len() <= 1 {
+            error_logger.soft_panic_or_log(
+                "Incorrect number of arrangements in reduce collation",
+                &format!(
+                    "len={len}, debug_name={debug_name}",
+                    len = arrangements.len(),
+                ),
+            );
+        }
 
-                    // Note that hierarchical and basic reductions guard against negative
-                    // multiplicities, and if we only had accumulable aggregations, we would not
-                    // have produced a collation plan, so we do not repeat the check here.
+        let mut to_concat = vec![];
+
+        // First, lets collect all results into a single collection.
+        for (reduction_type, arrangement) in arrangements.into_iter() {
+            let collection = arrangement
+                .as_collection(move |key, val| (key.clone(), (reduction_type, val.clone())));
+            to_concat.push(collection);
+        }
+
+        // For each key above, we need to have exactly as many rows as there are distinct
+        // reduction types required by `aggregate_types`. We thus prepare here a properly
+        // deduplicated version of `aggregate_types` for validation during processing below.
+        let mut distinct_aggregate_types = aggregate_types.clone();
+        distinct_aggregate_types.sort_unstable();
+        distinct_aggregate_types.dedup();
+        let n_distinct_aggregate_types = distinct_aggregate_types.len();
+
+        let aggregate_types_err = aggregate_types.clone();
+        use differential_dataflow::collection::concatenate;
+        let (oks, errs) = concatenate(scope, to_concat)
+            .arrange_named::<RowSpine<_, _, _, _>>("Arrange ReduceCollation")
+            .reduce_pair::<_, RowSpine<_, _, _, _>, _, ErrValSpine<_, _, _>>(
+                "ReduceCollation",
+                "ReduceCollation Errors",
+                {
+                    let mut row_buf = Row::default();
+                    move |_key, input, output| {
+                        // The inputs are pairs of a reduction type, and a row consisting of densely
+                        // packed fused aggregate values.
+                        //
+                        // We need to reconstitute the final value by:
+                        // 1. Extracting out the fused rows by type
+                        // 2. For each aggregate, figure out what type it is, and grab the relevant
+                        //    value from the corresponding fused row.
+                        // 3. Stitch all the values together into one row.
+                        let mut accumulable = DatumList::empty().iter();
+                        let mut hierarchical = DatumList::empty().iter();
+                        let mut basic = DatumList::empty().iter();
+
+                        // Note that hierarchical and basic reductions guard against negative
+                        // multiplicities, and if we only had accumulable aggregations, we would not
+                        // have produced a collation plan, so we do not repeat the check here.
+                        if input.len() != n_distinct_aggregate_types {
+                            return;
+                        }
+
+                        for ((reduction_type, row), _) in input.iter() {
+                            match reduction_type {
+                                ReductionType::Accumulable => accumulable = row.iter(),
+                                ReductionType::Hierarchical => hierarchical = row.iter(),
+                                ReductionType::Basic => basic = row.iter(),
+                            }
+                        }
+
+                        // Merge results into the order they were asked for.
+                        let mut row_packer = row_buf.packer();
+                        for typ in aggregate_types.iter() {
+                            let datum = match typ {
+                                ReductionType::Accumulable => accumulable.next(),
+                                ReductionType::Hierarchical => hierarchical.next(),
+                                ReductionType::Basic => basic.next(),
+                            };
+                            let Some(datum) = datum else { return };
+                            row_packer.push(datum);
+                        }
+                        // If we did not have enough values to stitch together, then we do not generate
+                        // an output row. Not outputting here corresponds to the semantics of an
+                        // equi-join on the key, similarly to the proposal in PR #17013.
+                        //
+                        // Note that we also do not want to have anything left over to stich.  If we do,
+                        // then we also have an error and would violate join semantics.
+                        if (accumulable.next(), hierarchical.next(), basic.next())
+                            == (None, None, None)
+                        {
+                            output.push((row_buf.clone(), 1));
+                        }
+                    }
+                },
+                move |key, input, output| {
                     if input.len() != n_distinct_aggregate_types {
+                        // We expected to stitch together exactly as many aggregate types as requested
+                        // by the collation. If we cannot, we log an error and produce no output for
+                        // this key.
+                        let message = "Mismatched aggregates for key in ReduceCollation";
+                        error_logger.log(
+                            message,
+                            &format!(
+                                "key={key:?}, debug_name={debug_name}, \
+                                 n_aggregates_requested={requested}, \
+                                 n_distinct_aggregate_types={n_distinct_aggregate_types}",
+                                requested = input.len(),
+                            ),
+                        );
+                        output.push((EvalError::Internal(message.to_string()).into(), 1));
                         return;
                     }
 
+                    let mut accumulable = DatumList::empty().iter();
+                    let mut hierarchical = DatumList::empty().iter();
+                    let mut basic = DatumList::empty().iter();
                     for ((reduction_type, row), _) in input.iter() {
                         match reduction_type {
                             ReductionType::Accumulable => accumulable = row.iter(),
@@ -382,428 +401,563 @@ where
                         }
                     }
 
-                    // Merge results into the order they were asked for.
-                    let mut row_packer = row_buf.packer();
-                    for typ in aggregate_types.iter() {
+                    for typ in aggregate_types_err.iter() {
                         let datum = match typ {
                             ReductionType::Accumulable => accumulable.next(),
                             ReductionType::Hierarchical => hierarchical.next(),
                             ReductionType::Basic => basic.next(),
                         };
-                        let Some(datum) = datum else { return };
-                        row_packer.push(datum);
+                        if datum.is_some() {
+                            continue;
+                        }
+
+                        // We cannot properly reconstruct a row if aggregates are missing.
+                        // This situation is not expected, so we log an error if it occurs.
+                        let message = "Missing value for key in ReduceCollation";
+                        error_logger.log(
+                            message,
+                            &format!("typ={typ:?}, key={key:?}, debug_name={debug_name}"),
+                        );
+                        output.push((EvalError::Internal(message.to_string()).into(), 1));
+                        return;
                     }
-                    // If we did not have enough values to stitch together, then we do not generate
-                    // an output row. Not outputting here corresponds to the semantics of an
-                    // equi-join on the key, similarly to the proposal in PR #17013.
-                    //
-                    // Note that we also do not want to have anything left over to stich.  If we do,
-                    // then we also have an error and would violate join semantics.
+
+                    // Note that we also do not want to have anything left over to stich.
+                    // If we do, then we also have an error and would violate join semantics.
                     if (accumulable.next(), hierarchical.next(), basic.next()) == (None, None, None)
                     {
-                        output.push((row_buf.clone(), 1));
+                        return;
                     }
-                }
-            },
-            move |key, input, output| {
-                if input.len() != n_distinct_aggregate_types {
-                    // We expected to stitch together exactly as many aggregate types as requested
-                    // by the collation. If we cannot, we log an error and produce no output for
-                    // this key.
-                    let message = "Mismatched aggregates for key in ReduceCollation";
-                    error_logger.log(
-                        message,
-                        &format!(
-                            "key={key:?}, debug_name={debug_name}, \
-                             n_aggregates_requested={requested}, \
-                             n_distinct_aggregate_types={n_distinct_aggregate_types}",
-                            requested = input.len(),
-                        ),
-                    );
+
+                    let message = "Rows too large for key in ReduceCollation";
+                    error_logger.log(message, &format!("key={key:?}, debug_name={debug_name}"));
                     output.push((EvalError::Internal(message.to_string()).into(), 1));
-                    return;
-                }
+                },
+            );
+        (oks, errs.as_collection(|_, v| v.clone()))
+    }
 
-                let mut accumulable = DatumList::empty().iter();
-                let mut hierarchical = DatumList::empty().iter();
-                let mut basic = DatumList::empty().iter();
-                for ((reduction_type, row), _) in input.iter() {
-                    match reduction_type {
-                        ReductionType::Accumulable => accumulable = row.iter(),
-                        ReductionType::Hierarchical => hierarchical = row.iter(),
-                        ReductionType::Basic => basic = row.iter(),
+    /// Build the dataflow to compute the set of distinct keys.
+    fn build_distinct<S>(
+        &self,
+        collection: Collection<S, (Row, Row), Diff>,
+    ) -> (Arrangement<S, Row>, Collection<S, DataflowError, Diff>)
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        let error_logger = self.error_logger();
+        let debug_name = self.debug_name.to_string();
+
+        let (output, errors) = collection
+            .arrange_named::<RowSpine<_, _, _, _>>("Arranged DistinctBy")
+            .reduce_pair::<_, RowSpine<_, _, _, _>, _, ErrValSpine<_, _, _>>(
+                "DistinctBy",
+                "DistinctByErrorCheck",
+                |_key, _input, output| {
+                    // We're pushing an empty row here because the key is implicitly added by the
+                    // arrangement, and the permutation logic takes care of using the key part of the
+                    // output.
+                    output.push((Row::default(), 1));
+                },
+                move |_key, input: &[(_, Diff)], output| {
+                    for (row, count) in input.iter() {
+                        if count.is_positive() {
+                            continue;
+                        }
+                        let message = "Non-positive multiplicity in DistinctBy";
+                        error_logger.log(
+                            message,
+                            &format!("row={row:?}, count={count}, debug_name={debug_name}"),
+                        );
+                        output.push((EvalError::Internal(message.to_string()).into(), 1));
+                        return;
                     }
-                }
+                },
+            );
+        (output, errors.as_collection(|_k, v| v.clone()))
+    }
 
-                for typ in aggregate_types_err.iter() {
-                    let datum = match typ {
-                        ReductionType::Accumulable => accumulable.next(),
-                        ReductionType::Hierarchical => hierarchical.next(),
-                        ReductionType::Basic => basic.next(),
-                    };
-                    if datum.is_some() {
-                        continue;
+    /// Build the dataflow to compute the set of distinct keys.
+    ///
+    /// This implementation maintains the rows that don't appear in the output.
+    fn build_distinct_retractions<S>(
+        &self,
+        collection: Collection<S, (Row, Row), Diff>,
+    ) -> (Collection<S, Row, Diff>, Collection<S, DataflowError, Diff>)
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        let error_logger = self.error_logger();
+        let debug_name = self.debug_name.to_string();
+
+        let (negated_result, errs) = collection
+            .arrange_named::<RowSpine<Row, _, _, _>>("Arranged DistinctBy Retractions input")
+            .reduce_abelian::<_, RowSpine<_, _, _, _>>("Reduce DistinctBy Retractions", {
+                move |key, input, output| {
+                    for (row, count) in input.iter() {
+                        if count.is_positive() {
+                            continue;
+                        }
+                        let message = "Non-positive multiplicity in DistinctBy Retractions";
+                        error_logger.log(
+                            message,
+                            &format!("row={row:?}, count={count}, debug_name={debug_name}"),
+                        );
+                        output.push((Err(message.to_string()), 1));
+                        return;
                     }
 
-                    // We cannot properly reconstruct a row if aggregates are missing.
-                    // This situation is not expected, so we log an error if it occurs.
-                    let message = "Missing value for key in ReduceCollation";
-                    error_logger.log(
-                        message,
-                        &format!("typ={typ:?}, key={key:?}, debug_name={debug_name}"),
+                    output.push((Ok(key.clone()), -1));
+                    output.extend(
+                        input
+                            .iter()
+                            .map(|(values, count)| (Ok((*values).clone()), *count)),
                     );
-                    output.push((EvalError::Internal(message.to_string()).into(), 1));
-                    return;
                 }
-
-                // Note that we also do not want to have anything left over to stich.
-                // If we do, then we also have an error and would violate join semantics.
-                if (accumulable.next(), hierarchical.next(), basic.next()) == (None, None, None) {
-                    return;
-                }
-
-                let message = "Rows too large for key in ReduceCollation";
-                error_logger.log(message, &format!("key={key:?}, debug_name={debug_name}"));
-                output.push((EvalError::Internal(message.to_string()).into(), 1));
-            },
-        );
-    (oks, errs.as_collection(|_, v| v.clone()))
-}
-
-/// Build the dataflow to compute the set of distinct keys.
-fn build_distinct<G>(
-    debug_name: &str,
-    collection: Collection<G, (Row, Row), Diff>,
-    error_logger: ErrorLogger,
-) -> (Arrangement<G, Row>, Collection<G, DataflowError, Diff>)
-where
-    G: Scope,
-    G::Timestamp: Lattice,
-{
-    let debug_name = debug_name.to_string();
-    let (output, errors) = collection
-        .arrange_named::<RowSpine<_, _, _, _>>("Arranged DistinctBy")
-        .reduce_pair::<_, RowSpine<_, _, _, _>, _, ErrValSpine<_, _, _>>(
-            "DistinctBy",
-            "DistinctByErrorCheck",
-            |_key, _input, output| {
-                // We're pushing an empty row here because the key is implicitly added by the
-                // arrangement, and the permutation logic takes care of using the key part of the
-                // output.
-                output.push((Row::default(), 1));
-            },
-            move |_key, input: &[(_, Diff)], output| {
-                for (row, count) in input.iter() {
-                    if count.is_positive() {
-                        continue;
-                    }
-                    let message = "Non-positive multiplicity in DistinctBy";
-                    error_logger.log(
-                        message,
-                        &format!("row={row:?}, count={count}, debug_name={debug_name}"),
-                    );
-                    output.push((EvalError::Internal(message.to_string()).into(), 1));
-                    return;
-                }
-            },
-        );
-    (output, errors.as_collection(|_k, v| v.clone()))
-}
-
-/// Build the dataflow to compute the set of distinct keys.
-///
-/// This implementation maintains the rows that don't appear in the output.
-fn build_distinct_retractions<G, T>(
-    debug_name: &str,
-    collection: Collection<G, (Row, Row), Diff>,
-    error_logger: ErrorLogger,
-) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
-where
-    G: Scope,
-    G::Timestamp: Lattice + Refines<T>,
-    T: Timestamp + Lattice,
-{
-    let debug_name = debug_name.to_string();
-    let (negated_result, errs) = collection
-        .arrange_named::<RowSpine<Row, _, _, _>>("Arranged DistinctBy Retractions input")
-        .reduce_abelian::<_, RowSpine<_, _, _, _>>("Reduce DistinctBy Retractions", {
-            move |key, input, output| {
-                for (row, count) in input.iter() {
-                    if count.is_positive() {
-                        continue;
-                    }
-                    let message = "Non-positive multiplicity in DistinctBy Retractions";
-                    error_logger.log(
-                        message,
-                        &format!("row={row:?}, count={count}, debug_name={debug_name}"),
-                    );
-                    output.push((Err(message.to_string()), 1));
-                    return;
-                }
-
-                output.push((Ok(key.clone()), -1));
-                output.extend(
-                    input
-                        .iter()
-                        .map(|(values, count)| (Ok((*values).clone()), *count)),
-                );
-            }
-        })
-        .as_collection(|k, v| (k.clone(), v.clone()))
-        .map_fallible("Demux Errors", |(key, result)| match result {
-            Ok(row) => Ok((key, row)),
-            Err(message) => Err(EvalError::Internal(message).into()),
-        });
-    use timely::dataflow::operators::Map;
-    (
-        negated_result
-            .negate()
-            .concat(&collection)
-            .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated DistinctBy Retractions")
-            .inner
-            .map(|((k, _), time, count)| (k, time, count))
-            .as_collection(),
-        errs,
-    )
-}
-
-/// Build the dataflow to compute and arrange multiple non-accumulable,
-/// non-hierarchical aggregations on `input`.
-///
-/// This function assumes that we are explicitly rendering multiple basic aggregations.
-/// For each aggregate, we render a different reduce operator, and then fuse
-/// results together into a final arrangement that presents all the results
-/// in the order specified by `aggrs`.
-fn build_basic_aggregates<G>(
-    debug_name: &str,
-    input: Collection<G, (Row, Row), Diff>,
-    aggrs: Vec<(usize, AggregateExpr)>,
-    error_logger: ErrorLogger,
-) -> (Arrangement<G, Row>, Collection<G, DataflowError, Diff>)
-where
-    G: Scope,
-    G::Timestamp: Lattice,
-{
-    // We are only using this function to render multiple basic aggregates and
-    // stitch them together. If that's not true we should complain.
-    if aggrs.len() <= 1 {
-        error_logger.soft_panic_or_log(
-            "Too few aggregations when building basic aggregates",
-            &format!("len={len}, debug_name={debug_name}", len = aggrs.len()),
+            })
+            .as_collection(|k, v| (k.clone(), v.clone()))
+            .map_fallible("Demux Errors", |(key, result)| match result {
+                Ok(row) => Ok((key, row)),
+                Err(message) => Err(EvalError::Internal(message).into()),
+            });
+        use timely::dataflow::operators::Map;
+        (
+            negated_result
+                .negate()
+                .concat(&collection)
+                .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated DistinctBy Retractions")
+                .inner
+                .map(|((k, _), time, count)| (k, time, count))
+                .as_collection(),
+            errs,
         )
     }
-    let mut err_output = None;
-    let mut to_collect = Vec::new();
-    for (index, aggr) in aggrs {
-        let (result, errs) = build_basic_aggregate(
-            debug_name,
-            input.clone(),
-            index,
-            &aggr,
-            err_output.is_none(),
-            error_logger.clone(),
-        );
-        if errs.is_some() {
-            err_output = errs
+
+    /// Build the dataflow to compute and arrange multiple non-accumulable,
+    /// non-hierarchical aggregations on `input`.
+    ///
+    /// This function assumes that we are explicitly rendering multiple basic aggregations.
+    /// For each aggregate, we render a different reduce operator, and then fuse
+    /// results together into a final arrangement that presents all the results
+    /// in the order specified by `aggrs`.
+    fn build_basic_aggregates<S>(
+        &self,
+        input: Collection<S, (Row, Row), Diff>,
+        aggrs: Vec<(usize, AggregateExpr)>,
+    ) -> (Arrangement<S, Row>, Collection<S, DataflowError, Diff>)
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        // We are only using this function to render multiple basic aggregates and
+        // stitch them together. If that's not true we should complain.
+        if aggrs.len() <= 1 {
+            self.error_logger().soft_panic_or_log(
+                "Too few aggregations when building basic aggregates",
+                &format!(
+                    "len={len}, debug_name={name}",
+                    len = aggrs.len(),
+                    name = self.debug_name,
+                ),
+            )
         }
-        to_collect.push(result.as_collection(move |key, val| (key.clone(), (index, val.clone()))));
-    }
-    let output = differential_dataflow::collection::concatenate(&mut input.scope(), to_collect)
-        .arrange_named::<RowSpine<_, _, _, _>>("Arranged ReduceFuseBasic input")
-        .reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceFuseBasic", {
-            let mut row_buf = Row::default();
-            move |_key, input, output| {
-                let mut row_packer = row_buf.packer();
-                for ((_, row), _) in input.iter() {
-                    let datum = row.unpack_first();
-                    row_packer.push(datum);
+        let mut err_output = None;
+        let mut to_collect = Vec::new();
+        for (index, aggr) in aggrs {
+            let (result, errs) =
+                self.build_basic_aggregate(input.clone(), index, &aggr, err_output.is_none());
+            if errs.is_some() {
+                err_output = errs
+            }
+            to_collect
+                .push(result.as_collection(move |key, val| (key.clone(), (index, val.clone()))));
+        }
+        let output = differential_dataflow::collection::concatenate(&mut input.scope(), to_collect)
+            .arrange_named::<RowSpine<_, _, _, _>>("Arranged ReduceFuseBasic input")
+            .reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceFuseBasic", {
+                let mut row_buf = Row::default();
+                move |_key, input, output| {
+                    let mut row_packer = row_buf.packer();
+                    for ((_, row), _) in input.iter() {
+                        let datum = row.unpack_first();
+                        row_packer.push(datum);
+                    }
+                    output.push((row_buf.clone(), 1));
                 }
-                output.push((row_buf.clone(), 1));
+            });
+        (
+            output,
+            err_output.expect("expected to validate in at least one aggregate"),
+        )
+    }
+
+    /// Build the dataflow to compute a single basic aggregation.
+    ///
+    /// This method also applies distinctness if required.
+    fn build_basic_aggregate<S>(
+        &self,
+        input: Collection<S, (Row, Row), Diff>,
+        index: usize,
+        aggr: &AggregateExpr,
+        validating: bool,
+    ) -> (
+        Arrangement<S, Row>,
+        Option<Collection<S, DataflowError, Diff>>,
+    )
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        let AggregateExpr {
+            func,
+            expr: _,
+            distinct,
+        } = aggr.clone();
+
+        // Extract the value we were asked to aggregate over.
+        let mut row_buf = Row::default();
+        let mut partial = input.map(move |(key, row)| {
+            let value = row.iter().nth(index).unwrap();
+            row_buf.packer().push(value);
+            (key, row_buf.clone())
+        });
+
+        let mut err_output = None;
+
+        // If `distinct` is set, we restrict ourselves to the distinct `(key, val)`.
+        if distinct {
+            if validating {
+                let (oks, errs) = self
+                    .build_reduce_inaccumulable_distinct::<_, Result<(), String>>(partial)
+                    .as_collection(|k, v| (k.clone(), v.clone()))
+                    .map_fallible("Demux Errors", move |(key, result)| match result {
+                        Ok(()) => Ok(key),
+                        Err(m) => Err(EvalError::Internal(m).into()),
+                    });
+                err_output = Some(errs);
+                partial = oks;
+            } else {
+                partial = self
+                    .build_reduce_inaccumulable_distinct::<_, ()>(partial)
+                    .as_collection(|k, _| k.clone());
+            }
+        }
+
+        let arranged =
+            partial.arrange_named::<RowSpine<_, Row, _, _>>("Arranged ReduceInaccumulable");
+        let oks = arranged.reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceInaccumulable", {
+            let mut row_buf = Row::default();
+            move |_key, source, target| {
+                // We respect the multiplicity here (unlike in hierarchical aggregation)
+                // because we don't know that the aggregation method is not sensitive
+                // to the number of records.
+                let iter = source.iter().flat_map(|(v, w)| {
+                    // Note that in the non-positive case, this is wrong, but harmless because
+                    // our other reduction will produce an error.
+                    let count = usize::try_from(*w).unwrap_or(0);
+                    std::iter::repeat(v.iter().next().unwrap()).take(count)
+                });
+                row_buf.packer().push(func.eval(iter, &RowArena::new()));
+                target.push((row_buf.clone(), 1));
             }
         });
-    (
-        output,
-        err_output.expect("expected to validate in at least one aggregate"),
+
+        // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here, but
+        // we then wouldn't be able to do this error check conditionally.  See its documentation for the
+        // rationale around using a second reduction here.
+        if validating && err_output.is_none() {
+            let error_logger = self.error_logger();
+            let debug_name = self.debug_name.to_string();
+
+            let errs = arranged.reduce_abelian::<_, ErrValSpine<_, _, _>>(
+                "ReduceInaccumulable Error Check",
+                move |_key, source, target| {
+                    // Negative counts would be surprising, but until we are 100% certain we won't
+                    // see them, we should report when we do. We may want to bake even more info
+                    // in here in the future.
+                    for (value, count) in source.iter() {
+                        if count.is_positive() {
+                            continue;
+                        }
+
+                        let message = "Non-positive accumulation in ReduceInaccumulable";
+                        error_logger.log(
+                            message,
+                            &format!("value={value:?}, count={count}, debug_name={debug_name}"),
+                        );
+                        target.push((EvalError::Internal(message.to_string()).into(), 1));
+                        return;
+                    }
+                },
+            );
+            (oks, Some(errs.as_collection(|_, v| v.clone())))
+        } else {
+            (oks, err_output)
+        }
+    }
+
+    fn build_reduce_inaccumulable_distinct<S, R>(
+        &self,
+        input: Collection<S, (Row, Row), Diff>,
+    ) -> KeyArrangement<S, (Row, Row), R>
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+        R: MaybeValidatingRow<(), String>,
+    {
+        let error_logger = self.error_logger();
+        let debug_name = self.debug_name.to_string();
+
+        input
+            .arrange_named::<RowSpine<(Row, Row), _, _, _>>("Arranged ReduceInaccumulable")
+            .reduce_abelian::<_, RowSpine<_, _, _, _>>(
+                "ReduceInaccumulable",
+                move |_, source, t| {
+                    if let Some(err) = R::into_error() {
+                        for (value, count) in source.iter() {
+                            if count.is_positive() {
+                                continue;
+                            }
+
+                            let message =
+                                "Non-positive accumulation in ReduceInaccumulable DISTINCT";
+                            error_logger.log(
+                                message,
+                                &format!("value={value:?}, count={count}, debug_name={debug_name}"),
+                            );
+                            t.push((err(message.to_string()), 1));
+                            return;
+                        }
+                    }
+                    t.push((R::ok(()), 1))
+                },
+            )
+    }
+
+    /// Build the dataflow to compute and arrange multiple hierarchical aggregations
+    /// on non-monotonic inputs.
+    ///
+    /// This function renders a single reduction tree that computes aggregations with
+    /// a priority queue implemented with a series of reduce operators that partition
+    /// the input into buckets, and compute the aggregation over very small buckets
+    /// and feed the results up to larger buckets.
+    ///
+    /// Note that this implementation currently ignores the distinct bit because we
+    /// currently only perform min / max hierarchically and the reduction tree
+    /// efficiently suppresses non-distinct updates.
+    fn build_bucketed<S>(
+        &self,
+        input: Collection<S, (Row, Row), Diff>,
+        BucketedPlan {
+            aggr_funcs,
+            skips,
+            buckets,
+        }: BucketedPlan,
+    ) -> (
+        Arrangement<S, Row>,
+        Option<Collection<S, DataflowError, Diff>>,
     )
-}
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        let mut err_output: Option<Collection<S, _, _>> = None;
+        let arranged_output = input.scope().region_named("ReduceHierarchical", |inner| {
+            let input = input.enter(inner);
 
-/// Build the dataflow to compute a single basic aggregation.
-///
-/// This method also applies distinctness if required.
-fn build_basic_aggregate<G>(
-    debug_name: &str,
-    input: Collection<G, (Row, Row), Diff>,
-    index: usize,
-    aggr: &AggregateExpr,
-    validating: bool,
-    error_logger: ErrorLogger,
-) -> (
-    Arrangement<G, Row>,
-    Option<Collection<G, DataflowError, Diff>>,
-)
-where
-    G: Scope,
-    G::Timestamp: Lattice,
-{
-    let AggregateExpr {
-        func,
-        expr: _,
-        distinct,
-    } = aggr.clone();
+            // Gather the relevant values into a vec of rows ordered by aggregation_index
+            let mut row_buf = Row::default();
+            let input = input.map(move |(key, row)| {
+                let mut values = Vec::with_capacity(skips.len());
+                let mut row_iter = row.iter();
+                for skip in skips.iter() {
+                    row_buf.packer().push(row_iter.nth(*skip).unwrap());
+                    values.push(row_buf.clone());
+                }
 
-    // Extract the value we were asked to aggregate over.
-    let mut row_buf = Row::default();
-    let mut partial = input.map(move |(key, row)| {
-        let value = row.iter().nth(index).unwrap();
-        row_buf.packer().push(value);
-        (key, row_buf.clone())
-    });
+                (key, values)
+            });
 
-    let mut err_output = None;
+            // Repeatedly apply hierarchical reduction with a progressively coarser key.
+            let mut stage = input.map(move |(key, values)| ((key, values.hashed()), values));
+            let mut validating = true;
+            for b in buckets.into_iter() {
+                let input = stage.map(move |((key, hash), values)| ((key, hash % b), values));
 
-    // If `distinct` is set, we restrict ourselves to the distinct `(key, val)`.
-    if distinct {
-        if validating {
-            let (oks, errs) = build_reduce_inaccumulable_distinct::<_, Result<(), String>>(
-                debug_name,
-                partial,
-                error_logger.clone(),
+                // We only want the first stage to perform validation of whether invalid accumulations
+                // were observed in the input. Subsequently, we will either produce an error in the error
+                // stream or produce correct data in the output stream.
+                let negated_output = if validating {
+                    let (oks, errs) = self
+                        .build_bucketed_negated_output::<_, Result<Vec<Row>, (Row, u64)>>(
+                            &input,
+                            aggr_funcs.clone(),
+                        )
+                        .map_fallible(
+                            "Checked Invalid Accumulations",
+                            |(key, result)| match result {
+                                Err((key, _)) => {
+                                    let message = format!(
+                                        "Invalid data in source, saw non-positive accumulation \
+                                         for key {key:?} in hierarchical mins-maxes aggregate"
+                                    );
+                                    Err(EvalError::Internal(message).into())
+                                }
+                                Ok(values) => Ok((key, values)),
+                            },
+                        );
+                    validating = false;
+                    err_output = Some(errs.leave_region());
+                    oks
+                } else {
+                    self.build_bucketed_negated_output::<_, Vec<Row>>(&input, aggr_funcs.clone())
+                };
+
+                stage = negated_output
+                    .negate()
+                    .concat(&input)
+                    .consolidate_named::<RowKeySpine<_, _, _>>(
+                        "Consolidated MinsMaxesHierarchical",
+                    );
+            }
+
+            // Discard the hash from the key and return to the format of the input data.
+            let partial = stage.map(|((key, _hash), values)| (key, values));
+
+            // Build a series of stages for the reduction
+            // Arrange the final result into (key, Row)
+            let error_logger = self.error_logger();
+            let debug_name = self.debug_name.to_string();
+            let arranged =
+                partial.arrange_named::<RowSpine<_, Vec<Row>, _, _>>("Arrange ReduceMinsMaxes");
+            // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
+            // but we then wouldn't be able to do this error check conditionally.  See its documentation
+            // for the rationale around using a second reduction here.
+            if validating {
+                let errs = arranged
+                    .reduce_abelian::<_, ErrValSpine<_, _, _>>(
+                        "ReduceMinsMaxes Error Check",
+                        move |_key, source, target| {
+                            // Negative counts would be surprising, but until we are 100% certain we wont
+                            // see them, we should report when we do. We may want to bake even more info
+                            // in here in the future.
+                            for (val, count) in source.iter() {
+                                if count.is_positive() {
+                                    continue;
+                                }
+
+                                let message = "Non-positive accumulation in ReduceMinsMaxes";
+                                error_logger.log(
+                                    message,
+                                    &format!("val={val:?}, count={count}, debug_name={debug_name}"),
+                                );
+                                target.push((EvalError::Internal(message.to_string()).into(), 1));
+                                return;
+                            }
+                        },
+                    )
+                    .as_collection(|_, v| v.clone());
+                err_output = Some(errs.leave_region());
+            }
+            arranged
+                .reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceMinsMaxes", {
+                    let mut row_buf = Row::default();
+                    move |_key, source: &[(&Vec<Row>, Diff)], target: &mut Vec<(Row, Diff)>| {
+                        let mut row_packer = row_buf.packer();
+                        for (aggr_index, func) in aggr_funcs.iter().enumerate() {
+                            let iter = source
+                                .iter()
+                                .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
+                            row_packer.push(func.eval(iter, &RowArena::new()));
+                        }
+                        target.push((row_buf.clone(), 1));
+                    }
+                })
+                .leave_region()
+        });
+        (arranged_output, err_output)
+    }
+
+    /// Build the dataflow for one stage of a reduction tree for multiple hierarchical
+    /// aggregates.
+    ///
+    /// `buckets` indicates the number of buckets in this stage. We do some non
+    /// obvious trickery here to limit the memory usage per layer by internally
+    /// holding only the elements that were rejected by this stage. However, the
+    /// output collection maintains the `((key, bucket), (passing value)` for this
+    /// stage.
+    /// `validating` indicates whether we want this stage to perform error detection
+    /// for invalid accumulations. Once a stage is clean of such errors, subsequent
+    /// stages can skip validation.
+    fn build_bucketed_negated_output<S, R>(
+        &self,
+        input: &Collection<S, ((Row, u64), Vec<Row>), Diff>,
+        aggrs: Vec<AggregateFunc>,
+    ) -> Collection<S, ((Row, u64), R), Diff>
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+        R: MaybeValidatingRow<Vec<Row>, (Row, u64)>,
+    {
+        let error_logger = self.error_logger();
+        let debug_name = self.debug_name.to_string();
+        let arranged_input = input
+            .arrange_named::<RowSpine<_, Vec<Row>, _, _>>("Arranged MinsMaxesHierarchical input");
+
+        arranged_input
+            .reduce_abelian::<_, RowSpine<_, _, _, _>>(
+                "Reduced Fallibly MinsMaxesHierarchical",
+                move |key, source, target| {
+                    if let Some(err) = R::into_error() {
+                        // Should negative accumulations reach us, we should loudly complain.
+                        for (value, count) in source.iter() {
+                            if count.is_positive() {
+                                continue;
+                            }
+                            error_logger.log(
+                                "Non-positive accumulation in MinsMaxesHierarchical",
+                                &format!(
+                                    "key={key:?}, value={value:?}, count={count}, \
+                                     debug_name={debug_name}"
+                                ),
+                            );
+                            // After complaining, output an error here so that we can eventually
+                            // report it in an error stream.
+                            target.push((err(key.clone()), -1));
+                            return;
+                        }
+                    }
+                    let mut output = Vec::with_capacity(aggrs.len());
+                    for (aggr_index, func) in aggrs.iter().enumerate() {
+                        let iter = source
+                            .iter()
+                            .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
+                        output.push(Row::pack_slice(&[func.eval(iter, &RowArena::new())]));
+                    }
+                    // We only want to arrange the parts of the input that are not part of the output.
+                    // More specifically, we want to arrange it so that `input.concat(&output.negate())`
+                    // gives us the intended value of this aggregate function. Also we assume that regardless
+                    // of the multiplicity of the final result in the input, we only want to have one copy
+                    // in the output.
+                    target.push((R::ok(output), -1));
+                    target.extend(
+                        source
+                            .iter()
+                            .map(|(values, cnt)| (R::ok((*values).clone()), *cnt)),
+                    );
+                },
             )
             .as_collection(|k, v| (k.clone(), v.clone()))
-            .map_fallible("Demux Errors", move |(key, result)| match result {
-                Ok(()) => Ok(key),
-                Err(m) => Err(EvalError::Internal(m).into()),
-            });
-            err_output = Some(errs);
-            partial = oks;
-        } else {
-            partial = build_reduce_inaccumulable_distinct::<_, ()>(
-                debug_name,
-                partial,
-                error_logger.clone(),
-            )
-            .as_collection(|k, _| k.clone());
-        }
     }
 
-    let arranged = partial.arrange_named::<RowSpine<_, Row, _, _>>("Arranged ReduceInaccumulable");
-    let oks = arranged.reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceInaccumulable", {
-        let mut row_buf = Row::default();
-        move |_key, source, target| {
-            // We respect the multiplicity here (unlike in hierarchical aggregation)
-            // because we don't know that the aggregation method is not sensitive
-            // to the number of records.
-            let iter = source.iter().flat_map(|(v, w)| {
-                // Note that in the non-positive case, this is wrong, but harmless because
-                // our other reduction will produce an error.
-                let count = usize::try_from(*w).unwrap_or(0);
-                std::iter::repeat(v.iter().next().unwrap()).take(count)
-            });
-            row_buf.packer().push(func.eval(iter, &RowArena::new()));
-            target.push((row_buf.clone(), 1));
-        }
-    });
-
-    // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here, but
-    // we then wouldn't be able to do this error check conditionally.  See its documentation for the
-    // rationale around using a second reduction here.
-    if validating && err_output.is_none() {
-        let debug_name = debug_name.to_string();
-        let errs = arranged.reduce_abelian::<_, ErrValSpine<_, _, _>>(
-            "ReduceInaccumulable Error Check",
-            move |_key, source, target| {
-                // Negative counts would be surprising, but until we are 100% certain we won't
-                // see them, we should report when we do. We may want to bake even more info
-                // in here in the future.
-                for (value, count) in source.iter() {
-                    if count.is_positive() {
-                        continue;
-                    }
-
-                    let message = "Non-positive accumulation in ReduceInaccumulable";
-                    error_logger.log(
-                        message,
-                        &format!("value={value:?}, count={count}, debug_name={debug_name}"),
-                    );
-                    target.push((EvalError::Internal(message.to_string()).into(), 1));
-                    return;
-                }
-            },
-        );
-        (oks, Some(errs.as_collection(|_, v| v.clone())))
-    } else {
-        (oks, err_output)
-    }
-}
-
-fn build_reduce_inaccumulable_distinct<G, R>(
-    debug_name: &str,
-    input: Collection<G, (Row, Row), Diff>,
-    error_logger: ErrorLogger,
-) -> KeyArrangement<G, (Row, Row), R>
-where
-    G: Scope,
-    G::Timestamp: Lattice,
-    R: MaybeValidatingRow<(), String>,
-{
-    let debug_name = debug_name.to_string();
-    input
-        .arrange_named::<RowSpine<(Row, Row), _, _, _>>("Arranged ReduceInaccumulable")
-        .reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceInaccumulable", move |_, source, t| {
-            if let Some(err) = R::into_error() {
-                for (value, count) in source.iter() {
-                    if count.is_positive() {
-                        continue;
-                    }
-
-                    let message = "Non-positive accumulation in ReduceInaccumulable DISTINCT";
-                    error_logger.log(
-                        message,
-                        &format!("value={value:?}, count={count}, debug_name={debug_name}"),
-                    );
-                    t.push((err(message.to_string()), 1));
-                    return;
-                }
-            }
-            t.push((R::ok(()), 1))
-        })
-}
-
-/// Build the dataflow to compute and arrange multiple hierarchical aggregations
-/// on non-monotonic inputs.
-///
-/// This function renders a single reduction tree that computes aggregations with
-/// a priority queue implemented with a series of reduce operators that partition
-/// the input into buckets, and compute the aggregation over very small buckets
-/// and feed the results up to larger buckets.
-///
-/// Note that this implementation currently ignores the distinct bit because we
-/// currently only perform min / max hierarchically and the reduction tree
-/// efficiently suppresses non-distinct updates.
-fn build_bucketed<G>(
-    debug_name: &str,
-    input: Collection<G, (Row, Row), Diff>,
-    BucketedPlan {
-        aggr_funcs,
-        skips,
-        buckets,
-    }: BucketedPlan,
-    error_logger: ErrorLogger,
-) -> (
-    Arrangement<G, Row>,
-    Option<Collection<G, DataflowError, Diff>>,
-)
-where
-    G: Scope,
-    G::Timestamp: Lattice,
-{
-    let mut err_output: Option<Collection<G, _, _>> = None;
-    let arranged_output = input.scope().region_named("ReduceHierarchical", |inner| {
-        let input = input.enter(inner);
-
+    /// Build the dataflow to compute and arrange multiple hierarchical aggregations
+    /// on monotonic inputs.
+    fn build_monotonic<S>(
+        &self,
+        collection: Collection<S, (Row, Row), Diff>,
+        MonotonicPlan { aggr_funcs, skips }: MonotonicPlan,
+    ) -> (Arrangement<S, Row>, Collection<S, DataflowError, Diff>)
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
         // Gather the relevant values into a vec of rows ordered by aggregation_index
         let mut row_buf = Row::default();
-        let input = input.map(move |(key, row)| {
+        let collection = collection.map(move |(key, row)| {
             let mut values = Vec::with_capacity(skips.len());
             let mut row_iter = row.iter();
             for skip in skips.iter() {
@@ -814,224 +968,24 @@ where
             (key, values)
         });
 
-        // Repeatedly apply hierarchical reduction with a progressively coarser key.
-        let mut stage = input.map(move |(key, values)| ((key, values.hashed()), values));
-        let mut validating = true;
-        for b in buckets.into_iter() {
-            let input = stage.map(move |((key, hash), values)| ((key, hash % b), values));
-
-            // We only want the first stage to perform validation of whether invalid accumulations
-            // were observed in the input. Subsequently, we will either produce an error in the error
-            // stream or produce correct data in the output stream.
-            let negated_output = if validating {
-                let (oks, errs) = build_bucketed_negated_output::<_, Result<Vec<Row>, (Row, u64)>>(
-                    debug_name,
-                    &input,
-                    aggr_funcs.clone(),
-                    error_logger.clone(),
-                )
-                .map_fallible(
-                    "Checked Invalid Accumulations",
-                    |(key, result)| match result {
-                        Err((key, _)) => {
-                            let message = format!(
-                                "Invalid data in source, saw non-positive accumulation for \
-                                 key {key:?} in hierarchical mins-maxes aggregate"
-                            );
-                            Err(EvalError::Internal(message).into())
-                        }
-                        Ok(values) => Ok((key, values)),
-                    },
-                );
-                validating = false;
-                err_output = Some(errs.leave_region());
-                oks
-            } else {
-                build_bucketed_negated_output::<_, Vec<Row>>(
-                    debug_name,
-                    &input,
-                    aggr_funcs.clone(),
-                    error_logger.clone(),
-                )
-            };
-
-            stage = negated_output
-                .negate()
-                .concat(&input)
-                .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated MinsMaxesHierarchical");
-        }
-
-        // Discard the hash from the key and return to the format of the input data.
-        let partial = stage.map(|((key, _hash), values)| (key, values));
-
-        // Build a series of stages for the reduction
-        // Arrange the final result into (key, Row)
-        let debug_name = debug_name.to_string();
-        let arranged =
-            partial.arrange_named::<RowSpine<_, Vec<Row>, _, _>>("Arrange ReduceMinsMaxes");
-        // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
-        // but we then wouldn't be able to do this error check conditionally.  See its documentation
-        // for the rationale around using a second reduction here.
-        if validating {
-            let errs = arranged
-                .reduce_abelian::<_, ErrValSpine<_, _, _>>(
-                    "ReduceMinsMaxes Error Check",
-                    move |_key, source, target| {
-                        // Negative counts would be surprising, but until we are 100% certain we wont
-                        // see them, we should report when we do. We may want to bake even more info
-                        // in here in the future.
-                        for (val, count) in source.iter() {
-                            if count.is_positive() {
-                                continue;
-                            }
-
-                            let message = "Non-positive accumulation in ReduceMinsMaxes";
-                            error_logger.log(
-                                message,
-                                &format!("val={val:?}, count={count}, debug_name={debug_name}"),
-                            );
-                            target.push((EvalError::Internal(message.to_string()).into(), 1));
-                            return;
-                        }
-                    },
-                )
-                .as_collection(|_, v| v.clone());
-            err_output = Some(errs.leave_region());
-        }
-        arranged
-            .reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceMinsMaxes", {
-                let mut row_buf = Row::default();
-                move |_key, source: &[(&Vec<Row>, Diff)], target: &mut Vec<(Row, Diff)>| {
-                    let mut row_packer = row_buf.packer();
-                    for (aggr_index, func) in aggr_funcs.iter().enumerate() {
-                        let iter = source
-                            .iter()
-                            .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
-                        row_packer.push(func.eval(iter, &RowArena::new()));
-                    }
-                    target.push((row_buf.clone(), 1));
-                }
-            })
-            .leave_region()
-    });
-    (arranged_output, err_output)
-}
-
-/// Build the dataflow for one stage of a reduction tree for multiple hierarchical
-/// aggregates.
-///
-/// `buckets` indicates the number of buckets in this stage. We do some non
-/// obvious trickery here to limit the memory usage per layer by internally
-/// holding only the elements that were rejected by this stage. However, the
-/// output collection maintains the `((key, bucket), (passing value)` for this
-/// stage.
-/// `validating` indicates whether we want this stage to perform error detection
-/// for invalid accumulations. Once a stage is clean of such errors, subsequent
-/// stages can skip validation.
-fn build_bucketed_negated_output<G, R>(
-    debug_name: &str,
-    input: &Collection<G, ((Row, u64), Vec<Row>), Diff>,
-    aggrs: Vec<AggregateFunc>,
-    error_logger: ErrorLogger,
-) -> Collection<G, ((Row, u64), R), Diff>
-where
-    G: Scope,
-    G::Timestamp: Lattice,
-    R: MaybeValidatingRow<Vec<Row>, (Row, u64)>,
-{
-    let debug_name = debug_name.to_string();
-    let arranged_input =
-        input.arrange_named::<RowSpine<_, Vec<Row>, _, _>>("Arranged MinsMaxesHierarchical input");
-
-    arranged_input
-        .reduce_abelian::<_, RowSpine<_, _, _, _>>(
-            "Reduced Fallibly MinsMaxesHierarchical",
-            move |key, source, target| {
-                if let Some(err) = R::into_error() {
-                    // Should negative accumulations reach us, we should loudly complain.
-                    for (value, count) in source.iter() {
-                        if count.is_positive() {
-                            continue;
-                        }
-                        error_logger.log(
-                            "Non-positive accumulation in MinsMaxesHierarchical",
-                            &format!(
-                                "key={key:?}, value={value:?}, count={count}, \
-                                 debug_name={debug_name}"
-                            ),
-                        );
-                        // After complaining, output an error here so that we can eventually
-                        // report it in an error stream.
-                        target.push((err(key.clone()), -1));
-                        return;
-                    }
-                }
-                let mut output = Vec::with_capacity(aggrs.len());
-                for (aggr_index, func) in aggrs.iter().enumerate() {
-                    let iter = source
-                        .iter()
-                        .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
-                    output.push(Row::pack_slice(&[func.eval(iter, &RowArena::new())]));
-                }
-                // We only want to arrange the parts of the input that are not part of the output.
-                // More specifically, we want to arrange it so that `input.concat(&output.negate())`
-                // gives us the intended value of this aggregate function. Also we assume that regardless
-                // of the multiplicity of the final result in the input, we only want to have one copy
-                // in the output.
-                target.push((R::ok(output), -1));
-                target.extend(
-                    source
-                        .iter()
-                        .map(|(values, cnt)| (R::ok((*values).clone()), *cnt)),
-                );
-            },
-        )
-        .as_collection(|k, v| (k.clone(), v.clone()))
-}
-
-/// Build the dataflow to compute and arrange multiple hierarchical aggregations
-/// on monotonic inputs.
-fn build_monotonic<G>(
-    debug_name: &str,
-    collection: Collection<G, (Row, Row), Diff>,
-    MonotonicPlan { aggr_funcs, skips }: MonotonicPlan,
-    error_logger: ErrorLogger,
-) -> (Arrangement<G, Row>, Collection<G, DataflowError, Diff>)
-where
-    G: Scope,
-    G::Timestamp: Lattice,
-{
-    // Gather the relevant values into a vec of rows ordered by aggregation_index
-    let mut row_buf = Row::default();
-    let collection = collection.map(move |(key, row)| {
-        let mut values = Vec::with_capacity(skips.len());
-        let mut row_iter = row.iter();
-        for skip in skips.iter() {
-            row_buf.packer().push(row_iter.nth(*skip).unwrap());
-            values.push(row_buf.clone());
-        }
-
-        (key, values)
-    });
-
-    // We arrange the inputs ourself to force it into a leaner structure because we know we
-    // won't care about values.
-    let consolidated =
-        collection.consolidate_named::<RowKeySpine<_, _, _>>("Consolidated ReduceMonotonic input");
-    let debug_name = debug_name.to_string();
-    let (partial, errs) = consolidated.ensure_monotonic(move |data, diff| {
-        error_logger.log(
-            "Non-monotonic input to ReduceMonotonic",
-            &format!("data={data:?}, diff={diff}, debug_name={debug_name}"),
-        );
-        let m = "tried to build a monotonic reduction on non-monotonic input".to_string();
-        (EvalError::Internal(m).into(), 1)
-    });
-    // We can place our rows directly into the diff field, and
-    // only keep the relevant one corresponding to evaluating our
-    // aggregate, instead of having to do a hierarchical reduction.
-    let partial =
-        partial.explode_one(move |(key, values)| {
+        // We arrange the inputs ourself to force it into a leaner structure because we know we
+        // won't care about values.
+        let consolidated = collection
+            .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated ReduceMonotonic input");
+        let error_logger = self.error_logger();
+        let debug_name = self.debug_name.to_string();
+        let (partial, errs) = consolidated.ensure_monotonic(move |data, diff| {
+            error_logger.log(
+                "Non-monotonic input to ReduceMonotonic",
+                &format!("data={data:?}, diff={diff}, debug_name={debug_name}"),
+            );
+            let m = "tried to build a monotonic reduction on non-monotonic input".to_string();
+            (EvalError::Internal(m).into(), 1)
+        });
+        // We can place our rows directly into the diff field, and
+        // only keep the relevant one corresponding to evaluating our
+        // aggregate, instead of having to do a hierarchical reduction.
+        let partial = partial.explode_one(move |(key, values)| {
             let mut output = Vec::new();
             for (row, func) in values.into_iter().zip(aggr_funcs.iter()) {
                 output.push(monoids::get_monoid(row, func).expect(
@@ -1040,23 +994,554 @@ where
             }
             (key, output)
         });
-    let output = partial
-        .arrange_named::<RowKeySpine<_, _, Vec<ReductionMonoid>>>("ArrangeMonotonic")
-        .reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceMonotonic", {
-            let mut row_buf = Row::default();
-            move |_key, input, output| {
-                let mut row_packer = row_buf.packer();
-                let accum = &input[0].1;
-                for monoid in accum.iter() {
-                    use ReductionMonoid::*;
-                    match monoid {
-                        Min(row) | Max(row) => row_packer.extend(row.iter()),
+        let output = partial
+            .arrange_named::<RowKeySpine<_, _, Vec<ReductionMonoid>>>("ArrangeMonotonic")
+            .reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceMonotonic", {
+                let mut row_buf = Row::default();
+                move |_key, input, output| {
+                    let mut row_packer = row_buf.packer();
+                    let accum = &input[0].1;
+                    for monoid in accum.iter() {
+                        use ReductionMonoid::*;
+                        match monoid {
+                            Min(row) | Max(row) => row_packer.extend(row.iter()),
+                        }
+                    }
+                    output.push((row_buf.clone(), 1));
+                }
+            });
+        (output, errs)
+    }
+
+    /// Build the dataflow to compute and arrange multiple accumulable aggregations.
+    ///
+    /// The incoming values are moved to the update's "difference" field, at which point
+    /// they can be accumulated in place. The `count` operator promotes the accumulated
+    /// values to data, at which point a final map applies operator-specific logic to
+    /// yield the final aggregate.
+    fn build_accumulable<S>(
+        &self,
+        collection: Collection<S, (Row, Row), Diff>,
+        AccumulablePlan {
+            full_aggrs,
+            simple_aggrs,
+            distinct_aggrs,
+        }: AccumulablePlan,
+    ) -> (Arrangement<S, Row>, Collection<S, DataflowError, Diff>)
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        // we must have called this function with something to reduce
+        if full_aggrs.len() == 0 || simple_aggrs.len() + distinct_aggrs.len() != full_aggrs.len() {
+            self.error_logger().soft_panic_or_log(
+                "Incorrect numbers of aggregates in accummulable reduction rendering",
+                &format!(
+                    "full_aggrs={}, simple_aggrs={}, distinct_aggrs={}, debug_name={}",
+                    full_aggrs.len(),
+                    simple_aggrs.len(),
+                    distinct_aggrs.len(),
+                    self.debug_name,
+                ),
+            );
+        }
+
+        // Some of the aggregations may have the `distinct` bit set, which means that they'll
+        // need to be extracted from `collection` and be subjected to `distinct` with `key`.
+        // Other aggregations can be directly moved in to the `diff` field.
+        //
+        // In each case, the resulting collection should have `data` shaped as `(key, ())`
+        // and a `diff` that is a vector with length `3 * aggrs.len()`. The three values are
+        // generally the count, and then two aggregation-specific values. The size could be
+        // reduced if we want to specialize for the aggregations.
+
+        let float_scale = f64::from(1 << 24);
+
+        // Instantiate a default vector for diffs with the correct types at each
+        // position.
+        let zero_diffs: (Vec<_>, Diff) = (
+            full_aggrs
+                .iter()
+                .map(|f| match f.func {
+                    AggregateFunc::Any | AggregateFunc::All => Accum::Bool {
+                        trues: 0,
+                        falses: 0,
+                    },
+                    AggregateFunc::SumFloat32 | AggregateFunc::SumFloat64 => Accum::Float {
+                        accum: 0,
+                        pos_infs: 0,
+                        neg_infs: 0,
+                        nans: 0,
+                        non_nulls: 0,
+                    },
+                    AggregateFunc::SumNumeric => Accum::Numeric {
+                        accum: OrderedDecimal(NumericAgg::zero()),
+                        pos_infs: 0,
+                        neg_infs: 0,
+                        nans: 0,
+                        non_nulls: 0,
+                    },
+                    _ => Accum::SimpleNumber {
+                        accum: 0,
+                        non_nulls: 0,
+                    },
+                })
+                .collect(),
+            0,
+        );
+
+        // Two aggregation-specific values for each aggregation.
+        let datum_to_accumulator = move |datum: Datum, aggr: &AggregateFunc| {
+            match aggr {
+                AggregateFunc::Count => Accum::SimpleNumber {
+                    accum: 0, // unused for AggregateFunc::Count
+                    non_nulls: if datum.is_null() { 0 } else { 1 },
+                },
+                AggregateFunc::Any | AggregateFunc::All => match datum {
+                    Datum::True => Accum::Bool {
+                        trues: 1,
+                        falses: 0,
+                    },
+                    Datum::Null => Accum::Bool {
+                        trues: 0,
+                        falses: 0,
+                    },
+                    Datum::False => Accum::Bool {
+                        trues: 0,
+                        falses: 1,
+                    },
+                    x => panic!("Invalid argument to AggregateFunc::Any: {x:?}"),
+                },
+                AggregateFunc::Dummy => match datum {
+                    Datum::Dummy => Accum::SimpleNumber {
+                        accum: 0,
+                        non_nulls: 0,
+                    },
+                    x => panic!("Invalid argument to AggregateFunc::Dummy: {x:?}"),
+                },
+                AggregateFunc::SumFloat32 | AggregateFunc::SumFloat64 => {
+                    let n = match datum {
+                        Datum::Float32(n) => f64::from(*n),
+                        Datum::Float64(n) => *n,
+                        Datum::Null => 0f64,
+                        x => panic!("Invalid argument to AggregateFunc::{aggr:?}: {x:?}"),
+                    };
+
+                    let nans = Diff::from(n.is_nan());
+                    let pos_infs = Diff::from(n == f64::INFINITY);
+                    let neg_infs = Diff::from(n == f64::NEG_INFINITY);
+                    let non_nulls = Diff::from(datum != Datum::Null);
+
+                    // Map the floating point value onto a fixed precision domain
+                    // All special values should map to zero, since they are tracked separately
+                    let accum = if nans > 0 || pos_infs > 0 || neg_infs > 0 {
+                        0
+                    } else {
+                        // This operation will truncate to i128::MAX if out of range.
+                        // TODO(benesch): rewrite to avoid `as`.
+                        #[allow(clippy::as_conversions)]
+                        {
+                            (n * float_scale) as i128
+                        }
+                    };
+
+                    Accum::Float {
+                        accum,
+                        pos_infs,
+                        neg_infs,
+                        nans,
+                        non_nulls,
                     }
                 }
-                output.push((row_buf.clone(), 1));
+                AggregateFunc::SumNumeric => match datum {
+                    Datum::Numeric(n) => {
+                        let (accum, pos_infs, neg_infs, nans) = if n.0.is_infinite() {
+                            if n.0.is_negative() {
+                                (NumericAgg::zero(), 0, 1, 0)
+                            } else {
+                                (NumericAgg::zero(), 1, 0, 0)
+                            }
+                        } else if n.0.is_nan() {
+                            (NumericAgg::zero(), 0, 0, 1)
+                        } else {
+                            // Take a narrow decimal (datum) into a wide decimal
+                            // (aggregator).
+                            let mut cx_agg = numeric::cx_agg();
+                            (cx_agg.to_width(n.0), 0, 0, 0)
+                        };
+
+                        Accum::Numeric {
+                            accum: OrderedDecimal(accum),
+                            pos_infs,
+                            neg_infs,
+                            nans,
+                            non_nulls: 1,
+                        }
+                    }
+                    Datum::Null => Accum::Numeric {
+                        accum: OrderedDecimal(NumericAgg::zero()),
+                        pos_infs: 0,
+                        neg_infs: 0,
+                        nans: 0,
+                        non_nulls: 0,
+                    },
+                    x => panic!("Invalid argument to AggregateFunc::SumNumeric: {x:?}"),
+                },
+                _ => {
+                    // Other accumulations need to disentangle the accumulable
+                    // value from its NULL-ness, which is not quite as easily
+                    // accumulated.
+                    match datum {
+                        Datum::Int16(i) => Accum::SimpleNumber {
+                            accum: i128::from(i),
+                            non_nulls: 1,
+                        },
+                        Datum::Int32(i) => Accum::SimpleNumber {
+                            accum: i128::from(i),
+                            non_nulls: 1,
+                        },
+                        Datum::Int64(i) => Accum::SimpleNumber {
+                            accum: i128::from(i),
+                            non_nulls: 1,
+                        },
+                        Datum::UInt16(u) => Accum::SimpleNumber {
+                            accum: i128::from(u),
+                            non_nulls: 1,
+                        },
+                        Datum::UInt32(u) => Accum::SimpleNumber {
+                            accum: i128::from(u),
+                            non_nulls: 1,
+                        },
+                        Datum::UInt64(u) => Accum::SimpleNumber {
+                            accum: i128::from(u),
+                            non_nulls: 1,
+                        },
+                        Datum::MzTimestamp(t) => Accum::SimpleNumber {
+                            accum: i128::from(u64::from(t)),
+                            non_nulls: 1,
+                        },
+                        Datum::Null => Accum::SimpleNumber {
+                            accum: 0,
+                            non_nulls: 0,
+                        },
+                        x => panic!("Accumulating non-integer data: {x:?}"),
+                    }
+                }
             }
-        });
-    (output, errs)
+        };
+
+        let mut to_aggregate = Vec::new();
+        if simple_aggrs.len() > 0 {
+            // First, collect all non-distinct aggregations in one pass.
+            let easy_cases = collection.explode_one({
+                let zero_diffs = zero_diffs.clone();
+                move |(key, row)| {
+                    let mut diffs = zero_diffs.clone();
+                    // Try to unpack only the datums we need. Unfortunately, since we
+                    // can't random access into a Row, we have to iterate through one by one.
+                    // TODO: Even though we don't have random access, we could still avoid unpacking
+                    // everything that we don't care about, and it might be worth it to extend the
+                    // Row API to do that.
+                    let mut row_iter = row.iter().enumerate();
+                    for (accumulable_index, datum_index, aggr) in simple_aggrs.iter() {
+                        let mut datum = row_iter.next().unwrap();
+                        while datum_index != &datum.0 {
+                            datum = row_iter.next().unwrap();
+                        }
+                        let datum = datum.1;
+                        diffs.0[*accumulable_index] = datum_to_accumulator(datum, &aggr.func);
+                        diffs.1 = 1;
+                    }
+                    ((key, ()), diffs)
+                }
+            });
+            to_aggregate.push(easy_cases);
+        }
+
+        // Next, collect all aggregations that require distinctness.
+        for (accumulable_index, datum_index, aggr) in distinct_aggrs.into_iter() {
+            let mut row_buf = Row::default();
+            let collection = collection
+                .map(move |(key, row)| {
+                    let value = row.iter().nth(datum_index).unwrap();
+                    row_buf.packer().push(value);
+                    (key, row_buf.clone())
+                })
+                .map(|k| (k, ()))
+                .arrange_named::<RowKeySpine<(Row, Row), _, _>>("Arranged Accumulable")
+                .reduce_abelian::<_, RowKeySpine<_, _, _>>(
+                    "Reduced Accumulable",
+                    move |_k, _s, t| t.push(((), 1)),
+                )
+                .as_collection(|k, _| k.clone())
+                .explode_one({
+                    let zero_diffs = zero_diffs.clone();
+                    move |(key, row)| {
+                        let datum = row.iter().next().unwrap();
+                        let mut diffs = zero_diffs.clone();
+                        diffs.0[accumulable_index] = datum_to_accumulator(datum, &aggr.func);
+                        diffs.1 = 1;
+                        ((key, ()), diffs)
+                    }
+                });
+            to_aggregate.push(collection);
+        }
+
+        // now concatenate, if necessary, multiple aggregations
+        let collection = if to_aggregate.len() == 1 {
+            to_aggregate.remove(0)
+        } else {
+            differential_dataflow::collection::concatenate(&mut collection.scope(), to_aggregate)
+        };
+
+        let error_logger = self.error_logger();
+        let debug_name = self.debug_name.to_string();
+        let err_full_aggrs = full_aggrs.clone();
+        let (arranged_output, arranged_errs) = collection
+            .arrange_named::<RowKeySpine<_, _, (Vec<Accum>, Diff)>>("ArrangeAccumulable")
+            .reduce_pair::<_, RowSpine<_, _, _, _>, _, ErrValSpine<_, _, _>>(
+                "ReduceAccumulable",
+                "AccumulableErrorCheck",
+                {
+                    let mut row_buf = Row::default();
+                    move |_key, input, output| {
+                        let (ref accums, total) = input[0].1;
+                        let mut row_packer = row_buf.packer();
+
+                        for (aggr, accum) in full_aggrs.iter().zip(accums) {
+                            // The finished value depends on the aggregation function in a variety of ways.
+                            // For all aggregates but count, if only null values were
+                            // accumulated, then the output is null.
+                            let value = if total > 0
+                                && accum.is_zero()
+                                && aggr.func != AggregateFunc::Count
+                            {
+                                Datum::Null
+                            } else {
+                                match (&aggr.func, &accum) {
+                                    (
+                                        AggregateFunc::Count,
+                                        Accum::SimpleNumber { non_nulls, .. },
+                                    ) => Datum::Int64(*non_nulls),
+                                    (AggregateFunc::All, Accum::Bool { falses, trues }) => {
+                                        // If any false, else if all true, else must be no false and some nulls.
+                                        if *falses > 0 {
+                                            Datum::False
+                                        } else if *trues == total {
+                                            Datum::True
+                                        } else {
+                                            Datum::Null
+                                        }
+                                    }
+                                    (AggregateFunc::Any, Accum::Bool { falses, trues }) => {
+                                        // If any true, else if all false, else must be no true and some nulls.
+                                        if *trues > 0 {
+                                            Datum::True
+                                        } else if *falses == total {
+                                            Datum::False
+                                        } else {
+                                            Datum::Null
+                                        }
+                                    }
+                                    (AggregateFunc::Dummy, _) => Datum::Dummy,
+                                    // If any non-nulls, just report the aggregate.
+                                    (
+                                        AggregateFunc::SumInt16,
+                                        Accum::SimpleNumber { accum, .. },
+                                    )
+                                    | (
+                                        AggregateFunc::SumInt32,
+                                        Accum::SimpleNumber { accum, .. },
+                                    ) => {
+                                        // This conversion is safe, as long as we have less than 2^32
+                                        // summands.
+                                        // TODO(benesch): are we guaranteed to have less than 2^32 summands?
+                                        // If so, rewrite to avoid `as`.
+                                        #[allow(clippy::as_conversions)]
+                                        Datum::Int64(*accum as i64)
+                                    }
+                                    (
+                                        AggregateFunc::SumInt64,
+                                        Accum::SimpleNumber { accum, .. },
+                                    ) => Datum::from(*accum),
+                                    (
+                                        AggregateFunc::SumUInt16,
+                                        Accum::SimpleNumber { accum, .. },
+                                    )
+                                    | (
+                                        AggregateFunc::SumUInt32,
+                                        Accum::SimpleNumber { accum, .. },
+                                    ) => {
+                                        if !accum.is_negative() {
+                                            // Our semantics of overflow are not clearly articulated wrt.
+                                            // unsigned vs. signed types (#17758). We adopt an unsigned
+                                            // wrapping behavior to match what we do above for signed types.
+                                            // TODO(vmarcos): remove potentially dangerous usage of `as`.
+                                            #[allow(clippy::as_conversions)]
+                                            Datum::UInt64(*accum as u64)
+                                        } else {
+                                            // Note that we return a value here, but an error in the other
+                                            // operator of the reduce_pair. Therefore, we expect that this
+                                            // value will never be exposed as an output.
+                                            Datum::Null
+                                        }
+                                    }
+                                    (
+                                        AggregateFunc::SumUInt64,
+                                        Accum::SimpleNumber { accum, .. },
+                                    ) => {
+                                        if !accum.is_negative() {
+                                            Datum::from(*accum)
+                                        } else {
+                                            // Note that we return a value here, but an error in the other
+                                            // operator of the reduce_pair. Therefore, we expect that this
+                                            // value will never be exposed as an output.
+                                            Datum::Null
+                                        }
+                                    }
+                                    (
+                                        AggregateFunc::SumFloat32,
+                                        Accum::Float {
+                                            accum,
+                                            pos_infs,
+                                            neg_infs,
+                                            nans,
+                                            non_nulls: _,
+                                        },
+                                    ) => {
+                                        if *nans > 0 || (*pos_infs > 0 && *neg_infs > 0) {
+                                            // NaNs are NaNs and cases where we've seen a
+                                            // mixture of positive and negative infinities.
+                                            Datum::from(f32::NAN)
+                                        } else if *pos_infs > 0 {
+                                            Datum::from(f32::INFINITY)
+                                        } else if *neg_infs > 0 {
+                                            Datum::from(f32::NEG_INFINITY)
+                                        } else {
+                                            // TODO(benesch): remove potentially dangerous usage of `as`.
+                                            #[allow(clippy::as_conversions)]
+                                            {
+                                                Datum::from(((*accum as f64) / float_scale) as f32)
+                                            }
+                                        }
+                                    }
+                                    (
+                                        AggregateFunc::SumFloat64,
+                                        Accum::Float {
+                                            accum,
+                                            pos_infs,
+                                            neg_infs,
+                                            nans,
+                                            non_nulls: _,
+                                        },
+                                    ) => {
+                                        if *nans > 0 || (*pos_infs > 0 && *neg_infs > 0) {
+                                            // NaNs are NaNs and cases where we've seen a
+                                            // mixture of positive and negative infinities.
+                                            Datum::from(f64::NAN)
+                                        } else if *pos_infs > 0 {
+                                            Datum::from(f64::INFINITY)
+                                        } else if *neg_infs > 0 {
+                                            Datum::from(f64::NEG_INFINITY)
+                                        } else {
+                                            // TODO(benesch): remove potentially dangerous usage of `as`.
+                                            #[allow(clippy::as_conversions)]
+                                            {
+                                                Datum::from((*accum as f64) / float_scale)
+                                            }
+                                        }
+                                    }
+                                    (
+                                        AggregateFunc::SumNumeric,
+                                        Accum::Numeric {
+                                            accum,
+                                            pos_infs,
+                                            neg_infs,
+                                            nans,
+                                            non_nulls: _,
+                                        },
+                                    ) => {
+                                        let mut cx_datum = numeric::cx_datum();
+                                        let d = cx_datum.to_width(accum.0);
+                                        // Take a wide decimal (aggregator) into a
+                                        // narrow decimal (datum). If this operation
+                                        // overflows the datum, this new value will be
+                                        // +/- infinity. However, the aggregator tracks
+                                        // the amount of overflow, making it invertible.
+                                        let inf_d = d.is_infinite();
+                                        let neg_d = d.is_negative();
+                                        let pos_inf = *pos_infs > 0 || (inf_d && !neg_d);
+                                        let neg_inf = *neg_infs > 0 || (inf_d && neg_d);
+                                        if *nans > 0 || (pos_inf && neg_inf) {
+                                            // NaNs are NaNs and cases where we've seen a
+                                            // mixture of positive and negative infinities.
+                                            Datum::from(Numeric::nan())
+                                        } else if pos_inf {
+                                            Datum::from(Numeric::infinity())
+                                        } else if neg_inf {
+                                            let mut cx = numeric::cx_datum();
+                                            let mut d = Numeric::infinity();
+                                            cx.neg(&mut d);
+                                            Datum::from(d)
+                                        } else {
+                                            Datum::from(d)
+                                        }
+                                    }
+                                    _ => panic!(
+                                        "Unexpected accumulation (aggr={:?}, accum={accum:?})",
+                                        aggr.func
+                                    ),
+                                }
+                            };
+
+                            row_packer.push(value);
+                        }
+                        output.push((row_buf.clone(), 1));
+                    }
+                },
+                move |key, input, output| {
+                    let (ref accums, total) = input[0].1;
+                    for (aggr, accum) in err_full_aggrs.iter().zip(accums) {
+                        // We first test here if inputs without net-positive records are present,
+                        // producing an error to the logs and to the query output if that is the case.
+                        if total == 0 && !accum.is_zero() {
+                            error_logger.log(
+                                "Net-zero records with non-zero accumulation in ReduceAccumulable",
+                                &format!("aggr={aggr:?}, accum={accum:?}, debug_name={debug_name}"),
+                            );
+                            let message = format!(
+                                "Invalid data in source, saw net-zero records for key {key} \
+                                 with non-zero accumulation in accumulable aggregate"
+                            );
+                            output.push((EvalError::Internal(message).into(), 1));
+                        }
+                        match (&aggr.func, &accum) {
+                            (AggregateFunc::SumUInt16, Accum::SimpleNumber { accum, .. })
+                            | (AggregateFunc::SumUInt32, Accum::SimpleNumber { accum, .. })
+                            | (AggregateFunc::SumUInt64, Accum::SimpleNumber { accum, .. }) => {
+                                if accum.is_negative() {
+                                    error_logger.log(
+                                    "Invalid negative unsigned aggregation in ReduceAccumulable",
+                                    &format!(
+                                        "aggr={aggr:?}, accum={accum:?}, debug_name={debug_name}"
+                                    ),
+                                );
+                                    let message = format!(
+                                        "Invalid data in source, saw negative accumulation with \
+                                         unsigned type for key {key}"
+                                    );
+                                    output.push((EvalError::Internal(message).into(), 1));
+                                }
+                            }
+                            _ => (), // no more errors to check for at this point!
+                        }
+                    }
+                },
+            );
+        (
+            arranged_output,
+            arranged_errs.as_collection(|_key, error| error.clone()),
+        )
+    }
 }
 
 /// Accumulates values for the various types of accumulable aggregations.
@@ -1309,518 +1794,6 @@ impl Multiply<Diff> for Accum {
             }
         }
     }
-}
-
-/// Build the dataflow to compute and arrange multiple accumulable aggregations.
-///
-/// The incoming values are moved to the update's "difference" field, at which point
-/// they can be accumulated in place. The `count` operator promotes the accumulated
-/// values to data, at which point a final map applies operator-specific logic to
-/// yield the final aggregate.
-fn build_accumulable<G>(
-    debug_name: &str,
-    collection: Collection<G, (Row, Row), Diff>,
-    AccumulablePlan {
-        full_aggrs,
-        simple_aggrs,
-        distinct_aggrs,
-    }: AccumulablePlan,
-    error_logger: ErrorLogger,
-) -> (Arrangement<G, Row>, Collection<G, DataflowError, Diff>)
-where
-    G: Scope,
-    G::Timestamp: Lattice,
-{
-    // we must have called this function with something to reduce
-    if full_aggrs.len() == 0 || simple_aggrs.len() + distinct_aggrs.len() != full_aggrs.len() {
-        error_logger.soft_panic_or_log(
-            "Incorrect numbers of aggregates in accummulable reduction rendering",
-            &format!(
-                "full_aggrs={}, simple_aggrs={}, distinct_aggrs={}, debug_name={debug_name}",
-                full_aggrs.len(),
-                simple_aggrs.len(),
-                distinct_aggrs.len()
-            ),
-        );
-    }
-
-    // Some of the aggregations may have the `distinct` bit set, which means that they'll
-    // need to be extracted from `collection` and be subjected to `distinct` with `key`.
-    // Other aggregations can be directly moved in to the `diff` field.
-    //
-    // In each case, the resulting collection should have `data` shaped as `(key, ())`
-    // and a `diff` that is a vector with length `3 * aggrs.len()`. The three values are
-    // generally the count, and then two aggregation-specific values. The size could be
-    // reduced if we want to specialize for the aggregations.
-
-    let float_scale = f64::from(1 << 24);
-
-    // Instantiate a default vector for diffs with the correct types at each
-    // position.
-    let zero_diffs: (Vec<_>, Diff) = (
-        full_aggrs
-            .iter()
-            .map(|f| match f.func {
-                AggregateFunc::Any | AggregateFunc::All => Accum::Bool {
-                    trues: 0,
-                    falses: 0,
-                },
-                AggregateFunc::SumFloat32 | AggregateFunc::SumFloat64 => Accum::Float {
-                    accum: 0,
-                    pos_infs: 0,
-                    neg_infs: 0,
-                    nans: 0,
-                    non_nulls: 0,
-                },
-                AggregateFunc::SumNumeric => Accum::Numeric {
-                    accum: OrderedDecimal(NumericAgg::zero()),
-                    pos_infs: 0,
-                    neg_infs: 0,
-                    nans: 0,
-                    non_nulls: 0,
-                },
-                _ => Accum::SimpleNumber {
-                    accum: 0,
-                    non_nulls: 0,
-                },
-            })
-            .collect(),
-        0,
-    );
-
-    // Two aggregation-specific values for each aggregation.
-    let datum_to_accumulator = move |datum: Datum, aggr: &AggregateFunc| {
-        match aggr {
-            AggregateFunc::Count => Accum::SimpleNumber {
-                accum: 0, // unused for AggregateFunc::Count
-                non_nulls: if datum.is_null() { 0 } else { 1 },
-            },
-            AggregateFunc::Any | AggregateFunc::All => match datum {
-                Datum::True => Accum::Bool {
-                    trues: 1,
-                    falses: 0,
-                },
-                Datum::Null => Accum::Bool {
-                    trues: 0,
-                    falses: 0,
-                },
-                Datum::False => Accum::Bool {
-                    trues: 0,
-                    falses: 1,
-                },
-                x => panic!("Invalid argument to AggregateFunc::Any: {x:?}"),
-            },
-            AggregateFunc::Dummy => match datum {
-                Datum::Dummy => Accum::SimpleNumber {
-                    accum: 0,
-                    non_nulls: 0,
-                },
-                x => panic!("Invalid argument to AggregateFunc::Dummy: {x:?}"),
-            },
-            AggregateFunc::SumFloat32 | AggregateFunc::SumFloat64 => {
-                let n = match datum {
-                    Datum::Float32(n) => f64::from(*n),
-                    Datum::Float64(n) => *n,
-                    Datum::Null => 0f64,
-                    x => panic!("Invalid argument to AggregateFunc::{aggr:?}: {x:?}"),
-                };
-
-                let nans = Diff::from(n.is_nan());
-                let pos_infs = Diff::from(n == f64::INFINITY);
-                let neg_infs = Diff::from(n == f64::NEG_INFINITY);
-                let non_nulls = Diff::from(datum != Datum::Null);
-
-                // Map the floating point value onto a fixed precision domain
-                // All special values should map to zero, since they are tracked separately
-                let accum = if nans > 0 || pos_infs > 0 || neg_infs > 0 {
-                    0
-                } else {
-                    // This operation will truncate to i128::MAX if out of range.
-                    // TODO(benesch): rewrite to avoid `as`.
-                    #[allow(clippy::as_conversions)]
-                    {
-                        (n * float_scale) as i128
-                    }
-                };
-
-                Accum::Float {
-                    accum,
-                    pos_infs,
-                    neg_infs,
-                    nans,
-                    non_nulls,
-                }
-            }
-            AggregateFunc::SumNumeric => match datum {
-                Datum::Numeric(n) => {
-                    let (accum, pos_infs, neg_infs, nans) = if n.0.is_infinite() {
-                        if n.0.is_negative() {
-                            (NumericAgg::zero(), 0, 1, 0)
-                        } else {
-                            (NumericAgg::zero(), 1, 0, 0)
-                        }
-                    } else if n.0.is_nan() {
-                        (NumericAgg::zero(), 0, 0, 1)
-                    } else {
-                        // Take a narrow decimal (datum) into a wide decimal
-                        // (aggregator).
-                        let mut cx_agg = numeric::cx_agg();
-                        (cx_agg.to_width(n.0), 0, 0, 0)
-                    };
-
-                    Accum::Numeric {
-                        accum: OrderedDecimal(accum),
-                        pos_infs,
-                        neg_infs,
-                        nans,
-                        non_nulls: 1,
-                    }
-                }
-                Datum::Null => Accum::Numeric {
-                    accum: OrderedDecimal(NumericAgg::zero()),
-                    pos_infs: 0,
-                    neg_infs: 0,
-                    nans: 0,
-                    non_nulls: 0,
-                },
-                x => panic!("Invalid argument to AggregateFunc::SumNumeric: {x:?}"),
-            },
-            _ => {
-                // Other accumulations need to disentangle the accumulable
-                // value from its NULL-ness, which is not quite as easily
-                // accumulated.
-                match datum {
-                    Datum::Int16(i) => Accum::SimpleNumber {
-                        accum: i128::from(i),
-                        non_nulls: 1,
-                    },
-                    Datum::Int32(i) => Accum::SimpleNumber {
-                        accum: i128::from(i),
-                        non_nulls: 1,
-                    },
-                    Datum::Int64(i) => Accum::SimpleNumber {
-                        accum: i128::from(i),
-                        non_nulls: 1,
-                    },
-                    Datum::UInt16(u) => Accum::SimpleNumber {
-                        accum: i128::from(u),
-                        non_nulls: 1,
-                    },
-                    Datum::UInt32(u) => Accum::SimpleNumber {
-                        accum: i128::from(u),
-                        non_nulls: 1,
-                    },
-                    Datum::UInt64(u) => Accum::SimpleNumber {
-                        accum: i128::from(u),
-                        non_nulls: 1,
-                    },
-                    Datum::MzTimestamp(t) => Accum::SimpleNumber {
-                        accum: i128::from(u64::from(t)),
-                        non_nulls: 1,
-                    },
-                    Datum::Null => Accum::SimpleNumber {
-                        accum: 0,
-                        non_nulls: 0,
-                    },
-                    x => panic!("Accumulating non-integer data: {x:?}"),
-                }
-            }
-        }
-    };
-
-    let mut to_aggregate = Vec::new();
-    if simple_aggrs.len() > 0 {
-        // First, collect all non-distinct aggregations in one pass.
-        let easy_cases = collection.explode_one({
-            let zero_diffs = zero_diffs.clone();
-            move |(key, row)| {
-                let mut diffs = zero_diffs.clone();
-                // Try to unpack only the datums we need. Unfortunately, since we
-                // can't random access into a Row, we have to iterate through one by one.
-                // TODO: Even though we don't have random access, we could still avoid unpacking
-                // everything that we don't care about, and it might be worth it to extend the
-                // Row API to do that.
-                let mut row_iter = row.iter().enumerate();
-                for (accumulable_index, datum_index, aggr) in simple_aggrs.iter() {
-                    let mut datum = row_iter.next().unwrap();
-                    while datum_index != &datum.0 {
-                        datum = row_iter.next().unwrap();
-                    }
-                    let datum = datum.1;
-                    diffs.0[*accumulable_index] = datum_to_accumulator(datum, &aggr.func);
-                    diffs.1 = 1;
-                }
-                ((key, ()), diffs)
-            }
-        });
-        to_aggregate.push(easy_cases);
-    }
-
-    // Next, collect all aggregations that require distinctness.
-    for (accumulable_index, datum_index, aggr) in distinct_aggrs.into_iter() {
-        let mut row_buf = Row::default();
-        let collection = collection
-            .map(move |(key, row)| {
-                let value = row.iter().nth(datum_index).unwrap();
-                row_buf.packer().push(value);
-                (key, row_buf.clone())
-            })
-            .map(|k| (k, ()))
-            .arrange_named::<RowKeySpine<(Row, Row), _, _>>("Arranged Accumulable")
-            .reduce_abelian::<_, RowKeySpine<_, _, _>>("Reduced Accumulable", move |_k, _s, t| {
-                t.push(((), 1))
-            })
-            .as_collection(|k, _| k.clone())
-            .explode_one({
-                let zero_diffs = zero_diffs.clone();
-                move |(key, row)| {
-                    let datum = row.iter().next().unwrap();
-                    let mut diffs = zero_diffs.clone();
-                    diffs.0[accumulable_index] = datum_to_accumulator(datum, &aggr.func);
-                    diffs.1 = 1;
-                    ((key, ()), diffs)
-                }
-            });
-        to_aggregate.push(collection);
-    }
-
-    // now concatenate, if necessary, multiple aggregations
-    let collection = if to_aggregate.len() == 1 {
-        to_aggregate.remove(0)
-    } else {
-        differential_dataflow::collection::concatenate(&mut collection.scope(), to_aggregate)
-    };
-
-    let debug_name = debug_name.to_string();
-    let err_full_aggrs = full_aggrs.clone();
-    let (arranged_output, arranged_errs) = collection
-        .arrange_named::<RowKeySpine<_, _, (Vec<Accum>, Diff)>>("ArrangeAccumulable")
-        .reduce_pair::<_, RowSpine<_, _, _, _>, _, ErrValSpine<_, _, _>>(
-            "ReduceAccumulable",
-            "AccumulableErrorCheck",
-            {
-                let mut row_buf = Row::default();
-                move |_key, input, output| {
-                    let (ref accums, total) = input[0].1;
-                    let mut row_packer = row_buf.packer();
-
-                    for (aggr, accum) in full_aggrs.iter().zip(accums) {
-                        // The finished value depends on the aggregation function in a variety of ways.
-                        // For all aggregates but count, if only null values were
-                        // accumulated, then the output is null.
-                        let value = if total > 0
-                            && accum.is_zero()
-                            && aggr.func != AggregateFunc::Count
-                        {
-                            Datum::Null
-                        } else {
-                            match (&aggr.func, &accum) {
-                                (AggregateFunc::Count, Accum::SimpleNumber { non_nulls, .. }) => {
-                                    Datum::Int64(*non_nulls)
-                                }
-                                (AggregateFunc::All, Accum::Bool { falses, trues }) => {
-                                    // If any false, else if all true, else must be no false and some nulls.
-                                    if *falses > 0 {
-                                        Datum::False
-                                    } else if *trues == total {
-                                        Datum::True
-                                    } else {
-                                        Datum::Null
-                                    }
-                                }
-                                (AggregateFunc::Any, Accum::Bool { falses, trues }) => {
-                                    // If any true, else if all false, else must be no true and some nulls.
-                                    if *trues > 0 {
-                                        Datum::True
-                                    } else if *falses == total {
-                                        Datum::False
-                                    } else {
-                                        Datum::Null
-                                    }
-                                }
-                                (AggregateFunc::Dummy, _) => Datum::Dummy,
-                                // If any non-nulls, just report the aggregate.
-                                (AggregateFunc::SumInt16, Accum::SimpleNumber { accum, .. })
-                                | (AggregateFunc::SumInt32, Accum::SimpleNumber { accum, .. }) => {
-                                    // This conversion is safe, as long as we have less than 2^32
-                                    // summands.
-                                    // TODO(benesch): are we guaranteed to have less than 2^32 summands?
-                                    // If so, rewrite to avoid `as`.
-                                    #[allow(clippy::as_conversions)]
-                                    Datum::Int64(*accum as i64)
-                                }
-                                (AggregateFunc::SumInt64, Accum::SimpleNumber { accum, .. }) => {
-                                    Datum::from(*accum)
-                                }
-                                (AggregateFunc::SumUInt16, Accum::SimpleNumber { accum, .. })
-                                | (AggregateFunc::SumUInt32, Accum::SimpleNumber { accum, .. }) => {
-                                    if !accum.is_negative() {
-                                        // Our semantics of overflow are not clearly articulated wrt.
-                                        // unsigned vs. signed types (#17758). We adopt an unsigned
-                                        // wrapping behavior to match what we do above for signed types.
-                                        // TODO(vmarcos): remove potentially dangerous usage of `as`.
-                                        #[allow(clippy::as_conversions)]
-                                        Datum::UInt64(*accum as u64)
-                                    } else {
-                                        // Note that we return a value here, but an error in the other
-                                        // operator of the reduce_pair. Therefore, we expect that this
-                                        // value will never be exposed as an output.
-                                        Datum::Null
-                                    }
-                                }
-                                (AggregateFunc::SumUInt64, Accum::SimpleNumber { accum, .. }) => {
-                                    if !accum.is_negative() {
-                                        Datum::from(*accum)
-                                    } else {
-                                        // Note that we return a value here, but an error in the other
-                                        // operator of the reduce_pair. Therefore, we expect that this
-                                        // value will never be exposed as an output.
-                                        Datum::Null
-                                    }
-                                }
-                                (
-                                    AggregateFunc::SumFloat32,
-                                    Accum::Float {
-                                        accum,
-                                        pos_infs,
-                                        neg_infs,
-                                        nans,
-                                        non_nulls: _,
-                                    },
-                                ) => {
-                                    if *nans > 0 || (*pos_infs > 0 && *neg_infs > 0) {
-                                        // NaNs are NaNs and cases where we've seen a
-                                        // mixture of positive and negative infinities.
-                                        Datum::from(f32::NAN)
-                                    } else if *pos_infs > 0 {
-                                        Datum::from(f32::INFINITY)
-                                    } else if *neg_infs > 0 {
-                                        Datum::from(f32::NEG_INFINITY)
-                                    } else {
-                                        // TODO(benesch): remove potentially dangerous usage of `as`.
-                                        #[allow(clippy::as_conversions)]
-                                        {
-                                            Datum::from(((*accum as f64) / float_scale) as f32)
-                                        }
-                                    }
-                                }
-                                (
-                                    AggregateFunc::SumFloat64,
-                                    Accum::Float {
-                                        accum,
-                                        pos_infs,
-                                        neg_infs,
-                                        nans,
-                                        non_nulls: _,
-                                    },
-                                ) => {
-                                    if *nans > 0 || (*pos_infs > 0 && *neg_infs > 0) {
-                                        // NaNs are NaNs and cases where we've seen a
-                                        // mixture of positive and negative infinities.
-                                        Datum::from(f64::NAN)
-                                    } else if *pos_infs > 0 {
-                                        Datum::from(f64::INFINITY)
-                                    } else if *neg_infs > 0 {
-                                        Datum::from(f64::NEG_INFINITY)
-                                    } else {
-                                        // TODO(benesch): remove potentially dangerous usage of `as`.
-                                        #[allow(clippy::as_conversions)]
-                                        {
-                                            Datum::from((*accum as f64) / float_scale)
-                                        }
-                                    }
-                                }
-                                (
-                                    AggregateFunc::SumNumeric,
-                                    Accum::Numeric {
-                                        accum,
-                                        pos_infs,
-                                        neg_infs,
-                                        nans,
-                                        non_nulls: _,
-                                    },
-                                ) => {
-                                    let mut cx_datum = numeric::cx_datum();
-                                    let d = cx_datum.to_width(accum.0);
-                                    // Take a wide decimal (aggregator) into a
-                                    // narrow decimal (datum). If this operation
-                                    // overflows the datum, this new value will be
-                                    // +/- infinity. However, the aggregator tracks
-                                    // the amount of overflow, making it invertible.
-                                    let inf_d = d.is_infinite();
-                                    let neg_d = d.is_negative();
-                                    let pos_inf = *pos_infs > 0 || (inf_d && !neg_d);
-                                    let neg_inf = *neg_infs > 0 || (inf_d && neg_d);
-                                    if *nans > 0 || (pos_inf && neg_inf) {
-                                        // NaNs are NaNs and cases where we've seen a
-                                        // mixture of positive and negative infinities.
-                                        Datum::from(Numeric::nan())
-                                    } else if pos_inf {
-                                        Datum::from(Numeric::infinity())
-                                    } else if neg_inf {
-                                        let mut cx = numeric::cx_datum();
-                                        let mut d = Numeric::infinity();
-                                        cx.neg(&mut d);
-                                        Datum::from(d)
-                                    } else {
-                                        Datum::from(d)
-                                    }
-                                }
-                                _ => panic!(
-                                    "Unexpected accumulation (aggr={:?}, accum={accum:?})",
-                                    aggr.func
-                                ),
-                            }
-                        };
-
-                        row_packer.push(value);
-                    }
-                    output.push((row_buf.clone(), 1));
-                }
-            },
-            move |key, input, output| {
-                let (ref accums, total) = input[0].1;
-                for (aggr, accum) in err_full_aggrs.iter().zip(accums) {
-                    // We first test here if inputs without net-positive records are present,
-                    // producing an error to the logs and to the query output if that is the case.
-                    if total == 0 && !accum.is_zero() {
-                        error_logger.log(
-                            "Net-zero records with non-zero accumulation in ReduceAccumulable",
-                            &format!("aggr={aggr:?}, accum={accum:?}, debug_name={debug_name}"),
-                        );
-                        let message = format!(
-                            "Invalid data in source, saw net-zero records for key {key} \
-                        with non-zero accumulation in accumulable aggregate"
-                        );
-                        output.push((EvalError::Internal(message).into(), 1));
-                    }
-                    match (&aggr.func, &accum) {
-                        (AggregateFunc::SumUInt16, Accum::SimpleNumber { accum, .. })
-                        | (AggregateFunc::SumUInt32, Accum::SimpleNumber { accum, .. })
-                        | (AggregateFunc::SumUInt64, Accum::SimpleNumber { accum, .. }) => {
-                            if accum.is_negative() {
-                                error_logger.log(
-                                    "Invalid negative unsigned aggregation in ReduceAccumulable",
-                                    &format!(
-                                        "aggr={aggr:?}, accum={accum:?}, debug_name={debug_name}"
-                                    ),
-                                );
-                                let message = format!(
-                                    "Invalid data in source, saw negative accumulation with \
-                            unsigned type for key {key}"
-                                );
-                                output.push((EvalError::Internal(message).into(), 1));
-                            }
-                        }
-                        _ => (), // no more errors to check for at this point!
-                    }
-                }
-            },
-        );
-    (
-        arranged_output,
-        arranged_errs.as_collection(|_key, error| error.clone()),
-    )
 }
 
 /// Monoids for in-place compaction of monotonic streams.

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -40,8 +40,9 @@ use mz_timely_util::operator::CollectionExt;
 use mz_timely_util::reduce::ReduceExt;
 
 use crate::render::context::{Arrangement, CollectionBundle, Context, KeyArrangement};
+use crate::render::errors::MaybeValidatingRow;
 use crate::render::reduce::monoids::ReductionMonoid;
-use crate::render::{ArrangementFlavor, MaybeValidatingRow};
+use crate::render::ArrangementFlavor;
 use crate::typedefs::{ErrValSpine, RowKeySpine, RowSpine};
 
 /// Render a dataflow based on the provided plan.

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -37,15 +37,15 @@ where
         &mut self,
         compute_state: &mut crate::compute_state::ComputeState,
         tokens: &mut BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
-        import_ids: BTreeSet<GlobalId>,
+        dependency_ids: BTreeSet<GlobalId>,
         sink_id: GlobalId,
         sink: &ComputeSinkDesc<CollectionMetadata>,
         probes: Vec<probe::Handle<mz_repr::Timestamp>>,
     ) {
         // put together tokens that belong to the export
         let mut needed_tokens = Vec::new();
-        for import_id in import_ids {
-            if let Some(token) = tokens.get(&import_id) {
+        for dep_id in dependency_ids {
+            if let Some(token) = tokens.get(&dep_id) {
                 needed_tokens.push(Rc::clone(token))
             }
         }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -258,15 +258,11 @@ where
             );
 
             let error_logger = self.error_logger();
-            let debug_name = self.debug_name.to_string();
             let (oks, errs) =
                 stage.map_fallible("Demuxing Errors", move |((k, h), result)| match result {
                     Err(v) => {
                         let message = "Negative multiplicities in TopK";
-                        error_logger.log(
-                            message,
-                            &format!("k={k:?}, h={h}, v={v:?}, debug_name={debug_name}"),
-                        );
+                        error_logger.log(message, &format!("k={k:?}, h={h}, v={v:?}"));
                         Err(EvalError::Internal(message.to_string()).into())
                     }
                     Ok(t) => Ok(((k, h), t)),
@@ -318,11 +314,10 @@ where
         let consolidated = collection
             .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated MonotonicTop1 input");
         let error_logger = self.error_logger();
-        let debug_name = self.debug_name.to_string();
         let (partial, errs) = consolidated.ensure_monotonic(move |data, diff| {
             error_logger.log(
                 "Non-monotonic input to MonotonicTop1",
-                &format!("data={data:?}, diff={diff}, debug_name={debug_name}"),
+                &format!("data={data:?}, diff={diff}"),
             );
             let m = "tried to build monotonic top-1 on non-monotonic input".to_string();
             (EvalError::Internal(m).into(), 1)

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -35,9 +35,8 @@ use mz_repr::{DatumVec, Diff, Row};
 use mz_storage_client::types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
 
-use crate::render::context::CollectionBundle;
-use crate::render::context::Context;
-use crate::render::MaybeValidatingRow;
+use crate::render::context::{CollectionBundle, Context};
+use crate::render::errors::MaybeValidatingRow;
 use crate::typedefs::{RowKeySpine, RowSpine};
 
 // The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -35,7 +35,6 @@ use mz_storage_client::types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
 
 use crate::render::context::{CollectionBundle, Context};
-use crate::render::errors::ErrorLogger;
 use crate::render::errors::MaybeValidatingRow;
 use crate::typedefs::{RowKeySpine, RowSpine};
 
@@ -62,13 +61,7 @@ where
                     group_key,
                     order_key,
                 }) => {
-                    let (oks, errs) = render_top1_monotonic(
-                        ok_input,
-                        group_key,
-                        order_key,
-                        &self.debug_name,
-                        self.error_logger(),
-                    );
+                    let (oks, errs) = self.render_top1_monotonic(ok_input, group_key, order_key);
                     err_collection = err_collection.concat(&errs);
                     oks
                 }
@@ -128,17 +121,8 @@ where
                     // intra-ts thinning. The maximum number of records per timestamp is
                     // (num_workers * limit), which we expect to be a small number and so we render
                     // a single topk stage.
-                    let (result, errs) = build_topk_stage(
-                        thinned,
-                        order_key,
-                        1u64,
-                        0,
-                        limit,
-                        arity,
-                        false,
-                        &self.debug_name,
-                        self.error_logger(),
-                    );
+                    let (result, errs) =
+                        self.build_topk_stage(thinned, order_key, 1u64, 0, limit, arity, false);
                     retractions.set(&collection.concat(&result.negate()));
                     soft_assert_or_log!(
                         errs.is_none(),
@@ -155,16 +139,8 @@ where
                     arity,
                     buckets,
                 }) => {
-                    let (oks, errs) = build_topk(
-                        ok_input,
-                        group_key,
-                        order_key,
-                        offset,
-                        limit,
-                        arity,
-                        buckets,
-                        &self.debug_name,
-                        self.error_logger(),
+                    let (oks, errs) = self.build_topk(
+                        ok_input, group_key, order_key, offset, limit, arity, buckets,
                     );
                     err_collection = err_collection.concat(&errs);
                     oks
@@ -174,381 +150,366 @@ where
             (ok_result.leave_region(), err_collection.leave_region())
         });
 
-        return CollectionBundle::from_collections(ok_result, err_collection);
+        CollectionBundle::from_collections(ok_result, err_collection)
+    }
 
-        /// Constructs a TopK dataflow subgraph.
-        fn build_topk<G>(
-            collection: Collection<G, Row, Diff>,
-            group_key: Vec<usize>,
-            order_key: Vec<mz_expr::ColumnOrder>,
-            offset: usize,
-            limit: Option<usize>,
-            arity: usize,
-            buckets: Vec<u64>,
-            debug_name: &str,
-            error_logger: ErrorLogger,
-        ) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
-        where
-            G: Scope,
-            G::Timestamp: Lattice,
-        {
-            let mut datum_vec = mz_repr::DatumVec::new();
-            let mut collection = collection.map({
-                move |row| {
-                    let row_hash = row.hashed();
-                    let group_row = {
-                        let datums = datum_vec.borrow_with(&row);
-                        let iterator = group_key.iter().map(|i| datums[*i]);
-                        let total_size = mz_repr::datums_size(iterator.clone());
-                        let mut group_row = Row::with_capacity(total_size);
-                        group_row.packer().extend(iterator);
-                        group_row
-                    };
-                    ((group_row, row_hash), row)
-                }
-            });
+    /// Constructs a TopK dataflow subgraph.
+    fn build_topk<S>(
+        &self,
+        collection: Collection<S, Row, Diff>,
+        group_key: Vec<usize>,
+        order_key: Vec<mz_expr::ColumnOrder>,
+        offset: usize,
+        limit: Option<usize>,
+        arity: usize,
+        buckets: Vec<u64>,
+    ) -> (Collection<S, Row, Diff>, Collection<S, DataflowError, Diff>)
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        let mut datum_vec = mz_repr::DatumVec::new();
+        let mut collection = collection.map({
+            move |row| {
+                let row_hash = row.hashed();
+                let group_row = {
+                    let datums = datum_vec.borrow_with(&row);
+                    let iterator = group_key.iter().map(|i| datums[*i]);
+                    let total_size = mz_repr::datums_size(iterator.clone());
+                    let mut group_row = Row::with_capacity(total_size);
+                    group_row.packer().extend(iterator);
+                    group_row
+                };
+                ((group_row, row_hash), row)
+            }
+        });
 
-            let mut validating = true;
-            let mut err_collection: Option<Collection<G, _, _>> = None;
+        let mut validating = true;
+        let mut err_collection: Option<Collection<S, _, _>> = None;
 
-            if let Some(limit) = limit {
-                // These bucket values define the shifts that happen to the 64 bit hash of the
-                // record, and should have the properties that 1. there are not too many of them,
-                // and 2. each has a modest difference to the next.
-                for bucket in buckets.into_iter() {
-                    // here we do not apply `offset`, but instead restrict ourself with a limit
-                    // that includes the offset. We cannot apply `offset` until we perform the
-                    // final, complete reduction.
-                    let (oks, errs) = build_topk_stage(
-                        collection,
-                        order_key.clone(),
-                        bucket,
-                        0,
-                        Some(offset + limit),
-                        arity,
-                        validating,
-                        debug_name,
-                        error_logger.clone(),
-                    );
-                    collection = oks;
-                    if validating {
-                        err_collection = errs;
-                        validating = false;
-                    }
+        if let Some(limit) = limit {
+            // These bucket values define the shifts that happen to the 64 bit hash of the
+            // record, and should have the properties that 1. there are not too many of them,
+            // and 2. each has a modest difference to the next.
+            for bucket in buckets.into_iter() {
+                // here we do not apply `offset`, but instead restrict ourself with a limit
+                // that includes the offset. We cannot apply `offset` until we perform the
+                // final, complete reduction.
+                let (oks, errs) = self.build_topk_stage(
+                    collection,
+                    order_key.clone(),
+                    bucket,
+                    0,
+                    Some(offset + limit),
+                    arity,
+                    validating,
+                );
+                collection = oks;
+                if validating {
+                    err_collection = errs;
+                    validating = false;
                 }
             }
-
-            // We do a final step, both to make sure that we complete the reduction, and to correctly
-            // apply `offset` to the final group, as we have not yet been applying it to the partially
-            // formed groups.
-            let (oks, errs) = build_topk_stage(
-                collection,
-                order_key,
-                1u64,
-                offset,
-                limit,
-                arity,
-                validating,
-                debug_name,
-                error_logger,
-            );
-            collection = oks;
-            if validating {
-                err_collection = errs;
-            }
-            (
-                collection.map(|((_key, _hash), row)| row),
-                err_collection.expect("at least one stage validated its inputs"),
-            )
         }
 
-        // To provide a robust incremental orderby-limit experience, we want to avoid grouping *all*
-        // records (or even large groups) and then applying the ordering and limit. Instead, a more
-        // robust approach forms groups of bounded size and applies the offset and limit to each,
-        // and then increases the sizes of the groups.
-
-        // Builds a "stage", which uses a finer grouping than is required to reduce the volume of
-        // updates, and to reduce the amount of work on the critical path for updates. The cost is
-        // a larger number of arrangements when this optimization does nothing beneficial.
-        fn build_topk_stage<G>(
-            collection: Collection<G, ((Row, u64), Row), Diff>,
-            order_key: Vec<mz_expr::ColumnOrder>,
-            modulus: u64,
-            offset: usize,
-            limit: Option<usize>,
-            arity: usize,
-            validating: bool,
-            debug_name: &str,
-            error_logger: ErrorLogger,
-        ) -> (
-            Collection<G, ((Row, u64), Row), Diff>,
-            Option<Collection<G, DataflowError, Diff>>,
+        // We do a final step, both to make sure that we complete the reduction, and to correctly
+        // apply `offset` to the final group, as we have not yet been applying it to the partially
+        // formed groups.
+        let (oks, errs) = self.build_topk_stage(
+            collection, order_key, 1u64, offset, limit, arity, validating,
+        );
+        collection = oks;
+        if validating {
+            err_collection = errs;
+        }
+        (
+            collection.map(|((_key, _hash), row)| row),
+            err_collection.expect("at least one stage validated its inputs"),
         )
-        where
-            G: Scope,
-            G::Timestamp: Lattice,
-        {
-            let input = collection.map(move |((key, hash), row)| ((key, hash % modulus), row));
-            let (oks, errs) = if validating {
-                let stage = build_topk_negated_stage::<G, Result<Row, Row>>(
-                    &input, order_key, offset, limit, arity,
-                );
+    }
 
-                let debug_name = debug_name.to_string();
-                let (oks, errs) =
-                    stage.map_fallible("Demuxing Errors", move |((k, h), result)| match result {
-                        Err(v) => {
-                            let message = "Negative multiplicities in TopK";
-                            error_logger.log(
-                                message,
-                                &format!("k={k:?}, h={h}, v={v:?}, debug_name={debug_name}"),
-                            );
-                            Err(EvalError::Internal(message.to_string()).into())
-                        }
-                        Ok(t) => Ok(((k, h), t)),
-                    });
-                (oks, Some(errs))
-            } else {
-                (
-                    build_topk_negated_stage::<G, Row>(&input, order_key, offset, limit, arity),
-                    None,
-                )
-            };
-            (
-                oks.negate()
-                    .concat(&input)
-                    .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated TopK"),
-                errs,
-            )
-        }
+    // To provide a robust incremental orderby-limit experience, we want to avoid grouping *all*
+    // records (or even large groups) and then applying the ordering and limit. Instead, a more
+    // robust approach forms groups of bounded size and applies the offset and limit to each,
+    // and then increases the sizes of the groups.
 
-        fn build_topk_negated_stage<G, R>(
-            input: &Collection<G, ((Row, u64), Row), Diff>,
-            order_key: Vec<mz_expr::ColumnOrder>,
-            offset: usize,
-            limit: Option<usize>,
-            arity: usize,
-        ) -> Collection<G, ((Row, u64), R), Diff>
-        where
-            G: Scope,
-            G::Timestamp: Lattice,
-            R: MaybeValidatingRow<Row, Row>,
-        {
-            // We only want to arrange parts of the input that are not part of the actual output
-            // such that `input.concat(&negated_output.negate())` yields the correct TopK
-            input
-                .arrange_named::<RowSpine<(Row, u64), _, _, _>>("Arranged TopK input")
-                .reduce_abelian::<_, RowSpine<_, _, _, _>>("Reduced TopK input", {
-                    move |_key, source, target: &mut Vec<(R, Diff)>| {
-                        if let Some(err) = R::into_error() {
-                            for (row, diff) in source.iter() {
-                                if diff.is_positive() {
-                                    continue;
-                                }
-                                target.push((err((*row).clone()), -1));
-                                return;
-                            }
-                        }
+    // Builds a "stage", which uses a finer grouping than is required to reduce the volume of
+    // updates, and to reduce the amount of work on the critical path for updates. The cost is
+    // a larger number of arrangements when this optimization does nothing beneficial.
+    fn build_topk_stage<S>(
+        &self,
+        collection: Collection<S, ((Row, u64), Row), Diff>,
+        order_key: Vec<mz_expr::ColumnOrder>,
+        modulus: u64,
+        offset: usize,
+        limit: Option<usize>,
+        arity: usize,
+        validating: bool,
+    ) -> (
+        Collection<S, ((Row, u64), Row), Diff>,
+        Option<Collection<S, DataflowError, Diff>>,
+    )
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        let input = collection.map(move |((key, hash), row)| ((key, hash % modulus), row));
+        let (oks, errs) = if validating {
+            let stage = build_topk_negated_stage::<S, Result<Row, Row>>(
+                &input, order_key, offset, limit, arity,
+            );
 
-                        // Determine if we must actually shrink the result set.
-                        // TODO(benesch): avoid dangerous `as` conversion.
-                        #[allow(clippy::as_conversions)]
-                        let must_shrink = offset > 0
-                            || limit
-                                .map(|l| source.iter().map(|(_, d)| *d).sum::<Diff>() as usize > l)
-                                .unwrap_or(false);
-                        if !must_shrink {
-                            return;
-                        }
-
-                        // First go ahead and emit all records
-                        for (row, diff) in source.iter() {
-                            target.push((R::ok((*row).clone()), diff.clone()));
-                        }
-                        // local copies that may count down to zero.
-                        let mut offset = offset;
-                        let mut limit = limit;
-
-                        // The order in which we should produce rows.
-                        let mut indexes = (0..source.len()).collect::<Vec<_>>();
-                        // We decode the datums once, into a common buffer for efficiency.
-                        // Each row should contain `arity` columns; we should check that.
-                        let mut buffer = Vec::with_capacity(arity * source.len());
-                        for (index, row) in source.iter().enumerate() {
-                            buffer.extend(row.0.iter());
-                            assert_eq!(buffer.len(), arity * (index + 1));
-                        }
-                        let width = buffer.len() / source.len();
-
-                        //todo: use arrangements or otherwise make the sort more performant?
-                        indexes.sort_by(|left, right| {
-                            let left = &buffer[left * width..][..width];
-                            let right = &buffer[right * width..][..width];
-                            // Note: source was originally ordered by the u8 array representation
-                            // of rows, but left.cmp(right) uses Datum::cmp.
-                            mz_expr::compare_columns(&order_key, left, right, || left.cmp(right))
-                        });
-
-                        // We now need to lay out the data in order of `buffer`, but respecting
-                        // the `offset` and `limit` constraints.
-                        for index in indexes.into_iter() {
-                            let (row, mut diff) = source[index];
-                            if !diff.is_positive() {
-                                continue;
-                            }
-                            // If we are still skipping early records ...
-                            if offset > 0 {
-                                let to_skip = std::cmp::min(offset, usize::try_from(diff).unwrap());
-                                offset -= to_skip;
-                                diff -= Diff::try_from(to_skip).unwrap();
-                            }
-                            // We should produce at most `limit` records.
-                            // TODO(benesch): avoid dangerous `as` conversion.
-                            #[allow(clippy::as_conversions)]
-                            if let Some(limit) = &mut limit {
-                                diff = std::cmp::min(diff, Diff::try_from(*limit).unwrap());
-                                *limit -= diff as usize;
-                            }
-                            // Output the indicated number of rows.
-                            if diff > 0 {
-                                // Emit retractions for the elements actually part of
-                                // the set of TopK elements.
-                                target.push((R::ok(row.clone()), -diff));
-                            }
-                        }
+            let error_logger = self.error_logger();
+            let debug_name = self.debug_name.to_string();
+            let (oks, errs) =
+                stage.map_fallible("Demuxing Errors", move |((k, h), result)| match result {
+                    Err(v) => {
+                        let message = "Negative multiplicities in TopK";
+                        error_logger.log(
+                            message,
+                            &format!("k={k:?}, h={h}, v={v:?}, debug_name={debug_name}"),
+                        );
+                        Err(EvalError::Internal(message.to_string()).into())
                     }
-                })
-                .as_collection(|k, v| (k.clone(), v.clone()))
-        }
+                    Ok(t) => Ok(((k, h), t)),
+                });
+            (oks, Some(errs))
+        } else {
+            (
+                build_topk_negated_stage::<S, Row>(&input, order_key, offset, limit, arity),
+                None,
+            )
+        };
+        (
+            oks.negate()
+                .concat(&input)
+                .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated TopK"),
+            errs,
+        )
+    }
 
-        fn render_top1_monotonic<G>(
-            collection: Collection<G, Row, Diff>,
-            group_key: Vec<usize>,
-            order_key: Vec<mz_expr::ColumnOrder>,
-            debug_name: &str,
-            error_logger: ErrorLogger,
-        ) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
-        where
-            G: Scope,
-            G::Timestamp: Lattice,
-        {
-            // We can place our rows directly into the diff field, and only keep the relevant one
-            // corresponding to evaluating our aggregate, instead of having to do a hierarchical
-            // reduction.
-            let collection = collection.map({
-                let mut datum_vec = mz_repr::DatumVec::new();
-                move |row| {
-                    let group_key = {
-                        let datums = datum_vec.borrow_with(&row);
-                        let iterator = group_key.iter().map(|i| datums[*i]);
-                        let total_size = mz_repr::datums_size(iterator.clone());
-                        let mut group_key = Row::with_capacity(total_size);
-                        group_key.packer().extend(iterator);
-                        group_key
-                    };
-                    (group_key, row)
+    fn render_top1_monotonic<S>(
+        &self,
+        collection: Collection<S, Row, Diff>,
+        group_key: Vec<usize>,
+        order_key: Vec<mz_expr::ColumnOrder>,
+    ) -> (Collection<S, Row, Diff>, Collection<S, DataflowError, Diff>)
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        // We can place our rows directly into the diff field, and only keep the relevant one
+        // corresponding to evaluating our aggregate, instead of having to do a hierarchical
+        // reduction.
+        let collection = collection.map({
+            let mut datum_vec = mz_repr::DatumVec::new();
+            move |row| {
+                let group_key = {
+                    let datums = datum_vec.borrow_with(&row);
+                    let iterator = group_key.iter().map(|i| datums[*i]);
+                    let total_size = mz_repr::datums_size(iterator.clone());
+                    let mut group_key = Row::with_capacity(total_size);
+                    group_key.packer().extend(iterator);
+                    group_key
+                };
+                (group_key, row)
+            }
+        });
+
+        // We arrange the inputs ourself to force it into a leaner structure because we know we
+        // won't care about values.
+        let consolidated = collection
+            .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated MonotonicTop1 input");
+        let error_logger = self.error_logger();
+        let debug_name = self.debug_name.to_string();
+        let (partial, errs) = consolidated.ensure_monotonic(move |data, diff| {
+            error_logger.log(
+                "Non-monotonic input to MonotonicTop1",
+                &format!("data={data:?}, diff={diff}, debug_name={debug_name}"),
+            );
+            let m = "tried to build monotonic top-1 on non-monotonic input".to_string();
+            (EvalError::Internal(m).into(), 1)
+        });
+        let partial = partial.explode_one(move |(group_key, row)| {
+            (
+                group_key,
+                monoids::Top1Monoid {
+                    row,
+                    order_key: order_key.clone(),
+                },
+            )
+        });
+        let result = partial
+            .map(|k| (k, ()))
+            .arrange_named::<RowSpine<Row, _, _, _>>("Arranged MonotonicTop1 partial")
+            .reduce_abelian::<_, RowSpine<_, _, _, _>>("MonotonicTop1", {
+                move |_key, input, output| {
+                    let accum: &monoids::Top1Monoid = &input[0].1;
+                    output.push((accum.row.clone(), 1));
                 }
             });
+        // TODO(#7331): Here we discard the arranged output.
+        (result.as_collection(|_k, v| v.clone()), errs)
+    }
+}
 
-            // We arrange the inputs ourself to force it into a leaner structure because we know we
-            // won't care about values.
-            let consolidated = collection
-                .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated MonotonicTop1 input");
-            let debug_name = debug_name.to_string();
-            let (partial, errs) = consolidated.ensure_monotonic(move |data, diff| {
-                error_logger.log(
-                    "Non-monotonic input to MonotonicTop1",
-                    &format!("data={data:?}, diff={diff}, debug_name={debug_name}"),
-                );
-                let m = "tried to build monotonic top-1 on non-monotonic input".to_string();
-                (EvalError::Internal(m).into(), 1)
-            });
-            let partial = partial.explode_one(move |(group_key, row)| {
-                (
-                    group_key,
-                    monoids::Top1Monoid {
-                        row,
-                        order_key: order_key.clone(),
-                    },
-                )
-            });
-            let result = partial
-                .map(|k| (k, ()))
-                .arrange_named::<RowSpine<Row, _, _, _>>("Arranged MonotonicTop1 partial")
-                .reduce_abelian::<_, RowSpine<_, _, _, _>>("MonotonicTop1", {
-                    move |_key, input, output| {
-                        let accum: &monoids::Top1Monoid = &input[0].1;
-                        output.push((accum.row.clone(), 1));
+fn build_topk_negated_stage<G, R>(
+    input: &Collection<G, ((Row, u64), Row), Diff>,
+    order_key: Vec<mz_expr::ColumnOrder>,
+    offset: usize,
+    limit: Option<usize>,
+    arity: usize,
+) -> Collection<G, ((Row, u64), R), Diff>
+where
+    G: Scope,
+    G::Timestamp: Lattice,
+    R: MaybeValidatingRow<Row, Row>,
+{
+    // We only want to arrange parts of the input that are not part of the actual output
+    // such that `input.concat(&negated_output.negate())` yields the correct TopK
+    input
+        .arrange_named::<RowSpine<(Row, u64), _, _, _>>("Arranged TopK input")
+        .reduce_abelian::<_, RowSpine<_, _, _, _>>("Reduced TopK input", {
+            move |_key, source, target: &mut Vec<(R, Diff)>| {
+                if let Some(err) = R::into_error() {
+                    for (row, diff) in source.iter() {
+                        if diff.is_positive() {
+                            continue;
+                        }
+                        target.push((err((*row).clone()), -1));
+                        return;
+                    }
+                }
+
+                // Determine if we must actually shrink the result set.
+                // TODO(benesch): avoid dangerous `as` conversion.
+                #[allow(clippy::as_conversions)]
+                let must_shrink = offset > 0
+                    || limit
+                        .map(|l| source.iter().map(|(_, d)| *d).sum::<Diff>() as usize > l)
+                        .unwrap_or(false);
+                if !must_shrink {
+                    return;
+                }
+
+                // First go ahead and emit all records
+                for (row, diff) in source.iter() {
+                    target.push((R::ok((*row).clone()), diff.clone()));
+                }
+                // local copies that may count down to zero.
+                let mut offset = offset;
+                let mut limit = limit;
+
+                // The order in which we should produce rows.
+                let mut indexes = (0..source.len()).collect::<Vec<_>>();
+                // We decode the datums once, into a common buffer for efficiency.
+                // Each row should contain `arity` columns; we should check that.
+                let mut buffer = Vec::with_capacity(arity * source.len());
+                for (index, row) in source.iter().enumerate() {
+                    buffer.extend(row.0.iter());
+                    assert_eq!(buffer.len(), arity * (index + 1));
+                }
+                let width = buffer.len() / source.len();
+
+                //todo: use arrangements or otherwise make the sort more performant?
+                indexes.sort_by(|left, right| {
+                    let left = &buffer[left * width..][..width];
+                    let right = &buffer[right * width..][..width];
+                    // Note: source was originally ordered by the u8 array representation
+                    // of rows, but left.cmp(right) uses Datum::cmp.
+                    mz_expr::compare_columns(&order_key, left, right, || left.cmp(right))
+                });
+
+                // We now need to lay out the data in order of `buffer`, but respecting
+                // the `offset` and `limit` constraints.
+                for index in indexes.into_iter() {
+                    let (row, mut diff) = source[index];
+                    if !diff.is_positive() {
+                        continue;
+                    }
+                    // If we are still skipping early records ...
+                    if offset > 0 {
+                        let to_skip = std::cmp::min(offset, usize::try_from(diff).unwrap());
+                        offset -= to_skip;
+                        diff -= Diff::try_from(to_skip).unwrap();
+                    }
+                    // We should produce at most `limit` records.
+                    // TODO(benesch): avoid dangerous `as` conversion.
+                    #[allow(clippy::as_conversions)]
+                    if let Some(limit) = &mut limit {
+                        diff = std::cmp::min(diff, Diff::try_from(*limit).unwrap());
+                        *limit -= diff as usize;
+                    }
+                    // Output the indicated number of rows.
+                    if diff > 0 {
+                        // Emit retractions for the elements actually part of
+                        // the set of TopK elements.
+                        target.push((R::ok(row.clone()), -diff));
+                    }
+                }
+            }
+        })
+        .as_collection(|k, v| (k.clone(), v.clone()))
+}
+
+fn render_intra_ts_thinning<S>(
+    collection: Collection<S, (Row, Row), Diff>,
+    order_key: Vec<mz_expr::ColumnOrder>,
+    limit: usize,
+) -> Collection<S, (Row, Row), Diff>
+where
+    S: Scope,
+    S::Timestamp: Lattice,
+{
+    let mut aggregates = BTreeMap::new();
+    let mut vector = Vec::new();
+    let shared = Rc::new(RefCell::new(monoids::Top1MonoidShared {
+        order_key,
+        left: DatumVec::new(),
+        right: DatumVec::new(),
+    }));
+    collection
+        .inner
+        .unary_notify(
+            Pipeline,
+            "TopKIntraTimeThinning",
+            [],
+            move |input, output, notificator| {
+                while let Some((time, data)) = input.next() {
+                    data.swap(&mut vector);
+                    let agg_time = aggregates
+                        .entry(time.time().clone())
+                        .or_insert_with(BTreeMap::new);
+                    for ((grp_row, row), record_time, diff) in vector.drain(..) {
+                        let monoid = monoids::Top1MonoidLocal {
+                            row,
+                            shared: Rc::clone(&shared),
+                        };
+                        let topk =
+                            agg_time
+                                .entry((grp_row, record_time))
+                                .or_insert_with(move || {
+                                    topk_agg::TopKBatch::new(limit.try_into().expect("must fit"))
+                                });
+                        topk.update(monoid, diff);
+                    }
+                    notificator.notify_at(time.retain());
+                }
+
+                notificator.for_each(|time, _, _| {
+                    if let Some(aggs) = aggregates.remove(time.time()) {
+                        let mut session = output.session(&time);
+                        for ((grp_row, record_time), topk) in aggs {
+                            session.give_iterator(topk.into_iter().map(|(monoid, diff)| {
+                                (
+                                    (grp_row.clone(), monoid.into_row()),
+                                    record_time.clone(),
+                                    diff,
+                                )
+                            }))
+                        }
                     }
                 });
-            // TODO(#7331): Here we discard the arranged output.
-            (result.as_collection(|_k, v| v.clone()), errs)
-        }
-
-        fn render_intra_ts_thinning<G>(
-            collection: Collection<G, (Row, Row), Diff>,
-            order_key: Vec<mz_expr::ColumnOrder>,
-            limit: usize,
-        ) -> Collection<G, (Row, Row), Diff>
-        where
-            G: Scope,
-            G::Timestamp: Lattice,
-        {
-            let mut aggregates = BTreeMap::new();
-            let mut vector = Vec::new();
-            let shared = Rc::new(RefCell::new(monoids::Top1MonoidShared {
-                order_key,
-                left: DatumVec::new(),
-                right: DatumVec::new(),
-            }));
-            collection
-                .inner
-                .unary_notify(
-                    Pipeline,
-                    "TopKIntraTimeThinning",
-                    [],
-                    move |input, output, notificator| {
-                        while let Some((time, data)) = input.next() {
-                            data.swap(&mut vector);
-                            let agg_time = aggregates
-                                .entry(time.time().clone())
-                                .or_insert_with(BTreeMap::new);
-                            for ((grp_row, row), record_time, diff) in vector.drain(..) {
-                                let monoid = monoids::Top1MonoidLocal {
-                                    row,
-                                    shared: Rc::clone(&shared),
-                                };
-                                let topk = agg_time.entry((grp_row, record_time)).or_insert_with(
-                                    move || {
-                                        topk_agg::TopKBatch::new(
-                                            limit.try_into().expect("must fit"),
-                                        )
-                                    },
-                                );
-                                topk.update(monoid, diff);
-                            }
-                            notificator.notify_at(time.retain());
-                        }
-
-                        notificator.for_each(|time, _, _| {
-                            if let Some(aggs) = aggregates.remove(time.time()) {
-                                let mut session = output.session(&time);
-                                for ((grp_row, record_time), topk) in aggs {
-                                    session.give_iterator(topk.into_iter().map(|(monoid, diff)| {
-                                        (
-                                            (grp_row.clone(), monoid.into_row()),
-                                            record_time.clone(),
-                                            diff,
-                                        )
-                                    }))
-                                }
-                            }
-                        });
-                    },
-                )
-                .as_collection()
-        }
-    }
+            },
+        )
+        .as_collection()
 }
 
 /// Types for in-place intra-ts aggregation of monotonic streams.


### PR DESCRIPTION
This PR modifies the error logging behavior of compute operators to only log messages to Sentry when the dataflow is not in the process of shutting down. This avoids producing noise caused by dataflow operators emitting partial update sets when they are cancelled. It is a precondition for enabling the faster dataflow shutdown methods described in the ["Faster Dataflow Shutdown" design](https://github.com/MaterializeInc/materialize/pull/18760).

The shutdown checking is performed through a shutdown token that is wrapped inside a new `ErrorLogger` type that gets passed around to the various operator renderers. An `ErrorLogger` encapsulates both shutdown checking and our `warn!`/`error!` logging format.

### Motivation

  * This PR adds a known-desirable feature.

Enables https://github.com/MaterializeInc/materialize/pull/18760.

### Tips for reviewer

Look at the commits and their descriptions separately!

* The first commit moves the `MaybeValidatingRow` trait into a new `mz_compute::render::errors` module, which is also where the new `ErrorLogger` type lives.
* The second commit adds the `ErrorLogger` type.
* The third commit attaches a shutdown token to the rendering `Context` and updates the top-level rendering code to make sure the token gets added to the exports depending on it.
* The fourth commits adjusts error logging in dataflow operators to use the `ErrorLogger`, rather than using the `warn!`/`error!` macros directly.
* The fifth commit makes most of the free-standing reduce and top-k rendering functions methods of the `Context` type. Rather than requiring `debug_name` and `error_logger` arguments, they can now get these fields directly from the context, reducing the number of function arguments that need to be passed.

Unfortunately, the diff for the last commit is quite hairy, since it changes not only the indentation level, but also causes rustfmt to re-wrap many of the higher-indented lines. Hiding whitespace changes helps a bit, but still produces a diff much larger than it should be. Since the last commit is a pure code organization change and doesn't affect functionality, I would be fine with dropping it if you'd rather not review it.

~~One thought about the `ErrorLogger` type: It would be quite easy to also wrap the `debug_name`, in addition to the token, inside it. Then we wouldn't have to pass that around in rendering anymore. The drawback is that we'd lose our current flexibility in formatting the "details" part. We'd probably need to put the dataflow name as a fixed prefix of the message, so constructs like "found invalid accumulations in dataflow {debug_name}" would no longer be possible.~~ This is now implemented in the sixth commit!

If anyone has an idea how to actually test this change, I'd be happy to hear it! I couldn't come up with a way to provoke invalid retractions during dataflow shutdown (they should be impossible today), much less doing so in a reliable way.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
