### PR TITLE
sql: support join_using_alias

### DIFF
--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -647,10 +647,15 @@ impl<T: AstInfo> AstDisplay for Join<T> {
                             f.write_str(" ON ");
                             f.write_node(expr);
                         }
-                        JoinConstraint::Using(attrs) => {
+                        JoinConstraint::Using { columns, alias } => {
                             f.write_str(" USING (");
-                            f.write_node(&display::comma_separated(attrs));
+                            f.write_node(&display::comma_separated(columns));
                             f.write_str(")");
+
+                            if let Some(join_using_alias) = alias {
+                                f.write_str(" AS ");
+                                f.write_node(join_using_alias);
+                            }
                         }
                         _ => {}
                     }
@@ -708,7 +713,10 @@ pub enum JoinOperator<T: AstInfo> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum JoinConstraint<T: AstInfo> {
     On(Expr<T>),
-    Using(Vec<Ident>),
+    Using {
+        columns: Vec<Ident>,
+        alias: Option<Ident>,
+    },
     Natural,
 }
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5379,6 +5379,25 @@ impl<'a> Parser<'a> {
         })
     }
 
+    fn parse_join_using_alias(&mut self, column_names: Vec<Ident>) -> Result<Option<Ident>, ParserError> {
+        if self.parse_keyword(AS) {
+            return match self.next_token() {
+                // Accept any identifier after `AS`, including keywords.
+                Some(Token::Keyword(kw)) => Ok(Some(kw.into_ident())),
+                Some(Token::Ident(id)) => Ok(Some(Ident::new(id))),
+                not_an_ident => {
+                    return self.expected(
+                        self.peek_prev_pos(),
+                        "an identifier after AS",
+                        not_an_ident,
+                    );
+                }
+            };
+        }
+
+        Ok(None)
+    }
+
     fn parse_join_constraint(&mut self, natural: bool) -> Result<JoinConstraint<Raw>, ParserError> {
         if natural {
             Ok(JoinConstraint::Natural)
@@ -5387,7 +5406,8 @@ impl<'a> Parser<'a> {
             Ok(JoinConstraint::On(constraint))
         } else if self.parse_keyword(USING) {
             let columns = self.parse_parenthesized_column_list(Mandatory)?;
-            Ok(JoinConstraint::Using(columns))
+            let alias = self.parse_join_using_alias(columns.clone())?;
+            Ok(JoinConstraint::Using { columns, alias })
         } else {
             self.expected(
                 self.peek_pos(),

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -597,14 +597,14 @@ SELECT * FROM t1 JOIN t2 AS foo USING (c1)
 ----
 SELECT * FROM t1 JOIN t2 AS foo USING (c1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: Some(TableAlias { name: Ident("foo"), columns: [], strict: false }) }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: Some(TableAlias { name: Ident("foo"), columns: [], strict: false }) }, join_operator: Inner(Using { columns: [Ident("c1")], alias: None }) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 JOIN t2 foo USING (c1)
 ----
 SELECT * FROM t1 JOIN t2 AS foo USING (c1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: Some(TableAlias { name: Ident("foo"), columns: [], strict: false }) }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: Some(TableAlias { name: Ident("foo"), columns: [], strict: false }) }, join_operator: Inner(Using { columns: [Ident("c1")], alias: None }) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 NATURAL JOIN t2
@@ -646,7 +646,7 @@ SELECT c1, c2 FROM t1, t4 JOIN t2 ON t2.c = t1.c LEFT JOIN t3 USING (q, c) WHERE
 ----
 SELECT c1, c2 FROM t1, t4 JOIN t2 ON t2.c = t1.c LEFT JOIN t3 USING (q, c) WHERE t4.c = t1.c
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }, Expr { expr: Identifier([Ident("c2")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t4")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: Inner(On(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("t2"), Ident("c")]), expr2: Some(Identifier([Ident("t1"), Ident("c")])) })) }, Join { relation: Table { name: Name(UnresolvedItemName([Ident("t3")])), alias: None }, join_operator: LeftOuter(Using([Ident("q"), Ident("c")])) }] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("t4"), Ident("c")]), expr2: Some(Identifier([Ident("t1"), Ident("c")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }, Expr { expr: Identifier([Ident("c2")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t4")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: Inner(On(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("t2"), Ident("c")]), expr2: Some(Identifier([Ident("t1"), Ident("c")])) })) }, Join { relation: Table { name: Name(UnresolvedItemName([Ident("t3")])), alias: None }, join_operator: LeftOuter(Using { columns: [Ident("q"), Ident("c")], alias: None }) }] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("t4"), Ident("c")]), expr2: Some(Identifier([Ident("t1"), Ident("c")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM a NATURAL JOIN (b NATURAL JOIN (c NATURAL JOIN d NATURAL JOIN e)) NATURAL JOIN (f NATURAL JOIN (g NATURAL JOIN h))
@@ -695,28 +695,64 @@ SELECT c1 FROM t1 INNER JOIN t2 USING (c1)
 ----
 SELECT c1 FROM t1 JOIN t2 USING (c1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: Inner(Using { columns: [Ident("c1")], alias: None }) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT x.c1 FROM t1 INNER JOIN t2 USING (c1) AS x
+----
+SELECT x.c1 FROM t1 JOIN t2 USING (c1) AS x
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("x"), Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: Inner(Using { columns: [Ident("c1")], alias: Some(Ident("x")) }) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
 
 parse-statement
 SELECT c1 FROM t1 LEFT OUTER JOIN t2 USING (c1)
 ----
 SELECT c1 FROM t1 LEFT JOIN t2 USING (c1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: LeftOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: LeftOuter(Using { columns: [Ident("c1")], alias: None }) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT x.c1 FROM t1 LEFT OUTER JOIN t2 USING (c1) AS x
+----
+SELECT x.c1 FROM t1 LEFT JOIN t2 USING (c1) AS x
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("x"), Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: LeftOuter(Using { columns: [Ident("c1")], alias: Some(Ident("x")) }) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT c1 FROM t1 RIGHT OUTER JOIN t2 USING (c1)
 ----
 SELECT c1 FROM t1 RIGHT JOIN t2 USING (c1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: RightOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: RightOuter(Using { columns: [Ident("c1")], alias: None }) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT x.c1 FROM t1 RIGHT OUTER JOIN t2 USING (c1) AS x
+----
+SELECT x.c1 FROM t1 RIGHT JOIN t2 USING (c1) AS x
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("x"), Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: RightOuter(Using { columns: [Ident("c1")], alias: Some(Ident("x")) }) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT c1 FROM t1 FULL OUTER JOIN t2 USING (c1)
 ----
 SELECT c1 FROM t1 FULL JOIN t2 USING (c1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: FullOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: FullOuter(Using { columns: [Ident("c1")], alias: None }) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT x.c1 FROM t1 FULL OUTER JOIN t2 USING (c1) AS x
+----
+SELECT x.c1 FROM t1 FULL JOIN t2 USING (c1) AS x
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("x"), Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t1")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t2")])), alias: None }, join_operator: FullOuter(Using { columns: [Ident("c1")], alias: Some(Ident("x")) }) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM t1 JOIN t2 USING (c1) AS
+----
+error: Expected identifier, found EOF
+SELECT * FROM t1 JOIN t2 USING (c1) AS
+                                      ^
 
 parse-statement
 SELECT * FROM a OUTER JOIN b ON 1

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2954,7 +2954,7 @@ fn plan_join(
 
     let (expr, scope) = match constraint {
         JoinConstraint::On(expr) => {
-            let product_scope: Scope = left_scope.product(right_scope)?;
+            let product_scope = left_scope.product(right_scope)?;
             let ecx = &ExprContext {
                 qcx: left_qcx,
                 name: "ON clause",

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3142,10 +3142,14 @@ fn plan_using_constraint(
                 item: alias_name.clone().to_string(),
             };
 
+            let new_item_col = both_scope.items.len() + new_items.len();
+            join_cols.push(new_item_col);
+            hidden_cols.push(new_item_col);
+
             new_items.push(ScopeItem::from_name(Some(new_item), column_name.clone().to_string()));
 
-            // Should be able to use either `lhs` or `rhs` here since the column
-            // is available in both scopes
+            // Should be safe to use either `lhs` or `rhs` here since the column
+            // is available in both scopes and must have the same type of the new item.
             map_exprs.push(HirScalarExpr::Column(lhs));
         }
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2992,7 +2992,7 @@ fn plan_join(
                 kind,
                 alias.as_ref(),
             )?
-        },
+        }
         JoinConstraint::Natural => {
             // We shouldn't need to set ambiguous_columns on both the right and left qcx since they
             // have the same scx. However, it doesn't hurt to be safe.
@@ -3146,7 +3146,10 @@ fn plan_using_constraint(
             join_cols.push(new_item_col);
             hidden_cols.push(new_item_col);
 
-            new_items.push(ScopeItem::from_name(Some(new_item), column_name.clone().to_string()));
+            new_items.push(ScopeItem::from_name(
+                Some(new_item),
+                column_name.clone().to_string(),
+            ));
 
             // Should be safe to use either `lhs` or `rhs` here since the column
             // is available in both scopes and must have the same type of the new item.

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3122,11 +3122,19 @@ fn plan_using_constraint(
         // Unlike regular table aliases, a `join_using_alias` should not hide the
         // names of the joined relations.
         if let Some(alias_name) = alias {
-            new_items.push(ScopeItem::from_name(Some(PartialItemName {
+            let new_item = PartialItemName {
                 database: None,
                 schema: None,
                 item: alias_name.clone().to_string(),
-            }), column_name.clone().to_string()));
+            };
+
+            for partial_item_name in both_scope.table_names() {
+                if partial_item_name.matches(&new_item) {
+                    sql_bail!("table name \"{}\" specified more than once", new_item)
+                }
+            }
+
+            new_items.push(ScopeItem::from_name(Some(new_item), column_name.clone().to_string()));
 
             // Should be able to use either `lhs` or `rhs` here since the column
             // is available in both scopes

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2954,7 +2954,7 @@ fn plan_join(
 
     let (expr, scope) = match constraint {
         JoinConstraint::On(expr) => {
-            let product_scope = left_scope.product(right_scope)?;
+            let product_scope: Scope = left_scope.product(right_scope)?;
             let ecx = &ExprContext {
                 qcx: left_qcx,
                 name: "ON clause",
@@ -2975,19 +2975,24 @@ fn plan_join(
             let joined = left.join(right, on, kind);
             (joined, product_scope)
         }
-        JoinConstraint::Using(column_names) => plan_using_constraint(
-            &column_names
+        JoinConstraint::Using { columns, alias } => {
+            let column_names = &columns
                 .iter()
                 .map(|ident| normalize::column_name(ident.clone()))
-                .collect::<Vec<_>>(),
-            left_qcx,
-            left,
-            left_scope,
-            &right_qcx,
-            right,
-            right_scope,
-            kind,
-        )?,
+                .collect::<Vec<_>>();
+
+            plan_using_constraint(
+                &column_names,
+                left_qcx,
+                left,
+                left_scope,
+                &right_qcx,
+                right,
+                right_scope,
+                kind,
+                alias.as_ref(),
+            )?
+        },
         JoinConstraint::Natural => {
             // We shouldn't need to set ambiguous_columns on both the right and left qcx since they
             // have the same scx. However, it doesn't hurt to be safe.
@@ -3008,6 +3013,7 @@ fn plan_join(
                 right,
                 right_scope,
                 kind,
+                None,
             )?
         }
     };
@@ -3025,6 +3031,7 @@ fn plan_using_constraint(
     right: HirRelationExpr,
     right_scope: Scope,
     kind: JoinKind,
+    alias: Option<&Ident>,
 ) -> Result<(HirRelationExpr, Scope), PlanError> {
     let mut both_scope = left_scope.clone().product(right_scope.clone())?;
 
@@ -3108,6 +3115,22 @@ fn plan_using_constraint(
                 });
                 new_items.push(ScopeItem::from_column_name(column_name));
             }
+        }
+
+        // If a `join_using_alias` is present, add a new scope item that accepts
+        // only table-qualified references for each specified join column.
+        // Unlike regular table aliases, a `join_using_alias` should not hide the
+        // names of the joined relations.
+        if let Some(alias_name) = alias {
+            new_items.push(ScopeItem::from_name(Some(PartialItemName {
+                database: None,
+                schema: None,
+                item: alias_name.clone().to_string(),
+            }), column_name.clone().to_string()));
+
+            // Should be able to use either `lhs` or `rhs` here since the column
+            // is available in both scopes
+            map_exprs.push(HirScalarExpr::Column(lhs))
         }
 
         join_exprs.push(HirScalarExpr::CallBinary {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2976,7 +2976,7 @@ fn plan_join(
             (joined, product_scope)
         }
         JoinConstraint::Using { columns, alias } => {
-            let column_names = &columns
+            let column_names = columns
                 .iter()
                 .map(|ident| normalize::column_name(ident.clone()))
                 .collect::<Vec<_>>();

--- a/src/sql/src/plan/scope.rs
+++ b/src/sql/src/plan/scope.rs
@@ -432,7 +432,7 @@ impl Scope {
         }
     }
 
-    fn table_names(&self) -> BTreeSet<&PartialItemName> {
+    pub fn table_names(&self) -> BTreeSet<&PartialItemName> {
         self.items
             .iter()
             .filter_map(|name| name.table_name.as_ref())

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -688,38 +688,6 @@ SELECT f1, t1.f2 AS f1 FROM t1 JOIN t2 USING (f1) ORDER BY f1;
 query error  common column name "f2" appears more than once in left table
 SELECT * FROM t1 LEFT JOIN t2 USING (f1) RIGHT JOIN t3 USING (f2);
 
-# Test join using aliases
-# Adapted from: https://github.com/postgres/postgres/blob/master/src/test/regress/sql/join.sql
-
-query T
-SELECT * FROM t1 JOIN t2 USING (f1) AS x WHERE t1.f2 = 1;
-----
-
-query error column "t1.f1" does not exist
-SELECT * FROM (t1 JOIN t2 USING (f1)) AS x WHERE t1.f1 = 1;
-
-query T
-SELECT * FROM t1 JOIN t2 USING (f2) AS x WHERE x.f2 = 1;
-----
-
-query error column "x.f5" does not exist
-SELECT * FROM t1 JOIN t2 USING (f1) AS x WHERE x.f5 = 'one';
-
-query error column "x.f4" does not exist
-SELECT * FROM (t3 JOIN t4 USING (f3) AS x) AS xx WHERE x.f4 = 1;
-
-query error table name "a1" specified more than once
-SELECT * FROM t1 a1 JOIN t2 a2 USING (f1) AS a1
-
-query T
-SELECT x.* FROM t3 JOIN t4 USING (f3) AS x WHERE t3.f1 = 1;
-----
-
-query T
-SELECT ROW(x.*) FROM t1 JOIN t2 USING (f1) AS x WHERE t1.f1 = 1;
-----
-
-
 statement ok
 INSERT INTO t1 VALUES
     (1, 2),
@@ -756,6 +724,61 @@ statement ok
 INSERT INTO t4 VALUES
     (4, 3),
     (9, 10);
+
+# Test join using aliases
+# Adapted from: https://github.com/postgres/postgres/blob/master/src/test/regress/sql/join.sql
+
+query T
+SELECT * FROM t1 JOIN t2 USING (f1) AS x WHERE t1.f2 = 1;
+----
+
+query III colnames
+SELECT * FROM t1 JOIN t2 USING (f1) AS x WHERE t1.f1 = 3;
+----
+f1  f2  f2
+3   4   4
+
+query III colnames
+SELECT * FROM t1 JOIN t2 USING (f1) AS x;
+----
+f1  f2  f2
+3   4   4
+
+query II colnames
+SELECT * FROM t1 JOIN t2 USING (f1, f2) AS x;
+----
+f1  f2
+3   4
+
+query error column "t1.f1" does not exist
+SELECT * FROM (t1 JOIN t2 USING (f1)) AS x WHERE t1.f1 = 1;
+
+query error column "x.f5" does not exist
+SELECT * FROM t1 JOIN t2 USING (f1) AS x WHERE x.f5 = 'one';
+
+query error column "x.f4" does not exist
+SELECT * FROM (t3 JOIN t4 USING (f3) AS x) AS xx WHERE x.f4 = 1;
+
+query error table name "a1" specified more than once
+SELECT * FROM t1 a1 JOIN t2 a2 USING (f1) AS a1
+
+query I colnames
+SELECT x.* FROM t3 JOIN t4 USING (f3) AS x WHERE t3.f3 = 4;
+----
+f3
+4
+
+query II colnames
+SELECT x.* FROM t1 JOIN t2 USING (f1, f2) AS x;
+----
+f1  f2
+3   4
+
+query T colnames
+SELECT ROW(x.*) FROM t1 JOIN t2 USING (f1) AS x;
+----
+row
+("(3)")
 
 # Left
 

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -750,6 +750,21 @@ SELECT * FROM t1 JOIN t2 USING (f1, f2) AS x;
 f1  f2
 3   4
 
+query II colnames
+SELECT * FROM (SELECT x.f2 AS f3 FROM t1 JOIN t2 USING (f2) AS x) t5 JOIN t3 USING (f3) AS x;
+----
+f3  f1
+4   3
+
+query error table name "x" specified more than once
+SELECT * FROM t1 JOIN t2 USING (f1) AS x JOIN t3 USING (f1) AS x;
+
+query IIII colnames
+SELECT * FROM t1 JOIN t2 USING (f1) AS x JOIN t3 USING (f1) AS y;
+----
+f1  f2  f2  f3
+3   4   4   4
+
 query error column "t1.f1" does not exist
 SELECT * FROM (t1 JOIN t2 USING (f1)) AS x WHERE t1.f1 = 1;
 
@@ -779,6 +794,31 @@ SELECT ROW(x.*) FROM t1 JOIN t2 USING (f1) AS x;
 ----
 row
 ("(3)")
+
+statement ok
+CREATE VIEW v1 AS SELECT x.* FROM t1 JOIN t2 USING (f1) AS x WHERE x.f1 = 3;
+
+query T colnames
+SELECT * FROM v1;
+----
+f1
+3
+
+# Ensure the output from `SHOW CREATE VIEW` contains a correctly-formed `AS` part
+
+mode standard
+
+query TT
+SHOW CREATE VIEW v1;
+----
+materialize.public.v1
+CREATE VIEW "materialize"."public"."v1" AS SELECT "x".* FROM "materialize"."public"."t1" JOIN "materialize"."public"."t2" USING ("f1") AS "x" WHERE "x"."f1" = 3
+
+mode cockroach
+
+statement ok
+DROP VIEW v1;
+
 
 # Left
 

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -688,6 +688,38 @@ SELECT f1, t1.f2 AS f1 FROM t1 JOIN t2 USING (f1) ORDER BY f1;
 query error  common column name "f2" appears more than once in left table
 SELECT * FROM t1 LEFT JOIN t2 USING (f1) RIGHT JOIN t3 USING (f2);
 
+# Test join using aliases
+# Adapted from: https://github.com/postgres/postgres/blob/master/src/test/regress/sql/join.sql
+
+query T
+SELECT * FROM t1 JOIN t2 USING (f1) AS x WHERE t1.f2 = 1;
+----
+
+query error column "t1.f1" does not exist
+SELECT * FROM (t1 JOIN t2 USING (f1)) AS x WHERE t1.f1 = 1;
+
+query T
+SELECT * FROM t1 JOIN t2 USING (f2) AS x WHERE x.f2 = 1;
+----
+
+query error column "x.f5" does not exist
+SELECT * FROM t1 JOIN t2 USING (f1) AS x WHERE x.f5 = 'one';
+
+query error column "x.f4" does not exist
+SELECT * FROM (t3 JOIN t4 USING (f3) AS x) AS xx WHERE x.f4 = 1;
+
+query error table name "a1" specified more than once
+SELECT * FROM t1 a1 JOIN t2 a2 USING (f1) AS a1
+
+query T
+SELECT x.* FROM t3 JOIN t4 USING (f3) AS x WHERE t3.f1 = 1;
+----
+
+query T
+SELECT ROW(x.*) FROM t1 JOIN t2 USING (f1) AS x WHERE t1.f1 = 1;
+----
+
+
 statement ok
 INSERT INTO t1 VALUES
     (1, 2),


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Solves #16910

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

- Made `table_names()` public in `Scope`. Not sure if its privacy is intentional and we should try to not expose it.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds support for optional join using aliases
