### PR TITLE
cloudtest: Fortify test_missing_secret

### DIFF
--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -175,8 +175,9 @@ def test_missing_secret(mz: MaterializeApplication) -> None:
     )[0]
     pod_name = cluster_pod_name(cluster_id, replica_id, 0)
 
-    mz.kubectl("exec", pod_name, "--", "bash", "-c", "kill -9 `pidof clusterd`")
+    # wait for the cluster to be ready first before attempting to kill it
     wait(condition="condition=Ready", resource=f"{pod_name}")
+    mz.kubectl("exec", pod_name, "--", "bash", "-c", "kill -9 `pidof clusterd`")
 
     mz.testdrive.run(
         input=dedent(


### PR DESCRIPTION
The test was not properly waiting for a K8s pod to become ready before attempting to call kubectl exec on it.

Fixes #18957

### Motivation

  * This PR fixes a previously unreported bug.
CI was failing, especially when run under coverage where a new persistent volume claim is being created.