### PR TITLE
Fix `LetRec` lowering when inserting an `ArrangeBy`

### DIFF
--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -27,9 +27,9 @@ use mz_expr::{
 use mz_ore::soft_panic_or_log;
 use mz_ore::str::Indent;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
-use mz_repr::{Diff, GlobalId, Row};
-use mz_repr::explain::{DummyHumanizer, ExplainConfig, ExprHumanizer, PlanRenderingContext};
 use mz_repr::explain::text::text_string_at;
+use mz_repr::explain::{DummyHumanizer, ExplainConfig, ExprHumanizer, PlanRenderingContext};
+use mz_repr::{Diff, GlobalId, Row};
 
 use crate::plan::join::{DeltaJoinPlan, JoinPlan, LinearJoinPlan};
 use crate::plan::reduce::{KeyValPlan, ReducePlan};
@@ -1115,11 +1115,29 @@ impl<T: timely::progress::Timestamp> Plan<T> {
 
                         let forms = AvailableCollections::new_raw();
 
-                        lir_value = Plan::ArrangeBy {
-                            input: Box::new(lir_value),
-                            forms,
-                            input_key,
-                            input_mfp,
+                        // We just want to insert an `ArrangeBy` to form an unarranged collection,
+                        // but there is a complication: We shouldn't break the invariant (created by
+                        // `NormalizeLets`, and relied upon by the rendering) that there isn't
+                        // anything between two `LetRec`s. So if `lir_value` is itself a `LetRec`,
+                        // then we insert the `ArrangeBy` on the `body` of the inner `LetRec`,
+                        // instead of on top of the inner `LetRec`.
+                        lir_value = match lir_value {
+                            Plan::LetRec { ids, values, body } => Plan::LetRec {
+                                ids,
+                                values,
+                                body: Box::new(Plan::ArrangeBy {
+                                    input: body,
+                                    forms,
+                                    input_key,
+                                    input_mfp,
+                                }),
+                            },
+                            lir_value => Plan::ArrangeBy {
+                                input: Box::new(lir_value),
+                                forms,
+                                input_key,
+                                input_mfp,
+                            },
                         };
                         v_keys.raw = true;
                     }

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -332,3 +332,38 @@ SELECT round, COUNT(*) FROM (
 GROUP BY round;
 ----
 0  10
+
+## Regression test for https://github.com/MaterializeInc/materialize/issues/18949
+## Test the situation when a WMR cte has an inner WMR whose body ends with an arrangement.
+query I
+WITH MUTUALLY RECURSIVE
+  cnt (i int) AS (
+    (WITH MUTUALLY RECURSIVE
+       cnt (i int) AS (
+         SELECT 1 AS i
+         UNION
+         SELECT i+1 FROM cnt WHERE i < 3)
+       SELECT i FROM cnt
+    )
+    UNION
+    SELECT i+100 FROM cnt WHERE i < 500)
+SELECT i FROM cnt;
+----
+1
+2
+3
+301
+302
+303
+101
+102
+103
+401
+402
+403
+201
+202
+203
+501
+502
+503


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/18949: Before adding the `ArrangeBy`, we check whether `lir_value` is a `LetRec`, and if yes, then we put the `ArrangeBy` on top of its body, instead of on top of the whole `LetRec`.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/18949

### Tips for reviewer

The first commit adds the same pretty-printing convenience methods to LIR `Plan` that `MirRelationExpr` has. (I used these now while debugging.)

The second commit has the actual fix.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
