### PR TITLE
test: Fix upgrade role tests

### DIFF
--- a/test/upgrade/check-from-current_source-role.td
+++ b/test/upgrade/check-from-current_source-role.td
@@ -7,6 +7,25 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ skip-if
+SELECT mz_version_num() < 5200;
+
+> SELECT name FROM mz_roles;
+group
+joe
+mz_system
+mz_introspection
+materialize
+superuser_login
+"space role"
+
+$ postgres-execute connection=postgres://superuser_login:some_bogus_password@${testdrive.materialize-sql-addr}
+SELECT 1;
+
+> SELECT name FROM mz_roles WHERE name = 'joe' OR name = 'group';
+joe
+group
+
 > SELECT role.name AS role, member.name AS member, grantor.name AS grantor FROM mz_role_members membership LEFT JOIN mz_roles role ON membership.role_id = role.id LEFT JOIN mz_roles member ON membership.member = member.id LEFT JOIN mz_roles grantor ON membership.grantor = grantor.id;
 group  joe  mz_system
 

--- a/test/upgrade/check-from-v0.47.0-role.td
+++ b/test/upgrade/check-from-v0.47.0-role.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ skip-if
-SELECT mz_version_num() <= 5200;
+SELECT mz_version_num() >= 5200;
 
 > SELECT name FROM mz_roles;
 default_owner
@@ -26,9 +26,6 @@ SELECT 1;
 > SELECT name FROM mz_roles WHERE name = 'joe' OR name = 'group';
 joe
 group
-
-$ skip-if
-SELECT mz_version_num() >= 5200;
 
 > SELECT role.name AS role, member.name AS member, grantor.name AS grantor FROM mz_role_members membership LEFT JOIN mz_roles role ON membership.role_id = role.id LEFT JOIN mz_roles member ON membership.member = member.id LEFT JOIN mz_roles grantor ON membership.grantor = grantor.id;
 group  joe  mz_system


### PR DESCRIPTION
### Motivation
This PR fixes an upgrade test


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
