### PR TITLE
`NormalizeLets` -- inlining at inner nesting levels

### DIFF
--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -63,6 +63,83 @@ Explained Query:
 
 EOF
 
+## Test inlining at an inner nesting level. (#18889)
+## `bar` is used only in `baz`, so it should be inlined. The inner WMR should have only one cte.
+query T multiline
+EXPLAIN WITH MUTUALLY RECURSIVE
+    foo (a int8) AS (
+        WITH MUTUALLY RECURSIVE
+            bar (b int8) AS (
+                SELECT * FROM (SELECT * FROM foo UNION ALL SELECT * FROM baz)
+            ),
+            baz (b int8) AS (
+                SELECT b + 3 FROM bar WHERE b > -5
+            )
+        SELECT * FROM (SELECT * FROM foo EXCEPT ALL SELECT * FROM baz)
+    )
+SELECT * FROM foo;
+----
+Explained Query:
+  Return
+    Get l1
+  With Mutually Recursive
+    cte l1 =
+      Return
+        Threshold
+          Union
+            Get l1
+            Negate
+              Get l0
+      With Mutually Recursive
+        cte l0 =
+          Project (#1)
+            Map ((#0 + 3))
+              Union
+                Filter (#0 > -5)
+                  Get l1
+                Filter (#0 > -5)
+                  Get l0
+
+EOF
+
+statement ok
+CREATE TABLE t1(f0 int);
+
+## Test inlining a cte from a `Let` into a `LetRec`.
+query T multiline
+EXPLAIN WITH(raw)
+WITH
+  cte0 AS (
+    SELECT * from t1 where f0 < 27
+  )
+SELECT * FROM
+(
+  WITH MUTUALLY RECURSIVE
+    cnt (i int) AS (
+      (SELECT f0 AS i FROM cte0)
+      UNION
+      SELECT i+1 FROM cnt)
+  SELECT * FROM cnt
+);
+----
+Explained Query:
+  Return
+    Get l0
+  With Mutually Recursive
+    cte l0 =
+      Distinct group_by=[#0]
+        Union
+          Filter (#0 < 27)
+            Get materialize.public.t1
+          Project (#1)
+            Map ((#0 + 1))
+              Get l0
+
+Source materialize.public.t1
+  filter=((#0 < 27))
+
+EOF
+
 ## Test consolidation of not-really nested recursive query.
 query T multiline
 EXPLAIN WITH MUTUALLY RECURSIVE
@@ -112,5 +189,77 @@ Explained Query:
     cte l0 =
       Distinct group_by=[#0]
         Get l0
+
+EOF
+
+statement ok
+CREATE TABLE edges (src int, dst int);
+
+## Complex inlining and other things
+query T multiline
+EXPLAIN WITH MUTUALLY RECURSIVE
+    label (node int, comp int) AS (
+        SELECT dst, MIN(comp)
+        FROM (
+            SELECT dst, dst AS comp FROM edges
+            UNION ALL
+            SELECT edges.dst, label.comp
+            FROM edges, label
+            WHERE edges.src = label.node
+        )
+        GROUP BY dst
+    )
+SELECT round, COUNT(*) FROM (
+    WITH MUTUALLY RECURSIVE
+        relabel (node int, comp int, round int) AS (
+            SELECT DISTINCT ON(node) node, comp, round
+            FROM (
+                SELECT node, comp, 0 as round FROM label
+                UNION ALL
+                SELECT edges.dst, relabel.comp, relabel.round + 1
+                FROM edges, relabel
+                WHERE edges.src = relabel.node
+            )
+            ORDER BY node, comp
+        )
+    SELECT round FROM relabel
+)
+GROUP BY round;
+----
+Explained Query:
+  Return
+    Return
+      Reduce group_by=[#0] aggregates=[count(*)]
+        Project (#2)
+          Get l1
+    With Mutually Recursive
+      cte l1 =
+        TopK group_by=[#0] order_by=[#1 asc nulls_last] limit=1 monotonic=false
+          Union
+            Map (0)
+              Get l0
+            Project (#1, #3, #5)
+              Map ((#4 + 1))
+                Join on=(#0 = #2) type=differential
+                  ArrangeBy keys=[[#0]]
+                    Filter (#0) IS NOT NULL
+                      Get materialize.public.edges
+                  ArrangeBy keys=[[#0]]
+                    Filter (#0) IS NOT NULL
+                      Get l1
+  With Mutually Recursive
+    cte l0 =
+      Reduce group_by=[#0] aggregates=[min(#1)]
+        Union
+          Project (#1, #1)
+            Get materialize.public.edges
+          Project (#1, #3)
+            Join on=(#0 = #2) type=differential
+              ArrangeBy keys=[[#0]]
+                Filter (#0) IS NOT NULL
+                  Get materialize.public.edges
+              ArrangeBy keys=[[#0]]
+                Filter (#0) IS NOT NULL
+                  Get l0
 
 EOF


### PR DESCRIPTION


### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/18889

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
