### PR TITLE
storage: FORMAT JSON

### DIFF
--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -29,6 +29,7 @@ from materialize.checks.identifiers import *  # noqa: F401 F403
 from materialize.checks.insert_select import *  # noqa: F401 F403
 from materialize.checks.join_implementations import *  # noqa: F401 F403
 from materialize.checks.join_types import *  # noqa: F401 F403
+from materialize.checks.json_source import *  # noqa: F401 F403
 from materialize.checks.jsonb_type import *  # noqa: F401 F403
 from materialize.checks.kafka_formats import *  # noqa: F401 F403
 from materialize.checks.large_tables import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/json_source.py
+++ b/misc/python/materialize/checks/json_source.py
@@ -1,0 +1,79 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+from typing import List
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.util import MzVersion
+
+
+class JsonSource(Check):
+    """Test CREATE SOURCE ... FORMAT JSON"""
+
+    def _can_run(self) -> bool:
+        return self.base_version >= MzVersion.parse("0.52.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                $ kafka-create-topic topic=format-json
+
+                $ kafka-ingest format=bytes topic=format-json repeat=10000
+                {"f1": 1}
+
+                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
+                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
+
+                > CREATE SOURCE format_jsonA
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-json-${testdrive.seed}')
+                  FORMAT JSON
+
+                > CREATE SOURCE format_jsonB
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-json-${testdrive.seed}')
+                  FORMAT JSON
+                """
+            )
+        )
+
+    def manipulate(self) -> List[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                $ kafka-ingest format=bytes topic=format-json repeat=10000
+                {"f2": 1}
+                """,
+                """
+                $ kafka-ingest format=bytes topic=format-json repeat=10000
+                {"f3": 1}
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT SUM((data -> 'f1')::STRING::INTEGER) + SUM((data -> 'f2')::STRING::INTEGER) + SUM((data -> 'f3')::STRING::INTEGER) FROM format_jsonA;
+                30000
+
+                > SHOW CREATE SOURCE format_jsonA;
+                materialize.public.format_jsona "CREATE SOURCE \\"materialize\\".\\"public\\".\\"format_jsona\\" FROM KAFKA CONNECTION \\"materialize\\".\\"public\\".\\"kafka_conn\\" (TOPIC = 'testdrive-format-json-1') FORMAT JSON EXPOSE PROGRESS AS \\"materialize\\".\\"public\\".\\"format_jsonA_progress\\""
+
+                > SELECT SUM((data -> 'f1')::STRING::INTEGER) + SUM((data -> 'f2')::STRING::INTEGER) + SUM((data -> 'f3')::STRING::INTEGER) FROM format_jsonB;
+                30000
+
+                > SHOW CREATE SOURCE format_jsonB;
+                materialize.public.format_jsonb "CREATE SOURCE \\"materialize\\".\\"public\\".\\"format_jsonb\\" FROM KAFKA CONNECTION \\"materialize\\".\\"public\\".\\"kafka_conn\\" (TOPIC = 'testdrive-format-json-1') FORMAT JSON EXPOSE PROGRESS AS \\"materialize\\".\\"public\\".\\"format_jsonB_progress\\""
+           """
+            )
+        )

--- a/misc/python/materialize/checks/json_source.py
+++ b/misc/python/materialize/checks/json_source.py
@@ -67,13 +67,13 @@ class JsonSource(Check):
                 30000
 
                 > SHOW CREATE SOURCE format_jsonA;
-                materialize.public.format_jsona "CREATE SOURCE \\"materialize\\".\\"public\\".\\"format_jsona\\" FROM KAFKA CONNECTION \\"materialize\\".\\"public\\".\\"kafka_conn\\" (TOPIC = 'testdrive-format-json-1') FORMAT JSON EXPOSE PROGRESS AS \\"materialize\\".\\"public\\".\\"format_jsonA_progress\\""
+                materialize.public.format_jsona "CREATE SOURCE \\"materialize\\".\\"public\\".\\"format_jsona\\" FROM KAFKA CONNECTION \\"materialize\\".\\"public\\".\\"kafka_conn\\" (TOPIC = 'testdrive-format-json-1') FORMAT JSON EXPOSE PROGRESS AS \\"materialize\\".\\"public\\".\\"format_jsona_progress\\""
 
                 > SELECT SUM((data -> 'f1')::STRING::INTEGER) + SUM((data -> 'f2')::STRING::INTEGER) + SUM((data -> 'f3')::STRING::INTEGER) FROM format_jsonB;
                 30000
 
                 > SHOW CREATE SOURCE format_jsonB;
