### PR TITLE
testdrive: Fortify testdrive-fortify-divergent-dataflow-cancellation.td

### DIFF
--- a/test/testdrive/divergent-dataflow-cancellation.td
+++ b/test/testdrive/divergent-dataflow-cancellation.td
@@ -25,6 +25,9 @@
       flip(x int) AS (VALUES(1) EXCEPT ALL SELECT * FROM flip)
   SELECT * FROM flip
 
+# In case the environment has other replicas
+> SET cluster_replica = r1
+
 # Ensure the dataflow was successfully installed.
 > SELECT count(*)
   FROM mz_internal.mz_dataflows


### PR DESCRIPTION
The test was failing when run with --replicas 4, so use an explicit SET cluster_replica directive before any introspection queries.

### Motivation

  * This PR fixes a previously unreported bug.

Nightly CI with --replicas 4 was failing.