### PR TITLE
redo of #18737

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3568,7 +3568,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(ArrayAny, ArrayAny) => BinaryFunc::Lt => Bool, 1072;
             params!(RecordAny, RecordAny) => BinaryFunc::Lt => Bool, 2990;
             params!(MzTimestamp, MzTimestamp)=>BinaryFunc::Lt =>Bool, oid::FUNC_MZ_TIMESTAMP_LT_MZ_TIMESTAMP_OID;
-            params!(RangeAny, RangeAny) => BinaryFunc::Eq => Bool, 3884;
+            params!(RangeAny, RangeAny) => BinaryFunc::Lt => Bool, 3884;
         },
         "<=" => Scalar {
             params!(Numeric, Numeric) => BinaryFunc::Lte => Bool, 1755;
@@ -3596,7 +3596,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(ArrayAny, ArrayAny) => BinaryFunc::Lte => Bool, 1074;
             params!(RecordAny, RecordAny) => BinaryFunc::Lte => Bool, 2992;
             params!(MzTimestamp, MzTimestamp)=>BinaryFunc::Lte =>Bool, oid::FUNC_MZ_TIMESTAMP_LTE_MZ_TIMESTAMP_OID;
-            params!(RangeAny, RangeAny) => BinaryFunc::Eq => Bool, 3885;
+            params!(RangeAny, RangeAny) => BinaryFunc::Lte => Bool, 3885;
         },
         ">" => Scalar {
             params!(Numeric, Numeric) => BinaryFunc::Gt => Bool, 1756;
@@ -3624,7 +3624,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(ArrayAny, ArrayAny) => BinaryFunc::Gt => Bool, 1073;
             params!(RecordAny, RecordAny) => BinaryFunc::Gt => Bool, 2991;
             params!(MzTimestamp, MzTimestamp)=>BinaryFunc::Gt =>Bool, oid::FUNC_MZ_TIMESTAMP_GT_MZ_TIMESTAMP_OID;
-            params!(RangeAny, RangeAny) => BinaryFunc::Eq => Bool, 3887;
+            params!(RangeAny, RangeAny) => BinaryFunc::Gt => Bool, 3887;
         },
         ">=" => Scalar {
             params!(Numeric, Numeric) => BinaryFunc::Gte => Bool, 1757;
@@ -3652,7 +3652,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(ArrayAny, ArrayAny) => BinaryFunc::Gte => Bool, 1075;
             params!(RecordAny, RecordAny) => BinaryFunc::Gte => Bool, 2993;
             params!(MzTimestamp, MzTimestamp)=>BinaryFunc::Gte =>Bool, oid::FUNC_MZ_TIMESTAMP_GTE_MZ_TIMESTAMP_OID;
-            params!(RangeAny, RangeAny) => BinaryFunc::Eq => Bool, 3886;
+            params!(RangeAny, RangeAny) => BinaryFunc::Gte => Bool, 3886;
         },
         // Warning!
         // - If you are writing functions here that do not simply use

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -665,12 +665,12 @@ true
 query B
 select '(,)'::int4range > 'empty'::int4range;
 ----
-false
+true
 
 query B
 select '(,)'::int4range >= 'empty'::int4range;
 ----
-false
+true
 
 query B
 select '(,)'::int4range < 'empty'::int4range;
@@ -1817,12 +1817,12 @@ true
 query B
 select '(,)'::int8range > 'empty'::int8range;
 ----
-false
+true
 
 query B
 select '(,)'::int8range >= 'empty'::int8range;
 ----
-false
+true
 
 query B
 select '(,)'::int8range < 'empty'::int8range;
@@ -2904,12 +2904,12 @@ true
 query B
 select '(,)'::daterange > 'empty'::daterange;
 ----
-false
+true
 
 query B
 select '(,)'::daterange >= 'empty'::daterange;
 ----
-false
+true
 
 query B
 select '(,)'::daterange < 'empty'::daterange;
@@ -4067,12 +4067,12 @@ true
 query B
 select '(,)'::numrange > 'empty'::numrange;
 ----
-false
+true
 
 query B
 select '(,)'::numrange >= 'empty'::numrange;
 ----
-false
+true
 
 query B
 select '(,)'::numrange < 'empty'::numrange;
@@ -5806,12 +5806,12 @@ true
 query B
 select '(,)'::tsrange > 'empty'::tsrange;
 ----
-false
+true
 
 query B
 select '(,)'::tsrange >= 'empty'::tsrange;
 ----
-false
+true
 
 query B
 select '(,)'::tsrange < 'empty'::tsrange;
@@ -7532,12 +7532,12 @@ true
 query B
 select '(,)'::tstzrange > 'empty'::tstzrange;
 ----
-false
+true
 
 query B
 select '(,)'::tstzrange >= 'empty'::tstzrange;
 ----
-false
+true
 
 query B
 select '(,)'::tstzrange < 'empty'::tstzrange;


### PR DESCRIPTION
redo of #18737 to see if I can break through some caching issue

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
