### PR TITLE
Include in cluster in source creation error message

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -235,6 +235,11 @@ impl AdapterError {
                     ),
                 }
             )),
+            AdapterError::SourceOrSinkSizeRequired { .. } => Some(
+                "Either specify the cluster that will maintain this object via IN CLUSTER or \
+                specify size via SIZE option."
+                    .into(),
+            ),
             AdapterError::SafeModeViolation(_) => Some(
                 "The Materialize server you are connected to is running in \
                  safe mode, which limits the features that are available."
@@ -384,7 +389,7 @@ impl fmt::Display for AdapterError {
                 write!(f, "unknown source size {size}")
             }
             AdapterError::SourceOrSinkSizeRequired { .. } => {
-                write!(f, "size option is required")
+                write!(f, "must specify either cluster or size option")
             }
             AdapterError::InvalidTableMutationSelection => {
                 f.write_str("invalid selection: operation may only refer to user-defined tables")

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -193,7 +193,7 @@ fn test_source_sink_size_required() {
     let result = client.batch_execute("CREATE SOURCE lg FROM LOAD GENERATOR COUNTER");
     assert_eq!(
         result.unwrap_err().unwrap_db_error().message(),
-        "size option is required"
+        "must specify either cluster or size option"
     );
 
     // Sources work with an explicit size.
@@ -205,7 +205,7 @@ fn test_source_sink_size_required() {
     let result = client.batch_execute("ALTER SOURCE lg RESET (SIZE)");
     assert_eq!(
         result.unwrap_err().unwrap_db_error().message(),
-        "size option is required"
+        "must specify either cluster or size option"
     );
 
     client
@@ -219,7 +219,7 @@ fn test_source_sink_size_required() {
     let result = client.batch_execute("CREATE SINK snk FROM mz_sources INTO KAFKA CONNECTION conn (TOPIC 'foo') FORMAT JSON ENVELOPE DEBEZIUM");
     assert_eq!(
         result.unwrap_err().unwrap_db_error().message(),
-        "size option is required"
+        "must specify either cluster or size option"
     );
 
     // Sinks work with an explicit size.
@@ -229,7 +229,7 @@ fn test_source_sink_size_required() {
     let result = client.batch_execute("ALTER SINK snk RESET (SIZE)");
     assert_eq!(
         result.unwrap_err().unwrap_db_error().message(),
-        "size option is required"
+        "must specify either cluster or size option"
     );
 }
 


### PR DESCRIPTION
Also add hint that spells out both options.

Fixes #18565

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
