### PR TITLE
sql: improve known limitations for tables

### DIFF
--- a/doc/user/content/sql/create-table.md
+++ b/doc/user/content/sql/create-table.md
@@ -17,9 +17,8 @@ they consist of rows and columns where the columns are fixed when the table is
 created but rows can be added to at will via [`INSERT`](../insert) statements.
 
 {{< warning >}}
-At the moment, tables serve a niche use case. They lack some features that are
-standard in relational databases. In most situations, you should use
-[sources](/sql/create-source) instead.
+At the moment, tables have many [known limitations](#known-limitations). In most
+situations, you should use [sources](/sql/create-source) instead.
 {{< /warning >}}
 
 [//]: # "TODO(morsapaes) Bring back When to use a table? once there's more
@@ -44,18 +43,16 @@ _col&lowbar;type_ | The data type of the column indicated by _col&lowbar;name_.
 
 ## Details
 
-### Restrictions
+### Known limitations
 
-Additionally, tables do not currently support:
+Tables do not currently support:
+
 - Primary keys
 - Unique constraints
 - Check constraints
-- Insert statements that refer to data in other relations, e.g.:
 
-  ```sql
-  INSERT INTO t1 SELECT * FROM t2
-  ```
-- `UPDATE ...` and `DELETE` statements
+See also the known limitations for [`INSERT`](../insert#known-limitations),
+[`UPDATE`](../update#known-limitations), and [`DELETE`](../delete#known-limitations).
 
 ### Temporary tables
 

--- a/doc/user/content/sql/delete.md
+++ b/doc/user/content/sql/delete.md
@@ -21,7 +21,12 @@ _alias_ | Only permit references to _table_name_ as _alias_.
 
 ## Details
 
-`DELETE` cannot currently be used inside [transactions](../begin).
+### Known limitations
+
+* `DELETE` cannot be used inside [transactions](../begin).
+
+* **Low performance.** While processing a `DELETE` statement, Materialize cannot
+  process other `INSERT`, `UPDATE`, or `DELETE` statements.
 
 ## Examples
 

--- a/doc/user/content/sql/delete.md
+++ b/doc/user/content/sql/delete.md
@@ -24,7 +24,7 @@ _alias_ | Only permit references to _table_name_ as _alias_.
 ### Known limitations
 
 * `DELETE` cannot be used inside [transactions](../begin).
-
+* `DELETE` can reference [user-created tables](../create-table) but not [sources](../create-source).
 * **Low performance.** While processing a `DELETE` statement, Materialize cannot
   process other `INSERT`, `UPDATE`, or `DELETE` statements.
 

--- a/doc/user/content/sql/insert.md
+++ b/doc/user/content/sql/insert.md
@@ -33,6 +33,7 @@ The optional `RETURNING` clause causes `INSERT` to return values based on each i
 
 ### Known limitations
 
+* `INSERT ... SELECT` can reference [user-created tables](../create-table) but not [sources](../create-source).
 * **Low performance.** While processing an `INSERT ... SELECT` statement,
   Materialize cannot process other `INSERT`, `UPDATE`, or `DELETE` statements.
 

--- a/doc/user/content/sql/insert.md
+++ b/doc/user/content/sql/insert.md
@@ -31,6 +31,11 @@ _query_ | A [`SELECT`](../select) statements whose returned rows you want to wri
 
 The optional `RETURNING` clause causes `INSERT` to return values based on each inserted row.
 
+### Known limitations
+
+* **Low performance.** While processing an `INSERT ... SELECT` statement,
+  Materialize cannot process other `INSERT`, `UPDATE`, or `DELETE` statements.
+
 ## Examples
 
 To insert data into a table, execute an `INSERT` statement where the `VALUES` clause

--- a/doc/user/content/sql/update.md
+++ b/doc/user/content/sql/update.md
@@ -24,8 +24,8 @@ _alias_ | Only permit references to _table_name_ as _alias_.
 ### Known limitations
 
 * `UPDATE` cannot be used inside [transactions](../begin).
-* `UPDATE` cannot reference other tables.
-* **Low performance.** While processing a `UPDATE` statement, Materialize cannot
+* `UPDATE` can reference [user-created tables](../create-table) but not [sources](../create-source).
+* **Low performance.** While processing an `UPDATE` statement, Materialize cannot
   process other `INSERT`, `UPDATE`, or `DELETE` statements.
 
 ## Examples

--- a/doc/user/content/sql/update.md
+++ b/doc/user/content/sql/update.md
@@ -21,9 +21,12 @@ _alias_ | Only permit references to _table_name_ as _alias_.
 
 ## Details
 
-`UPDATE` cannot currently...
-- Be used inside [transactions](../begin)
-- Reference other tables
+### Known limitations
+
+* `UPDATE` cannot be used inside [transactions](../begin).
+* `UPDATE` cannot reference other tables.
+* **Low performance.** While processing a `UPDATE` statement, Materialize cannot
+  process other `INSERT`, `UPDATE`, or `DELETE` statements.
 
 ## Examples
 


### PR DESCRIPTION
`INSERT ... SELECT` is now supported; all of `INSERT ... SELECT`, `UPDATE`, and `DELETE` have performance caveats that need to be called out.

@jkosh44 @mjibson — I need your help wording the performance limitation for `INSERT ... SELECT`, `UPDATE`, and `DELETE`. I'm not sure I got it right.

@jseldess — this whole thing could use a copyedit. Would love to hand this off to the docs team!

### Motivation

  * This PR fixes a bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
