### PR TITLE
storage: bounded memory upsert snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chrono"
 version = "0.4.24"
-source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#5bc022ca811a81d0dd79e3254214ae05a74898b6"
+source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#84bbea51313b0c705fcf0ba82196234fe940050f"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -4851,6 +4851,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "bincode",
  "bytesize",
  "chrono",
  "clap",
@@ -4900,6 +4901,7 @@ dependencies = [
  "rdkafka",
  "regex",
  "rocksdb",
+ "seahash",
  "serde",
  "serde_json",
  "sha2",
@@ -6558,6 +6560,12 @@ name = "scratch"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96311ef4a16462c757bb6a39152c40f58f31cd2602a40fceb937e2bc34e6cbab"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.59"
 bytesize = "1.1.0"
+bincode = "1"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.20", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
@@ -56,6 +57,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = { version = "1.7.0" }
+seahash = "4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 sha2 = "0.10.6"


### PR DESCRIPTION
### Motivation

This makes recovering the upsert snapshot use memory proportional to the number of keys as opposed to the current method that uses memory proportional to the total number of updates.

We use a XOR trick in order to accumulate the snapshot without having to store the full unconsolidated history in memory. For all `(value, diff)` updates of a key we track:
- `diff_sum = SUM(diff)`
- `value_xor= XOR(bincode(value))`
- `checksum_sum = SUM(checksum(bincode(value)) * diff)`
- `len_sum = SUM(len(bincode(value)) * diff)`

#### Correctness

The method is correct because a well formed upsert snapshot will have for each key:
- Zero or one updates of the form `(cur_value, +1)`
- Zero or more pairs of updates of the form `(prev_value, +1)`, `(prev_value, -1)`

We are interested in extracting the `cur_value` of each key and discard all `prev_value`s that might be included in the stream. Since the history of `prev_value`s always comes in pairs, computing the XOR of those is always going to cancel their effects out. Also, since XOR is commutative this property is true independent of the order.

Therefore the accumulators will end up precisely in one of two states:
1. `diff == 0`, `checksum == 0`, `value == [0..]` => the key is not present
2. `diff == 1`, `checksum_sum == checksum(bincode(cur_value))` `value_xor == bincode(cur_value)` => the key is present

In the latter case we may end up with trailing zeros, but we are explicitly configure `bincode` to allow trailing bytes.

#### Robustness

In the absence of bugs, accumulating the diff and checksum is not required since we know that a well formed snapshot always satisfies `XOR(bincode(values)) == bincode(cur_value)`. However bugs may happen and so storing 16 more bytes per key to have a very high guarantee that we're not decoding garbage is more than worth it.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->



<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
