### PR TITLE
sql: Implement grant and revoke privilege

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6347,6 +6347,7 @@ impl Catalog {
         old_owner: RoleId,
         new_owner: RoleId,
     ) {
+        // TODO(jkosh44) Would be nice not to clone every privilege.
         let mut flat_privileges = MzAclItem::flatten(privileges);
 
         let mut new_present = false;
@@ -6373,7 +6374,7 @@ impl Catalog {
             // Group privileges by (grantee, grantor).
             let privilege_map: BTreeMap<_, Vec<_>> =
                 flat_privileges
-                    .drain(..)
+                    .into_iter()
                     .fold(BTreeMap::new(), |mut accum, privilege| {
                         accum
                             .entry((privilege.grantee, privilege.grantor))

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1547,7 +1547,7 @@ pub struct Database {
     pub schemas_by_id: BTreeMap<SchemaId, Schema>,
     pub schemas_by_name: BTreeMap<String, SchemaId>,
     pub owner_id: RoleId,
-    // Key is the role granted the privilege, value is the privilege itself.
+    // Key is the role that granted the privilege, value is the privilege itself.
     pub privileges: BTreeMap<RoleId, Vec<MzAclItem>>,
 }
 
@@ -1586,7 +1586,7 @@ pub struct Schema {
     pub items: BTreeMap<String, GlobalId>,
     pub functions: BTreeMap<String, GlobalId>,
     pub owner_id: RoleId,
-    // Key is the role granted the privilege, value is the privilege itself.
+    // Key is the role that granted the privilege, value is the privilege itself.
     pub privileges: BTreeMap<RoleId, Vec<MzAclItem>>,
 }
 
@@ -1684,7 +1684,7 @@ pub struct Cluster {
     pub replica_id_by_name: BTreeMap<String, ReplicaId>,
     pub replicas_by_id: BTreeMap<ReplicaId, ClusterReplica>,
     pub owner_id: RoleId,
-    // Key is the role granted the privilege, value is the privilege itself.
+    // Key is the role that granted the privilege, value is the privilege itself.
     pub privileges: BTreeMap<RoleId, Vec<MzAclItem>>,
 }
 
@@ -1750,7 +1750,7 @@ pub struct CatalogEntry {
     oid: u32,
     name: QualifiedItemName,
     owner_id: RoleId,
-    // Key is the role granted the privilege, value is the privilege itself.
+    // Key is the role that granted the privilege, value is the privilege itself.
     privileges: BTreeMap<RoleId, Vec<MzAclItem>>,
 }
 
@@ -4652,7 +4652,7 @@ impl Catalog {
     }
 
     /// Returns the privileges of an object by its ID.
-    /// Key is the role granted the privilege, value is the privilege itself.
+    /// Key is the role that granted the privilege, value is the privilege itself.
     pub fn get_privileges(
         &self,
         id: &ObjectId,

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -706,7 +706,7 @@ impl CatalogState {
         name: QualifiedItemName,
         item: CatalogItem,
         owner_id: RoleId,
-        privileges: Vec<MzAclItem>,
+        privileges: BTreeMap<RoleId, Vec<MzAclItem>>,
     ) {
         if !id.is_system() && !item.is_placeholder() {
             info!(
@@ -827,7 +827,7 @@ impl CatalogState {
         linked_object_id: Option<GlobalId>,
         introspection_source_indexes: Vec<(&'static BuiltinLog, GlobalId)>,
         owner_id: RoleId,
-        privileges: Vec<MzAclItem>,
+        privileges: BTreeMap<RoleId, Vec<MzAclItem>>,
     ) {
         let mut log_indexes = BTreeMap::new();
         for (log, index_id) in introspection_source_indexes {
@@ -882,7 +882,7 @@ impl CatalogState {
                     custom_logical_compaction_window: None,
                 }),
                 MZ_SYSTEM_ROLE_ID,
-                Vec::new(),
+                BTreeMap::new(),
             );
             log_indexes.insert(log.variant.clone(), index_id);
         }
@@ -1547,7 +1547,8 @@ pub struct Database {
     pub schemas_by_id: BTreeMap<SchemaId, Schema>,
     pub schemas_by_name: BTreeMap<String, SchemaId>,
     pub owner_id: RoleId,
-    pub privileges: Vec<MzAclItem>,
+    // Key is the role granted the privilege, value is the privilege itself.
+    pub privileges: BTreeMap<RoleId, Vec<MzAclItem>>,
 }
 
 impl Database {
@@ -1556,6 +1557,11 @@ impl Database {
     fn debug_json(&self) -> serde_json::Value {
         let schemas_by_str: BTreeMap<String, _> = self
             .schemas_by_id
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.debug_json()))
+            .collect();
+        let privileges_by_str: BTreeMap<String, _> = self
+            .privileges
             .iter()
             .map(|(key, value)| (key.to_string(), value))
             .collect();
@@ -1566,6 +1572,7 @@ impl Database {
             "schemas_by_id": schemas_by_str,
             "schemas_by_name": self.schemas_by_name,
             "owner_id": self.owner_id,
+            "privileges": privileges_by_str,
         })
     }
 }
@@ -1579,7 +1586,29 @@ pub struct Schema {
     pub items: BTreeMap<String, GlobalId>,
     pub functions: BTreeMap<String, GlobalId>,
     pub owner_id: RoleId,
-    pub privileges: Vec<MzAclItem>,
+    // Key is the role granted the privilege, value is the privilege itself.
+    pub privileges: BTreeMap<RoleId, Vec<MzAclItem>>,
+}
+
+impl Schema {
+    /// Returns a `Schema` formatted as a `serde_json::Value` that is suitable for debugging. For
+    /// example `CatalogState::dump`.
+    fn debug_json(&self) -> serde_json::Value {
+        let privileges_by_str: BTreeMap<String, _> = self
+            .privileges
+            .iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect();
+
+        serde_json::json!({
+            "name": self.name,
+            "id": self.id,
+            "items": self.items,
+            "functions": self.functions,
+            "owner_id": self.owner_id,
+            "privileges": privileges_by_str,
+        })
+    }
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -1655,7 +1684,8 @@ pub struct Cluster {
     pub replica_id_by_name: BTreeMap<String, ReplicaId>,
     pub replicas_by_id: BTreeMap<ReplicaId, ClusterReplica>,
     pub owner_id: RoleId,
-    pub privileges: Vec<MzAclItem>,
+    // Key is the role granted the privilege, value is the privilege itself.
+    pub privileges: BTreeMap<RoleId, Vec<MzAclItem>>,
 }
 
 impl Cluster {
@@ -1720,7 +1750,8 @@ pub struct CatalogEntry {
     oid: u32,
     name: QualifiedItemName,
     owner_id: RoleId,
-    privileges: Vec<MzAclItem>,
+    // Key is the role granted the privilege, value is the privilege itself.
+    privileges: BTreeMap<RoleId, Vec<MzAclItem>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -2489,7 +2520,7 @@ impl CatalogEntry {
     }
 
     /// Returns the privileges of the entry.
-    pub fn privileges(&self) -> &Vec<MzAclItem> {
+    pub fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>> {
         &self.privileges
     }
 }
@@ -2585,7 +2616,7 @@ pub struct BuiltinMigrationMetadata {
         u32,
         QualifiedItemName,
         RoleId,
-        Vec<MzAclItem>,
+        BTreeMap<RoleId, Vec<MzAclItem>>,
         CatalogItemRebuilder,
     )>,
     pub introspection_source_index_updates:
@@ -2688,7 +2719,7 @@ impl Catalog {
                     schemas_by_id: BTreeMap::new(),
                     schemas_by_name: BTreeMap::new(),
                     owner_id,
-                    privileges,
+                    privileges: MzAclItem::group_by_grantee(privileges),
                 },
             );
             catalog
@@ -2738,7 +2769,7 @@ impl Catalog {
                     items: BTreeMap::new(),
                     functions: BTreeMap::new(),
                     owner_id,
-                    privileges,
+                    privileges: MzAclItem::group_by_grantee(privileges),
                 },
             );
             schemas_by_name.insert(name.clone(), id);
@@ -2837,7 +2868,7 @@ impl Catalog {
                                 has_storage_collection: false,
                             }),
                             MZ_SYSTEM_ROLE_ID,
-                            vec![
+                            MzAclItem::group_by_grantee(vec![
                                 rbac::default_catalog_privilege(
                                     mz_sql_parser::ast::ObjectType::Source,
                                 ),
@@ -2845,7 +2876,7 @@ impl Catalog {
                                     mz_sql_parser::ast::ObjectType::Source,
                                     MZ_SYSTEM_ROLE_ID,
                                 ),
-                            ],
+                            ]),
                         );
                     }
 
@@ -2867,7 +2898,7 @@ impl Catalog {
                                 is_retained_metrics_object: table.is_retained_metrics_object,
                             }),
                             MZ_SYSTEM_ROLE_ID,
-                            vec![
+                            MzAclItem::group_by_grantee(vec![
                                 rbac::default_catalog_privilege(
                                     mz_sql_parser::ast::ObjectType::Table,
                                 ),
@@ -2875,7 +2906,7 @@ impl Catalog {
                                     mz_sql_parser::ast::ObjectType::Table,
                                     MZ_SYSTEM_ROLE_ID,
                                 ),
-                            ],
+                            ]),
                         );
                     }
                     Builtin::Index(_) => {
@@ -2907,7 +2938,7 @@ impl Catalog {
                             name,
                             item,
                             MZ_SYSTEM_ROLE_ID,
-                            vec![
+                            MzAclItem::group_by_grantee(vec![
                                 rbac::default_catalog_privilege(
                                     mz_sql_parser::ast::ObjectType::View,
                                 ),
@@ -2915,7 +2946,7 @@ impl Catalog {
                                     mz_sql_parser::ast::ObjectType::View,
                                     MZ_SYSTEM_ROLE_ID,
                                 ),
-                            ],
+                            ]),
                         );
                     }
 
@@ -2929,7 +2960,7 @@ impl Catalog {
                             name.clone(),
                             CatalogItem::Func(Func { inner: func.inner }),
                             MZ_SYSTEM_ROLE_ID,
-                            Vec::new(),
+                            BTreeMap::new(),
                         );
                     }
 
@@ -2956,7 +2987,7 @@ impl Catalog {
                                 is_retained_metrics_object: coll.is_retained_metrics_object,
                             }),
                             MZ_SYSTEM_ROLE_ID,
-                            vec![
+                            MzAclItem::group_by_grantee(vec![
                                 rbac::default_catalog_privilege(
                                     mz_sql_parser::ast::ObjectType::Source,
                                 ),
@@ -2964,7 +2995,7 @@ impl Catalog {
                                     mz_sql_parser::ast::ObjectType::Source,
                                     MZ_SYSTEM_ROLE_ID,
                                 ),
-                            ],
+                            ]),
                         );
                     }
                 }
@@ -3017,7 +3048,7 @@ impl Catalog {
                 linked_object_id,
                 all_indexes,
                 owner_id,
-                privileges,
+                MzAclItem::group_by_grantee(privileges),
             );
         }
 
@@ -3089,9 +3120,14 @@ impl Catalog {
                     };
 
                     let oid = catalog.allocate_oid()?;
-                    catalog
-                        .state
-                        .insert_item(id, oid, name, item, MZ_SYSTEM_ROLE_ID, Vec::new());
+                    catalog.state.insert_item(
+                        id,
+                        oid,
+                        name,
+                        item,
+                        MZ_SYSTEM_ROLE_ID,
+                        BTreeMap::new(),
+                    );
                 }
                 Builtin::Log(_)
                 | Builtin::Table(_)
@@ -3488,10 +3524,10 @@ impl Catalog {
                     depends_on: vec![],
                 }),
                 MZ_SYSTEM_ROLE_ID,
-                vec![
+                MzAclItem::group_by_grantee(vec![
                     rbac::default_catalog_privilege(mz_sql_parser::ast::ObjectType::Type),
                     rbac::owner_privilege(mz_sql_parser::ast::ObjectType::Type, MZ_SYSTEM_ROLE_ID),
-                ],
+                ]),
             );
         }
 
