### PR TITLE
Design doc for subscribe output types

### DIFF
--- a/doc/developer/design/20230418_subscribe_output.md
+++ b/doc/developer/design/20230418_subscribe_output.md
@@ -10,7 +10,7 @@ deletes of tuples, with their application-level data. To
 bridge that gap we introduce three ways to change how subscribe
 produces its output: `WITHIN TIMESTAMP ORDER BY`, `ENVELOPE UPSERT`,
 and `ENVELOPE DEBEZIUM`. These output types are simple to implement
-because they operate on the diffs present in a single timestamp. We 
+because they operate on the diffs present in a single timestamp. We
 hope they'll match the client's mental model of updates on their results.
 
 # Motivation
@@ -170,11 +170,11 @@ We'll put these options into production behind a launchdarkly flag
 that we can enable for clients if they're okay working without a
 backwards compatibility guarantee. That'll also let us gather feedback
 from clients using these features.
-	
+
 ## Testing and observability
 [testing-and-observability]: #testing-and-observability
 
-New testdrive tests that exercise these new output types. 
+New testdrive tests that exercise these new output types.
 
 There isn't a performance concern because these output types only need
 to sort the data for a given timestamp.
@@ -182,7 +182,7 @@ to sort the data for a given timestamp.
 ## Lifecycle
 [lifecycle]: #lifecycle
 
-The options will start life behind individual feature flags: 
+The options will start life behind individual feature flags:
  - `enable_within_timestamp_order_by_in_subscribe`
  - `enable_envelope_upsert_in_subscribe`
  - `enable_envelope_debezium_in_subscribe`

