### PR TITLE
docs: Update CREATEROLE attribute docs

### DIFF
--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -23,8 +23,8 @@ Field               | Use
 --------------------|-------------------------------------------------------------------------
 _role_name_         | A name for the role.
 **INHERIT**         | Grants the role the ability to inheritance of privileges of other roles.
-**CREATEROLE**      | Grants the role the ability to create, alter, and delete roles.
-**NOCREATEROLE**    | Denies the role the ability to create, alter, and delete roles.
+**CREATEROLE**      | Grants the role the ability to create, alter, delete roles and the ability to grant and revoke role membership. This attribute is very powerful. It allows roles to grant and revoke membership in other roles, even if it doesn't have explicit membership in those roles. As a consequence, any role with this attribute can obtain the privileges of any other role in the system.
+**NOCREATEROLE**    | Denies the role the ability to create, alter, delete roles and the ability to grant and revoke role membership.
 **CREATEDB**        | Grants the role the ability to create databases.
 **NOCREATEDB**      | Denies the role the ability to create databases.
 **CREATECLUSTER**   | Grants the role the ability to create clusters.

--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -24,7 +24,7 @@ Field               | Use
 _role_name_         | A name for the role.
 **INHERIT**         | Grants the role the ability to inheritance of privileges of other roles.
 **CREATEROLE**      | Grants the role the ability to create, alter, delete roles and the ability to grant and revoke role membership. This attribute is very powerful. It allows roles to grant and revoke membership in other roles, even if it doesn't have explicit membership in those roles. As a consequence, any role with this attribute can obtain the privileges of any other role in the system.
-**NOCREATEROLE**    | Denies the role the ability to create, alter, delete roles and the ability to grant and revoke role membership.
+**NOCREATEROLE**    | Denies the role the ability to create, alter, delete roles or grant and revoke role membership.
 **CREATEDB**        | Grants the role the ability to create databases.
 **NOCREATEDB**      | Denies the role the ability to create databases.
 **CREATECLUSTER**   | Grants the role the ability to create clusters.

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -27,7 +27,7 @@ Field               | Use
 _role_name_         | A name for the role.
 **INHERIT**         | Grants the role the ability to inheritance of privileges of other roles.
 **CREATEROLE**      | Grants the role the ability to create, alter, delete roles and the ability to grant and revoke role membership. This attribute is very powerful. It allows roles to grant and revoke membership in other roles, even if it doesn't have explicit membership in those roles. As a consequence, any role with this attribute can obtain the privileges of any other role in the system.
-**NOCREATEROLE**    | Denies the role the ability to create, alter, delete roles and the ability to grant and revoke role membership.
+**NOCREATEROLE**    | Denies the role the ability to create, alter, delete roles or grant and revoke role membership.
 **CREATEDB**        | Grants the role the ability to create databases.
 **NOCREATEDB**      | Denies the role the ability to create databases.
 **CREATECLUSTER**   | Grants the role the ability to create clusters.

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -26,8 +26,8 @@ Field               | Use
 --------------------|-------------------------------------------------------------------------
 _role_name_         | A name for the role.
 **INHERIT**         | Grants the role the ability to inheritance of privileges of other roles.
-**CREATEROLE**      | Grants the role the ability to create, alter, and delete roles.
-**NOCREATEROLE**    | Denies the role the ability to create, alter, and delete roles.
+**CREATEROLE**      | Grants the role the ability to create, alter, delete roles and the ability to grant and revoke role membership. This attribute is very powerful. It allows roles to grant and revoke membership in other roles, even if it doesn't have explicit membership in those roles. As a consequence, any role with this attribute can obtain the privileges of any other role in the system.
+**NOCREATEROLE**    | Denies the role the ability to create, alter, delete roles and the ability to grant and revoke role membership.
 **CREATEDB**        | Grants the role the ability to create databases.
 **NOCREATEDB**      | Denies the role the ability to create databases.
 **CREATECLUSTER**   | Grants the role the ability to create clusters.


### PR DESCRIPTION
### Motivation
Update docs.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
