### PR TITLE
Add test for `oom-killed` reason in `mz_cluster_replica_statuses`

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -145,7 +145,7 @@ class K8sService(K8sResource):
         self,
         port: Optional[str] = None,
         user: str = "materialize",
-        autocommit: bool = True
+        autocommit: bool = True,
     ) -> Cursor:
         """Get a cursor to run SQL queries against the service"""
         conn = self.sql_conn(port=port, user=user)

--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -145,10 +145,11 @@ class K8sService(K8sResource):
         self,
         port: Optional[str] = None,
         user: str = "materialize",
+        autocommit: bool = True
     ) -> Cursor:
         """Get a cursor to run SQL queries against the service"""
         conn = self.sql_conn(port=port, user=user)
-        conn.autocommit = True
+        conn.autocommit = autocommit
         return conn.cursor()
 
     def sql(

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -849,7 +849,6 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         fn into_service_event(pod: Pod) -> Result<ServiceEvent, anyhow::Error> {
             let process_id = pod.name_any().split('-').last().unwrap().parse()?;
             let service_id_label = "environmentd.materialize.cloud/service-id";
-            println!("[btv] pod: {pod:#?}");
             let service_id = pod
                 .labels()
                 .get(service_id_label)

--- a/test/cloudtest/test_replica_restart.py
+++ b/test/cloudtest/test_replica_restart.py
@@ -51,22 +51,18 @@ def assert_notice(conn: Connection, contains: bytes) -> None:
 
 
 def test_oom_clusterd(mz: MaterializeApplication) -> None:
-    def verify_status(expected_status: str, expected_reason: Optional[str]) -> None:
-        while True:
-            (status, reason) = mz.environmentd.sql_query(
-                """
-SELECT status, reason FROM mz_internal.mz_cluster_replica_statuses mcrs
+    def verify_cluster_oomed() -> None:
+        with mz.environmentd.sql_cursor(autocommit=False) as cur:
+            cur.execute("SET CLUSTER=mz_introspection")
+            cur.execute("""DECLARE c CURSOR FOR SUBSCRIBE TO (SELECT status, reason FROM mz_internal.mz_cluster_replica_statuses mcrs
 JOIN mz_cluster_replicas mcr ON mcrs.replica_id = mcr.id
 JOIN mz_clusters mc ON mcr.cluster_id = mc.id
-WHERE mc.name = 'default'
-            """
-            )[0]
-            if status == expected_status and reason == expected_reason:
-                break
-            else:
-                print(f"Got {status}, {reason}; expected {expected_status}, {expected_reason}");
-            
-            time.sleep(1)
+WHERE mc.name = 'default')""")
+            while True:
+                cur.execute("FETCH ALL c")
+                for (_ts, _diff, status, reason) in cur.fetchall():
+                    if status == 'not-ready' and reason == 'oom-killed':
+                        return
 
     mz.environmentd.sql("DROP VIEW IF EXISTS v CASCADE")
     # Once we create an index on this view, it is practically guaranteed to OOM
@@ -79,14 +75,11 @@ SELECT repeat('abc' || x || y, 1000000) FROM
     """
     )
     mz.environmentd.sql("CREATE DEFAULT INDEX i ON v")
-    mz.environmentd.sql("SET cluster=mz_introspection")
 
     # Wait for the cluster pod to OOM
-    verify_status("not-ready", "oom-killed")
+    verify_cluster_oomed()
 
     mz.environmentd.sql("DROP VIEW v CASCADE")
-    # Now that we've dropped the problematic view, the replica should come back
-    verify_status("ready", None)
 
 
 # Test that a crashed (and restarted) cluster replica generates expected notice

--- a/test/cloudtest/test_replica_restart.py
+++ b/test/cloudtest/test_replica_restart.py
@@ -63,6 +63,9 @@ WHERE mc.name = 'default'
             )[0]
             if status == expected_status and reason == expected_reason:
                 break
+            else:
+                print(f"Got {status}, {reason}; expected {expected_status}, {expected_reason}");
+            
             time.sleep(1)
 
     mz.environmentd.sql("DROP VIEW IF EXISTS v CASCADE")

--- a/test/cloudtest/test_replica_restart.py
+++ b/test/cloudtest/test_replica_restart.py
@@ -51,7 +51,7 @@ def assert_notice(conn: Connection, contains: bytes) -> None:
 
 
 def test_oom_clusterd(mz: MaterializeApplication) -> None:
-    def verify_status(status: str, reason: Optional[str]) -> None:
+    def verify_status(expected_status: str, expected_reason: Optional[str]) -> None:
         while True:
             (status, reason) = mz.environmentd.sql_query(
                 """
@@ -61,7 +61,7 @@ JOIN mz_clusters mc ON mcr.cluster_id = mc.id
 WHERE mc.name = 'default'
             """
             )[0]
-            if status == "not-ready":
+            if status == expected_status and reason == expected_reason:
                 break
             time.sleep(1)
 

--- a/test/cloudtest/test_replica_restart.py
+++ b/test/cloudtest/test_replica_restart.py
@@ -10,7 +10,6 @@
 import threading
 import time
 from io import StringIO
-from typing import Optional
 
 from pg8000 import Connection
 

--- a/test/cloudtest/test_replica_restart.py
+++ b/test/cloudtest/test_replica_restart.py
@@ -53,8 +53,8 @@ def test_oom_clusterd(mz: MaterializeApplication) -> None:
         while True:
             (status, reason) = mz.environmentd.sql_query("""
 SELECT status, reason FROM mz_internal.mz_cluster_replica_statuses mcrs
-JOIN mz_internal.mz_cluster_replicas mcr ON mcrs.replica_id = mcr.id
-JOIN mz_internal.mz_clusters mc ON mcr.cluster_id = mc.id
+JOIN mz_cluster_replicas mcr ON mcrs.replica_id = mcr.id
+JOIN mz_clusters mc ON mcr.cluster_id = mc.id
 WHERE mc.name = 'default'
             """)[0]
             if status == 'not-ready':

--- a/test/cloudtest/test_replica_restart.py
+++ b/test/cloudtest/test_replica_restart.py
@@ -45,40 +45,46 @@ def assert_notice(conn: Connection, contains: bytes) -> None:
             pass
         time.sleep(0.2)
 
+
 # Test that an OOMing cluster replica generates expected entries in
 # `mz_cluster_replica_statuses`
+
 
 def test_oom_clusterd(mz: MaterializeApplication) -> None:
     def verify_status(status: str, reason: Optional[str]) -> None:
         while True:
-            (status, reason) = mz.environmentd.sql_query("""
+            (status, reason) = mz.environmentd.sql_query(
+                """
 SELECT status, reason FROM mz_internal.mz_cluster_replica_statuses mcrs
 JOIN mz_cluster_replicas mcr ON mcrs.replica_id = mcr.id
 JOIN mz_clusters mc ON mcr.cluster_id = mc.id
 WHERE mc.name = 'default'
-            """)[0]
-            if status == 'not-ready':
+            """
+            )[0]
+            if status == "not-ready":
                 break
-            time.sleep(1)            
+            time.sleep(1)
 
-    
     mz.environmentd.sql("DROP VIEW IF EXISTS v CASCADE")
     # Once we create an index on this view, it is practically guaranteed to OOM
-    mz.environmentd.sql("""
+    mz.environmentd.sql(
+        """
 CREATE VIEW v AS
 SELECT repeat('abc' || x || y, 1000000) FROM
 (SELECT * FROM generate_series(1, 1000000)) a(x),
 (SELECT * FROM generate_series(1, 1000000)) b(y)
-    """)
+    """
+    )
     mz.environmentd.sql("CREATE DEFAULT INDEX i ON v")
     mz.environmentd.sql("SET cluster=mz_introspection")
-    
+
     # Wait for the cluster pod to OOM
-    verify_status('not-ready', 'oom-killed')
-    
+    verify_status("not-ready", "oom-killed")
+
     mz.environmentd.sql("DROP VIEW v CASCADE")
     # Now that we've dropped the problematic view, the replica should come back
-    verify_status('ready', None)
+    verify_status("ready", None)
+
 
 # Test that a crashed (and restarted) cluster replica generates expected notice
 # events.

--- a/test/cloudtest/test_replica_restart.py
+++ b/test/cloudtest/test_replica_restart.py
@@ -48,8 +48,6 @@ def assert_notice(conn: Connection, contains: bytes) -> None:
 
 # Test that an OOMing cluster replica generates expected entries in
 # `mz_cluster_replica_statuses`
-
-
 def test_oom_clusterd(mz: MaterializeApplication) -> None:
     def verify_cluster_oomed() -> None:
         with mz.environmentd.sql_cursor(autocommit=False) as cur:


### PR DESCRIPTION
This test creates an index on a query that is known to OOM, repeatedly checks `mz_cluster_replica_statuses` until the OOM is observed, clears the query, and then repeatedly checks until the cluster is observed ready.

It's possible to imagine that this test can have false negatives (i.e., the test is green but the underlying behavior is broken) if certain patterns of flapping occur in the data. I think this is unlikely to be a concern in practice. It would be more precise/elegant if we could control how long it takes a pod to restart after OOMing, but there doesn't currently seem to be a way to do so.