### PR TITLE
compute: Document that subscribe results are sorted by time

### DIFF
--- a/src/adapter/src/subscribe.rs
+++ b/src/adapter/src/subscribe.rs
@@ -91,12 +91,7 @@ impl ActiveSubscribe {
                 updates,
             }) => {
                 match updates {
-                    Ok(mut rows) => {
-                        // Sort results by time. We use stable sort here because it will produce deterministic
-                        // results since the cursor will always produce rows in the same order.
-                        // TODO: Is sorting necessary?
-                        rows.sort_by_key(|(time, _, _)| *time);
-
+                    Ok(rows) => {
                         let rows = rows
                             .into_iter()
                             .map(|(time, row, diff)| {

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -104,10 +104,10 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// replica must emit [`Batch`] responses that cover the entire time interval from the
     /// minimum time until the subscribe advances to the empty frontier or is
     /// dropped. The time intervals of consecutive [`Batch`]es must be increasing, contiguous,
-    /// non-overlapping, and non-empty. All updates transmitted in a batch must be consolidated and
-    /// have times within that batch’s time interval. All updates' times must be greater than or
-    /// equal to `as_of`. The `upper` of the first [`Batch`] of a subscribe must not be less than
-    /// that subscribe's initial `as_of` frontier.
+    /// non-overlapping, and non-empty. All updates transmitted in a batch must be consolidated,
+    /// sorted by time, and have times within that batch’s time interval. All updates' times must
+    /// be greater than or equal to `as_of`. The `upper` of the first [`Batch`] of a subscribe must
+    /// not be less than that subscribe's initial `as_of` frontier.
     ///
     /// The replica must send [`DroppedAt`] responses if the subscribe was dropped in response to
     /// an [`AllowCompaction` command] that advanced its read frontier to the empty frontier. The


### PR DESCRIPTION
Today we call consolidate_updates in send_batch which sorts the updates by time. Since consolidating needs to fundamentally group by time this guarantee seems reasonable for compute to make

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Remove the TODO in the adapter's subscribe code that I'm deleting in this PR

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
