### PR TITLE
sql: Allow dropping non-owned descendants

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1087,7 +1087,7 @@ impl Coordinator {
                 session,
                 plan.name.clone(),
                 plan.view.clone(),
-                plan.replace,
+                plan.drop_ids,
                 depends_on,
             )
             .await?;
@@ -1166,7 +1166,8 @@ impl Coordinator {
                     column_names,
                     cluster_id,
                 },
-            replace,
+            replace: _,
+            drop_ids,
             if_not_exists,
             ambiguous_columns,
         } = plan;
@@ -1221,7 +1222,7 @@ impl Coordinator {
 
         let mut ops = Vec::new();
         ops.extend(
-            replace
+            drop_ids
                 .into_iter()
                 .map(|id| catalog::Op::DropObject(ObjectId::Item(id))),
         );
@@ -1404,7 +1405,7 @@ impl Coordinator {
         let mut dropped_active_cluster = false;
 
         let mut dropped_roles: BTreeMap<_, _> = plan
-            .ids
+            .drop_ids
             .iter()
             .filter_map(|id| match id {
                 ObjectId::Role(role_id) => Some(role_id),
@@ -1437,7 +1438,7 @@ impl Coordinator {
             }
         }
 
-        for id in &plan.ids {
+        for id in &plan.drop_ids {
             match id {
                 ObjectId::Database(id) => {
                     let name = self.catalog().get_database(id).name();
@@ -1474,7 +1475,7 @@ impl Coordinator {
             }
         }
 
-        ops.extend(plan.ids.into_iter().map(catalog::Op::DropObject));
+        ops.extend(plan.drop_ids.into_iter().map(catalog::Op::DropObject));
         self.catalog_transact(Some(session), ops).await?;
 
         fail::fail_point!("after_sequencer_drop_replica");

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -345,10 +345,11 @@ fn generate_required_ownership(plan: &Plan) -> Vec<ObjectId> {
         | Plan::GrantRole(_)
         | Plan::RevokeRole(_) => Vec::new(),
         Plan::CreateView(CreateViewPlan { replace, .. })
-        | Plan::CreateMaterializedView(CreateMaterializedViewPlan { replace, .. }) => {
-            replace.iter().map(|id| ObjectId::Item(*id)).collect()
-        }
-        Plan::DropObjects(plan) => plan.ids.clone(),
+        | Plan::CreateMaterializedView(CreateMaterializedViewPlan { replace, .. }) => replace
+            .map(|id| vec![ObjectId::Item(id)])
+            .unwrap_or_default(),
+        // Do not need ownership of descendant objects.
+        Plan::DropObjects(plan) => plan.referenced_ids.clone(),
         Plan::AlterIndexSetOptions(plan) => vec![ObjectId::Item(plan.id)],
         Plan::AlterIndexResetOptions(plan) => vec![ObjectId::Item(plan.id)],
         Plan::AlterSink(plan) => vec![ObjectId::Item(plan.id)],

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -260,7 +260,7 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// The order is guaranteed to be in reverse dependency order, i.e. the leafs will appear
     /// earlier in the list than the roots. This is particularly userful for the order to drop
     /// objects.
-    fn object_dependents(&self, ids: Vec<ObjectId>) -> Vec<ObjectId>;
+    fn object_dependents(&self, ids: &Vec<ObjectId>) -> Vec<ObjectId>;
 
     /// Returns all the IDs of all objects that depend on `id`, including `id` themselves.
     ///

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -524,8 +524,10 @@ pub struct CreateTablePlan {
 pub struct CreateViewPlan {
     pub name: QualifiedItemName,
     pub view: View,
-    /// The IDs of the objects that this view is replacing, if any.
-    pub replace: Vec<GlobalId>,
+    /// The ID of the object that this view is replacing, if any.
+    pub replace: Option<GlobalId>,
+    /// The IDs of all objects that need to be dropped. This includes `replace` and any dependents.
+    pub drop_ids: Vec<GlobalId>,
     pub if_not_exists: bool,
     /// True if the view contains an expression that can make the exact column list
     /// ambiguous. For example `NATURAL JOIN` or `SELECT *`.
@@ -536,8 +538,10 @@ pub struct CreateViewPlan {
 pub struct CreateMaterializedViewPlan {
     pub name: QualifiedItemName,
     pub materialized_view: MaterializedView,
-    /// The IDs of the objects that this view is replacing, if any.
-    pub replace: Vec<GlobalId>,
+    /// The ID of the object that this view is replacing, if any.
+    pub replace: Option<GlobalId>,
+    /// The IDs of all objects that need to be dropped. This includes `replace` and any dependents.
+    pub drop_ids: Vec<GlobalId>,
     pub if_not_exists: bool,
     /// True if the materialized view contains an expression that can make the exact column list
     /// ambiguous. For example `NATURAL JOIN` or `SELECT *`.
@@ -560,7 +564,10 @@ pub struct CreateTypePlan {
 
 #[derive(Debug)]
 pub struct DropObjectsPlan {
-    pub ids: Vec<ObjectId>,
+    /// The IDs of only the objects directly referenced in the `DROP` statement.
+    pub referenced_ids: Vec<ObjectId>,
+    /// All object IDs to drop. Includes `referenced_ids` and all descendants.
+    pub drop_ids: Vec<ObjectId>,
     /// The type of object that was dropped explicitly in the DROP statement. `ids` may contain
     /// objects of different types due to CASCADE.
     pub object_type: ObjectType,

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -702,7 +702,7 @@ SELECT mz_roles.name
 ----
 joe
 
-statement error must be owner of SCHEMA jdb.public, DATABASE jdb
+statement error must be owner of DATABASE jdb
 DROP DATABASE jdb
 
 statement error must be owner of DATABASE jdb
@@ -835,7 +835,7 @@ SELECT mz_roles.name
 ----
 joe
 
-statement error must be owner of CLUSTER REPLICA jclus.jr1, CLUSTER jclus
+statement error must be owner of CLUSTER jclus
 DROP CLUSTER jclus
 
 statement error must be owner of CLUSTER jclus
@@ -1376,7 +1376,7 @@ DROP TABLE t;
 ----
 COMPLETE 0
 
-# Test that ownership is checked with cascading deletes
+# Test that ownership is not checked with cascading deletes
 
 statement ok
 CREATE TABLE t (a INT);
@@ -1387,12 +1387,7 @@ CREATE VIEW v AS SELECT * FROM t;
 COMPLETE 0
 
 statement error must be owner of VIEW materialize.public.v
-DROP TABLE t CASCADE;
-
-simple conn=mz_system,user=mz_system
-ALTER VIEW v OWNER TO materialize;
-----
-COMPLETE 0
+DROP VIEW v
 
 statement ok
 DROP TABLE t CASCADE;
@@ -1402,14 +1397,6 @@ CREATE VIEW v AS SELECT 1 AS a;
 
 simple conn=joe,user=joe
 CREATE INDEX i ON v(a);
-----
-COMPLETE 0
-
-statement error must be owner of INDEX materialize.public.i
-CREATE OR REPLACE VIEW v AS SELECT 2 AS a;
-
-simple conn=mz_system,user=mz_system
-ALTER INDEX i OWNER TO materialize;
 ----
 COMPLETE 0
 
@@ -1424,14 +1411,6 @@ CREATE MATERIALIZED VIEW mv AS SELECT 1 AS a;
 
 simple conn=joe,user=joe
 CREATE INDEX i ON mv(a);
-----
-COMPLETE 0
-
-statement error must be owner of INDEX materialize.public.i
-CREATE OR REPLACE MATERIALIZED VIEW mv AS SELECT 2 AS a;
-
-simple conn=mz_system,user=mz_system
-ALTER INDEX i OWNER TO materialize;
 ----
 COMPLETE 0
 


### PR DESCRIPTION
This commit reverts the changes made in
acc39ea1b9841fef17e42732754bc26e801a00ef. Specifically it allows dropping non-owned objects with a CASCADE statement. This aligns with the behavior in PostgreSQL. Roles are not allowed to directly drop objects if they don't own the object, but they can drop those objects indirectly through CASCADE. The other of
acc39ea1b9841fef17e42732754bc26e801a00ef, who's also the author of this commit, misunderstood the intended behavior.

Works towards resolving #18551
Part of #11579

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release fixes the behavior of dropping non-owned objects through `CASCADE`.
