### PR TITLE
storage: in NULL-key error message, give hint for resolving it

### DIFF
--- a/src/storage-client/src/types/errors.rs
+++ b/src/storage-client/src/types/errors.rs
@@ -235,6 +235,11 @@ impl Display for UpsertNullKeyError {
             write!(f, " in partition {}", partition_id)?;
         }
 
+        write!(
+            f,
+            "; to retract this error, produce a record upstream with a NULL key and NULL value",
+        )?;
+
         Ok(())
     }
 }

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -260,6 +260,9 @@ mammal1:
 ! select * from nullkey
 contains: record with NULL key in UPSERT source
 
+! select * from nullkey
+contains: to retract this error, produce a record upstream with a NULL key and NULL value
+
 # Ingest a null value for our null key, to retract it.
 $ kafka-ingest format=bytes topic=nullkey key-format=bytes key-terminator=:
 :


### PR DESCRIPTION
### Motivation

At least one user was confused about what to do.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
