### PR TITLE
test: Deflake storage usage collection test

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -94,6 +94,7 @@ use tungstenite::error::ProtocolError;
 use tungstenite::{Error, Message};
 
 use mz_environmentd::WebSocketResponse;
+use mz_ore::cast::CastLossy;
 use mz_ore::now::NowFn;
 use mz_ore::retry::Retry;
 use mz_pgrepr::UInt8;
@@ -617,38 +618,52 @@ fn test_storage_usage_doesnt_update_between_restarts() {
         .data_directory(data_dir.path());
 
     // Wait for initial storage usage collection.
-    let initial_timestamp: f64 = {
+    let initial_timestamp = {
         let server = util::start_server(config.clone()).unwrap();
         let mut client = server.connect(postgres::NoTls).unwrap();
         // Retry because it may take some time for the initial snapshot to be taken.
         Retry::default().max_duration(Duration::from_secs(60)).retry(|_| {
-            client
+                client
                     .query_one(
-                        "SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_catalog.mz_storage_usage;",
+                        "SELECT DISTINCT(EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8) FROM mz_catalog.mz_storage_usage;",
                         &[],
                     )
                     .map_err(|e| e.to_string()).unwrap()
                     .try_get::<_, f64>(0)
                     .map_err(|e| e.to_string())
-        }).unwrap()
+            }).unwrap()
     };
 
     // Another storage usage collection should not be scheduled immediately.
     {
         // Give plenty of time so we don't accidentally do another collection if this test is slow.
-        let storage_usage_collection_interval = Duration::from_secs(60 * 10);
-        let config =
-            config.with_storage_usage_collection_interval(storage_usage_collection_interval);
+        let config = config.with_storage_usage_collection_interval(Duration::from_secs(60 * 1000));
         let server = util::start_server(config).unwrap();
         let mut client = server.connect(postgres::NoTls).unwrap();
 
-        let updated_timestamp = client
-            .query_one(
-                "SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_catalog.mz_storage_usage;",
+        let collection_timestamps = client
+            .query(
+                "SELECT DISTINCT(EXTRACT(EPOCH FROM collection_timestamp)::float8) as epoch FROM mz_catalog.mz_storage_usage ORDER BY epoch DESC LIMIT 2;",
                 &[],
-            ).unwrap().get::<_, f64>(0);
+            ).unwrap();
+        match collection_timestamps.len() {
+            0 => panic!("storage usage disappeared"),
+            1 => assert_eq!(initial_timestamp, collection_timestamps[0].get::<_, f64>(0)),
+            // It's possible that after collecting the first usage timestamp but before shutting the
+            // server down, we collect another usage timestamp.
+            2 => {
+                let most_recent_timestamp = collection_timestamps[0].get::<_, f64>(0);
+                let second_most_recent_timestamp = collection_timestamps[1].get::<_, f64>(0);
 
-        assert_eq!(initial_timestamp, updated_timestamp);
+                let actual_collection_interval =
+                    most_recent_timestamp - second_most_recent_timestamp;
+                let expected_collection_interval: f64 =
+                    f64::cast_lossy(storage_usage_collection_interval.as_secs());
+
+                assert!(actual_collection_interval >= expected_collection_interval);
+            }
+            _ => unreachable!("query is limited to 2"),
+        }
     }
 }
 

--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -231,6 +231,13 @@ impl CastLossy<usize> for f64 {
     }
 }
 
+impl CastLossy<u64> for f64 {
+    #[allow(clippy::as_conversions)]
+    fn cast_lossy(from: u64) -> Self {
+        from as f64
+    }
+}
+
 #[test]
 fn test_try_cast_from() {
     let f64_i64_cases = vec![


### PR DESCRIPTION
This commit updates the
test_storage_usage_doesnt_update_between_restarts test so that it doesn't rely on the test timing and is deterministic. This should help deflake the test under slow executions.

Fixes #18896


### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
