### PR TITLE
python: Remove unnecessary f-strings

### DIFF
--- a/bin/pycheck
+++ b/bin/pycheck
@@ -36,6 +36,6 @@ if ! try_last_failed; then
         try bin/pyactivate -m mypy "$file"
     done
 fi
-try bin/pyactivate -m flake8 --select F --ignore F541 --extend-exclude venv "${flake8_folders[@]}"
+try bin/pyactivate -m flake8 --select F --extend-exclude venv "${flake8_folders[@]}"
 try bin/pyactivate -m pytest -qq --doctest-modules misc/python
 try_finish

--- a/ci/cleanup/aws.py
+++ b/ci/cleanup/aws.py
@@ -86,7 +86,7 @@ def clean_up_sqs() -> None:
 
 
 def clean_up_ec2() -> None:
-    print(f"Terminating scratch ec2 instances whose age exceeds the deletion time")
+    print("Terminating scratch ec2 instances whose age exceeds the deletion time")
     olds = [i["InstanceId"] for i in scratch.get_old_instances()]
     if olds:
         print(f"Instances to delete: {olds}")

--- a/ci/deploy/docker.py
+++ b/ci/deploy/docker.py
@@ -29,7 +29,7 @@ def main() -> None:
         # tags.
         return image.publish and (not buildkite_tag or image.mainline)
 
-    print(f"--- Tagging Docker images")
+    print("--- Tagging Docker images")
     deps = [
         repo.resolve_dependencies(image for image in repo if include_image(image))
         for repo in repos

--- a/ci/deploy_mz/docker.py
+++ b/ci/deploy_mz/docker.py
@@ -22,7 +22,7 @@ def main() -> None:
         mzbuild.Repository(Path("."), Arch.AARCH64, coverage=False),
     ]
 
-    print(f"--- Tagging Docker images")
+    print("--- Tagging Docker images")
     deps = [[repo.resolve_dependencies([repo.images["mz"]])["mz"]] for repo in repos]
 
     mzbuild.publish_multiarch_images(f"v{VERSION}", deps)

--- a/ci/deploy_mz/linux.py
+++ b/ci/deploy_mz/linux.py
@@ -20,10 +20,10 @@ def main() -> None:
     repo = mzbuild.Repository(Path("."), coverage=False)
     target = f"{repo.rd.arch}-unknown-linux-gnu"
 
-    print(f"--- Checking version")
+    print("--- Checking version")
     assert repo.rd.cargo_workspace.crates["mz"].version == VERSION
 
-    print(f"--- Building mz")
+    print("--- Building mz")
     deps = repo.resolve_dependencies([repo.images["mz"]])
     deps.ensure()
     # Extract the mz binary from the Docker image.
@@ -47,7 +47,7 @@ def main() -> None:
     print(f"--- Uploading {target} binary tarball")
     deploy_util.deploy_tarball(target, mz)
 
