### PR TITLE
[persist] ResultSpec for MirScalarExpr

### DIFF
--- a/src/expr/src/explain/json.rs
+++ b/src/expr/src/explain/json.rs
@@ -57,6 +57,7 @@ where
 
                     if let Some(PushdownInfo { trace }) = pushdown_info {
                         let pushdownable: Vec<_> = trace
+                            .0
                             .iter()
                             .enumerate()
                             .filter(|(_, p)| **p == Pushdownable::Yes)

--- a/src/expr/src/explain/json.rs
+++ b/src/expr/src/explain/json.rs
@@ -9,7 +9,8 @@
 
 //! `EXPLAIN AS JSON` support for structures defined in this crate.
 
-use crate::explain::ExplainSource;
+use crate::explain::{ExplainSource, PushdownInfo};
+use crate::interpret::Pushdownable;
 use mz_repr::explain::json::DisplayJson;
 
 use super::{ExplainMultiPlan, ExplainSinglePlan};
@@ -43,12 +44,33 @@ where
         let sources = self
             .sources
             .iter()
-            .map(|ExplainSource { id, op, .. }| {
-                serde_json::json!({
-                    "id": id,
-                    "op": op
-                })
-            })
+            .map(
+                |ExplainSource {
+                     id,
+                     op,
+                     pushdown_info,
+                 }| {
+                    let mut json = serde_json::json!({
+                        "id": id,
+                        "op": op,
+                    });
+
+                    if let Some(PushdownInfo { trace }) = pushdown_info {
+                        let pushdownable: Vec<_> = trace
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, p)| **p == Pushdownable::Yes)
+                            .map(|(i, _)| i)
+                            .collect();
+
+                        json.as_object_mut()
+                            .unwrap()
+                            .insert("pushdown".to_owned(), serde_json::json!(pushdownable));
+                    }
+
+                    json
+                },
+            )
             .collect::<Vec<_>>();
 
         let result = serde_json::json!({ "plans": plans, "sources": sources });

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -23,7 +23,7 @@ use mz_repr::explain::{
     UnsupportedFormat, UsedIndexes,
 };
 
-use crate::interpret::{Interpreter, Pushdownable, Trace};
+use crate::interpret::{Interpreter, Pushdownable, RelationTrace, Trace};
 use crate::{
     visit::Visit, Id, LocalId, MapFilterProject, MirRelationExpr, MirScalarExpr, RowSetFinishing,
 };
