### PR TITLE
cloudtest: plumb coverage toggle as parameter rather than env var

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -29,7 +29,7 @@ from kubernetes.client.exceptions import ApiException
 from kubernetes.config import new_client_from_config  # type: ignore
 from pg8000 import Connection, Cursor
 
-from materialize import ROOT, mzbuild, ui
+from materialize import ROOT, mzbuild
 
 
 class K8sResource:
@@ -63,12 +63,16 @@ class K8sResource:
         assert False
 
     def image(
-        self, service: str, tag: Optional[str] = None, release_mode: bool = True
+        self,
+        service: str,
+        tag: Optional[str],
+        *,
+        release_mode: bool,
+        coverage: bool,
     ) -> str:
         if tag is not None:
             return f"materialize/{service}:{tag}"
         else:
-            coverage = ui.env_is_truthy("CI_COVERAGE_ENABLED")
             repo = mzbuild.Repository(
                 ROOT, release_mode=release_mode, coverage=coverage
             )

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -69,12 +69,15 @@ class MaterializedAliasService(K8sService):
 class EnvironmentdStatefulSet(K8sStatefulSet):
     def __init__(
         self,
-        tag: Optional[str] = None,
-        release_mode: bool = True,
+        *,
+        tag: Optional[str],
+        release_mode: bool,
+        coverage: bool,
         log_filter: Optional[str] = None,
     ) -> None:
         self.tag = tag
         self.release_mode = release_mode
+        self.coverage = coverage
         self.log_filter = log_filter
         self.env: Dict[str, str] = {}
         super().__init__()
@@ -141,19 +144,37 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
         if self._meets_minimum_version("0.38.0"):
             args += [
                 "--clusterd-image",
-                self.image("clusterd", tag=self.tag, release_mode=self.release_mode),
+                self.image(
+                    "clusterd",
+                    tag=self.tag,
+                    release_mode=self.release_mode,
+                    coverage=self.coverage,
+                ),
             ]
         else:
             args += [
                 "--storaged-image",
-                self.image("storaged", tag=self.tag, release_mode=self.release_mode),
+                self.image(
+                    "storaged",
+                    tag=self.tag,
+                    release_mode=self.release_mode,
+                    coverage=self.coverage,
+                ),
                 "--computed-image",
-                self.image("computed", tag=self.tag, release_mode=self.release_mode),
+                self.image(
+                    "computed",
+                    tag=self.tag,
+                    release_mode=self.release_mode,
+                    coverage=self.coverage,
+                ),
             ]
         container = V1Container(
             name="environmentd",
             image=self.image(
-                "environmentd", tag=self.tag, release_mode=self.release_mode
+                "environmentd",
+                tag=self.tag,
+                release_mode=self.release_mode,
+                coverage=self.coverage,
             ),
             args=args,
             env=env,

--- a/misc/python/materialize/cloudtest/k8s/postgres.py
+++ b/misc/python/materialize/cloudtest/k8s/postgres.py
@@ -50,7 +50,7 @@ class PostgresDeployment(K8sDeployment):
         ports = [V1ContainerPort(container_port=5432, name="sql")]
         container = V1Container(
             name="postgres",
-            image=self.image("postgres", tag=None, release_mode=True),
+            image=self.image("postgres", tag=None, release_mode=True, coverage=False),
             args=["-c", "wal_level=logical"],
             env=env,
             ports=ports,

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -18,7 +18,9 @@ from materialize.cloudtest.wait import wait
 
 
 class Testdrive(K8sPod):
-    def __init__(self, release_mode: bool, aws_region: Optional[str] = None) -> None:
+    def __init__(
+        self, release_mode: bool, coverage: bool, aws_region: Optional[str] = None
+    ) -> None:
         self.aws_region = aws_region
 
         metadata = V1ObjectMeta(name="testdrive")
@@ -35,7 +37,11 @@ class Testdrive(K8sPod):
 
         container = V1Container(
             name="testdrive",
-            image=self.image("testdrive", release_mode=release_mode),
+            # NOTE(benesch): is it intentional that this does not pass through
+            # the tag from the caller?
+            image=self.image(
+                "testdrive", tag=None, release_mode=release_mode, coverage=coverage
+            ),
             command=["sleep", "infinity"],
             env=env,
         )

--- a/test/cloudtest/conftest.py
+++ b/test/cloudtest/conftest.py
@@ -9,6 +9,8 @@
 
 from typing import TYPE_CHECKING, Any
 
+from materialize import ui
+
 if TYPE_CHECKING:
     from _pytest.config import Config
 
@@ -28,6 +30,7 @@ def pytest_configure(config: "Config") -> None:
 def mz(pytestconfig: pytest.Config) -> MaterializeApplication:
     return MaterializeApplication(
         release_mode=(not pytestconfig.getoption("dev")),
+        coverage=(pytestconfig.getoption("coverage")),
         aws_region=pytestconfig.getoption("aws_region"),
         log_filter=pytestconfig.getoption("log_filter"),
     )
@@ -40,6 +43,11 @@ def aws_region(pytestconfig: pytest.Config) -> Any:
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--dev", action="store_true")
+    parser.addoption(
+        "--coverage",
+        action="store_true",
+        default=ui.env_is_truthy("CI_COVERAGE_ENABLED"),
+    )
     parser.addoption(
         "--aws-region",
         action="store",

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -66,10 +66,15 @@ class CloudtestUpgrade(Scenario):
 
 
 @pytest.mark.long
-def test_upgrade(aws_region: Optional[str]) -> None:
+def test_upgrade(default_mz: MaterializeApplication, aws_region: Optional[str]) -> None:
     """Test upgrade from the last released verison to the current source by running all the Platform Checks"""
 
-    mz = MaterializeApplication(tag=LAST_RELEASED_VERSION, aws_region=aws_region)
+    mz = MaterializeApplication(
+        release_mode=default_mz.release_mode,
+        coverage=default_mz.coverage,
+        tag=LAST_RELEASED_VERSION,
+        aws_region=aws_region,
+    )
     wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
 
     executor = CloudtestExecutor(application=mz)


### PR DESCRIPTION
Rather than having various components of cloudtest check the CI_COVERAGE_ENABLED environment variable, expose a command line parameter named `--coverage` whose value is plumbed through all cloudtest components that need access to this toggle. This matches how we handle `release_mode` in cloudtest, how we handle `coverage` in mzbuild, and is generally in line with our philosophy of only using environment variables at the edge of each tool.

Extends #18939.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

I didn't test this locally, so we should verify in Ci that cloudtest coverage builds are still working.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
