### PR TITLE
coverage: Enable unit tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -21,3 +21,14 @@ slow-timeout = { period = "120s", terminate-after = 2 }
 junit = { path = "junit_cargo-test.xml" }
 fail-fast = false
 failure-output = "immediate-final"
+
+[profile.coverage]
+slow-timeout = { period = "480s", terminate-after = 2 }
+junit = { path = "junit_cargo-test.xml" }
+fail-fast = false
+failure-output = "immediate-final"
+
+[[profile.coverage.overrides]]
+filter = "package(mz-environmentd)"
+threads-required = 8
+slow-timeout = { period = "800s", terminate-after = 2 }

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -159,6 +159,7 @@ RUN mkdir rust \
     && cargo install --root /usr/local --version "=0.12.2" --locked cargo-deny \
     && cargo install --root /usr/local --version ="0.9.18" --locked cargo-hakari \
     && cargo install --root /usr/local --version "=0.9.44" --locked cargo-nextest \
+    && cargo install --root /usr/local --version "=0.5.18" --locked cargo-llvm-cov \
     && `: Until https://github.com/est31/cargo-udeps/pull/147 is released in cargo-udeps` \
     && cargo install --root /usr/local --git https://github.com/est31/cargo-udeps --rev=b84d478ef3efd7264dba8c15c31a50c6399dc5bb --locked cargo-udeps --features=vendored-openssl \
     && cargo install --root /usr/local --version "=0.2.15" --no-default-features --features=s3,openssl/vendored sccache \

--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -7,9 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import multiprocessing
 import os
 
-from materialize import spawn
+from materialize import ROOT, spawn, ui
 from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import (
     Cockroach,
@@ -47,25 +48,76 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         f"postgres://postgres:postgres@localhost:{c.default_port('postgres')}"
     )
     cockroach_url = f"postgres://root@localhost:{c.default_port('cockroach')}"