--- a/doc/developer/design/20230418_subscribe_output.md
+++ b/doc/developer/design/20230418_subscribe_output.md
@@ -1,0 +1,277 @@
+- Feature name: Subscribe outputs
+- Associated: #10593
+
+# Summary
+[summary]: #summary
+
+Clients have had trouble using subscribe. They've struggled
+reconciling the current output of subscribe, a list of inserts and
+deletes of tuples, with their application-level data. To
+bridge that gap we introduce three ways to change how subscribe
+produces its output: `WITHIN TIMESTAMP ORDER BY`, `ENVELOPE UPSERT`,
+and `ENVELOPE DEBEZIUM`. These output types are simple to implement
+because they operate on the diffs present in a single timestamp and
+hopefully match the user's mental model.
+
+# Motivation
+[motivation]: #motivation
+
+Sometimes users want to think of the output of subscribe as a list of
+updates to the underlying relation. While the current output reflects
+the changes to the underlying relation, the lack of consistent
+ordering has troubled some clients. They worry about handling a case
+like `(k, v2, +1), (k, v1, -1)` where an update to the value of a
+particular key occurs before the deletion of its previous value. The
+output types proposed all solve this problem with varying degrees of
+flexibility. `ENVELOPE UPSERT` will transform the output of
+`SUBSCRIBE` into a series of `UPSERTS`; `ENVELOPE DEBEZIUM` will
+transform the output into a series of debezium updates with a `before`
+and `after` state. `WITHIN TIMESTAMP ORDER BY` is the most flexible:
+the client can specify a set of columns to order the output by (within
+each timestamp), including `mz_diff`. They can use this ordering to
+force retractions to occur before additions in order to simplify the
+client side handling.
+
+For the simple case of a one to one mapping between keys and values
+(there's one value at a time for each key), any of these output types
+would let the client see the changes to the underlying relation as a
+series of updates. `WITHIN TIMESTAMP ORDER BY` could also be used to
+sort the results from `SUBSCRIBE`; we can think of the results from
+`SUBSCRIBE` are naturally ordered by `mz_timestamp`, we could supply a
+secondary order. I don't think there are many real use cases that
+would benefit from this.
+
+
+# Explanation
+[explanation]: #explanation
+
+`WITHIN TIMESTAMP ORDER BY` takes a `ORDER BY` expression and sorts
+the returned data within each distinct timestamp. This `ORDER BY` can
+take any column in the underlying object or query in addition to the
+`mz_diff` column. A common use case of recovering updates to key-value
+data would be sort by all the keys and `mz_diff`. Since `SUBSCRIBE`
+guarantees that there won't be multiple updates for the same row
+(rephrased: the batch is already consolidated), this will produce data
+that looks like `(k, v1, -1), (k, v2, +1)`. If PROGRESS is set,
+progress messages are unaffected.
+
+`ENVELOPE UPSERT`: Takes a list of columns to interpret as a key and
+within each distinct timestamp interprets the updates as a series of
+upserts. The output columns are reordered to emit `(mz_timestamp,
+mz_state, k1, k2, .., v1, v2, ..)`. There is no `mz_diff` column. The
+values `v1, v2, ..` are set the last value if there's an update or an
+insert and are all set to `NULL` if the only updates to the key in
+that timestamp were deletions. `mz_state` is either `"delete"` or
+`"upsert"` to distinguish the two cases; when there are no values or
+the values can all be `NULL` this column is the only way to
+distinguish the cases. See the [update table](#update-table) for more
+examples. If PROGRESS is set we also return `mz_progressed` as usual
+after `mz_state` and each progress message nulls out all the key and
+value columns.
+
+Using `ENVELOPE UPSERT` when there is more than one live value per key
+can be confusing. The upserts generated have no way to express which
+value was deleted for a given key.
+
+`ENVELOPE DEBEZIUM`: Similarly to `ENVELOPE UPSERT`, takes a list of
+columns to interpret as a key and within each distinct timestamp emits
+debezium upserts with a `before` and `after` state. The output columns
+are reordered to emit `(mz_timestamp, mz_state, k1, k2, .., before_v1,
+before_v2, .., after_v1, after_v2, ..)`. There is no `mz_diff`
+column. When there is an addition, `mz_state` is set to `"insert"` and
+the `before` values are all set to `NULL`. When there is an update,
+`mz_state` is set to `"upsert"`, `before` has the previous contents,
+and `after` has the current values. When there is a deletion,
+`mz_state` is set to `"delete"`, the `before` values are set to the
+previous values and the `after` values are all `NULL`.
+
+Similar to `ENVELOPE UPSERT` the `ENVELOPE DEBEZIUM` is confusing when
+there is more than one live value per key because new values may
+either appear as inserts or upserts. See the [update
+table](#update-table) for the behavior.
+
+If PROGRESS is set, the key columns, the `before`, and the `after`
+values are all set to null and an addition `mz_progressed` column is
+inserted after `mz_state`.
+
+Composition of output modifiers. `WITHIN TIMESTAMP ORDER BY` and
+`ENVELOPE UPSERT` could be used together. `WITHIN TIMESTAMP ORDER BY`
+and `ENVELOPE DEBEZIUM` are harder to use together since `DEBEZIUM`
+produces two copies of the the value. I could see how `WITHIN
+TIMESTAMP ORDER BY` and `ENVELOPE UPSERT` could be used together if
+the user was able to use the order directly from subscribe. I would
+defer implementing it until we validate that these are useful for
+users.
+
+### Update table:
+[update-table]: #update-table
+
+| Updates | `ENVELOPE UPSERT` | `ENVELOPE DEBEZIUM` |
+| --- | --- | --- |
+| (k, v1, +1) | (k, v1) | (k, NULL, v1) |
+| (k, v1, +1), (k, v2, +1) | (k, v1), (k, v2) | (k, NULL, v1), (k, NULL, v2) |
+| (k, v1, -1), (k, v2, +1) | (k, v2) | (k, v1, v2) |
+| (k, v1, -1), (k, v2, +1), (k, v3, +1) | (k, v2), (k, v3) | either (k, v1, v2), (k, NULL, v3) or (k, v1, v3), (k, NULL, v2) |
+| (k, v1, -1), (k, v2, -1), (k, v3, +1) | (k, v3) | either (k, v1, NULL), (k, v2, v3) or (k, v2, NULL), (k, v1, v3) |
+| (k, v1, -1), (k, v2, -1), (k, v3, +1), (k, v4, +1) | (k, v3), (k, v4) | (k, v1, v3), (k, v2, v4) or (k, v2, v3), (k, v1, v4) |
+| (k, v1, -1) | (k, NULL) | (k, v1, NULL) |
+| (k, v1, -1), (k, v2, -1) | (k, NULL) | (k, v1, NULL), (k, v2, NULL) |
+
+
+We don't have to handle unconsolidated data.
+
+# Reference explanation
+[reference-explanation]: #reference-explanation
+
+For each of the three modes we're only changing the results for a
+given timestamp. The sorting and changing the output format can be
+done in `ActiveSubscribe::process_response` which is guaranteed to
+have a complete `SubscribeResponse`'s batch of data. The returned
+batches [don't
+overlap](https://github.com/MaterializeInc/materialize/blob/e781222ea382aa6a7eee1b0e50e94218988f4cad/src/compute-client/src/protocol/response.rs#L106-L110)
+so we can operate on one batch at a time.
+
+`WITHIN TIMESTAMP ORDER BY`: in `process_response`, for each timestamp
+we'll sort the rows by the given `ORDER BY`. This `ORDER BY` can be as
+complicated as any `SELECT`. This adds adds some logic to compiling a
+`SUBSCRIBE` plan but we can reuse most of the existing planning
+machinery.
+
+`ENVELOPE UPSERT` and `ENVELOPE DEBEZIUM`: similar to `WITHIN
+TIMESTAMP ORDER BY` the transformation can be done locally in
+`process_response`: the set of retractions and additions uniquely
+determine the resulting upsert envelopes. The planning work is small:
+finding the indexes of the key columns. The changes to describe are a
+tad more interesting: we have to reorder columns and remove the
+`mz_diff` column.
+
+For `ENVELOPE UPSERT`, if all the updates to a key are retractions we
+emit a deletion for that key. Otherwise we emit an upsert for every
+added row.
+
+For `ENVELOPE DEBEZIUM`, for a given timestamp and key, sort the
+updates by `mz_diff`. Pair up as many retractions and insertions as
+possible and emit one debezium update for that pair. Any leftovers get
+their own debezium update that's either a sole insertion or
+deletion. For the normal case of a single live value for a key this
+algorithm does the right thing; when there are multiple values we
+favor updates over inserts or deletes. There's no guarantee on the
+order of the debezium updates or how values get paired together since
+from MZ's perspective all these updates happened in the same moment.
+
+# Rollout
+[rollout]: #rollout
+
+We'll put these options into production behind a launchdarkly flag
+that we can enable for clients if they're okay working without a
+backwards compatibility guarantee. That'll also let us gather feedback
+from clients using these features.
+	
+## Testing and observability
+[testing-and-observability]: #testing-and-observability
+
+New testdrive tests that exercise these new output types. 
+
+There isn't a performance concern because these output types only need
+to sort the data for a given timestamp.
+
+## Lifecycle
+[lifecycle]: #lifecycle
+
+The options will start life behind individual feature flags: 
+ - `enable_within_timestamp_order_by_in_subscribe`
+ - `enable_envelope_upsert_in_subscribe`
+ - `enable_envelope_debezium_in_subscribe`
+
+After gathering feedback we'll have to decide if feature is worth the
+addition to the surface are of the language. Then we can promote it to
+stable.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+We're adding surface area to MZ's SQL dialect. While adding these
+output types under a flag will let us avoid backwards compatibility
+guarantees, it's always hard to take features away.
+
+The implementation of these features can't leverage data that only the
+database knows: the client could implement the same logic just as
+performantly and correctly. I think in cases where the database can
+completely answer the client's question it's worth pushing enough
+logic into the database to enable that (fx. while `SELECT .. ORDER BY
+..` may not have to sort if the underlying relation is sorted by the
+`ORDER BY` keys, it's still useful regardless because a sorted list of
+results is sometimes exactly what the user wants). The output of
+subscribe is too far from directly usable that client is going to have
+to write code that processes the results.
+
+# Conclusion and alternatives
+[conclusion-and-alternatives]: #conclusion-and-alternatives
+
+An alternative to this design is to tackle our client's underlying
+problems more directly. The underlying subscribe protocol gives an
+accurate representation of the current state of the query results. If
+there's demand for specific views on this state we could provide those
+directly with a client side library. For example, a common usecase I
+can imagine would be maintaining the results of a query client side in
+order to display them. Today even with these output types it's not
+straightforward to implement: the client has to write a little state
+machine in order to tell when it has the complete snapshot data and
+when it has a consistent view on the result set. A example
+implementation:
+
+```lang: python
+"""
+Maintains a map from the first `num_primary_keys` columns to the rest of the row
+Calls handleSnapshot with that map when there's a complete snapshot
+Calls handleUpdated with that map every time we've gotten on update
+`query` needs to ask for PROGRESS and SNAPSHOT
+"""
+def subscribe(query, num_primary_keys, handleSnapshot, handleUpdated):
+	table = {}
+	conn = psycopg.connect("user=...")
+	with conn.cursor() as cur:
+		first_message = True
+		saw_complete_snapshot = False
+		cur_batch_timestamp = None
+		saw_data_updates_in_cur_batch = False
+		for (progress, timestamp, diff, *data) in cur.stream(query):
+			if timestamp != cur_batch_timestamp:
+				# process the batch we just worked on unless it's the first message
+				if first_message:
+					first_message = False
+				elif saw_complete_snapshot:
+					if saw_data_updates_in_cur_batch:
+						handleUpdated(table)
+				else:
+					saw_complete_snapshot = True
+					handleSnapshot(table)
+				saw_data_updates_in_cur_batch = False
+				cur_batch_timestamp = timestamp
+
+	        if not progress:
+				saw_data_updates_in_cur_batch = True
+				for _ in range(diff):
+					table[data[:num_primary_keys]] = data[num_primary_keys:]
+				for _ in range(-diff):
+					if data[:num_primary_keys] in table and table[data[:num_primary_keys]] == data[num_primary_keys:]:
+						del table[data[:num_primary_keys]]
+```
+
+This design will only help with the bottom paragraph, when updating `table`.
+
+A client library can do things that aren't possible using the pgwire format, like call callbacks or maintain state. On the other hand it's a cumbersome tool: we'd need to maintain `n` different implementations and it might prove tempting to cheat and use features that aren't exposed to the pgwire format in the future. It's not clear to me if there's a small set of primitive operations that would cover enough use cases to carry their weight.
+
+The goal of this design is to enable clients to more easily use `SUBSCRIBE`. If it doesn't succeed we can try some of these alternatives.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+None
+
+# Future work
+[future-work]: #future-work
+
+The ultimate point of this work is making it easy for clients to use
+`SUBSCRIBE` in their applications. This is a step is gathering enough
+data to know what to do next.

--- a/doc/developer/design/20230418_subscribe_output.md
+++ b/doc/developer/design/20230418_subscribe_output.md
@@ -80,9 +80,9 @@ and are all set to `NULL` if the only updates to the key in that
 timestamp were deletions. There should not be multiple values for a
 given key. If materialize detects that case (which can only reasonably
 happen if there are multiple updates for the same key in a given
-timestamp), materialize will emit an update a "key violation"
-state. `mz_state` is either `"delete"`, `"upsert"`, or `"key
-violation"` to represent these three cases.
+timestamp), materialize will emit an update a "key_violation"
+state. `mz_state` is either `"delete"`, `"upsert"`, or
+`"key_violation"` to represent these three cases.
 
 If PROGRESS is set we also return `mz_progressed` as usual before
 `mz_state` and each progress message nulls out all the key and value
@@ -122,7 +122,7 @@ mz_timestamp | mz_state       | key  | value
 -- at time 500, introduce a key violation for key=1
 ...
 
-500          | key violation  | 1    | NULL
+500          | key_violation  | 1    | NULL
 
 ```
 
@@ -138,7 +138,7 @@ and `after` has the current values. When there is a deletion,
 `mz_state` is set to `"delete"`, the `before` values are set to the
 previous values and the `after` values are all `NULL`. If it's
 detected that there are multiple values for a given key, `mz_state` is
-set to `"key violation"` and `before` and `after` are both all set to
+set to `"key_violation"` and `before` and `after` are both all set to
 `NULL`.
 
 Similar to `ENVELOPE UPSERT`, `ENVELOPE DEBEZIUM` should not be used
@@ -183,7 +183,7 @@ mz_timestamp | mz_state        | key  | before_value | after_value
 -- at time 500, introduce a key violation
 ...
 
-500          | key violation   | 1    | NULL           | NULL
+500          | key_violation   | 1    | NULL           | NULL
 
 ```
 
@@ -226,7 +226,7 @@ For `ENVELOPE UPSERT`, there are four cases for a given timestamp and key.
  - [(k, v, +1)] => (upsert, k, v)
  - [(k, v, -1)] => (delete, k, NULL)
  - [(k, v1, -1), (k, v2, +1)] => (upsert, k, v2)
- - everything else => (key violation, k, NULL)
+ - everything else => (key_violation, k, NULL)
  
 "Everything else" includes multiple new values for a given key,
 multiple retractions of given values (perhaps key violations that
@@ -237,7 +237,7 @@ UPSERT`, just slightly different outputs:
  - [(k, v, +1)] => (insert, k, NULL, v)
  - [(k, v, -1)] => (delete, k, v, NULL)
  - [(k, v1, -1), (k, v2, +1)] => (upsert, k, v1, v2)
- - everything else => (key violation, k, NULL, NULL)
+ - everything else => (key_violation, k, NULL, NULL)
 
 # Rollout
 [rollout]: #rollout

--- a/doc/developer/design/20230418_subscribe_output.md
+++ b/doc/developer/design/20230418_subscribe_output.md
@@ -1,5 +1,5 @@
 - Feature name: Subscribe outputs
-- Associated: #10593
+- Associated: [#10593](https://github.com/MaterializeInc/materialize/issues/10593)
 
 # Summary
 [summary]: #summary
@@ -10,8 +10,8 @@ deletes of tuples, with their application-level data. To
 bridge that gap we introduce three ways to change how subscribe
 produces its output: `WITHIN TIMESTAMP ORDER BY`, `ENVELOPE UPSERT`,
 and `ENVELOPE DEBEZIUM`. These output types are simple to implement
-because they operate on the diffs present in a single timestamp and
-hopefully match the user's mental model.
+because they operate on the diffs present in a single timestamp. We 
+hope they'll match the user's mental model of updates on their results.
 
 # Motivation
 [motivation]: #motivation
@@ -220,7 +220,7 @@ machine in order to tell when it has the complete snapshot data and
 when it has a consistent view on the result set. A example
 implementation:
 
-```lang: python
+```python
 """
 Maintains a map from the first `num_primary_keys` columns to the rest of the row
 Calls handleSnapshot with that map when there's a complete snapshot

--- a/doc/developer/design/20230418_subscribe_output.md
+++ b/doc/developer/design/20230418_subscribe_output.md
@@ -11,35 +11,37 @@ bridge that gap we introduce three ways to change how subscribe
 produces its output: `WITHIN TIMESTAMP ORDER BY`, `ENVELOPE UPSERT`,
 and `ENVELOPE DEBEZIUM`. These output types are simple to implement
 because they operate on the diffs present in a single timestamp. We 
-hope they'll match the user's mental model of updates on their results.
+hope they'll match the client's mental model of updates on their results.
 
 # Motivation
 [motivation]: #motivation
 
-Sometimes users want to think of the output of subscribe as a list of
+Sometimes clients want to think of the output of subscribe as a list of
 updates to the underlying relation. While the current output reflects
 the changes to the underlying relation, the lack of consistent
 ordering has troubled some clients. They worry about handling a case
-like `(k, v2, +1), (k, v1, -1)` where an update to the value of a
-particular key occurs before the deletion of its previous value. The
-output types proposed all solve this problem with varying degrees of
-flexibility. `ENVELOPE UPSERT` will transform the output of
-`SUBSCRIBE` into a series of `UPSERTS`; `ENVELOPE DEBEZIUM` will
-transform the output into a series of debezium updates with a `before`
-and `after` state. `WITHIN TIMESTAMP ORDER BY` is the most flexible:
-the client can specify a set of columns to order the output by (within
-each timestamp), including `mz_diff`. They can use this ordering to
-force retractions to occur before additions in order to simplify the
-client side handling.
+like `(k, v2, +1), (k, v1, -1)` where an update appears as an insert
+for the new value for a particular key occurs followed by the deletion
+of its previous value. The output types proposed all solve this
+problem with varying degrees of flexibility. `ENVELOPE UPSERT` will
+transform the output of `SUBSCRIBE` into a series of `UPSERTS`;
+`ENVELOPE DEBEZIUM` will transform the output into a series of
+debezium updates with a `before` and `after` state. When viewed as
+upserts the ordering of retractions and insertions doesn't
+matter. `WITHIN TIMESTAMP ORDER BY` is the most flexible: the client
+can specify a set of columns to order the output by (within each
+timestamp), including `mz_diff`. They can use this ordering to force
+retractions to occur before additions in order to simplify the client
+side handling.
 
 For the simple case of a one to one mapping between keys and values
-(there's one value at a time for each key), any of these output types
-would let the client see the changes to the underlying relation as a
-series of updates. `WITHIN TIMESTAMP ORDER BY` could also be used to
-sort the results from `SUBSCRIBE`; we can think of the results from
-`SUBSCRIBE` are naturally ordered by `mz_timestamp`, we could supply a
-secondary order. I don't think there are many real use cases that
-would benefit from this.
+(there's at most one value at a time for each key), any of these
+output types would let the client see the changes to the underlying
+relation as a series of upserts. `WITHIN TIMESTAMP ORDER BY` could
+also be used to sort the results from `SUBSCRIBE`; we can think of the
+results from `SUBSCRIBE` are naturally ordered by `mz_timestamp`, we
+could supply a secondary order. I don't think there are many real use
+cases that would benefit from this.
 
 
 # Explanation
@@ -48,26 +50,26 @@ would benefit from this.
 `WITHIN TIMESTAMP ORDER BY` takes a `ORDER BY` expression and sorts
 the returned data within each distinct timestamp. This `ORDER BY` can
 take any column in the underlying object or query in addition to the
-`mz_diff` column. A common use case of recovering updates to key-value
+`mz_diff` column. A common use case of recovering upserts to key-value
 data would be sort by all the keys and `mz_diff`. Since `SUBSCRIBE`
 guarantees that there won't be multiple updates for the same row
 (rephrased: the batch is already consolidated), this will produce data
-that looks like `(k, v1, -1), (k, v2, +1)`. If PROGRESS is set,
-progress messages are unaffected.
+that looks like `(k, v1, -1), (k, v2, +1)` which are easier to handle
+for the client. If PROGRESS is set, progress messages are unaffected.
 
 `ENVELOPE UPSERT`: Takes a list of columns to interpret as a key and
 within each distinct timestamp interprets the updates as a series of
-upserts. The output columns are reordered to emit `(mz_timestamp,
-mz_state, k1, k2, .., v1, v2, ..)`. There is no `mz_diff` column. The
-values `v1, v2, ..` are set the last value if there's an update or an
-insert and are all set to `NULL` if the only updates to the key in
-that timestamp were deletions. `mz_state` is either `"delete"` or
+upserts. The output columns are reordered as `(mz_timestamp, mz_state,
+k1, k2, .., v1, v2, ..)`. There is no `mz_diff` column. The values
+`v1, v2, ..` are set the last value if there's an update or an insert
+and are all set to `NULL` if the only updates to the key in that
+timestamp were deletions. `mz_state` is either `"delete"` or
 `"upsert"` to distinguish the two cases; when there are no values or
 the values can all be `NULL` this column is the only way to
-distinguish the cases. See the [update table](#update-table) for more
-examples. If PROGRESS is set we also return `mz_progressed` as usual
-after `mz_state` and each progress message nulls out all the key and
-value columns.
+distinguish a deletion from an upsert. See the [update
+table](#update-table) for more examples. If PROGRESS is set we also
+return `mz_progressed` as usual after `mz_state` and each progress
+message nulls out all the key and value columns.
 
 Using `ENVELOPE UPSERT` when there is more than one live value per key
 can be confusing. The upserts generated have no way to express which
@@ -76,7 +78,7 @@ value was deleted for a given key.
 `ENVELOPE DEBEZIUM`: Similarly to `ENVELOPE UPSERT`, takes a list of
 columns to interpret as a key and within each distinct timestamp emits
 debezium upserts with a `before` and `after` state. The output columns
-are reordered to emit `(mz_timestamp, mz_state, k1, k2, .., before_v1,
+are reordered as `(mz_timestamp, mz_state, k1, k2, .., before_v1,
 before_v2, .., after_v1, after_v2, ..)`. There is no `mz_diff`
 column. When there is an addition, `mz_state` is set to `"insert"` and
 the `before` values are all set to `NULL`. When there is an update,
@@ -88,34 +90,36 @@ previous values and the `after` values are all `NULL`.
 Similar to `ENVELOPE UPSERT` the `ENVELOPE DEBEZIUM` is confusing when
 there is more than one live value per key because new values may
 either appear as inserts or upserts. See the [update
-table](#update-table) for the behavior.
+table](#update-table) for some example of confusing cases like rows 4
+and 5.
 
-If PROGRESS is set, the key columns, the `before`, and the `after`
-values are all set to null and an addition `mz_progressed` column is
-inserted after `mz_state`.
+If PROGRESS is set, the key, `before_v*` and `after_v*` are all set to
+`NULL` an addition `mz_progressed` column is inserted after
+`mz_state`.
 
-Composition of output modifiers. `WITHIN TIMESTAMP ORDER BY` and
-`ENVELOPE UPSERT` could be used together. `WITHIN TIMESTAMP ORDER BY`
-and `ENVELOPE DEBEZIUM` are harder to use together since `DEBEZIUM`
-produces two copies of the the value. I could see how `WITHIN
-TIMESTAMP ORDER BY` and `ENVELOPE UPSERT` could be used together if
-the user was able to use the order directly from subscribe. I would
-defer implementing it until we validate that these are useful for
-users.
+Today only one output modifier can be used at a time. `ENVELOPE
+DEBEZIUM` and `ENVELOPE UPSERT` are conflicting directions. `WITHIN
+TIMESTAMP ORDER BY` and `ENVELOPE DEBEZIUM` are hard to use together
+since `DEBEZIUM` produces two copies of the value and it would be
+difficult to distinguish between them. In theory, `WITHIN TIMESTAMP
+ORDER BY` and `ENVELOPE UPSERT` could be used together if the client
+wanted a specific sort order out of subscribe. There are few cases
+where that's useful so I propose disallowing it until there is client
+demand.
 
 ### Update table:
 [update-table]: #update-table
 
 | Updates | `ENVELOPE UPSERT` | `ENVELOPE DEBEZIUM` |
 | --- | --- | --- |
-| (k, v1, +1) | (k, v1) | (k, NULL, v1) |
-| (k, v1, +1), (k, v2, +1) | (k, v1), (k, v2) | (k, NULL, v1), (k, NULL, v2) |
-| (k, v1, -1), (k, v2, +1) | (k, v2) | (k, v1, v2) |
-| (k, v1, -1), (k, v2, +1), (k, v3, +1) | (k, v2), (k, v3) | either (k, v1, v2), (k, NULL, v3) or (k, v1, v3), (k, NULL, v2) |
-| (k, v1, -1), (k, v2, -1), (k, v3, +1) | (k, v3) | either (k, v1, NULL), (k, v2, v3) or (k, v2, NULL), (k, v1, v3) |
-| (k, v1, -1), (k, v2, -1), (k, v3, +1), (k, v4, +1) | (k, v3), (k, v4) | (k, v1, v3), (k, v2, v4) or (k, v2, v3), (k, v1, v4) |
-| (k, v1, -1) | (k, NULL) | (k, v1, NULL) |
-| (k, v1, -1), (k, v2, -1) | (k, NULL) | (k, v1, NULL), (k, v2, NULL) |
+| `(k, v1, +1)` | `(k, v1)` | `(k, NULL, v1)` |
+| `(k, v1, +1)`, `(k, v2, +1)` | `(k, v1)`, `(k, v2)` | `(k, NULL, v1)`, `(k, NULL, v2)` |
+| `(k, v1, -1)`, `(k, v2, +1)` | `(k, v2)` | `(k, v1, v2)` |
+| `(k, v1, -1)`, `(k, v2, +1)`, `(k, v3, +1)` | `(k, v2)`, `(k, v3)` | either `(k, v1, v2)`, `(k, NULL, v3)` or `(k, v1, v3)`, `(k, NULL, v2)` |
+| `(k, v1, -1)`, `(k, v2, -1)`, `(k, v3, +1)` | `(k, v3)` | either `(k, v1, NULL)`, `(k, v2, v3)` or `(k, v2, NULL)`, `(k, v1, v3)` |
+| `(k, v1, -1)`, `(k, v2, -1)`, `(k, v3, +1)`, `(k, v4, +1)` | `(k, v3)`, `(k, v4)` | `(k, v1, v3)`, `(k, v2, v4)` or `(k, v2, v3)`, `(k, v1, v4)` |
+| `(k, v1, -1)` | `(k, NULL)` | `(k, v1, NULL)` |
+| `(k, v1, -1)`, `(k, v2, -1)` | `(k, NULL)` | `(k, v1, NULL)`, `(k, v2, NULL)` |
 
 
 We don't have to handle unconsolidated data.
@@ -184,26 +188,15 @@ The options will start life behind individual feature flags:
  - `enable_envelope_debezium_in_subscribe`
 
 After gathering feedback we'll have to decide if feature is worth the
-addition to the surface are of the language. Then we can promote it to
+addition to the surface area of the language. Then we can promote it to
 stable.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
 We're adding surface area to MZ's SQL dialect. While adding these
-output types under a flag will let us avoid backwards compatibility
-guarantees, it's always hard to take features away.
-
-The implementation of these features can't leverage data that only the
-database knows: the client could implement the same logic just as
-performantly and correctly. I think in cases where the database can
-completely answer the client's question it's worth pushing enough
-logic into the database to enable that (fx. while `SELECT .. ORDER BY
-..` may not have to sort if the underlying relation is sorted by the
-`ORDER BY` keys, it's still useful regardless because a sorted list of
-results is sometimes exactly what the user wants). The output of
-subscribe is too far from directly usable that client is going to have
-to write code that processes the results.
+output types under a feature flag will let us avoid backwards
+compatibility guarantees, it's always hard to take features away.
 
 # Conclusion and alternatives
 [conclusion-and-alternatives]: #conclusion-and-alternatives
@@ -214,7 +207,7 @@ accurate representation of the current state of the query results. If
 there's demand for specific views on this state we could provide those
 directly with a client side library. For example, a common usecase I
 can imagine would be maintaining the results of a query client side in
-order to display them. Today even with these output types it's not
+order to display them. Even with these output types it's not
 straightforward to implement: the client has to write a little state
 machine in order to tell when it has the complete snapshot data and
 when it has a consistent view on the result set. A example
@@ -260,9 +253,17 @@ def subscribe(query, num_primary_keys, handleSnapshot, handleUpdated):
 
 This design will only help with the bottom paragraph, when updating `table`.
 
-A client library can do things that aren't possible using the pgwire format, like call callbacks or maintain state. On the other hand it's a cumbersome tool: we'd need to maintain `n` different implementations and it might prove tempting to cheat and use features that aren't exposed to the pgwire format in the future. It's not clear to me if there's a small set of primitive operations that would cover enough use cases to carry their weight.
+A client library can do things that aren't possible using the pgwire
+format, like call callbacks or maintain state. On the other hand it's
+a cumbersome tool: we'd need to maintain different implementations for
+different languages and it might be tempting to cheat and use features
+that aren't exposed to the pgwire format in the future. It's not clear
+to me if there's a small set of primitive operations that would cover
+enough use cases to carry their weight.
 
-The goal of this design is to enable clients to more easily use `SUBSCRIBE`. If it doesn't succeed we can try some of these alternatives.
+The goal of this design is to enable clients to more easily use
+`SUBSCRIBE`. It's a smaller step than whole client side libraries and
+may help. If it doesn't succeed we can try something else.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/doc/developer/design/20230418_subscribe_output.md
+++ b/doc/developer/design/20230418_subscribe_output.md
@@ -228,34 +228,34 @@ Calls handleUpdated with that map every time we've gotten on update
 `query` needs to ask for PROGRESS and SNAPSHOT
 """
 def subscribe(query, num_primary_keys, handleSnapshot, handleUpdated):
-	table = {}
-	conn = psycopg.connect("user=...")
-	with conn.cursor() as cur:
-		first_message = True
-		saw_complete_snapshot = False
-		cur_batch_timestamp = None
-		saw_data_updates_in_cur_batch = False
-		for (progress, timestamp, diff, *data) in cur.stream(query):
-			if timestamp != cur_batch_timestamp:
-				# process the batch we just worked on unless it's the first message
-				if first_message:
-					first_message = False
-				elif saw_complete_snapshot:
-					if saw_data_updates_in_cur_batch:
-						handleUpdated(table)
-				else:
-					saw_complete_snapshot = True
-					handleSnapshot(table)
-				saw_data_updates_in_cur_batch = False
-				cur_batch_timestamp = timestamp
+    table = {}
+    conn = psycopg.connect("user=...")
+    with conn.cursor() as cur:
+        first_message = True
+        saw_complete_snapshot = False
+        cur_batch_timestamp = None
+        saw_data_updates_in_cur_batch = False
+        for (progress, timestamp, diff, *data) in cur.stream(query):
+            if timestamp != cur_batch_timestamp:
+                # process the batch we just worked on unless it's the first message
+                if first_message:
+                    first_message = False
+                elif saw_complete_snapshot:
+                    if saw_data_updates_in_cur_batch:
+                        handleUpdated(table)
+                else:
+                    saw_complete_snapshot = True
+                    handleSnapshot(table)
+                saw_data_updates_in_cur_batch = False
+                cur_batch_timestamp = timestamp
 
-	        if not progress:
-				saw_data_updates_in_cur_batch = True
-				for _ in range(diff):
-					table[data[:num_primary_keys]] = data[num_primary_keys:]
-				for _ in range(-diff):
-					if data[:num_primary_keys] in table and table[data[:num_primary_keys]] == data[num_primary_keys:]:
-						del table[data[:num_primary_keys]]
+            if not progress:
+                saw_data_updates_in_cur_batch = True
+                for _ in range(diff):
+                    table[data[:num_primary_keys]] = data[num_primary_keys:]
+                for _ in range(-diff):
+                    if data[:num_primary_keys] in table and table[data[:num_primary_keys]] == data[num_primary_keys:]:
+                        del table[data[:num_primary_keys]]
 ```
 
 This design will only help with the bottom paragraph, when updating `table`.

--- a/doc/developer/design/20230418_subscribe_output.md
+++ b/doc/developer/design/20230418_subscribe_output.md
@@ -82,7 +82,7 @@ timestamp were deletions. `mz_state` is either `"delete"` or
 the values can all be `NULL` this column is the only way to
 distinguish a deletion from an upsert. See the [update
 table](#update-table) for more examples. If PROGRESS is set we also
-return `mz_progressed` as usual after `mz_state` and each progress
+return `mz_progressed` as usual before `mz_state` and each progress
 message nulls out all the key and value columns.
 
 Using `ENVELOPE UPSERT` when there is more than one live value per key
@@ -140,7 +140,7 @@ table](#update-table) for some example of confusing cases like rows 4
 and 5.
 
 If PROGRESS is set, the key, `before_v*` and `after_v*` are all set to
-`NULL` an addition `mz_progressed` column is inserted after
+`NULL` an addition `mz_progressed` column is inserted before
 `mz_state`.
 
 Today only one output modifier can be used at a time. `ENVELOPE

--- a/doc/developer/design/20230418_subscribe_output.md
+++ b/doc/developer/design/20230418_subscribe_output.md
@@ -227,7 +227,7 @@ For `ENVELOPE UPSERT`, there are four cases for a given timestamp and key.
  - [(k, v, -1)] => (delete, k, NULL)
  - [(k, v1, -1), (k, v2, +1)] => (upsert, k, v2)
  - everything else => (key_violation, k, NULL)
- 
+
 "Everything else" includes multiple new values for a given key,
 multiple retractions of given values (perhaps key violations that
 happened in the past that we may not have known about), or a mix.

--- a/doc/developer/design/20230418_subscribe_output.md
+++ b/doc/developer/design/20230418_subscribe_output.md
@@ -179,6 +179,10 @@ New testdrive tests that exercise these new output types.
 There isn't a performance concern because these output types only need
 to sort the data for a given timestamp.
 
+We'll add metrics to see how often these options are used in order to
+find clients that are using subscribe and get more detail on their
+usecases.
+
 ## Lifecycle
 [lifecycle]: #lifecycle
 


### PR DESCRIPTION
Design doc for new subscribe output types: WITHIN TIMESTAMP ORDER BY, ENVELOPE UPSERT, and ENVELOPE DEBEZIUM

[Rendered](https://github.com/andrewrodriguez-m/materialize/blob/subscribe-output-dd/doc/developer/design/20230418_subscribe_output.md)

### Motivation
#10593

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
