### PR TITLE
Rework `literal_lifting` so it is `recursion_safe`

### DIFF
--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -591,13 +591,14 @@ Explained Query:
       Get l0 // { arity: 2, types: "(integer, integer)" }
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[3, 5] // { arity: 2, types: "(integer, integer)" }
-        Union // { arity: 0, types: "()" }
-          Project () // { arity: 0, types: "()" }
-            Filter (#0 = 3) AND (#1 = 5) // { arity: 2, types: "(integer, integer)" }
-              Get materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
-          Project () // { arity: 0, types: "()" }
-            Get l0 // { arity: 2, types: "(integer?, integer?)" }
+      Map (3, 5) // { arity: 2, types: "(integer, integer)" }
+        Distinct // { arity: 0, types: "()" }
+          Union // { arity: 0, types: "()" }
+            Project () // { arity: 0, types: "()" }
+              Filter (#0 = 3) AND (#1 = 5) // { arity: 2, types: "(integer, integer)" }
+                Get materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
+            Project () // { arity: 0, types: "()" }
+              Get l0 // { arity: 2, types: "(integer?, integer?)" }
 
 Source materialize.public.t1
   filter=((#0 = 3) AND (#1 = 5))
@@ -649,8 +650,9 @@ SELECT f1, f2, f1 IS NOT NULL, f2 IS NULL FROM c0;
 ----
 Explained Query:
   Return // { arity: 4, types: "(integer?, integer?, boolean, boolean)" }
-    Map (true, (#1) IS NULL) // { arity: 4, types: "(integer?, integer?, boolean, boolean)" }
-      Get l0 // { arity: 2, types: "(integer?, integer?)" }
+    Project (#0, #1, #3, #2) // { arity: 4, types: "(integer?, integer?, boolean, boolean)" }
+      Map ((#1) IS NULL, true) // { arity: 4, types: "(integer?, integer?, boolean, boolean)" }
+        Get l0 // { arity: 2, types: "(integer?, integer?)" }
   With Mutually Recursive
     cte l0 =
       Distinct group_by=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
@@ -682,23 +684,26 @@ Explained Query:
     Get l1 // { arity: 3, types: "(integer, integer?, integer?)" }
   With Mutually Recursive
     cte l1 =
-      Distinct group_by=[2, #0, #1] // { arity: 3, types: "(integer, integer?, integer?)" }
-        Union // { arity: 2, types: "(integer?, integer?)" }
-          CrossJoin type=differential // { arity: 2, types: "(integer, integer?)" }
-            ArrangeBy keys=[[]] // { arity: 0, types: "()" }
-              Project () // { arity: 0, types: "()" }
-                Get l0 // { arity: 1, types: "(integer)" }
-            ArrangeBy keys=[[]] // { arity: 2, types: "(integer, integer?)" }
-              Get materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
-          Project (#1, #2) // { arity: 2, types: "(integer?, integer?)" }
-            Get l1 // { arity: 3, types: "(integer?, integer?, integer?)" }
+      Project (#2, #0, #1) // { arity: 3, types: "(integer, integer?, integer?)" }
+        Map (2) // { arity: 3, types: "(integer?, integer?, integer)" }
+          Distinct group_by=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
+            Union // { arity: 2, types: "(integer?, integer?)" }
+              CrossJoin type=differential // { arity: 2, types: "(integer, integer?)" }
+                ArrangeBy keys=[[]] // { arity: 0, types: "()" }
+                  Project () // { arity: 0, types: "()" }
+                    Get l0 // { arity: 1, types: "(integer)" }
+                ArrangeBy keys=[[]] // { arity: 2, types: "(integer, integer?)" }
+                  Get materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
+              Project (#1, #2) // { arity: 2, types: "(integer?, integer?)" }
+                Get l1 // { arity: 3, types: "(integer?, integer?, integer?)" }
     cte l0 =
-      Distinct group_by=[1] // { arity: 1, types: "(integer)" }
-        Union // { arity: 0, types: "()" }
-          Project () // { arity: 0, types: "()" }
-            Get l0 // { arity: 1, types: "(integer?)" }
-          Constant // { arity: 0, types: "()" }
-            - ()
+      Map (1) // { arity: 1, types: "(integer)" }
+        Distinct // { arity: 0, types: "()" }
+          Union // { arity: 0, types: "()" }
+            Project () // { arity: 0, types: "()" }
+              Get l0 // { arity: 1, types: "(integer?)" }
+            Constant // { arity: 0, types: "()" }
+              - ()
 
 EOF
 
@@ -728,22 +733,25 @@ Explained Query:
     Get l1 // { arity: 3, types: "(boolean, integer?, integer?)" }
   With Mutually Recursive
     cte l1 =
-      Distinct group_by=[false, #0, #1] // { arity: 3, types: "(boolean, integer?, integer?)" }
-        Union // { arity: 2, types: "(integer?, integer?)" }
-          CrossJoin type=differential // { arity: 2, types: "(integer, integer?)" }
-            ArrangeBy keys=[[]] // { arity: 0, types: "()" }
-              Project () // { arity: 0, types: "()" }
-                Get l0 // { arity: 1, types: "(integer)" }
-            ArrangeBy keys=[[]] // { arity: 2, types: "(integer, integer?)" }
-              Get materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
-          Project (#1, #2) // { arity: 2, types: "(integer?, integer?)" }
-            Get l1 // { arity: 3, types: "(boolean?, integer?, integer?)" }
+      Project (#2, #0, #1) // { arity: 3, types: "(boolean, integer?, integer?)" }
+        Map (false) // { arity: 3, types: "(integer?, integer?, boolean)" }
+          Distinct group_by=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
+            Union // { arity: 2, types: "(integer?, integer?)" }
+              CrossJoin type=differential // { arity: 2, types: "(integer, integer?)" }
+                ArrangeBy keys=[[]] // { arity: 0, types: "()" }
+                  Project () // { arity: 0, types: "()" }
+                    Get l0 // { arity: 1, types: "(integer)" }
+                ArrangeBy keys=[[]] // { arity: 2, types: "(integer, integer?)" }
+                  Get materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
+              Project (#1, #2) // { arity: 2, types: "(integer?, integer?)" }
+                Get l1 // { arity: 3, types: "(boolean?, integer?, integer?)" }
     cte l0 =
-      Distinct group_by=[1] // { arity: 1, types: "(integer)" }
-        Union // { arity: 0, types: "()" }
-          Project () // { arity: 0, types: "()" }
-            Get l0 // { arity: 1, types: "(integer?)" }
-          Constant // { arity: 0, types: "()" }
-            - ()
+      Map (1) // { arity: 1, types: "(integer)" }
+        Distinct // { arity: 0, types: "()" }
+          Union // { arity: 0, types: "()" }
+            Project () // { arity: 0, types: "()" }
+              Get l0 // { arity: 1, types: "(integer?)" }
+            Constant // { arity: 0, types: "()" }
+              - ()
 
 EOF

--- a/test/sqllogictest/transform/literal_lifting.slt
+++ b/test/sqllogictest/transform/literal_lifting.slt
@@ -1,0 +1,92 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test various cases of literal lifting
+#
+
+mode cockroach
+
+statement ok
+CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
+
+# WITH MUTUALLY RECURSIVE support
+# -------------------------------
+
+# Single non-recursive binding under `WITH MUTUALLY RECURSIVE`
+query T multiline
+EXPLAIN WITH(arity, join_impls)
+WITH MUTUALLY RECURSIVE
+  c0(x INT, y INT) AS (
+    SELECT * FROM c0
+    UNION
+    SELECT f1, 42 FROM t1
+    UNION
+    SELECT f2, 42 FROM t1
+  )
+SELECT * FROM c0
+----
+Explained Query:
+  Return // { arity: 2 }
+    Get l0 // { arity: 2 }
+  With Mutually Recursive
+    cte l0 =
+      Map (42) // { arity: 2 }
+        Distinct group_by=[#0] // { arity: 1 }
+          Union // { arity: 1 }
+            Distinct group_by=[#0] // { arity: 1 }
+              Union // { arity: 1 }
+                Project (#0) // { arity: 1 }
+                  Get l0 // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Get materialize.public.t1 // { arity: 2 }
+            Project (#1) // { arity: 1 }
+              Get materialize.public.t1 // { arity: 2 }
+
+EOF
+
+# Multiple bindings under `WITH MUTUALLY RECURSIVE`
+query T multiline
+EXPLAIN WITH(arity, join_impls)
+WITH MUTUALLY RECURSIVE
+  c0(x INT, y INT) AS (
+    SELECT f1, 42 FROM t1
+    UNION
+    SELECT f2, 42 FROM t1
+  ),
+  c1(x INT, y INT) AS (
+    SELECT * FROM c0
+    UNION
+    SELECT * FROM c1
+  )
+SELECT * FROM c0 UNION ALL SELECT * FROM c1
+----
+Explained Query:
+  Return // { arity: 2 }
+    Union // { arity: 2 }
+      Map (42) // { arity: 2 }
+        Get l0 // { arity: 1 }
+      Get l1 // { arity: 2 }
+  With Mutually Recursive
+    cte l1 =
+      Map (42) // { arity: 2 }
+        Distinct group_by=[#0] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l0 // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Get l1 // { arity: 2 }
+    cte l0 =
+      Distinct group_by=[#0] // { arity: 1 }
+        Union // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Get materialize.public.t1 // { arity: 2 }
+          Project (#1) // { arity: 1 }
+            Get materialize.public.t1 // { arity: 2 }
+
+EOF

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -21,14 +21,15 @@ Explained Query:
     Get l0
   With Mutually Recursive
     cte l0 =
-      Project (#0)
-        Distinct group_by=[1, #0]
-          Union
-            Project (#1)
-              Map (7)
-                Get l0
-            Constant
-              - (2)
+      Project (#1)
+        Map (1)
+          Distinct group_by=[#0]
+            Union
+              Project (#1)
+                Map (7)
+                  Get l0
+              Constant
+                - (2)
 
 EOF
 

--- a/test/sqllogictest/transform/redundant_join.slt
+++ b/test/sqllogictest/transform/redundant_join.slt
@@ -144,7 +144,8 @@ Explained Query:
       Project (#2) // { arity: 1 }
         Get l1 // { arity: 3 }
       Project (#1) // { arity: 1 }
-        Get l0 // { arity: 2 }
+        Map (42) // { arity: 2 }
+          Get l0 // { arity: 1 }
   With Mutually Recursive
     cte l1 =
       Distinct group_by=[#0..=#2] // { arity: 3 }
@@ -153,17 +154,16 @@ Explained Query:
             Union // { arity: 3 }
               Get l1 // { arity: 3 }
               Project (#0, #0, #0) // { arity: 3 }
-                Get l0 // { arity: 2 }
+                Get l0 // { arity: 1 }
           Join on=(#2 = (#0 % 2)) type=differential // { arity: 3 }
             implementation
-              %0:t2[(#0 % 2)]K » %1:l0[#0]K
+              %1:l0[#0]UK » %0:t2[(#0 % 2)]K
             ArrangeBy keys=[[(#0 % 2)]] // { arity: 2 }
               Get materialize.public.t2 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Get l0 // { arity: 2 }
+              Get l0 // { arity: 1 }
     cte l0 =
-      Distinct group_by=[(#0 % 2), 42] // { arity: 2 }
+      Distinct group_by=[(#0 % 2)] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get materialize.public.t2 // { arity: 2 }
 


### PR DESCRIPTION
Implements the **`LetRec` implementation (basic)** solution from MaterializeInc/database-issues#5334.

Fixes MaterializeInc/database-issues#5334.

### Motivation

* This PR adds a known-desirable feature.

### Tips for reviewer

1. The first commit generalizes the `join` case a bit so I can add a meaningful test case.
1. The second commit implements the `LetRec` case.
1. I've only added a minimal `literal_lifting.slt` to demonstrate the WMR support.
1. I've also added a `*.spec` test to MaterializeInc/materialize#18714 (see the "transform: add literal_lifting spec WIP" commit).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