-    spawn.runv(
-        [
+
+    env = dict(
+        os.environ,
+        ZOOKEEPER_ADDR=f"localhost:{c.default_port('zookeeper')}",
+        KAFKA_ADDRS="localhost:30123",
+        SCHEMA_REGISTRY_URL=f"http://localhost:{c.default_port('schema-registry')}",
+        POSTGRES_URL=postgres_url,
+        COCKROACH_URL=cockroach_url,
+        MZ_SOFT_ASSERTIONS="1",
+        MZ_PERSIST_EXTERNAL_STORAGE_TEST_S3_BUCKET="mtlz-test-persist-1d-lifecycle-delete",
+        MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL=cockroach_url,
+    )
+
+    coverage = ui.env_is_truthy("CI_COVERAGE_ENABLED")
+
+    if coverage:
+        # TODO(def-): For coverage inside of clusterd called from unit tests need
+        # to set LLVM_PROFILE_FILE in test code invoking clusterd and later
+        # aggregate the data.
+        (ROOT / "coverage").mkdir(exist_ok=True)
+        env["CARGO_LLVM_COV_SETUP"] = "no"
+        # There is no pure build command in cargo-llvm-cov, so run with
+        # --version as a workaround.
+        spawn.runv(
+            [
+                "cargo",
+                "llvm-cov",
+                "run",
+                "--bin",
+                "clusterd",
+                "--no-report",
+                "--",
+                "--version",
+            ],
+            env=env,
+        )
+
+        cmd = [
             "cargo",
-            "build",
-            "--bin",
-            "clusterd",
+            "llvm-cov",
+            "nextest",
+            "--no-clean",
+            "--workspace",
+            "--lcov",
+            "--output-path",
+            "coverage/cargotest.lcov",
+            # This can cause intermittent coverage problems, but
+            # single-threaded is too slow:
+            # https://github.com/rust-lang/rust/issues/91092
+            f"--test-threads={multiprocessing.cpu_count()}",
+            "--profile=coverage",
+            "--no-fail-fast",
         ]
-    )
-    spawn.runv(
-        ["cargo", "nextest", "run", "--profile=ci", *args.args],
-        env=dict(
-            os.environ,
-            ZOOKEEPER_ADDR=f"localhost:{c.default_port('zookeeper')}",
-            KAFKA_ADDRS="localhost:30123",
-            SCHEMA_REGISTRY_URL=f"http://localhost:{c.default_port('schema-registry')}",
-            POSTGRES_URL=postgres_url,
-            COCKROACH_URL=cockroach_url,
-            MZ_SOFT_ASSERTIONS="1",
-            MZ_PERSIST_EXTERNAL_STORAGE_TEST_S3_BUCKET="mtlz-test-persist-1d-lifecycle-delete",
-            MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL=cockroach_url,
-        ),
-    )
+        try:
+            spawn.runv(cmd + args.args, env=env)
+        finally:
+            spawn.runv(["xz", "-0", "coverage/cargotest.lcov"])
+            spawn.runv(
+                ["buildkite-agent", "artifact", "upload", "coverage/cargotest.lcov.xz"]
+            )
+    else:
+        spawn.runv(
+            [
+                "cargo",
+                "build",
+                "--bin",
+                "clusterd",
+            ],
+            env=env,
+        )
+
+        cmd = ["cargo", "nextest", "run", "--profile=ci"]
+        spawn.runv(cmd + args.args, env=env)

--- a/ci/test/coverage_report.sh
+++ b/ci/test/coverage_report.sh
@@ -19,13 +19,17 @@ buildkite-agent artifact download 'coverage/*.xz' coverage/
 find coverage -name '*.xz' -exec xz -d {} \;
 
 ci_uncollapsed_heading "Uncovered Lines in Pull Request"
-find coverage -name '*.lcov' -exec bin/ci-coverage-pr-report {} +
+find coverage -name '*.lcov' -not -name 'cargotest.lcov' -exec bin/ci-coverage-pr-report --unittests=coverage/cargotest.lcov {} +
 buildkite-agent artifact upload junit_coverage*.xml
 
 ci_unimportant_heading "Create coverage report"
-REPORT=coverage_"$BUILDKITE_BUILD_ID"
-# This can probably be removed if I can figure out the tag issue:
+REPORT=coverage_without_unittests_"$BUILDKITE_BUILD_ID"
+REPORT_UNITTESTS=coverage_with_unittests_"$BUILDKITE_BUILD_ID"
+head -n1 coverage/cargotest.lcov # TODO(def-) Check if this matches the expected path
 find coverage -name '*.lcov' -exec sed -i "s#SF:/var/lib/buildkite-agent/builds/buildkite-.*/materialize/coverage/#SF:#" {} +
-find coverage -name '*.lcov' -exec genhtml -o "$REPORT" {} +
+find coverage -name '*.lcov' -not -name 'cargotest.lcov' -exec genhtml -o "$REPORT" {} +
+find coverage -name '*.lcov' -exec genhtml -o "$REPORT_UNITTESTS" {} +
 tar cfJ "$REPORT".tar.xz "$REPORT"
+tar cfJ "$REPORT_UNITTESTS".tar.xz "$REPORT_UNITTESTS"
 buildkite-agent artifact upload "$REPORT".tar.xz
+buildkite-agent artifact upload "$REPORT_UNITTESTS".tar.xz

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -150,7 +150,6 @@ steps:
           composition: cargo-test
     agents:
       queue: builder-linux-x86_64
-    coverage: skip
 
   - id: miri-test
     label: Miri test

--- a/doc/developer/code-coverage.md
+++ b/doc/developer/code-coverage.md
@@ -18,6 +18,8 @@ After some time your [Coverage run](https://buildkite.com/materialize/coverage/b
 
 We can see that some of the newly added code is not covered. This is the point where we should think about if we can write an explicit test case that tests this code adequately.
 
+Code that is only covered by unit tests, but not by any end-to-end test, is highlighted with a `.` instead of `!`.
+
 Additionally you can also download the full coverage report in HTML format from the artifacts of the "Analyze code coverage for PR" step. This should only be necessary if you are interested in seeing coverage of the entire product:
 
 ![Artifacts](assets/coverage-artifacts.png)
@@ -26,11 +28,9 @@ Additionally you can also download the full coverage report in HTML format from 
 
 The [Coverage](https://buildkite.com/materialize/coverage/builds) Buildkite pipeline runs a subset of tests from the [Tests](https://buildkite.com/materialize/tests) pipeline, which is already automatically run against each pull request. The excluded tests are marked with a `coverage: skip` in the [`pipeline.template.yml`](https://github.com/MaterializeInc/materialize/blob/main/ci/test/pipeline.template.yml):
 
-- Cargo test: Code should be tested in a real environment using SQL/Kafka/etc., unit test can give an incomplete picture of reliability
-- Miri test: Subset of cargo test
+- Miri test: Subset of cargo test, no additional use
 - Maelstrom coverage of persist: Randomized testing probably shouldn't count for coverage, not stable
 - Feature benchmark (Kafka only): Benchmarks shouldn't count for coverage
-- Cloudtest (WIP)
 
 https://github.com/MaterializeInc/materialize/blob/8147c0b1a6a4b6d0c318f947a23ca4c57ad47142/ci/test/pipeline.template.yml#L155-L162
 

--- a/misc/python/materialize/checks/large_tables.py
+++ b/misc/python/materialize/checks/large_tables.py
@@ -70,6 +70,7 @@ class ManyRows(Check):
                 > INSERT INTO many_rows SELECT 'b' || generate_series FROM generate_series(1, 1000000);
                 """,
                 """
+                > SET statement_timeout = '120s';
                 > INSERT INTO many_rows SELECT * FROM many_rows;
                 """,
             ]

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -67,7 +67,7 @@ class ErrorLog:
         self.line_nr = line_nr
 
 
-def main(argv: List[str]) -> int:
+def main() -> int:
     parser = argparse.ArgumentParser(
         prog="ci-logged-errors-detect",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -218,4 +218,4 @@ def get_known_issues_from_github() -> list[KnownIssue]:
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main())

--- a/src/ccsr/tests/client.rs
+++ b/src/ccsr/tests/client.rs
@@ -92,6 +92,7 @@ pub static SCHEMA_REGISTRY_URL: Lazy<reqwest::Url> =
     });
 
 #[tokio::test]
+#[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/materialize/issues/18900
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_method` on OS `linux`
 async fn test_client() -> Result<(), anyhow::Error> {
     let client = mz_ccsr::ClientConfig::new(SCHEMA_REGISTRY_URL.clone()).build()?;

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -761,7 +761,7 @@ fn wait_for_refresh(frontegg_server: &MzCloudServer, expires_in_secs: u64) {
     let expected = *frontegg_server.refreshes.lock().unwrap() + 1;
     Retry::default()
         .factor(1.0)
-        .max_duration(Duration::from_secs(expires_in_secs + 10))
+        .max_duration(Duration::from_secs(expires_in_secs + 20))
         .retry(|_| {
             let refreshes = *frontegg_server.refreshes.lock().unwrap();
             if refreshes >= expected {
@@ -799,8 +799,8 @@ fn test_auth_expiry() {
     let encoding_key =
         EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
 
-    const EXPIRES_IN_SECS: u64 = 20;
-    const REFRESH_BEFORE_SECS: u64 = 10;
+    const EXPIRES_IN_SECS: u64 = 40;
+    const REFRESH_BEFORE_SECS: u64 = 20;
     let (_role_tx, role_rx) = tokio::sync::mpsc::unbounded_channel();
     let frontegg_server = start_mzcloud(
         encoding_key,
@@ -1577,8 +1577,8 @@ fn test_auth_admin() {
         EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
     let now = SYSTEM_TIME.clone();
 
-    const EXPIRES_IN_SECS: u64 = 20;
-    const REFRESH_BEFORE_SECS: u64 = 10;
+    const EXPIRES_IN_SECS: u64 = 40;
+    const REFRESH_BEFORE_SECS: u64 = 20;
     let (role_tx, role_rx) = tokio::sync::mpsc::unbounded_channel();
     let frontegg_server = start_mzcloud(
         encoding_key,

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -566,7 +566,7 @@ fn pg_test_inner(dir: PathBuf) {
             _ => panic!("only tcp connections supported"),
         };
         let user = config.get_user().unwrap();
-        let timeout = Duration::from_secs(60);
+        let timeout = Duration::from_secs(120);
 
         mz_pgtest::run_test(tf, addr, user.to_string(), timeout);
     });

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -610,6 +610,7 @@ fn test_storage_usage_updates_between_restarts() {
 }
 
 #[test]
+#[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/materialize/issues/18896
 fn test_storage_usage_doesnt_update_between_restarts() {
     let data_dir = tempfile::tempdir().unwrap();
     let storage_usage_collection_interval = Duration::from_secs(10);

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1297,6 +1297,7 @@ fn test_explain_timestamp_json() {
 // Feel free to modify this test if that product requirement changes,
 // but please at least keep _something_ that tests that custom compaction windows are working.
 #[test]
+#[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/materialize/issues/18934
 fn test_utilization_hold() {
     const THIRTY_DAYS_MS: u64 = 30 * 24 * 60 * 60 * 1000;
     // `mz_introspection` tests indexes, `default` tests tables.
@@ -1678,7 +1679,7 @@ fn test_timeline_read_holds() {
 
     // Make sure that the table and view are joinable immediately at some timestamp.
     let mut mz_join_client = server.connect(postgres::NoTls).unwrap();
-    let _ = mz_ore::test::timeout(Duration::from_millis(1_000), move || {
+    let _ = mz_ore::test::timeout(Duration::from_millis(2_000), move || {
         Ok(mz_join_client
             .query_one(&format!("SELECT COUNT(t.a) FROM t, {view_name};"), &[])
             .unwrap()
@@ -2139,6 +2140,7 @@ fn test_idle_in_transaction_session_timeout() {
 }
 
 #[test]
+#[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/materialize/issues/18897
 fn test_coord_startup_blocking() {
     let initial_time = 0;
     let now = Arc::new(Mutex::new(initial_time));

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -917,6 +917,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/materialize/issues/18901
     #[cfg_attr(miri, ignore)] // too slow
     fn test_truncate_string_proptest() {
         fn testcase(x: &str) {

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -925,6 +925,7 @@ mod tests {
     use super::*;
 
     #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/materialize/issues/18898
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`
     async fn s3_blob() -> Result<(), ExternalError> {
         mz_ore::test::init_logging();


### PR DESCRIPTION
Display them separately with a "." instead of "!" marker.

Also provide a separate coverage report which includes unit tests.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
