### PR TITLE
sql: support array casting

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -417,6 +417,7 @@ message ProtoUnaryFunc {
         google.protobuf.Empty mz_acl_item_grantor = 292;
         google.protobuf.Empty mz_acl_item_grantee = 293;
         google.protobuf.Empty mz_acl_item_privileges = 294;
+        ProtoCastToVariableType cast_array_to_array = 295;
     }
 }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4068,6 +4068,7 @@ derive_unary!(
     CastUuidToString,
     CastRecordToString,
     CastRecord1ToRecord2,
+    CastArrayToArray,
     CastArrayToString,
     CastListToString,
     CastList1ToList2,
@@ -4793,6 +4794,10 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                     cast_exprs: inner.cast_exprs.into_proto(),
                 })
             }
+            UnaryFunc::CastArrayToArray(inner) => CastArrayToArray(Box::new(ProtoCastToVariableType {
+                return_ty: Some(inner.return_ty.into_proto()),
+                cast_expr: Some(inner.cast_expr.into_proto()),
+            })),
             UnaryFunc::CastArrayToString(func) => CastArrayToString(func.ty.into_proto()),
             UnaryFunc::CastListToString(func) => CastListToString(func.ty.into_proto()),
             UnaryFunc::CastList1ToList2(inner) => {
@@ -5173,6 +5178,11 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                         .return_ty
                         .into_rust_if_some("ProtoCastRecord1ToRecord2::return_ty")?,
                     cast_exprs: inner.cast_exprs.into_rust()?,
+                }
+                .into()),
+                CastArrayToArray(inner) => Ok(impls::CastArrayToArray {
+                    return_ty: inner.return_ty.into_rust_if_some("ProtoCastArrayToArray::return_ty")?,
+                    cast_expr: inner.cast_expr.into_rust_if_some("ProtoCastArrayToArray::cast_expr")?,
                 }
                 .into()),
                 CastArrayToString(ty) => Ok(impls::CastArrayToString {

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4794,10 +4794,12 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                     cast_exprs: inner.cast_exprs.into_proto(),
                 })
             }
