### PR TITLE
sql: Populate pg_auth_members

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2584,12 +2584,16 @@ FROM (VALUES
 pub const PG_AUTH_MEMBERS: BuiltinView = BuiltinView {
     name: "pg_auth_members",
     schema: PG_CATALOG_SCHEMA,
-    sql: "CREATE VIEW pg_catalog.pg_auth_members AS SELECT
-    NULL::pg_catalog.oid as roleid,
-    NULL::pg_catalog.oid as member,
-    NULL::pg_catalog.oid as grantor,
-    NULL::pg_catalog.bool as admin_option
-WHERE false",
+    sql: "CREATE VIEW pg_catalog.pg_auth_members AS SELECT  
+    role.oid AS roleid,
+    member.oid AS member,
+    grantor.oid AS grantor,
+    -- Materialize hasn't implemented admin_option.
+    false as admin_option
+FROM mz_role_members membership
+LEFT JOIN mz_roles role ON membership.role_id = role.id
+LEFT JOIN mz_roles member ON membership.member = member.id
+LEFT JOIN mz_roles grantor ON membership.grantor = grantor.id",
 };
 
 pub const MZ_PEEK_DURATIONS_HISTOGRAM_PER_WORKER: BuiltinView = BuiltinView {

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2591,9 +2591,9 @@ pub const PG_AUTH_MEMBERS: BuiltinView = BuiltinView {
     -- Materialize hasn't implemented admin_option.
     false as admin_option
 FROM mz_role_members membership
-LEFT JOIN mz_roles role ON membership.role_id = role.id
-LEFT JOIN mz_roles member ON membership.member = member.id
-LEFT JOIN mz_roles grantor ON membership.grantor = grantor.id",
+JOIN mz_roles role ON membership.role_id = role.id
+JOIN mz_roles member ON membership.member = member.id
+JOIN mz_roles grantor ON membership.grantor = grantor.id",
 };
 
 pub const MZ_PEEK_DURATIONS_HISTOGRAM_PER_WORKER: BuiltinView = BuiltinView {

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2584,7 +2584,7 @@ FROM (VALUES
 pub const PG_AUTH_MEMBERS: BuiltinView = BuiltinView {
     name: "pg_auth_members",
     schema: PG_CATALOG_SCHEMA,
-    sql: "CREATE VIEW pg_catalog.pg_auth_members AS SELECT  
+    sql: "CREATE VIEW pg_catalog.pg_auth_members AS SELECT
     role.oid AS roleid,
     member.oid AS member,
     grantor.oid AS grantor,

--- a/test/sqllogictest/role_membership.slt
+++ b/test/sqllogictest/role_membership.slt
@@ -306,6 +306,31 @@ query TTT
 SELECT * FROM role_members
 ----
 
+# Test pg_auth_members
+
+statement ok
+GRANT group3 TO joe, group1, group2
+
+statement ok
+GRANT group1 TO joe
+
+query I
+SELECT COUNT(*) FROM pg_auth_members
+----
+4
+
+query TTTB
+SELECT role.name, member.name, grantor.name, members.admin_option
+FROM pg_auth_members members
+LEFT JOIN mz_roles role ON members.roleid = role.oid
+LEFT JOIN mz_roles member ON members.member = member.oid
+LEFT JOIN mz_roles grantor ON members.grantor = grantor.oid
+----
+group1  joe     mz_system  false
+group3  joe     mz_system  false
+group3  group1  mz_system  false
+group3  group2  mz_system  false
+
 # Disable RBAC checks
 
 simple conn=mz_system,user=mz_system

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -153,6 +153,6 @@ name                nullable    type
 name                nullable    type
 ------------------------------------------------------------
  roleid             false       oid
- member           false       oid
+ member             false       oid
  grantor            false       oid
  admin_option       false       boolean


### PR DESCRIPTION
Previously the pg_auth_members catalog table was always empty. This commit populates the table so that it contains actual rows for all the role memberships in the system.

Fixes #18971

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release will populate the `pg_auth_members` catalog tables.
