### PR TITLE
persist: react immediately to state changes in the same process

### DIFF
--- a/src/persist-client/benches/benches.rs
+++ b/src/persist-client/benches/benches.rs
@@ -173,7 +173,7 @@ fn create_mem_mem_client() -> Result<PersistClient, ExternalError> {
     let consensus = Arc::new(MemConsensus::default());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let cpu_heavy_runtime = Arc::new(CpuHeavyRuntime::new());
-    let shared_states = Arc::new(StateCache::default());
+    let shared_states = Arc::new(StateCache::new(Arc::clone(&metrics)));
     PersistClient::new(
         cfg,
         blob,
@@ -199,7 +199,7 @@ async fn create_file_pg_client(
     let consensus = Arc::clone(&postgres_consensus);
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let cpu_heavy_runtime = Arc::new(CpuHeavyRuntime::new());
-    let shared_states = Arc::new(StateCache::default());
+    let shared_states = Arc::new(StateCache::new(Arc::clone(&metrics)));
     let client = PersistClient::new(
         cfg,
         blob,
@@ -228,7 +228,7 @@ async fn create_s3_pg_client(
     let consensus = Arc::clone(&postgres_consensus);
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let cpu_heavy_runtime = Arc::new(CpuHeavyRuntime::new());
-    let shared_states = Arc::new(StateCache::default());
+    let shared_states = Arc::new(StateCache::new(Arc::clone(&metrics)));
     let client = PersistClient::new(
         cfg,
         blob,

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -672,7 +672,7 @@ impl Service for TransactorService {
 
         // Wire up the TransactorService.
         let cpu_heavy_runtime = Arc::new(CpuHeavyRuntime::new());
-        let shared_states = Arc::new(StateCache::default());
+        let shared_states = Arc::new(StateCache::new(Arc::clone(&metrics)));
         let client = PersistClient::new(
             config,
             blob,

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -433,9 +433,9 @@ async fn make_machine(
     let machine = Machine::<crate::cli::inspect::K, crate::cli::inspect::V, u64, i64>::new(
         cfg.clone(),
         shard_id,
-        metrics,
+        Arc::clone(&metrics),
         state_versions,
-        &StateCache::default(),
+        &StateCache::new(metrics),
     )
     .await?;
 

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -606,7 +606,7 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
         make_consensus(&cfg, &args.consensus_uri, NO_COMMIT, Arc::clone(&metrics)).await?;
     let blob = make_blob(&cfg, &args.blob_uri, NO_COMMIT, Arc::clone(&metrics)).await?;
     let cpu_heavy_runtime = Arc::new(CpuHeavyRuntime::new());
-    let state_cache = Arc::new(StateCache::default());
+    let state_cache = Arc::new(StateCache::new(Arc::clone(&metrics)));
     let usage = StorageUsageClient::open(PersistClient::new(
         cfg,
         blob,

--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -109,7 +109,7 @@ where
 
     /// Returns a new [StateWatch] for changes to this Applier's State.
     pub fn watch(&self) -> StateWatch<K, V, T, D> {
-        StateWatch::new(Arc::clone(&self.state), &self.metrics)
+        StateWatch::new(Arc::clone(&self.state), Arc::clone(&self.metrics))
     }
 
     /// Fetches the latest state from Consensus and passes its `upper` to the provided closure.

--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -57,7 +57,7 @@ pub struct Applier<K, V, T, D> {
     //
     // NB: This is very intentionally not pub(crate) so that it's easy to reason
     //     very locally about the duration of locks.
-    state: LockingTypedState<K, V, T, D>,
+    state: Arc<LockingTypedState<K, V, T, D>>,
 }
 
 // Impl Clone regardless of the type params.
@@ -69,7 +69,7 @@ impl<K, V, T: Clone, D> Clone for Applier<K, V, T, D> {
             shard_metrics: Arc::clone(&self.shard_metrics),
             state_versions: Arc::clone(&self.state_versions),
             shard_id: self.shard_id,
-            state: self.state.clone(),
+            state: Arc::clone(&self.state),
         }
     }
 }

--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -30,7 +30,7 @@ use crate::internal::maintenance::RoutineMaintenance;
 use crate::internal::metrics::{CmdMetrics, Metrics, ShardMetrics};
 use crate::internal::paths::{PartialRollupKey, RollupId};
 use crate::internal::state::{
-    ExpiryMetrics, HollowBatch, Since, StateCollections, TypedState, Upper,
+    ExpiryMetrics, HollowBatch, Since, SnapshotErr, StateCollections, TypedState, Upper,
 };
 use crate::internal::state_diff::StateDiff;
 use crate::internal::state_versions::{EncodedRollup, StateVersions};
@@ -206,10 +206,7 @@ where
             })
     }
 
-    pub fn snapshot(
-        &self,
-        as_of: &Antichain<T>,
-    ) -> Result<Result<Vec<HollowBatch<T>>, Upper<T>>, Since<T>> {
+    pub fn snapshot(&self, as_of: &Antichain<T>) -> Result<Vec<HollowBatch<T>>, SnapshotErr<T>> {
         self.state
             .read_lock(&self.metrics.locks.applier_read_noncacheable, |state| {
                 state.snapshot(as_of)

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -743,7 +743,7 @@ where
         }
     }
 
-    pub fn next_listen_batch(&self, frontier: &Antichain<T>) -> Option<HollowBatch<T>> {
+    pub fn next_listen_batch(&self, frontier: &Antichain<T>) -> Result<HollowBatch<T>, SeqNo> {
         self.applier.next_listen_batch(frontier)
     }
 

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -496,6 +496,7 @@ impl MetricsVecs {
             applier_read_cacheable: self.lock_metrics("applier_read_cacheable"),
             applier_read_noncacheable: self.lock_metrics("applier_read_noncacheable"),
             applier_write: self.lock_metrics("applier_write"),
+            watch: self.lock_metrics("watch"),
         }
     }
 
@@ -1464,6 +1465,7 @@ pub struct LocksMetrics {
     pub(crate) applier_read_cacheable: LockMetrics,
     pub(crate) applier_read_noncacheable: LockMetrics,
     pub(crate) applier_write: LockMetrics,
+    pub(crate) watch: LockMetrics,
 }
 
 #[derive(Debug)]

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1482,6 +1482,8 @@ pub struct LockMetrics {
 pub struct WatchMetrics {
     pub(crate) listen_woken_via_watch: IntCounter,
     pub(crate) listen_woken_via_sleep: IntCounter,
+    pub(crate) snapshot_woken_via_watch: IntCounter,
+    pub(crate) snapshot_woken_via_sleep: IntCounter,
     pub(crate) notify_sent: IntCounter,
     pub(crate) notify_noop: IntCounter,
     pub(crate) notify_recv: IntCounter,
@@ -1495,11 +1497,19 @@ impl WatchMetrics {
         WatchMetrics {
             listen_woken_via_watch: registry.register(metric!(
                 name: "mz_persist_listen_woken_via_watch",
-                help: "count of listen next batches discovered via watch notify",
+                help: "count of listen next batches wakes via watch notify",
             )),
             listen_woken_via_sleep: registry.register(metric!(
                 name: "mz_persist_listen_woken_via_sleep",
-                help: "count of listen next batches discovered via sleep",
+                help: "count of listen next batches wakes via sleep",
+            )),
+            snapshot_woken_via_watch: registry.register(metric!(
+                name: "mz_persist_snapshot_woken_via_watch",
+                help: "count of snapshot wakes via watch notify",
+            )),
+            snapshot_woken_via_sleep: registry.register(metric!(
+                name: "mz_persist_snapshot_woken_via_sleep",
+                help: "count of snapshot wakes via sleep",
             )),
             notify_sent: registry.register(metric!(
                 name: "mz_persist_watch_notify_sent",

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -73,6 +73,8 @@ pub struct Metrics {
     pub audit: UsageAuditMetrics,
     /// Metrics for locking.
     pub locks: LocksMetrics,
+    /// Metrics for StateWatch.
+    pub watch: WatchMetrics,
 
     /// Metrics for the persist sink.
     pub sink: SinkMetrics,
@@ -114,6 +116,7 @@ impl Metrics {
             shards: ShardsMetrics::new(registry),
             audit: UsageAuditMetrics::new(registry),
             locks: vecs.locks_metrics(),
+            watch: WatchMetrics::new(registry),
             sink: SinkMetrics::new(registry),
             s3_blob: S3BlobMetrics::new(registry),
             postgres_consensus: PostgresConsensusMetrics::new(registry),
@@ -1473,6 +1476,57 @@ pub struct LockMetrics {
     pub(crate) acquire_count: IntCounter,
     pub(crate) blocking_acquire_count: IntCounter,
     pub(crate) blocking_seconds: Counter,
+}
+
+#[derive(Debug)]
+pub struct WatchMetrics {
+    pub(crate) listen_woken_via_watch: IntCounter,
+    pub(crate) listen_woken_via_sleep: IntCounter,
+    pub(crate) notify_sent: IntCounter,
+    pub(crate) notify_noop: IntCounter,
+    pub(crate) notify_recv: IntCounter,
+    pub(crate) notify_lagged: IntCounter,
+    pub(crate) notify_wait_started: IntCounter,
+    pub(crate) notify_wait_finished: IntCounter,
+}
+
+impl WatchMetrics {
+    fn new(registry: &MetricsRegistry) -> Self {
+        WatchMetrics {
+            listen_woken_via_watch: registry.register(metric!(
+                name: "mz_persist_listen_woken_via_watch",
+                help: "count of listen next batches discovered via watch notify",
+            )),
+            listen_woken_via_sleep: registry.register(metric!(
+                name: "mz_persist_listen_woken_via_sleep",
+                help: "count of listen next batches discovered via sleep",
+            )),
+            notify_sent: registry.register(metric!(
+                name: "mz_persist_watch_notify_sent",
+                help: "count of watch notifications sent to a non-empty broadcast channel",
+            )),
+            notify_noop: registry.register(metric!(
+                name: "mz_persist_watch_notify_noop",
+                help: "count of watch notifications sent to an broadcast channel",
+            )),
+            notify_recv: registry.register(metric!(
+                name: "mz_persist_watch_notify_recv",
+                help: "count of watch notifications received from the broadcast channel",
+            )),
+            notify_lagged: registry.register(metric!(
+                name: "mz_persist_watch_notify_lagged",
+                help: "count of lagged events in the watch notification broadcast channel",
+            )),
+            notify_wait_started: registry.register(metric!(
+                name: "mz_persist_watch_notify_wait_started",
+                help: "count of watch wait calls started",
+            )),
+            notify_wait_finished: registry.register(metric!(
+                name: "mz_persist_watch_notify_wait_finished",
+                help: "count of watch wait calls resolved",
+            )),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -347,6 +347,13 @@ pub enum CompareAndAppendBreak<T> {
     InvalidUsage(InvalidUsage<T>),
 }
 
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum SnapshotErr<T> {
+    AsOfNotYetAvailable(SeqNo, Upper<T>),
+    AsOfHistoricalDistinctionsLost(Since<T>),
+}
+
 impl<T> StateCollections<T>
 where
     T: Timestamp + Lattice + Codec64,
@@ -1254,16 +1261,18 @@ where
     /// Returns the batches that contain updates up to (and including) the given `as_of`. The
     /// result `Vec` contains blob keys, along with a [`Description`] of what updates in the
     /// referenced parts are valid to read.
-    pub fn snapshot(
-        &self,
-        as_of: &Antichain<T>,
-    ) -> Result<Result<Vec<HollowBatch<T>>, Upper<T>>, Since<T>> {
+    pub fn snapshot(&self, as_of: &Antichain<T>) -> Result<Vec<HollowBatch<T>>, SnapshotErr<T>> {
         if PartialOrder::less_than(as_of, self.collections.trace.since()) {
-            return Err(Since(self.collections.trace.since().clone()));
+            return Err(SnapshotErr::AsOfHistoricalDistinctionsLost(Since(
+                self.collections.trace.since().clone(),
+            )));
         }
         let upper = self.collections.trace.upper();
         if PartialOrder::less_equal(upper, as_of) {
-            return Ok(Err(Upper(upper.clone())));
+            return Err(SnapshotErr::AsOfNotYetAvailable(
+                self.seqno,
+                Upper(upper.clone()),
+            ));
         }
 
         let mut batches = Vec::new();
@@ -1273,7 +1282,7 @@ where
             }
             batches.push(b.clone());
         });
-        Ok(Ok(batches))
+        Ok(batches)
     }
 
     // NB: Unlike the other methods here, this one is read-only.
@@ -1634,13 +1643,19 @@ mod tests {
         // Cannot take a snapshot with as_of == shard upper.
         assert_eq!(
             state.snapshot(&Antichain::from_elem(0)),
-            Ok(Err(Upper(Antichain::from_elem(0))))
+            Err(SnapshotErr::AsOfNotYetAvailable(
+                SeqNo(0),
+                Upper(Antichain::from_elem(0))
+            ))
         );
 
         // Cannot take a snapshot with as_of > shard upper.
         assert_eq!(
             state.snapshot(&Antichain::from_elem(5)),
-            Ok(Err(Upper(Antichain::from_elem(0))))
+            Err(SnapshotErr::AsOfNotYetAvailable(
+                SeqNo(0),
+                Upper(Antichain::from_elem(0))
+            ))
         );
 
         let writer_id = WriterId::new();
@@ -1662,23 +1677,29 @@ mod tests {
         // Can take a snapshot with as_of < upper.
         assert_eq!(
             state.snapshot(&Antichain::from_elem(0)),
-            Ok(Ok(vec![hollow(0, 5, &["key1"], 1)]))
+            Ok(vec![hollow(0, 5, &["key1"], 1)])
         );
 
         // Can take a snapshot with as_of >= shard since, as long as as_of < shard_upper.
         assert_eq!(
             state.snapshot(&Antichain::from_elem(4)),
-            Ok(Ok(vec![hollow(0, 5, &["key1"], 1)]))
+            Ok(vec![hollow(0, 5, &["key1"], 1)])
         );
 
         // Cannot take a snapshot with as_of >= upper.
         assert_eq!(
             state.snapshot(&Antichain::from_elem(5)),
-            Ok(Err(Upper(Antichain::from_elem(5))))
+            Err(SnapshotErr::AsOfNotYetAvailable(
+                SeqNo(0),
+                Upper(Antichain::from_elem(5))
+            ))
         );
         assert_eq!(
             state.snapshot(&Antichain::from_elem(6)),
-            Ok(Err(Upper(Antichain::from_elem(5))))
+            Err(SnapshotErr::AsOfNotYetAvailable(
+                SeqNo(0),
+                Upper(Antichain::from_elem(5))
+            ))
         );
 
         let reader = LeasedReaderId::new();
@@ -1705,7 +1726,9 @@ mod tests {
         // Cannot take a snapshot with as_of < shard_since.
         assert_eq!(
             state.snapshot(&Antichain::from_elem(1)),
-            Err(Since(Antichain::from_elem(2)))
+            Err(SnapshotErr::AsOfHistoricalDistinctionsLost(Since(
+                Antichain::from_elem(2)
+            )))
         );
 
         // Advance the upper to 10 via an empty batch.
@@ -1722,13 +1745,16 @@ mod tests {
         // Can still take snapshots at times < upper.
         assert_eq!(
             state.snapshot(&Antichain::from_elem(7)),
-            Ok(Ok(vec![hollow(0, 5, &["key1"], 1), hollow(5, 10, &[], 0)]))
+            Ok(vec![hollow(0, 5, &["key1"], 1), hollow(5, 10, &[], 0)])
         );
 
         // Cannot take snapshots with as_of >= upper.
         assert_eq!(
             state.snapshot(&Antichain::from_elem(10)),
-            Ok(Err(Upper(Antichain::from_elem(10))))
+            Err(SnapshotErr::AsOfNotYetAvailable(
+                SeqNo(0),
+                Upper(Antichain::from_elem(10))
+            ))
         );
 
         // Advance upper to 15.
@@ -1746,26 +1772,26 @@ mod tests {
         // batches that are too far in the future for the requested as_of).
         assert_eq!(
             state.snapshot(&Antichain::from_elem(9)),
-            Ok(Ok(vec![hollow(0, 5, &["key1"], 1), hollow(5, 10, &[], 0)]))
+            Ok(vec![hollow(0, 5, &["key1"], 1), hollow(5, 10, &[], 0)])
         );
 
         // Don't filter out batches whose lowers are <= the requested as_of.
         assert_eq!(
             state.snapshot(&Antichain::from_elem(10)),
-            Ok(Ok(vec![
+            Ok(vec![
                 hollow(0, 5, &["key1"], 1),
                 hollow(5, 10, &[], 0),
                 hollow(10, 15, &["key2"], 1)
-            ]))
+            ])
         );
 
         assert_eq!(
             state.snapshot(&Antichain::from_elem(11)),
-            Ok(Ok(vec![
+            Ok(vec![
                 hollow(0, 5, &["key1"], 1),
                 hollow(5, 10, &[], 0),
                 hollow(10, 15, &["key2"], 1)
-            ]))
+            ])
         );
     }
 

--- a/src/persist-client/src/internal/watch.rs
+++ b/src/persist-client/src/internal/watch.rs
@@ -1,0 +1,300 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Notifications for state changes.
+
+use std::sync::Arc;
+
+use mz_persist::location::SeqNo;
+use tokio::sync::broadcast;
+use tracing::debug;
+
+use crate::cache::LockingTypedState;
+use crate::internal::metrics::Metrics;
+
+#[derive(Debug)]
+pub struct StateWatchNotifier {
+    tx: broadcast::Sender<SeqNo>,
+}
+
+impl Default for StateWatchNotifier {
+    fn default() -> Self {
+        let (tx, _rx) = broadcast::channel(1);
+        StateWatchNotifier { tx }
+    }
+}
+
+impl StateWatchNotifier {
+    /// Wake up any watchers of this state.
+    ///
+    /// This must be called while under the same lock that modified the state to
+    /// avoid any potential for out of order SeqNos in the broadcast channel.
+    ///
+    /// This restriction can be lifted (i.e. we could notify after releasing the
+    /// write lock), but we'd have to reason about out of order SeqNos in the
+    /// broadcast channel. In particular, if we see `RecvError::Lagged` then
+    /// it's possible we lost X+1 and got X, so if X isn't sufficient to return,
+    /// we'd need to grab the read lock and verify the real SeqNo.
+    pub(crate) fn notify(&self, seqno: SeqNo) {
+        match self.tx.send(seqno) {
+            // Someone got woken up.
+            Ok(_) => {}
+            // No one is listening, that's also fine.
+            Err(_) => {}
+        }
+    }
+}
+
+/// A reactive subscription to changes in [LockingTypedState].
+///
+/// Invariants:
+/// - The `state.seqno` only advances (never regresses). This is guaranteed by
+///   LockingTypedState.
+/// - `seqno_high_water` is always <= `state.seqno`.
+/// - If `seqno_high_water` is < `state.seqno`, then we'll get a notification on
+///   `rx`. This is maintained by notifying new seqnos under the same lock which
+///   adds them.
+/// - `seqno_high_water` always holds the highest value received in the channel
+///   This is maintained by `wait_for_seqno_gt` taking an exclusive reference to
+///   self.
+#[derive(Debug)]
+pub struct StateWatch<K, V, T, D> {
+    state: Arc<LockingTypedState<K, V, T, D>>,
+    seqno_high_water: SeqNo,
+    rx: broadcast::Receiver<SeqNo>,
+}
+
+impl<K, V, T, D> StateWatch<K, V, T, D> {
+    pub(crate) fn new(state: Arc<LockingTypedState<K, V, T, D>>, metrics: &Metrics) -> Self {
+        // Important! We have to subscribe to the broadcast channel _before_ we
+        // grab the current seqno. Otherwise, we could race with a write to
+        // state and miss a notification. Tokio guarantees that "the returned
+        // Receiver will receive values sent after the call to subscribe", and
+        // the read_lock linearizes the subscribe to be _before_ whatever
+        // seqno_high_water we get here.
+        let rx = state.notifier().tx.subscribe();
+        let seqno_high_water = state.read_lock(&metrics.locks.watch, |x| x.seqno);
+        StateWatch {
+            state,
+            seqno_high_water,
+            rx,
+        }
+    }
+
+    /// Blocks until the State has a SeqNo >= the requested one.
+    ///
+    /// This method is cancel-safe.
+    pub async fn wait_for_seqno_ge(&mut self, requested: SeqNo) {
+        debug!("wait_for_seqno_ge {} {}", self.state.shard_id(), requested);
+        loop {
+            if self.seqno_high_water >= requested {
+                break;
+            }
+            match self.rx.recv().await {
+                Ok(x) => {
+                    assert!(x >= self.seqno_high_water);
+                    self.seqno_high_water = x;
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    unreachable!("we're holding on to a reference to the sender")
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    // This is just a hint that our buffer (of size 1) filled
+                    // up, which is totally fine. The broadcast channel
+                    // guarantees that the most recent N (again, =1 here) are
+                    // kept, so just loop around. This branch means we should be
+                    // able to read a new value immediately.
+                    continue;
+                }
+            }
+        }
+        debug!(
+            "wait_for_seqno_ge {} {} returning",
+            self.state.shard_id(),
+            requested
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::Context;
+    use std::time::Duration;
+
+    use futures::FutureExt;
+    use futures_task::noop_waker;
+    use mz_build_info::DUMMY_BUILD_INFO;
+    use mz_ore::cast::CastFrom;
+    use mz_ore::metrics::MetricsRegistry;
+    use timely::progress::Antichain;
+
+    use crate::cache::StateCache;
+    use crate::cfg::{PersistConfig, PersistParameters, RetryParameters};
+    use crate::internal::state::TypedState;
+    use crate::tests::new_test_client;
+    use crate::ShardId;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn state_watch() {
+        mz_ore::test::init_logging();
+        let metrics = Metrics::new(&PersistConfig::new_for_tests(), &MetricsRegistry::new());
+        let cache = StateCache::default();
+        let shard_id = ShardId::new();
+        let state = cache
+            .get::<(), (), u64, i64, _, _>(shard_id, || async {
+                Ok(TypedState::new(
+                    DUMMY_BUILD_INFO.semver_version(),
+                    shard_id,
+                    "host".to_owned(),
+                    0u64,
+                ))
+            })
+            .await
+            .unwrap();
+        assert_eq!(state.read_lock(&metrics.locks.watch, |x| x.seqno), SeqNo(0));
+
+        // A watch for 0 resolves immediately.
+        let mut w0 = StateWatch::new(Arc::clone(&state), &metrics);
+        let () = w0.wait_for_seqno_ge(SeqNo(0)).await;
+
+        // A watch for 1 does not yet resolve.
+        let w0s1 = w0.wait_for_seqno_ge(SeqNo(1)).shared();
+        assert_eq!(w0s1.clone().now_or_never(), None);
+
+        // After mutating state, the watch for 1 does resolve.
+        state.write_lock(&metrics.locks.applier_write, |state| {
+            state.seqno = state.seqno.next()
+        });
+        let () = w0s1.await;
+
+        // A watch for an old seqno immediately resolves.
+        let () = w0.wait_for_seqno_ge(SeqNo(0)).await;
+
+        // We can create a new watch and it also behaves.
+        let mut w1 = StateWatch::new(Arc::clone(&state), &metrics);
+        let () = w1.wait_for_seqno_ge(SeqNo(0)).await;
+        let () = w1.wait_for_seqno_ge(SeqNo(1)).await;
+        assert_eq!(w1.wait_for_seqno_ge(SeqNo(2)).now_or_never(), None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn state_watch_concurrency() {
+        mz_ore::test::init_logging();
+        let metrics = Arc::new(Metrics::new(
+            &PersistConfig::new_for_tests(),
+            &MetricsRegistry::new(),
+        ));
+        let cache = StateCache::default();
+        let shard_id = ShardId::new();
+        let state = cache
+            .get::<(), (), u64, i64, _, _>(shard_id, || async {
+                Ok(TypedState::new(
+                    DUMMY_BUILD_INFO.semver_version(),
+                    shard_id,
+                    "host".to_owned(),
+                    0u64,
+                ))
+            })
+            .await
+            .unwrap();
+        assert_eq!(state.read_lock(&metrics.locks.watch, |x| x.seqno), SeqNo(0));
+
+        const NUM_WATCHES: usize = 100;
+        const NUM_WRITES: usize = 20;
+
+        let watches = (0..NUM_WATCHES)
+            .map(|idx| {
+                let state = Arc::clone(&state);
+                let metrics = Arc::clone(&metrics);
+                mz_ore::task::spawn(|| "watch", async move {
+                    let mut watch = StateWatch::new(Arc::clone(&state), &metrics);
+                    // We stared at 0, so N writes means N+1 seqnos.
+                    let wait_seqno = SeqNo(u64::cast_from(idx % NUM_WRITES + 1));
+                    let () = watch.wait_for_seqno_ge(wait_seqno).await;
+                    let observed_seqno =
+                        state.read_lock(&metrics.locks.applier_read_noncacheable, |x| x.seqno);
+                    tracing::info!("{} vs {}", wait_seqno, observed_seqno);
+                    assert!(
+                        wait_seqno <= observed_seqno,
+                        "{} vs {}",
+                        wait_seqno,
+                        observed_seqno
+                    );
+                })
+            })
+            .collect::<Vec<_>>();
+        let writes = (0..NUM_WRITES)
+            .map(|_| {
+                let state = Arc::clone(&state);
+                let metrics = Arc::clone(&metrics);
+                mz_ore::task::spawn(|| "write", async move {
+                    state.write_lock(&metrics.locks.applier_write, |x| {
+                        x.seqno = x.seqno.next();
+                        eprintln!("wrote {}", x.seqno);
+                    });
+                })
+            })
+            .collect::<Vec<_>>();
+        for watch in watches {
+            assert!(watch.await.is_ok());
+        }
+        for write in writes {
+            assert!(write.await.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn state_watch_listen_snapshot() {
+        mz_ore::test::init_logging();
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let client = new_test_client().await;
+        // Override the listen poll so that it's useless.
+        PersistParameters {
+            next_listen_batch_retryer: Some(RetryParameters {
+                initial_backoff: Duration::from_secs(1_000_000),
+                multiplier: 1,
+                clamp: Duration::from_secs(1_000_000),
+            }),
+            ..PersistParameters::default()
+        }
+        .apply(&client.cfg);
+
+        let (mut write, mut read) = client.expect_open::<(), (), u64, i64>(ShardId::new()).await;
+
+        // Grab a snapshot for 1, which doesn't resolve yet. Also grab a listen
+        // for 0, which resolves but doesn't yet resolve the next batch.
+        let mut listen = read
+            .clone("test")
+            .await
+            .listen(Antichain::from_elem(0))
+            .await
+            .unwrap();
+        let mut snapshot = Box::pin(read.snapshot(Antichain::from_elem(0)));
+        assert!(Pin::new(&mut snapshot).poll(&mut cx).is_pending());
+        let mut listen_next_batch = Box::pin(listen.next());
+        assert!(Pin::new(&mut listen_next_batch).poll(&mut cx).is_pending());
+
+        // Now update the frontier, which should allow the snapshot to resolve
+        // and the listen to resolve its next batch. Because we disabled the
+        // polling, the listen_next_batch future will block forever and timeout
+        // the test if the watch doesn't work.
+        write.expect_compare_and_append(&[], 0, 1).await;
+        let _ = listen_next_batch.await;
+
+        // For good measure, also resolve the snapshot, though we haven't broken
+        // the polling on this.
+        let _ = snapshot.await;
+    }
+}

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -954,7 +954,7 @@ mod tests {
                 (k.to_owned(), v.to_owned(), t.to_owned(), d.to_owned(), None)
             }
 
-            client.shared_states = Arc::new(StateCache::default());
+            client.shared_states = Arc::new(StateCache::new_no_metrics());
             assert_eq!(
                 client
                     .open::<Vec<u8>, String, u64, i64>(

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -153,6 +153,7 @@ mod internal {
     pub mod state_diff;
     pub mod state_versions;
     pub mod trace;
+    pub mod watch;
 
     #[cfg(test)]
     pub mod datadriven;

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -896,7 +896,7 @@ where
         frontier: &Antichain<T>,
         watch: &mut StateWatch<K, V, T, D>,
     ) -> HollowBatch<T> {
-        let seqno = match self.machine.next_listen_batch(frontier) {
+        let mut seqno = match self.machine.next_listen_batch(frontier) {
             Ok(b) => return b,
             Err(seqno) => seqno,
         };
@@ -910,7 +910,7 @@ where
             .applier
             .fetch_and_update_state(Some(seqno))
             .await;
-        let seqno = match self.machine.next_listen_batch(frontier) {
+        seqno = match self.machine.next_listen_batch(frontier) {
             Ok(b) => return b,
             Err(seqno) => seqno,
         };
@@ -962,7 +962,7 @@ where
                 }
             }
 
-            let seqno = match self.machine.next_listen_batch(frontier) {
+            seqno = match self.machine.next_listen_batch(frontier) {
                 Ok(b) => return b,
                 Err(seqno) => seqno,
             };

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -12,12 +12,15 @@
 use std::backtrace::Backtrace;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
 use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
+use futures::stream::{FuturesUnordered, StreamExt};
+use futures::FutureExt;
 use futures::Stream;
 use mz_ore::now::EpochMillis;
 use mz_ore::task::RuntimeExt;
@@ -893,57 +896,109 @@ where
         frontier: &Antichain<T>,
         watch: &mut StateWatch<K, V, T, D>,
     ) -> HollowBatch<T> {
-        let mut retry: Option<MetricsRetryStream> = None;
+        let seqno = match self.machine.next_listen_batch(frontier) {
+            Ok(b) => return b,
+            Err(seqno) => seqno,
+        };
+
+        // Our state might just be out of date. Fetch the newest state
+        // immediately and try again.
+        //
+        // TODO: Once we have state pubsub, we probably want to remove this
+        // optimization and jump straight to watch+sleep.
+        self.machine
+            .applier
+            .fetch_and_update_state(Some(seqno))
+            .await;
+        let seqno = match self.machine.next_listen_batch(frontier) {
+            Ok(b) => return b,
+            Err(seqno) => seqno,
+        };
+
+        // The latest state still doesn't have a new frontier for us:
+        // watch+sleep in a loop until it does.
+        let sleeps = self.metrics.retries.next_listen_batch.stream(
+            self.cfg
+                .dynamic
+                .next_listen_batch_retry_params()
+                .into_retry(SystemTime::now())
+                .into_retry_stream(),
+        );
+
+        enum Wake<'a, K, V, T, D> {
+            Watch(&'a mut StateWatch<K, V, T, D>),
+            Sleep(MetricsRetryStream),
+        }
+        let mut wakes = FuturesUnordered::<
+            std::pin::Pin<Box<dyn Future<Output = Wake<K, V, T, D>> + Send + Sync>>,
+        >::new();
+        wakes.push(Box::pin(
+            watch
+                .wait_for_seqno_ge(seqno.next())
+                .map(Wake::Watch)
+                .instrument(trace_span!("snapshot::watch")),
+        ));
+        wakes.push(Box::pin(
+            sleeps
+                .sleep()
+                .map(Wake::Sleep)
+                .instrument(trace_span!("snapshot::sleep")),
+        ));
+
         loop {
+            assert_eq!(wakes.len(), 2);
+            let wake = wakes.next().await.expect("wakes should be non-empty");
+            // Note that we don't need to fetch in the Watch case, because the
+            // Watch wakeup is a signal that the shared state has already been
+            // updated.
+            match &wake {
+                Wake::Watch(_) => self.metrics.watch.listen_woken_via_watch.inc(),
+                Wake::Sleep(_) => {
+                    self.metrics.watch.listen_woken_via_sleep.inc();
+                    self.machine
+                        .applier
+                        .fetch_and_update_state(Some(seqno))
+                        .await;
+                }
+            }
+
             let seqno = match self.machine.next_listen_batch(frontier) {
                 Ok(b) => return b,
                 Err(seqno) => seqno,
             };
-            // Only sleep after the first fetch, because the first time through
-            // maybe our state was just out of date.
-            retry = match retry.take() {
-                None => Some(
-                    self.metrics.retries.next_listen_batch.stream(
-                        self.cfg
-                            .dynamic
-                            .next_listen_batch_retry_params()
-                            .into_retry(SystemTime::now())
-                            .into_retry_stream(),
-                    ),
-                ),
-                Some(retry) => {
-                    // Wait a bit and try again. Intentionally don't ever log
-                    // this at info level.
+
+            // There might be some holdup in the next batch being
+            // produced. Perhaps we've quiesced a table or maybe a
+            // dataflow is taking a long time to start up because it has
+            // to read a lot of data. Heartbeat ourself so we don't
+            // accidentally lose our lease while we wait for things to
+            // resume.
+            self.maybe_heartbeat_reader().await;
+
+            // Wait a bit and try again. Intentionally don't ever log
+            // this at info level.
+            match wake {
+                Wake::Watch(watch) => wakes.push(Box::pin(
+                    async move {
+                        watch.wait_for_seqno_ge(seqno.next()).await;
+                        Wake::Watch(watch)
+                    }
+                    .instrument(trace_span!("snapshot::watch")),
+                )),
+                Wake::Sleep(sleeps) => {
                     debug!(
                         "{}: next_listen_batch didn't find new data, retrying in {:?}",
                         self.reader_id,
-                        retry.next_sleep()
+                        sleeps.next_sleep()
                     );
-                    let retry = tokio::select! {
-                        retry = retry.sleep().instrument(trace_span!("listen::sleep")) => {
-                            self.metrics.watch.listen_woken_via_sleep.inc();
-                            debug!("listen {} got woken via sleep", self.machine.shard_id());
-                            Some(retry)
-                        },
-                        _ = watch.wait_for_seqno_ge(seqno.next()).instrument(trace_span!("listen::wait_for_seqno_ge")) => {
-                            self.metrics.watch.listen_woken_via_watch.inc();
-                            debug!("listen {} got woken via watch", self.machine.shard_id());
-                            None
-                        },
-                    };
-
-                    // There might be some holdup in the next batch being
-                    // produced. Perhaps we've quiesced a table or maybe a
-                    // dataflow is taking a long time to start up because it has
-                    // to read a lot of data. Heartbeat ourself so we don't
-                    // accidentally lose our lease while we wait for things to
-                    // resume.
-                    self.maybe_heartbeat_reader().await;
-
-                    retry
+                    wakes.push(Box::pin(
+                        sleeps
+                            .sleep()
+                            .map(Wake::Sleep)
+                            .instrument(trace_span!("snapshot::sleep")),
+                    ));
                 }
-            };
-            self.machine.applier.fetch_and_update_state(None).await;
+            }
         }
     }
 


### PR DESCRIPTION
This came out of some skunkworks explorations around pushing persist
state. That's still ongoing, but this seemed to be a minor win and
uncontroversial enough that it was worth pulling it out.

Now that we have at most one copy of State in a process for a given
shard, there's an easy place to hook into to notify anyone else in the
same process who might be waiting for a new version of the state
(primarily Listens).

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

I ran out of steam/time right about when it was time to fill in all the various rustdoc, so you'll probably notice that's a bit light. Lemme know any questions you come up with while grokking this and I'll make sure the docs get updated to include answers.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