-            UnaryFunc::CastArrayToArray(inner) => CastArrayToArray(Box::new(ProtoCastToVariableType {
-                return_ty: Some(inner.return_ty.into_proto()),
-                cast_expr: Some(inner.cast_expr.into_proto()),
-            })),
+            UnaryFunc::CastArrayToArray(inner) => {
+                CastArrayToArray(Box::new(ProtoCastToVariableType {
+                    return_ty: Some(inner.return_ty.into_proto()),
+                    cast_expr: Some(inner.cast_expr.into_proto()),
+                }))
+            }
             UnaryFunc::CastArrayToString(func) => CastArrayToString(func.ty.into_proto()),
             UnaryFunc::CastListToString(func) => CastListToString(func.ty.into_proto()),
             UnaryFunc::CastList1ToList2(inner) => {
@@ -5181,8 +5183,12 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                 }
                 .into()),
                 CastArrayToArray(inner) => Ok(impls::CastArrayToArray {
-                    return_ty: inner.return_ty.into_rust_if_some("ProtoCastArrayToArray::return_ty")?,
-                    cast_expr: inner.cast_expr.into_rust_if_some("ProtoCastArrayToArray::cast_expr")?,
+                    return_ty: inner
+                        .return_ty
+                        .into_rust_if_some("ProtoCastArrayToArray::return_ty")?,
+                    cast_expr: inner
+                        .cast_expr
+                        .into_rust_if_some("ProtoCastArrayToArray::cast_expr")?,
                 }
                 .into()),
                 CastArrayToString(ty) => Ok(impls::CastArrayToString {

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -164,17 +164,19 @@ impl LazyUnaryFunc for CastArrayToArray {
         let arr = a.unwrap_array();
         let dims = arr.dims().into_iter().collect::<Vec<ArrayDimension>>();
 
-        let casted_datums = arr.elements().iter().map(|datum| {
-            self.cast_expr.eval(&[datum], temp_storage)
-        }).collect::<Result<Vec<Datum<'a>>, EvalError>>()?;
+        let casted_datums = arr
+            .elements()
+            .iter()
+            .map(|datum| self.cast_expr.eval(&[datum], temp_storage))
+            .collect::<Result<Vec<Datum<'a>>, EvalError>>()?;
 
-        Ok(temp_storage.make_datum(|packer| { packer.push_array(&dims, casted_datums).unwrap(); }))
+        Ok(temp_storage.make_datum(|packer| {
+            packer.push_array(&dims, casted_datums).unwrap();
+        }))
     }
 
     fn output_type(&self, _input_type: ColumnType) -> ColumnType {
-        self.return_ty
-            .clone()
-            .nullable(true)
+        self.return_ty.clone().nullable(true)
     }
 
     fn propagates_nulls(&self) -> bool {

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -171,7 +171,9 @@ impl LazyUnaryFunc for CastArrayToArray {
             .collect::<Result<Vec<Datum<'a>>, EvalError>>()?;
 
         Ok(temp_storage.make_datum(|packer| {
-            packer.push_array(&dims, casted_datums).expect("failed to construct array");
+            packer
+                .push_array(&dims, casted_datums)
+                .expect("failed to construct array");
         }))
     }
 

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -9,6 +9,7 @@
 
 use std::fmt;
 
+use mz_repr::adt::array::ArrayDimension;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -134,5 +135,67 @@ impl LazyUnaryFunc for CastArrayToString {
 impl fmt::Display for CastArrayToString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("arraytostr")
+    }
+}
+
+/// Casts an array of one type to an array of another type. Does so by casting
+/// each element of the first array to the desired inner type and collecting
+/// the results into a new array.
+#[derive(
+    Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
+)]
+pub struct CastArrayToArray {
+    pub return_ty: ScalarType,
+    pub cast_expr: Box<MirScalarExpr>,
+}
+
+impl LazyUnaryFunc for CastArrayToArray {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        a: &'a MirScalarExpr,
+    ) -> Result<Datum<'a>, EvalError> {
+        let a = a.eval(datums, temp_storage)?;
+        if a.is_null() {
+            return Ok(Datum::Null);
+        }
+
+        let arr = a.unwrap_array();
+        let dims = arr.dims().into_iter().collect::<Vec<ArrayDimension>>();
+
+        let casted_datums = arr.elements().iter().map(|datum| {
+            self.cast_expr.eval(&[datum], temp_storage)
+        }).collect::<Result<Vec<Datum<'a>>, EvalError>>()?;
+
+        Ok(temp_storage.make_datum(|packer| { packer.push_array(&dims, casted_datums).unwrap(); }))
+    }
+
+    fn output_type(&self, _input_type: ColumnType) -> ColumnType {
+        self.return_ty
+            .clone()
+            .nullable(true)
+    }
+
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+}
+
+impl fmt::Display for CastArrayToArray {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("arraytoarray")
     }
 }

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -171,7 +171,7 @@ impl LazyUnaryFunc for CastArrayToArray {
             .collect::<Result<Vec<Datum<'a>>, EvalError>>()?;
 
         Ok(temp_storage.make_datum(|packer| {
-            packer.push_array(&dims, casted_datums).unwrap();
+            packer.push_array(&dims, casted_datums).expect("failed to construct array");
         }))
     }
 

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -852,3 +852,64 @@ SELECT ARRAY[ARRAY[customer.first_name], ARRAY[customer.zip], ARRAY[customer.id:
 query error db error: ERROR: array_in not yet supported
 SELECT array_in('', 0, 0)
 ----
+
+# Array casting for column expressions
+
+statement ok
+CREATE TABLE array_t2 (
+    a int[],
+    b string[][],
+    c varchar[],
+    d int[][]
+);
+
+statement ok
+INSERT INTO array_t2 VALUES (
+    array[1, 2, 3, 4, 5],
+    array[['t1', 't2', 't3']],
+    array['test1', 'test2', 'test3', 'test4']::varchar[],
+    array[[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+);
+
+query T
+SELECT a::string[]::int[]::text[]::float8[] FROM array_t2;
+----
+{1,2,3,4,5}
+
+query T
+SELECT b::text[] FROM array_t2;
+----
+{{t1,t2,t3}}
+
+query T
+SELECT b::text[] FROM array_t2;
+----
+{{t1,t2,t3}}
+
+query T
+SELECT d::text[][1][1] FROM array_t2;
+----
+{{0,1,2},{3,4,5},{6,7,8}}
+
+query T
+SELECT (d::text[])[1][1] FROM array_t2;
+----
+0
+
+query T
+SELECT (d::text[])[1] FROM array_t2;
+----
+NULL
+
+query T
+SELECT CAST(a as text[]) FROM array_t2;
+----
+{1,2,3,4,5}
+
+statement ok
+UPDATE array_t2 SET c = NULL;
+
+query T
+SELECT c::int[] FROM array_t2;
+----
+NULL

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -872,14 +872,30 @@ INSERT INTO array_t2 VALUES (
 );
 
 query T
+SELECT pg_typeof(a::string[]::int[]::text[]::float8[]) FROM array_t2;
+----
+double precision[]
+
+query T
+SELECT pg_typeof(a::string[]) FROM array_t2;
+----
+text[]
+
+query T
+SELECT pg_typeof(a::string[]::int[]) FROM array_t2;
+----
+integer[]
+
+query error Evaluation error: invalid input syntax for type integer: invalid digit found in string: "t1"
+SELECT b::int[] FROM array_t2;
+
+query error CAST does not support casting from integer\[\] to date\[\]
+SELECT a::date[] FROM array_t2;
+
+query T
 SELECT a::string[]::int[]::text[]::float8[] FROM array_t2;
 ----
 {1,2,3,4,5}
-
-query T
-SELECT b::text[] FROM array_t2;
-----
-{{t1,t2,t3}}
 
 query T
 SELECT b::text[] FROM array_t2;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.
     - Solves #18703

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
