### PR TITLE
persist: add initial pushdown metrics

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -644,6 +644,7 @@ pub struct BatchWriteMetrics {
 
     pub(crate) step_consolidation: Counter,
     pub(crate) step_columnar_encoding: Counter,
+    pub(crate) step_stats: Counter,
     pub(crate) step_part_writing: Counter,
 }
 
@@ -676,6 +677,10 @@ impl BatchWriteMetrics {
             step_columnar_encoding: registry.register(metric!(
                 name: format!("mz_persist_{}_step_columnar_encoding", name),
                 help: format!("time spent columnar encoding {} updates", name),
+            )),
+            step_stats: registry.register(metric!(
+                name: format!("mz_persist_{}_step_stats", name),
+                help: format!("time spent computing {} update stats", name),
             )),
             step_part_writing: registry.register(metric!(
                 name: format!("mz_persist_{}_step_part_writing", name),

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -184,6 +184,7 @@ where
     G::Timestamp: Timestamp + Lattice + Codec64 + TotalOrder,
 {
     let cfg = clients.cfg().clone();
+    let metrics = clients.metrics.shards.shard(&shard_id);
     let worker_index = scope.index();
     let num_workers = scope.peers();
 
@@ -412,7 +413,13 @@ where
                                     // TODO(mfp): Push the filter down into the Subscribe?
                                     if cfg.dynamic.stats_filter_enabled() {
                                         let should_fetch = part_desc.stats.as_ref().map_or(true, |stats| should_fetch_part(stats));
-                                        if !should_fetch {
+                                        let bytes = u64::cast_from(part_desc.encoded_size_bytes);
+                                        if should_fetch {
+                                            metrics.pushdown.parts_fetched_count.inc();
+                                            metrics.pushdown.parts_fetched_bytes.inc_by(bytes);
+                                        } else {
+                                            metrics.pushdown.parts_filtered_count.inc();
+                                            metrics.pushdown.parts_filtered_bytes.inc_by(bytes);
                                             // TODO(mfp): We'll want to run this auditing in prod
                                             // for e.g. some random fraction of parts. For now, turn
                                             // it on for every part in CI via soft assert. We'll

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -36,7 +36,7 @@ use timely::progress::{Antichain, Timestamp};
 use timely::scheduling::Activator;
 use timely::PartialOrder;
 use tokio::sync::mpsc;
-use tracing::{info, trace};
+use tracing::{debug, trace};
 
 use crate::cache::PersistClientCache;
 use crate::fetch::{FetchedPart, SerdeLeasedBatchPart};
@@ -430,8 +430,7 @@ where
                                             if should_audit {
                                                 part_desc.request_filter_pushdown_audit();
                                             } else {
-                                                // TODO(mfp): Downgrade this to debug! at some point.
-                                                info!("skipping part because of stats filter {:?}", part_desc.stats);
+                                                debug!("skipping part because of stats filter {:?}", part_desc.stats);
                                                 lease_returner.return_leased_part(part_desc);
                                                 continue;
                                             }


### PR DESCRIPTION
Ideally this would also include, for cases where we don't filter, a breakdown of _why_ we didn't filter. Intentionally waiting on that until after #18560 lands.

Touches #12684

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
