### PR TITLE
doc/user: polish v0.52 release notes

### DIFF
--- a/doc/user/content/releases/v0.51.md
+++ b/doc/user/content/releases/v0.51.md
@@ -1,11 +1,56 @@
 ---
 title: "Materialize v0.51"
-date: 2023-04-17
-released: false
+date: 2023-04-19
+released: true
 ---
 
 ## v0.51.0
 
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
+#### Sources and sinks
+
+* Add support for replicating tables from specific schemas in the
+  [PostgreSQL source](/sql/create-source/postgres/), using the new `FOR SCHEMAS(...)`
+  option:
+
+  ```sql
+	CREATE SOURCE mz_source
+	  FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
+	  FOR SCHEMAS (public, finance)
+	  WITH (SIZE = '3xsmall');
+	```
+
+  With this option, only tables that are part of the publication _and_
+  namespaced with the specified schema(s) will be replicated.
+
+#### SQL
+
+* Add `disk_bytes` to the `mz_internal.mz_cluster_replica_{metrics, sizes}`
+  system catalog tables. This column is currently `NULL`. In the future, it
+  will allow users to inspect disk utilization for each cluster replica.
+
+* Add the `translate` [string function](/sql/functions/#string-func), which
+  replaces a set of characters in a string with another set of characters
+  (one by one, regardless of the order of those characters):
+
+  ```sql
+  SELECT translate('12345', '134', 'ax');
+
+	 translate
+	-----------
+	 a2x5
+  ```
+
+* Add new configuration parameters:
+
+  | Configuration parameter      | Scope    | Description                                                                             |
+  | ---------------------------- | -------- | --------------------------------------------------------------------------------------- |
+  | `enable_session_rbac_checks` | Session  | **Read-only.** Boolean flag indicating whether RBAC is enabled for the current session. |
+  | `enable_rbac_checks`         | System   | Boolean flag indicating whether to apply RBAC checks before executing statements. Setting this variable requires _superuser_ privileges. |
+
+  This is part of the work to enable **Role-based access control** (RBAC) in a
+  future release {{% gh 11579 %}}.
+
+#### Bug fixes and other improvements
+
+* Improve the reliability of SSH tunnel connections in the presence of short
+  idle TCP connection timeouts.

--- a/doc/user/content/releases/v0.52.md
+++ b/doc/user/content/releases/v0.52.md
@@ -1,0 +1,11 @@
+---
+title: "Materialize v0.52"
+date: 2023-04-26
+released: false
+---
+
+## v0.52.0
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}

--- a/doc/user/content/sql/show.md
+++ b/doc/user/content/sql/show.md
@@ -27,6 +27,7 @@ Materialize reserves system variables for region-wide configuration. Although it
 Name                                        | Default value                                                         | Description   |
 --------------------------------------------|-----------------------------------------------------------------------|---------------|
 allowed_cluster_replica_sizes               | `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`  | The allowed sizes when creating a new cluster replica.
+enable_rbac_checks                          | `false`                                                               | Boolean flag indicating whether to apply RBAC checks before executing statements. Setting this variable requires _superuser_ privileges.
 max_aws_privatelink_connections             | `0`                                                                   | The maximum number of AWS PrivateLink connections in the region, across all schemas.
 max_clusters                                | `10`                                                                  | The maximum number of clusters in the region.
 max_databases                               | `1000`                                                                | The maximum number of databases in the region.

--- a/doc/user/layouts/shortcodes/session-variables.html
+++ b/doc/user/layouts/shortcodes/session-variables.html
@@ -19,16 +19,17 @@ client_min_messages                         | `notice`                  | The me
 datestyle                                   | `ISO, MDY`                | The display format for date and time values. The only supported value is `ISO, MDY`.
 emit_timestamp_notice                       | `false`                   | Boolean flag indicating whether to send a `notice` specifying query timestamps.
 emit_trace_id_notice                        | `false`                   | Boolean flag indicating whether to send a `notice` specifying the trace ID, when available.
-extra_float_digits                          | `3`                       | Adjusts the number of digits displayed for floating-point values.
+enable_session_rbac_checks                  | `false`                   | **Read-only.** Boolean flag indicating whether RBAC is enabled for the current session.
+extra_float_digits                          | `3`                       | Boolean flag indicating whether to adjust the number of digits displayed for floating-point values.
 failpoints                                  |                           | Allows failpoints to be dynamically activated.
 idle_in_transaction_session_timeout         | `120 seconds`             | The maximum allowed duration that a session can sit idle in a transaction before being terminated. If this value is specified without units, it is taken as milliseconds. A value of zero disables the timeout.
-integer_datetimes                           | `true`                    | **Read-only.** Reports whether the server uses 64-bit-integer dates and times.
+integer_datetimes                           | `true`                    | **Read-only.** Boolean flag indicating whether the server uses 64-bit-integer dates and times.
 intervalstyle                               | `postgres`                | The display format for interval values. The only supported value is `postgres`.
 is_superuser                                |                           | **Read-only.** Reports whether the current session is a _superuser_ with admin privileges.
 mz_version                                  | Version-dependent         | **Read-only.** Shows the Materialize server version.
 server_version                              | Version-dependent         | **Read-only.** The PostgreSQL compatible server version.
 server_version_num                          | Version-dependent         | **Read-only.** The PostgreSQL compatible server version as an integer.
-sql_safe_updates                            | `false`                   | Prohibits SQL statements that may be overly destructive.
-standard_conforming_strings                 | `true`                    | Causes ordinary string literals (`'...'`) to treat backslashes literally. The only supported value is `true`.
+sql_safe_updates                            | `false`                   | Boolean flag indicating whether to prohibit SQL statements that may be overly destructive.
+standard_conforming_strings                 | `true`                    | Boolean flag indicating whether ordinary string literals (`'...'`) should treat backslashes literally. The only supported value is `true`.
 statement_timeout                           | `10 seconds`              | The maximum allowed duration of `INSERT`, `SELECT`, `UPDATE`, and `DELETE` operations. If this value is specified without units, it is taken as milliseconds.
 timezone                                    | `UTC`                     | The time zone for displaying and interpreting timestamps. The only supported value is `UTC`.


### PR DESCRIPTION
Release notes for v0.52. 🐘 

## Tips for reviewer

* #18743 needs to be merged along with the release notes.
* I was debating whether to retroactively write a release note for #18310 in v0.49, now that the LD flag was enabled and this behaviour is already present in user environments. After chatting with Parker, it sounds reasonable to include this change in v0.52, which is when the feature will be considered GA.