-    print(f"--- Publishing Debian package")
+    print("--- Publishing Debian package")
     filename = f"mz_{VERSION}_{repo.rd.arch.go_str()}.deb"
     print(f"Publishing {filename}")
     spawn.runv(

--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -27,7 +27,7 @@ SERVICES = [
         port="30123:30123",
         allow_host_ports=True,
         extra_environment=[
-            f"KAFKA_ADVERTISED_LISTENERS=HOST://localhost:30123,PLAINTEXT://kafka:9092",
+            "KAFKA_ADVERTISED_LISTENERS=HOST://localhost:30123,PLAINTEXT://kafka:9092",
             "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=HOST:PLAINTEXT,PLAINTEXT:PLAINTEXT",
         ],
     ),
@@ -60,7 +60,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         env=dict(
             os.environ,
             ZOOKEEPER_ADDR=f"localhost:{c.default_port('zookeeper')}",
-            KAFKA_ADDRS=f"localhost:30123",
+            KAFKA_ADDRS="localhost:30123",
             SCHEMA_REGISTRY_URL=f"http://localhost:{c.default_port('schema-registry')}",
             POSTGRES_URL=postgres_url,
             COCKROACH_URL=cockroach_url,

--- a/ci/test/dev_tag.py
+++ b/ci/test/dev_tag.py
@@ -20,7 +20,7 @@ def main() -> None:
         mzbuild.Repository(Path("."), Arch.X86_64, coverage=False),
         mzbuild.Repository(Path("."), Arch.AARCH64, coverage=False),
     ]
-    print(f"--- Tagging development Docker images")
+    print("--- Tagging development Docker images")
     deps = [
         repo.resolve_dependencies(image for image in repo if image.publish)
         for repo in repos

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -45,9 +45,9 @@ class MaterializeIndexConfig(dbtClassMixin):
             dbt.exceptions.CompilationError(f"Could not parse index config: {msg}")
         except TypeError:
             dbt.exceptions.CompilationError(
-                f"Invalid index config:\n"
+                "Invalid index config:\n"
                 f"  Got: {raw_index}\n"
-                f'  Expected a dictionary with at minimum a "columns" key'
+                '  Expected a dictionary with at minimum a "columns" key'
             )
 
 

--- a/misc/python/materialize/benches/avro_ingest.py
+++ b/misc/python/materialize/benches/avro_ingest.py
@@ -139,7 +139,7 @@ def main() -> None:
         TO KAFKA (BROKER '{args.confluent_host}:9092')"""
     )
     cur.execute(
-        f"""CREATE SOURCE src
+        """CREATE SOURCE src
         FROM KAFKA CONNECTION kafka_conn (TOPIC 'bench_data')
         FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn"""
     )

--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -120,7 +120,7 @@ class Owners(Check):
             + self._create_objects("owner_role_02", 6)
             + self._create_objects("owner_role_03", 7)
             + dedent(
-                f"""
+                """
                 $ psql-execute command="\\l owner_db*"
                 \\                             List of databases
                    Name    |     Owner     | Encoding | Collate | Ctype | Access privileges

--- a/misc/python/materialize/ci_util/__init__.py
+++ b/misc/python/materialize/ci_util/__init__.py
@@ -80,7 +80,7 @@ def get_artifacts() -> Any:
     if "CI" not in os.environ:
         return []
 
-    ui.header(f"Getting artifact informations from Buildkite")
+    ui.header("Getting artifact informations from Buildkite")
     build = os.environ["BUILDKITE_BUILD_NUMBER"]
     build_id = os.environ["BUILDKITE_BUILD_ID"]
     job = os.environ["BUILDKITE_JOB_ID"]

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -199,7 +199,7 @@ def get_known_issues_from_github() -> list[KnownIssue]:
         headers["Authorization"] = f"Bearer {token}"
 
     response = requests.get(
-        f'https://api.github.com/search/issues?q=repo:MaterializeInc/materialize%20type:issue%20in:body%20"ci-regexp%3A"',
+        'https://api.github.com/search/issues?q=repo:MaterializeInc/materialize%20type:issue%20in:body%20"ci-regexp%3A"',
         headers=headers,
     )
 

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -26,7 +26,7 @@ from materialize.ui import UIError
 KNOWN_PROGRAMS = ["environmentd", "sqllogictest"]
 REQUIRED_SERVICES = ["clusterd"]
 
-DEFAULT_POSTGRES = f"postgres://root@localhost:26257/materialize"
+DEFAULT_POSTGRES = "postgres://root@localhost:26257/materialize"
 
 # sets entitlements on the built binary, e.g. environmentd, so you can inspect it with Instruments
 MACOS_ENTITLEMENTS_DATA = """
@@ -186,10 +186,10 @@ def main() -> int:
                 # Setting the listen addresses below to 0.0.0.0 is required
                 # to allow Prometheus running in Docker (misc/prometheus)
                 # access these services to scrape metrics.
-                f"--internal-http-listen-addr=0.0.0.0:6878",
-                f"--orchestrator=process",
+                "--internal-http-listen-addr=0.0.0.0:6878",
+                "--orchestrator=process",
                 f"--orchestrator-process-secrets-directory={mzdata}/secrets",
-                f"--orchestrator-process-tcp-proxy-listen-addr=0.0.0.0",
+                "--orchestrator-process-tcp-proxy-listen-addr=0.0.0.0",
                 f"--orchestrator-process-prometheus-service-discovery-directory={mzdata}/prometheus",
                 f"--persist-consensus-url={args.postgres}?options=--search_path=consensus",
                 f"--persist-blob-url=file://{mzdata}/persist/blob",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -179,7 +179,7 @@ class Composition:
                     # `allow_host_ports` is `True`
                     raise UIError(
                         "programming error: disallowed host port in service {name!r}",
-                        hint=f'Add `"allow_host_ports": True` to the service config to disable this check.',
+                        hint='Add `"allow_host_ports": True` to the service config to disable this check.',
                     )
 
             if "allow_host_ports" in config:

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -668,7 +668,7 @@ class Localstack(Service):
     def __init__(
         self,
         name: str = "localstack",
-        image: str = f"localstack/localstack:0.13.1",
+        image: str = "localstack/localstack:0.13.1",
         port: int = 4566,
         environment: List[str] = ["HOSTNAME_EXTERNAL=localstack"],
         volumes: List[str] = ["/var/run/docker.sock:/var/run/docker.sock"],
@@ -694,7 +694,7 @@ class Minio(Service):
     def __init__(
         self,
         name: str = "minio",
-        image: str = f"minio/minio:RELEASE.2022-09-25T15-44-53Z.fips",
+        image: str = "minio/minio:RELEASE.2022-09-25T15-44-53Z.fips",
         setup_materialize: bool = False,
     ) -> None:
         # We can pre-create buckets in minio by creating subdirectories in

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -75,7 +75,7 @@ class Materialized(Service):
             # TODO(benesch): remove the following environment variables
             # after v0.38 ships, since these environment variables will be
             # baked into the Docker image.
-            f"MZ_ORCHESTRATOR=process",
+            "MZ_ORCHESTRATOR=process",
             # Please think twice before forwarding additional environment
             # variables from the host, as it's easy to write tests that are
             # then accidentally dependent on the state of the host machine.
@@ -133,7 +133,7 @@ class Materialized(Service):
 
         command += [
             "--orchestrator-process-tcp-proxy-listen-addr=0.0.0.0",
-            f"--orchestrator-process-prometheus-service-discovery-directory=/mzdata/prometheus",
+            "--orchestrator-process-prometheus-service-discovery-directory=/mzdata/prometheus",
         ]
 
         command += options

--- a/misc/python/materialize/optbench/sql.py
+++ b/misc/python/materialize/optbench/sql.py
@@ -47,14 +47,14 @@ class Query:
 
         if dialect == Dialect.PG:
             if timing:
-                return "\n".join([f"EXPLAIN (ANALYZE, TIMING TRUE)", self.query])
+                return "\n".join(["EXPLAIN (ANALYZE, TIMING TRUE)", self.query])
             else:
-                return "\n".join([f"EXPLAIN", self.query])
+                return "\n".join(["EXPLAIN", self.query])
         else:
             if timing:
-                return "\n".join([f"EXPLAIN WITH(timing)", self.query])
+                return "\n".join(["EXPLAIN WITH(timing)", self.query])
             else:
-                return "\n".join([f"EXPLAIN", self.query])
+                return "\n".join(["EXPLAIN", self.query])
 
 
 class ExplainOutput:

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -82,16 +82,16 @@ def cargo(
         sysroot = spawn.capture([f"{_target}-cc", "-print-sysroot"]).strip()
         rustflags += [f"-L{sysroot}/lib"]
         extra_env = {
-            f"CMAKE_SYSTEM_NAME": "Linux",
+            "CMAKE_SYSTEM_NAME": "Linux",
             f"CARGO_TARGET_{_target_env}_LINKER": f"{_target}-cc",
-            f"CARGO_TARGET_DIR": str(ROOT / "target-xcompile"),
-            f"TARGET_AR": f"{_target}-ar",
-            f"TARGET_CPP": f"{_target}-cpp",
-            f"TARGET_CC": f"{_target}-cc",
-            f"TARGET_CXX": f"{_target}-c++",
-            f"TARGET_CXXSTDLIB": "static=stdc++",
-            f"TARGET_LD": f"{_target}-ld",
-            f"TARGET_RANLIB": f"{_target}-ranlib",
+            "CARGO_TARGET_DIR": str(ROOT / "target-xcompile"),
+            "TARGET_AR": f"{_target}-ar",
+            "TARGET_CPP": f"{_target}-cpp",
+            "TARGET_CC": f"{_target}-cc",
+            "TARGET_CXX": f"{_target}-c++",
+            "TARGET_CXXSTDLIB": "static=stdc++",
+            "TARGET_LD": f"{_target}-ld",
+            "TARGET_RANLIB": f"{_target}-ranlib",
         }
     else:
         # NOTE(benesch): The required Rust flags have to be duplicated with

--- a/misc/python/materialize/zippy/peek_actions.py
+++ b/misc/python/materialize/zippy/peek_actions.py
@@ -25,7 +25,7 @@ class PeekCancellation(Action):
     def run(self, c: Composition) -> None:
         c.testdrive(
             dedent(
-                f"""
+                """
                     > DROP TABLE IF EXISTS peek_cancellation;
                     > CREATE TABLE IF NOT EXISTS peek_cancellation (f1 INTEGER);
                     > INSERT INTO peek_cancellation SELECT generate_series(1, 1000);

--- a/misc/python/materialize/zippy/postgres_actions.py
+++ b/misc/python/materialize/zippy/postgres_actions.py
@@ -83,7 +83,7 @@ class CreatePostgresTable(Action):
 
     def run(self, c: Composition) -> None:
         if self.new_postgres_table:
-            primary_key = f"PRIMARY KEY" if self.postgres_table.has_pk else ""
+            primary_key = "PRIMARY KEY" if self.postgres_table.has_pk else ""
             c.testdrive(
                 dedent(
                     f"""

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -49,7 +49,7 @@ class Scenario:
 
 class PgCdcScenario(Scenario):
     PG_SETUP = dedent(
-        f"""
+        """
         > CREATE SECRET pgpass AS 'postgres'
         > CREATE CONNECTION pg FOR POSTGRES
           HOST postgres,
@@ -67,7 +67,7 @@ class PgCdcScenario(Scenario):
         """
     )
     MZ_SETUP = dedent(
-        f"""
+        """
         > CREATE SOURCE mz_source
           IN CLUSTER clusterd
           FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
@@ -124,7 +124,7 @@ class KafkaScenario(Scenario):
     )
 
     END_MARKER = dedent(
-        f"""
+        """
         $ kafka-ingest format=avro key-format=avro topic=topic1 schema=${{value-schema}} key-schema=${{key-schema}}
         "ZZZ" {{"f1": "END MARKER"}}
         """
@@ -187,7 +187,7 @@ SCENARIOS = [
         + "\n".join(
             [
                 dedent(
-                    f"""
+                    """
                     $ postgres-execute connection=postgres://postgres:postgres@postgres
                     UPDATE t1 SET f2 = f2 + 1;
                     """
@@ -289,7 +289,7 @@ SCENARIOS = [
         )
         + KafkaScenario.END_MARKER
         + dedent(
-            f"""
+            """
             # Expect just the two MARKERs
             > SELECT * FROM v1;
             2
@@ -323,7 +323,7 @@ SCENARIOS = [
             ]
         )
         + dedent(
-            f"""
+            """
             > SELECT * FROM v1;
             0
             """

--- a/test/cloudtest/test_compute_shared_fate.py
+++ b/test/cloudtest/test_compute_shared_fate.py
@@ -92,7 +92,7 @@ def kill_clusterd(
     mz: MaterializeApplication, compute_id: int, signal: str = "SIGKILL"
 ) -> None:
     cluster_id, replica_id = mz.environmentd.sql_query(
-        f"SELECT cluster_id, id FROM mz_cluster_replicas WHERE name = 'shared_fate_replica'"
+        "SELECT cluster_id, id FROM mz_cluster_replicas WHERE name = 'shared_fate_replica'"
     )[0]
 
     pod_name = cluster_pod_name(cluster_id, replica_id, compute_id)

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -87,7 +87,7 @@ def test_crash_storage(mz: MaterializeApplication) -> None:
     populate(mz, 1)
 
     [cluster_id, replica_id] = mz.environmentd.sql_query(
-        f"SELECT s.cluster_id, r.id FROM mz_sources s JOIN mz_cluster_replicas r ON r.cluster_id = s.cluster_id WHERE s.name = 's1'"
+        "SELECT s.cluster_id, r.id FROM mz_sources s JOIN mz_cluster_replicas r ON r.cluster_id = s.cluster_id WHERE s.name = 's1'"
     )[0]
     pod_name = cluster_pod_name(cluster_id, replica_id)
 
@@ -106,8 +106,8 @@ def test_crash_environmentd(mz: MaterializeApplication) -> None:
 
     def get_replica() -> Tuple[V1Pod, V1StatefulSet]:
         """Find the stateful set for the replica of the default cluster"""
-        compute_pod_name = f"cluster-u1-replica-1-0"
-        ss_name = f"cluster-u1-replica-1"
+        compute_pod_name = "cluster-u1-replica-1-0"
+        ss_name = "cluster-u1-replica-1"
         compute_pod = mz.environmentd.api().read_namespaced_pod(
             compute_pod_name, mz.environmentd.namespace()
         )

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -171,11 +171,11 @@ def test_missing_secret(mz: MaterializeApplication) -> None:
     # Restart the storage computed and confirm that the source errors out properly
 
     cluster_id, replica_id = mz.environmentd.sql_query(
-        f"SELECT cluster_id, id FROM mz_cluster_replicas WHERE name = 'to_be_killed'"
+        "SELECT cluster_id, id FROM mz_cluster_replicas WHERE name = 'to_be_killed'"
     )[0]
     pod_name = cluster_pod_name(cluster_id, replica_id, 0)
 
-    mz.kubectl("exec", pod_name, "--", "bash", "-c", f"kill -9 `pidof clusterd`")
+    mz.kubectl("exec", pod_name, "--", "bash", "-c", "kill -9 `pidof clusterd`")
     wait(condition="condition=Ready", resource=f"{pod_name}")
 
     mz.testdrive.run(
@@ -209,9 +209,9 @@ def test_missing_secret(mz: MaterializeApplication) -> None:
         "--",
         "bash",
         "-c",
-        f"kill -9 `pidof environmentd`",
+        "kill -9 `pidof environmentd`",
     )
-    wait(condition="condition=Ready", resource=f"pod/environmentd-0")
+    wait(condition="condition=Ready", resource="pod/environmentd-0")
 
     mz.testdrive.run(
         input=dedent(

--- a/test/cloudtest/test_ssh_tunnels.py
+++ b/test/cloudtest/test_ssh_tunnels.py
@@ -94,7 +94,7 @@ def test_ssh_tunnels(mz: MaterializeApplication) -> None:
         no_reset=True,
     )
 
-    environmentd_pod_name = f"pod/environmentd-0"
+    environmentd_pod_name = "pod/environmentd-0"
 
     # Kill environmentd to force a restart, to test reloading secrets on restart
     mz.kubectl(

--- a/test/cloudtest/test_storage_shared_fate.py
+++ b/test/cloudtest/test_storage_shared_fate.py
@@ -126,7 +126,7 @@ def kill_clusterd(
     mz: MaterializeApplication, compute_id: int, signal: str = "SIGKILL"
 ) -> None:
     cluster_id, replica_id = mz.environmentd.sql_query(
-        f"SELECT cluster_id, id FROM mz_cluster_replicas WHERE name = 'storage_shared_fate_replica'"
+        "SELECT cluster_id, id FROM mz_cluster_replicas WHERE name = 'storage_shared_fate_replica'"
     )[0]
 
     pod_name = cluster_pod_name(cluster_id, replica_id, compute_id)

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -570,7 +570,7 @@ def workflow_test_github_15496(c: Composition) -> None:
         )
         c.testdrive(
             dedent(
-                f"""
+                """
             > SET cluster = cluster1;
 
             # Run a query that would generate a panic before the fix.
@@ -618,7 +618,7 @@ def workflow_test_github_17177(c: Composition) -> None:
         )
         c.testdrive(
             dedent(
-                f"""
+                """
             # Set data for test up
             > SET cluster = cluster1;
 
@@ -719,7 +719,7 @@ def workflow_test_github_17510(c: Composition) -> None:
         )
         c.testdrive(
             dedent(
-                f"""
+                """
             > SET cluster = cluster1;
 
             # Run a queries that would generate panics before the fix.
@@ -860,7 +860,7 @@ def workflow_test_github_17509(c: Composition) -> None:
         )
         c.testdrive(
             dedent(
-                f"""
+                """
             > SET cluster = cluster1;
 
             # The query below would return a null previously, but now fails cleanly.
@@ -1320,7 +1320,7 @@ def workflow_test_mz_subscriptions(c: Composition) -> None:
         future.
         """
         output = c.sql_query(
-            f"""
+            """
             SELECT s.user, c.name, t.name
             FROM mz_internal.mz_subscriptions s
               JOIN mz_clusters c ON (c.id = s.cluster_id)

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -900,7 +900,7 @@ class KafkaEnvelopeNoneBytesScalability(ScenarioBig):
     def shared(self) -> List[Action]:
         return [
             TdAction(
-                f"""
+                """
 $ kafka-create-topic topic=kafka-scalability partitions=8
 """
             ),
@@ -1039,7 +1039,7 @@ ALTER TABLE pk_table REPLICA IDENTITY FULL;
 
     def before(self) -> Action:
         return TdAction(
-            f"""
+            """
 > DROP SOURCE IF EXISTS mz_source_pgcdc;
             """
         )
@@ -1075,7 +1075,7 @@ class PgCdcStreaming(PgCdc):
 
     def shared(self) -> Action:
         return TdAction(
-            f"""
+            """
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
@@ -1088,7 +1088,7 @@ CREATE PUBLICATION p1 FOR ALL TABLES;
 
     def before(self) -> Action:
         return TdAction(
-            f"""
+            """
 > DROP SOURCE IF EXISTS s1;
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
@@ -1144,7 +1144,7 @@ class QueryLatency(Coordinator):
     """Measure the time it takes to run SELECT 1 queries"""
 
     def benchmark(self) -> MeasurementSource:
-        selects = "\n".join(f"> SELECT 1\n1\n" for i in range(0, self.n()))
+        selects = "\n".join("> SELECT 1\n1\n" for i in range(0, self.n()))
 
         return Td(
             f"""
@@ -1170,7 +1170,7 @@ class ConnectionLatency(Coordinator):
 
     def benchmark(self) -> MeasurementSource:
         connections = "\n".join(
-            f"""
+            """
 $ postgres-execute connection=postgres://materialize:materialize@${{testdrive.materialize-sql-addr}}
 SELECT 1;
 """
@@ -1205,7 +1205,7 @@ class StartupEmpty(Startup):
         return [
             Lambda(lambda e: e.RestartMz()),
             Td(
-                f"""
+                """
 > SELECT 1;
   /* B */
 1
@@ -1222,7 +1222,7 @@ class StartupLoaded(Scenario):
     def shared(self) -> Action:
         return TdAction(
             self.schema()
-            + f"""
+            + """
 $ kafka-create-topic topic=startup-time
 
 $ kafka-ingest format=avro topic=startup-time schema=${{schema}} repeat=1

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -86,7 +86,7 @@ true
 
     def benchmark(self) -> MeasurementSource:
         hundred_selects = "\n".join(
-            f"> SELECT * FROM v1 WHERE f1 = 1;\n1\n" for i in range(0, 1000)
+            "> SELECT * FROM v1 WHERE f1 = 1;\n1\n" for i in range(0, 1000)
         )
 
         return Td(

--- a/test/feature-benchmark/scenarios_subscribe.py
+++ b/test/feature-benchmark/scenarios_subscribe.py
@@ -76,7 +76,7 @@ class SubscribeParallel(Scenario):
 class SubscribeParallelTable(SubscribeParallel):
     def create_subscribe_source(self) -> str:
         return dedent(
-            f"""
+            """
              > DROP TABLE IF EXISTS s1;
              > CREATE TABLE s1 (f1 TEXT);
              """
@@ -89,7 +89,7 @@ class SubscribeParallelTable(SubscribeParallel):
 class SubscribeParallelTableWithIndex(SubscribeParallel):
     def create_subscribe_source(self) -> str:
         return dedent(
-            f"""
+            """
              > DROP TABLE IF EXISTS s1;
              > CREATE TABLE s1 (f1 INTEGER);
              > CREATE DEFAULT INDEX ON s1;

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -166,14 +166,14 @@ class KafkaTopics(Generator):
         )
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS csr_conn
+            """> CREATE CONNECTION IF NOT EXISTS csr_conn
                 FOR CONFLUENT SCHEMA REGISTRY
                 URL '${{testdrive.schema-registry-url}}';
                 """
         )
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS kafka_conn
+            """> CREATE CONNECTION IF NOT EXISTS kafka_conn
             TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
             """
         )
@@ -220,14 +220,14 @@ class KafkaSourcesSameTopic(Generator):
         print('"123" {"f1": "123"}')
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS csr_conn
+            """> CREATE CONNECTION IF NOT EXISTS csr_conn
             FOR CONFLUENT SCHEMA REGISTRY
             URL '${{testdrive.schema-registry-url}}';
             """
         )
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS kafka_conn
+            """> CREATE CONNECTION IF NOT EXISTS kafka_conn
             TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
             """
         )
@@ -272,14 +272,14 @@ class KafkaPartitions(Generator):
             print(f'"{i}" {{"f1": "{i}"}}')
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS csr_conn
+            """> CREATE CONNECTION IF NOT EXISTS csr_conn
             FOR CONFLUENT SCHEMA REGISTRY
             URL '${{testdrive.schema-registry-url}}';
             """
         )
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS kafka_conn
+            """> CREATE CONNECTION IF NOT EXISTS kafka_conn
             TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
             """
         )
@@ -328,20 +328,20 @@ class KafkaRecordsEnvelopeNone(Generator):
         print('{"f1": "123"}')
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS csr_conn
+            """> CREATE CONNECTION IF NOT EXISTS csr_conn
             FOR CONFLUENT SCHEMA REGISTRY
             URL '${{testdrive.schema-registry-url}}';
             """
         )
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS kafka_conn
+            """> CREATE CONNECTION IF NOT EXISTS kafka_conn
             TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
             """
         )
 
         print(
-            f"""> CREATE SOURCE kafka_records_envelope_none
+            """> CREATE SOURCE kafka_records_envelope_none
               FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-records-envelope-none-${{testdrive.seed}}')
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
               ENVELOPE NONE;
@@ -377,20 +377,20 @@ class KafkaRecordsEnvelopeUpsertSameValue(Generator):
         print('{"key": "fish"} {"f1": "fish"}')
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS csr_conn
+            """> CREATE CONNECTION IF NOT EXISTS csr_conn
             FOR CONFLUENT SCHEMA REGISTRY
             URL '${{testdrive.schema-registry-url}}';
             """
         )
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS kafka_conn
+            """> CREATE CONNECTION IF NOT EXISTS kafka_conn
             TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
             """
         )
 
         print(
-            f"""> CREATE SOURCE kafka_records_envelope_upsert_same
+            """> CREATE SOURCE kafka_records_envelope_upsert_same
               FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-records-envelope-upsert-same-${{testdrive.seed}}')
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
               ENVELOPE UPSERT;
@@ -429,20 +429,20 @@ class KafkaRecordsEnvelopeUpsertDistinctValues(Generator):
         )
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS csr_conn
+            """> CREATE CONNECTION IF NOT EXISTS csr_conn
             FOR CONFLUENT SCHEMA REGISTRY
             URL '${{testdrive.schema-registry-url}}';
             """
         )
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS kafka_conn
+            """> CREATE CONNECTION IF NOT EXISTS kafka_conn
             TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
             """
         )
 
         print(
-            f"""> CREATE SOURCE kafka_records_envelope_upsert_distinct
+            """> CREATE SOURCE kafka_records_envelope_upsert_distinct
               FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-records-envelope-upsert-distinct-${{testdrive.seed}}')
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
               ENVELOPE UPSERT;
@@ -459,7 +459,7 @@ class KafkaRecordsEnvelopeUpsertDistinctValues(Generator):
         print('{"key": "${kafka-ingest.iteration}"}')
 
         print(
-            f"> SELECT COUNT(*), COUNT(DISTINCT f1) FROM kafka_records_envelope_upsert_distinct;\n0 0"
+            "> SELECT COUNT(*), COUNT(DISTINCT f1) FROM kafka_records_envelope_upsert_distinct;\n0 0"
         )
 
 
@@ -479,7 +479,7 @@ class KafkaSinks(Generator):
             print(f"> CREATE MATERIALIZED VIEW v{i} (f1) AS VALUES ({i})")
 
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS csr_conn
+            """> CREATE CONNECTION IF NOT EXISTS csr_conn
             FOR CONFLUENT SCHEMA REGISTRY
             URL '${{testdrive.schema-registry-url}}';
             """
@@ -524,10 +524,10 @@ class KafkaSinksSameSource(Generator):
         )
         print("> CREATE MATERIALIZED VIEW v1 (f1) AS VALUES (123)")
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}');"""
+            """> CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}');"""
         )
         print(
-            f"""> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (URL '${{testdrive.schema-registry-url}}');"""
+            """> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (URL '${{testdrive.schema-registry-url}}');"""
         )
 
         for i in cls.all():
@@ -734,8 +734,8 @@ class SubqueriesNested(Generator):
     def body(cls) -> None:
         print("> CREATE TABLE t1 (f1 INTEGER);")
         print("> INSERT INTO t1 VALUES (1);")
-        print(f"> SELECT 1 WHERE 1 = ")
-        print("\n".join(f"  (SELECT * FROM t1 WHERE f1 = " for i in cls.all()))
+        print("> SELECT 1 WHERE 1 = ")
+        print("\n".join("  (SELECT * FROM t1 WHERE f1 = " for i in cls.all()))
         print("  1" + "".join("  )" for i in cls.all()) + ";")
         print("1")
 
@@ -936,9 +936,9 @@ class WhereConditionAnd(Generator):
 class WhereConditionAndSameColumn(Generator):
     @classmethod
     def body(cls) -> None:
-        print(f"> CREATE TABLE t1 (f1 INTEGER);")
+        print("> CREATE TABLE t1 (f1 INTEGER);")
 
-        print(f"> INSERT INTO t1 VALUES (1);")
+        print("> INSERT INTO t1 VALUES (1);")
 
         where_condition = " AND ".join(f"f1 <= {i}" for i in cls.all())
         print(f"> SELECT f1 FROM t1 WHERE {where_condition};")
@@ -962,9 +962,9 @@ class WhereConditionOr(Generator):
 class WhereConditionOrSameColumn(Generator):
     @classmethod
     def body(cls) -> None:
-        print(f"> CREATE TABLE t1 (f1 INTEGER);")
+        print("> CREATE TABLE t1 (f1 INTEGER);")
 
-        print(f"> INSERT INTO t1 VALUES (1);")
+        print("> INSERT INTO t1 VALUES (1);")
 
         where_condition = " OR ".join(f"f1 = {i}" for i in cls.all())
         print(f"> SELECT f1 FROM t1 WHERE {where_condition};")
@@ -1087,7 +1087,7 @@ class UnionsNested(Generator):
         print("> CREATE TABLE t1 (f1 INTEGER);")
         print("> INSERT INTO t1 VALUES (1)")
 
-        print(f"> SELECT f1 + 0 FROM t1 UNION DISTINCT ")
+        print("> SELECT f1 + 0 FROM t1 UNION DISTINCT ")
         print(
             "\n".join(
                 f"  (SELECT f1 + {i} - {i} FROM t1 UNION DISTINCT " for i in cls.all()
@@ -1166,7 +1166,7 @@ class RowsJoinOneToOne(Generator):
             f"> CREATE MATERIALIZED VIEW v1 AS SELECT * FROM generate_series(1, {cls.COUNT});"
         )
         print(
-            f"> SELECT COUNT(*) FROM v1 AS a1, v1 AS a2 WHERE a1.generate_series = a2.generate_series;"
+            "> SELECT COUNT(*) FROM v1 AS a1, v1 AS a2 WHERE a1.generate_series = a2.generate_series;"
         )
         print(f"{cls.COUNT}")
 
@@ -1179,7 +1179,7 @@ class RowsJoinOneToMany(Generator):
         print(
             f"> CREATE MATERIALIZED VIEW v1 AS SELECT * FROM generate_series(1, {cls.COUNT});"
         )
-        print(f"> SELECT COUNT(*) FROM v1 AS a1, (SELECT 1) AS a2;")
+        print("> SELECT COUNT(*) FROM v1 AS a1, (SELECT 1) AS a2;")
         print(f"{cls.COUNT}")
 
 
@@ -1191,7 +1191,7 @@ class RowsJoinCross(Generator):
         print(
             f"> CREATE MATERIALIZED VIEW v1 AS SELECT * FROM generate_series(1, {cls.COUNT});"
         )
-        print(f"> SELECT COUNT(*) FROM v1 AS a1, v1 AS a2;")
+        print("> SELECT COUNT(*) FROM v1 AS a1, v1 AS a2;")
         print(f"{cls.COUNT**2}")
 
 
@@ -1225,7 +1225,7 @@ class RowsJoinDifferential(Generator):
         print(
             f"> CREATE MATERIALIZED VIEW v1 AS SELECT generate_series AS f1, generate_series AS f2 FROM (SELECT * FROM generate_series(1, {cls.COUNT}));"
         )
-        print(f"> SELECT COUNT(*) FROM v1 AS a1, v1 AS a2 WHERE a1.f1 = a2.f1;")
+        print("> SELECT COUNT(*) FROM v1 AS a1, v1 AS a2 WHERE a1.f1 = a2.f1;")
         print(f"{cls.COUNT}")
 
 
@@ -1237,7 +1237,7 @@ class RowsJoinOuter(Generator):
         print(
             f"> CREATE MATERIALIZED VIEW v1 AS SELECT generate_series AS f1, generate_series AS f2 FROM (SELECT * FROM generate_series(1, {cls.COUNT}));"
         )
-        print(f"> SELECT COUNT(*) FROM v1 AS a1 LEFT JOIN v1 AS a2 USING (f1);")
+        print("> SELECT COUNT(*) FROM v1 AS a1 LEFT JOIN v1 AS a2 USING (f1);")
         print(f"{cls.COUNT}")
 
 

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -40,7 +40,7 @@ SERVICES = [
         no_reset=True,
         seed=1,
         entrypoint_extra=[
-            f"--var=replicas=1",
+            "--var=replicas=1",
             f"--var=default-replica-size={Materialized.Size.DEFAULT_SIZE}-{Materialized.Size.DEFAULT_SIZE}",
             f"--var=default-storage-size={Materialized.Size.DEFAULT_SIZE}",
         ],

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -156,7 +156,7 @@ class ArrangedIndex(AllowCompactionCheck):
     def find_ids(self, c: Composition) -> None:
         cursor = c.sql_cursor()
         cursor.execute(
-            f"""
+            """
                 SELECT idx.id FROM mz_catalog.mz_views AS views, mz_catalog.mz_indexes AS idx
                 WHERE views.name = 'ct1' AND views.id = idx.on_id
             """

--- a/test/ssh-connection/mzcompose.py
+++ b/test/ssh-connection/mzcompose.py
@@ -121,7 +121,7 @@ def workflow_pg_restart_bastion(c: Composition) -> None:
         "ssh-bastion-host",
         "bash",
         "-c",
-        f"cat /etc/ssh/keys/ssh_host_ed25519_key.pub",
+        "cat /etc/ssh/keys/ssh_host_ed25519_key.pub",
         capture=True,
     ).stdout.strip()
 
@@ -145,7 +145,7 @@ def workflow_pg_restart_bastion(c: Composition) -> None:
         "ssh-bastion-host",
         "bash",
         "-c",
-        f"cat /etc/ssh/keys/ssh_host_ed25519_key.pub",
+        "cat /etc/ssh/keys/ssh_host_ed25519_key.pub",
         capture=True,
     ).stdout.strip()
     assert (

--- a/test/storage-usage/mzcompose.py
+++ b/test/storage-usage/mzcompose.py
@@ -136,7 +136,7 @@ database_objects = [
     DatabaseObject(
         name="materialized_view_constant",
         testdrive=dedent(
-            f"""
+            """
             > CREATE MATERIALIZED VIEW obj AS SELECT generate_series::text , REPEAT('x', 1024) FROM generate_series(1, 1024)
             """
         ),
@@ -147,7 +147,7 @@ database_objects = [
     DatabaseObject(
         name="materialized_view_small_output",
         testdrive=dedent(
-            f"""
+            """
             > CREATE TABLE t1 (f1 TEXT)
             > INSERT INTO t1 SELECT generate_series::text || REPEAT('x', 1024) FROM generate_series(1, 1024)
 
@@ -161,7 +161,7 @@ database_objects = [
         name="pg_cdc_source",
         testdrive=PG_CDC_SETUP
         + dedent(
-            f"""
+            """
             $ postgres-execute connection=postgres://postgres:postgres@postgres
             CREATE TABLE pg_table (f1 TEXT);
             INSERT INTO pg_table SELECT generate_series::text || REPEAT('x', 1024) FROM generate_series(1, 1024)
@@ -179,7 +179,7 @@ database_objects = [
         name="pg_cdc_subsource",
         testdrive=PG_CDC_SETUP
         + dedent(
-            f"""
+            """
             $ postgres-execute connection=postgres://postgres:postgres@postgres
             CREATE TABLE pg_table1 (f1 TEXT);
             INSERT INTO pg_table1 SELECT generate_series::text || REPEAT('x', 1024) FROM generate_series(1, 1024)


### PR DESCRIPTION
We could also enable something like pylint's f-string-without-interpolation / W1309

https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/f-string-without-interpolation.html

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
