### PR TITLE
sql: make error message of `require_unsafe_mode` more actionable

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -69,7 +69,8 @@ use mz_sql::names::{
 use mz_sql::plan::{
     CreateConnectionPlan, CreateIndexPlan, CreateMaterializedViewPlan, CreateSecretPlan,
     CreateSinkPlan, CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan, Params,
-    Plan, PlanContext, SourceSinkClusterConfig as PlanStorageClusterConfig, StatementDesc,
+    Plan, PlanContext, PlanError, SourceSinkClusterConfig as PlanStorageClusterConfig,
+    StatementDesc,
 };
 use mz_sql::session::user::{INTROSPECTION_USER, SYSTEM_USER};
 use mz_sql::session::vars::{
@@ -1367,7 +1368,9 @@ impl CatalogState {
 
     pub fn require_unsafe_mode(&self, feature_name: &'static str) -> Result<(), AdapterError> {
         if !self.config.unsafe_mode {
-            Err(AdapterError::Unsupported(feature_name))
+            Err(AdapterError::PlanError(PlanError::RequiresUnsafe {
+                feature: feature_name.to_string(),
+            }))
         } else {
             Ok(())
         }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -50,6 +50,9 @@ pub enum PlanError {
         feature: String,
         documentation_link: String,
     },
+    RequiresUnsafe {
+        feature: String,
+    },
     UnknownColumn {
         table: Option<PartialItemName>,
         column: ColumnName,
@@ -190,6 +193,9 @@ impl PlanError {
             Self::PostgresConnectionErr { cause } => Some(cause.to_string_with_causes()),
             Self::InvalidProtobufSchema { cause } => Some(cause.to_string_with_causes()),
             Self::InvalidOptionValue { err, .. } => err.detail(),
+            Self::RequiresUnsafe { .. } => {
+                Some("The requested feature is used only for internal development and testing of Materialize.".into())
+            }
             _ => None,
         }
     }
@@ -275,6 +281,10 @@ impl fmt::Display for PlanError {
             }
             Self::NeverSupported { feature, documentation_link: documentation_path } => {
                 write!(f, "{feature} is not supported, for more information consult the documentation at https://materialize.com/docs/{documentation_path}",)?;
+                Ok(())
+            }
+            Self::RequiresUnsafe { feature} => {
+                write!(f, "{feature} is not supported",)?;
                 Ok(())
             }
             Self::UnknownColumn { table, column } => write!(

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -712,7 +712,9 @@ impl<'a> StatementContext<'a> {
 
     pub fn require_unsafe_mode(&self, feature_name: &str) -> Result<(), PlanError> {
         if !self.unsafe_mode() {
-            sql_bail!("{} is unsupported", feature_name)
+            return Err(PlanError::RequiresUnsafe {
+                feature: feature_name.to_string(),
+            });
         }
         Ok(())
     }


### PR DESCRIPTION
### Motivation

At least one (internal) user wasted time figuring out what was going on.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
