### PR TITLE
frontegg-auth: compare emails case insensitively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4006,6 +4006,7 @@ dependencies = [
  "derivative",
  "jsonwebtoken",
  "mz-ore",
+ "mz-sql",
  "reqwest",
  "serde",
  "thiserror",

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -722,7 +722,6 @@ async fn auth(
             User {
                 external_metadata: Some(ExternalUserMetadata {
                     user_id: claims.best_user_id(),
-                    group_id: claims.tenant_id,
                     admin: claims.admin(frontegg.admin_role()),
                 }),
                 name: claims.email,

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -720,10 +720,7 @@ async fn auth(
             };
             let claims = frontegg.validate_access_token(&token, user.as_deref())?;
             User {
-                external_metadata: Some(ExternalUserMetadata {
-                    user_id: claims.best_user_id(),
-                    admin: claims.admin(frontegg.admin_role()),
-                }),
+                external_metadata: Some(ExternalUserMetadata::from(&claims)),
                 name: claims.email,
             }
         }

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -306,7 +306,8 @@ enum Assert<E, D = ()> {
 
 enum TestCase<'a> {
     Pgwire {
-        user: &'static str,
+        user_to_auth_as: &'a str,
+        user_reported_by_system: &'a str,
         password: Option<&'a str>,
         ssl_mode: SslMode,
         configure: Box<dyn Fn(&mut SslConnectorBuilder) -> Result<(), ErrorStack> + 'a>,
@@ -318,7 +319,8 @@ enum TestCase<'a> {
         >,
     },
     Http {
-        user: &'static str,
+        user_to_auth_as: &'a str,
+        user_reported_by_system: &'a str,
         scheme: Scheme,
         headers: &'a HeaderMap,
         configure: Box<dyn Fn(&mut SslConnectorBuilder) -> Result<(), ErrorStack> + 'a>,
@@ -353,7 +355,8 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
     for test in tests {
         match test {
             TestCase::Pgwire {
-                user,
+                user_to_auth_as,
+                user_reported_by_system,
                 password,
                 ssl_mode,
                 configure,
@@ -361,26 +364,26 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
             } => {
                 println!(
                     "pgwire user={} password={:?} ssl_mode={:?}",
-                    user, password, ssl_mode
+                    user_to_auth_as, password, ssl_mode
                 );
 
                 let tls = make_pg_tls(configure);
                 let mut pg_client = server.pg_config();
                 pg_client
                     .ssl_mode(*ssl_mode)
-                    .user(user)
+                    .user(user_to_auth_as)
                     .password(password.unwrap_or(""));
 
                 match assert {
                     Assert::Success => {
                         let mut pg_client = pg_client.connect(tls).unwrap();
                         let row = pg_client.query_one("SELECT current_user", &[]).unwrap();
-                        assert_eq!(row.get::<_, String>(0), *user);
+                        assert_eq!(row.get::<_, String>(0), *user_reported_by_system);
                     }
                     Assert::SuccessSuperuserCheck(is_superuser) => {
                         let mut pg_client = pg_client.connect(tls.clone()).unwrap();
                         let row = pg_client.query_one("SELECT current_user", &[]).unwrap();
-                        assert_eq!(row.get::<_, String>(0), *user);
+                        assert_eq!(row.get::<_, String>(0), *user_reported_by_system);
                         let row = pg_client.query_one("SHOW is_superuser", &[]).unwrap();
                         let expected = if *is_superuser { "on" } else { "off" };
                         assert_eq!(row.get::<_, String>(0), *expected);
@@ -418,7 +421,8 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
                 }
             }
             TestCase::Http {
-                user,
+                user_to_auth_as,
+                user_reported_by_system,
                 scheme,
                 headers,
                 configure,
@@ -471,7 +475,7 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
                     assert_eq!(res.results[0].rows, expected_rows)
                 }
 
-                println!("http user={} scheme={}", user, scheme);
+                println!("http user={} scheme={}", user_to_auth_as, scheme);
 
                 let uri = Uri::builder()
                     .scheme(scheme.clone())
@@ -493,10 +497,18 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
 
                 match assert {
                     Assert::Success => {
-                        assert_success_response(res, vec![vec![user.to_string()]], &runtime);
+                        assert_success_response(
+                            res,
+                            vec![vec![user_reported_by_system.to_string()]],
+                            &runtime,
+                        );
                     }
                     Assert::SuccessSuperuserCheck(is_superuser) => {
-                        assert_success_response(res, vec![vec![user.to_string()]], &runtime);
+                        assert_success_response(
+                            res,
+                            vec![vec![user_reported_by_system.to_string()]],
+                            &runtime,
+                        );
                         let res =
                             query_http_api("SHOW is_superuser", &uri, headers, configure, &runtime);
                         let expected = if *is_superuser { "on" } else { "off" };
@@ -884,7 +896,7 @@ fn test_auth_base() {
     let users = BTreeMap::from([
         (
             (client_id.to_string(), secret.to_string()),
-            "user@_.com".to_string(),
+            "uSeR@_.com".to_string(),
         ),
         (
             (system_client_id.to_string(), system_secret.to_string()),
@@ -892,7 +904,7 @@ fn test_auth_base() {
         ),
     ]);
     let roles = BTreeMap::from([
-        ("user@_.com".to_string(), Vec::new()),
+        ("uSeR@_.com".to_string(), Vec::new()),
         (SYSTEM_USER.name.to_string(), Vec::new()),
     ]);
     let encoding_key =
@@ -904,7 +916,7 @@ fn test_auth_base() {
     };
     let claims = Claims {
         exp: 1000,
-        email: "user@_.com".to_string(),
+        email: "uSeR@_.com".to_string(),
         sub: Uuid::new_v4(),
         user_id: None,
         tenant_id,
@@ -961,10 +973,15 @@ fn test_auth_base() {
         },
         mz_frontegg_auth::Client::default(),
     );
-    let frontegg_user = "user@_.com";
+    let frontegg_user = "uSeR@_.com";
     let frontegg_password = &format!("mzp_{client_id}{secret}");
     let frontegg_basic = Authorization::basic(frontegg_user, frontegg_password);
     let frontegg_header_basic = make_header(frontegg_basic);
+
+    let frontegg_user_lowercase = frontegg_user.to_lowercase();
+    let frontegg_basic_lowercase =
+        Authorization::basic(&frontegg_user_lowercase, frontegg_password);
+    let frontegg_header_basic_lowercase = make_header(frontegg_basic_lowercase);
 
     let frontegg_system_password = &format!("mzp_{system_client_id}{system_secret}");
     let frontegg_system_basic = Authorization::basic(&SYSTEM_USER.name, frontegg_system_password);
@@ -1013,22 +1030,51 @@ fn test_auth_base() {
             },
             // TLS with a password should succeed.
             TestCase::Pgwire {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 password: Some(frontegg_password),
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
             },
             TestCase::Http {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 scheme: Scheme::HTTPS,
                 headers: &frontegg_header_basic,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
             },
+            // Email comparisons should be case insensitive.
+            TestCase::Pgwire {
+                user_to_auth_as: &frontegg_user_lowercase,
+                user_reported_by_system: frontegg_user,
+                password: Some(frontegg_password),
+                ssl_mode: SslMode::Require,
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::Success,
+            },
+            TestCase::Http {
+                user_to_auth_as: &frontegg_user_lowercase,
+                user_reported_by_system: frontegg_user,
+                scheme: Scheme::HTTPS,
+                headers: &frontegg_header_basic_lowercase,
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::Success,
+            },
+            TestCase::Ws {
+                auth: &WebSocketAuth::Basic {
+                    user: frontegg_user_lowercase.to_string(),
+                    password: frontegg_password.to_string(),
+                    options: BTreeMap::default(),
+                },
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::Success,
+            },
             // Password can be base64 encoded UUID bytes.
             TestCase::Pgwire {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 password: {
                     let mut buf = vec![];
                     buf.extend(client_id.as_bytes());
@@ -1044,7 +1090,8 @@ fn test_auth_base() {
             },
             // Password can be base64 encoded UUID bytes without padding.
             TestCase::Pgwire {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 password: {
                     let mut buf = vec![];
                     buf.extend(client_id.as_bytes());
@@ -1060,7 +1107,8 @@ fn test_auth_base() {
             },
             // Password can include arbitrary special characters.
             TestCase::Pgwire {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 password: {
                     let mut password = frontegg_password.clone();
                     password.insert(10, '-');
@@ -1073,7 +1121,8 @@ fn test_auth_base() {
             },
             // Bearer auth doesn't need the clientid or secret.
             TestCase::Http {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 scheme: Scheme::HTTPS,
                 headers: &make_header(Authorization::bearer(&frontegg_jwt).unwrap()),
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1081,7 +1130,8 @@ fn test_auth_base() {
             },
             // No TLS fails.
             TestCase::Pgwire {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 password: Some(frontegg_password),
                 ssl_mode: SslMode::Disable,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1094,7 +1144,8 @@ fn test_auth_base() {
                 })),
             },
             TestCase::Http {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 scheme: Scheme::HTTP,
                 headers: &frontegg_header_basic,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1102,7 +1153,8 @@ fn test_auth_base() {
             },
             // Wrong, but existing, username.
             TestCase::Pgwire {
-                user: "materialize",
+                user_to_auth_as: "materialize",
+                user_reported_by_system: "materialize",
                 password: Some(frontegg_password),
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1112,7 +1164,8 @@ fn test_auth_base() {
                 })),
             },
             TestCase::Http {
-                user: "materialize",
+                user_to_auth_as: "materialize",
+                user_reported_by_system: "materialize",
                 scheme: Scheme::HTTPS,
                 headers: &make_header(Authorization::basic("materialize", frontegg_password)),
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1123,7 +1176,8 @@ fn test_auth_base() {
             },
             // Wrong password.
             TestCase::Pgwire {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 password: Some("bad password"),
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1133,7 +1187,8 @@ fn test_auth_base() {
                 })),
             },
             TestCase::Http {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 scheme: Scheme::HTTPS,
                 headers: &make_header(Authorization::basic(frontegg_user, "bad password")),
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1144,7 +1199,8 @@ fn test_auth_base() {
             },
             // Bad password prefix.
             TestCase::Pgwire {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 password: Some(&format!("mznope_{client_id}{secret}")),
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1154,7 +1210,8 @@ fn test_auth_base() {
                 })),
             },
             TestCase::Http {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 scheme: Scheme::HTTPS,
                 headers: &make_header(Authorization::basic(
                     frontegg_user,
@@ -1168,7 +1225,8 @@ fn test_auth_base() {
             },
             // No password.
             TestCase::Pgwire {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 password: None,
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1178,7 +1236,8 @@ fn test_auth_base() {
                 })),
             },
             TestCase::Http {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 scheme: Scheme::HTTPS,
                 headers: &no_headers,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1189,7 +1248,8 @@ fn test_auth_base() {
             },
             // Bad auth scheme
             TestCase::Http {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 scheme: Scheme::HTTPS,
                 headers: &HeaderMap::from_iter(vec![(
                     AUTHORIZATION,
@@ -1203,7 +1263,8 @@ fn test_auth_base() {
             },
             // Bad tenant.
             TestCase::Http {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 scheme: Scheme::HTTPS,
                 headers: &make_header(Authorization::bearer(&bad_tenant_jwt).unwrap()),
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1214,7 +1275,8 @@ fn test_auth_base() {
             },
             // Expired.
             TestCase::Http {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 scheme: Scheme::HTTPS,
                 headers: &make_header(Authorization::bearer(&expired_jwt).unwrap()),
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1225,7 +1287,8 @@ fn test_auth_base() {
             },
             // System user cannot login via external ports.
             TestCase::Pgwire {
-                user: &*SYSTEM_USER.name,
+                user_to_auth_as: &*SYSTEM_USER.name,
+                user_reported_by_system: &*SYSTEM_USER.name,
                 password: Some(frontegg_system_password),
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1234,7 +1297,8 @@ fn test_auth_base() {
                 })),
             },
             TestCase::Http {
-                user: &*SYSTEM_USER.name,
+                user_to_auth_as: &*SYSTEM_USER.name,
+                user_reported_by_system: &*SYSTEM_USER.name,
                 scheme: Scheme::HTTPS,
                 headers: &frontegg_system_header_basic,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1257,7 +1321,8 @@ fn test_auth_base() {
             },
             // Public role cannot login.
             TestCase::Pgwire {
-                user: PUBLIC_ROLE_NAME.as_str(),
+                user_to_auth_as: PUBLIC_ROLE_NAME.as_str(),
+                user_reported_by_system: PUBLIC_ROLE_NAME.as_str(),
                 password: Some(frontegg_system_password),
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1266,7 +1331,8 @@ fn test_auth_base() {
                 })),
             },
             TestCase::Http {
-                user: PUBLIC_ROLE_NAME.as_str(),
+                user_to_auth_as: PUBLIC_ROLE_NAME.as_str(),
+                user_reported_by_system: PUBLIC_ROLE_NAME.as_str(),
                 scheme: Scheme::HTTPS,
                 headers: &frontegg_system_header_basic,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1299,14 +1365,16 @@ fn test_auth_base() {
         &[
             // Explicitly disabling TLS should succeed.
             TestCase::Pgwire {
-                user: "materialize",
+                user_to_auth_as: "materialize",
+                user_reported_by_system: "materialize",
                 password: None,
                 ssl_mode: SslMode::Disable,
                 configure: Box::new(|_| Ok(())),
                 assert: Assert::Success,
             },
             TestCase::Http {
-                user: &*HTTP_DEFAULT_USER.name,
+                user_to_auth_as: &*HTTP_DEFAULT_USER.name,
+                user_reported_by_system: &*HTTP_DEFAULT_USER.name,
                 scheme: Scheme::HTTP,
                 headers: &no_headers,
                 configure: Box::new(|_| Ok(())),
@@ -1314,7 +1382,8 @@ fn test_auth_base() {
             },
             // Preferring TLS should fall back to no TLS.
             TestCase::Pgwire {
-                user: "materialize",
+                user_to_auth_as: "materialize",
+                user_reported_by_system: "materialize",
                 password: None,
                 ssl_mode: SslMode::Prefer,
                 configure: Box::new(|_| Ok(())),
@@ -1322,7 +1391,8 @@ fn test_auth_base() {
             },
             // Requiring TLS should fail.
             TestCase::Pgwire {
-                user: "materialize",
+                user_to_auth_as: "materialize",
+                user_reported_by_system: "materialize",
                 password: None,
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|_| Ok(())),
@@ -1334,7 +1404,8 @@ fn test_auth_base() {
                 })),
             },
             TestCase::Http {
-                user: &*HTTP_DEFAULT_USER.name,
+                user_to_auth_as: &*HTTP_DEFAULT_USER.name,
+                user_reported_by_system: &*HTTP_DEFAULT_USER.name,
                 scheme: Scheme::HTTPS,
                 headers: &no_headers,
                 configure: Box::new(|_| Ok(())),
@@ -1348,7 +1419,8 @@ fn test_auth_base() {
             },
             // System user cannot login via external ports.
             TestCase::Pgwire {
-                user: &*SYSTEM_USER.name,
+                user_to_auth_as: &*SYSTEM_USER.name,
+                user_reported_by_system: &*SYSTEM_USER.name,
                 password: None,
                 ssl_mode: SslMode::Disable,
                 configure: Box::new(|_| Ok(())),
@@ -1369,7 +1441,8 @@ fn test_auth_base() {
         &[
             // Non-existent role will be created.
             TestCase::Pgwire {
-                user: frontegg_user,
+                user_to_auth_as: frontegg_user,
+                user_reported_by_system: frontegg_user,
                 password: Some(frontegg_password),
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1378,7 +1451,8 @@ fn test_auth_base() {
             // Test that specifying an mzcloud header does nothing and uses the default
             // user.
             TestCase::Http {
-                user: &*HTTP_DEFAULT_USER.name,
+                user_to_auth_as: &*HTTP_DEFAULT_USER.name,
+                user_reported_by_system: &*HTTP_DEFAULT_USER.name,
                 scheme: Scheme::HTTPS,
                 headers: &frontegg_header_basic,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1386,7 +1460,8 @@ fn test_auth_base() {
             },
             // Disabling TLS should fail.
             TestCase::Pgwire {
-                user: "materialize",
+                user_to_auth_as: "materialize",
+                user_reported_by_system: "materialize",
                 password: None,
                 ssl_mode: SslMode::Disable,
                 configure: Box::new(|_| Ok(())),
@@ -1399,7 +1474,8 @@ fn test_auth_base() {
                 })),
             },
             TestCase::Http {
-                user: &*HTTP_DEFAULT_USER.name,
+                user_to_auth_as: &*HTTP_DEFAULT_USER.name,
+                user_reported_by_system: &*HTTP_DEFAULT_USER.name,
                 scheme: Scheme::HTTP,
                 headers: &no_headers,
                 configure: Box::new(|_| Ok(())),
@@ -1407,7 +1483,8 @@ fn test_auth_base() {
             },
             // Preferring TLS should succeed.
             TestCase::Pgwire {
-                user: "materialize",
+                user_to_auth_as: "materialize",
+                user_reported_by_system: "materialize",
                 password: None,
                 ssl_mode: SslMode::Prefer,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1415,14 +1492,16 @@ fn test_auth_base() {
             },
             // Requiring TLS should succeed.
             TestCase::Pgwire {
-                user: "materialize",
+                user_to_auth_as: "materialize",
+                user_reported_by_system: "materialize",
                 password: None,
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Success,
             },
             TestCase::Http {
-                user: &*HTTP_DEFAULT_USER.name,
+                user_to_auth_as: &*HTTP_DEFAULT_USER.name,
+                user_reported_by_system: &*HTTP_DEFAULT_USER.name,
                 scheme: Scheme::HTTPS,
                 headers: &no_headers,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1430,7 +1509,8 @@ fn test_auth_base() {
             },
             // System user cannot login via external ports.
             TestCase::Pgwire {
-                user: &*SYSTEM_USER.name,
+                user_to_auth_as: &*SYSTEM_USER.name,
+                user_reported_by_system: &*SYSTEM_USER.name,
                 password: None,
                 ssl_mode: SslMode::Prefer,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1480,7 +1560,8 @@ fn test_auth_intermediate_ca() {
         &server,
         &[
             TestCase::Pgwire {
-                user: "materialize",
+                user_to_auth_as: "materialize",
+                user_reported_by_system: "materialize",
                 password: None,
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| b.set_ca_file(ca.ca_cert_path())),
@@ -1489,7 +1570,8 @@ fn test_auth_intermediate_ca() {
                 })),
             },
             TestCase::Http {
-                user: &*HTTP_DEFAULT_USER.name,
+                user_to_auth_as: &*HTTP_DEFAULT_USER.name,
+                user_reported_by_system: &*HTTP_DEFAULT_USER.name,
                 scheme: Scheme::HTTPS,
                 headers: &HeaderMap::new(),
                 configure: Box::new(|b| b.set_ca_file(ca.ca_cert_path())),
@@ -1512,14 +1594,16 @@ fn test_auth_intermediate_ca() {
         &server,
         &[
             TestCase::Pgwire {
-                user: "materialize",
+                user_to_auth_as: "materialize",
+                user_reported_by_system: "materialize",
                 password: None,
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| b.set_ca_file(ca.ca_cert_path())),
                 assert: Assert::Success,
             },
             TestCase::Http {
-                user: &*HTTP_DEFAULT_USER.name,
+                user_to_auth_as: &*HTTP_DEFAULT_USER.name,
+                user_reported_by_system: &*HTTP_DEFAULT_USER.name,
                 scheme: Scheme::HTTPS,
                 headers: &HeaderMap::new(),
                 configure: Box::new(|b| b.set_ca_file(ca.ca_cert_path())),
@@ -1615,14 +1699,16 @@ fn test_auth_admin() {
             &server,
             &[
                 TestCase::Pgwire {
-                    user: frontegg_user,
+                    user_to_auth_as: frontegg_user,
+                    user_reported_by_system: frontegg_user,
                     password: Some(frontegg_password),
                     ssl_mode: SslMode::Require,
                     configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                     assert: Assert::SuccessSuperuserCheck(false),
                 },
                 TestCase::Http {
-                    user: frontegg_user,
+                    user_to_auth_as: frontegg_user,
+                    user_reported_by_system: frontegg_user,
                     scheme: Scheme::HTTPS,
                     headers: &frontegg_header_basic,
                     configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -1652,14 +1738,16 @@ fn test_auth_admin() {
             &server,
             &[
                 TestCase::Pgwire {
-                    user: admin_frontegg_user,
+                    user_to_auth_as: admin_frontegg_user,
+                    user_reported_by_system: admin_frontegg_user,
                     password: Some(admin_frontegg_password),
                     ssl_mode: SslMode::Require,
                     configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                     assert: Assert::SuccessSuperuserCheck(true),
                 },
                 TestCase::Http {
-                    user: admin_frontegg_user,
+                    user_to_auth_as: admin_frontegg_user,
+                    user_reported_by_system: admin_frontegg_user,
                     scheme: Scheme::HTTPS,
                     headers: &admin_frontegg_header_basic,
                     configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -12,6 +12,7 @@ base64 = "0.13.1"
 derivative = "2.2.0"
 jsonwebtoken = "8.2.0"
 mz-ore = { path = "../ore", features = ["network"] }
+mz-sql = { path = "../sql" }
 reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.37"

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -78,7 +78,9 @@ mod auth;
 mod client;
 mod error;
 
-pub use auth::{Authentication, AuthenticationConfig, Claims, REFRESH_SUFFIX};
+pub use auth::{
+    Authentication, AuthenticationConfig, Claims, ValidatedApiTokenResponse, REFRESH_SUFFIX,
+};
 pub use client::tokens::{ApiTokenArgs, ApiTokenResponse, RefreshToken};
 pub use client::Client;
 pub use error::Error;

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -160,16 +160,7 @@ where
         }
     }
 
-    // Construct session.
-    let mut session = adapter_client.new_session(
-        conn.conn_id().clone(),
-        User {
-            name: user.clone(),
-            external_metadata: None,
-        },
-    );
-
-    let is_expired = if let Some(frontegg) = frontegg {
+    let (mut session, is_expired) = if let Some(frontegg) = frontegg {
         conn.send(BackendMessage::AuthenticationCleartextPassword)
             .await?;
         conn.flush().await?;
@@ -184,23 +175,41 @@ where
                     .await
             }
         };
-        let external_metadata_tx = session.retain_external_metadata_transmitter();
         match frontegg
             .exchange_password_for_token(&password)
             .await
-            .and_then(|token| {
-                frontegg.continuously_validate_access_token(token, user.clone(), move |claims| {
-                    // Ignore error if client has hung up.
-                    let _ = external_metadata_tx.send(ExternalUserMetadata::from(&claims));
-                })
+            .and_then(|response| {
+                let response = frontegg.validate_api_token_response(response, Some(&user))?;
+
+                // Create a session based on the validated claims.
+                //
+                // In particular, it's important that the username come from the
+                // claims, as Frontegg may return an email address with
+                // different casing than the user supplied via the pgwire
+                // username field. We want to use the Frontegg casing as
+                // canonical.
+                let mut session = adapter_client.new_session(
+                    conn.conn_id().clone(),
+                    User {
+                        name: response.claims.email.clone(),
+                        external_metadata: Some(ExternalUserMetadata::from(&response.claims)),
+                    },
+                );
+
+                // Arrange to continuously refresh and revalidate the access
+                // token, updating the session as necessary.
+                let external_metadata_tx = session.retain_external_metadata_transmitter();
+                let is_expired =
+                    frontegg.continuously_revalidate_api_token_response(response, move |claims| {
+                        // Ignore error if client has hung up.
+                        let _ = external_metadata_tx.send(ExternalUserMetadata::from(claims));
+                    });
+
+                Ok((session, is_expired))
             }) {
-            Ok(is_expired) => {
-                // Make sure to apply the initial claims.
-                session.apply_external_metadata_updates();
-                is_expired.left_future()
-            }
+            Ok((session, is_expired)) => (session, is_expired.left_future()),
             Err(e) => {
-                warn!("PGwire connection failed authentication: {}", e);
+                warn!("pgwire connection failed authentication: {}", e);
                 return conn
                     .send(ErrorResponse::fatal(
                         SqlState::INVALID_PASSWORD,
@@ -210,8 +219,16 @@ where
             }
         }
     } else {
+        let session = adapter_client.new_session(
+            conn.conn_id().clone(),
+            User {
+                name: user.clone(),
+                external_metadata: None,
+            },
+        );
         // No frontegg check, so is_expired never resolves.
-        pending().right_future()
+        let is_expired = pending().right_future();
+        (session, is_expired)
     };
 
     for (name, value) in params {

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -319,7 +319,6 @@ where
 fn convert_claims_to_external_metadata(claims: Claims, admin_role: &str) -> ExternalUserMetadata {
     ExternalUserMetadata {
         user_id: claims.best_user_id(),
-        group_id: claims.tenant_id,
         admin: claims.admin(admin_role),
     }
 }

--- a/src/sql/src/session/user.rs
+++ b/src/sql/src/session/user.rs
@@ -48,8 +48,6 @@ pub struct User {
 pub struct ExternalUserMetadata {
     /// The ID of the user in the external system.
     pub user_id: Uuid,
-    /// The ID of the user's active group in the external system.
-    pub group_id: Uuid,
     /// Indicates if the user is an admin in the external system.
     pub admin: bool,
 }


### PR DESCRIPTION
Frontegg performs case-insensitive comparisons on emails. This commit teaches Materialize to do the same.

At least one user has been tripped up by the old behavior of case-sensitive comparisons; specifically, they were invited to their Materialize Cloud account with an email spelled

    First.Last@corp.com

but were attempting to log in as first.last@corp.com. This worked to log into the web UI, but not via pgwire.

The actual behavior change is in frontegg-auth and is quite straightforward, but the diff has a lot of noise because:

  1. The auth tests required adaptation to distinguish between the user supplied to the pgwire/HTTP protocol (possibly wrongly cased) and the user reported by `SELECT current_user` (always canonically cased).

  2. The pgwire package was creating sessions using the username supplied to the protocol (possibly wrongly cased), rather than the user returned by Frontegg (always canonically cased).

User names inside of Materialize remain case sensitive. Users can type

    CREATE ROLE "first.last@corp.com";
    CREATE ROLE "First.Last@corp.com";

in order to create two distinct roles; however they will only be able to log into whichever role has the casing that Frontegg has deemed canonical for that email (i.e., whatever casing was used whenever the user was invited to the tenant).

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.
  * https://materializeinc.slack.com/archives/C02940WNMRQ/p1681223674727189
  * https://materializeinc.slack.com/archives/C04SN4BEQ0N/p1681223548546919

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Logging in to a Materialize region now performs a case insensitive comparison on the email address, rather than a case sensitive comparison, to match the behavior of the web UI.
