### PR TITLE
storage: per-subsource resumption frontiers

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -624,6 +624,13 @@ pub trait CreateResumptionFrontierCalc<T: Timestamp + Lattice + Codec64> {
     ) -> ResumptionFrontierCalculator<T>;
 }
 
+/// Holds both the [`WriteHandle`] and the last effective upper we want to use for that handle.
+///
+/// We use the term "effective upper" because we might want to "move the upper backward" so that the
+/// shard's upper appears to be the resumption frontier. This upper, then, is _not_ appropriate to
+/// use with [`WriteHandle::compare_and_append`] (i.e. it is not appropriate to use as the
+/// `expected_upper` argument), but is meant to be used in contexts where [`WriteHandle::append`] is
+/// appropriate.
 pub struct UpperState<T: Timestamp + Lattice + Codec64> {
     handle: WriteHandle<SourceData, (), T, Diff>,
     last_upper: Antichain<T>,
@@ -648,6 +655,11 @@ impl<T: Timestamp + Lattice + Codec64> std::fmt::Debug for UpperState<T> {
 }
 
 #[derive(Debug)]
+/// Provides convenience method to to efficiently calculate a new _resumption frontier_ from the
+/// shards desribed by its `upper_states.
+///
+/// For details about the resumption frontier calculation logic, see
+/// [`Self::calculate_resumption_frontier`]'s implementation.
 pub struct ResumptionFrontierCalculator<T: Timestamp + Lattice + Codec64> {
     initial_frontier: Antichain<T>,
     upper_states: BTreeMap<GlobalId, UpperState<T>>,
@@ -664,6 +676,8 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T> {
         }
     }
 
+    /// Determine the resumption frontier of an ingestion comprised of the shards described by
+    /// `upper_states`.
     pub async fn calculate_resumption_frontier(&mut self) -> Antichain<T> {
         // Refresh all write handles' uppers.
         for UpperState { handle, last_upper } in self.upper_states.values_mut() {
@@ -672,6 +686,7 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T> {
 
         let mut resume_upper = self.initial_frontier.clone();
 
+        // The resumption frontier is the min of (the stored initial frontier, all uppers).
         for t in self
             .upper_states
             .values()
@@ -681,7 +696,24 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T> {
             resume_upper.insert(t.clone());
         }
 
+        // Ensure no upper exceeds the resume upper; however, uppers are permitted to be below it;
+        // this is currently the same as setting each upper to the resume upper, but will, in the
+        // future, let us add collections whose uppers are beneath the resume upper.
+        for UpperState { last_upper, .. } in self.upper_states.values_mut() {
+            if PartialOrder::less_than(&resume_upper, last_upper) {
+                *last_upper = resume_upper.clone();
+            }
+        }
+
         resume_upper
+    }
+
+    /// Get the most recent uppers of the shards used to generate the last resumption frontier.
+    pub fn get_uppers(&self) -> BTreeMap<GlobalId, Antichain<T>> {
+        self.upper_states
+            .iter()
+            .map(|(id, state)| (*id, state.last_upper.clone()))
+            .collect()
     }
 }
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -611,22 +611,78 @@ impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
 
 /// A trait that is used to calculate safe _resumption frontiers_ for a source.
 ///
-/// Use [`ResumptionFrontierCalculator::initialize_state`] for creating an
-/// opaque state that you should keep around. Then repeatedly call
-/// [`ResumptionFrontierCalculator::calculate_resumption_frontier`] with the
-/// state to efficiently calculate an up-to-date frontier.
+/// Use [`CreateResumptionFrontierCalc::create_calc`] to create a [`ResumptionFrontierCalculator`].
+/// Then repeatedly call [`ResumptionFrontierCalculator::calculate_resumption_frontier`] to
+/// efficiently calculate an up-to-date frontier.
 #[async_trait]
-pub trait ResumptionFrontierCalculator<T> {
-    /// Opaque state that a `ResumptionFrontierCalculator` needs to repeatedly
-    /// (and efficiently) calculate a _resumption frontier_.
-    type State;
+pub trait CreateResumptionFrontierCalc<T: Timestamp + Lattice + Codec64> {
+    /// Creates a [`ResumptionFrontierCalculator`], which can be used to efficiently calculate a new
+    /// _resumption frontier_ when needed.
+    async fn create_calc(
+        &self,
+        client_cache: &PersistClientCache,
+    ) -> ResumptionFrontierCalculator<T>;
+}
 
-    /// Creates an opaque state type that can be used to efficiently calculate a
-    /// new _resumption frontier_ when needed.
-    async fn initialize_state(&self, client_cache: &PersistClientCache) -> Self::State;
+pub struct UpperState<T: Timestamp + Lattice + Codec64> {
+    handle: WriteHandle<SourceData, (), T, Diff>,
+    last_upper: Antichain<T>,
+}
 
-    /// Calculates a new, safe _resumption frontier_.
-    async fn calculate_resumption_frontier(&self, state: &mut Self::State) -> Antichain<T>;
+impl<T: Timestamp + Lattice + Codec64> UpperState<T> {
+    pub fn new(handle: WriteHandle<SourceData, (), T, Diff>) -> Self {
+        UpperState {
+            handle,
+            last_upper: Antichain::from_elem(T::minimum()),
+        }
+    }
+}
+
+impl<T: Timestamp + Lattice + Codec64> std::fmt::Debug for UpperState<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpperState")
+            .field("handle", &"<omitted>")
+            .field("last_upper", &self.last_upper)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct ResumptionFrontierCalculator<T: Timestamp + Lattice + Codec64> {
+    initial_frontier: Antichain<T>,
+    upper_states: BTreeMap<GlobalId, UpperState<T>>,
+}
+
+impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T> {
+    pub fn new(
+        initial_frontier: Antichain<T>,
+        upper_states: BTreeMap<GlobalId, UpperState<T>>,
+    ) -> Self {
+        ResumptionFrontierCalculator {
+            initial_frontier,
+            upper_states,
+        }
+    }
+
+    pub async fn calculate_resumption_frontier(&mut self) -> Antichain<T> {
+        // Refresh all write handles' uppers.
+        for UpperState { handle, last_upper } in self.upper_states.values_mut() {
+            *last_upper = handle.fetch_recent_upper().await.clone();
+        }
+
+        let mut resume_upper = self.initial_frontier.clone();
+
+        for t in self
+            .upper_states
+            .values()
+            .map(|UpperState { last_upper, .. }| last_upper.elements())
+            .flatten()
+        {
+            resume_upper.insert(t.clone());
+        }
+
+        resume_upper
+    }
 }
 
 /// The subset of [`CollectionMetadata`] that must be durable stored.
@@ -1565,8 +1621,8 @@ where
                         instance_id: ingestion.instance_id,
                         remap_collection_id: ingestion.remap_collection_id,
                     };
-                    let mut state = desc.initialize_state(&self.persist).await;
-                    let resume_upper = desc.calculate_resumption_frontier(&mut state).await;
+                    let mut calc = desc.create_calc(&self.persist).await;
+                    let resume_upper = calc.calculate_resumption_frontier().await;
 
                     // Fetch the client for this ingestion's instance.
                     let client = self

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -24,7 +24,6 @@ use itertools::Itertools;
 use mz_expr::{MirScalarExpr, PartitionId};
 use mz_ore::now::NowFn;
 use mz_persist_client::cache::PersistClientCache;
-use mz_persist_client::write::WriteHandle;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::columnar::{
     ColumnFormat, ColumnGet, ColumnPush, Data, DataType, PartDecoder, PartEncoder, Schema,
@@ -50,7 +49,9 @@ use timely::progress::timestamp::Refines;
 use timely::progress::{PathSummary, Timestamp};
 use uuid::Uuid;
 
-use crate::controller::{CollectionMetadata, ResumptionFrontierCalculator};
+use crate::controller::{
+    CollectionMetadata, CreateResumptionFrontierCalc, ResumptionFrontierCalculator, UpperState,
+};
 use crate::types::connections::{KafkaConnection, PostgresConnection};
 use crate::types::errors::{DataflowError, ProtoDataflowError};
 use crate::types::instances::StorageInstanceId;
@@ -112,15 +113,14 @@ pub struct SourceExport<S = ()> {
 }
 
 #[async_trait]
-impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
+impl<T: Timestamp + Lattice + Codec64> CreateResumptionFrontierCalc<T>
     for IngestionDescription<CollectionMetadata>
 {
-    // A `WriteHandle` per used shard. Once we have source envelopes that keep additional shards we
-    // have to specialize this some more.
-    type State = Vec<WriteHandle<SourceData, (), T, Diff>>;
-
-    async fn initialize_state(&self, client_cache: &PersistClientCache) -> Self::State {
-        let mut handles = vec![];
+    async fn create_calc(
+        &self,
+        client_cache: &PersistClientCache,
+    ) -> ResumptionFrontierCalculator<T> {
+        let mut upper_states = BTreeMap::new();
         for (id, export) in self.source_exports.iter() {
             // Explicit destructuring to force a compile error when the metadata change
             let CollectionMetadata {
@@ -143,7 +143,7 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
                 )
                 .await
                 .unwrap();
-            handles.push(handle);
+            upper_states.insert(*id, UpperState::new(handle));
         }
 
         let remap_relation_desc = self.desc.connection.timestamp_desc();
@@ -157,7 +157,7 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
             relation_desc: _,
         } = &self.ingestion_metadata
         {
-            let remap_handle = client_cache
+            let handle = client_cache
                 .open(persist_location.clone())
                 .await
                 .expect("error creating persist client")
@@ -170,27 +170,10 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
                 )
                 .await
                 .unwrap();
-            handles.push(remap_handle);
+            upper_states.insert(self.remap_collection_id, UpperState::new(handle));
         }
 
-        handles
-    }
-
-    async fn calculate_resumption_frontier(&self, handles: &mut Self::State) -> Antichain<T> {
-        // An ingestion can resume at the minimum of..
-        let mut resume_upper = Antichain::new();
-
-        // ..the upper frontier of each shard
-        for handle in handles {
-            handle.fetch_recent_upper().await;
-            for t in handle.upper().elements() {
-                resume_upper.insert(t.clone());
-            }
-        }
-
-        // ..the upper of an implied envelope state shard. Eventually this could become actual
-        // state shards and this section will be removed.
-        let envelope_upper = match self.desc.envelope {
+        let initial_frontier = match self.desc.envelope {
             // We can only resume with the None envelope, which is stateless,
             // or with the [Debezium] Upsert envelope, which is easy
             //   (re-ingest the last emitted state)
@@ -198,11 +181,8 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
             // Otherwise re-ingest everything
             _ => Antichain::from_elem(T::minimum()),
         };
-        for t in envelope_upper {
-            resume_upper.insert(t);
-        }
 
-        resume_upper
+        ResumptionFrontierCalculator::new(initial_frontier, upper_states)
     }
 }
 

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -6,6 +6,7 @@
 //! Types for cluster-internal control messages that can be broadcast to all
 //! workers from individual operators/workers.
 
+use std::collections::BTreeMap;
 use std::time::Instant;
 
 use mz_repr::{GlobalId, Row};
@@ -63,7 +64,7 @@ pub enum InternalStorageCommand {
         /// The frontier at which we should (re-)start ingestion.
         resumption_frontier: Antichain<mz_repr::Timestamp>,
         /// The frontier at which we should (re-)start ingestion in the source time domain.
-        source_resumption_frontier: Vec<Row>,
+        source_resumption_frontier: BTreeMap<GlobalId, Vec<Row>>,
     },
     /// Render a sink dataflow.
     CreateSinkDataflow(

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -228,7 +228,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
     primary_source_id: GlobalId,
     description: IngestionDescription<CollectionMetadata>,
     resume_upper: Antichain<mz_repr::Timestamp>,
-    source_resume_upper: Vec<Row>,
+    source_resume_upper: BTreeMap<GlobalId, Vec<Row>>,
 ) {
     let worker_id = timely_worker.index();
     let worker_logging = timely_worker.log_register().get("timely");

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -12,6 +12,7 @@
 //! See [`render_source`] for more details.
 
 use std::any::Any;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -73,7 +74,7 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
     id: GlobalId,
     description: IngestionDescription<CollectionMetadata>,
     resume_upper: Antichain<mz_repr::Timestamp>,
-    source_resume_upper: Vec<Row>,
+    source_resume_upper: BTreeMap<GlobalId, Vec<Row>>,
     storage_state: &mut crate::storage_state::StorageState,
 ) -> (
     Vec<(

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -104,8 +104,11 @@ impl SourceRender for LoadGeneratorSourceConnection {
                 return;
             }
 
-            let resume_upper =
-                Antichain::from_iter(config.source_resume_upper.iter().map(MzOffset::decode_row));
+            let resume_upper = Antichain::from_iter(
+                config.source_resume_upper[&config.id]
+                    .iter()
+                    .map(MzOffset::decode_row),
+            );
 
             let Some(mut offset) = resume_upper.into_option() else {
                 return

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -222,8 +222,7 @@ impl SourceRender for KafkaSourceConnection {
             let mut partition_capabilities = BTreeMap::new();
             let mut max_pid = None;
             let resume_upper = Antichain::from_iter(
-                config
-                    .source_resume_upper
+                config.source_resume_upper[&config.id]
                     .iter()
                     .map(Partitioned::<_, _>::decode_row),
             );

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -129,8 +129,14 @@ impl SourceRender for PostgresSourceConnection {
         Stream<G, (usize, HealthStatusUpdate)>,
         Rc<dyn Any>,
     ) {
-        let resume_upper =
-            Antichain::from_iter(config.source_resume_upper.iter().map(MzOffset::decode_row));
+        // TODO: make snapshot::render take all resume uppers, but only send main resume upper to replication::render
+        let resume_upper = Antichain::from_iter(
+            config.source_resume_upper[&config.id]
+                .iter()
+                .map(MzOffset::decode_row),
+        );
+
+        tracing::warn!("PG {:?} resumer_upper {:?}", config.id, resume_upper);
 
         // Collect the tables that we will be ingesting.
         let mut table_info = BTreeMap::new();

--- a/src/storage/src/source/resumption.rs
+++ b/src/storage/src/source/resumption.rs
@@ -18,7 +18,7 @@ use std::rc::Rc;
 use differential_dataflow::Hashable;
 use mz_ore::cast::CastFrom;
 use mz_repr::Timestamp;
-use mz_storage_client::controller::ResumptionFrontierCalculator;
+use mz_storage_client::controller::CreateResumptionFrontierCalc;
 use mz_timely_util::builder_async::OperatorBuilder;
 use timely::dataflow::operators::CapabilitySet;
 use timely::dataflow::Scope;
@@ -44,7 +44,7 @@ pub fn resumption_operator<G, R>(
 ) -> (timely::dataflow::Stream<G, ()>, Rc<dyn Any>)
 where
     G: Scope<Timestamp = Timestamp> + Clone,
-    R: ResumptionFrontierCalculator<Timestamp> + 'static,
+    R: CreateResumptionFrontierCalc<Timestamp> + 'static,
 {
     let RawSourceCreationConfig {
         id,
@@ -81,13 +81,13 @@ where
         // See <https://docs.rs/tokio/latest/tokio/time/struct.Interval.html#method.tick>
         interval.tick().await;
 
-        let mut calc_state = calc.initialize_state(&persist_clients).await;
+        let mut calc = calc.create_calc(&persist_clients).await;
 
         while !upper.is_empty() {
             interval.tick().await;
 
             // Get a new lower bound for the resumption frontier
-            let new_upper = calc.calculate_resumption_frontier(&mut calc_state).await;
+            let new_upper = calc.calculate_resumption_frontier().await;
 
             if PartialOrder::less_than(&upper, &new_upper) {
                 tracing::debug!(

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -123,11 +123,13 @@ pub struct RawSourceCreationConfig {
     pub storage_metadata: CollectionMetadata,
     /// The upper frontier this source should resume ingestion at
     pub resume_upper: Antichain<mz_repr::Timestamp>,
-    /// The upper frontier this source should resume ingestion at in the source time domain. Since
-    /// every source has a different timestamp type we carry the timestamps of this frontier in an
-    /// encoded `Vec<Row>` form which will get decoded once we reach the connection specialized
-    /// functions.
-    pub source_resume_upper: Vec<Row>,
+    /// For each source export, the upper frontier this source should resume ingestion at in the
+    /// source time domain.
+    ///
+    /// Since every source has a different timestamp type we carry the timestamps of this frontier
+    /// in an encoded `Vec<Row>` form which will get decoded once we reach the connection
+    /// specialized functions.
+    pub source_resume_upper: BTreeMap<GlobalId, Vec<Row>>,
     /// A handle to the persist client cache
     pub persist_clients: Arc<PersistClientCache>,
     /// Place to share statistics updates with storage state.

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -52,7 +52,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistClient, PersistLocation, ShardId};
 use mz_repr::{Diff, GlobalId, RelationDesc, Row};
 use mz_storage_client::client::SourceStatisticsUpdate;
-use mz_storage_client::controller::{CollectionMetadata, ResumptionFrontierCalculator};
+use mz_storage_client::controller::{CollectionMetadata, CreateResumptionFrontierCalc};
 use mz_storage_client::healthcheck::MZ_SOURCE_STATUS_HISTORY_DESC;
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::errors::SourceError;
@@ -182,7 +182,7 @@ pub fn create_raw_source<'g, G: Scope<Timestamp = ()>, C, R>(
 )
 where
     C: SourceConnection + SourceRender + Clone + 'static,
-    R: ResumptionFrontierCalculator<mz_repr::Timestamp> + 'static,
+    R: CreateResumptionFrontierCalc<mz_repr::Timestamp> + 'static,
 {
     let worker_id = config.worker_id;
     let id = config.id;

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -24,7 +24,7 @@ use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::Codec64;
 use mz_repr::{Diff, GlobalId, Row};
 use mz_service::local::Activatable;
-use mz_storage_client::controller::{CollectionMetadata, ResumptionFrontierCalculator};
+use mz_storage_client::controller::{CollectionMetadata, CreateResumptionFrontierCalc};
 use mz_storage_client::types::sources::{
     GenericSourceConnection, IngestionDescription, KafkaSourceConnection,
     LoadGeneratorSourceConnection, PostgresSourceConnection, SourceConnection, SourceData,
@@ -162,14 +162,12 @@ impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
                         ingestion_description,
                         _phantom_data,
                     ) => {
-                        let mut state = ingestion_description
-                            .initialize_state(&persist_clients)
+                        let mut calc = ingestion_description
+                            .create_calc(&persist_clients)
                             .instrument(span.clone())
                             .await;
-                        let resume_upper: Antichain<T> = ingestion_description
-                            .calculate_resumption_frontier(&mut state)
-                            .instrument(span)
-                            .await;
+                        let resume_upper: Antichain<T> =
+                            calc.calculate_resumption_frontier().instrument(span).await;
 
                         // Create a specialized description to be able to call the generic method
                         let source_resume_upper = match ingestion_description.desc.connection {

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -270,12 +270,16 @@ where
                 let async_storage_worker = Rc::clone(&worker.storage_state.async_worker);
                 let internal_command_fabric = &mut HaltingInternalCommandSender::new();
 
-                let source_resumption_frontier = match &desc.connection {
-                    GenericSourceConnection::Kafka(c) => minimum_frontier(c),
-                    GenericSourceConnection::Postgres(c) => minimum_frontier(c),
-                    GenericSourceConnection::TestScript(c) => minimum_frontier(c),
-                    GenericSourceConnection::LoadGenerator(c) => minimum_frontier(c),
-                };
+                let source_resumption_frontier = std::iter::once((
+                    id,
+                    match &desc.connection {
+                        GenericSourceConnection::Kafka(c) => minimum_frontier(c),
+                        GenericSourceConnection::Postgres(c) => minimum_frontier(c),
+                        GenericSourceConnection::TestScript(c) => minimum_frontier(c),
+                        GenericSourceConnection::LoadGenerator(c) => minimum_frontier(c),
+                    },
+                ))
+                .collect();
 
                 // NOTE: We only feed internal commands into the worker,
                 // bypassing "external" StorageCommand and the async worker that


### PR DESCRIPTION
To support adding tables to PG sources (#15832), the idea is to support taking source tables whose LSN is 0 up to the `replication_lsn`. The first step to supporting that is demultiplexing the resumption frontier of each collection, which this PR does.

### Motivation

This PR adds a known-desirable feature. Part of #15832

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  This has a design document that @petrosagg drafted, which I cannot currently locate.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
