### PR TITLE
persist: fix test flake in test_truncate_string_proptest

### DIFF
--- a/src/persist-types/proptest-regressions/stats.txt
+++ b/src/persist-types/proptest-regressions/stats.txt
@@ -1,0 +1,16 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc dbeaf5be7c581d2a5eb4959b72b1ffc1b9a980160516e2f9a5753dbac0385ec7 # shrinks to x = "߿®"

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -927,7 +927,10 @@ mod tests {
                 assert!(lower.len() <= max_len);
                 assert!(lower.as_str() <= x);
                 if let Some(upper) = upper {
-                    assert!(upper.len() <= max_len);
+                    // As explained in a comment in the impl, we don't quite
+                    // treat the max_len as a hard bound here. Give it a little
+                    // wiggle room.
+                    assert!(upper.len() <= max_len + char::MAX.len_utf8());
                     assert!(upper.as_str() >= x);
                 }
             }


### PR DESCRIPTION
The impl doesn't treat max_len as a completely hard bound in a certain edge case. The randomized test was finding this case (yay) and flaking CI (boo). Fix the issue by making the randomized test slightly more lenient.

Closes #18901

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
