### PR TITLE
storage: move `responsible_for` fn to a better place

### DIFF
--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -90,20 +90,14 @@ impl SourceRender for LoadGeneratorSourceConnection {
         Stream<G, (usize, HealthStatusUpdate)>,
         Rc<dyn Any>,
     ) {
-        let mut builder = AsyncOperatorBuilder::new(config.name, scope.clone());
+        let mut builder = AsyncOperatorBuilder::new(config.name.clone(), scope.clone());
 
         let (mut data_output, stream) = builder.new_output();
 
         let button = builder.build(move |caps| async move {
             let mut cap = caps.into_element();
 
-            let responsible = crate::source::responsible_for(
-                &config.id,
-                config.worker_id,
-                config.worker_count,
-                (),
-            );
-            if !responsible {
+            if !config.responsible_for(()) {
                 return;
             }
 

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -91,11 +91,7 @@ pub struct KafkaSourceReader {
 }
 
 pub struct KafkaOffsetCommiter {
-    source_id: GlobalId,
-    /// Worker ID
-    worker_id: usize,
-    /// Total count of workers
-    worker_count: usize,
+    config: RawSourceCreationConfig,
     topic_name: String,
     consumer: Arc<BaseConsumer<BrokerRewritingClientContext<GlueConsumerContext>>>,
 }
@@ -226,14 +222,7 @@ impl SourceRender for KafkaSourceConnection {
             let mut start_offsets: BTreeMap<_, i64> = self
                 .start_offsets
                 .into_iter()
-                .filter(|(pid, _offset)| {
-                    crate::source::responsible_for(
-                        &config.id,
-                        config.worker_id,
-                        config.worker_count,
-                        pid,
-                    )
-                })
+                .filter(|(pid, _offset)| config.responsible_for(pid))
                 .map(|(k, v)| (k, v))
                 .collect();
 
@@ -248,12 +237,7 @@ impl SourceRender for KafkaSourceConnection {
             for ts in resume_upper.elements() {
                 if let Some(pid) = ts.partition() {
                     max_pid = std::cmp::max(max_pid, Some(*pid));
-                    if crate::source::responsible_for(
-                        &config.id,
-                        config.worker_id,
-                        config.worker_count,
-                        pid,
-                    ) {
+                    if config.responsible_for(pid) {
                         let restored_offset = i64::try_from(ts.timestamp().offset)
                             .expect("restored kafka offsets must fit into i64");
                         if let Some(start_offset) = start_offsets.get_mut(pid) {
@@ -377,7 +361,7 @@ impl SourceRender for KafkaSourceConnection {
                 include_headers: self.include_headers.is_some(),
                 _metadata_thread_handle: metadata_thread_handle,
                 partition_metrics: KafkaPartitionMetrics::new(
-                    config.base_metrics,
+                    config.base_metrics.clone(),
                     partition_ids,
                     topic.clone(),
                     config.id,
@@ -387,9 +371,7 @@ impl SourceRender for KafkaSourceConnection {
             };
 
             let offset_committer = KafkaOffsetCommiter {
-                source_id: config.id,
-                worker_id: config.worker_id,
-                worker_count: config.worker_count,
+                config: config.clone(),
                 topic_name: topic.clone(),
                 consumer,
             };
@@ -417,13 +399,7 @@ impl SourceRender for KafkaSourceConnection {
                     let mut max_pid = None;
                     for pid in partitions {
                         max_pid = std::cmp::max(max_pid, Some(pid));
-                        let is_responsible = crate::source::responsible_for(
-                            &reader.id,
-                            reader.worker_id,
-                            reader.worker_count,
-                            pid,
-                        );
-                        if is_responsible {
+                        if config.responsible_for(pid) {
                             reader.ensure_partition(pid);
                             let part_min_ts = Partitioned::with_partition(pid, MzOffset::from(0));
                             reader
@@ -559,12 +535,7 @@ impl KafkaOffsetCommiter {
         let mut offsets = vec![];
         for ts in frontier.iter() {
             if let Some(pid) = ts.partition() {
-                if crate::source::responsible_for(
-                    &self.source_id,
-                    self.worker_id,
-                    self.worker_count,
-                    pid,
-                ) {
+                if self.config.responsible_for(pid) {
                     offsets.push((pid.clone(), *ts.timestamp()));
                 }
             }
@@ -580,7 +551,7 @@ impl KafkaOffsetCommiter {
             }
             let consumer = Arc::clone(&self.consumer);
             mz_ore::task::spawn_blocking(
-                || format!("source({}) kafka offset commit", self.source_id),
+                || format!("source({}) kafka offset commit", self.config.id),
                 move || consumer.commit(&tpl, CommitMode::Sync),
             )
             .await??;

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -25,11 +25,6 @@
 // https://github.com/tokio-rs/prost/issues/237
 #![allow(missing_docs)]
 
-use differential_dataflow::Hashable;
-
-use mz_ore::cast::CastFrom;
-use mz_repr::GlobalId;
-
 use crate::source::types::SourceMessage;
 use crate::source::types::SourceReaderError;
 
@@ -50,15 +45,3 @@ pub use postgres::PostgresSourceReader;
 pub use source_reader_pipeline::create_raw_source;
 pub(crate) use source_reader_pipeline::health_operator;
 pub use source_reader_pipeline::{RawSourceCreationConfig, SourceCreationParams};
-
-/// Returns true if the given source id/worker id is responsible for handling the given
-/// partition.
-pub fn responsible_for<P: Hashable>(
-    _source_id: &GlobalId,
-    worker_id: usize,
-    worker_count: usize,
-    pid: P,
-) -> bool {
-    // Distribute partitions equally amongst workers.
-    (usize::cast_from(pid.hashed().into()) % worker_count) == worker_id
-}

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -294,14 +294,7 @@ impl SourceRender for PostgresSourceConnection {
             let mut data_capability = capabilities.pop().unwrap();
             assert!(capabilities.is_empty());
 
-            let active_read_worker = crate::source::responsible_for(
-                &config.id,
-                config.worker_id,
-                config.worker_count,
-                (),
-            );
-
-            if !active_read_worker {
+            if !config.responsible_for(()) {
                 return;
             }
 


### PR DESCRIPTION
### Motivation

Better ergonomics but also fixes an important bug in `responsible_for` (that I think I introduced during the time that we had some single threaded shenanigans) where no matter the source id, all partitions with the same value were being ingested by the same worker.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
