### PR TITLE
Bump fs_extra version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2182,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "fs_extra"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"


### PR DESCRIPTION
This should get rid of deprecation warnings related to `fs_extra`. Sibling of https://github.com/MaterializeInc/materialize/pull/18985 .