### PR TITLE
stash: batch large updates

### DIFF
--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -92,7 +92,7 @@ mod postgres;
 mod transaction;
 
 pub use crate::postgres::{DebugStashFactory, Stash, StashFactory};
-pub use crate::transaction::Transaction;
+pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 
 pub type Diff = i64;
 pub type Timestamp = i64;

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -958,6 +958,9 @@ impl<T> TransactionError<T> {
             Some(&SqlState::UNDEFINED_TABLE)
                 | Some(&SqlState::WRONG_OBJECT_TYPE)
                 | Some(&SqlState::READ_ONLY_SQL_TRANSACTION)
+                // Cockroach reports errors from sql.conn.max_read_buffer_message_size as this (as
+                // well as others).
+                | Some(&SqlState::PROTOCOL_VIOLATION)
         ) {
             return false;
         }


### PR DESCRIPTION
Do some very rough size estimation and break up large INSERT statements at points well below cockroach's default message size.

Fixes #18869

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a