### PR TITLE
Add deserialize derive for the pub struct AppPassword

### DIFF
--- a/src/frontegg-auth/src/app_password.rs
+++ b/src/frontegg-auth/src/app_password.rs
@@ -11,6 +11,7 @@ use std::error::Error;
 use std::fmt;
 use std::str::FromStr;
 
+use serde::Deserialize;
 use uuid::Uuid;
 
 /// The prefix that identifies an app password as a Materialize password.
@@ -33,6 +34,7 @@ pub const PREFIX: &str = "mzp_";
 ///     This format allows for the UUIDs to be formatted with hyphens, or
 ///     not.
 ///
+#[derive(Deserialize)]
 pub struct AppPassword {
     /// The client ID embedded in the app password.
     pub client_id: Uuid,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Adding `#[derive(Deserialize)]` to the pub structure `AppPassword`.

While it is not a need by the crate itself it is useful for other crates trying to Deserialize an `AppPassword` straight from a network request. 

[E.g. FronteggClient crate](https://github.com/MaterializeInc/materialize/pull/18854/files/8c7bc233bdf6d286431976130e0a5f594e4a16ba#r1172205996)
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
