### PR TITLE
persist: rework JsonStats

### DIFF
--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -28,8 +28,8 @@ message ProtoHollowBatchPart {
     uint64 encoded_size_bytes = 2;
 
     // TODO(mfp): This is definitely not the final way for us to store this.
-    mz_persist_types.stats.ProtoStructStats key_stats = 536870910;
-    reserved 536870911;
+    mz_persist_types.stats.ProtoStructStats key_stats = 536870909;
+    reserved 536870910, 536870911;
 }
 
 message ProtoHollowBatch {

--- a/src/persist-types/src/stats.proto
+++ b/src/persist-types/src/stats.proto
@@ -70,10 +70,10 @@ message ProtoPrimitiveStats {
 }
 
 message ProtoJsonStats {
-    uint64 json_nulls = 1;
-    oneof values {
-        google.protobuf.Empty none = 2;
-        google.protobuf.Empty mixed = 3;
+    oneof kind {
+        google.protobuf.Empty none = 1;
+        google.protobuf.Empty mixed = 2;
+        google.protobuf.Empty json_nulls = 3;
         ProtoPrimitiveStats bools = 4;
         ProtoPrimitiveStats strings = 5;
         ProtoPrimitiveStats numerics = 6;

--- a/src/persist-types/src/stats.proto
+++ b/src/persist-types/src/stats.proto
@@ -9,6 +9,8 @@
 
 syntax = "proto3";
 
+import "google/protobuf/empty.proto";
+
 package mz_persist_types.stats;
 
 message ProtoStructStats {
@@ -69,14 +71,19 @@ message ProtoPrimitiveStats {
 
 message ProtoJsonStats {
     uint64 json_nulls = 1;
-    ProtoPrimitiveStats bools = 2;
-    ProtoPrimitiveStats string = 3;
-    ProtoPrimitiveStats numeric = 4;
-    uint64 list = 5;
-    map<string, ProtoJsonStats> map = 6;
-    // The inverse of what you might normally imagine, for backwards-compatibility.
-    // TODO(mfp): make this more uniform.
-    bool no_maps = 7;
+    oneof values {
+        google.protobuf.Empty none = 2;
+        google.protobuf.Empty mixed = 3;
+        ProtoPrimitiveStats bools = 4;
+        ProtoPrimitiveStats strings = 5;
+        ProtoPrimitiveStats numerics = 6;
+        google.protobuf.Empty lists = 7;
+        ProtoJsonMapStats maps = 8;
+    }
+}
+
+message ProtoJsonMapStats {
+    map<string, ProtoJsonStats> elements = 1;
 }
 
 message ProtoBytesStats {


### PR DESCRIPTION
At interpret-time, we don't need detailed stats about cases where more than one "category" of json datums (bool, numeric, string, list, map) were present. In practice, these will always involve some sort of cast, which would error on at least one of the categories. So, we rework our json stats to be detailed if 0 or 1 categories are present, but replaced with a sentinel if more than 1 are present. Note that this is not true of JsonNull, so it's pulled out and always counted.

This is strictly less information than we used to keep, so we could add a migration to convert the old format to the new, but this has only been used on staging, so we save the complexity and pick a new proto id for part stats.

Touches #12684 

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Verified that the included proptest catches a copy-pasta bug that I had at one point during development.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
