### PR TITLE
controller: test deserialization of ReplicaAllocation from json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3764,6 +3764,7 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
+ "serde_json",
  "timely",
  "tokio",
  "tokio-stream",

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -25,6 +25,7 @@ mz-storage-client = { path = "../storage-client" }
 once_cell = "1.16.0"
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.89"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.24.2"
 tokio-stream = "0.1.11"

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -85,6 +85,23 @@ pub struct ReplicaAllocation {
     pub credits_per_hour: Numeric,
 }
 
+#[test]
+#[cfg_attr(miri, ignore)]
+// We test this particularly because we deserialize values from strings.
+fn test_replica_allocation_deserialization() {
+    let data = r#"
+        {
+            "cpu_limit": 1.0,
+            "memory_limit": "10GiB",
+            "scale": 16,
+            "workers": 1,
+            "credits_per_hour": "16"
+        }"#;
+
+    let _: ReplicaAllocation = serde_json::from_str(data)
+        .expect("deserialization from JSON succeeds for ReplicaAllocation");
+}
+
 /// Configures the location of a cluster replica.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ReplicaLocation {


### PR DESCRIPTION
#18914 lacked a proper unit test, so adding it.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
