### PR TITLE
persist: remove `CmdMetrics::run_cmd`

### DIFF
--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -91,14 +91,9 @@ where
         let shard_metrics = metrics.shards.shard(&shard_id);
         let state = shared_states
             .get::<K, V, T, D, _, _>(shard_id, || {
-                metrics
-                    .cmds
-                    .init_state
-                    .run_cmd(&shard_metrics, |_cas_mismatch_metric| {
-                        // No cas_mismatch retries because we just use the returned
-                        // state on a mismatch.
-                        state_versions.maybe_init_shard(&shard_metrics)
-                    })
+                metrics.cmds.init_state.run_cmd(&shard_metrics, || {
+                    state_versions.maybe_init_shard(&shard_metrics)
+                })
             })
             .await?;
         Ok(Applier {

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -528,11 +528,11 @@ impl CmdMetrics {
     ) -> Result<R, E>
     where
         F: std::future::Future<Output = Result<R, E>>,
-        CmdFn: FnOnce(CmdCasMismatchMetric) -> F,
+        CmdFn: FnOnce() -> F,
     {
         self.started.inc();
         let start = Instant::now();
-        let res = cmd_fn(CmdCasMismatchMetric(self.cas_mismatch.clone())).await;
+        let res = cmd_fn().await;
         self.seconds.inc_by(start.elapsed().as_secs_f64());
         match res.as_ref() {
             Ok(_) => {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Clarifies our metrics usage that `cas_mismatch` isn't incremented with `run_cmd` usage. Alternatively, we could just inline these counters to the one use of `run_cmd`, being `init_state`

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
