### PR TITLE
python: Fix for removed f-strings

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -125,8 +125,8 @@ class KafkaScenario(Scenario):
 
     END_MARKER = dedent(
         """
-        $ kafka-ingest format=avro key-format=avro topic=topic1 schema=${{value-schema}} key-schema=${{key-schema}}
-        "ZZZ" {{"f1": "END MARKER"}}
+        $ kafka-ingest format=avro key-format=avro topic=topic1 schema=${value-schema} key-schema=${key-schema}
+        "ZZZ" {"f1": "END MARKER"}
         """
     )
 

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -1171,7 +1171,7 @@ class ConnectionLatency(Coordinator):
     def benchmark(self) -> MeasurementSource:
         connections = "\n".join(
             """
-$ postgres-execute connection=postgres://materialize:materialize@${{testdrive.materialize-sql-addr}}
+$ postgres-execute connection=postgres://materialize:materialize@${testdrive.materialize-sql-addr}
 SELECT 1;
 """
             for i in range(0, self.n())

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -168,13 +168,13 @@ class KafkaTopics(Generator):
         print(
             """> CREATE CONNECTION IF NOT EXISTS csr_conn
                 FOR CONFLUENT SCHEMA REGISTRY
-                URL '${{testdrive.schema-registry-url}}';
+                URL '${testdrive.schema-registry-url}';
                 """
         )
 
         print(
             """> CREATE CONNECTION IF NOT EXISTS kafka_conn
-            TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
+            TO KAFKA (BROKER '${testdrive.kafka-addr}');
             """
         )
 
@@ -222,13 +222,13 @@ class KafkaSourcesSameTopic(Generator):
         print(
             """> CREATE CONNECTION IF NOT EXISTS csr_conn
             FOR CONFLUENT SCHEMA REGISTRY
-            URL '${{testdrive.schema-registry-url}}';
+            URL '${testdrive.schema-registry-url}';
             """
         )
 
         print(
             """> CREATE CONNECTION IF NOT EXISTS kafka_conn
-            TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
+            TO KAFKA (BROKER '${testdrive.kafka-addr}');
             """
         )
 
@@ -274,13 +274,13 @@ class KafkaPartitions(Generator):
         print(
             """> CREATE CONNECTION IF NOT EXISTS csr_conn
             FOR CONFLUENT SCHEMA REGISTRY
-            URL '${{testdrive.schema-registry-url}}';
+            URL '${testdrive.schema-registry-url}';
             """
         )
 
         print(
             """> CREATE CONNECTION IF NOT EXISTS kafka_conn
-            TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
+            TO KAFKA (BROKER '${testdrive.kafka-addr}');
             """
         )
 
@@ -330,19 +330,19 @@ class KafkaRecordsEnvelopeNone(Generator):
         print(
             """> CREATE CONNECTION IF NOT EXISTS csr_conn
             FOR CONFLUENT SCHEMA REGISTRY
-            URL '${{testdrive.schema-registry-url}}';
+            URL '${testdrive.schema-registry-url}';
             """
         )
 
         print(
             """> CREATE CONNECTION IF NOT EXISTS kafka_conn
-            TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
+            TO KAFKA (BROKER '${testdrive.kafka-addr}');
             """
         )
 
         print(
             """> CREATE SOURCE kafka_records_envelope_none
-              FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-records-envelope-none-${{testdrive.seed}}')
+              FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-records-envelope-none-${testdrive.seed}')
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
               ENVELOPE NONE;
               """
@@ -379,19 +379,19 @@ class KafkaRecordsEnvelopeUpsertSameValue(Generator):
         print(
             """> CREATE CONNECTION IF NOT EXISTS csr_conn
             FOR CONFLUENT SCHEMA REGISTRY
-            URL '${{testdrive.schema-registry-url}}';
+            URL '${testdrive.schema-registry-url}';
             """
         )
 
         print(
             """> CREATE CONNECTION IF NOT EXISTS kafka_conn
-            TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
+            TO KAFKA (BROKER '${testdrive.kafka-addr}');
             """
         )
 
         print(
             """> CREATE SOURCE kafka_records_envelope_upsert_same
-              FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-records-envelope-upsert-same-${{testdrive.seed}}')
+              FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-records-envelope-upsert-same-${testdrive.seed}')
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
               ENVELOPE UPSERT;
               """
@@ -431,19 +431,19 @@ class KafkaRecordsEnvelopeUpsertDistinctValues(Generator):
         print(
             """> CREATE CONNECTION IF NOT EXISTS csr_conn
             FOR CONFLUENT SCHEMA REGISTRY
-            URL '${{testdrive.schema-registry-url}}';
+            URL '${testdrive.schema-registry-url}';
             """
         )
 
         print(
             """> CREATE CONNECTION IF NOT EXISTS kafka_conn
-            TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
+            TO KAFKA (BROKER '${testdrive.kafka-addr}');
             """
         )
 
         print(
             """> CREATE SOURCE kafka_records_envelope_upsert_distinct
-              FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-records-envelope-upsert-distinct-${{testdrive.seed}}')
+              FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-records-envelope-upsert-distinct-${testdrive.seed}')
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
               ENVELOPE UPSERT;
               """
@@ -481,7 +481,7 @@ class KafkaSinks(Generator):
         print(
             """> CREATE CONNECTION IF NOT EXISTS csr_conn
             FOR CONFLUENT SCHEMA REGISTRY
-            URL '${{testdrive.schema-registry-url}}';
+            URL '${testdrive.schema-registry-url}';
             """
         )
 
@@ -524,10 +524,10 @@ class KafkaSinksSameSource(Generator):
         )
         print("> CREATE MATERIALIZED VIEW v1 (f1) AS VALUES (123)")
         print(
-            """> CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}');"""
+            """> CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}');"""
         )
         print(
-            """> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (URL '${{testdrive.schema-registry-url}}');"""
+            """> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (URL '${testdrive.schema-registry-url}');"""
         )
 
         for i in cls.all():


### PR DESCRIPTION
Forgot to switch the escaped {{}} strings which are sent to testdrive, follow-up to https://github.com/MaterializeInc/materialize/pull/18821
As seen in nightly: https://buildkite.com/materialize/nightlies/builds/2234#01879bdc-9ae4-4bf8-9c15-c02d0ac7a505

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
