### PR TITLE
stash-debug: teach upgrade check about replica sizes

### DIFF
--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -85,13 +85,14 @@ use std::{
     sync::Arc,
 };
 
+use anyhow::Context;
 use clap::Parser;
 use once_cell::sync::Lazy;
 
 use mz_adapter::{
     catalog::{
         storage::{self as catalog, BootstrapArgs},
-        Catalog, Config,
+        Catalog, ClusterReplicaSizeMap, Config,
     },
     DUMMY_AVAILABILITY_ZONE,
 };
@@ -135,7 +136,9 @@ enum Action {
     /// or error message. Exits with 0 if the upgrade would succeed, otherwise
     /// non-zero. Can be used on a running environmentd. Operates without
     /// interfering with it or committing any data to that stash.
-    UpgradeCheck,
+    UpgradeCheck {
+        cluster_replica_sizes: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -178,10 +181,16 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             let stash = factory.open(args.postgres_url, None, tls).await?;
             edit(stash, usage, collection, key, value).await
         }
-        Action::UpgradeCheck => {
+        Action::UpgradeCheck {
+            cluster_replica_sizes,
+        } => {
             // upgrade needs fake writes, so use a savepoint.
             let stash = factory.open_savepoint(args.postgres_url, tls).await?;
-            upgrade_check(stash, usage).await
+            let cluster_replica_sizes: ClusterReplicaSizeMap = match cluster_replica_sizes {
+                None => Default::default(),
+                Some(json) => serde_json::from_str(&json).context("parsing replica size map")?,
+            };
+            upgrade_check(stash, usage, cluster_replica_sizes).await
         }
     }
 }
@@ -204,8 +213,12 @@ async fn dump(mut stash: Stash, usage: Usage, mut target: impl Write) -> Result<
     write!(&mut target, "\n")?;
     Ok(())
 }
-async fn upgrade_check(stash: Stash, usage: Usage) -> Result<(), anyhow::Error> {
-    let msg = usage.upgrade_check(stash).await?;
+async fn upgrade_check(
+    stash: Stash,
+    usage: Usage,
+    cluster_replica_sizes: ClusterReplicaSizeMap,
+) -> Result<(), anyhow::Error> {
+    let msg = usage.upgrade_check(stash, cluster_replica_sizes).await?;
     println!("{msg}");
     Ok(())
 }
@@ -366,7 +379,11 @@ impl Usage {
         anyhow::bail!("unknown collection {} for stash {:?}", collection, self)
     }
 
-    async fn upgrade_check(&self, stash: Stash) -> Result<String, anyhow::Error> {
+    async fn upgrade_check(
+        &self,
+        stash: Stash,
+        cluster_replica_sizes: ClusterReplicaSizeMap,
+    ) -> Result<String, anyhow::Error> {
         if !matches!(self, Self::Catalog) {
             anyhow::bail!("upgrade_check expected Catalog stash, found {:?}", self);
         }
@@ -392,7 +409,7 @@ impl Usage {
             now,
             skip_migrations: false,
             metrics_registry,
-            cluster_replica_sizes: Default::default(),
+            cluster_replica_sizes,
             default_storage_cluster_size: None,
             bootstrap_system_parameters: Default::default(),
             availability_zones: vec![],


### PR DESCRIPTION
This is required to actually use this on a production database.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a