### PR TITLE
test: Ignore drain timeouts during a CRDB rolling restart test

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -518,6 +518,7 @@ class Composition:
         capture: bool = False,
         capture_stderr: bool = False,
         stdin: Optional[str] = None,
+        check: bool = True,
     ) -> subprocess.CompletedProcess:
         """Execute a one-off command in a service's running container
 
@@ -545,6 +546,7 @@ class Composition:
             capture=capture,
             capture_stderr=capture_stderr,
             stdin=stdin,
+            check=check,
         )
 
     def pull_if_variable(self, services: List[str]) -> None:

--- a/test/crdb-restarts/mzcompose.py
+++ b/test/crdb-restarts/mzcompose.py
@@ -97,12 +97,16 @@ DISRUPTIONS = [
         name="drain",
         disruption=lambda c, id: c.exec(
             # Execute the 'drain' command on a different node from the one that we are draining
+            #
+            # Draining may sometimes time out, but we continue with the restart in case this happens,
+            # as a real life CRDB upgrade procedure will most likely also ignore such a timeout.
             f"cockroach{(id % 2) + 1}",
             "cockroach",
             "node",
             "drain",
             str(id + 1),
             "--insecure",
+            check=False,
         ),
     ),
 ]


### PR DESCRIPTION
Sometimes crdb's drain command is unable to drain all the connections from a node. Ignore this when it happens and proceed with the rolling restart as it will be assumed that in practice, during a rolling upgrade in production, the same sequence of events will happen -- a drain timeout will be ignored and the upgrade will proceed.

### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI was failing because draining never completed.


### Tips for reviewer

I have asked both the storage and the crdb slack channels as to whether unable to successfully drain could be a bug in either product, but still the test should proceed in the face of such a situation, because a CRDB upgrade on the cloud is likely to also proceed if that same thing happens in production.