### PR TITLE
adapter: Update ObjectId to handle temp schemas

### DIFF
--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -17,7 +17,7 @@ use mz_ore::str::StrExt;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::role_id::RoleId;
 use mz_sql::catalog::SessionCatalog;
-use mz_sql::names::{ObjectId, SchemaSpecifier};
+use mz_sql::names::ObjectId;
 use mz_sql::plan::{AlterOwnerPlan, CreateMaterializedViewPlan, CreateViewPlan, Plan};
 use mz_sql::session::vars::SystemVars;
 use mz_sql_parser::ast::{ObjectType, QualifiedReplica};
@@ -401,9 +401,8 @@ fn ownership_err(
                     ObjectType::Database,
                     catalog.get_database(&id).name().to_string(),
                 ),
-                ObjectId::Schema((database_spec, schema_id)) => {
-                    let schema =
-                        catalog.get_schema(&database_spec, &SchemaSpecifier::Id(schema_id));
+                ObjectId::Schema((database_spec, schema_spec)) => {
+                    let schema = catalog.get_schema(&database_spec, &schema_spec);
                     let name = catalog.resolve_full_schema_name(schema.name());
                     (ObjectType::Schema, name.to_string())
                 }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -300,6 +300,13 @@ pub enum SchemaSpecifier {
 
 impl SchemaSpecifier {
     const TEMPORARY_SCHEMA_ID: u64 = 0;
+
+    pub fn is_system(&self) -> bool {
+        match self {
+            SchemaSpecifier::Temporary => false,
+            SchemaSpecifier::Id(id) => id.is_system(),
+        }
+    }
 }
 
 impl fmt::Display for SchemaSpecifier {
@@ -432,16 +439,6 @@ pub enum ResolvedSchemaName {
 }
 
 impl ResolvedSchemaName {
-    /// Panics if this is `Self::Error`.
-    pub fn database_spec(&self) -> &ResolvedDatabaseSpecifier {
-        match self {
-            ResolvedSchemaName::Schema { database_spec, .. } => database_spec,
-            ResolvedSchemaName::Error => {
-                unreachable!("should have been handled by name resolution")
-            }
-        }
-    }
-
     /// Panics if this is `Self::Error`.
     pub fn schema_spec(&self) -> &SchemaSpecifier {
         match self {
@@ -782,7 +779,7 @@ pub enum ObjectId {
     Cluster(ClusterId),
     ClusterReplica((ClusterId, ReplicaId)),
     Database(DatabaseId),
-    Schema((ResolvedDatabaseSpecifier, SchemaId)),
+    Schema((ResolvedDatabaseSpecifier, SchemaSpecifier)),
     Role(RoleId),
     Item(GlobalId),
 }
@@ -806,7 +803,7 @@ impl ObjectId {
             _ => panic!("ObjectId::unwrap_database_id called on {self:?}"),
         }
     }
-    pub fn unwrap_schema_id(self) -> (ResolvedDatabaseSpecifier, SchemaId) {
+    pub fn unwrap_schema_id(self) -> (ResolvedDatabaseSpecifier, SchemaSpecifier) {
         match self {
             ObjectId::Schema(id) => id,
             _ => panic!("ObjectId::unwrap_schema_id called on {self:?}"),
@@ -836,10 +833,14 @@ impl TryFrom<ResolvedObjectName> for ObjectId {
                 Ok(ObjectId::ClusterReplica((name.cluster_id, name.replica_id)))
             }
             ResolvedObjectName::Database(name) => Ok(ObjectId::Database(*name.database_id())),
-            ResolvedObjectName::Schema(name) => Ok(ObjectId::Schema((
-                *name.database_spec(),
-                name.schema_spec().into(),
-            ))),
+            ResolvedObjectName::Schema(name) => match name {
+                ResolvedSchemaName::Schema {
+                    database_spec,
+                    schema_spec,
+                    ..
+                } => Ok(ObjectId::Schema((database_spec, schema_spec))),
+                ResolvedSchemaName::Error => Err(anyhow!("error in name resolution")),
+            },
             ResolvedObjectName::Role(name) => Ok(ObjectId::Role(name.id)),
             ResolvedObjectName::Item(name) => match name {
                 ResolvedItemName::Item { id, .. } => Ok(ObjectId::Item(id)),


### PR DESCRIPTION
This commit updates the ObjectId enum so that it can be used for temporary schemas.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
