### PR TITLE
adapter: Remove the `enable_auto_route_introspection_queries` LD Flag

### DIFF
--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -7,8 +7,6 @@ menu:
 
 ---
 
-{{< show-command-note >}}
-
 `SHOW CLUSTER REPLICAS` lists the [replicas](/overview/key-concepts/#cluster-replicas) for each cluster configured in Materialize. A cluster named `default` with a single replica named `r1` will exist in every environment; this cluster can be dropped at any time.
 
 ## Syntax

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -7,8 +7,6 @@ menu:
 
 ---
 
-{{< show-command-note >}}
-
 `SHOW CLUSTERS` lists the [clusters](/overview/key-concepts/#clusters) configured in Materialize.
 
 ## Syntax

--- a/doc/user/content/sql/show-columns.md
+++ b/doc/user/content/sql/show-columns.md
@@ -8,8 +8,6 @@ aliases:
     - /sql/show-column
 ---
 
-{{< show-command-note >}}
-
 `SHOW COLUMNS` lists the columns available from an item&mdash;either sources, materialized views, or non-materialized views.
 
 ## Syntax

--- a/doc/user/content/sql/show-connections.md
+++ b/doc/user/content/sql/show-connections.md
@@ -8,8 +8,6 @@ aliases:
     - /sql/show-connection
 ---
 
-{{< show-command-note >}}
-
 `SHOW CONNECTIONS` lists the connections configured in Materialize.
 
 ## Syntax

--- a/doc/user/content/sql/show-databases.md
+++ b/doc/user/content/sql/show-databases.md
@@ -6,8 +6,6 @@ menu:
     parent: commands
 ---
 
-{{< show-command-note >}}
-
 `SHOW DATABASES` returns a list of all databases available to your Materialize
 instances.
 

--- a/doc/user/content/sql/show-indexes.md
+++ b/doc/user/content/sql/show-indexes.md
@@ -6,8 +6,6 @@ menu:
     parent: commands
 ---
 
-{{< show-command-note >}}
-
 `SHOW INDEXES` provides details about indexes built on a source, view, or materialized view.
 
 ## Syntax

--- a/doc/user/content/sql/show-materialized-views.md
+++ b/doc/user/content/sql/show-materialized-views.md
@@ -6,8 +6,6 @@ menu:
     parent: commands
 ---
 
-{{< show-command-note >}}
-
 `SHOW MATERIALIZED VIEWS` returns a list of materialized views being maintained
 in Materialize.
 

--- a/doc/user/content/sql/show-objects.md
+++ b/doc/user/content/sql/show-objects.md
@@ -8,8 +8,6 @@ aliases:
     - /sql/show-object
 ---
 
-{{< show-command-note >}}
-
 `SHOW OBJECTS` returns a list of all objects available to your Materialize instances in a given schema.
 Objects include tables, sources, sinks, views, indexes, secrets and connections.
 

--- a/doc/user/content/sql/show-schemas.md
+++ b/doc/user/content/sql/show-schemas.md
@@ -6,8 +6,6 @@ menu:
     parent: commands
 ---
 
-{{< show-command-note >}}
-
 `SHOW SCHEMAS` returns a list of all schemas available to your Materialize
 instances.
 

--- a/doc/user/content/sql/show-secrets.md
+++ b/doc/user/content/sql/show-secrets.md
@@ -6,8 +6,6 @@ menu:
     parent: commands
 ---
 
-{{< show-command-note >}}
-
 `SHOW SECRETS` lists the names of the secrets securely stored in Materialize's secret management system. There is no way to show the contents of an existing secret, though you can override it using the [`ALTER SECRET`](../alter-secret) statement.
 
 ## Syntax

--- a/doc/user/content/sql/show-sinks.md
+++ b/doc/user/content/sql/show-sinks.md
@@ -8,8 +8,6 @@ aliases:
     - /sql/show-sink
 ---
 
-{{< show-command-note >}}
-
 `SHOW SINKS` returns a list of all sinks available to your Materialize instances.
 
 ## Syntax

--- a/doc/user/content/sql/show-sources.md
+++ b/doc/user/content/sql/show-sources.md
@@ -6,8 +6,6 @@ menu:
     parent: commands
 ---
 
-{{< show-command-note >}}
-
 `SHOW SOURCES` returns a list of all sources available to your Materialize
 instances.
 

--- a/doc/user/content/sql/show-tables.md
+++ b/doc/user/content/sql/show-tables.md
@@ -6,8 +6,6 @@ menu:
     parent: commands
 ---
 
-{{< show-command-note >}}
-
 `SHOW TABLES` returns a list of all tables available to your Materialize instances.
 
 ## Syntax

--- a/doc/user/content/sql/show-types.md
+++ b/doc/user/content/sql/show-types.md
@@ -6,8 +6,6 @@ menu:
     parent: commands
 ---
 
-{{< show-command-note >}}
-
 `SHOW TYPES` returns a list of the data types in your Materialize instance. By default, only custom types are returned.
 
 ## Syntax

--- a/doc/user/content/sql/show-views.md
+++ b/doc/user/content/sql/show-views.md
@@ -6,8 +6,6 @@ menu:
     parent: commands
 ---
 
-{{< show-command-note >}}
-
 `SHOW VIEWS` returns a list of views in your Materialize instances.
 
 ## Syntax

--- a/doc/user/layouts/shortcodes/show-command-note.html
+++ b/doc/user/layouts/shortcodes/show-command-note.html
@@ -1,4 +1,0 @@
-<div class="note">
-  <strong class="gutter">NOTE!</strong>
-  For improved performance, execute this command in the <code>mz_introspection</code> cluster. To switch clusters, use <code>SET CLUSTER = mz_introspection;</code>.
-</div>

--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -159,7 +159,6 @@ mod tests {
         let vars = SystemVars::default();
         let sync = SynchronizedParameters::new(vars);
 
-        // A smoke test to ensure the variables we want to get synced, are getting synced
-        assert!(sync.is_synchronized("enable_auto_route_introspection_queries"));
+        assert!(!sync.synchronized().is_empty());
     }
 }

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -39,15 +39,8 @@ pub fn auto_run_on_introspection<'a, 's>(
     session: &'s mut Session,
     depends_on: impl IntoIterator<Item = GlobalId>,
 ) -> Option<&'a Cluster> {
-    // We consider the feature to be enabled if we're in unsafe mode (e.g. testing) or
-    // the LaunchDarkly flag is set (e.g. in prod).
-    let feature_enabled = catalog.unsafe_mode()
-        || catalog
-            .system_config()
-            .enable_auto_route_introspection_queries();
-
-    // Bail if the feature isn't enabled, or the user has disabled it via the SessionVar.
-    if !feature_enabled || !session.vars().auto_route_introspection_queries() {
+    // Bail if the user has disabled it via the SessionVar.
+    if !session.vars().auto_route_introspection_queries() {
         return None;
     }
 

--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -245,7 +245,7 @@ http
 {"query":"SHOW VIEWS"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[["v"]],"col_names":["name"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[["v"]],"col_names":["name"],"notices":[{"message":"query was automatically run on the \"mz_introspection\" cluster","severity":"debug"}]}]}
 
 http
 {"query":"SET cluster = default"}

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -708,21 +708,6 @@ pub const ENABLE_SESSION_RBAC_CHECKS: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
-/// This is separate from the [`AUTO_ROUTE_INTROSPECTION_QUERIES`] `ServerVar` so we can
-/// independently roll out this feature via LaunchDarkly without effecting user's ability
-/// to disable the behavior for there sessions.
-pub const ENABLE_AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_auto_route_introspection_queries"),
-    value: &false,
-    description:
-        "Whether the feature to force queries that depends only on system tables to run on the mz_introspection cluster, is enabled (Materialize).",
-    internal: true,
-    safe: true,
-};
-
-/// This is separate from the [`ENABLE_AUTO_ROUTE_INTROSPECTION_QUERIES`] `ServerVar` so we
-/// can independently roll out this feature via LaunchDarkly. Users can set this var as
-/// a session variable, while we can control the feature overall with the former.
 pub const AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("auto_route_introspection_queries"),
     value: &true,
