### PR TITLE
compute: Guarantee that subscribe response data is consolidated

### DIFF
--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -104,10 +104,10 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// replica must emit [`Batch`] responses that cover the entire time interval from the
     /// minimum time until the subscribe advances to the empty frontier or is
     /// dropped. The time intervals of consecutive [`Batch`]es must be increasing, contiguous,
-    /// non-overlapping, and non-empty. All updates transmitted in a batch must have times within
-    /// that batch’s time interval. All updates' times must be greater than or equal to `as_of`.
-    /// The `upper` of the first [`Batch`] of a subscribe must not be less than that subscribe's
-    /// initial `as_of` frontier.
+    /// non-overlapping, and non-empty. All updates transmitted in a batch must be consolidated and
+    /// have times within that batch’s time interval. All updates' times must be greater than or
+    /// equal to `as_of`. The `upper` of the first [`Batch`] of a subscribe must not be less than
+    /// that subscribe's initial `as_of` frontier.
     ///
     /// The replica must send [`DroppedAt`] responses if the subscribe was dropped in response to
     /// an [`AllowCompaction` command] that advanced its read frontier to the empty frontier. The

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -356,7 +356,10 @@ where
                         if old_frontier != new_frontier && !entry.dropped {
                             let updates = match &mut entry.stashed_updates {
                                 Ok(stashed_updates) => {
+                                    // The compute protocol requires us to only send out
+                                    // consolidated batches.
                                     consolidate_updates(stashed_updates);
+
                                     let mut ship = Vec::new();
                                     let mut keep = Vec::new();
                                     for (time, data, diff) in stashed_updates.drain(..) {

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -223,6 +223,7 @@ impl SubscribeProtocol {
             return;
         }
 
+        // The compute protocol requires us to only send out consolidated batches.
         consolidate_updates(rows);
         consolidate_updates(errors);
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->
I thought this was guaranteed but couldn't find explicit documentation. Not having to handle unconsolidated data makes processing subscribe responses a little easier.

### Motivation
This is already guaranteed [here](https://github.com/MaterializeInc/materialize/blob/b42bb1d831badeac7b3efc985746cf707e0efdbc/src/compute-client/src/service.rs#L359)

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
