### PR TITLE
sql: Remove inheritance of role attributes

### DIFF
--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -147,7 +147,7 @@ pub fn check_plan(
     // Validate that the current session has the required attributes to execute the provided plan.
     // Note: role attributes are not inherited by role membership.
     if let Some(required_attribute) = generate_required_plan_attribute(plan) {
-        if !required_attribute.check_role(&role_id, catalog) {
+        if !required_attribute.check_role(role_id, catalog) {
             return Err(AdapterError::Unauthorized(UnauthorizedError::Attribute {
                 action: plan.name().to_string(),
                 attribute: required_attribute,

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -145,8 +145,9 @@ pub fn check_plan(
     }
 
     // Validate that the current session has the required attributes to execute the provided plan.
+    // Note: role attributes are not inherited by role membership.
     if let Some(required_attribute) = generate_required_plan_attribute(plan) {
-        if !required_attribute.check_roles(&role_membership, catalog) {
+        if !required_attribute.check_role(&role_id, catalog) {
             return Err(AdapterError::Unauthorized(UnauthorizedError::Attribute {
                 action: plan.name().to_string(),
                 attribute: required_attribute,
@@ -277,17 +278,6 @@ impl Attribute {
             Attribute::CreateDB => role.create_db(),
             Attribute::CreateCluster => role.create_cluster(),
         }
-    }
-
-    /// Reports whether any role has the privilege granted by the attribute.
-    fn check_roles<'a>(
-        &self,
-        role_ids: impl IntoIterator<Item = &'a RoleId>,
-        catalog: &impl SessionCatalog,
-    ) -> bool {
-        role_ids
-            .into_iter()
-            .any(|role_id| self.check_role(role_id, catalog))
     }
 }
 

--- a/test/sqllogictest/role_attributes.slt
+++ b/test/sqllogictest/role_attributes.slt
@@ -432,44 +432,14 @@ DROP CLUSTER foo;
 ----
 COMPLETE 0
 
-# Test that the attribute check apply through role membership
+# Test that role attributes are not inherited through role membership
 
-# Parent
+## Parent
 
 simple conn=mz_system,user=mz_system
-ALTER ROLE joe NOCREATEROLE NOCREATEDB NOCREATECLUSTER
+ALTER ROLE joe NOCREATEROLE NOCREATEDB NOCREATECLUSTER;
 ----
 COMPLETE 0
-
-simple conn=joe,user=joe
-CREATE ROLE bar;
-----
-db error: ERROR: permission denied to create role
-DETAIL: You must have the CREATEROLE attribute to create role
-
-simple conn=joe,user=joe
-ALTER ROLE foo CREATECLUSTER;
-----
-db error: ERROR: permission denied to alter role
-DETAIL: You must have the CREATEROLE attribute to alter role
-
-simple conn=joe,user=joe
-DROP ROLE foo;
-----
-db error: ERROR: permission denied to drop roles
-DETAIL: You must have the CREATEROLE attribute to drop roles
-
-simple conn=joe,user=joe
-CREATE DATABASE foo;
-----
-db error: ERROR: permission denied to create database
-DETAIL: You must have the CREATEDB attribute to create database
-
-simple conn=joe,user=joe
-CREATE CLUSTER foo REPLICAS (r1 (size '1'));
-----
-db error: ERROR: permission denied to create cluster
-DETAIL: You must have the CREATECLUSTER attribute to create cluster
 
 simple conn=mz_system,user=mz_system
 CREATE ROLE joe_parent CREATEROLE CREATEDB CREATECLUSTER
@@ -484,52 +454,47 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE ROLE bar;
 ----
-COMPLETE 0
+db error: ERROR: permission denied to create role
+DETAIL: You must have the CREATEROLE attribute to create role
 
 simple conn=joe,user=joe
 ALTER ROLE foo CREATECLUSTER;
 ----
-COMPLETE 0
+db error: ERROR: permission denied to alter role
+DETAIL: You must have the CREATEROLE attribute to alter role
 
 simple conn=joe,user=joe
 DROP ROLE foo;
 ----
-COMPLETE 0
+db error: ERROR: permission denied to drop roles
+DETAIL: You must have the CREATEROLE attribute to drop roles
 
 simple conn=joe,user=joe
 CREATE DATABASE foo;
 ----
-COMPLETE 0
+db error: ERROR: permission denied to create database
+DETAIL: You must have the CREATEDB attribute to create database
 
 simple conn=joe,user=joe
 CREATE CLUSTER foo REPLICAS (r1 (size '1'));
 ----
-COMPLETE 0
+db error: ERROR: permission denied to create cluster
+DETAIL: You must have the CREATECLUSTER attribute to create cluster
 
-simple conn=mz_system,user=mz_system
-DROP ROLE bar;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-CREATE ROLE foo;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-DROP DATABASE foo;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-DROP CLUSTER foo;
-----
-COMPLETE 0
-
-# Grandparent
+## Grandparent
 
 simple conn=mz_system,user=mz_system
 ALTER ROLE joe_parent NOCREATEROLE NOCREATEDB NOCREATECLUSTER
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE joe_grandparent CREATEROLE CREATEDB CREATECLUSTER
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT joe_grandparent TO joe_parent
 ----
 COMPLETE 0
 
@@ -563,61 +528,6 @@ CREATE CLUSTER foo REPLICAS (r1 (size '1'));
 db error: ERROR: permission denied to create cluster
 DETAIL: You must have the CREATECLUSTER attribute to create cluster
 
-simple conn=mz_system,user=mz_system
-CREATE ROLE joe_grandparent CREATEROLE CREATEDB CREATECLUSTER
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-GRANT joe_grandparent TO joe_parent
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-CREATE ROLE bar;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-ALTER ROLE foo CREATECLUSTER;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-DROP ROLE foo;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-CREATE DATABASE foo;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-CREATE CLUSTER foo REPLICAS (r1 (size '1'));
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-DROP ROLE bar;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-CREATE ROLE foo;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-DROP DATABASE foo;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-DROP CLUSTER foo;
-----
-COMPLETE 0
-
 # Check if INHERIT works
 
 simple conn=mz_system,user=mz_system
@@ -627,61 +537,6 @@ COMPLETE 0
 
 simple conn=mz_system,user=mz_system
 CREATE ROLE joeson INHERIT
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-GRANT joe to joeson
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER ROLE joe CREATEROLE CREATEDB CREATECLUSTER
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-CREATE ROLE bar;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-ALTER ROLE foo CREATECLUSTER;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-DROP ROLE foo;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-CREATE DATABASE foo;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-CREATE CLUSTER foo REPLICAS (r1 (size '1'));
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-DROP ROLE bar;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-CREATE ROLE foo;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-DROP DATABASE foo;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-DROP CLUSTER foo;
 ----
 COMPLETE 0
 


### PR DESCRIPTION
Previously, roles inherited role attributes of all their member roles. This was incorrect and not has PostgreSQL works. This commit removes this inheritance.

Part of #11579

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