@@ -57,17 +57,18 @@ pub struct ExplainSinglePlan<'a, T> {
 #[allow(missing_debug_implementations)]
 pub struct PushdownInfo {
     /// Pushdown-able columns in the source.
-    pub trace: Vec<Pushdownable>,
+    pub trace: RelationTrace,
 }
 
 impl<C: AsMut<Indent>> DisplayText<C> for PushdownInfo {
     fn fmt_text(&self, f: &mut Formatter<'_>, ctx: &mut C) -> std::fmt::Result {
-        if !self.trace.is_empty() {
+        if !self.trace.0.is_empty() {
             writeln!(
                 f,
                 "{}pushdown=({})",
                 ctx.as_mut(),
                 self.trace
+                    .0
                     .iter()
                     .enumerate()
                     .filter_map(|(id, p)| match p {

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -98,7 +98,7 @@ impl<'a> ExplainSource<'a> {
     ) -> ExplainSource<'a> {
         let pushdown_info = if context.config.mfp_pushdown {
             Some(PushdownInfo {
-                trace: Trace.eval_mfp(op),
+                trace: Trace.mfp_filter(op),
             })
         } else {
             None

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -1,0 +1,1194 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+use mz_repr::adt::datetime::DateTimeUnits;
+use mz_repr::{ColumnType, Datum, RelationType, Row, RowArena, ScalarType};
+
+use crate::{
+    BinaryFunc, EvalError, MapFilterProject, MfpPlan, MirScalarExpr, UnaryFunc,
+    UnmaterializableFunc, VariadicFunc,
+};
+
+/// Tracks whether a function is monotonic, either increasing or decreasing.
+/// This property is useful for static analysis because a monotonic function maps ranges to ranges:
+/// ie. if `a` is between `b` and `c` inclusive, then `f(a)` is between `f(b)` and `f(c)` inclusive.
+/// (However, if either `f(b)` and `f(c)` error or return null, we don't assume anything about `f(a)`.
+///
+/// This should likely be moved to a function annotation in the future.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum Monotonic {
+    /// Monotonic in this argument.
+    Yes,
+    /// We haven't classified this one yet. (Conservatively treated as "no", but a distinct
+    /// enum so it's easy to tell whether someone's thought about a particular function yet.)
+    /// This should likely be removed when this becomes a function annotation.
+    Maybe,
+    /// We don't know any useful properties of this function.
+    No,
+}
+
+fn unary_monotonic(func: &UnaryFunc) -> Monotonic {
+    use crate::func::impls as funcs;
+    use Monotonic::*;
+    use UnaryFunc::*;
+    match func {
+        // Casts are generally monotonic.
+        CastUint64ToNumeric(_)
+        | CastNumericToUint64(_)
+        | CastNumericToMzTimestamp(_)
+        | CastUint64ToMzTimestamp(_)
+        | CastTimestampToMzTimestamp(_)
+        | CastTimestampTzToMzTimestamp(_) => Yes,
+        // Including JSON casts.
+        CastJsonbToNumeric(_)
+        | CastJsonbToBool(_)
+        | CastJsonbToString(_)
+        | CastJsonbToInt64(_)
+        | CastJsonbToFloat64(_) => Yes,
+
+        // Extracting the "most significant bits" of the a timestamp is monotonic.
+        ExtractTimestamp(funcs::ExtractTimestamp(units))
+        | ExtractTimestampTz(funcs::ExtractTimestampTz(units)) => match units {
+            DateTimeUnits::Epoch
+            | DateTimeUnits::Millennium
+            | DateTimeUnits::Century
+            | DateTimeUnits::Decade
+            | DateTimeUnits::Year => Yes,
+            _ => No,
+        },
+        DateTruncTimestamp(_) | DateTruncTimestampTz(_) => Yes,
+        // Negation is monotonically decreasing, but that's fine.
+        NegInt64(_) | NegNumeric(_) | Not(_) => Yes,
+        // Trivially monotonic, since all non-null values map to `false`.
+        IsNull(_) => Yes,
+        AbsInt64(_) => No,
+        _ => Maybe,
+    }
+}
+
+fn binary_monotonic(func: &BinaryFunc) -> (Monotonic, Monotonic) {
+    use BinaryFunc::*;
+    use Monotonic::*;
+
+    match func {
+        AddInt64 | MulInt64 | AddNumeric | MulNumeric | SubInt64 | SubNumeric => (Yes, Yes),
+        AddInterval | SubInterval => (Yes, Yes),
+        AddTimestampInterval
+        | AddTimestampTzInterval
+        | SubTimestampInterval
+        | SubTimestampTzInterval => (Yes, Yes),
+        // Monotonic in the left argument, but the right hand side has a discontinuity.
+        // Could be treated as monotonic if we also captured the valid domain of the function args.
+        DivInt64 | DivNumeric => (Yes, No),
+        Lt | Lte | Gt | Gte => (Yes, Yes),
+        _ => (Maybe, Maybe),
+    }
+}
+
+fn variadic_monotonic(func: &VariadicFunc) -> Monotonic {
+    use Monotonic::*;
+    use VariadicFunc::*;
+    match func {
+        And | Or => Yes,
+        _ => Maybe,
+    }
+}
+
+/// An inclusive range of non-null datum values.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum Values<'a> {
+    /// This range contains no values.
+    Empty,
+    /// An inclusive range. Invariant: the first element is always <= the second.
+    Within(Datum<'a>, Datum<'a>),
+    /// This range might contain any value. Since we're overapproximating, this is often used
+    /// as a "safe fallback" when we can't determine the right boundaries for a range.
+    All,
+}
+
+impl<'a> Values<'a> {
+    fn just(a: Datum<'a>) -> Values<'a> {
+        Self::Within(a, a)
+    }
+
+    fn union(self, other: Values<'a>) -> Values<'a> {
+        match (self, other) {
+            (Values::Empty, r) => r,
+            (r, Values::Empty) => r,
+            (Values::Within(a0, a1), Values::Within(b0, b1)) => {
+                Values::Within(a0.min(b0), a1.max(b1))
+            }
+            (Values::All, _) => Values::All,
+            (_, Values::All) => Values::All,
+        }
+    }
+
+    fn intersect(self, other: Values<'a>) -> Values<'a> {
+        match (self, other) {
+            (Values::Empty, _) => Values::Empty,
+            (_, Values::Empty) => Values::Empty,
+            (Values::Within(a0, a1), Values::Within(b0, b1)) => {
+                let min = a0.max(b0);
+                let max = a1.min(b1);
+                if min <= max {
+                    Values::Within(min, max)
+                } else {
+                    Values::Empty
+                }
+            }
+            (Values::All, v) => v,
+            (v, Values::All) => v,
+        }
+    }
+}
+
+/// An approximation of the set of values an expression might have, including whether or not it
+/// might be null or an error value. This is generally an _overapproximation_, in the sense that
+/// [ResultSpec::may_contain] may return true even if the argument is not included in the set.
+/// (However, it should never return false when the value _is_ included!)
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ResultSpec<'a> {
+    /// True if the expression may evaluate to [Datum::Null].
+    nullable: bool,
+    /// True if the expression may evaluate to an error.
+    fallible: bool,
+    /// The range of possible (non-null) values that the expression may evaluate to.
+    values: Values<'a>,
+    /// If this expression evaluates to a [Datum::Map], additional constraints on specific
+    /// fields within that Map. If a field is not present in the map, it is unconstrained,
+    /// in the sense of [ResultSpec::anything]. For a map to be considered an element of
+    /// the set, it must match _all_ of these field constraints and be present in `values`.
+    map_spec: Option<BTreeMap<Datum<'a>, ResultSpec<'a>>>,
+}
+
+impl<'a> ResultSpec<'a> {
+    /// No results match this spec. (For example, an empty table.)
+    pub fn nothing() -> Self {
+        ResultSpec {
+            nullable: false,
+            fallible: false,
+            values: Values::Empty,
+            map_spec: None,
+        }
+    }
+
+    /// Every result matches this spec.
+    pub fn anything() -> Self {
+        ResultSpec {
+            nullable: true,
+            fallible: true,
+            values: Values::All,
+            map_spec: Some(BTreeMap::new()),
+        }
+    }
+
+    /// A spec that only matches null.
+    pub fn null() -> Self {
+        ResultSpec {
+            nullable: true,
+            ..Self::nothing()
+        }
+    }
+
+    /// A spec that only matches error values.
+    pub fn fails() -> Self {
+        ResultSpec {
+            fallible: true,
+            ..Self::nothing()
+        }
+    }
+
+    /// A spec that matches all values of a given type.
+    pub fn has_type(col: &ColumnType, fallible: bool) -> ResultSpec<'a> {
+        let values = match &col.scalar_type {
+            ScalarType::Bool => Values::Within(Datum::False, Datum::True),
+            _ => Values::All,
+        };
+        ResultSpec {
+            nullable: col.nullable,
+            fallible,
+            values,
+            map_spec: Some(BTreeMap::new()),
+        }
+    }
+
+    /// A spec that only matches the given value.
+    pub fn value(value: Datum<'a>) -> ResultSpec<'a> {
+        if value.is_null() {
+            Self::null()
+        } else {
+            Self::value_between(value, value)
+        }
+    }
+
+    /// A spec that matches values between the given (non-null) min and max.
+    pub fn value_between(min: Datum<'a>, max: Datum<'a>) -> ResultSpec<'a> {
+        assert!(!min.is_null());
+        assert!(!max.is_null());
+        assert!(min <= max);
+        ResultSpec {
+            values: Values::Within(min, max),
+            map_spec: Some(BTreeMap::new()),
+            ..ResultSpec::nothing()
+        }
+    }
+
+    /// A spec that matches any non-null value.
+    pub fn value_all() -> ResultSpec<'a> {
+        ResultSpec {
+            values: Values::All,
+            map_spec: Some(BTreeMap::new()),
+            ..ResultSpec::nothing()
+        }
+    }
+
+    /// A spec that matches Datum::Maps of the given type.
+    pub fn map_spec(map: BTreeMap<Datum<'a>, ResultSpec<'a>>) -> ResultSpec<'a> {
+        ResultSpec {
+            values: Values::All,
+            map_spec: Some(map),
+            ..ResultSpec::nothing()
+        }
+    }
+
+    /// Given two specs, returns a new spec that matches anything that either original spec would match.
+    pub fn union(self, other: ResultSpec<'a>) -> ResultSpec<'a> {
+        ResultSpec {
+            nullable: self.nullable || other.nullable,
+            fallible: self.fallible || other.fallible,
+            values: self.values.union(other.values),
+            map_spec: match (self.map_spec, other.map_spec) {
+                (Some(mut self_map), Some(mut other_map)) => {
+                    self_map.retain(|datum, spec| {
+                        if let Some(other_spec) = other_map.remove(datum) {
+                            *spec = spec.clone().union(other_spec);
+                        }
+                        *spec != Self::anything()
+                    });
+                    Some(self_map)
+                }
+                (Some(self_map), None) => Some(self_map),
+                (None, Some(other_map)) => Some(other_map),
+                (None, None) => None,
+            },
+        }
+    }
+
+    /// Given two specs, returns a new spec that only matches things that both original specs would match.
+    pub fn intersect(self, other: ResultSpec<'a>) -> ResultSpec<'a> {
+        ResultSpec {
+            nullable: self.nullable && other.nullable,
+            fallible: self.fallible && other.fallible,
+            values: self.values.intersect(other.values),
+            map_spec: match (self.map_spec, other.map_spec) {
+                (Some(mut self_map), Some(other_map)) => {
+                    for (datum, other_spec) in other_map {
+                        let spec = self_map.entry(datum).or_insert_with(Self::anything);
+                        *spec = spec.clone().intersect(other_spec);
+                    }
+                    Some(self_map)
+                }
+                (None, _) => None,
+                (_, None) => None,
+            },
+        }
+    }
+
+    /// Check if a particular value matches the spec.
+    pub fn may_contain(&self, value: Datum<'a>) -> bool {
+        if value == Datum::Null {
+            return self.nullable;
+        }
+
+        match &self.values {
+            Values::Empty => false,
+            Values::Within(min, max) => *min <= value && value <= *max,
+            Values::All => true,
+        }
+    }
+
+    /// Check if an error value matches the spec.
+    pub fn may_fail(&self) -> bool {
+        self.fallible
+    }
+
+    /// This function "maps" a function across the set of valid datums, returning the set of possible
+    /// results.
+    ///
+    /// If we actually stored a set of every possible value, this could by done by passing
+    /// each datup to the function one-by-one and unioning the resulting sets. This is possible
+    /// when our values set is empty or contains a single datum, but when it contains a range,
+    /// we need a little metadata about the function to be able to infer a useful result.
+    fn flat_map(
+        self,
+        is_monotonic: Monotonic,
+        mut datum_map: impl FnMut(Datum<'a>) -> ResultSpec<'a>,
+    ) -> ResultSpec<'a> {
+        let null_spec = if self.nullable {
+            datum_map(Datum::Null)
+        } else {
+            ResultSpec::nothing()
+        };
+
+        let error_spec = ResultSpec {
+            fallible: self.fallible,
+            ..Self::nothing()
+        };
+
+        let values_spec = match self.values {
+            Values::Empty => ResultSpec::nothing(),
+            // If this range contains a single datum, just call the function.
+            Values::Within(min, max) if min == max => datum_map(min),
+            // If this is a range of booleans, we know all the values... just try them.
+            Values::Within(Datum::False, Datum::True) => {
+                datum_map(Datum::False).union(datum_map(Datum::True))
+            }
+            // Otherwise, if our function is monotonic, we can try mapping the input
+            // range to an output range.
+            Values::Within(min, max) => match is_monotonic {
+                Monotonic::Yes => {
+                    let min_column = datum_map(min);
+                    let max_column = datum_map(max);
+                    if min_column.nullable
+                        || min_column.fallible
+                        || max_column.nullable
+                        || max_column.fallible
+                    {
+                        ResultSpec::anything()
+                    } else {
+                        min_column.union(max_column)
+                    }
+                }
+                Monotonic::Maybe | Monotonic::No => ResultSpec::anything(),
+            },
+            Values::All => ResultSpec::anything(),
+        };
+
+        null_spec.union(error_spec).union(values_spec)
+    }
+}
+
+/// [Abstract interpretation](https://en.wikipedia.org/wiki/Abstract_interpretation) for
+/// [MirScalarExpr].
+///
+/// [MirScalarExpr::eval] implements a "concrete interpreter" for the expression type: given an
+/// expression and specific column values as input, it returns a specific value for the output.
+/// This could be reimplemented using this trait... but it's most useful for "abstract"
+/// interpretations of the expression, where we generalize about sets of possible inputs and outputs.
+/// See [Trace] and [ColumnSpecs] for how this can be useful in practice.
+pub trait Interpreter {
+    type Summary: Sized + Clone;
+
+    /// A column of the input row.
+    fn eval_column(&self, id: usize) -> Self::Summary;
+
+    /// A literal value.
+    /// (Stored as a row, because we can't own a Datum.)
+    fn eval_literal(&self, result: &Result<Row, EvalError>, col_type: &ColumnType)
+        -> Self::Summary;
+
+    /// A call to an unmaterializable function.
+    ///
+    /// These functions cannot be evaluated by `MirScalarExpr::eval`. They must
+    /// be transformed away by a higher layer.
+    fn eval_unmaterializable(&self, func: &UnmaterializableFunc) -> Self::Summary;
+
+    /// A function call that takes one expression as an argument.
+    fn eval_unary(&self, func: &UnaryFunc, expr: Self::Summary) -> Self::Summary;
+
+    /// A function call that takes two expressions as arguments.
+    fn eval_binary(
+        &self,
+        func: &BinaryFunc,
+        left: Self::Summary,
+        right: Self::Summary,
+    ) -> Self::Summary;
+
+    /// A function call that takes an arbitrary number of arguments.
+    fn eval_variadic(&self, func: &VariadicFunc, exprs: Vec<Self::Summary>) -> Self::Summary;
+
+    /// Conditionally evaluated expressions.
+    fn eval_if(
+        &self,
+        cond: Self::Summary,
+        then: Self::Summary,
+        els: Self::Summary,
+    ) -> Self::Summary;
+
+    /// Evaluate an entire expression, by delegating to the fine-grained methods on [Interpreter].
+    fn eval_expr(&self, expr: &MirScalarExpr) -> Self::Summary {
+        match expr {
+            MirScalarExpr::Column(id) => self.eval_column(*id),
+            MirScalarExpr::Literal(value, col_type) => self.eval_literal(value, col_type),
+            MirScalarExpr::CallUnmaterializable(func) => self.eval_unmaterializable(func),
+            MirScalarExpr::CallUnary { func, expr } => {
+                let expr_range = self.eval_expr(expr);
+                self.eval_unary(func, expr_range)
+            }
+            MirScalarExpr::CallBinary { func, expr1, expr2 } => {
+                let expr1_range = self.eval_expr(expr1);
+                let expr2_range = self.eval_expr(expr2);
+                self.eval_binary(func, expr1_range, expr2_range)
+            }
+            MirScalarExpr::CallVariadic { func, exprs } => {
+                let exprs: Vec<_> = exprs.into_iter().map(|e| self.eval_expr(e)).collect();
+                self.eval_variadic(func, exprs)
+            }
+            MirScalarExpr::If { cond, then, els } => {
+                let cond_range = self.eval_expr(cond);
+                let then_range = self.eval_expr(then);
+                let els_range = self.eval_expr(els);
+                self.eval_if(cond_range, then_range, els_range)
+            }
+        }
+    }
+
+    /// Specifically, this evaluates the map and filters stages of an MFP: summarize each of the
+    /// map expressions, then `and` together all of the filters.
+    fn eval_mfp(&self, mfp: &MapFilterProject) -> Self::Summary {
+        let mfp_eval = MfpEval::new(self, mfp.input_arity, &mfp.expressions);
+        // NB: self should not be used after this point!
+        let predicates = mfp
+            .predicates
+            .iter()
+            .map(|(_, e)| mfp_eval.eval_expr(e))
+            .collect();
+        mfp_eval.eval_variadic(&VariadicFunc::And, predicates)
+    }
+
+    /// Similar to [Self::eval_mfp], but includes the additional temporal filters that have been
+    /// broken out.
+    fn eval_mfp_plan(&self, plan: &MfpPlan) -> Self::Summary {
+        let mfp_eval = MfpEval::new(self, plan.mfp.input_arity, &plan.mfp.expressions);
+        // NB: self should not be used after this point!
+        let mut results: Vec<_> = plan
+            .mfp
+            .predicates
+            .iter()
+            .map(|(_, e)| mfp_eval.eval_expr(e))
+            .collect();
+        let mz_now = mfp_eval.eval_unmaterializable(&UnmaterializableFunc::MzNow);
+        for bound in &plan.lower_bounds {
+            let bound_range = mfp_eval.eval_expr(bound);
+            let result = mfp_eval.eval_binary(&BinaryFunc::Lte, bound_range, mz_now.clone());
+            results.push(result);
+        }
+        for bound in &plan.upper_bounds {
+            let bound_range = mfp_eval.eval_expr(bound);
+            let result = mfp_eval.eval_binary(&BinaryFunc::Gte, bound_range, mz_now.clone());
+            results.push(result);
+        }
+        self.eval_variadic(&VariadicFunc::And, results)
+    }
+}
+
+/// Wrap another interpreter, but tack a few extra columns on at the end. An internal implementation
+/// detail of `eval_mfp` and `eval_mfp_plan`.
+struct MfpEval<'a, E: Interpreter + ?Sized> {
+    evaluator: &'a E,
+    input_arity: usize,
+    expressions: Vec<E::Summary>,
+}
+
+impl<'a, E: Interpreter + ?Sized> MfpEval<'a, E> {
+    fn new(evaluator: &'a E, input_arity: usize, expressions: &[MirScalarExpr]) -> Self {
+        let mut mfp_eval = MfpEval {
+            evaluator,
+            input_arity,
+            expressions: vec![],
+        };
+        for expr in expressions {
+            let result = mfp_eval.eval_expr(expr);
+            mfp_eval.expressions.push(result);
+        }
+        mfp_eval
+    }
+}
+
+impl<'a, E: Interpreter + ?Sized> Interpreter for MfpEval<'a, E> {
+    type Summary = E::Summary;
+
+    fn eval_column(&self, id: usize) -> Self::Summary {
+        if id < self.input_arity {
+            self.evaluator.eval_column(id)
+        } else {
+            self.expressions[id - self.input_arity].clone()
+        }
+    }
+
+    fn eval_literal(
+        &self,
+        result: &Result<Row, EvalError>,
+        col_type: &ColumnType,
+    ) -> Self::Summary {
+        self.evaluator.eval_literal(result, col_type)
+    }
+
+    fn eval_unmaterializable(&self, func: &UnmaterializableFunc) -> Self::Summary {
+        self.evaluator.eval_unmaterializable(func)
+    }
+
+    fn eval_unary(&self, func: &UnaryFunc, expr: Self::Summary) -> Self::Summary {
+        self.evaluator.eval_unary(func, expr)
+    }
+
+    fn eval_binary(
+        &self,
+        func: &BinaryFunc,
+        left: Self::Summary,
+        right: Self::Summary,
+    ) -> Self::Summary {
+        self.evaluator.eval_binary(func, left, right)
+    }
+
+    fn eval_variadic(&self, func: &VariadicFunc, exprs: Vec<Self::Summary>) -> Self::Summary {
+        self.evaluator.eval_variadic(func, exprs)
+    }
+
+    fn eval_if(
+        &self,
+        cond: Self::Summary,
+        then: Self::Summary,
+        els: Self::Summary,
+    ) -> Self::Summary {
+        self.evaluator.eval_if(cond, then, els)
+    }
+}
+
+/// For a given column and expression, does the range of the column influence the range of the
+/// expression? (ie. if the expression is a filter, could we tell that the filter
+/// will never return True?)
+#[derive(Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Debug)]
+pub enum Pushdownable {
+    No,
+    Maybe,
+    Yes,
+}
+
+impl Pushdownable {
+    fn apply_fn(mut columns: Vec<Self>, is_monotonic: Monotonic) -> Vec<Self> {
+        match is_monotonic {
+            Monotonic::Yes => {
+                // Still correlated, nothing to do.
+            }
+            Monotonic::No => {
+                // A function that we know we can't see through. No reason to expect the range
+                // of the columns to affect the range of the expression.
+                for col in &mut columns {
+                    *col = Pushdownable::No;
+                }
+            }
+            Monotonic::Maybe => {
+                // A function that we may or may not be able to see through.
+                for col in &mut columns {
+                    *col = Pushdownable::Maybe.min(*col);
+                }
+            }
+        }
+        columns
+    }
+
+    fn merge(mut columns: Vec<Self>, other: Vec<Self>) -> Vec<Self> {
+        let new_len = columns.len().max(other.len());
+        columns.resize(new_len, Pushdownable::No);
+        for (my_col, other_col) in columns.iter_mut().zip(other.iter()) {
+            *my_col = (*other_col).max(*my_col);
+        }
+        columns
+    }
+}
+
+/// An interpreter that traces how information about the source columns flows through the expression.
+///
+#[derive(Debug)]
+pub struct Trace;
+
+impl Interpreter for Trace {
+    /// For every column in the data, we track whether or not that column is "pusdownable".
+    /// (If the column is not present in the summary, we default to `false`.
+    type Summary = Vec<Pushdownable>;
+
+    fn eval_column(&self, id: usize) -> Self::Summary {
+        let mut columns = vec![Pushdownable::No; id];
+        columns.push(Pushdownable::Yes);
+        columns
+    }
+
+    fn eval_literal(
+        &self,
+        _result: &Result<Row, EvalError>,
+        _col_type: &ColumnType,
+    ) -> Self::Summary {
+        Vec::default()
+    }
+
+    fn eval_unmaterializable(&self, _func: &UnmaterializableFunc) -> Self::Summary {
+        Vec::default()
+    }
+
+    fn eval_unary(&self, func: &UnaryFunc, expr: Self::Summary) -> Self::Summary {
+        Pushdownable::apply_fn(expr, unary_monotonic(func))
+    }
+
+    fn eval_binary(
+        &self,
+        func: &BinaryFunc,
+        left: Self::Summary,
+        right: Self::Summary,
+    ) -> Self::Summary {
+        // TODO: this is duplicative! If we have more than one or two special-cased functions
+        // we should find some way to share the list between `Trace` and `ColumnSpecs`.
+        let (left_monotonic, right_monotonic) = match func {
+            BinaryFunc::JsonbGetString { stringify: false } => (Monotonic::Yes, Monotonic::No),
+            _ => binary_monotonic(func),
+        };
+        Pushdownable::merge(
+            Pushdownable::apply_fn(left, left_monotonic),
+            Pushdownable::apply_fn(right, right_monotonic),
+        )
+    }
+
+    fn eval_variadic(&self, func: &VariadicFunc, exprs: Vec<Self::Summary>) -> Self::Summary {
+        let is_monotonic = variadic_monotonic(func);
+        exprs.into_iter().fold(Vec::default(), |acc, columns| {
+            Pushdownable::merge(acc, Pushdownable::apply_fn(columns, is_monotonic))
+        })
+    }
+
+    fn eval_if(
+        &self,
+        cond: Self::Summary,
+        then: Self::Summary,
+        els: Self::Summary,
+    ) -> Self::Summary {
+        Pushdownable::merge(cond, Pushdownable::merge(then, els))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ColumnSpec<'a> {
+    pub col_type: ColumnType,
+    pub range: ResultSpec<'a>,
+}
+
+/// An interpreter that:
+/// - stores both the type and the range of possible values for every column and
+///   unmaterializable function. (See the `push_` methods.)
+/// - given an expression (or MFP, etc.), returns the range of possible results that evaluating that
+///   expression might have. (See the `eval_` methods.)
+#[derive(Clone, Debug)]
+pub struct ColumnSpecs<'a> {
+    pub columns: Vec<ColumnSpec<'a>>,
+    pub unmaterializables: BTreeMap<UnmaterializableFunc, ResultSpec<'a>>,
+    pub arena: &'a RowArena,
+}
+
+impl<'a> ColumnSpecs<'a> {
+    /// Create a new, empty set of column specs. (Initially, the only assumption we make about the
+    /// data in the column is that it matches the type.)
+    pub fn new(relation: RelationType, arena: &'a RowArena) -> Self {
+        ColumnSpecs {
+            columns: relation
+                .column_types
+                .into_iter()
+                .map(|ct| ColumnSpec {
+                    range: ResultSpec::has_type(&ct, false),
+                    col_type: ct,
+                })
+                .collect(),
+            unmaterializables: Default::default(),
+            arena,
+        }
+    }
+
+    /// Restrict the set of possible values in a given column. (By intersecting it with the existing
+    /// spec.)
+    pub fn push_column(&mut self, id: usize, update: ResultSpec<'a>) {
+        let range = &mut self.columns.get_mut(id).expect("valid column id").range;
+        *range = range.clone().intersect(update);
+    }
+
+    /// Restrict the set of possible values a given unmaterializable func might return. (By
+    /// intersecting it with the existing spec.)
+    pub fn push_unmaterializable(&mut self, func: UnmaterializableFunc, update: ResultSpec<'a>) {
+        let range = self
+            .unmaterializables
+            .entry(func.clone())
+            .or_insert_with(|| ResultSpec::has_type(&func.output_type(), true));
+        *range = range.clone().intersect(update);
+    }
+
+    fn eval_result<'b, E>(&self, result: Result<Datum<'b>, E>) -> ResultSpec<'a> {
+        match result {
+            Ok(Datum::Null) => ResultSpec {
+                nullable: true,
+                ..ResultSpec::nothing()
+            },
+            Ok(d) => ResultSpec {
+                values: Values::just(self.arena.make_datum(|packer| packer.push(d))),
+                ..ResultSpec::nothing()
+            },
+            Err(_) => ResultSpec {
+                fallible: true,
+                ..ResultSpec::nothing()
+            },
+        }
+    }
+}
+
+impl<'a> Interpreter for ColumnSpecs<'a> {
+    type Summary = ColumnSpec<'a>;
+
+    fn eval_column(&self, id: usize) -> Self::Summary {
+        self.columns[id].clone()
+    }
+
+    fn eval_literal(
+        &self,
+        result: &Result<Row, EvalError>,
+        col_type: &ColumnType,
+    ) -> Self::Summary {
+        let col_type = col_type.clone();
+        let range = self.eval_result(result.as_ref().map(|row| {
+            self.arena
+                .make_datum(|packer| packer.push(row.unpack_first()))
+        }));
+        ColumnSpec { col_type, range }
+    }
+
+    fn eval_unmaterializable(&self, func: &UnmaterializableFunc) -> Self::Summary {
+        let col_type = func.output_type();
+        let range = self
+            .unmaterializables
+            .get(func)
+            .cloned()
+            .unwrap_or(ResultSpec::has_type(&func.output_type(), true));
+        ColumnSpec { col_type, range }
+    }
+
+    fn eval_unary(&self, func: &UnaryFunc, summary: Self::Summary) -> Self::Summary {
+        let is_monotonic = unary_monotonic(func);
+        let expr = MirScalarExpr::CallUnary {
+            func: func.clone(),
+            expr: Box::new(MirScalarExpr::Column(0)),
+        };
+        let col_type = func.output_type(summary.col_type);
+        let range = summary
+            .range
+            .flat_map(is_monotonic, |datum| {
+                self.eval_result(expr.eval(&[datum], self.arena))
+            })
+            .intersect(ResultSpec::has_type(&col_type, true));
+
+        ColumnSpec { col_type, range }
+    }
+
+    fn eval_binary(
+        &self,
+        func: &BinaryFunc,
+        left: Self::Summary,
+        right: Self::Summary,
+    ) -> Self::Summary {
+        let (left_monotonic, right_monotonic) = binary_monotonic(func);
+        let expr = MirScalarExpr::CallBinary {
+            func: func.clone(),
+            expr1: Box::new(MirScalarExpr::Column(0)),
+            expr2: Box::new(MirScalarExpr::Column(1)),
+        };
+        let col_type = func.output_type(left.col_type, right.col_type);
+
+        let range_special = match func {
+            BinaryFunc::JsonbGetString { stringify: false } => {
+                right
+                    .range
+                    .clone()
+                    .flat_map(Monotonic::No, |datum| match datum {
+                        Datum::Null => ResultSpec::null(),
+                        key => match &left.range.map_spec {
+                            None => ResultSpec::nothing(),
+                            Some(map_spec) => map_spec
+                                .get(&key)
+                                .cloned()
+                                .unwrap_or_else(ResultSpec::anything),
+                        },
+                    })
+            }
+            _ => ResultSpec::anything(),
+        };
+
+        let range = left
+            .range
+            .flat_map(left_monotonic, |left| {
+                right.range.clone().flat_map(right_monotonic, |right| {
+                    self.eval_result(expr.eval(&[left, right], self.arena))
+                })
+            })
+            .intersect(ResultSpec::has_type(&col_type, true))
+            .intersect(range_special);
+        ColumnSpec { col_type, range }
+    }
+
+    fn eval_variadic(&self, func: &VariadicFunc, args: Vec<Self::Summary>) -> Self::Summary {
+        fn eval_loop<'a>(
+            is_monotonic: Monotonic,
+            stack: &mut Vec<Datum<'a>>,
+            remaining: &[ResultSpec<'a>],
+            datum_map: &mut impl FnMut(&[Datum<'a>]) -> ResultSpec<'a>,
+        ) -> ResultSpec<'a> {
+            if remaining.is_empty() {
+                datum_map(stack)
+            } else {
+                remaining[0].clone().flat_map(is_monotonic, |datum| {
+                    stack.push(datum);
+                    let result = eval_loop(is_monotonic, stack, &remaining[1..], datum_map);
+                    stack.pop();
+                    result
+                })
+            }
+        }
+        let fn_expr = MirScalarExpr::CallVariadic {
+            func: func.clone(),
+            exprs: (0..args.len()).map(MirScalarExpr::Column).collect(),
+        };
+        let mut col_types = vec![];
+        let mut ranges = vec![];
+        for ColumnSpec { col_type, range } in args {
+            col_types.push(col_type);
+            ranges.push(range);
+        }
+
+        let col_type = func.output_type(col_types);
+
+        let mut stack = vec![];
+        let range = eval_loop(
+            variadic_monotonic(func),
+            &mut stack,
+            &ranges,
+            &mut |datums| self.eval_result(fn_expr.eval(datums, self.arena)),
+        )
+        .intersect(ResultSpec::has_type(&col_type, true));
+
+        ColumnSpec { col_type, range }
+    }
+
+    fn eval_if(
+        &self,
+        cond: Self::Summary,
+        then: Self::Summary,
+        els: Self::Summary,
+    ) -> Self::Summary {
+        let col_type = ColumnType {
+            scalar_type: then.col_type.scalar_type,
+            nullable: then.col_type.nullable || els.col_type.nullable,
+        };
+
+        let range = cond
+            .range
+            .flat_map(Monotonic::Yes, |datum| match datum {
+                Datum::True => then.range.clone(),
+                Datum::False => els.range.clone(),
+                _ => ResultSpec::fails(),
+            })
+            .intersect(ResultSpec::has_type(&col_type, true));
+
+        ColumnSpec { col_type, range }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use mz_ore::panic;
+    use mz_repr::{Datum, PropDatum, RowArena, ScalarType};
+
+    use crate::func::{AbsInt64, CastJsonbToNumeric};
+    use crate::{BinaryFunc, MirScalarExpr, UnaryFunc};
+
+    use super::*;
+
+    fn gen_datums_for_type(typ: &ScalarType) -> impl Strategy<Value = Datum<'static>> {
+        let values: Vec<_> = typ.interesting_datums().collect();
+        prop::sample::select(values).boxed()
+    }
+
+    fn gen_column() -> impl Strategy<Value = (ColumnType, Datum<'static>)> {
+        any::<ColumnType>()
+            .prop_filter("need at least one value", |c| {
+                c.scalar_type.interesting_datums().count() > 0
+            })
+            .prop_flat_map(|col| {
+                gen_datums_for_type(&col.scalar_type).prop_map(move |datum| (col.clone(), datum))
+            })
+    }
+
+    #[test]
+    fn test_trivial_spec_matches() {
+        fn check(datum: PropDatum) -> Result<(), TestCaseError> {
+            let datum: Datum = (&datum).into();
+            let spec = if datum.is_null() {
+                ResultSpec::null()
+            } else {
+                ResultSpec::value(datum)
+            };
+            assert!(spec.may_contain(datum));
+            Ok(())
+        }
+
+        proptest!(|(datum in mz_repr::arb_datum())| {
+            check(datum)?;
+        });
+
+        assert!(ResultSpec::fails().may_fail());
+    }
+
+    #[test]
+    fn test_equivalence() {
+        fn check(
+            expr: MirScalarExpr,
+            columns: Vec<(ColumnType, Datum<'static>)>,
+        ) -> Result<(), TestCaseError> {
+            let (columns, datums): (Vec<_>, Vec<_>) = columns.into_iter().unzip();
+            let relation = RelationType::new(columns);
+
+            // Unfortunately, our expr generator does not guarantee that the generated expr
+            // is safe to eval. (`eval` will often panic on expressions that are impossible to
+            // create normally.) First check that eval does not panic on the given inputs, and
+            // that the expression is well-typed.
+            let maybe_panic = panic::catch_unwind(|| {
+                let arena = RowArena::new();
+                struct Typecheck(RelationType);
+                impl Interpreter for Typecheck {
+                    type Summary = ColumnType;
+
+                    fn eval_column(&self, id: usize) -> Self::Summary {
+                        self.0.column_types[id].clone()
+                    }
+
+                    fn eval_literal(
+                        &self,
+                        _result: &Result<Row, EvalError>,
+                        col_type: &ColumnType,
+                    ) -> Self::Summary {
+                        col_type.clone()
+                    }
+
+                    fn eval_unmaterializable(&self, func: &UnmaterializableFunc) -> Self::Summary {
+                        func.output_type()
+                    }
+
+                    fn eval_unary(&self, func: &UnaryFunc, expr: Self::Summary) -> Self::Summary {
+                        func.output_type(expr)
+                    }
+
+                    fn eval_binary(
+                        &self,
+                        func: &BinaryFunc,
+                        left: Self::Summary,
+                        right: Self::Summary,
+                    ) -> Self::Summary {
+                        func.output_type(left, right)
+                    }
+
+                    fn eval_variadic(
+                        &self,
+                        func: &VariadicFunc,
+                        exprs: Vec<Self::Summary>,
+                    ) -> Self::Summary {
+                        func.output_type(exprs)
+                    }
+
+                    fn eval_if(
+                        &self,
+                        _cond: Self::Summary,
+                        then: Self::Summary,
+                        els: Self::Summary,
+                    ) -> Self::Summary {
+                        then.union(&els).expect("well-typed expression")
+                    }
+                }
+                let _ = Typecheck(relation.clone()).eval_expr(&expr);
+                expr.eval(&datums, &arena).map(|_| ())
+            });
+
+            prop_assume!(!matches!(maybe_panic, Err(_)), "skip invalid expressions");
+            prop_assume!(
+                !matches!(maybe_panic, Ok(Err(EvalError::Internal(_)))),
+                "skip internal errors"
+            );
+
+            // From here, we can assume that evaluating the expression with the given props
+            // is safe. We want to ensure that the spec we get when evaluating an expression using
+            // `ColumnSpecs` always contains the _actual_ value of that column when evaluated with
+            // eval. (This is an important correctness property of abstract interpretation.)
+            let arena = RowArena::new();
+            let eval_result = expr.eval(&datums, &arena);
+
+            let mut interpreter = ColumnSpecs::new(relation, &arena);
+
+            for (id, datum) in datums.iter().enumerate() {
+                interpreter.push_column(id, ResultSpec::value(*datum));
+            }
+            let spec = interpreter.eval_expr(&expr);
+
+            match eval_result {
+                Ok(value) => {
+                    assert!(spec.range.may_contain(value))
+                }
+                Err(_) => {
+                    assert!(spec.range.may_fail());
+                }
+            }
+
+            Ok(())
+        }
+
+        proptest!(|(expr: MirScalarExpr, columns in prop::collection::vec(gen_column(), 0..10))| {
+            check(expr, columns)?;
+        });
+    }
+
+    #[test]
+    fn test_eval_range() {
+        // Example inspired by the tumbling windows temporal filter in the docs
+        let period_ms = MirScalarExpr::Literal(
+            Ok(Row::pack_slice(&[Datum::Int64(10)])),
+            ScalarType::UInt64.nullable(false),
+        );
+        let expr = MirScalarExpr::CallBinary {
+            func: BinaryFunc::Gte,
+            expr1: Box::new(MirScalarExpr::CallUnmaterializable(
+                UnmaterializableFunc::MzNow,
+            )),
+            expr2: Box::new(MirScalarExpr::CallBinary {
+                func: BinaryFunc::MulInt64,
+                expr1: Box::new(period_ms.clone()),
+                expr2: Box::new(MirScalarExpr::CallBinary {
+                    func: BinaryFunc::DivInt64,
+                    expr1: Box::new(MirScalarExpr::Column(0)),
+                    expr2: Box::new(period_ms),
+                }),
+            }),
+        };
+
+        {
+            // Non-overlapping windows
+            let arena = RowArena::new();
+            let mut interpreter = ColumnSpecs::new(
+                RelationType::new(vec![ScalarType::UInt64.nullable(false)]),
+                &arena,
+            );
+            interpreter.push_unmaterializable(
+                UnmaterializableFunc::MzNow,
+                ResultSpec::value_between(10i64.into(), 20i64.into()),
+            );
+            interpreter.push_column(0, ResultSpec::value_between(30i64.into(), 40i64.into()));
+
+            let range_out = interpreter.eval_expr(&expr).range;
+            assert!(range_out.may_contain(Datum::False));
+            assert!(!range_out.may_contain(Datum::True));
+            assert!(!range_out.may_contain(Datum::Null));
+            assert!(!range_out.may_fail());
+        }
+
+        {
+            // Overlapping windows
+            let arena = RowArena::new();
+            let mut interpreter = ColumnSpecs::new(
+                RelationType::new(vec![ScalarType::UInt64.nullable(false)]),
+                &arena,
+            );
+            interpreter.push_unmaterializable(
+                UnmaterializableFunc::MzNow,
+                ResultSpec::value_between(10i64.into(), 35i64.into()),
+            );
+            interpreter.push_column(0, ResultSpec::value_between(30i64.into(), 40i64.into()));
+
+            let range_out = interpreter.eval_expr(&expr).range;
+            assert!(range_out.may_contain(Datum::False));
+            assert!(range_out.may_contain(Datum::True));
+            assert!(!range_out.may_contain(Datum::Null));
+            assert!(!range_out.may_fail());
+        }
+    }
+
+    #[test]
+    fn test_jsonb() {
+        let arena = RowArena::new();
+
+        let expr = MirScalarExpr::CallUnary {
+            func: UnaryFunc::CastJsonbToNumeric(CastJsonbToNumeric(None)),
+            expr: Box::new(MirScalarExpr::CallBinary {
+                func: BinaryFunc::JsonbGetString { stringify: false },
+                expr1: Box::new(MirScalarExpr::Column(0)),
+                expr2: Box::new(MirScalarExpr::Literal(
+                    Ok(Row::pack_slice(&["ts".into()])),
+                    ScalarType::String.nullable(false),
+                )),
+            }),
+        };
+
+        // Non-overlapping windows
+        let mut interpreter = ColumnSpecs::new(
+            RelationType::new(vec![ScalarType::Jsonb.nullable(true)]),
+            &arena,
+        );
+        interpreter.push_column(
+            0,
+            ResultSpec::map_spec(
+                [(
+                    "ts".into(),
+                    ResultSpec::value_between(
+                        Datum::Numeric(100.into()),
+                        Datum::Numeric(300.into()),
+                    ),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+        );
+
+        let range_out = interpreter.eval_expr(&expr).range;
+        assert!(!range_out.may_contain(Datum::Numeric(0.into())));
+        assert!(range_out.may_contain(Datum::Numeric(200.into())));
+        assert!(!range_out.may_contain(Datum::Numeric(400.into())));
+    }
+
+    #[test]
+    fn test_trace() {
+        use super::Trace;
+
+        let _input_type = ScalarType::UInt64.nullable(false);
+        let expr = MirScalarExpr::CallBinary {
+            func: BinaryFunc::Gte,
+            expr1: Box::new(MirScalarExpr::Column(0)),
+            expr2: Box::new(MirScalarExpr::CallBinary {
+                func: BinaryFunc::AddInt64,
+                expr1: Box::new(MirScalarExpr::Column(1)),
+                expr2: Box::new(MirScalarExpr::CallUnary {
+                    func: UnaryFunc::AbsInt64(AbsInt64),
+                    expr: Box::new(MirScalarExpr::Column(3)),
+                }),
+            }),
+        };
+        let trace = Trace.eval_expr(&expr);
+        assert_eq!(
+            trace,
+            vec![
+                Pushdownable::Yes, // one side of a conditional
+                Pushdownable::Yes, // other side of the conditional, nested in +
+                Pushdownable::No,  // not referenced!
+                Pushdownable::No   // referenced, but we can't see through abs()
+            ]
+        )
+    }
+}

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -26,7 +26,7 @@ use crate::{
 /// This should likely be moved to a function annotation in the future.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum Monotonic {
-    /// Monotonic in this argument.
+    /// Monotonic in this argument. (Either increasing or decreasing, non-strict.)
     Yes,
     /// We haven't classified this one yet. (Conservatively treated as "no", but a distinct
     /// enum so it's easy to tell whether someone's thought about a particular function yet.)
@@ -75,6 +75,12 @@ fn unary_monotonic(func: &UnaryFunc) -> Monotonic {
     }
 }
 
+/// Describes the pointwise behaviour of each of the two arguments of the function.
+/// (ie. the first element of the tuple is `Monotonic::Yes` if, for any value of the second argument
+/// increasing the first argument causes the result of the function to either monotonically
+/// increase or decrease.) For example, subtraction is considered monotonic in both arguments:
+/// in the first because `a - C` increases monotonically as `a` increases, and in the second because
+/// `C - b` decreases monotonically as `b` increases.
 fn binary_monotonic(func: &BinaryFunc) -> (Monotonic, Monotonic) {
     use BinaryFunc::*;
     use Monotonic::*;
@@ -94,6 +100,9 @@ fn binary_monotonic(func: &BinaryFunc) -> (Monotonic, Monotonic) {
     }
 }
 
+/// Describes the pointwise behaviour of each of the arguments to our variadic function.
+/// (ie. returns `Monotonic::Yes` if, for each argument of the function, increasing that argument
+/// causes the result of the function to either monotonically increase or decrease.)
 fn variadic_monotonic(func: &VariadicFunc) -> Monotonic {
     use Monotonic::*;
     use VariadicFunc::*;

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -966,57 +966,7 @@ mod tests {
             // that the expression is well-typed.
             let maybe_panic = panic::catch_unwind(|| {
                 let arena = RowArena::new();
-                struct Typecheck(RelationType);
-                impl Interpreter for Typecheck {
-                    type Summary = ColumnType;
-
-                    fn eval_column(&self, id: usize) -> Self::Summary {
-                        self.0.column_types[id].clone()
-                    }
-
-                    fn eval_literal(
-                        &self,
-                        _result: &Result<Row, EvalError>,
-                        col_type: &ColumnType,
-                    ) -> Self::Summary {
-                        col_type.clone()
-                    }
-
-                    fn eval_unmaterializable(&self, func: &UnmaterializableFunc) -> Self::Summary {
-                        func.output_type()
-                    }
-
-                    fn eval_unary(&self, func: &UnaryFunc, expr: Self::Summary) -> Self::Summary {
-                        func.output_type(expr)
-                    }
-
-                    fn eval_binary(
-                        &self,
-                        func: &BinaryFunc,
-                        left: Self::Summary,
-                        right: Self::Summary,
-                    ) -> Self::Summary {
-                        func.output_type(left, right)
-                    }
-
-                    fn eval_variadic(
-                        &self,
-                        func: &VariadicFunc,
-                        exprs: Vec<Self::Summary>,
-                    ) -> Self::Summary {
-                        func.output_type(exprs)
-                    }
-
-                    fn eval_if(
-                        &self,
-                        _cond: Self::Summary,
-                        then: Self::Summary,
-                        els: Self::Summary,
-                    ) -> Self::Summary {
-                        then.union(&els).expect("well-typed expression")
-                    }
-                }
-                let _ = Typecheck(relation.clone()).eval_expr(&expr);
+                let _ = expr.typ(&relation.column_types);
                 expr.eval(&datums, &arena).map(|_| ())
             });
 

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -85,6 +85,7 @@ use serde::{Deserialize, Serialize};
 use mz_repr::GlobalId;
 
 mod id;
+mod interpret;
 mod linear;
 mod relation;
 mod scalar;
@@ -97,6 +98,7 @@ pub use relation::canonicalize;
 
 pub use id::{Id, LocalId, PartitionId, SourceInstanceId};
 pub use id::{ProtoId, ProtoLocalId, ProtoPartitionId};
+pub use interpret::{ColumnSpec, ColumnSpecs, Interpreter, ResultSpec, Trace};
 pub use linear::{
     memoize_expr,
     plan::{MfpPlan, MfpPushdown, SafeMfpPlan},

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1442,7 +1442,7 @@ pub mod plan {
     /// A wrapper type which indicates it is safe to simply evaluate all expressions.
     #[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
     pub struct SafeMfpPlan {
-        mfp: MapFilterProject,
+        pub(crate) mfp: MapFilterProject,
     }
 
     impl RustType<ProtoSafeMfpPlan> for SafeMfpPlan {
@@ -1566,13 +1566,13 @@ pub mod plan {
     #[derive(Arbitrary, Clone, Debug, PartialEq)]
     pub struct MfpPlan {
         /// Normal predicates to evaluate on `&[Datum]` and expect `Ok(Datum::True)`.
-        mfp: SafeMfpPlan,
+        pub(crate) mfp: SafeMfpPlan,
         /// Expressions that when evaluated lower-bound `MzNow`.
         #[proptest(strategy = "prop::collection::vec(any::<MirScalarExpr>(), 0..2)")]
-        lower_bounds: Vec<MirScalarExpr>,
+        pub(crate) lower_bounds: Vec<MirScalarExpr>,
         /// Expressions that when evaluated upper-bound `MzNow`.
         #[proptest(strategy = "prop::collection::vec(any::<MirScalarExpr>(), 0..2)")]
-        upper_bounds: Vec<MirScalarExpr>,
+        pub(crate) upper_bounds: Vec<MirScalarExpr>,
     }
 
     impl RustType<ProtoMfpPlan> for MfpPlan {

--- a/src/expr/tests/test_runner.rs
+++ b/src/expr/tests/test_runner.rs
@@ -197,7 +197,7 @@ mod test {
             .map(|col_exprs| {
                 col_exprs
                     .into_iter()
-                    .map(|expr| interpreter.eval_expr(&expr).range)
+                    .map(|expr| interpreter.expr(&expr).range)
                     .reduce(|a, b| a.union(b))
                     .expect("at least one literal")
             })
@@ -206,7 +206,7 @@ mod test {
         for (id, spec) in specs.into_iter().enumerate() {
             interpreter.push_column(id, spec);
         }
-        let output = interpreter.eval_expr(&expr);
+        let output = interpreter.expr(&expr);
 
         let mut may_contain: Vec<_> = tests
             .iter()

--- a/src/expr/tests/test_runner.rs
+++ b/src/expr/tests/test_runner.rs
@@ -74,13 +74,14 @@
 // END LINT CONFIG
 
 mod test {
+    use itertools::Itertools;
     use mz_expr::canonicalize::{canonicalize_equivalences, canonicalize_predicates};
-    use mz_expr::{MapFilterProject, MirScalarExpr};
+    use mz_expr::{ColumnSpecs, Interpreter, MapFilterProject, MirScalarExpr};
     use mz_expr_test_util::*;
     use mz_lowertest::{deserialize, deserialize_optional, tokenize, MzReflect};
     use mz_ore::result::ResultExt;
     use mz_ore::str::separated;
-    use mz_repr::ColumnType;
+    use mz_repr::{ColumnType, RelationType, RowArena};
 
     use serde::{Deserialize, Serialize};
 
@@ -178,6 +179,49 @@ mod test {
         Ok(equivalences)
     }
 
+    fn test_interpret(s: &str) -> Result<Vec<String>, String> {
+        let mut input_stream = tokenize(s)?.into_iter();
+        let mut ctx = MirScalarExprDeserializeContext::default();
+        let types: Vec<ColumnType> = deserialize(&mut input_stream, "Vec<ColumnType>", &mut ctx)?;
+        let values: Vec<Vec<MirScalarExpr>> =
+            deserialize(&mut input_stream, "Vec<Vec<MirScalarExpr>>", &mut ctx)?;
+        let expr: MirScalarExpr = deserialize(&mut input_stream, "MirScalarExpr", &mut ctx)?;
+        let tests: Vec<MirScalarExpr> =
+            deserialize(&mut input_stream, "Vec<MirScalarExpr>", &mut ctx)?;
+
+        let arena = RowArena::new();
+        let mut interpreter = ColumnSpecs::new(RelationType::new(types), &arena);
+
+        let specs: Vec<_> = values
+            .into_iter()
+            .map(|col_exprs| {
+                col_exprs
+                    .into_iter()
+                    .map(|expr| interpreter.eval_expr(&expr).range)
+                    .reduce(|a, b| a.union(b))
+                    .expect("at least one literal")
+            })
+            .collect();
+
+        for (id, spec) in specs.into_iter().enumerate() {
+            interpreter.push_column(id, spec);
+        }
+        let output = interpreter.eval_expr(&expr);
+
+        let mut may_contain: Vec<_> = tests
+            .iter()
+            .map(|t| t.eval(&[], &arena).expect("literal datum"))
+            .filter(|d| output.range.may_contain(*d))
+            .map(|d| d.to_string())
+            .collect();
+
+        if output.range.may_fail() {
+            may_contain.push("<err>".into())
+        }
+
+        Ok(may_contain)
+    }
+
     #[test]
     fn run() {
         datadriven::walk("tests/testdata", |f| {
@@ -205,6 +249,12 @@ mod test {
                                 separated(" ", filter.iter()),
                                 separated(" ", project.iter())
                             )
+                        }
+                        Err(err) => format!("error: {}\n", err),
+                    },
+                    "interpret" => match test_interpret(&s.input) {
+                        Ok(contains) => {
+                            format!("may contain: [{}]\n", contains.into_iter().join(" "))
                         }
                         Err(err) => format!("error: {}\n", err),
                     },

--- a/src/expr/tests/testdata/interpret
+++ b/src/expr/tests/testdata/interpret
@@ -26,62 +26,62 @@ interpret
 may contain: [5]
 
 # A temporal-style filter: compare a value to some function of the column.
+# Expression: (2100 >= 300 + insert_ms)
 interpret
 [string numeric]
 [
   [("hello" string) ("goodbye" string)]
   [(2000.0 numeric) (2050.0 numeric)]
 ]
-# Expression: (2100 >= 300 + insert_ms)
 (call_binary gte (2100.0 numeric) (call_binary add_numeric (300.0 numeric) #1))
 [true false null]
 ----
 may contain: [false]
 
 # The same, but the filter matches.
+# Expression: (2900 >= 300 + insert_ms)
 interpret
 [string numeric]
 [
   [("hello" string) ("goodbye" string)]
   [(2000.0 numeric) (2050.0 numeric)]
 ]
-# Expression: (2900 >= 300 + insert_ms)
 (call_binary gte (2900.0 numeric) (call_binary add_numeric (300.0 numeric) #1))
 [true false null]
 ----
 may contain: [true]
 
 # JSONB ->
+# Expression: (json_col -> "created_ms")
 interpret
 [jsonb]
 [
   [("{\"created_ms\": 1000}" jsonb) ("{\"created_ms\": 2000}" jsonb) ("{\"created_ms\": 3000}" jsonb)]
 ]
-# Expression: (json_col -> "created_ms")
 (call_binary (jsonb_get_string false) #0 ("created_ms" string))
 [(0 numeric) (2050 numeric) (4000 numeric) null]
 ----
 may contain: [2050]
 
 # JSONB ->> (string column)
+# Expression: (json_col ->> "code")
 interpret
 [jsonb]
 [
   [("{\"code\": \"00135\"}" jsonb) ("{\"code\": \"22122\"}" jsonb) ("{\"code\": \"34153\"}" jsonb)]
 ]
-# Expression: (json_col ->> "code")
 (call_binary (jsonb_get_string true) #0 ("code" string))
 ["00000" "20000" "2" "80000"]
 ----
 may contain: ["20000" "2"]
 
 # JSONB ->> (numeric column... unsupported)
+# Expression: (json_col ->> "created_ms")
 interpret
 [jsonb]
 [
   [("{\"created_ms\": 1000}" jsonb) ("{\"created_ms\": 2000}" jsonb) ("{\"created_ms\": 3000}" jsonb)]
 ]
-# Expression: (json_col ->> "created_ms")
 (call_binary (jsonb_get_string true) #0 ("code" string))
 ["00000" "20000" "2" "80000"]
 ----

--- a/src/expr/tests/testdata/interpret
+++ b/src/expr/tests/testdata/interpret
@@ -1,0 +1,83 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# An interpret test case specifies, in order:
+# - The column types.
+# - Literal values for each column. Our spec for that column will be the union of the
+#   specs of the column's values.
+# - The expression. We'll interpret the expression to get an output spec.
+# - Literal values to test the output spec against.
+
+# Is this thing on? Check that basic integer ranges work as expected.
+interpret
+[int32]
+[
+  [4 6]
+]
+#0
+[3 5 7 ("test" string)]
+----
+may contain: [5]
+
+# A temporal-style filter: compare a value to some function of the column.
+interpret
+[string numeric]
+[
+  [("hello" string) ("goodbye" string)]
+  [(2000.0 numeric) (2050.0 numeric)]
+]
+(call_binary gte (2100.0 numeric) (call_binary add_numeric (300.0 numeric) #1))
+[true false null]
+----
+may contain: [false]
+
+# The same, but the filter matches.
+interpret
+[string numeric]
+[
+  [("hello" string) ("goodbye" string)]
+  [(2000.0 numeric) (2050.0 numeric)]
+]
+(call_binary gte (2900.0 numeric) (call_binary add_numeric (300.0 numeric) #1))
+[true false null]
+----
+may contain: [true]
+
+# JSONB ->
+interpret
+[jsonb]
+[
+  [("{\"created_ms\": 1000}" jsonb) ("{\"created_ms\": 2000}" jsonb) ("{\"created_ms\": 3000}" jsonb)]
+]
+(call_binary (jsonb_get_string false) #0 ("created_ms" string))
+[(0 numeric) (2050 numeric) (4000 numeric) null]
+----
+may contain: [2050]
+
+# JSONB ->> (string column)
+interpret
+[jsonb]
+[
+  [("{\"code\": \"00135\"}" jsonb) ("{\"code\": \"22122\"}" jsonb) ("{\"code\": \"34153\"}" jsonb)]
+]
+(call_binary (jsonb_get_string true) #0 ("code" string))
+["00000" "20000" "2" "80000"]
+----
+may contain: ["20000" "2"]
+
+# JSONB ->> (numeric column... unsupported)
+interpret
+[jsonb]
+[
+  [("{\"created_ms\": 1000}" jsonb) ("{\"created_ms\": 2000}" jsonb) ("{\"created_ms\": 3000}" jsonb)]
+]
+(call_binary (jsonb_get_string true) #0 ("code" string))
+["00000" "20000" "2" "80000"]
+----
+may contain: ["00000" "20000" "2" "80000" <err>]

--- a/src/expr/tests/testdata/interpret
+++ b/src/expr/tests/testdata/interpret
@@ -32,6 +32,7 @@ interpret
   [("hello" string) ("goodbye" string)]
   [(2000.0 numeric) (2050.0 numeric)]
 ]
+# Expression: (2100 >= 300 + insert_ms)
 (call_binary gte (2100.0 numeric) (call_binary add_numeric (300.0 numeric) #1))
 [true false null]
 ----
@@ -44,6 +45,7 @@ interpret
   [("hello" string) ("goodbye" string)]
   [(2000.0 numeric) (2050.0 numeric)]
 ]
+# Expression: (2900 >= 300 + insert_ms)
 (call_binary gte (2900.0 numeric) (call_binary add_numeric (300.0 numeric) #1))
 [true false null]
 ----
@@ -55,6 +57,7 @@ interpret
 [
   [("{\"created_ms\": 1000}" jsonb) ("{\"created_ms\": 2000}" jsonb) ("{\"created_ms\": 3000}" jsonb)]
 ]
+# Expression: (json_col -> "created_ms")
 (call_binary (jsonb_get_string false) #0 ("created_ms" string))
 [(0 numeric) (2050 numeric) (4000 numeric) null]
 ----
@@ -66,6 +69,7 @@ interpret
 [
   [("{\"code\": \"00135\"}" jsonb) ("{\"code\": \"22122\"}" jsonb) ("{\"code\": \"34153\"}" jsonb)]
 ]
+# Expression: (json_col ->> "code")
 (call_binary (jsonb_get_string true) #0 ("code" string))
 ["00000" "20000" "2" "80000"]
 ----
@@ -77,6 +81,7 @@ interpret
 [
   [("{\"created_ms\": 1000}" jsonb) ("{\"created_ms\": 2000}" jsonb) ("{\"created_ms\": 3000}" jsonb)]
 ]
+# Expression: (json_col ->> "created_ms")
 (call_binary (jsonb_get_string true) #0 ("code" string))
 ["00000" "20000" "2" "80000"]
 ----

--- a/src/repr-test-util/src/lib.rs
+++ b/src/repr-test-util/src/lib.rs
@@ -84,6 +84,7 @@ use proc_macro2::TokenTree;
 use mz_lowertest::deserialize_optional_generic;
 use mz_ore::str::StrExt;
 use mz_repr::adt::numeric::Numeric;
+use mz_repr::strconv::parse_jsonb;
 use mz_repr::{Datum, Row, RowArena, ScalarType};
 
 /* #endregion */
@@ -151,6 +152,9 @@ where
                         .unwrap(),
                     ))
                 }
+                ScalarType::Jsonb => parse_jsonb(&mz_lowertest::unquote(litval))
+                    .map(|jsonb| temp_storage.push_unary_row(jsonb.into_row()))
+                    .map_err(|parse| format!("Invalid JSON literal: {:?}", parse)),
                 _ => Err(format!("Unsupported literal type {:?}", littyp)),
             }
         }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -2408,7 +2408,7 @@ impl<'a> ScalarType {
 
     /// Returns various interesting datums for a ScalarType (max, min, 0 values,
     /// etc.).
-    pub fn interesting_datums(&self) -> impl Iterator<Item = Datum> {
+    pub fn interesting_datums(&self) -> impl Iterator<Item = Datum<'static>> {
         // TODO: Is there a better way than packing everything into Lazys and
         // Rows? `&[Datum::X(x)]` doesn't seem to work because some Datum
         // variants need to call non-const functions to construct themselves.

--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -1,0 +1,137 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+# Verify filter pushdown information for various temporal filters.
+# For straightforward temporal filters like these, every column mentioned in the filter
+# should be present in the pushdown list.
+
+statement ok
+CREATE TABLE events (
+    content text,
+    insert_ms numeric,
+    delete_ms numeric
+);
+
+query T multiline
+EXPLAIN WITH(mfp_pushdown)
+SELECT count(*)
+FROM events
+WHERE mz_now() >= insert_ms
+  AND mz_now() < delete_ms;
+----
+Explained Query:
+  Return
+    Union
+      Get l0
+      Map (0)
+        Union
+          Negate
+            Project ()
+              Get l0
+          Constant
+            - ()
+  With
+    cte l0 =
+      Reduce aggregates=[count(*)]
+        Project ()
+          Filter (mz_now() < numeric_to_mz_timestamp(#2)) AND (mz_now() >= numeric_to_mz_timestamp(#1))
+            Get materialize.public.events
+
+Source materialize.public.events
+  filter=((mz_now() >= numeric_to_mz_timestamp(#1)) AND (mz_now() < numeric_to_mz_timestamp(#2)))
+  pushdown=(#1, #2)
+
+EOF
+
+query T multiline
+EXPLAIN WITH(mfp_pushdown)
+SELECT content, insert_ms
+FROM events
+-- The event should appear in only one interval of duration `10000`.
+-- The interval begins here ...
+WHERE mz_now() >= 10000 * (insert_ms / 10000)
+-- ... and ends here.
+  AND mz_now() < 10000 * (1 + insert_ms / 10000)
+----
+Explained Query:
+  Project (#0, #1)
+    Filter (mz_now() >= numeric_to_mz_timestamp((10000 * #3))) AND (mz_now() < numeric_to_mz_timestamp((10000 * (1 + #3))))
+      Map ((#1 / 10000))
+        Get materialize.public.events
+
+Source materialize.public.events
+  filter=((mz_now() < numeric_to_mz_timestamp((10000 * (1 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
+  map=((#1 / 10000))
+  pushdown=(#1)
+
+EOF
+
+query T multiline
+EXPLAIN WITH(mfp_pushdown)
+SELECT content, insert_ms
+FROM events
+-- The event should appear in `6` intervals each of width `10000`.
+-- The interval begins here ...
+WHERE mz_now() >= 10000 * (insert_ms / 10000)
+-- ... and ends here.
+  AND mz_now() < 6 * (10000 + insert_ms / 10000)
+----
+Explained Query:
+  Project (#0, #1)
+    Filter (mz_now() >= numeric_to_mz_timestamp((10000 * #3))) AND (mz_now() < numeric_to_mz_timestamp((6 * (10000 + #3))))
+      Map ((#1 / 10000))
+        Get materialize.public.events
+
+Source materialize.public.events
+  filter=((mz_now() < numeric_to_mz_timestamp((6 * (10000 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
+  map=((#1 / 10000))
+  pushdown=(#1)
+
+EOF
+
+query T multiline
+EXPLAIN WITH(mfp_pushdown)
+SELECT content, insert_ms
+FROM events
+-- The event should appear inside the interval that begins at
+-- `insert_ms` and ends at  `insert_ms + 30000`.
+-- The interval begins here ..
+WHERE mz_now() >= insert_ms
+-- ... and ends here.
+  AND mz_now() < insert_ms + 30000
+----
+Explained Query:
+  Project (#0, #1)
+    Filter (mz_now() >= numeric_to_mz_timestamp(#1)) AND (mz_now() < numeric_to_mz_timestamp((#1 + 30000)))
+      Get materialize.public.events
+
+Source materialize.public.events
+  filter=((mz_now() < numeric_to_mz_timestamp((#1 + 30000))) AND (mz_now() >= numeric_to_mz_timestamp(#1)))
+  pushdown=(#1)
+
+EOF
+
+query T multiline
+EXPLAIN WITH(mfp_pushdown)
+SELECT content, insert_ms, delete_ms
+FROM events
+WHERE mz_now() >= insert_ms + 60000
+  AND mz_now() < delete_ms + 60000;
+----
+Explained Query:
+  Filter (mz_now() < numeric_to_mz_timestamp((#2 + 60000))) AND (mz_now() >= numeric_to_mz_timestamp((#1 + 60000)))
+    Get materialize.public.events
+
+Source materialize.public.events
+  filter=((mz_now() >= numeric_to_mz_timestamp((#1 + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 60000))))
+  pushdown=(#1, #2)
+
+EOF


### PR DESCRIPTION
Includes:
- An abstract interpreter for `MirScalarExpr`, `ColumnSpecs`. This allows us to reason about the possible outputs of an expression, given constraints on the possible set of inputs. (While this does not depend on Persist, our representation of possible inputs and outputs are chosen to be exactly what is needed for MFP filter pushdown.)
- An implementation for the recently-added `mfp_pushdown` explain flag that uses the new machinery to generate more accurate explanations. (This also adds support for JSON output.)

### Motivation

Specified in https://github.com/MaterializeInc/materialize/pull/18007. [Deep link to the relevant section of the design.](https://github.com/pH14/materialize/blob/persist-design-doc-mfp/doc/developer/design/20230306_persist_mfp_pushdown.md#filtering-parts)

### Tips for reviewer

This is a large PR! You may want to go commit-by-commit. (I'm also happy to make changes that would make it easier to review, or to discuss elsewhere if you prefer.)

Relatively new to this part of the codebase; happy for feedback on style etc.

The usage of this code will be in a followup PR, and even then behind a feature flag. We plan to follow up with tests etc. that cover this code more thoroughly. For now I'm most interested to get alignment on the general approach.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
