### PR TITLE
pg-cdc: Test that the Pg snapshot is not re-ingested on restart

### DIFF
--- a/test/pg-cdc-resumption/configure-materalize.td
+++ b/test/pg-cdc-resumption/configure-materalize.td
@@ -10,11 +10,11 @@
 > DROP SECRET IF EXISTS pgpass CASCADE;
 > DROP CONNECTION IF EXISTS pg CASCADE;
 
-> CREATE SECRET pgpass AS 'postgres'
+> CREATE SECRET pgpass AS 'materialize'
 > CREATE CONNECTION pg TO POSTGRES (
     HOST toxiproxy,
     DATABASE postgres,
-    USER postgres,
+    USER materialize,
     PASSWORD SECRET pgpass
   );
 

--- a/test/pg-cdc-resumption/postgres-disable-select-permission.td
+++ b/test/pg-cdc-resumption/postgres-disable-select-permission.td
@@ -8,8 +8,4 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-CREATE USER materialize PASSWORD 'materialize';
-ALTER USER materialize REPLICATION;
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO materialize;
-
-CREATE PUBLICATION mz_source FOR ALL TABLES;
+REVOKE SELECT ON ALL TABLES IN SCHEMA "public" FROM materialize;


### PR DESCRIPTION
* Confirm that Mz does not re-ingest the entire Pg snapshot on restart by revoking its SELECT privilege before said restart.

* Run each scenario in isolation: always start with c.down()

* Have Mz use a non-privileged user to connect to Postgres

Relates to #13724

  * This PR adds a known-desirable feature.