### PR TITLE
[persist] Track whether or not our JSON contains a map

### DIFF
--- a/src/persist-types/src/stats.proto
+++ b/src/persist-types/src/stats.proto
@@ -74,6 +74,9 @@ message ProtoJsonStats {
     ProtoPrimitiveStats numeric = 4;
     uint64 list = 5;
     map<string, ProtoJsonStats> map = 6;
+    // The inverse of what you might normally imagine, for backwards-compatibility.
+    // TODO(mfp): make this more uniform.
+    bool no_maps = 7;
 }
 
 message ProtoBytesStats {

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -191,6 +191,7 @@ fn jsonb_stats_datum(stats: &mut JsonStats, datum: Datum<'_>) -> Result<(), Stri
                 let key_stats = stats.map.entry(k.to_owned()).or_default();
                 let () = jsonb_stats_datum(key_stats, v)?;
             }
+            stats.maps = true;
         }
         _ => {
             return Err(format!(


### PR DESCRIPTION
### Motivation

```
materialize=> select '7'::jsonb::numeric;
 numeric 
---------
       7
(1 row)

materialize=> select '{}'::jsonb::numeric;
ERROR:  cannot cast jsonb object to type numeric
```

If we want to be able to push down casts on `jsonb` columns, it's important that we know when the column is all of a single type. However, currently totally empty `jsonb` objects -- `{}` -- don't show up in stats at all. This is a minimal change that captures them in stats in a backwards - compatible way.

### Tips for reviewer

This is not how I'd do things from scratch, but it seems like the smallest change that captures the information we need. I left a TODO to revisit this code when we're cleaning up / getting ready to use this for real.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
