### PR TITLE
fix: `mz_ore` features

### DIFF
--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -71,7 +71,7 @@ tokio-test = "0.4.2"
 default = ["workspace-hack"]
 async = ["async-trait", "futures", "openssl", "tokio-openssl", "tokio"]
 bytes_ = ["bytes", "smallvec", "smallvec/const_generics"]
-network = ["async", "bytes", "hyper", "smallvec", "tonic"]
+network = ["async", "bytes", "hyper", "smallvec", "tonic", "tracing"]
 tracing_ = [
   "anyhow",
   "atty",


### PR DESCRIPTION
### Motivation

Currently crates that depend on the `network` feature from `mz_ore` but not the `tracing_` feature, e.g. the `stash` crate, won't compile.

Adds the `tracing` crate as required for the `network` feature since we use `tracing::warn!` in the `netio` module.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
