### PR TITLE
orchestrator-process: push removal of UDS sockets into Listener::bind

### DIFF
--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -518,14 +518,6 @@ impl NamespacedProcessOrchestrator {
             supervise_existing_process(&state_updater, &pid_file).await;
 
             loop {
-                for path in listen_addrs.values() {
-                    if let Err(e) = fs::remove_file(path).await {
-                        if e.kind() != io::ErrorKind::NotFound {
-                            warn!("unable to remove {path} while launching {full_id}-{i}: {e}")
-                        }
-                    }
-                }
-
                 let mut cmd = if command_wrapper.is_empty() {
                     let mut cmd = Command::new(&image);
                     cmd.args(&args);


### PR DESCRIPTION
The current approach to cleaning up UDS sockets from failed processes can result in `clusterd` processes getting wedged attempting to bind a UDS socket that already exists (#17845).

The issue was that the process orchestrator was responsible for cleaning up sockets only after a process failed. If a process had an internal retry loop that attempted to rebind to a UDS socket that it had previously bound, that bind attempt would fail.

This commit fixes the issue by having `Listener::bind` unlink any existing UDS socket, rather than the process orchestrator.

Fix #17845.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

@philip-stoev could you see if this fixes #17845? I don't have time to attempt the repro myself, I'm afraid. It seems like there is a release qualification job that might need to be reverted?

Also, as mentioned in that issue, it would be immensely helpful if you could enable `INFO` logs for environmentd in Zippy. It's very hard to debug this stuff without them.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
