### PR TITLE
doc/user: add documentation for JOIN ... USING ... AS

### DIFF
--- a/doc/user/content/transform-data/join.md
+++ b/doc/user/content/transform-data/join.md
@@ -47,6 +47,7 @@ _select\_stmt_ | A [`SELECT` statement](/sql/select).
 _table\_ref_ | The table expression you want to join, i.e. the right-hand table.
 _table\_func\_call_ | A call to a [table function](/sql/functions/#table-func).
 **USING (** _col\_ref..._ **)** | If the join condition does not require table-level qualification (i.e. joining tables on columns with the same name), the columns to join the tables on. For example, `USING (customer_id)`.
+_join\_using\_alias_ | A table alias for the join columns specified in the `USING` clause. The columns will remain referenceable by their original names. For example, given `lhs JOIN rhs USING (c) AS joint`, the column `c` will be referenceable as `lhs.c`, `rhs.c`, and `joint.c`.
 **ON** _expression_ | The condition on which to join the tables. For example `ON purchase.customer_id = customer.id`.
 _select&lowbar;pred_ | The remaining [`SELECT`](/sql/select) clauses you want to use, e.g. `...WHERE expr GROUP BY col_ref HAVING expr`.
 

--- a/doc/user/layouts/partials/sql-grammar/join-expr.svg
+++ b/doc/user/layouts/partials/sql-grammar/join-expr.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="675" height="377">
+<svg xmlns="http://www.w3.org/2000/svg" width="915" height="409">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="96" height="32"/>
@@ -75,30 +75,41 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="491" y="207">,</text>
-   <rect x="587" y="233" width="26" height="32" rx="10"/>
-   <rect x="585"
+   <rect x="607" y="265" width="40" height="32" rx="10"/>
+   <rect x="605"
+         y="263"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="615" y="283">AS</text>
+   <rect x="667" y="265" width="120" height="32"/>
+   <rect x="665" y="263" width="120" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="675" y="283">join_using_alias</text>
+   <rect x="827" y="233" width="26" height="32" rx="10"/>
+   <rect x="825"
          y="231"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="595" y="251">)</text>
-   <rect x="333" y="277" width="40" height="32" rx="10"/>
+   <text class="terminal" x="835" y="251">)</text>
+   <rect x="333" y="309" width="40" height="32" rx="10"/>
    <rect x="331"
-         y="275"
+         y="307"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="341" y="295">ON</text>
-   <rect x="393" y="277" width="92" height="32"/>
-   <rect x="391" y="275" width="92" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="401" y="295">expression</text>
-   <rect x="553" y="343" width="94" height="32"/>
-   <rect x="551" y="341" width="94" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="561" y="361">select_post</text>
+   <text class="terminal" x="341" y="327">ON</text>
+   <rect x="393" y="309" width="92" height="32"/>
+   <rect x="391" y="307" width="92" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="401" y="327">expression</text>
+   <rect x="793" y="375" width="94" height="32"/>
+   <rect x="791" y="373" width="94" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="801" y="393">select_post</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m96 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-146 66 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m68 0 h10 m0 0 h158 m-266 0 h20 m246 0 h20 m-286 0 q10 0 10 10 m266 0 q0 -10 10 -10 m-276 10 v24 m266 0 v-24 m-266 24 q0 10 10 10 m246 0 q10 0 10 -10 m-256 10 h10 m88 0 h10 m20 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m40 -76 h10 m52 0 h10 m0 0 h10 m78 0 h10 m0 0 h152 m-628 0 h20 m608 0 h20 m-648 0 q10 0 10 10 m628 0 q0 -10 10 -10 m-638 10 v144 m628 0 v-144 m-628 144 q0 10 10 10 m608 0 q10 0 10 -10 m-618 10 h10 m78 0 h10 m0 0 h10 m52 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m64 0 h10 m-104 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m84 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-84 0 h10 m24 0 h10 m0 0 h40 m20 44 h10 m26 0 h10 m-320 0 h20 m300 0 h20 m-340 0 q10 0 10 10 m320 0 q0 -10 10 -10 m-330 10 v24 m320 0 v-24 m-320 24 q0 10 10 10 m300 0 q10 0 10 -10 m-310 10 h10 m40 0 h10 m0 0 h10 m92 0 h10 m0 0 h128 m42 -208 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 274 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m3 0 h-3"/>
-   <polygon points="665 357 673 353 673 361"/>
-   <polygon points="665 357 657 353 657 361"/>
+         d="m17 17 h2 m0 0 h10 m96 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-146 66 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m68 0 h10 m0 0 h158 m-266 0 h20 m246 0 h20 m-286 0 q10 0 10 10 m266 0 q0 -10 10 -10 m-276 10 v24 m266 0 v-24 m-266 24 q0 10 10 10 m246 0 q10 0 10 -10 m-256 10 h10 m88 0 h10 m20 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m40 -76 h10 m52 0 h10 m0 0 h10 m78 0 h10 m0 0 h392 m-868 0 h20 m848 0 h20 m-888 0 q10 0 10 10 m868 0 q0 -10 10 -10 m-878 10 v144 m868 0 v-144 m-868 144 q0 10 10 10 m848 0 q10 0 10 -10 m-858 10 h10 m78 0 h10 m0 0 h10 m52 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m64 0 h10 m-104 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m84 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-84 0 h10 m24 0 h10 m0 0 h40 m40 44 h10 m0 0 h190 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v12 m220 0 v-12 m-220 12 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m40 0 h10 m0 0 h10 m120 0 h10 m20 -32 h10 m26 0 h10 m-560 0 h20 m540 0 h20 m-580 0 q10 0 10 10 m560 0 q0 -10 10 -10 m-570 10 v56 m560 0 v-56 m-560 56 q0 10 10 10 m540 0 q10 0 10 -10 m-550 10 h10 m40 0 h10 m0 0 h10 m92 0 h10 m0 0 h368 m42 -240 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 306 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m3 0 h-3"/>
+   <polygon points="905 389 913 385 913 393"/>
+   <polygon points="905 389 897 385 897 393"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -263,7 +263,7 @@ func_justify_interval ::=
   'justify_interval' '(' interval ')'
 join_expr ::=
     select_pred ('CROSS' | 'NATURAL' join_type?) 'JOIN' table_ref select_post
-	| select_pred join_type 'JOIN' table_ref ( 'USING' '(' ( ( col_ref ) ( ( ',' col_ref ) )* ) ')' | 'ON' expression ) select_post
+	| select_pred join_type 'JOIN' table_ref ( 'USING' '(' ( ( col_ref ) ( ( ',' col_ref ) )* ) ('AS' join_using_alias)? ')' | 'ON' expression ) select_post
 join_type ::=
     ( 'FULL' ( 'OUTER' |  ) | 'LEFT' ( 'OUTER' |  ) | 'RIGHT' ( 'OUTER' |  ) | 'INNER' | )
 jsonb_agg ::=


### PR DESCRIPTION
Added in #18793 to fix #16910.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR adds documentation for an existing feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
