### PR TITLE
docs: Update create pg source docs for schemas

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/create-source-postgres.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-postgres.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="667" height="901">
+<svg xmlns="http://www.w3.org/2000/svg" width="707" height="989">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -20,114 +20,114 @@
    <rect x="371" y="3" width="82" height="32"/>
    <rect x="369" y="1" width="82" height="32" class="nonterminal"/>
    <text class="nonterminal" x="379" y="21">src_name</text>
-   <rect x="121" y="133" width="104" height="32" rx="10"/>
-   <rect x="119"
+   <rect x="141" y="133" width="104" height="32" rx="10"/>
+   <rect x="139"
          y="131"
          width="104"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="129" y="151">IN CLUSTER</text>
-   <rect x="245" y="133" width="108" height="32"/>
-   <rect x="243" y="131" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="253" y="151">cluster_name</text>
-   <rect x="393" y="101" width="60" height="32" rx="10"/>
-   <rect x="391"
+   <text class="terminal" x="149" y="151">IN CLUSTER</text>
+   <rect x="265" y="133" width="108" height="32"/>
+   <rect x="263" y="131" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="273" y="151">cluster_name</text>
+   <rect x="413" y="101" width="60" height="32" rx="10"/>
+   <rect x="411"
          y="99"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="401" y="119">FROM</text>
-   <rect x="473" y="101" width="96" height="32" rx="10"/>
-   <rect x="471"
+   <text class="terminal" x="421" y="119">FROM</text>
+   <rect x="493" y="101" width="96" height="32" rx="10"/>
+   <rect x="491"
          y="99"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="481" y="119">POSTGRES</text>
-   <rect x="108" y="199" width="116" height="32" rx="10"/>
-   <rect x="106"
+   <text class="terminal" x="501" y="119">POSTGRES</text>
+   <rect x="128" y="199" width="116" height="32" rx="10"/>
+   <rect x="126"
          y="197"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="116" y="217">CONNECTION</text>
-   <rect x="244" y="199" width="136" height="32"/>
-   <rect x="242" y="197" width="136" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="252" y="217">connection_name</text>
-   <rect x="400" y="199" width="26" height="32" rx="10"/>
-   <rect x="398"
+   <text class="terminal" x="136" y="217">CONNECTION</text>
+   <rect x="264" y="199" width="136" height="32"/>
+   <rect x="262" y="197" width="136" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="272" y="217">connection_name</text>
+   <rect x="420" y="199" width="26" height="32" rx="10"/>
+   <rect x="418"
          y="197"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="408" y="217">(</text>
-   <rect x="446" y="199" width="116" height="32" rx="10"/>
-   <rect x="444"
+   <text class="terminal" x="428" y="217">(</text>
+   <rect x="466" y="199" width="116" height="32" rx="10"/>
+   <rect x="464"
          y="197"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="454" y="217">PUBLICATION</text>
-   <rect x="268" y="265" width="134" height="32"/>
-   <rect x="266" y="263" width="134" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="276" y="283">publication_name</text>
-   <rect x="95" y="375" width="24" height="32" rx="10"/>
-   <rect x="93"
+   <text class="terminal" x="474" y="217">PUBLICATION</text>
+   <rect x="288" y="265" width="134" height="32"/>
+   <rect x="286" y="263" width="134" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="296" y="283">publication_name</text>
+   <rect x="115" y="375" width="24" height="32" rx="10"/>
+   <rect x="113"
          y="373"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="103" y="393">,</text>
-   <rect x="139" y="375" width="134" height="32" rx="10"/>
-   <rect x="137"
+   <text class="terminal" x="123" y="393">,</text>
+   <rect x="159" y="375" width="134" height="32" rx="10"/>
+   <rect x="157"
          y="373"
          width="134"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="147" y="393">TEXT COLUMNS</text>
-   <rect x="313" y="375" width="26" height="32" rx="10"/>
-   <rect x="311"
+   <text class="terminal" x="167" y="393">TEXT COLUMNS</text>
+   <rect x="333" y="375" width="26" height="32" rx="10"/>
+   <rect x="331"
          y="373"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="321" y="393">(</text>
-   <rect x="379" y="375" width="110" height="32"/>
-   <rect x="377" y="373" width="110" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="387" y="393">column_name</text>
-   <rect x="379" y="331" width="24" height="32" rx="10"/>
-   <rect x="377"
+   <text class="terminal" x="341" y="393">(</text>
+   <rect x="399" y="375" width="110" height="32"/>
+   <rect x="397" y="373" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="407" y="393">column_name</text>
+   <rect x="399" y="331" width="24" height="32" rx="10"/>
+   <rect x="397"
          y="329"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="387" y="349">,</text>
-   <rect x="529" y="375" width="26" height="32" rx="10"/>
-   <rect x="527"
+   <text class="terminal" x="407" y="349">,</text>
+   <rect x="549" y="375" width="26" height="32" rx="10"/>
+   <rect x="547"
          y="373"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="537" y="393">)</text>
-   <rect x="322" y="473" width="26" height="32" rx="10"/>
-   <rect x="320"
+   <text class="terminal" x="557" y="393">)</text>
+   <rect x="342" y="473" width="26" height="32" rx="10"/>
+   <rect x="340"
          y="471"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="330" y="491">)</text>
+   <text class="terminal" x="350" y="491">)</text>
    <rect x="45" y="539" width="138" height="32" rx="10"/>
    <rect x="43"
          y="537"
