### PR TITLE
upgrade test: Fix the UpgradeEntireMzFourVersions scenario

### DIFF
--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -136,7 +136,6 @@ class UpgradeEntireMzFourVersions(Scenario):
             Manipulate(self, phase=2),
             KillMz(),
             StartMz(tag=released_versions[0]),
-            Validate(self),
             KillMz(),
             StartMz(tag=None),
             Validate(self),


### PR DESCRIPTION
The test was running validate() on a Mz version that was not the current HEAD.

Since we do not provide a mechanism by which validate() can know the version it is running on, it is safest to proclaim that validate() should only ever run against HEAD.


### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI was failing.