### PR TITLE
adapter: Update attributes for linked clusters

### DIFF
--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -209,7 +209,7 @@ fn generate_required_plan_attribute(plan: &Plan) -> Option<Attribute> {
         }
         Plan::CreateSource(CreateSourcePlan { cluster_config, .. })
         | Plan::CreateSink(CreateSinkPlan { cluster_config, .. }) => {
-            if cluster_config.will_create_new_cluster() {
+            if cluster_config.cluster_id().is_none() {
                 Some(Attribute::CreateCluster)
             } else {
                 None

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -218,7 +218,7 @@ fn generate_required_plan_attribute(plan: &Plan) -> Option<Attribute> {
         Plan::CreateSources(plans) => {
             if plans
                 .iter()
-                .any(|plan| plan.plan.cluster_config.will_create_new_cluster())
+                .any(|plan| plan.plan.cluster_config.cluster_id().is_none())
             {
                 Some(Attribute::CreateCluster)
             } else {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -49,7 +49,6 @@ use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::role_id::RoleId;
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
 use mz_sql_parser::ast::TransactionIsolationLevel;
-use mz_storage_client::types::instances::StorageInstanceId;
 use mz_storage_client::types::sinks::{SinkEnvelope, StorageSinkConnectionBuilder};
 use mz_storage_client::types::sources::{SourceDesc, Timeline};
 pub use optimize::OptimizerConfig;

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -232,7 +232,7 @@ impl Plan {
             Plan::CreateCluster(_) => "create cluster",
             Plan::CreateClusterReplica(_) => "create cluster replica",
             Plan::CreateSource(_) => "create source",
-            Plan::CreateSources(_) => "create sources",
+            Plan::CreateSources(_) => "create source",
             Plan::CreateSecret(_) => "create secret",
             Plan::CreateSink(_) => "create sink",
             Plan::CreateTable(_) => "create table",
@@ -485,6 +485,15 @@ pub enum SourceSinkClusterConfig {
     /// to the active cluster. This behavior won't be ergonomic until we have
     /// multipurpose clusters though.
     Undefined,
+}
+
+impl SourceSinkClusterConfig {
+    pub fn will_create_new_cluster(&self) -> bool {
+        match self {
+            SourceSinkClusterConfig::Existing { .. } => false,
+            SourceSinkClusterConfig::Linked { .. } | SourceSinkClusterConfig::Undefined => true,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -467,7 +467,7 @@ pub enum SourceSinkClusterConfig {
     /// Use an existing cluster.
     Existing {
         /// The ID of the cluster to use.
-        id: StorageInstanceId,
+        id: ClusterId,
     },
     /// Create a new linked storage cluster of the specified size.
     ///
@@ -488,10 +488,12 @@ pub enum SourceSinkClusterConfig {
 }
 
 impl SourceSinkClusterConfig {
-    pub fn will_create_new_cluster(&self) -> bool {
+    /// Returns the ID of the cluster that this source/sink will be created on, if one exists. If
+    /// one doesn't exist, then a new cluster will be created.
+    pub fn cluster_id(&self) -> Option<&ClusterId> {
         match self {
-            SourceSinkClusterConfig::Existing { .. } => false,
-            SourceSinkClusterConfig::Linked { .. } | SourceSinkClusterConfig::Undefined => true,
+            SourceSinkClusterConfig::Existing { id } => Some(id),
+            SourceSinkClusterConfig::Linked { .. } | SourceSinkClusterConfig::Undefined => None,
         }
     }
 }

--- a/test/sqllogictest/role_attributes.slt
+++ b/test/sqllogictest/role_attributes.slt
@@ -540,6 +540,29 @@ CREATE ROLE joeson INHERIT
 ----
 COMPLETE 0
 
+# Test that you need CREATECLUSTER to make sources with linked clusters
+
+simple conn=mz_system,user=mz_system
+ALTER ROLE joe NOCREATEROLE NOCREATEDB NOCREATECLUSTER;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+CREATE SOURCE src FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+db error: ERROR: permission denied to create source
+DETAIL: You must have the CREATECLUSTER attribute to create source
+
+simple conn=mz_system,user=mz_system
+ALTER ROLE joe CREATECLUSTER;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+CREATE SOURCE src FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
 # Disable RBAC checks
 
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
This commit updates the required attributes for creating linked clusters for sources and sinks. A role will need the CREATECLUSTER attribute to create a sink or source if it results in creating a linked cluster.

Part of #11579

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release will require the CREATECLUSTER attribute when creating sources and sinks that result in new clusters, when RBAC is turned on.
