### PR TITLE
coverage: Ignore lines that can't be covered

### DIFF
--- a/misc/python/materialize/cli/ci_coverage_pr_report.py
+++ b/misc/python/materialize/cli/ci_coverage_pr_report.py
@@ -50,12 +50,12 @@ def find_modified_lines() -> Coverage:
         line = line_raw.decode("utf-8")
         # +++ b/src/adapter/src/coord/command_handler.rs
         if line.startswith("+++"):
+            file = line.removeprefix("+++ b/")
             if not line.endswith(".rs"):
                 continue
-            file = line.removeprefix("+++ b/")
             coverage[file] = OrderedDict()
         # @@ -641,7 +640,6 @@ impl Coordinator {
-        elif line.startswith("@@ ") and file:
+        elif line.startswith("@@ ") and file in coverage:
             # We only care about the second value ("+640,6" in the example),
             # which contains the line number and length of the modified block
             # in new code state.


### PR DESCRIPTION
See the comment line here for example:
https://buildkite.com/materialize/coverage/builds/22#01878e65-e544-4217-a19e-55fe86c699d4

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