@@ -3809,7 +3845,7 @@ impl Catalog {
                 &name,
                 serialized_item,
                 entry.owner_id,
-                entry.privileges.clone(),
+                MzAclItem::flatten(entry.privileges()),
             )?;
         }
         tx.update_system_object_mappings(std::mem::take(
@@ -3928,7 +3964,7 @@ impl Catalog {
                 item.name,
                 catalog_item,
                 item.owner_id,
-                item.privileges,
+                MzAclItem::group_by_grantee(item.privileges),
             );
         }
 
@@ -4414,10 +4450,10 @@ impl Catalog {
                 items: BTreeMap::new(),
                 functions: BTreeMap::new(),
                 owner_id,
-                privileges: vec![rbac::owner_privilege(
+                privileges: MzAclItem::group_by_grantee(vec![rbac::owner_privilege(
                     mz_sql_parser::ast::ObjectType::Schema,
                     owner_id,
-                )],
+                )]),
             },
         );
         Ok(())
@@ -4613,6 +4649,25 @@ impl Catalog {
     /// Returns the default size to use for linked clusters.
     pub fn default_linked_cluster_size(&self) -> String {
         self.state.default_linked_cluster_size()
+    }
+
+    /// Returns the privileges of an object by its ID.
+    /// Key is the role granted the privilege, value is the privilege itself.
+    pub fn get_privileges(
+        &self,
+        id: &ObjectId,
+        conn_id: ConnectionId,
+    ) -> Option<&BTreeMap<RoleId, Vec<MzAclItem>>> {
+        match id {
+            ObjectId::Cluster(id) => Some(self.get_cluster(*id).privileges()),
+            ObjectId::Database(id) => Some(self.get_database(id).privileges()),
+            ObjectId::Schema((database_spec, schema_id)) => Some(
+                self.get_schema(database_spec, &SchemaSpecifier::from(*schema_id), conn_id)
+                    .privileges(),
+            ),
+            ObjectId::Item(id) => Some(self.get_entry(id).privileges()),
+            ObjectId::ClusterReplica(_) | ObjectId::Role(_) => None,
+        }
     }
 
     #[tracing::instrument(name = "catalog::transact", level = "debug", skip_all)]
@@ -5011,7 +5066,7 @@ impl Catalog {
                             schemas_by_id: BTreeMap::new(),
                             schemas_by_name: BTreeMap::new(),
                             owner_id,
-                            privileges: database_privileges,
+                            privileges: MzAclItem::group_by_grantee(database_privileges),
                         },
                     );
                     state
@@ -5042,7 +5097,7 @@ impl Catalog {
                         database_id,
                         DEFAULT_SCHEMA.to_string(),
                         owner_id,
-                        default_schema_privileges,
+                        MzAclItem::group_by_grantee(default_schema_privileges),
                     )?;
                 }
                 Op::CreateSchema {
@@ -5096,7 +5151,7 @@ impl Catalog {
                         database_id,
                         schema_name,
                         owner_id,
-                        privileges,
+                        MzAclItem::group_by_grantee(privileges),
                     )?;
                 }
                 Op::CreateRole {
@@ -5191,7 +5246,7 @@ impl Catalog {
                         linked_object_id,
                         introspection_sources,
                         owner_id,
-                        privileges,
+                        MzAclItem::group_by_grantee(privileges),
                     );
                     builtin_table_updates.push(state.pack_cluster_update(&name, 1));
                     if let Some(linked_object_id) = linked_object_id {
@@ -5387,7 +5442,14 @@ impl Catalog {
                             details,
                         )?;
                     }
-                    state.insert_item(id, oid, name, item, owner_id, privileges);
+                    state.insert_item(
+                        id,
+                        oid,
+                        name,
+                        item,
+                        owner_id,
+                        MzAclItem::group_by_grantee(privileges),
+                    );
                     builtin_table_updates.extend(state.pack_item_update(id, 1));
                 }
                 Op::DropObject(id) => match id {
@@ -5711,6 +5773,154 @@ impl Catalog {
                         }),
                     )?;
                 }
