### PR TITLE
sql: don't advance AS OF AT LEAST to upper

### DIFF
--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -978,8 +978,8 @@ impl QueryWhen {
     /// Returns whether the candidate can be advanced to the upper.
     pub fn can_advance_to_upper(&self) -> bool {
         match self {
-            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) | QueryWhen::Freshest => true,
-            QueryWhen::AtTimestamp(_) => false,
+            QueryWhen::Immediately | QueryWhen::Freshest => true,
+            QueryWhen::AtTimestamp(_) | QueryWhen::AtLeastTimestamp(_) => false,
         }
     }
     /// Returns whether the candidate must be advanced to the upper.


### PR DESCRIPTION
Previously we would advance AT LEAST to the upper because...we could? It improved freshness while still meeting the requirement of AT LEAST, which is that the specified timestamp is included in the output. However, this interacts poorly with SUBSCRIBE UP TO, because the upper might be in advance of the UP TO, causing an error.

Instead use the oldest valid timestamp for AT LEAST. The meaning has changed to: get the data as close as possible to the specified timestamp. This allows for historical queries to return more detailed data.

Fixes #18910

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a