### PR TITLE
controller: serde ReplicaAllocation credits_per_hour via strings

### DIFF
--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -17,7 +17,6 @@ use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use differential_dataflow::lattice::Lattice;
 use futures::stream::{BoxStream, StreamExt, TryStreamExt};
-use mz_ore::halt;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -34,13 +33,14 @@ use mz_orchestrator::{
     CpuLimit, LabelSelectionLogic, LabelSelector, MemoryLimit, Service, ServiceConfig,
     ServiceEvent, ServicePort,
 };
+use mz_ore::halt;
 use mz_ore::task::{AbortOnDropHandle, JoinHandleExt};
+use mz_repr::adt::numeric::Numeric;
 use mz_repr::GlobalId;
 
 use crate::Controller;
 
 pub use mz_compute_client::controller::DEFAULT_COMPUTE_REPLICA_LOGGING_INTERVAL_MICROS as DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS;
-use mz_repr::adt::numeric::Numeric;
 
 /// Identifies a cluster.
 pub type ClusterId = ComputeInstanceId;
@@ -81,6 +81,7 @@ pub struct ReplicaAllocation {
     /// The number of worker threads in the replica.
     pub workers: usize,
     /// The number of credits per hour that the replica consumes.
+    #[serde(deserialize_with = "mz_repr::adt::numeric::str_serde::deserialize")]
     pub credits_per_hour: Numeric,
 }
 

--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -78,6 +78,24 @@ static U128_SPLITTER_AGG: Lazy<NumericAgg> = Lazy::new(|| {
     cx.parse("340282366920938463463374607431768211456").unwrap()
 });
 
+/// Module to simplify serde'ing a `Numeric` through its string representation.
+pub mod str_serde {
+    use std::str::FromStr;
+
+    use serde::Deserialize;
+
+    use super::Numeric;
+
+    /// Deserializing a [`Numeric`] value from its `String` representation.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Numeric, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let buf = String::deserialize(deserializer)?;
+        Numeric::from_str(&buf).map_err(serde::de::Error::custom)
+    }
+}
+
 /// The `max_scale` of a [`ScalarType::Numeric`].
 ///
 /// This newtype wrapper ensures that the scale is within the valid range.


### PR DESCRIPTION
### Motivation

This PR fixes a recognized bug. Fixes #18913

Note that I think we can perform a more substantive/long-term fix by changing how `Deserialize` works for `Numeric`, but no need to delay the release on that account. MaterializeInc/rust-dec#73

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
