### PR TITLE
testdrive: Fix indexes.td

### DIFF
--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -266,6 +266,7 @@ bar_ind bar <VARIABLE_OUTPUT> {a}
 > SET CLUSTER TO default
 
 > DROP CLUSTER clstr CASCADE;
+> DROP CLUSTER my_cluster CASCADE;
 
 # Test creating indexes on system objects
 > CREATE INDEX sys_ind ON mz_array_types (id)


### PR DESCRIPTION
The test was was not dropping a cluster it created. This caused other unrelated tests that were performing SHOW CLUSTERS to fail.

@parker-timmerman FYI

### Motivation

  * This PR fixes a previously unreported bug.


Nightly CI was failing.

### Tips for reviewer

@def- @nrainer-materialize we have a similar situation roughly once every two weeks:
- a testdrive test does not clean up properly after itself
- the normal CI runs the testdrive tests in 4 separate parallel jobs, so the test in question does not run with any other test that is affected by the missing cleanup
- in Nightly, we have a bunch of jobs that run all testdrive tests together, so an affected test will then fail.

-> a follow up PR to fix is needed.

This mostly affects clusters, as each testdrive test performs `DROP DATABASE materialize` on startup, which drops a bunch of stuff automatically, but clusters are outside of this hierarchy so are not dropped.

MySQL's testdrive equivalent had a post-test check that will fail a test if it left any objects behind. We may need a similar or equivalent solution in our CI as well.