-                materialize.public.format_jsonb "CREATE SOURCE \\"materialize\\".\\"public\\".\\"format_jsonb\\" FROM KAFKA CONNECTION \\"materialize\\".\\"public\\".\\"kafka_conn\\" (TOPIC = 'testdrive-format-json-1') FORMAT JSON EXPOSE PROGRESS AS \\"materialize\\".\\"public\\".\\"format_jsonB_progress\\""
+                materialize.public.format_jsonb "CREATE SOURCE \\"materialize\\".\\"public\\".\\"format_jsonb\\" FROM KAFKA CONNECTION \\"materialize\\".\\"public\\".\\"kafka_conn\\" (TOPIC = 'testdrive-format-json-1') FORMAT JSON EXPOSE PROGRESS AS \\"materialize\\".\\"public\\".\\"format_jsonb_progress\\""
            """
             )
         )

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6832,6 +6832,11 @@ fn enable_features_required_for_catalog_open(session_catalog: &mut ConnCatalog) 
             .system_vars_mut()
             .set_enable_with_mutually_recursive(true);
     }
+    if !session_catalog.system_vars().enable_format_json() {
+        session_catalog
+            .system_vars_mut()
+            .set_enable_format_json(true);
+    }
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -53,6 +53,9 @@ pub enum PlanError {
     RequiresUnsafe {
         feature: String,
     },
+    RequiresVarOrUnsafe {
+        feature: String,
+    },
     UnknownColumn {
         table: Option<PartialItemName>,
         column: ColumnName,
@@ -196,6 +199,9 @@ impl PlanError {
             Self::RequiresUnsafe { .. } => {
                 Some("The requested feature is used only for internal development and testing of Materialize.".into())
             }
+            Self::RequiresVarOrUnsafe { .. } => {
+                Some("The requested feature is not currently enabled on this account.".into())
+            }
             _ => None,
         }
     }
@@ -285,6 +291,10 @@ impl fmt::Display for PlanError {
             }
             Self::RequiresUnsafe { feature} => {
                 write!(f, "{feature} is not supported",)?;
+                Ok(())
+            }
+            Self::RequiresVarOrUnsafe { feature} => {
+                write!(f, "{feature} is not enabled",)?;
                 Ok(())
             }
             Self::UnknownColumn { table, column } => write!(

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -726,6 +726,13 @@ impl<'a> StatementContext<'a> {
         Ok(())
     }
 
+    pub fn require_format_json(&self) -> Result<(), PlanError> {
+        if !self.unsafe_mode() && !self.catalog.system_vars().enable_format_json() {
+            sql_bail!("`FORMAT JSON` is not enabled")
+        }
+        Ok(())
+    }
+
     pub fn finalize_param_types(self) -> Result<Vec<ScalarType>, PlanError> {
         let param_types = self.param_types.into_inner();
         let mut out = vec![];

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -34,6 +34,7 @@ use crate::normalize;
 use crate::plan::error::PlanError;
 use crate::plan::{query, with_options};
 use crate::plan::{Params, Plan, PlanContext, PlanKind};
+use crate::session::vars::SystemVars;
 
 pub(crate) mod ddl;
 mod dml;
@@ -719,18 +720,31 @@ impl<'a> StatementContext<'a> {
         Ok(())
     }
 
-    pub fn require_with_mutually_recursive(&self) -> Result<(), PlanError> {
-        if !self.unsafe_mode() && !self.catalog.system_vars().enable_with_mutually_recursive() {
-            sql_bail!("`WITH MUTUALLY RECURSIVE` syntax is not enabled")
+    fn require_var_or_unsafe_mode<F>(
+        &self,
+        feature_flag: F,
+        feature_name: &str,
+    ) -> Result<(), PlanError>
+    where
+        F: Fn(&SystemVars) -> bool,
+    {
+        if !self.unsafe_mode() && !feature_flag(self.catalog.system_vars()) {
+            return Err(PlanError::RequiresVarOrUnsafe {
+                feature: feature_name.to_string(),
+            });
         }
         Ok(())
     }
 
+    pub fn require_with_mutually_recursive(&self) -> Result<(), PlanError> {
+        self.require_var_or_unsafe_mode(
+            SystemVars::enable_with_mutually_recursive,
+            "`WITH MUTUALLY RECURSIVE` syntax",
+        )
+    }
+
     pub fn require_format_json(&self) -> Result<(), PlanError> {
-        if !self.unsafe_mode() && !self.catalog.system_vars().enable_format_json() {
-            sql_bail!("`FORMAT JSON` is not enabled")
-        }
-        Ok(())
+        self.require_var_or_unsafe_mode(SystemVars::enable_format_json, "`FORMAT JSON")
     }
 
     pub fn finalize_param_types(self) -> Result<Vec<ScalarType>, PlanError> {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1580,7 +1580,7 @@ fn get_encoding_inner(
                     .map_err(|_| sql_err!("CSV delimiter must be an ASCII character"))?,
             })
         }
-        Format::Json => bail_unsupported!("JSON sources"),
+        Format::Json => DataEncodingInner::Json,
         Format::Text => DataEncodingInner::Text,
     }))
 }
@@ -1630,7 +1630,7 @@ fn get_unnamed_key_envelope(key: &DataEncoding) -> Result<KeyEnvelope, PlanError
         DataEncodingInner::RowCodec(_) => {
             sql_bail!("{} sources cannot use INCLUDE KEY", key.op_name())
         }
-        DataEncodingInner::Bytes | DataEncodingInner::Text => false,
+        DataEncodingInner::Bytes | DataEncodingInner::Json | DataEncodingInner::Text => false,
         DataEncodingInner::Avro(_)
         | DataEncodingInner::Csv(_)
         | DataEncodingInner::Protobuf(_)

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1580,7 +1580,10 @@ fn get_encoding_inner(
                     .map_err(|_| sql_err!("CSV delimiter must be an ASCII character"))?,
             })
         }
-        Format::Json => DataEncodingInner::Json,
+        Format::Json => {
+            scx.require_format_json()?;
+            DataEncodingInner::Json
+        }
         Format::Text => DataEncodingInner::Text,
     }))
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -665,6 +665,15 @@ static ENABLE_MONOTONIC_ONESHOT_SELECTS: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
+/// Feature flag indicating whether `FORMAT JSON` sources are enabled.
+static ENABLE_FORMAT_JSON: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_format_json"),
+    value: &false,
+    description: "Feature flag indicating whether `FORMAT JSON` sources are enabled (Materialize).",
+    internal: true,
+    safe: true,
+};
+
 /// Feature flag indicating whether real time recency is enabled.
 static REAL_TIME_RECENCY: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("real_time_recency"),
@@ -1468,6 +1477,7 @@ impl Default for SystemVars {
             .with_var(&MOCK_AUDIT_EVENT_TIMESTAMP)
             .with_var(&ENABLE_WITH_MUTUALLY_RECURSIVE)
             .with_var(&ENABLE_MONOTONIC_ONESHOT_SELECTS)
+            .with_var(&ENABLE_FORMAT_JSON)
             .with_var(&ENABLE_LD_RBAC_CHECKS)
             .with_var(&ENABLE_RBAC_CHECKS)
             .with_var(&PG_REPLICATION_CONNECT_TIMEOUT)
@@ -1801,6 +1811,20 @@ impl SystemVars {
     /// Returns the `enable_monotonic_oneshot_selects` configuration parameter.
     pub fn enable_monotonic_oneshot_selects(&self) -> bool {
         *self.expect_value(&ENABLE_MONOTONIC_ONESHOT_SELECTS)
+    }
+
+    /// Returns the `enable_format_json` configuration parameter.
+    pub fn enable_format_json(&self) -> bool {
+        *self.expect_value(&ENABLE_FORMAT_JSON)
+    }
+
+    /// Sets the `enable_format_json` configuration parameter.
+    pub fn set_enable_format_json(&mut self, value: bool) -> bool {
+        self.vars
+            .get_mut(ENABLE_FORMAT_JSON.name)
+            .expect("var known to exist")
+            .set(VarInput::Flat(value.format().as_str()))
+            .expect("valid parameter value")
     }
 
     /// Returns the `enable_ld_rbac_checks` configuration parameter.

--- a/src/storage-client/src/types/errors.proto
+++ b/src/storage-client/src/types/errors.proto
@@ -24,6 +24,7 @@ message ProtoDecodeError {
 message ProtoDecodeErrorKind {
     oneof kind {
         string text = 1;
+        string bytes = 2;
     }
 }
 

--- a/src/storage-client/src/types/errors.rs
+++ b/src/storage-client/src/types/errors.rs
@@ -75,6 +75,7 @@ impl Display for DecodeError {
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum DecodeErrorKind {
     Text(String),
+    Bytes(String),
 }
 
 impl RustType<ProtoDecodeErrorKind> for DecodeErrorKind {
@@ -83,6 +84,7 @@ impl RustType<ProtoDecodeErrorKind> for DecodeErrorKind {
         ProtoDecodeErrorKind {
             kind: Some(match self {
                 DecodeErrorKind::Text(v) => Text(v.clone()),
+                DecodeErrorKind::Bytes(v) => Bytes(v.clone()),
             }),
         }
     }
@@ -91,6 +93,7 @@ impl RustType<ProtoDecodeErrorKind> for DecodeErrorKind {
         use proto_decode_error_kind::Kind::*;
         match proto.kind {
             Some(Text(v)) => Ok(DecodeErrorKind::Text(v)),
+            Some(Bytes(v)) => Ok(DecodeErrorKind::Bytes(v)),
             None => Err(TryFromProtoError::missing_field("ProtoDecodeError::kind")),
         }
     }
@@ -100,6 +103,7 @@ impl Display for DecodeErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             DecodeErrorKind::Text(e) => write!(f, "Text: {}", e),
+            DecodeErrorKind::Bytes(e) => write!(f, "Bytes: {}", e),
         }
     }
 }

--- a/src/storage-client/src/types/sources/encoding.proto
+++ b/src/storage-client/src/types/sources/encoding.proto
@@ -38,6 +38,7 @@ message ProtoDataEncodingInner {
         google.protobuf.Empty bytes = 5;
         google.protobuf.Empty text = 6;
         mz_repr.relation_and_scalar.ProtoRelationDesc row_codec = 7;
+        google.protobuf.Empty json = 8;
     }
 }
 

--- a/src/storage/src/decode/metrics/mod.rs
+++ b/src/storage/src/decode/metrics/mod.rs
@@ -41,6 +41,7 @@ impl DecodeMetrics {
             DataDecoderInner::DelimitedBytes { format, .. }
             | DataDecoderInner::PreDelimited(format) => match format {
                 PreDelimitedFormat::Bytes => "raw",
+                PreDelimitedFormat::Json => "json",
                 PreDelimitedFormat::Text => "text",
                 PreDelimitedFormat::Regex(..) => "regex",
                 PreDelimitedFormat::Protobuf(..) => "protobuf",

--- a/test/sql-feature-flags/mzcompose.py
+++ b/test/sql-feature-flags/mzcompose.py
@@ -190,6 +190,38 @@ class WithMutuallyRecursive(FeatureTestScenario):
         return f"SELECT * FROM wmr_{ordinal:02d}"
 
 
+class FormatJson(FeatureTestScenario):
+    @classmethod
+    def feature_name(cls) -> str:
+        return "enable_format_json"
+
+    @classmethod
+    def feature_error(cls) -> str:
+        return "`FORMAT JSON` is not enabled"
+
+    @classmethod
+    def create_item(cls, ordinal: int) -> str:
+        return dedent(
+            f"""
+            CREATE CONNECTION kafka_conn_{ordinal:02d}
+                TO KAFKA (BROKER 'foo');
+            CREATE SOURCE data
+                FROM KAFKA CONNECTION kafka_conn (TOPIC 'bar')
+                FORMAT JSON;
+            """
+        )
+
+    @classmethod
+    def drop_item(cls, ordinal: int) -> str:
+        return f"DROP CONNECTION kafka_conn_{ordinal:02d} CASCADE;"
+
+    @classmethod
+    def query_item(cls, ordinal: int) -> str:
+        # Test cannot spin up infra for this feature to be tested, but we just want to verify it
+        # plans successfully.
+        return "SELECT true;"
+
+
 def run_test(c: Composition, args: argparse.Namespace) -> None:
     c.up("materialized")
     c.up("testdrive", persistent=True)

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -548,3 +548,43 @@ offset
 > SELECT "offset" FROM include_metadata_ts WHERE ts < '2021-01-01'
 offset
 ------
+
+
+#
+# JSON UPSERT source
+
+$ kafka-create-topic topic=format-json-bytes partitions=1
+
+$ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-json-bytes
+"object":{"a":"b","c":"d"}
+"array":[1,2,3]
+"int":1
+"float":1.23
+"str":"hello"
+
+> CREATE SOURCE format_json
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-json-bytes-${testdrive.seed}')
+  KEY FORMAT JSON
+  VALUE FORMAT JSON
+  ENVELOPE UPSERT;
+
+> SELECT * FROM format_json ORDER BY key
+"\"array\"" [1,2,3]
+"\"float\"" 1.23
+"\"int\"" 1
+"\"object\"" "{\"a\":\"b\",\"c\":\"d\"}"
+"\"str\"" "\"hello\""
+
+$ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-json-bytes
+"object":{"y":"z"}
+"array":[10,9,8]
+"int":99
+"float":3.14
+"str":"bye"
+
+> SELECT * FROM format_json ORDER BY key
+"\"array\"" [10,9,8]
+"\"float\"" 3.14
+"\"int\"" 99
+"\"object\"" "{\"y\":\"z\"}"
+"\"str\"" "\"bye\""

--- a/test/testdrive/source-format-json.td
+++ b/test/testdrive/source-format-json.td
@@ -35,12 +35,14 @@ $ kafka-ingest format=bytes topic=data
 1
 1.23
 "hello"
+""
 
 > SELECT * FROM data
 [1,2,3]
 1
 1.23
 "\"hello\""
+"\"\""
 "{\"a\":\"b\",\"c\":\"d\"}"
 
 $ kafka-ingest format=bytes topic=data

--- a/test/testdrive/source-format-json.td
+++ b/test/testdrive/source-format-json.td
@@ -42,3 +42,9 @@ $ kafka-ingest format=bytes topic=data
 1.23
 "\"hello\""
 "{\"a\":\"b\",\"c\":\"d\"}"
+
+$ kafka-ingest format=bytes topic=data
+hello
+
+!SELECT * FROM data
+exact:Decode error: Bytes: Failed to decode JSON: hello (original bytes: [68, 65, 6c, 6c, 6f])

--- a/test/testdrive/source-format-json.td
+++ b/test/testdrive/source-format-json.td
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Verify behavior of FORMAT JSON
+
+$ kafka-create-topic topic=data partitions=1
+$ kafka-ingest format=bytes topic=data
+{"a":"b","c":"d"}
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE SOURCE data
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FORMAT JSON;
+
+> SELECT DISTINCT pg_typeof(data) FROM data;
+jsonb
+
+> SELECT * FROM data
+"{\"a\":\"b\",\"c\":\"d\"}"
+
+# It's a dict so this is not just a string masquerading as JSON
+> SELECT data -> 'a' FROM data;
+"\"b\""
+
+$ kafka-ingest format=bytes topic=data
+[1,2,3]
+1
+1.23
+"hello"
+
+> SELECT * FROM data
+[1,2,3]
+1
+1.23
+"\"hello\""
+"{\"a\":\"b\",\"c\":\"d\"}"


### PR DESCRIPTION
Persist requested we support this format, so here we are.

@MaterializeInc/qa I was not exhaustive with these tests given that _I_ know we're just using the same bytes->JSON conversion we support elsewhere. However, I would welcome more tests or a nod that this is sufficient.

cc @MaterializeInc/persist ; if you all can check that this meets your needs, would be much appreciated.

### Motivation

This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support `FORMAT JSON`, which can ingest a stream of bytes and convert them directly into rows of `json`-formatted data.
