### PR TITLE
Retain and index `mz_cluster_replica_statuses`

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1728,7 +1728,7 @@ pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| Builti
         .with_column("status", ScalarType::String.nullable(false))
         .with_column("reason", ScalarType::String.nullable(true))
         .with_column("updated_at", ScalarType::TimestampTz.nullable(false)),
-    is_retained_metrics_object: false,
+    is_retained_metrics_object: true,
 });
 
 pub static MZ_CLUSTER_REPLICA_SIZES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -3397,6 +3397,15 @@ pub const MZ_CLUSTER_REPLICA_SIZES_IND: BuiltinIndex = BuiltinIndex {
     sql: "CREATE INDEX mz_cluster_replica_sizes_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_cluster_replica_sizes (size)",
+    is_retained_metrics_object: true,
+};
+
+pub const MZ_CLUSTER_REPLICA_STATUSES_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_cluster_replica_statuses_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_cluster_replica_statuses_ind
+IN CLUSTER mz_introspection
+ON mz_internal.mz_cluster_replica_statuses (replica_id)",
     is_retained_metrics_object: true,
 };
 


### PR DESCRIPTION
Required to get OOMs in the console.

Analysis of memory usage in the `mz_introspection` replica: the maximum usage per crash-looping replica is as follows. Each element in the index will occupy about 96 bytes. There will be two entries per update. In steady state a crash-looping process boots every 5 minutes. There are 7200 5-minute periods in 30 days.

96 bytes * 2 * 5 * 7200 = 6.72 MB. This is the cost per permanently alive flapping replica process, which I think is acceptable.
 
### Motivation


  * This PR adds a feature that has not yet been specified.

We want to surface a log of cluster events (OOMs, etc.) in the console.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Enable time-travel queries (past 30 days) on `mz_cluster_replica_statuses