### PR TITLE
storage: bring back "Starting" status

### DIFF
--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -35,6 +35,7 @@ $ set-from-sql var=source_id
 SELECT id FROM mz_sources WHERE name = 'kafka_source'
 
 > select * from mz_internal.mz_source_status_history where source_id = '${source_id}' order by occurred_at;
+"<TIMESTAMP> UTC" ${source_id} starting <null> <null>
 "<TIMESTAMP> UTC" ${source_id} running <null> <null>
 
 > select * from mz_internal.mz_source_statuses where id = '${source_id}';
@@ -73,6 +74,7 @@ $ kafka-verify-data format=avro sink=materialize.public.kafka_sink sort-messages
 "${sink_id}" kafka_sink kafka "<TIMESTAMP> UTC" running <null> <null>
 
 > select * from mz_internal.mz_source_status_history where source_id = '${source_id}' order by occurred_at;
+"<TIMESTAMP> UTC" ${source_id} starting <null> <null>
 "<TIMESTAMP> UTC" ${source_id} running <null> <null>
 
 > select * from mz_internal.mz_source_statuses where id = '${source_id}';
@@ -100,6 +102,7 @@ SELECT id FROM mz_sinks WHERE name = 'kafka_sink_2'
 "<TIMESTAMP> UTC" ${sink_id_2} running <null> <null>
 
 > select * from mz_internal.mz_source_status_history where source_id = '${source_id_2}' order by occurred_at;
+"<TIMESTAMP> UTC" ${source_id_2} starting <null> <null>
 "<TIMESTAMP> UTC" ${source_id_2} running <null> <null>
 
 > select * from mz_internal.mz_sink_statuses where id in ('${sink_id}', '${sink_id_2}') order by id;
@@ -122,5 +125,6 @@ SELECT id FROM mz_sinks WHERE name = 'kafka_sink_2'
 > DROP SOURCE kafka_source
 
 > select * from mz_internal.mz_source_status_history where source_id = '${source_id}' order by occurred_at;
+"<TIMESTAMP> UTC" ${source_id} starting <null> <null>
 "<TIMESTAMP> UTC" ${source_id} running <null> <null>
 "<TIMESTAMP> UTC" ${source_id} dropped <null> <null>


### PR DESCRIPTION
fixes #18989

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
