### PR TITLE
Add kill switch to LaunchDarkly

### DIFF
--- a/src/adapter/src/config/mod.rs
+++ b/src/adapter/src/config/mod.rs
@@ -56,7 +56,7 @@ pub async fn system_parameter_sync(
         backend.pull(&mut params).await;
         let launchdarkly_killed =
             <bool as Value>::parse(VarInput::Flat(&params.get(LAUNCHDARKLY_KILL_SWITCH.name())))
-                .unwrap();
+                .expect("This is known to be a bool");
         if !launchdarkly_killed && frontend.pull(&mut params) {
             backend.push(&mut params).await;
         }

--- a/src/adapter/src/config/mod.rs
+++ b/src/adapter/src/config/mod.rs
@@ -10,7 +10,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use mz_sql::session::vars::{Value, Var, VarInput, LAUNCHDARKLY_KILL_SWITCH};
+use mz_sql::session::vars::{Value, Var, VarInput, ENABLE_LAUNCHDARKLY};
 use tokio::time;
 
 mod backend;
@@ -54,10 +54,10 @@ pub async fn system_parameter_sync(
     loop {
         interval.tick().await;
         backend.pull(&mut params).await;
-        let launchdarkly_killed =
-            <bool as Value>::parse(VarInput::Flat(&params.get(LAUNCHDARKLY_KILL_SWITCH.name())))
+        let launchdarkly_enabled =
+            <bool as Value>::parse(VarInput::Flat(&params.get(ENABLE_LAUNCHDARKLY.name())))
                 .expect("This is known to be a bool");
-        if !launchdarkly_killed && frontend.pull(&mut params) {
+        if launchdarkly_enabled && frontend.pull(&mut params) {
             backend.push(&mut params).await;
         }
     }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -646,6 +646,17 @@ pub static CONFIG_HAS_SYNCED_ONCE: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
+/// Boolean flag indicating whether to completely disable syncing from
+/// LaunchDarkly.  Used as an emergency measure to still be able to
+/// alter parameters while LD is broken.
+pub static LAUNCHDARKLY_KILL_SWITCH: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("launchdarkly_kill_switch"),
+    value: &false,
+    description: "Boolean flag indicating whether flag synchronization from LaunchDarkly should be paused (Materialize).",
+    internal: true,
+    safe: true,
+};
+
 /// Feature flag indicating whether `WITH MUTUALLY RECURSIVE` queries are enabled.
 static ENABLE_WITH_MUTUALLY_RECURSIVE: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("enable_with_mutually_recursive"),
@@ -1475,6 +1486,7 @@ impl Default for SystemVars {
             .with_var(&PG_REPLICATION_KEEPALIVES_INTERVAL)
             .with_var(&PG_REPLICATION_KEEPALIVES_RETRIES)
             .with_var(&PG_REPLICATION_TCP_USER_TIMEOUT)
+            .with_var(&LAUNCHDARKLY_KILL_SWITCH)
     }
 }
 
@@ -1609,6 +1621,12 @@ impl SystemVars {
     /// Returns the `config_has_synced_once` configuration parameter.
     pub fn config_has_synced_once(&self) -> bool {
         *self.expect_value(&CONFIG_HAS_SYNCED_ONCE)
+    }
+
+    /// Returns the value of the `launchdarkly_kill_switch`
+    /// configuration parameter.
+    pub fn launchdarkly_kill_switch(&self) -> bool {
+        *self.expect_value(&LAUNCHDARKLY_KILL_SWITCH)
     }
 
     /// Returns the value of the `max_aws_privatelink_connections` configuration parameter.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -646,13 +646,13 @@ pub static CONFIG_HAS_SYNCED_ONCE: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
-/// Boolean flag indicating whether to completely disable syncing from
-/// LaunchDarkly.  Used as an emergency measure to still be able to
-/// alter parameters while LD is broken.
-pub static LAUNCHDARKLY_KILL_SWITCH: ServerVar<bool> = ServerVar {
+/// Boolean flag indicating whether to enable syncing from
+/// LaunchDarkly. Can be turned off as an emergency measure to still
+/// be able to alter parameters while LD is broken.
+pub static ENABLE_LAUNCHDARKLY: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("launchdarkly_kill_switch"),
-    value: &false,
-    description: "Boolean flag indicating whether flag synchronization from LaunchDarkly should be paused (Materialize).",
+    value: &true,
+    description: "Boolean flag indicating whether flag synchronization from LaunchDarkly should be enabled (Materialize).",
     internal: true,
     safe: true,
 };
@@ -1486,7 +1486,7 @@ impl Default for SystemVars {
             .with_var(&PG_REPLICATION_KEEPALIVES_INTERVAL)
             .with_var(&PG_REPLICATION_KEEPALIVES_RETRIES)
             .with_var(&PG_REPLICATION_TCP_USER_TIMEOUT)
-            .with_var(&LAUNCHDARKLY_KILL_SWITCH)
+            .with_var(&ENABLE_LAUNCHDARKLY)
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1623,12 +1623,6 @@ impl SystemVars {
         *self.expect_value(&CONFIG_HAS_SYNCED_ONCE)
     }
 
-    /// Returns the value of the `launchdarkly_kill_switch`
-    /// configuration parameter.
-    pub fn launchdarkly_kill_switch(&self) -> bool {
-        *self.expect_value(&LAUNCHDARKLY_KILL_SWITCH)
-    }
-
     /// Returns the value of the `max_aws_privatelink_connections` configuration parameter.
     pub fn max_aws_privatelink_connections(&self) -> u32 {
         *self.expect_value(&MAX_AWS_PRIVATELINK_CONNECTIONS)

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -650,7 +650,7 @@ pub static CONFIG_HAS_SYNCED_ONCE: ServerVar<bool> = ServerVar {
 /// LaunchDarkly. Can be turned off as an emergency measure to still
 /// be able to alter parameters while LD is broken.
 pub static ENABLE_LAUNCHDARKLY: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("launchdarkly_kill_switch"),
+    name: UncasedStr::new("enable_launchdarkly"),
     value: &true,
     description: "Boolean flag indicating whether flag synchronization from LaunchDarkly should be enabled (Materialize).",
     internal: true,

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -148,6 +148,7 @@ pub struct State {
     _tempfile: Option<tempfile::TempDir>,
     default_timeout: Duration,
     timeout: Duration,
+    
     max_tries: usize,
     initial_backoff: Duration,
     backoff_factor: f64,

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -148,7 +148,6 @@ pub struct State {
     _tempfile: Option<tempfile::TempDir>,
     default_timeout: Duration,
     timeout: Duration,
-
     max_tries: usize,
     initial_backoff: Duration,
     backoff_factor: f64,

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -148,7 +148,7 @@ pub struct State {
     _tempfile: Option<tempfile::TempDir>,
     default_timeout: Duration,
     timeout: Duration,
-    
+
     max_tries: usize,
     initial_backoff: Duration,
     backoff_factor: f64,

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -161,14 +161,16 @@ def workflow_default(c: Composition) -> None:
         # Assert that max_result_size is 4 GiB - 1 byte.
         c.testdrive("\n".join(["> SHOW max_result_size", "4294967295"]))
 
+        def sys(command: str):
+            c.testdrive("\n".join(['$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr', '$ postgres-execute connection=mz_system', command]))
         # Assert that we can turn off synchronization
-        c.testdrive("> ALTER SYSTEM SET launchdarkly_kill_switch=on")
-        c.testdrive("> ALTER SYSTEM SET max_result_size=1234")
+        sys("> ALTER SYSTEM SET launchdarkly_kill_switch=on")
+        sys("> ALTER SYSTEM SET max_result_size=1234")
         # The new value should not be replaced, even after 15 seconds
         sleep(15)
         c.testdrive("\n".join(["> SHOW max_result_size", "1234"]))
         # The value should be reset after we turn the kill switch back off
-        c.testdrive("> ALTER SYSTEM SET launchdarkly_kill_switch=on")
+        sys("> ALTER SYSTEM SET launchdarkly_kill_switch=on")
         c.testdrive("\n".join(["> SHOW max_result_size", "4294967295"]))
         
         # Remove custom targeting.

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -161,7 +161,7 @@ def workflow_default(c: Composition) -> None:
         # Assert that max_result_size is 4 GiB - 1 byte.
         c.testdrive("\n".join(["> SHOW max_result_size", "4294967295"]))
 
-        def sys(command: str):
+        def sys(command: str) -> None:
             c.testdrive(
                 "\n".join(
                     [

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -164,13 +164,13 @@ def workflow_default(c: Composition) -> None:
         def sys(command: str):
             c.testdrive("\n".join(['$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}', '$ postgres-execute connection=mz_system', command]))
         # Assert that we can turn off synchronization
-        sys("> ALTER SYSTEM SET launchdarkly_kill_switch=on")
+        sys("> ALTER SYSTEM SET enable_launchdarkly=off")
         sys("> ALTER SYSTEM SET max_result_size=1234")
         # The new value should not be replaced, even after 15 seconds
         sleep(15)
         c.testdrive("\n".join(["> SHOW max_result_size", "1234"]))
         # The value should be reset after we turn the kill switch back off
-        sys("> ALTER SYSTEM SET launchdarkly_kill_switch=on")
+        sys("> ALTER SYSTEM SET enable_launchdarkly=on")
         c.testdrive("\n".join(["> SHOW max_result_size", "4294967295"]))
         
         # Remove custom targeting.

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -164,13 +164,13 @@ def workflow_default(c: Composition) -> None:
         def sys(command: str):
             c.testdrive("\n".join(['$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}', '$ postgres-execute connection=mz_system', command]))
         # Assert that we can turn off synchronization
-        sys("> ALTER SYSTEM SET enable_launchdarkly=off")
-        sys("> ALTER SYSTEM SET max_result_size=1234")
+        sys("ALTER SYSTEM SET enable_launchdarkly=off")
+        sys("ALTER SYSTEM SET max_result_size=1234")
         # The new value should not be replaced, even after 15 seconds
         sleep(15)
         c.testdrive("\n".join(["> SHOW max_result_size", "1234"]))
         # The value should be reset after we turn the kill switch back off
-        sys("> ALTER SYSTEM SET enable_launchdarkly=on")
+        sys("ALTER SYSTEM SET enable_launchdarkly=on")
         c.testdrive("\n".join(["> SHOW max_result_size", "4294967295"]))
         
         # Remove custom targeting.

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -162,7 +162,7 @@ def workflow_default(c: Composition) -> None:
         c.testdrive("\n".join(["> SHOW max_result_size", "4294967295"]))
 
         def sys(command: str):
-            c.testdrive("\n".join(['$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr', '$ postgres-execute connection=mz_system', command]))
+            c.testdrive("\n".join(['$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}', '$ postgres-execute connection=mz_system', command]))
         # Assert that we can turn off synchronization
         sys("> ALTER SYSTEM SET launchdarkly_kill_switch=on")
         sys("> ALTER SYSTEM SET max_result_size=1234")

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -162,7 +162,16 @@ def workflow_default(c: Composition) -> None:
         c.testdrive("\n".join(["> SHOW max_result_size", "4294967295"]))
 
         def sys(command: str):
-            c.testdrive("\n".join(['$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}', '$ postgres-execute connection=mz_system', command]))
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
+                        "$ postgres-execute connection=mz_system",
+                        command,
+                    ]
+                )
+            )
+
         # Assert that we can turn off synchronization
         sys("ALTER SYSTEM SET enable_launchdarkly=off")
         sys("ALTER SYSTEM SET max_result_size=1234")
@@ -172,7 +181,7 @@ def workflow_default(c: Composition) -> None:
         # The value should be reset after we turn the kill switch back off
         sys("ALTER SYSTEM SET enable_launchdarkly=on")
         c.testdrive("\n".join(["> SHOW max_result_size", "4294967295"]))
-        
+
         # Remove custom targeting.
         ld_client.update_targeting(
             LD_FEATURE_FLAG_KEY,


### PR DESCRIPTION
This mitigates an ongoing issue (https://github.com/MaterializeInc/materialize/issues/18941) with LaunchDarkly discovered during the on-call, which causes us not to be able to address issues without rebooting.

While waiting for that issue to be resolved, this will allow us to completely stop syncing from LaunchDarkly, and use `ALTER SYSTEM` to set flags to whatever we want.