@@ -136,127 +136,154 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="53" y="557">FOR ALL TABLES</text>
-   <rect x="45" y="627" width="106" height="32" rx="10"/>
-   <rect x="43"
+   <rect x="65" y="627" width="106" height="32" rx="10"/>
+   <rect x="63"
          y="625"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="645">FOR TABLES</text>
-   <rect x="171" y="627" width="26" height="32" rx="10"/>
-   <rect x="169"
+   <text class="terminal" x="73" y="645">FOR TABLES</text>
+   <rect x="191" y="627" width="26" height="32" rx="10"/>
+   <rect x="189"
          y="625"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="179" y="645">(</text>
-   <rect x="237" y="627" width="96" height="32"/>
-   <rect x="235" y="625" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="245" y="645">table_name</text>
-   <rect x="373" y="659" width="40" height="32" rx="10"/>
-   <rect x="371"
+   <text class="terminal" x="199" y="645">(</text>
+   <rect x="257" y="627" width="96" height="32"/>
+   <rect x="255" y="625" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="265" y="645">table_name</text>
+   <rect x="393" y="659" width="40" height="32" rx="10"/>
+   <rect x="391"
          y="657"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="381" y="677">AS</text>
-   <rect x="433" y="659" width="106" height="32"/>
-   <rect x="431" y="657" width="106" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="441" y="677">subsrc_name</text>
-   <rect x="237" y="583" width="24" height="32" rx="10"/>
-   <rect x="235"
+   <text class="terminal" x="401" y="677">AS</text>
+   <rect x="453" y="659" width="106" height="32"/>
+   <rect x="451" y="657" width="106" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="461" y="677">subsrc_name</text>
+   <rect x="257" y="583" width="24" height="32" rx="10"/>
+   <rect x="255"
          y="581"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="245" y="601">,</text>
-   <rect x="599" y="627" width="26" height="32" rx="10"/>
-   <rect x="597"
+   <text class="terminal" x="265" y="601">,</text>
+   <rect x="65" y="747" width="124" height="32" rx="10"/>
+   <rect x="63"
+         y="745"
+         width="124"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="765">FOR SCHEMAS</text>
+   <rect x="209" y="747" width="26" height="32" rx="10"/>
+   <rect x="207"
+         y="745"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="217" y="765">(</text>
+   <rect x="275" y="747" width="114" height="32"/>
+   <rect x="273" y="745" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="283" y="765">schema_name</text>
+   <rect x="275" y="703" width="24" height="32" rx="10"/>
+   <rect x="273"
+         y="701"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="283" y="721">,</text>
+   <rect x="639" y="627" width="26" height="32" rx="10"/>
+   <rect x="637"
          y="625"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="607" y="645">)</text>
-   <rect x="101" y="741" width="76" height="32" rx="10"/>
-   <rect x="99"
-         y="739"
+   <text class="terminal" x="647" y="645">)</text>
+   <rect x="121" y="829" width="76" height="32" rx="10"/>
+   <rect x="119"
+         y="827"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="109" y="759">EXPOSE</text>
-   <rect x="197" y="741" width="96" height="32" rx="10"/>
-   <rect x="195"
-         y="739"
+   <text class="terminal" x="129" y="847">EXPOSE</text>
+   <rect x="217" y="829" width="96" height="32" rx="10"/>
+   <rect x="215"
+         y="827"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="205" y="759">PROGRESS</text>
-   <rect x="313" y="741" width="40" height="32" rx="10"/>
-   <rect x="311"
-         y="739"
+   <text class="terminal" x="225" y="847">PROGRESS</text>
+   <rect x="333" y="829" width="40" height="32" rx="10"/>
+   <rect x="331"
+         y="827"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="321" y="759">AS</text>
-   <rect x="373" y="741" width="196" height="32"/>
-   <rect x="371" y="739" width="196" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="381" y="759">progress_subsource_name</text>
-   <rect x="255" y="851" width="58" height="32" rx="10"/>
-   <rect x="253"
-         y="849"
+   <text class="terminal" x="341" y="847">AS</text>
+   <rect x="393" y="829" width="196" height="32"/>
+   <rect x="391" y="827" width="196" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="401" y="847">progress_subsource_name</text>
+   <rect x="295" y="939" width="58" height="32" rx="10"/>
+   <rect x="293"
+         y="937"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="263" y="869">WITH</text>
-   <rect x="333" y="851" width="26" height="32" rx="10"/>
-   <rect x="331"
-         y="849"
+   <text class="terminal" x="303" y="957">WITH</text>
+   <rect x="373" y="939" width="26" height="32" rx="10"/>
+   <rect x="371"
+         y="937"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="341" y="869">(</text>
-   <rect x="399" y="851" width="48" height="32"/>
-   <rect x="397" y="849" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="407" y="869">field</text>
-   <rect x="467" y="851" width="28" height="32" rx="10"/>
-   <rect x="465"
-         y="849"
+   <text class="terminal" x="381" y="957">(</text>
+   <rect x="439" y="939" width="48" height="32"/>
+   <rect x="437" y="937" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="447" y="957">field</text>
+   <rect x="507" y="939" width="28" height="32" rx="10"/>
+   <rect x="505"
+         y="937"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="475" y="869">=</text>
-   <rect x="515" y="851" width="38" height="32"/>
-   <rect x="513" y="849" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="523" y="869">val</text>
-   <rect x="399" y="807" width="24" height="32" rx="10"/>
-   <rect x="397"
-         y="805"
+   <text class="terminal" x="515" y="957">=</text>
+   <rect x="555" y="939" width="38" height="32"/>
+   <rect x="553" y="937" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="563" y="957">val</text>
+   <rect x="439" y="895" width="24" height="32" rx="10"/>
+   <rect x="437"
+         y="893"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="407" y="825">,</text>
-   <rect x="593" y="851" width="26" height="32" rx="10"/>
-   <rect x="591"
-         y="849"
+   <text class="terminal" x="447" y="913">,</text>
+   <rect x="633" y="939" width="26" height="32" rx="10"/>
+   <rect x="631"
+         y="937"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="601" y="869">)</text>
+   <text class="terminal" x="641" y="957">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-396 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m96 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-505 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m116 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-338 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m134 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-371 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m0 0 h10 m134 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m20 44 h10 m26 0 h10 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v14 m282 0 v-14 m-282 14 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m0 0 h252 m-500 -34 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v30 m520 0 v-30 m-520 30 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m0 0 h490 m22 -50 l2 0 m2 0 l2 0 m2 0 l2 0 m-317 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-367 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h442 m-620 0 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v68 m620 0 v-68 m-620 68 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m20 44 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-608 170 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-398 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
-   <polygon points="657 865 665 861 665 869"/>
-   <polygon points="657 865 649 861 649 869"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-376 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m96 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-505 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m116 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-338 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m134 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-371 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m0 0 h10 m134 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m20 44 h10 m26 0 h10 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v14 m282 0 v-14 m-282 14 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m0 0 h252 m-500 -34 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v30 m520 0 v-30 m-520 30 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m0 0 h490 m22 -50 l2 0 m2 0 l2 0 m2 0 l2 0 m-317 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-387 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h482 m-660 0 h20 m640 0 h20 m-680 0 q10 0 10 10 m660 0 q0 -10 10 -10 m-670 10 v68 m660 0 v-68 m-660 68 q0 10 10 10 m640 0 q10 0 10 -10 m-630 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m-554 44 h20 m554 0 h20 m-594 0 q10 0 10 10 m574 0 q0 -10 10 -10 m-584 10 v100 m574 0 v-100 m-574 100 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m124 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m114 0 h10 m-154 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m134 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-134 0 h10 m24 0 h10 m0 0 h90 m20 44 h190 m20 -120 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-628 258 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-378 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="697 953 705 949 705 957"/>
+   <polygon points="697 953 689 949 689 957"/>
 </svg>


### PR DESCRIPTION
This commit updates the railroad diagram for the PostgreSQL variant of `CREATE SOURCE` to include the `FOR SCHEMAS` syntax. The grammar had already been updated in a previous commit, but the new railroad diagram was never generated.

### Motivation
Update docs.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