@@ -1461,7 +1446,6 @@ impl Default for SystemVars {
             .with_var(&ENABLE_WITH_MUTUALLY_RECURSIVE)
             .with_var(&ENABLE_LD_RBAC_CHECKS)
             .with_var(&ENABLE_RBAC_CHECKS)
-            .with_var(&ENABLE_AUTO_ROUTE_INTROSPECTION_QUERIES)
             .with_var(&PG_REPLICATION_CONNECT_TIMEOUT)
             .with_var(&PG_REPLICATION_KEEPALIVES_IDLE)
             .with_var(&PG_REPLICATION_KEEPALIVES_INTERVAL)
@@ -1793,13 +1777,6 @@ impl SystemVars {
     /// Returns the `enable_rbac_checks` configuration parameter.
     pub fn enable_rbac_checks(&self) -> bool {
         *self.expect_value(&ENABLE_RBAC_CHECKS)
-    }
-
-    /// Returns the `enable_auto_route_introspection_queries` configuration parameter.
-    ///
-    /// Note: this is generally intended to be set via LaunchDarkly
-    pub fn enable_auto_route_introspection_queries(&self) -> bool {
-        *self.expect_value(&ENABLE_AUTO_ROUTE_INTROSPECTION_QUERIES)
     }
 }
 


### PR DESCRIPTION
### Motivation

Fixes #18457 

This PR removes the `ENABLE_AUTO_ROUTE_INTROSPECTION_QUERIES` LaunchDarkly flag that was introduced to gate #18310. The original feature shipped with `v0.49` and this PR should be included in `v0.52`, so the feature will have had 3 weeks of bake time.

In addition to removing the LD flag, we also remove the note from our docs that indicates users should set their cluster to `mz_introspection`. With this feature the documented queries get automatically run on this cluster.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Queries that only depend on system tables, e.g. the `SHOW ...` commands, will automatically get run on the `mz_introspection` cluster, which contain in-memory indexes on these tables to speed up the execution.
