### PR TITLE
compute: persist_sink unsoundness

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -232,6 +232,13 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
             if frontier.is_empty() {
                 // Indicates that we may drop `id`, as there are no more valid times to read.
 
+                // Ignore drop commands on worker 0, to simulate delay.
+                let worker = self.timely_worker.index();
+                if worker == 0 {
+                    return;
+                }
+                println!("[{worker}] dropping tokens for collection {id}");
+
                 let is_subscribe = self.compute_state.sink_tokens.contains_key(&id)
                     && !self.compute_state.sink_write_frontiers.contains_key(&id);
 

--- a/test/testdrive/token-correctness2.td
+++ b/test/testdrive/token-correctness2.td
@@ -1,0 +1,73 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Set up a storage cluster to host the sink
+> DROP CLUSTER IF EXISTS storage;
+> CREATE CLUSTER storage REPLICAS (r1 (SIZE '1'))
+
+# Set up a replica with two workers:
+> DROP CLUSTER IF EXISTS test;
+> CREATE CLUSTER test REPLICAS (r (SIZE '2'));
+> SET CLUSTER = test;
+
+# Create a materialized view reading from an index:
+> CREATE TABLE t (a int);
+> CREATE DEFAULT INDEX ON t;
+> CREATE MATERIALIZED VIEW mv AS SELECT * FROM t;
+
+# Feed a bunch of data into the MV:
+> INSERT INTO t SELECT * FROM generate_series(1, 10);
+
+> CREATE CONNECTION kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE SINK mv_sink IN CLUSTER storage FROM mv INTO KAFKA CONNECTION kafka_conn (TOPIC 'mv-${testdrive.seed}')
+  FORMAT JSON ENVELOPE DEBEZIUM
+
+# Wait for the initial data to be written
+$ kafka-verify-data format=json topic=mv-${testdrive.seed} key=false sort-messages=true
+{"before": null, "after": {"a": 1}}
+{"before": null, "after": {"a": 10}}
+{"before": null, "after": {"a": 2}}
+{"before": null, "after": {"a": 3}}
+{"before": null, "after": {"a": 4}}
+{"before": null, "after": {"a": 5}}
+{"before": null, "after": {"a": 6}}
+{"before": null, "after": {"a": 7}}
+{"before": null, "after": {"a": 8}}
+{"before": null, "after": {"a": 9}}
+
+# This sends a drop command but it is ignored, simulating a delay.
+> DROP SINK mv_sink;
+
+# This drops the token in worker 1 but not worker 0:
+#   [1] dropping tokens for collection u3
+> DROP MATERIALIZED VIEW mv;
+
+# Give some time for clusterds to partially drop their tokens
+> SELECT mz_internal.mz_sleep(0.5);
+<null>
+
+# # Insert more data into the table:
+# Observe that worker 0 continues to write and append (incomplete) batches even though worker 1 has dropped the dataflow.
+#   [0] writing 5 updates
+#   appending 1
+> INSERT INTO t SELECT * FROM generate_series(1, 10);
+
+# Observe partial data written out to kafka
+$ kafka-verify-data format=json topic=mv-${testdrive.seed} key=false sort-messages=true
+{"before": null, "after": {"a": 1}}
+{"before": null, "after": {"a": 10}}
+{"before": null, "after": {"a": 2}}
+{"before": null, "after": {"a": 3}}
+{"before": null, "after": {"a": 4}}
+{"before": null, "after": {"a": 5}}
+{"before": null, "after": {"a": 6}}
+{"before": null, "after": {"a": 7}}
+{"before": null, "after": {"a": 8}}
+{"before": null, "after": {"a": 9}}


### PR DESCRIPTION
@petrosagg pointed out that the compute `persist_sink` might be unsound when multiple workers observe a dataflow drop at different times. This is a reproduction of that issue.

### Explanation

A COMPUTE worker shuts down dataflows by dropping tokens. Dataflow operators can observe token dropping and behave accordingly. Dataflow inputs react by ceasing to ingest more data and shutting down. Dataflow outputs react by ceasing to output more data and shutting down. This works well for single-worker Timely clusters. But the current implementation turns out to be unsound for multi-worker clusters. In such clusters, some workers can receive the "drop dataflow" command later than others and continue running under the assumption that the dataflow is still alive. As a result, dataflow outputs can produce partial sets of updates for time slices during which some of the workers have already registered the shutdown. This is unsound because consumers of these outputs don't expect seeing only partial collection contents.

### Reproduction

To demonstrate the issue, I made the following code changes (first commit):
* Adding prints to `persist_sink` to make the unsound behavior easily observable.
* Fixing the active worker of single-worker operators within `persist_sink` to worker 0, to make (c) reliable.
* Ignoring "drop collection" commands in worker 1, to simulate these commands arriving arbitrarily delayed.

With these changes deployed, the unsound behavior can be observed by running the below commands:

```sql
-- Set up a replica with two workers:
create cluster test replicas (r (size '2'));
set cluster = test;

-- Create a materialized view reading from an index:
create table t (a int);
create default index on t;
create materialized view mv as select * from t;

-- Feed a bunch of data into the MV:
insert into t select * from generate_series(1, 2000);
-- Every time you run this insert, you should see MZ print something like this:
--   [1] writing 1001 updates
--   [0] writing 999 updates
--   appending 2

-- Now drop the MV:
drop materialized view mv;
-- This drops the token in worker 1 but not worker 0:
--   [1] dropping tokens for collection u3

-- Insert more data into the table:
insert into t select * from generate_series(1, 2000);
-- Observe that worker 0 continues to write and append (incomplete) batches even though worker 1 has dropped the dataflow.
--   [0] writing 999 updates
--   appending 1
```

### Observability

The demonstrated unsoundness wouldn't have any impact in practice if we could guarantee that a materialized view is never read anymore once at least one of the workers has received a "drop collection" command. However, we cannot guarantee this in at least two cases:

1. A storage sink might still be running reading from the MV collection and writing its contents out to an external system like Kafka. Even though adapter drops sinks before it drops the collections they read from, these drop operations are not synchronous, so it is possible that the compute worker sees the drop command before the storage sink does. @petrosagg's commit on this PR has a testcase showing this scenario.
2. During reconciliation, MV dataflows can be dropped and recreated with the same target persist shard.
