### PR TITLE
Surface OOMs in `mz_cluster_replica_statuses`

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -913,7 +913,7 @@ impl CatalogState {
             process_status: (0..config.location.num_processes())
                 .map(|process_id| {
                     let status = ClusterReplicaProcessStatus {
-                        status: ClusterStatus::NotReady,
+                        status: ClusterStatus::NotReady(None),
                         time: to_datetime((self.config.now)()),
                     };
                     (u64::cast_from(process_id), status)
@@ -1629,7 +1629,18 @@ impl ClusterReplica {
             .values()
             .fold(ClusterStatus::Ready, |s, p| match (s, p.status) {
                 (ClusterStatus::Ready, ClusterStatus::Ready) => ClusterStatus::Ready,
-                _ => ClusterStatus::NotReady,
+                (x, y) => {
+                    let reason_x = match x {
+                        ClusterStatus::NotReady(reason) => reason,
+                        ClusterStatus::Ready => None,
+                    };
+                    let reason_y = match y {
+                        ClusterStatus::NotReady(reason) => reason,
+                        ClusterStatus::Ready => None,
+                    };
+                    // Arbitrarily pick the first known not-ready reason.
+                    ClusterStatus::NotReady(reason_x.or(reason_y))
+                }
             })
     }
 }
@@ -1637,6 +1648,7 @@ impl ClusterReplica {
 #[derive(Debug, Serialize, Clone)]
 pub struct ClusterReplicaProcessStatus {
     pub status: ClusterStatus,
+
     pub time: DateTime<Utc>,
 }
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1648,7 +1648,6 @@ impl ClusterReplica {
 #[derive(Debug, Serialize, Clone)]
 pub struct ClusterReplicaProcessStatus {
     pub status: ClusterStatus,
-
     pub time: DateTime<Utc>,
 }
 

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1680,6 +1680,7 @@ pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| Builti
         .with_column("replica_id", ScalarType::String.nullable(false))
         .with_column("process_id", ScalarType::UInt64.nullable(false))
         .with_column("status", ScalarType::String.nullable(false))
+        .with_column("reason", ScalarType::String.nullable(true))
         .with_column("updated_at", ScalarType::TimestampTz.nullable(false)),
     is_retained_metrics_object: false,
 });

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -248,15 +248,12 @@ impl CatalogState {
         diff: Diff,
     ) -> BuiltinTableUpdate {
         let event = self.get_cluster_status(cluster_id, replica_id, process_id);
-        let status = match event.status {
-            ClusterStatus::Ready => "ready",
-            ClusterStatus::NotReady(_) => "not-ready",
-        };
+        let status = event.status.as_kebab_case_str();
 
         let not_ready_reason = match event.status {
             ClusterStatus::Ready => None,
             ClusterStatus::NotReady(None) => None,
-            ClusterStatus::NotReady(Some(NotReadyReason::OOMKilled)) => Some("oom-killed"),
+            ClusterStatus::NotReady(Some(NotReadyReason::OomKilled)) => Some("oom-killed"),
         };
 
         // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -108,7 +108,7 @@ impl AdapterNotice {
             AdapterNotice::ClusterReplicaStatusChanged { status, .. } => {
                 match status {
                     ServiceStatus::NotReady(None) => Some("The cluster replica may be restarting or going offline.".into()),
-                    ServiceStatus::NotReady(Some(NotReadyReason::OOMKilled)) => Some("The cluster replica may have run out of memory and been killed.".into()),
+                    ServiceStatus::NotReady(Some(NotReadyReason::OomKilled)) => Some("The cluster replica may have run out of memory and been killed.".into()),
                     ServiceStatus::Ready => None,
                 }
             },

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -857,7 +857,6 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 .ok_or_else(|| anyhow!("missing label: {service_id_label}"))?
                 .clone();
 
-            let pod2 = pod.clone();
             let oomed = pod
                 .status
                 .as_ref()
@@ -884,8 +883,6 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             let status = if pod_ready {
                 ServiceStatus::Ready
             } else {
-                println!("[btv] {pod2:#?}");
-                // XXX
                 if oomed {
                     ServiceStatus::NotReady(Some(NotReadyReason::OOMKilled))
                 } else {

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -883,11 +883,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             let status = if pod_ready {
                 ServiceStatus::Ready
             } else {
-                if oomed {
-                    ServiceStatus::NotReady(Some(NotReadyReason::OOMKilled))
-                } else {
-                    ServiceStatus::NotReady(None)
-                }
+                ServiceStatus::NotReady(oomed.then_some(NotReadyReason::OomKilled))
             };
             let time = if let Some(time) = last_probe_time {
                 time.0

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -811,7 +811,7 @@ enum ProcessStatus {
 impl From<ProcessStatus> for ServiceStatus {
     fn from(status: ProcessStatus) -> ServiceStatus {
         match status {
-            ProcessStatus::NotReady => ServiceStatus::NotReady,
+            ProcessStatus::NotReady => ServiceStatus::NotReady(None),
             ProcessStatus::Ready { .. } => ServiceStatus::Ready,
         }
     }

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -155,7 +155,7 @@ pub struct ServiceEvent {
 /// Why the service is not ready, if known
 #[derive(Debug, Clone, Copy, Serialize, Eq, PartialEq)]
 pub enum NotReadyReason {
-    OOMKilled,
+    OomKilled,
 }
 
 /// Describes the status of an orchestrated service.

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -152,13 +152,21 @@ pub struct ServiceEvent {
     pub time: DateTime<Utc>,
 }
 
+/// Why the service is not ready, if known
+#[derive(Debug, Clone, Copy, Serialize, Eq, PartialEq)]
+pub enum NotReadyReason {
+    OOMKilled,
+}
+
 /// Describes the status of an orchestrated service.
 #[derive(Debug, Clone, Copy, Serialize, Eq, PartialEq)]
 pub enum ServiceStatus {
     /// Service is ready to accept requests.
     Ready,
     /// Service is not ready to accept requests.
-    NotReady,
+    /// The inner element is `None` if the reason
+    /// is unknown
+    NotReady(Option<NotReadyReason>),
 }
 
 impl ServiceStatus {
@@ -166,7 +174,7 @@ impl ServiceStatus {
     pub fn as_kebab_case_str(&self) -> &'static str {
         match self {
             ServiceStatus::Ready => "ready",
-            ServiceStatus::NotReady => "not-ready",
+            ServiceStatus::NotReady(_) => "not-ready",
         }
     }
 }


### PR DESCRIPTION
When reporting a pod status change, check whether it's due to OOM, and report this in `mz_cluster_replica_statuses` 

Tested manually. No automated tests because I don't know a way to force pods to OOM that doesn't take several minutes.

Partially fixes https://github.com/MaterializeInc/materialize/issues/18621