+                Op::GrantPrivilege {
+                    object_id,
+                    privilege,
+                } => match object_id {
+                    ObjectId::Cluster(id) => {
+                        let cluster_name = state.get_cluster(id).name().to_string();
+                        if id.is_system() {
+                            return Err(AdapterError::Catalog(Error::new(
+                                ErrorKind::ReadOnlyCluster(cluster_name),
+                            )));
+                        }
+                        builtin_table_updates.push(state.pack_cluster_update(&cluster_name, -1));
+                        let cluster = state.get_cluster_mut(id);
+                        Self::grant_object_privilege(&mut cluster.privileges, privilege);
+                        tx.update_cluster(id, cluster)?;
+                        builtin_table_updates.push(state.pack_cluster_update(&cluster_name, 1));
+                    }
+                    ObjectId::Database(id) => {
+                        let database = state.get_database(&id);
+                        builtin_table_updates.push(state.pack_database_update(database, -1));
+                        let database = state.get_database_mut(&id);
+                        Self::grant_object_privilege(&mut database.privileges, privilege);
+                        let database = state.get_database(&id);
+                        tx.update_database(id, database)?;
+                        builtin_table_updates.push(state.pack_database_update(database, 1));
+                    }
+                    ObjectId::Schema((database_spec, schema_id)) => {
+                        builtin_table_updates.push(state.pack_schema_update(
+                            &database_spec,
+                            &schema_id,
+                            -1,
+                        ));
+                        let schema = state.get_schema_mut(
+                            &database_spec,
+                            &schema_id.into(),
+                            session
+                                .map(|session| session.conn_id())
+                                .unwrap_or(SYSTEM_CONN_ID),
+                        );
+                        Self::grant_object_privilege(&mut schema.privileges, privilege);
+                        let database_id = match &database_spec {
+                            ResolvedDatabaseSpecifier::Ambient => None,
+                            ResolvedDatabaseSpecifier::Id(id) => Some(*id),
+                        };
+                        tx.update_schema(database_id, schema_id, schema)?;
+                        builtin_table_updates.push(state.pack_schema_update(
+                            &database_spec,
+                            &schema_id,
+                            1,
+                        ));
+                    }
+                    ObjectId::Item(id) => {
+                        if id.is_system() {
+                            let entry = state.get_entry(&id);
+                            let full_name = state.resolve_full_name(
+                                entry.name(),
+                                session.map(|session| session.conn_id()),
+                            );
+                            return Err(AdapterError::Catalog(Error::new(
+                                ErrorKind::ReadOnlyItem(full_name.to_string()),
+                            )));
+                        }
+                        builtin_table_updates.extend(state.pack_item_update(id, -1));
+                        let entry = state.get_entry_mut(&id);
+                        Self::grant_object_privilege(&mut entry.privileges, privilege);
+                        tx.update_item(
+                            id,
+                            &entry.name().item,
+                            &Self::serialize_item(entry.item()),
+                        )?;
+                        builtin_table_updates.extend(state.pack_item_update(id, 1));
+                    }
+                    ObjectId::Role(_) | ObjectId::ClusterReplica(_) => {}
+                },
+                Op::RevokePrivilege {
+                    object_id,
+                    privilege,
+                } => match object_id {
+                    ObjectId::Cluster(id) => {
+                        let cluster_name = state.get_cluster(id).name().to_string();
+                        if id.is_system() {
+                            return Err(AdapterError::Catalog(Error::new(
+                                ErrorKind::ReadOnlyCluster(cluster_name),
+                            )));
+                        }
+                        builtin_table_updates.push(state.pack_cluster_update(&cluster_name, -1));
+                        let cluster = state.get_cluster_mut(id);
+                        Self::revoke_object_privilege(&mut cluster.privileges, privilege);
+                        tx.update_cluster(id, cluster)?;
+                        builtin_table_updates.push(state.pack_cluster_update(&cluster_name, 1));
+                    }
+                    ObjectId::Database(id) => {
+                        let database = state.get_database(&id);
+                        builtin_table_updates.push(state.pack_database_update(database, -1));
+                        let database = state.get_database_mut(&id);
+                        Self::revoke_object_privilege(&mut database.privileges, privilege);
+                        let database = state.get_database(&id);
+                        tx.update_database(id, database)?;
+                        builtin_table_updates.push(state.pack_database_update(database, 1));
+                    }
+                    ObjectId::Schema((database_spec, schema_id)) => {
+                        builtin_table_updates.push(state.pack_schema_update(
+                            &database_spec,
+                            &schema_id,
+                            -1,
+                        ));
+                        let schema = state.get_schema_mut(
+                            &database_spec,
+                            &schema_id.into(),
+                            session
+                                .map(|session| session.conn_id())
+                                .unwrap_or(SYSTEM_CONN_ID),
+                        );
+                        Self::revoke_object_privilege(&mut schema.privileges, privilege);
+                        let database_id = match &database_spec {
+                            ResolvedDatabaseSpecifier::Ambient => None,
+                            ResolvedDatabaseSpecifier::Id(id) => Some(*id),
+                        };
+                        tx.update_schema(database_id, schema_id, schema)?;
+                        builtin_table_updates.push(state.pack_schema_update(
+                            &database_spec,
+                            &schema_id,
+                            1,
+                        ));
+                    }
+                    ObjectId::Item(id) => {
+                        if id.is_system() {
+                            let entry = state.get_entry(&id);
+                            let full_name = state.resolve_full_name(
+                                entry.name(),
+                                session.map(|session| session.conn_id()),
+                            );
+                            return Err(AdapterError::Catalog(Error::new(
+                                ErrorKind::ReadOnlyItem(full_name.to_string()),
+                            )));
+                        }
+                        builtin_table_updates.extend(state.pack_item_update(id, -1));
+                        let entry = state.get_entry_mut(&id);
+                        Self::revoke_object_privilege(&mut entry.privileges, privilege);
+                        tx.update_item(
+                            id,
+                            &entry.name().item,
+                            &Self::serialize_item(entry.item()),
+                        )?;
+                        builtin_table_updates.extend(state.pack_item_update(id, 1));
+                    }
+                    ObjectId::Role(_) | ObjectId::ClusterReplica(_) => {}
+                },
                 Op::RenameItem {
                     id,
                     to_name,
@@ -6092,7 +6302,7 @@ impl Catalog {
             database_id: DatabaseId,
             schema_name: String,
             owner_id: RoleId,
-            privileges: Vec<MzAclItem>,
+            privileges: BTreeMap<RoleId, Vec<MzAclItem>>,
         ) -> Result<(), AdapterError> {
             info!(
                 "create schema {}.{}",
@@ -6133,12 +6343,14 @@ impl Catalog {
     /// implementation:
     /// <https://github.com/postgres/postgres/blob/43a33ef54e503b61f269d088f2623ba3b9484ad7/src/backend/utils/adt/acl.c#L1078-L1177>
     fn update_privilege_owners(
-        privileges: &mut Vec<MzAclItem>,
+        privileges: &mut BTreeMap<RoleId, Vec<MzAclItem>>,
         old_owner: RoleId,
         new_owner: RoleId,
     ) {
+        let mut flat_privileges = MzAclItem::flatten(privileges);
+
         let mut new_present = false;
-        for privilege in privileges.iter_mut() {
+        for privilege in flat_privileges.iter_mut() {
             // Old owner's granted privilege are updated to be granted by the new
             // owner.
             if privilege.grantor == old_owner {
@@ -6160,8 +6372,8 @@ impl Catalog {
         if new_present {
             // Group privileges by (grantee, grantor).
             let privilege_map: BTreeMap<_, Vec<_>> =
-                privileges
-                    .into_iter()
+                flat_privileges
+                    .drain(..)
                     .fold(BTreeMap::new(), |mut accum, privilege| {
                         accum
                             .entry((privilege.grantee, privilege.grantor))
@@ -6169,8 +6381,9 @@ impl Catalog {
                             .push(privilege);
                         accum
                     });
+
             // Consolidate and update all privileges.
-            *privileges = privilege_map
+            flat_privileges = privilege_map
                 .into_iter()
                 .map(|((grantee, grantor), values)|
                     // Combine the acl_mode of all mz_aclitems with the same grantee and grantor.
@@ -6183,6 +6396,53 @@ impl Catalog {
                         },
                     ))
                 .collect();
+        }
+
+        *privileges = MzAclItem::group_by_grantee(flat_privileges);
+    }
+
+    fn grant_object_privilege(
+        privileges: &mut BTreeMap<RoleId, Vec<MzAclItem>>,
+        privilege: MzAclItem,
+    ) {
+        let grantee_privileges = privileges.entry(privilege.grantee).or_default();
+        if let Some(existing_privilege) = grantee_privileges
+            .iter_mut()
+            .find(|cur_privilege| cur_privilege.grantor == privilege.grantor)
+        {
+            // sanity check that the catalog data is consistent.
+            assert_eq!(
+                privilege.grantee, existing_privilege.grantee,
+                "catalog privileges out of sync"
+            );
+            existing_privilege.acl_mode = existing_privilege.acl_mode.union(privilege.acl_mode);
+        } else {
+            grantee_privileges.push(privilege);
+        }
+    }
+
+    fn revoke_object_privilege(
+        privileges: &mut BTreeMap<RoleId, Vec<MzAclItem>>,
+        privilege: MzAclItem,
+    ) {
+        let grantee_privileges = privileges.entry(privilege.grantee).or_default();
+        if let Some(existing_privilege) = grantee_privileges
+            .iter_mut()
+            .find(|cur_privilege| cur_privilege.grantor == privilege.grantor)
+        {
+            // sanity check that the catalog data is consistent.
+            assert_eq!(
+                privilege.grantee, existing_privilege.grantee,
+                "catalog privileges out of sync"
+            );
+            existing_privilege.acl_mode =
+                existing_privilege.acl_mode.difference(privilege.acl_mode);
+        }
+
+        // Remove empty privileges
+        grantee_privileges.retain(|privilege| !privilege.acl_mode.is_empty());
+        if grantee_privileges.is_empty() {
+            privileges.remove(&privilege.grantee);
         }
     }
 
@@ -6556,6 +6816,56 @@ impl Catalog {
     pub fn ensure_not_reserved_role(&self, role_id: &RoleId) -> Result<(), Error> {
         self.state.ensure_not_reserved_role(role_id)
     }
+
+    pub fn ensure_not_reserved_object(
+        &self,
+        object_id: &ObjectId,
+        conn_id: ConnectionId,
+    ) -> Result<(), Error> {
+        match object_id {
+            ObjectId::Cluster(cluster_id) | ObjectId::ClusterReplica((cluster_id, _)) => {
+                if cluster_id.is_system() {
+                    let cluster = self.get_cluster(*cluster_id);
+                    Err(Error::new(ErrorKind::ReadOnlyCluster(
+                        cluster.name().to_string(),
+                    )))
+                } else {
+                    Ok(())
+                }
+            }
+            ObjectId::Database(database_id) => {
+                if database_id.is_system() {
+                    let database = self.get_database(database_id);
+                    Err(Error::new(ErrorKind::ReadOnlyDatabase(
+                        database.name().to_string(),
+                    )))
+                } else {
+                    Ok(())
+                }
+            }
+            ObjectId::Schema((database_spec, schema_id)) => {
+                if schema_id.is_system() {
+                    let schema =
+                        self.get_schema(database_spec, &SchemaSpecifier::Id(*schema_id), conn_id);
+                    Err(Error::new(ErrorKind::ReadOnlySystemSchema(
+                        schema.name().schema.clone(),
+                    )))
+                } else {
+                    Ok(())
+                }
+            }
+            ObjectId::Role(role_id) => self.ensure_not_reserved_role(role_id),
+            ObjectId::Item(item_id) => {
+                if item_id.is_system() {
+                    let item = self.get_entry(item_id);
+                    let name = self.resolve_full_name(item.name(), Some(conn_id));
+                    Err(Error::new(ErrorKind::ReadOnlyItem(name.to_string())))
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
 }
 
 pub fn is_reserved_name(name: &str) -> bool {
@@ -6642,6 +6952,10 @@ pub enum Op {
     },
     DropObject(ObjectId),
     DropTimeline(Timeline),
+    GrantPrivilege {
+        object_id: ObjectId,
+        privilege: MzAclItem,
+    },
     GrantRole {
         role_id: RoleId,
         member_id: RoleId,
@@ -6655,6 +6969,10 @@ pub enum Op {
     UpdateOwner {
         id: ObjectId,
         new_owner: RoleId,
+    },
+    RevokePrivilege {
+        object_id: ObjectId,
+        privilege: MzAclItem,
     },
     RevokeRole {
         role_id: RoleId,
@@ -7199,6 +7517,10 @@ impl SessionCatalog for ConnCatalog<'_> {
         let mut seen = BTreeSet::new();
         self.state.item_dependents(id, &mut seen)
     }
+
+    fn all_object_privileges(&self, object_type: mz_sql_parser::ast::ObjectType) -> AclMode {
+        rbac::all_object_privileges(object_type)
+    }
 }
 
 impl mz_sql::catalog::CatalogDatabase for Database {
@@ -7220,6 +7542,10 @@ impl mz_sql::catalog::CatalogDatabase for Database {
 
     fn owner_id(&self) -> RoleId {
         self.owner_id
+    }
+
+    fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>> {
+        &self.privileges
     }
 }
 
@@ -7246,6 +7572,10 @@ impl mz_sql::catalog::CatalogSchema for Schema {
 
     fn owner_id(&self) -> RoleId {
         self.owner_id
+    }
+
+    fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>> {
+        &self.privileges
     }
 }
 
@@ -7306,6 +7636,10 @@ impl mz_sql::catalog::CatalogCluster<'_> for Cluster {
 
     fn owner_id(&self) -> RoleId {
         self.owner_id
+    }
+
+    fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>> {
+        &self.privileges
     }
 }
 
@@ -7416,6 +7750,10 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
 
     fn owner_id(&self) -> RoleId {
         self.owner_id
+    }
+
+    fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>> {
+        &self.privileges
     }
 }
 
@@ -8442,72 +8780,89 @@ mod tests {
         let other_role = RoleId::User(3);
 
         // older owner exists as grantor.
-        let mut privileges = vec![
-            MzAclItem {
-                grantee: other_role,
-                grantor: old_owner,
-                acl_mode: AclMode::UPDATE,
-            },
-            MzAclItem {
-                grantee: other_role,
-                grantor: new_owner,
-                acl_mode: AclMode::SELECT,
-            },
-        ];
+        let mut privileges = BTreeMap::new();
+        privileges.insert(
+            other_role,
+            vec![
+                MzAclItem {
+                    grantee: other_role,
+                    grantor: old_owner,
+                    acl_mode: AclMode::UPDATE,
+                },
+                MzAclItem {
+                    grantee: other_role,
+                    grantor: new_owner,
+                    acl_mode: AclMode::SELECT,
+                },
+            ],
+        );
         Catalog::update_privilege_owners(&mut privileges, old_owner, new_owner);
+        assert_eq!(1, privileges.len());
         assert_eq!(
-            vec![MzAclItem {
+            &vec![MzAclItem {
                 grantee: other_role,
                 grantor: new_owner,
                 acl_mode: AclMode::SELECT.union(AclMode::UPDATE)
             }],
-            privileges
+            privileges.get(&other_role).expect("other_role is grantee")
         );
 
         // older owner exists as grantee.
-        let mut privileges = vec![
-            MzAclItem {
+        let mut privileges = BTreeMap::new();
+        privileges.insert(
+            old_owner,
+            vec![MzAclItem {
                 grantee: old_owner,
                 grantor: other_role,
                 acl_mode: AclMode::UPDATE,
-            },
-            MzAclItem {
+            }],
+        );
+        privileges.insert(
+            new_owner,
+            vec![MzAclItem {
                 grantee: new_owner,
                 grantor: other_role,
                 acl_mode: AclMode::SELECT,
-            },
-        ];
+            }],
+        );
         Catalog::update_privilege_owners(&mut privileges, old_owner, new_owner);
+        assert_eq!(1, privileges.len());
         assert_eq!(
-            vec![MzAclItem {
+            &vec![MzAclItem {
                 grantee: new_owner,
                 grantor: other_role,
                 acl_mode: AclMode::SELECT.union(AclMode::UPDATE)
             }],
-            privileges
+            privileges.get(&new_owner).expect("new_owner is grantee")
         );
 
         // older owner exists as grantee and grantor.
-        let mut privileges = vec![
-            MzAclItem {
+        let mut privileges = BTreeMap::new();
+        privileges.insert(
+            old_owner,
+            vec![MzAclItem {
                 grantee: old_owner,
                 grantor: old_owner,
                 acl_mode: AclMode::UPDATE,
-            },
-            MzAclItem {
+            }],
+        );
+        privileges.insert(
+            new_owner,
+            vec![MzAclItem {
                 grantee: new_owner,
                 grantor: new_owner,
                 acl_mode: AclMode::SELECT,
-            },
-        ];
+            }],
+        );
         Catalog::update_privilege_owners(&mut privileges, old_owner, new_owner);
+        assert_eq!(1, privileges.len());
         assert_eq!(
-            vec![MzAclItem {
+            &vec![MzAclItem {
                 grantee: new_owner,
                 grantor: new_owner,
                 acl_mode: AclMode::SELECT.union(AclMode::UPDATE)
             }],
-            privileges
+            privileges.get(&new_owner).expect("new_owner is grantee")
         );
     }
 }

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -706,7 +706,7 @@ impl CatalogState {
         name: QualifiedItemName,
         item: CatalogItem,
         owner_id: RoleId,
-        privileges: BTreeMap<RoleId, Vec<MzAclItem>>,
+        privileges: PrivilegeMap,
     ) {
         if !id.is_system() && !item.is_placeholder() {
             info!(
@@ -882,7 +882,7 @@ impl CatalogState {
                     custom_logical_compaction_window: None,
                 }),
                 MZ_SYSTEM_ROLE_ID,
-                BTreeMap::new(),
+                PrivilegeMap::new(),
             );
             log_indexes.insert(log.variant.clone(), index_id);
         }
@@ -1631,8 +1631,7 @@ impl Role {
 #[serde(into = "BTreeMap<String, RoleId>")]
 #[serde(try_from = "BTreeMap<String, RoleId>")]
 pub struct RoleMembership {
-    /// Key is the role
-    /// that some role is a member of, value is the grantor role ID.
+    /// Key is the role that some role is a member of, value is the grantor role ID.
     // TODO(jkosh44) This structure does not allow a role to have multiple of the same membership
     // from different grantors. This isn't a problem now since we don't implement ADMIN OPTION, but
     // we should figure this out before implementing ADMIN OPTION. It will likely require a messy
@@ -2957,7 +2956,7 @@ impl Catalog {
                             name.clone(),
                             CatalogItem::Func(Func { inner: func.inner }),
                             MZ_SYSTEM_ROLE_ID,
-                            BTreeMap::new(),
+                            PrivilegeMap::new(),
                         );
                     }
 
@@ -3123,7 +3122,7 @@ impl Catalog {
                         name,
                         item,
                         MZ_SYSTEM_ROLE_ID,
-                        BTreeMap::new(),
+                        PrivilegeMap::new(),
                     );
                 }
                 Builtin::Log(_)
@@ -7721,7 +7720,7 @@ mod tests {
     use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
     use mz_repr::role_id::RoleId;
     use mz_repr::{GlobalId, RelationDesc, RelationType, ScalarType};
-    use mz_sql::catalog::CatalogDatabase;
+    use mz_sql::catalog::{CatalogDatabase, PrivilegeMap};
     use mz_sql::names;
     use mz_sql::names::{
         DatabaseId, ItemQualifiers, PartialItemName, QualifiedItemName, ResolvedDatabaseSpecifier,
@@ -8731,7 +8730,7 @@ mod tests {
         let other_role = RoleId::User(3);
 
         // older owner exists as grantor.
-        let mut privileges = BTreeMap::new();
+        let mut privileges = PrivilegeMap::new();
         privileges.insert(
             other_role,
             vec![
@@ -8759,7 +8758,7 @@ mod tests {
         );
 
         // older owner exists as grantee.
-        let mut privileges = BTreeMap::new();
+        let mut privileges = PrivilegeMap::new();
         privileges.insert(
             old_owner,
             vec![MzAclItem {
@@ -8788,7 +8787,7 @@ mod tests {
         );
 
         // older owner exists as grantee and grantor.
-        let mut privileges = BTreeMap::new();
+        let mut privileges = PrivilegeMap::new();
         privileges.insert(
             old_owner,
             vec![MzAclItem {

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5784,6 +5784,11 @@ impl Catalog {
                     }
                     ObjectId::Database(id) => {
                         let database = state.get_database(&id);
+                        if id.is_system() {
+                            return Err(AdapterError::Catalog(Error::new(
+                                ErrorKind::ReadOnlyDatabase(database.name().to_string()),
+                            )));
+                        }
                         builtin_table_updates.push(state.pack_database_update(database, -1));
                         let database = state.get_database_mut(&id);
                         Self::grant_object_privilege(&mut database.privileges, privilege);
@@ -5792,6 +5797,18 @@ impl Catalog {
                         builtin_table_updates.push(state.pack_database_update(database, 1));
                     }
                     ObjectId::Schema((database_spec, schema_id)) => {
+                        if schema_id.is_system() {
+                            let schema = state.get_schema(
+                                &database_spec,
+                                &schema_id.into(),
+                                session
+                                    .map(|session| session.conn_id())
+                                    .unwrap_or(SYSTEM_CONN_ID),
+                            );
+                            return Err(AdapterError::Catalog(Error::new(
+                                ErrorKind::ReadOnlySystemSchema(schema.name().schema.clone()),
+                            )));
+                        }
                         builtin_table_updates.push(state.pack_schema_update(
                             &database_spec,
                             &schema_id,
@@ -5858,6 +5875,11 @@ impl Catalog {
                     }
                     ObjectId::Database(id) => {
                         let database = state.get_database(&id);
+                        if id.is_system() {
+                            return Err(AdapterError::Catalog(Error::new(
+                                ErrorKind::ReadOnlyDatabase(database.name().to_string()),
+                            )));
+                        }
                         builtin_table_updates.push(state.pack_database_update(database, -1));
                         let database = state.get_database_mut(&id);
                         Self::revoke_object_privilege(&mut database.privileges, privilege);
@@ -5866,6 +5888,18 @@ impl Catalog {
                         builtin_table_updates.push(state.pack_database_update(database, 1));
                     }
                     ObjectId::Schema((database_spec, schema_id)) => {
+                        if schema_id.is_system() {
+                            let schema = state.get_schema(
+                                &database_spec,
+                                &schema_id.into(),
+                                session
+                                    .map(|session| session.conn_id())
+                                    .unwrap_or(SYSTEM_CONN_ID),
+                            );
+                            return Err(AdapterError::Catalog(Error::new(
+                                ErrorKind::ReadOnlySystemSchema(schema.name().schema.clone()),
+                            )));
+                        }
                         builtin_table_updates.push(state.pack_schema_update(
                             &database_spec,
                             &schema_id,

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -29,7 +29,9 @@ use mz_repr::adt::mz_acl_item::MzAclItem;
 use mz_repr::role_id::RoleId;
 use mz_repr::{Datum, Diff, GlobalId, Row};
 use mz_sql::ast::{CreateIndexStatement, Statement};
-use mz_sql::catalog::{CatalogCluster, CatalogDatabase, CatalogSchema, CatalogType, TypeCategory};
+use mz_sql::catalog::{
+    CatalogCluster, CatalogDatabase, CatalogSchema, CatalogType, PrivilegeMap, TypeCategory,
+};
 use mz_sql::func::FuncImplCatalogDetails;
 use mz_sql::names::{ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier};
 use mz_sql_parser::ast::display::AstDisplay;
@@ -1232,7 +1234,7 @@ impl CatalogState {
         }
     }
 
-    fn pack_privilege_array_row(&self, privileges: &BTreeMap<RoleId, Vec<MzAclItem>>) -> Row {
+    fn pack_privilege_array_row(&self, privileges: &PrivilegeMap) -> Row {
         let mut row = Row::default();
         let flat_privileges = MzAclItem::flatten(privileges);
         row.packer()

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
 
 use bytesize::ByteSize;

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
 
 use bytesize::ByteSize;
@@ -24,10 +25,11 @@ use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::jsonb::Jsonb;
+use mz_repr::adt::mz_acl_item::MzAclItem;
 use mz_repr::role_id::RoleId;
 use mz_repr::{Datum, Diff, GlobalId, Row};
 use mz_sql::ast::{CreateIndexStatement, Statement};
-use mz_sql::catalog::{CatalogDatabase, CatalogType, TypeCategory};
+use mz_sql::catalog::{CatalogCluster, CatalogDatabase, CatalogSchema, CatalogType, TypeCategory};
 use mz_sql::func::FuncImplCatalogDetails;
 use mz_sql::names::{ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier};
 use mz_sql_parser::ast::display::AstDisplay;
@@ -88,19 +90,7 @@ impl CatalogState {
         database: &Database,
         diff: Diff,
     ) -> BuiltinTableUpdate {
-        let mut row = Row::default();
-        row.packer()
-            .push_array(
-                &[ArrayDimension {
-                    lower_bound: 1,
-                    length: database.privileges.len(),
-                }],
-                database
-                    .privileges
-                    .iter()
-                    .map(|mz_acl_item| Datum::MzAclItem(mz_acl_item.clone())),
-            )
-            .expect("privileges is 1 dimensional, and its length is used for the array length");
+        let row = self.pack_privilege_array_row(database.privileges());
         let privileges = row.unpack_first();
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_DATABASES),
@@ -128,19 +118,7 @@ impl CatalogState {
                 &self.database_by_id[id].schemas_by_id[schema_id],
             ),
         };
-        let mut row = Row::default();
-        row.packer()
-            .push_array(
-                &[ArrayDimension {
-                    lower_bound: 1,
-                    length: schema.privileges.len(),
-                }],
-                schema
-                    .privileges
-                    .iter()
-                    .map(|mz_acl_item| Datum::MzAclItem(mz_acl_item.clone())),
-            )
-            .expect("privileges is 1 dimensional, and its length is used for the array length");
+        let row = self.pack_privilege_array_row(schema.privileges());
         let privileges = row.unpack_first();
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_SCHEMAS),
@@ -205,19 +183,7 @@ impl CatalogState {
     pub(super) fn pack_cluster_update(&self, name: &str, diff: Diff) -> BuiltinTableUpdate {
         let id = self.clusters_by_name[name];
         let cluster = &self.clusters_by_id[&id];
-        let mut row = Row::default();
-        row.packer()
-            .push_array(
-                &[ArrayDimension {
-                    lower_bound: 1,
-                    length: cluster.privileges.len(),
-                }],
-                cluster
-                    .privileges
-                    .iter()
-                    .map(|mz_acl_item| Datum::MzAclItem(mz_acl_item.clone())),
-            )
-            .expect("privileges is 1 dimensional, and its length is used for the array length");
+        let row = self.pack_privilege_array_row(cluster.privileges());
         let privileges = row.unpack_first();
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTERS),
@@ -331,20 +297,7 @@ impl CatalogState {
             .id;
         let name = &entry.name().item;
         let owner_id = entry.owner_id();
-        let mut privileges_row = Row::default();
-        privileges_row
-            .packer()
-            .push_array(
-                &[ArrayDimension {
-                    lower_bound: 1,
-                    length: entry.privileges.len(),
-                }],
-                entry
-                    .privileges
-                    .iter()
-                    .map(|mz_acl_item| Datum::MzAclItem(mz_acl_item.clone())),
-            )
-            .expect("privileges is 1 dimensional, and its length is used for the array length");
+        let privileges_row = self.pack_privilege_array_row(entry.privileges());
         let privileges = privileges_row.unpack_first();
         let mut updates = match entry.item() {
             CatalogItem::Log(_) => self.pack_source_update(
@@ -1277,5 +1230,22 @@ impl CatalogState {
             ]),
             diff,
         }
+    }
+
+    fn pack_privilege_array_row(&self, privileges: &BTreeMap<RoleId, Vec<MzAclItem>>) -> Row {
+        let mut row = Row::default();
+        let flat_privileges = MzAclItem::flatten(privileges);
+        row.packer()
+            .push_array(
+                &[ArrayDimension {
+                    lower_bound: 1,
+                    length: flat_privileges.len(),
+                }],
+                flat_privileges
+                    .into_iter()
+                    .map(|mz_acl_item| Datum::MzAclItem(mz_acl_item.clone())),
+            )
+            .expect("privileges is 1 dimensional, and its length is used for the array length");
+        row
     }
 }

--- a/src/adapter/src/catalog/error.rs
+++ b/src/adapter/src/catalog/error.rs
@@ -52,6 +52,8 @@ pub enum ErrorKind {
     ReservedReplicaName(String),
     #[error("system cluster '{0}' cannot be modified")]
     ReadOnlyCluster(String),
+    #[error("system database '{0}' cannot be modified")]
+    ReadOnlyDatabase(String),
     #[error("system schema '{0}' cannot be modified")]
     ReadOnlySystemSchema(String),
     #[error("system item '{0}' cannot be modified")]

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -2067,7 +2067,7 @@ impl<'a> Transaction<'a> {
                     name: cluster.name().to_string(),
                     linked_object_id: cluster.linked_object_id(),
                     owner_id: cluster.owner_id,
-                    privileges: Some(cluster.privileges.clone()),
+                    privileges: Some(MzAclItem::flatten(cluster.privileges())),
                 })
             } else {
                 None
@@ -2129,7 +2129,7 @@ impl<'a> Transaction<'a> {
                 Some(DatabaseValue {
                     name: database.name().to_string(),
                     owner_id: database.owner_id,
-                    privileges: Some(database.privileges.clone()),
+                    privileges: Some(MzAclItem::flatten(database.privileges())),
                 })
             } else {
                 None
@@ -2167,7 +2167,7 @@ impl<'a> Transaction<'a> {
                     database_ns: db_ns,
                     name: schema.name().schema.clone(),
                     owner_id: schema.owner_id,
-                    privileges: Some(schema.privileges.clone()),
+                    privileges: Some(MzAclItem::flatten(schema.privileges())),
                 })
             } else {
                 None

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -317,6 +317,8 @@ pub enum ExecuteResponse {
         /// How long to wait for results to arrive.
         timeout: ExecuteTimeout,
     },
+    /// The requested privilege was granted.
+    GrantedPrivilege,
     /// The requested role was granted.
     GrantedRole,
     /// The specified number of rows were inserted into the requested table.
@@ -325,6 +327,8 @@ pub enum ExecuteResponse {
     Prepare,
     /// A user-requested warning was raised.
     Raised,
+    /// The requested privilege was revoked.
+    RevokedPrivilege,
     /// The requested role was revoked.
     RevokedRole,
     /// Rows will be delivered via the specified future.
@@ -389,6 +393,7 @@ impl ExecuteResponse {
             DroppedObject(o) => Some(format!("DROP {o}")),
             EmptyQuery => None,
             Fetch { .. } => None,
+            GrantedPrivilege => Some("GRANT".into()),
             GrantedRole => Some("GRANT ROLE".into()),
             Inserted(n) => {
                 // "On successful completion, an INSERT command returns a
@@ -402,6 +407,7 @@ impl ExecuteResponse {
             }
             Prepare => Some("PREPARE".into()),
             Raised => Some("RAISE".into()),
+            RevokedPrivilege => Some("REVOKE".into()),
             RevokedRole => Some("REVOKE ROLE".into()),
             SendingRows { .. } => None,
             SetVariable { reset: true, .. } => Some("RESET".into()),
@@ -461,11 +467,13 @@ impl ExecuteResponse {
             }
             Execute | ReadThenWrite => vec![Deleted, Inserted, SendingRows, Updated],
             PlanKind::Fetch => vec![ExecuteResponseKind::Fetch],
+            GrantPrivilege => vec![GrantedPrivilege],
             GrantRole => vec![GrantedRole],
             CopyRows => vec![Inserted],
             Insert => vec![Inserted, SendingRows],
             PlanKind::Prepare => vec![ExecuteResponseKind::Prepare],
             PlanKind::Raise => vec![ExecuteResponseKind::Raised],
+            RevokePrivilege => vec![RevokedPrivilege],
             RevokeRole => vec![RevokedRole],
             PlanKind::SetVariable | ResetVariable => vec![ExecuteResponseKind::SetVariable],
             PlanKind::Subscribe => vec![Subscribing, CopyTo],

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -960,9 +960,11 @@ impl Coordinator {
                 | Op::AlterSink { .. }
                 | Op::AlterSource { .. }
                 | Op::DropTimeline(_)
+                | Op::GrantPrivilege { .. }
                 | Op::GrantRole { .. }
                 | Op::RenameItem { .. }
                 | Op::UpdateOwner { .. }
+                | Op::RevokePrivilege { .. }
                 | Op::RevokeRole { .. }
                 | Op::UpdateClusterReplicaStatus { .. }
                 | Op::UpdateStorageUsage { .. }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -960,11 +960,10 @@ impl Coordinator {
                 | Op::AlterSink { .. }
                 | Op::AlterSource { .. }
                 | Op::DropTimeline(_)
-                | Op::GrantPrivilege { .. }
+                | Op::UpdatePrivilege { .. }
                 | Op::GrantRole { .. }
                 | Op::RenameItem { .. }
                 | Op::UpdateOwner { .. }
-                | Op::RevokePrivilege { .. }
                 | Op::RevokeRole { .. }
                 | Op::UpdateClusterReplicaStatus { .. }
                 | Op::UpdateStorageUsage { .. }

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -209,6 +209,8 @@ pub fn user_privilege_hack(
         | Plan::RotateKeys(_)
         | Plan::GrantRole(_)
         | Plan::RevokeRole(_)
+        | Plan::GrantPrivilege(_)
+        | Plan::RevokePrivilege(_)
         | Plan::CopyRows(_) => {
             return Err(AdapterError::Unauthorized(
                 rbac::UnauthorizedError::Privilege {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -421,6 +421,18 @@ impl Coordinator {
             Plan::RotateKeys(RotateKeysPlan { id }) => {
                 tx.send(self.sequence_rotate_keys(&session, id).await, session);
             }
+            Plan::GrantPrivilege(plan) => {
+                tx.send(
+                    self.sequence_grant_privilege(&mut session, plan).await,
+                    session,
+                );
+            }
+            Plan::RevokePrivilege(plan) => {
+                tx.send(
+                    self.sequence_revoke_privilege(&mut session, plan).await,
+                    session,
+                );
+            }
             Plan::GrantRole(plan) => {
                 tx.send(self.sequence_grant_role(&mut session, plan).await, session);
             }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3734,7 +3734,7 @@ impl Coordinator {
             })
             .map(Cow::Borrowed)
             .unwrap_or_else(|| Cow::Owned(MzAclItem::empty(revokee, grantor)));
-        // The revoked privileges don't exists so we can return early.
+        // The revoked privileges don't exist so we can return early.
         if existing_privilege
             .acl_mode
             .intersection(acl_mode)

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -254,7 +254,9 @@ fn generate_required_plan_attribute(plan: &Plan) -> Option<Attribute> {
         | Plan::Execute(_)
         | Plan::Deallocate(_)
         | Plan::Raise(_)
-        | Plan::RotateKeys(_) => None,
+        | Plan::RotateKeys(_)
+        | Plan::GrantPrivilege(_)
+        | Plan::RevokePrivilege(_) => None,
     }
 }
 
@@ -355,6 +357,8 @@ fn generate_required_ownership(plan: &Plan) -> Vec<ObjectId> {
         Plan::AlterSecret(plan) => vec![ObjectId::Item(plan.id)],
         Plan::RotateKeys(plan) => vec![ObjectId::Item(plan.id)],
         Plan::AlterOwner(plan) => vec![plan.id.clone()],
+        Plan::GrantPrivilege(plan) => vec![plan.object_id.clone()],
+        Plan::RevokePrivilege(plan) => vec![plan.object_id.clone()],
     }
 }
 

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -797,9 +797,11 @@ async fn execute_stmt<S: ResultSender>(
         | ExecuteResponse::DiscardedAll
         | ExecuteResponse::DroppedObject(_)
         | ExecuteResponse::EmptyQuery
+        | ExecuteResponse::GrantedPrivilege
         | ExecuteResponse::GrantedRole
         | ExecuteResponse::Inserted(_)
         | ExecuteResponse::Raised
+        | ExecuteResponse::RevokedPrivilege
         | ExecuteResponse::RevokedRole
         | ExecuteResponse::SetVariable { .. }
         | ExecuteResponse::StartedTransaction { .. }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1405,10 +1405,12 @@ where
             | ExecuteResponse::DiscardedAll
             | ExecuteResponse::DiscardedTemp
             | ExecuteResponse::DroppedObject(_)
+            | ExecuteResponse::GrantedPrivilege
             | ExecuteResponse::GrantedRole
             | ExecuteResponse::Inserted(..)
             | ExecuteResponse::Prepare
             | ExecuteResponse::Raised
+            | ExecuteResponse::RevokedPrivilege
             | ExecuteResponse::RevokedRole
             | ExecuteResponse::StartedTransaction { .. }
             | ExecuteResponse::TransactionCommitted

--- a/src/repr/src/adt/mz_acl_item.rs
+++ b/src/repr/src/adt/mz_acl_item.rs
@@ -16,6 +16,7 @@ use columnation::{CloneRegion, Columnation};
 use mz_ore::str::StrExt;
 use mz_proto::{RustType, TryFromProtoError};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::mem::size_of;
 use std::ops::BitOrAssign;
@@ -189,6 +190,27 @@ impl MzAclItem {
 
     pub const fn binary_size() -> usize {
         RoleId::binary_size() + RoleId::binary_size() + size_of::<u64>()
+    }
+
+    pub fn group_by_grantee(items: Vec<MzAclItem>) -> BTreeMap<RoleId, Vec<MzAclItem>> {
+        items
+            .into_iter()
+            .fold(BTreeMap::new(), |mut accum, mz_acl_item| {
+                accum
+                    .entry(mz_acl_item.grantee)
+                    .or_default()
+                    .push(mz_acl_item);
+                accum
+            })
+    }
+
+    pub fn flatten(items: &BTreeMap<RoleId, Vec<MzAclItem>>) -> Vec<MzAclItem> {
+        items
+            .values()
+            .map(|items| items.into_iter())
+            .flatten()
+            .cloned()
+            .collect()
     }
 }
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2912,7 +2912,7 @@ impl_display_t!(GrantPrivilegeStatement);
 /// `REVOKE ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RevokePrivilegeStatement<T: AstInfo> {
-    /// The privileges being granted.
+    /// The privileges being revoked.
     pub privileges: Vec<Privilege>,
     /// The type of object.
     ///

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -30,6 +30,7 @@ use mz_build_info::BuildInfo;
 use mz_controller::clusters::{ClusterId, ReplicaId};
 use mz_expr::MirScalarExpr;
 use mz_ore::now::{EpochMillis, NowFn};
+use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::role_id::RoleId;
 use mz_repr::{ColumnName, GlobalId, RelationDesc};
@@ -267,6 +268,9 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// earlier in the list than `id`. This is particularly userful for the order to drop
     /// objects.
     fn item_dependents(&self, id: GlobalId) -> Vec<ObjectId>;
+
+    /// Returns all possible privileges associated with an object type.
+    fn all_object_privileges(&self, object_type: ObjectType) -> AclMode;
 }
 
 /// Configuration associated with a catalog.
@@ -324,6 +328,10 @@ pub trait CatalogDatabase {
 
     /// Returns the ID of the owning role.
     fn owner_id(&self) -> RoleId;
+
+    /// Returns the privileges associated with the database.
+    /// Key is the role granted the privilege, value is the privilege itself.
+    fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>>;
 }
 
 /// A schema in a [`SessionCatalog`].
@@ -346,6 +354,10 @@ pub trait CatalogSchema {
 
     /// Returns the ID of the owning role.
     fn owner_id(&self) -> RoleId;
+
+    /// Returns the privileges associated with the schema.
+    /// Key is the role granted the privilege, value is the privilege itself.
+    fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>>;
 }
 
 // TODO(jkosh44) When https://github.com/MaterializeInc/materialize/issues/17824 is implemented
@@ -498,6 +510,10 @@ pub trait CatalogCluster<'a> {
 
     /// Returns the ID of the owning role.
     fn owner_id(&self) -> RoleId;
+
+    /// Returns the privileges associated with the cluster.
+    /// Key is the role granted the privilege, value is the privilege itself.
+    fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>>;
 }
 
 /// A cluster replica in a [`SessionCatalog`]
@@ -583,6 +599,10 @@ pub trait CatalogItem {
 
     /// Returns the ID of the owning role.
     fn owner_id(&self) -> RoleId;
+
+    /// Returns the privileges associated with the item.
+    /// Key is the role granted the privilege, value is the privilege itself.
+    fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>>;
 }
 
 /// The type of a [`CatalogItem`].

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -330,7 +330,7 @@ pub trait CatalogDatabase {
     fn owner_id(&self) -> RoleId;
 
     /// Returns the privileges associated with the database.
-    /// Key is the role granted the privilege, value is the privilege itself.
+    /// Key is the role that granted the privilege, value is the privilege itself.
     fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>>;
 }
 
@@ -356,7 +356,7 @@ pub trait CatalogSchema {
     fn owner_id(&self) -> RoleId;
 
     /// Returns the privileges associated with the schema.
-    /// Key is the role granted the privilege, value is the privilege itself.
+    /// Key is the role that granted the privilege, value is the privilege itself.
     fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>>;
 }
 
@@ -512,7 +512,7 @@ pub trait CatalogCluster<'a> {
     fn owner_id(&self) -> RoleId;
 
     /// Returns the privileges associated with the cluster.
-    /// Key is the role granted the privilege, value is the privilege itself.
+    /// Key is the role that granted the privilege, value is the privilege itself.
     fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>>;
 }
 
@@ -601,7 +601,7 @@ pub trait CatalogItem {
     fn owner_id(&self) -> RoleId;
 
     /// Returns the privileges associated with the item.
-    /// Key is the role granted the privilege, value is the privilege itself.
+    /// Key is the role that granted the privilege, value is the privilege itself.
     fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>>;
 }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -311,6 +311,9 @@ impl CatalogConfig {
     }
 }
 
+/// Key is the role that granted the privilege, value is the privilege itself.
+pub type PrivilegeMap = BTreeMap<RoleId, Vec<MzAclItem>>;
+
 /// A database in a [`SessionCatalog`].
 pub trait CatalogDatabase {
     /// Returns a fully-specified name of the database.
@@ -330,8 +333,7 @@ pub trait CatalogDatabase {
     fn owner_id(&self) -> RoleId;
 
     /// Returns the privileges associated with the database.
-    /// Key is the role that granted the privilege, value is the privilege itself.
-    fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>>;
+    fn privileges(&self) -> &PrivilegeMap;
 }
 
 /// A schema in a [`SessionCatalog`].
@@ -356,8 +358,7 @@ pub trait CatalogSchema {
     fn owner_id(&self) -> RoleId;
 
     /// Returns the privileges associated with the schema.
-    /// Key is the role that granted the privilege, value is the privilege itself.
-    fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>>;
+    fn privileges(&self) -> &PrivilegeMap;
 }
 
 // TODO(jkosh44) When https://github.com/MaterializeInc/materialize/issues/17824 is implemented
@@ -512,8 +513,7 @@ pub trait CatalogCluster<'a> {
     fn owner_id(&self) -> RoleId;
 
     /// Returns the privileges associated with the cluster.
-    /// Key is the role that granted the privilege, value is the privilege itself.
-    fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>>;
+    fn privileges(&self) -> &PrivilegeMap;
 }
 
 /// A cluster replica in a [`SessionCatalog`]
@@ -601,8 +601,7 @@ pub trait CatalogItem {
     fn owner_id(&self) -> RoleId;
 
     /// Returns the privileges associated with the item.
-    /// Key is the role that granted the privilege, value is the privilege itself.
-    fn privileges(&self) -> &BTreeMap<RoleId, Vec<MzAclItem>>;
+    fn privileges(&self) -> &PrivilegeMap;
 }
 
 /// The type of a [`CatalogItem`].

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -44,6 +44,7 @@ use mz_controller::clusters::ClusterId;
 use mz_expr::{MirRelationExpr, MirScalarExpr, RowSetFinishing};
 use mz_ore::now::{self, NOW_ZERO};
 use mz_pgcopy::CopyFormatParams;
+use mz_repr::adt::mz_acl_item::AclMode;
 use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::role_id::RoleId;
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
@@ -141,6 +142,8 @@ pub enum Plan {
     RotateKeys(RotateKeysPlan),
     GrantRole(GrantRolePlan),
     RevokeRole(RevokeRolePlan),
+    GrantPrivilege(GrantPrivilegePlan),
+    RevokePrivilege(RevokePrivilegePlan),
 }
 
 impl Plan {
@@ -196,13 +199,13 @@ impl Plan {
             StatementKind::Execute => vec![PlanKind::Execute],
             StatementKind::Explain => vec![PlanKind::Explain],
             StatementKind::Fetch => vec![PlanKind::Fetch],
-            StatementKind::GrantPrivilege => vec![],
+            StatementKind::GrantPrivilege => vec![PlanKind::GrantPrivilege],
             StatementKind::GrantRole => vec![PlanKind::GrantRole],
             StatementKind::Insert => vec![PlanKind::Insert],
             StatementKind::Prepare => vec![PlanKind::Prepare],
             StatementKind::Raise => vec![PlanKind::Raise],
             StatementKind::ResetVariable => vec![PlanKind::ResetVariable],
-            StatementKind::RevokePrivilege => vec![],
+            StatementKind::RevokePrivilege => vec![PlanKind::RevokePrivilege],
             StatementKind::RevokeRole => vec![PlanKind::RevokeRole],
             StatementKind::Rollback => vec![PlanKind::AbortTransaction],
             StatementKind::Select => vec![PlanKind::Peek],
@@ -333,6 +336,8 @@ impl Plan {
             Plan::RotateKeys(_) => "rotate keys",
             Plan::GrantRole(_) => "grant role",
             Plan::RevokeRole(_) => "revoke role",
+            Plan::GrantPrivilege(_) => "grant privilege",
+            Plan::RevokePrivilege(_) => "revoke privilege",
         }
     }
 }
@@ -811,6 +816,30 @@ pub struct RevokeRolePlan {
     pub member_ids: Vec<RoleId>,
     /// The role that revoked the membership.
     pub grantor_id: RoleId,
+}
+
+#[derive(Debug)]
+pub struct GrantPrivilegePlan {
+    /// /// The privileges being granted on an object.
+    pub acl_mode: AclMode,
+    /// The ID of the object.
+    pub object_id: ObjectId,
+    /// The role that will granted the privileges.
+    pub grantee: RoleId,
+    /// The role that is granting the privileges.
+    pub grantor: RoleId,
+}
+
+#[derive(Debug)]
+pub struct RevokePrivilegePlan {
+    /// The privileges being revoked.
+    pub acl_mode: AclMode,
+    /// The ID of the object.
+    pub object_id: ObjectId,
+    /// The role that will have privileges revoked.
+    pub revokee: RoleId,
+    /// The role that will revoke the privileges.
+    pub grantor: RoleId,
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -695,6 +695,17 @@ impl<'a> StatementContext<'a> {
         Ok(data_type)
     }
 
+    pub fn get_object_type(&self, id: &ObjectId) -> ObjectType {
+        match id {
+            ObjectId::Cluster(_) => ObjectType::Cluster,
+            ObjectId::ClusterReplica(_) => ObjectType::ClusterReplica,
+            ObjectId::Database(_) => ObjectType::Database,
+            ObjectId::Schema(_) => ObjectType::Schema,
+            ObjectId::Role(_) => ObjectType::Role,
+            ObjectId::Item(item_id) => self.get_item(item_id).item_type().into(),
+        }
+    }
+
     pub fn unsafe_mode(&self) -> bool {
         self.catalog.config().unsafe_mode
     }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -27,6 +27,7 @@ use mz_ore::cast::{self, CastFrom, TryCastFrom};
 use mz_ore::str::StrExt;
 use mz_proto::RustType;
 use mz_repr::adt::interval::Interval;
+use mz_repr::adt::mz_acl_item::AclMode;
 use mz_repr::adt::system::Oid;
 use mz_repr::role_id::RoleId;
 use mz_repr::strconv;
@@ -37,8 +38,9 @@ use mz_sql_parser::ast::{
     AlterSourceAction, AlterSourceStatement, AlterSystemResetAllStatement,
     AlterSystemResetStatement, AlterSystemSetStatement, CreateTypeListOption,
     CreateTypeListOptionName, CreateTypeMapOption, CreateTypeMapOptionName, DeferredItemName,
-    GrantPrivilegeStatement, GrantRoleStatement, RevokePrivilegeStatement, RevokeRoleStatement,
-    SshConnectionOption, UnresolvedItemName, UnresolvedObjectName, UnresolvedSchemaName, Value,
+    GrantPrivilegeStatement, GrantRoleStatement, Privilege, RevokePrivilegeStatement,
+    RevokeRoleStatement, SshConnectionOption, UnresolvedItemName, UnresolvedObjectName,
+    UnresolvedSchemaName, Value,
 };
 use mz_storage_client::types::connections::aws::{AwsAssumeRole, AwsConfig, AwsCredentials};
 use mz_storage_client::types::connections::{
@@ -109,9 +111,10 @@ use crate::plan::{
     CreateClusterReplicaPlan, CreateConnectionPlan, CreateDatabasePlan, CreateIndexPlan,
     CreateMaterializedViewPlan, CreateRolePlan, CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan,
     CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan, DataSourceDesc,
-    DropObjectsPlan, FullItemName, GrantRolePlan, HirScalarExpr, Index, Ingestion,
-    MaterializedView, Params, Plan, QueryContext, ReplicaConfig, RevokeRolePlan, RotateKeysPlan,
-    Secret, Sink, Source, SourceSinkClusterConfig, Table, Type, View,
+    DropObjectsPlan, FullItemName, GrantPrivilegePlan, GrantRolePlan, HirScalarExpr, Index,
+    Ingestion, MaterializedView, Params, Plan, QueryContext, ReplicaConfig, RevokePrivilegePlan,
+    RevokeRolePlan, RotateKeysPlan, Secret, Sink, Source, SourceSinkClusterConfig, Table, Type,
+    View,
 };
 use crate::session::user::SYSTEM_USER;
 
@@ -4315,10 +4318,68 @@ pub fn describe_grant_privilege(
 }
 
 pub fn plan_grant_privilege(
-    _: &StatementContext,
-    _: GrantPrivilegeStatement<Aug>,
+    scx: &StatementContext,
+    GrantPrivilegeStatement {
+        privileges,
+        object_type,
+        name,
+        role,
+    }: GrantPrivilegeStatement<Aug>,
 ) -> Result<Plan, PlanError> {
-    bail_unsupported!("GRANT PRIVILEGE");
+    let mut acl_mode = AclMode::empty();
+    // PostgreSQL doesn't care about duplicate privileges, so we don't either.
+    for privilege in privileges {
+        acl_mode |= privilege_to_acl_mode(privilege);
+    }
+    let object_id = name
+        .try_into()
+        .expect("name resolution should handle invalid objects");
+    if let ObjectId::Item(id) = &object_id {
+        let item = scx.get_item(id);
+        let item_type: ObjectType = item.item_type().into();
+        if (item_type == ObjectType::View
+            || item_type == ObjectType::MaterializedView
+            || item_type == ObjectType::Source)
+            && object_type == ObjectType::Table
+        {
+            // This is an expected mis-match to match PostgreSQL semantics.
+        } else if item_type != object_type {
+            let object_name = scx.catalog.resolve_full_name(item.name()).to_string();
+            return Err(PlanError::InvalidObjectType {
+                expected_type: object_type,
+                actual_type: item_type,
+                object_name,
+            });
+        }
+    }
+
+    let actual_object_type = scx.get_object_type(&object_id);
+    let all_object_privileges = scx.catalog.all_object_privileges(actual_object_type);
+    let invalid_acl_mode = acl_mode.difference(all_object_privileges);
+    if !invalid_acl_mode.is_empty() {
+        let invalid_privileges = acl_mode_to_privileges(invalid_acl_mode);
+        return Err(PlanError::InvalidPrivilegeTypes {
+            privilege_types: invalid_privileges,
+            object_type: actual_object_type,
+        });
+    }
+
+    // In PostgreSQL, the grantor must always be either the object owner or some role that has been
+    // been explicitly granted grant options. In Materialize, we haven't implemented grant options
+    // so the grantor is always the object owner.
+    //
+    // For more details see:
+    // https://github.com/postgres/postgres/blob/78d5952dd0e66afc4447eec07f770991fa406cce/src/backend/utils/adt/acl.c#L5154-L5246
+    let grantor = scx
+        .catalog
+        .get_owner_id(&object_id)
+        .expect("cannot grant privileges on objects without owners");
+    Ok(Plan::GrantPrivilege(GrantPrivilegePlan {
+        acl_mode,
+        object_id,
+        grantee: role.id,
+        grantor,
+    }))
 }
 
 pub fn describe_revoke_privilege(
@@ -4329,10 +4390,97 @@ pub fn describe_revoke_privilege(
 }
 
 pub fn plan_revoke_privilege(
-    _: &StatementContext,
-    _: RevokePrivilegeStatement<Aug>,
+    scx: &StatementContext,
+    RevokePrivilegeStatement {
+        privileges,
+        object_type,
+        name,
+        role,
+    }: RevokePrivilegeStatement<Aug>,
 ) -> Result<Plan, PlanError> {
-    bail_unsupported!("REVOKE PRIVILEGE");
+    let mut acl_mode = AclMode::empty();
+    // PostgreSQL doesn't care about duplicate privileges, so we don't either.
+    for privilege in privileges {
+        acl_mode |= privilege_to_acl_mode(privilege);
+    }
+    let object_id = name
+        .try_into()
+        .expect("name resolution should handle invalid objects");
+    if let ObjectId::Item(id) = &object_id {
+        let item = scx.get_item(id);
+        let item_type: ObjectType = item.item_type().into();
+        if (item_type == ObjectType::View
+            || item_type == ObjectType::MaterializedView
+            || item_type == ObjectType::Source)
+            && object_type == ObjectType::Table
+        {
+            // This is an expected mis-match to match PostgreSQL semantics.
+        } else if item_type != object_type {
+            let object_name = scx.catalog.resolve_full_name(item.name()).to_string();
+            return Err(PlanError::InvalidObjectType {
+                expected_type: object_type,
+                actual_type: item_type,
+                object_name,
+            });
+        }
+    }
+
+    let actual_object_type = scx.get_object_type(&object_id);
+    let all_object_privileges = scx.catalog.all_object_privileges(actual_object_type);
+    let invalid_acl_mode = acl_mode.difference(all_object_privileges);
+    if !invalid_acl_mode.is_empty() {
+        let invalid_privileges = acl_mode_to_privileges(invalid_acl_mode);
+        return Err(PlanError::InvalidPrivilegeTypes {
+            privilege_types: invalid_privileges,
+            object_type: actual_object_type,
+        });
+    }
+
+    // In PostgreSQL, the grantor must always be either the object owner or some role that has been
+    // been explicitly granted grant options. In Materialize, we haven't implemented grant options
+    // so the grantor is always the object owner.
+    //
+    // For more details see:
+    // https://github.com/postgres/postgres/blob/78d5952dd0e66afc4447eec07f770991fa406cce/src/backend/utils/adt/acl.c#L5154-L5246
+    let grantor = scx
+        .catalog
+        .get_owner_id(&object_id)
+        .expect("cannot revoke privileges on objects without owners");
+    Ok(Plan::RevokePrivilege(RevokePrivilegePlan {
+        acl_mode,
+        object_id,
+        revokee: role.id,
+        grantor,
+    }))
+}
+
+fn privilege_to_acl_mode(privilege: Privilege) -> AclMode {
+    match privilege {
+        Privilege::SELECT => AclMode::SELECT,
+        Privilege::INSERT => AclMode::INSERT,
+        Privilege::UPDATE => AclMode::UPDATE,
+        Privilege::DELETE => AclMode::DELETE,
+        Privilege::USAGE => AclMode::USAGE,
+        Privilege::CREATE => AclMode::CREATE,
+    }
+}
+
+fn acl_mode_to_privileges(acl_mode: AclMode) -> Vec<Privilege> {
+    let mut privileges = Vec::new();
+    const ALL_PRIVILEGES: [Privilege; 6] = [
+        Privilege::SELECT,
+        Privilege::INSERT,
+        Privilege::UPDATE,
+        Privilege::DELETE,
+        Privilege::USAGE,
+        Privilege::CREATE,
+    ];
+    for privilege in ALL_PRIVILEGES {
+        if acl_mode.contains(privilege_to_acl_mode(privilege.clone())) {
+            privileges.push(privilege);
+        }
+    }
+    privileges
 }
 
 fn resolve_cluster<'a>(

--- a/test/sqllogictest/privileges.slt
+++ b/test/sqllogictest/privileges.slt
@@ -11,6 +11,22 @@ mode cockroach
 
 reset-server
 
+# Enable rbac checks.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_rbac_checks TO true;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_ld_rbac_checks TO true;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER ROLE materialize CREATEDB CREATECLUSTER CREATEROLE;
+----
+COMPLETE 0
+
 # Test mz_aclitem type and functions
 
 statement ok
@@ -152,11 +168,6 @@ SELECT mz_internal.make_mz_aclitem('u1', 's1', 'asdfa ljefioj')
 
 # Test default privileges
 
-simple conn=mz_system,user=mz_system
-ALTER ROLE materialize CREATEDB CREATECLUSTER;
-----
-COMPLETE 0
-
 ## Create some helper views
 
 statement ok
@@ -229,7 +240,7 @@ statement ok
 CREATE TABLE t (a INT);
 
 query TT
-SELECT name, privilege FROM item_privileges WHERE name ='t'
+SELECT name, privilege FROM item_privileges WHERE name = 't'
 ----
 t  materialize=arwd/materialize
 
@@ -237,7 +248,7 @@ statement ok
 CREATE VIEW v AS SELECT 1;
 
 query TT
-SELECT name, privilege FROM item_privileges WHERE name ='v'
+SELECT name, privilege FROM item_privileges WHERE name = 'v'
 ----
 v  materialize=r/materialize
 
@@ -245,7 +256,7 @@ statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT 1;
 
 query TT
-SELECT name, privilege FROM item_privileges WHERE name ='mv'
+SELECT name, privilege FROM item_privileges WHERE name = 'mv'
 ----
 mv  materialize=r/materialize
 
@@ -253,7 +264,7 @@ statement ok
 CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
 
 query TT
-SELECT name, privilege FROM item_privileges WHERE name ='s'
+SELECT name, privilege FROM item_privileges WHERE name = 's'
 ----
 s  materialize=r/materialize
 
@@ -261,7 +272,7 @@ statement ok
 CREATE TYPE ty AS LIST (ELEMENT TYPE=bool);
 
 query TT
-SELECT name, privilege FROM item_privileges WHERE name ='ty'
+SELECT name, privilege FROM item_privileges WHERE name = 'ty'
 ----
 ty  =U/materialize
 ty  materialize=U/materialize
@@ -270,7 +281,7 @@ statement ok
 CREATE SECRET se AS decode('c2VjcmV0Cg==', 'base64');
 
 query TT
-SELECT name, privilege FROM item_privileges WHERE name ='se'
+SELECT name, privilege FROM item_privileges WHERE name = 'se'
 ----
 se  materialize=U/materialize
 
@@ -278,7 +289,7 @@ statement ok
 CREATE CONNECTION conn TO KAFKA (BROKER 'localhost:9092');
 
 query TT
-SELECT name, privilege FROM item_privileges WHERE name ='conn'
+SELECT name, privilege FROM item_privileges WHERE name = 'conn'
 ----
 conn  materialize=U/materialize
 
@@ -286,7 +297,7 @@ statement ok
 CREATE CLUSTER c REPLICAS (r1 (SIZE '1'));
 
 query TT
-SELECT * FROM cluster_privileges WHERE name ='c'
+SELECT * FROM cluster_privileges WHERE name = 'c'
 ----
 c  materialize=UC/materialize
 
@@ -294,12 +305,12 @@ statement ok
 CREATE DATABASE d;
 
 query TT
-SELECT * FROM database_privileges WHERE name ='d'
+SELECT * FROM database_privileges WHERE name = 'd'
 ----
 d  materialize=UC/materialize
 
 query TT
-SELECT * FROM schema_privileges WHERE name ='public' ORDER BY name
+SELECT * FROM schema_privileges WHERE name = 'public' ORDER BY name
 ----
 public  =U/mz_system
 public  =U/materialize
@@ -310,15 +321,17 @@ statement ok
 CREATE SCHEMA sch;
 
 query TT
-SELECT * FROM schema_privileges WHERE name ='sch'
+SELECT * FROM schema_privileges WHERE name = 'sch'
 ----
 sch  materialize=UC/materialize
 
 # Changing the owner of an object should change the grantor of all privileges to the new owner and
 # transfer the privileges of the old owner to the new owner.
 
-statement ok
+simple conn=mz_system,user=mz_system
 CREATE ROLE joe
+----
+COMPLETE 0
 
 simple conn=mz_system,user=mz_system
 ALTER TABLE t OWNER TO joe
@@ -356,7 +369,7 @@ ALTER SOURCE s OWNER TO joe
 COMPLETE 0
 
 query TT
-SELECT name, privilege FROM item_privileges WHERE name ='s'
+SELECT name, privilege FROM item_privileges WHERE name = 's'
 ----
 s  joe=r/joe
 
@@ -366,7 +379,7 @@ ALTER TYPE ty OWNER TO joe
 COMPLETE 0
 
 query TT
-SELECT name, privilege FROM item_privileges WHERE name ='ty'
+SELECT name, privilege FROM item_privileges WHERE name = 'ty'
 ----
 ty  =U/joe
 ty  joe=U/joe
@@ -377,7 +390,7 @@ ALTER SECRET se OWNER TO joe
 COMPLETE 0
 
 query TT
-SELECT name, privilege FROM item_privileges WHERE name ='se'
+SELECT name, privilege FROM item_privileges WHERE name = 'se'
 ----
 se  joe=U/joe
 
@@ -387,7 +400,7 @@ ALTER CONNECTION conn OWNER TO joe
 COMPLETE 0
 
 query TT
-SELECT name, privilege FROM item_privileges WHERE name ='conn'
+SELECT name, privilege FROM item_privileges WHERE name = 'conn'
 ----
 conn  joe=U/joe
 
@@ -397,7 +410,7 @@ ALTER CLUSTER c OWNER TO joe
 COMPLETE 0
 
 query TT
-SELECT * FROM cluster_privileges WHERE name ='c'
+SELECT * FROM cluster_privileges WHERE name = 'c'
 ----
 c  joe=UC/joe
 
@@ -407,7 +420,7 @@ ALTER DATABASE d OWNER TO joe
 COMPLETE 0
 
 query TT
-SELECT * FROM database_privileges WHERE name ='d'
+SELECT * FROM database_privileges WHERE name = 'd'
 ----
 d  joe=UC/joe
 
@@ -417,18 +430,906 @@ ALTER SCHEMA sch OWNER TO joe
 COMPLETE 0
 
 query TT
-SELECT * FROM schema_privileges WHERE name ='sch'
+SELECT * FROM schema_privileges WHERE name = 'sch'
 ----
 sch  joe=UC/joe
 
-statement error GRANT PRIVILEGE not yet supported
-GRANT SELECT ON TABLE t TO joe
+## Switch the owners back to materialize
 
-statement error GRANT PRIVILEGE not yet supported
-GRANT SELECT ON TABLE t TO PUBLIC
+simple conn=mz_system,user=mz_system
+ALTER TABLE t OWNER TO materialize
+----
+COMPLETE 0
 
-statement error REVOKE PRIVILEGE not yet supported
-REVOKE SELECT ON TABLE t FROM joe
+simple conn=mz_system,user=mz_system
+ALTER VIEW v OWNER TO materialize
+----
+COMPLETE 0
 
-statement error REVOKE PRIVILEGE not yet supported
-REVOKE SELECT ON TABLE t FROM PUBLIC
+simple conn=mz_system,user=mz_system
+ALTER MATERIALIZED VIEW mv OWNER TO materialize
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SOURCE s OWNER TO materialize
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER TYPE ty OWNER TO materialize
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SECRET se OWNER TO materialize
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER CONNECTION conn OWNER TO materialize
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER CLUSTER c OWNER TO materialize
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER DATABASE d OWNER TO materialize
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SCHEMA sch OWNER TO materialize
+----
+COMPLETE 0
+
+# Test GRANT and REVOKE
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE other
+----
+COMPLETE 0
+
+## Table
+
+statement ok
+GRANT SELECT on TABLE t TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't'
+----
+t  joe=r/materialize
+t  materialize=arwd/materialize
+
+### Duplicate grants have no effect
+statement ok
+GRANT SELECT on TABLE t TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't'
+----
+t  joe=r/materialize
+t  materialize=arwd/materialize
+
+statement ok
+GRANT SELECT, INSERT, UPDATE on TABLE t TO PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't'
+----
+t  =arw/materialize
+t  joe=r/materialize
+t  materialize=arwd/materialize
+
+simple conn=joe1,user=joe
+GRANT SELECT on TABLE t TO other
+----
+db error: ERROR: must be owner of TABLE materialize.public.t
+
+statement error role "joe" cannot be dropped because some objects depend on it
+DROP ROLE joe
+
+statement ok
+REVOKE SELECT on TABLE t FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't'
+----
+t  =arw/materialize
+t  materialize=arwd/materialize
+
+### Duplicate revokes have no effect
+statement ok
+REVOKE SELECT on TABLE t FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't'
+----
+t  =arw/materialize
+t  materialize=arwd/materialize
+
+statement ok
+DROP ROLE joe
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+REVOKE INSERT, UPDATE ON TABLE t FROM PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't'
+----
+t  =r/materialize
+t  materialize=arwd/materialize
+
+statement error invalid privilege types USAGE, CREATE for TABLE
+GRANT USAGE, CREATE ON TABLE t TO joe
+
+## View
+
+statement ok
+GRANT SELECT on TABLE v TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v'
+----
+v  joe=r/materialize
+v  materialize=r/materialize
+
+### Duplicate grants have no effect
+statement ok
+GRANT SELECT on TABLE v TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v'
+----
+v  joe=r/materialize
+v  materialize=r/materialize
+
+statement ok
+GRANT SELECT on TABLE v TO PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v'
+----
+v  =r/materialize
+v  joe=r/materialize
+v  materialize=r/materialize
+
+simple conn=joe2,user=joe
+GRANT SELECT on TABLE v TO other
+----
+db error: ERROR: must be owner of VIEW materialize.public.v
+
+statement error role "joe" cannot be dropped because some objects depend on it
+DROP ROLE joe
+
+statement ok
+REVOKE SELECT on TABLE v FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v'
+----
+v  =r/materialize
+v  materialize=r/materialize
+
+### Duplicate revokes have no effect
+statement ok
+REVOKE SELECT on TABLE v FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v'
+----
+v  =r/materialize
+v  materialize=r/materialize
+
+statement ok
+DROP ROLE joe
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+REVOKE SELECT ON TABLE v FROM PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v'
+----
+v  materialize=r/materialize
+
+statement error invalid privilege types INSERT, UPDATE, DELETE, USAGE, CREATE for VIEW
+GRANT INSERT, UPDATE, DELETE, USAGE, CREATE ON TABLE v TO joe
+
+## Materialized View
+
+statement ok
+GRANT SELECT on TABLE mv TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'mv'
+----
+mv  joe=r/materialize
+mv  materialize=r/materialize
+
+### Duplicate grants have no effect
+statement ok
+GRANT SELECT on TABLE mv TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'mv'
+----
+mv  joe=r/materialize
+mv  materialize=r/materialize
+
+statement ok
+GRANT SELECT on TABLE mv TO PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'mv'
+----
+mv  =r/materialize
+mv  joe=r/materialize
+mv  materialize=r/materialize
+
+simple conn=joe3,user=joe
+GRANT SELECT on TABLE mv TO other
+----
+db error: ERROR: must be owner of MATERIALIZED VIEW materialize.public.mv
+
+statement error role "joe" cannot be dropped because some objects depend on it
+DROP ROLE joe
+
+statement ok
+REVOKE SELECT on TABLE mv FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'mv'
+----
+mv  =r/materialize
+mv  materialize=r/materialize
+
+### Duplicate revokes have no effect
+statement ok
+REVOKE SELECT on TABLE mv FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'mv'
+----
+mv  =r/materialize
+mv  materialize=r/materialize
+
+statement ok
+DROP ROLE joe
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+REVOKE SELECT ON TABLE mv FROM PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'mv'
+----
+mv  materialize=r/materialize
+
+statement error invalid privilege types INSERT, UPDATE, DELETE, USAGE, CREATE for MATERIALIZED VIEW
+GRANT INSERT, UPDATE, DELETE, USAGE, CREATE ON TABLE mv TO joe
+
+## Source
+
+statement ok
+GRANT SELECT on TABLE s TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 's'
+----
+s  joe=r/materialize
+s  materialize=r/materialize
+
+### Duplicate grants have no effect
+statement ok
+GRANT SELECT on TABLE s TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 's'
+----
+s  joe=r/materialize
+s  materialize=r/materialize
+
+statement ok
+GRANT SELECT on TABLE s TO PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 's'
+----
+s  =r/materialize
+s  joe=r/materialize
+s  materialize=r/materialize
+
+simple conn=joe4,user=joe
+GRANT SELECT on TABLE s TO other
+----
+db error: ERROR: must be owner of SOURCE materialize.public.s
+
+statement error role "joe" cannot be dropped because some objects depend on it
+DROP ROLE joe
+
+statement ok
+REVOKE SELECT on TABLE s FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 's'
+----
+s  =r/materialize
+s  materialize=r/materialize
+
+### Duplicate revokes have no effect
+statement ok
+REVOKE SELECT on TABLE s FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 's'
+----
+s  =r/materialize
+s  materialize=r/materialize
+
+statement ok
+DROP ROLE joe
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+REVOKE SELECT ON TABLE s FROM PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 's'
+----
+s  materialize=r/materialize
+
+statement error invalid privilege types INSERT, UPDATE, DELETE, USAGE, CREATE for SOURCE
+GRANT INSERT, UPDATE, DELETE, USAGE, CREATE ON TABLE s TO joe
+
+## Type
+
+statement ok
+GRANT USAGE on TYPE ty TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  joe=U/materialize
+ty  materialize=U/materialize
+
+### Duplicate grants have no effect
+statement ok
+GRANT USAGE on TYPE ty TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  joe=U/materialize
+ty  materialize=U/materialize
+
+simple conn=joe5,user=joe
+GRANT USAGE on TYPE ty TO other
+----
+db error: ERROR: must be owner of TYPE materialize.public.ty
+
+statement error role "joe" cannot be dropped because some objects depend on it
+DROP ROLE joe
+
+statement ok
+REVOKE USAGE on TYPE ty FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  materialize=U/materialize
+
+### Duplicate revokes have no effect
+statement ok
+REVOKE USAGE on TYPE ty FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  materialize=U/materialize
+
+statement ok
+DROP ROLE joe
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+REVOKE USAGE ON TYPE ty FROM PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'ty'
+----
+ty  materialize=U/materialize
+
+statement ok
+GRANT USAGE on TYPE ty TO PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  materialize=U/materialize
+
+statement error invalid privilege types SELECT, INSERT, UPDATE, DELETE, CREATE for TYPE
+GRANT INSERT, SELECT, UPDATE, DELETE, CREATE ON TYPE ty TO joe
+
+## Secret
+
+statement ok
+GRANT USAGE on SECRET se TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'se'
+----
+se  joe=U/materialize
+se  materialize=U/materialize
+
+### Duplicate grants have no effect
+statement ok
+GRANT USAGE on SECRET se TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'se'
+----
+se  joe=U/materialize
+se  materialize=U/materialize
+
+statement ok
+GRANT USAGE on SECRET se TO PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'se'
+----
+se  =U/materialize
+se  joe=U/materialize
+se  materialize=U/materialize
+
+simple conn=joe6,user=joe
+GRANT USAGE on SECRET se TO other
+----
+db error: ERROR: must be owner of SECRET materialize.public.se
+
+statement error role "joe" cannot be dropped because some objects depend on it
+DROP ROLE joe
+
+statement ok
+REVOKE USAGE on SECRET se FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'se'
+----
+se  =U/materialize
+se  materialize=U/materialize
+
+### Duplicate revokes have no effect
+statement ok
+REVOKE USAGE on SECRET se FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'se'
+----
+se  =U/materialize
+se  materialize=U/materialize
+
+statement ok
+DROP ROLE joe
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+REVOKE USAGE ON SECRET se FROM PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'se'
+----
+se  materialize=U/materialize
+
+statement error invalid privilege types SELECT, INSERT, UPDATE, DELETE, CREATE for SECRET
+GRANT INSERT, SELECT, UPDATE, DELETE, CREATE ON SECRET se TO joe
+
+## Connection
+
+statement ok
+GRANT USAGE on CONNECTION conn TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'conn'
+----
+conn  joe=U/materialize
+conn  materialize=U/materialize
+
+### Duplicate grants have no effect
+statement ok
+GRANT USAGE on CONNECTION conn TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'conn'
+----
+conn  joe=U/materialize
+conn  materialize=U/materialize
+
+statement ok
+GRANT USAGE on CONNECTION conn TO PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'conn'
+----
+conn  =U/materialize
+conn  joe=U/materialize
+conn  materialize=U/materialize
+
+simple conn=joe7,user=joe
+GRANT USAGE on CONNECTION conn TO other
+----
+db error: ERROR: must be owner of CONNECTION materialize.public.conn
+
+statement error role "joe" cannot be dropped because some objects depend on it
+DROP ROLE joe
+
+statement ok
+REVOKE USAGE on CONNECTION conn FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'conn'
+----
+conn  =U/materialize
+conn  materialize=U/materialize
+
+### Duplicate revokes have no effect
+statement ok
+REVOKE USAGE on CONNECTION conn FROM joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'conn'
+----
+conn  =U/materialize
+conn  materialize=U/materialize
+
+statement ok
+DROP ROLE joe
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+REVOKE USAGE ON CONNECTION conn FROM PUBLIC
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'conn'
+----
+conn  materialize=U/materialize
+
+statement error invalid privilege types SELECT, INSERT, UPDATE, DELETE, CREATE for CONNECTION
+GRANT INSERT, SELECT, UPDATE, DELETE, CREATE ON CONNECTION conn TO joe
+
+## Cluster
+
+statement ok
+GRANT USAGE on CLUSTER c TO joe
+
+query TT
+SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
+----
+c  joe=U/materialize
+c  materialize=UC/materialize
+
+### Duplicate grants have no effect
+statement ok
+GRANT USAGE on CLUSTER c TO joe
+
+query TT
+SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
+----
+c  joe=U/materialize
+c  materialize=UC/materialize
+
+statement ok
+GRANT USAGE, CREATE on CLUSTER c TO PUBLIC
+
+query TT
+SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
+----
+c  =UC/materialize
+c  joe=U/materialize
+c  materialize=UC/materialize
+
+simple conn=joe8,user=joe
+GRANT USAGE on CLUSTER c TO other
+----
+db error: ERROR: must be owner of CLUSTER c
+
+statement error role "joe" cannot be dropped because some objects depend on it
+DROP ROLE joe
+
+statement ok
+REVOKE USAGE on CLUSTER c FROM joe
+
+query TT
+SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
+----
+c  =UC/materialize
+c  materialize=UC/materialize
+
+### Duplicate revokes have no effect
+statement ok
+REVOKE USAGE on CLUSTER c FROM joe
+
+query TT
+SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
+----
+c  =UC/materialize
+c  materialize=UC/materialize
+
+statement ok
+DROP ROLE joe
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+REVOKE CREATE, USAGE ON CLUSTER c FROM PUBLIC
+
+query TT
+SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
+----
+c  materialize=UC/materialize
+
+statement error invalid privilege types SELECT, INSERT, UPDATE, DELETE for CLUSTER
+GRANT INSERT, SELECT, UPDATE, DELETE ON CLUSTER c TO joe
+
+## Database
+
+statement ok
+GRANT USAGE on DATABASE d TO joe
+
+query TT
+SELECT name, privilege FROM database_privileges WHERE name = 'd'
+----
+d  joe=U/materialize
+d  materialize=UC/materialize
+
+### Duplicate grants have no effect
+statement ok
+GRANT USAGE on DATABASE d TO joe
+
+query TT
+SELECT name, privilege FROM database_privileges WHERE name = 'd'
+----
+d  joe=U/materialize
+d  materialize=UC/materialize
+
+statement ok
+GRANT USAGE, CREATE on DATABASE d TO PUBLIC
+
+query TT
+SELECT name, privilege FROM database_privileges WHERE name = 'd'
+----
+d  =UC/materialize
+d  joe=U/materialize
+d  materialize=UC/materialize
+
+simple conn=joe9,user=joe
+GRANT USAGE on DATABASE d TO other
+----
+db error: ERROR: must be owner of DATABASE d
+
+statement error role "joe" cannot be dropped because some objects depend on it
+DROP ROLE joe
+
+statement ok
+REVOKE USAGE on DATABASE d FROM joe
+
+query TT
+SELECT name, privilege FROM database_privileges WHERE name = 'd'
+----
+d  =UC/materialize
+d  materialize=UC/materialize
+
+### Duplicate revokes have no effect
+statement ok
+REVOKE USAGE on DATABASE d FROM joe
+
+query TT
+SELECT name, privilege FROM database_privileges WHERE name = 'd'
+----
+d  =UC/materialize
+d  materialize=UC/materialize
+
+statement ok
+DROP ROLE joe
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+REVOKE CREATE, USAGE ON DATABASE d FROM PUBLIC
+
+query TT
+SELECT name, privilege FROM database_privileges WHERE name = 'd'
+----
+d  materialize=UC/materialize
+
+statement error invalid privilege types SELECT, INSERT, UPDATE, DELETE for DATABASE
+GRANT INSERT, SELECT, UPDATE, DELETE ON DATABASE d TO joe
+
+## Schema
+
+statement ok
+GRANT USAGE on SCHEMA sch TO joe
+
+query TT
+SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
+----
+sch  joe=U/materialize
+sch  materialize=UC/materialize
+
+### Duplicate grants have no effect
+statement ok
+GRANT USAGE on SCHEMA sch TO joe
+
+query TT
+SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
+----
+sch  joe=U/materialize
+sch  materialize=UC/materialize
+
+statement ok
+GRANT USAGE, CREATE on SCHEMA sch TO PUBLIC
+
+query TT
+SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
+----
+sch  =UC/materialize
+sch  joe=U/materialize
+sch  materialize=UC/materialize
+
+simple conn=joe10,user=joe
+GRANT USAGE on SCHEMA sch TO other
+----
+db error: ERROR: must be owner of SCHEMA materialize.sch
+
+statement error role "joe" cannot be dropped because some objects depend on it
+DROP ROLE joe
+
+statement ok
+REVOKE USAGE on SCHEMA sch FROM joe
+
+query TT
+SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
+----
+sch  =UC/materialize
+sch  materialize=UC/materialize
+
+### Duplicate revokes have no effect
+statement ok
+REVOKE USAGE on SCHEMA sch FROM joe
+
+query TT
+SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
+----
+sch  =UC/materialize
+sch  materialize=UC/materialize
+
+statement ok
+DROP ROLE joe
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+REVOKE CREATE, USAGE ON SCHEMA sch FROM PUBLIC
+
+query TT
+SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
+----
+sch  materialize=UC/materialize
+
+statement error invalid privilege types SELECT, INSERT, UPDATE, DELETE for SCHEMA
+GRANT INSERT, SELECT, UPDATE, DELETE ON SCHEMA sch TO joe
+
+simple conn=mz_system,user=mz_system
+GRANT INSERT ON TABLE mz_views TO joe
+----
+db error: ERROR: system item 'mz_catalog.mz_views' cannot be modified
+
+simple conn=mz_system,user=mz_system
+REVOKE INSERT ON TABLE mz_views FROM joe
+----
+db error: ERROR: system item 'mz_catalog.mz_views' cannot be modified
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON TABLE mz_objects TO joe
+----
+db error: ERROR: system item 'mz_catalog.mz_objects' cannot be modified
+
+simple conn=mz_system,user=mz_system
+REVOKE SELECT ON TABLE mz_objects FROM joe
+----
+db error: ERROR: system item 'mz_catalog.mz_objects' cannot be modified
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON TABLE mz_internal.mz_sink_statuses TO joe
+----
+db error: ERROR: system item 'mz_internal.mz_sink_statuses' cannot be modified
+
+simple conn=mz_system,user=mz_system
+REVOKE SELECT ON TABLE mz_internal.mz_sink_statuses FROM joe
+----
+db error: ERROR: system item 'mz_internal.mz_sink_statuses' cannot be modified
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON TYPE bool TO joe
+----
+db error: ERROR: system item 'pg_catalog.bool' cannot be modified
+
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON TYPE bool FROM joe
+----
+db error: ERROR: system item 'pg_catalog.bool' cannot be modified
+
+simple conn=mz_system,user=mz_system
+GRANT CREATE ON CLUSTER mz_system TO joe
+----
+db error: ERROR: system cluster 'mz_system' cannot be modified
+
+simple conn=mz_system,user=mz_system
+GRANT CREATE ON CLUSTER mz_introspection TO joe
+----
+db error: ERROR: system cluster 'mz_introspection' cannot be modified
+
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON CLUSTER mz_system FROM joe
+----
+db error: ERROR: system cluster 'mz_system' cannot be modified
+
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON CLUSTER mz_introspection FROM joe
+----
+db error: ERROR: system cluster 'mz_introspection' cannot be modified
+
+simple conn=mz_system,user=mz_system
+GRANT CREATE ON SCHEMA pg_catalog TO joe
+----
+db error: ERROR: system schema 'pg_catalog' cannot be modified
+
+simple conn=mz_system,user=mz_system
+REVOKE CREATE ON SCHEMA pg_catalog FROM joe
+----
+db error: ERROR: system schema 'pg_catalog' cannot be modified
+
+## Test misc error scenarios
+
+statement error unknown database 't'
+GRANT SELECT ON DATABASE t TO joe
+
+statement error invalid privilege types USAGE for TABLE
+GRANT SELECT, USAGE ON TABLE t TO joe
+
+# Disable rbac checks.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_rbac_checks TO false;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_ld_rbac_checks TO false;
+----
+COMPLETE 0


### PR DESCRIPTION
This commit implements the privilege variants of the SQL commands `GRANT` and `REVOKE`.

Part of #11579


### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer
* Over half the added lines are tests.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release adds the `GRANT` and `REVOKE` commands for adding and removing object privileges.
