### PR TITLE
update clap and fix 1.69 clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.6",
  "libc",
  "winapi",
 ]
@@ -1007,7 +1007,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chrono"
 version = "0.4.24"
-source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#5bc022ca811a81d0dd79e3254214ae05a74898b6"
+source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#895d3b867ff318b5866cad7684d26279a45bc114"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -1087,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.20"
+version = "3.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
+checksum = "eef2b3ded6a26dfaec672a742c93c8cf6b689220324da509ec5caa20de55dc83"
 dependencies = [
  "atty",
  "bitflags",
@@ -1105,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "d756c5824fc5c0c1ee8e36000f576968dbcb2081def956c83fad6f40acd46f96"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1171,16 +1171,15 @@ checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
 
 [[package]]
 name = "console"
-version = "0.15.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
- "terminal_size",
  "unicode-width",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1940,13 +1939,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2035,7 +2034,7 @@ checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "winapi",
 ]
 
@@ -2429,6 +2428,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,12 +2670,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3011,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libloading"
@@ -3077,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
 
 [[package]]
 name = "lock_api"
@@ -5276,11 +5291,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -5572,7 +5587,7 @@ checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "smallvec",
  "windows-sys 0.42.0",
 ]
@@ -5997,19 +6012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "procfs"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de8dacb0873f77e6aefc6d71e044761fcc68060290f5b1089fcdf84626bb69"
-dependencies = [
- "bitflags",
- "byteorder",
- "hex",
- "lazy_static",
- "rustix",
-]
-
-[[package]]
 name = "prometheus"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6018,10 +6020,8 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
- "libc",
  "memchr",
  "parking_lot",
- "procfs",
  "thiserror",
 ]
 
@@ -6297,13 +6297,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -6465,16 +6474,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.37.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "a0661814f891c57c930a610266415528da53c4933e6dea5fb350cbfe048a9ece"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7261,15 +7270,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7283,19 +7292,19 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
- "libc",
- "winapi",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 dependencies = [
  "terminal_size",
 ]
@@ -8267,13 +8276,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8282,7 +8291,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -8291,13 +8309,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -8307,10 +8340,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8319,10 +8364,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8331,16 +8388,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
@@ -8416,7 +8491,6 @@ dependencies = [
  "postgres",
  "postgres-types",
  "proc-macro2",
- "prometheus",
  "prost",
  "prost-reflect",
  "prost-types",

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,20 @@ skip = [
     # up.
     { name = "socket2", version = "0.4.9" },
     { name = "windows-sys", version = "0.42.0" },
+    { name = "windows-sys", version = "0.45.0" },
+    { name = "windows-targets", version = "0.42.0" },
+    { name = "windows_aarch64_gnullvm", version = "0.42.0" },
+    { name = "windows_aarch64_msvc", version = "0.42.0" },
+    { name = "windows_i686_gnu", version = "0.42.0" },
+    { name = "windows_i686_msvc", version = "0.42.0" },
+    { name = "windows_x86_64_gnullvm", version = "0.42.0" },
+    { name = "windows_x86_64_gnu", version = "0.42.0" },
+    { name = "windows_x86_64_msvc", version = "0.42.0" },
+    # Newer versions of crates like `tempfile` are held back by crates like `atty`.
+    # This is very Unfortunate as we don't actually use these platforms.
+    { name = "hermit-abi", version = "0.1.6" },
+    { name = "hermit-abi", version = "0.2.6" },
+    { name = "redox_syscall", version = "0.2.10" },
 
     # Waiting for <https://github.com/blackbeam/rust_mysql_common/commit/2a6419aef2ff609cd35a5ce41a9eb48253a8214d>
     # to be released.

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.66"
 async-trait = "0.1.59"
 bytesize = "1.1.0"
-clap = { version = "3.2.20", features = ["derive", "env"] }
+clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 axum = "0.6.7"
-clap = { version = "3.2.20", features = ["derive", "env"] }
+clap = { version = "3.2.24", features = ["derive", "env"] }
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 mz-alloc = { path = "../alloc" }

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.66"
 async-trait = "0.1.59"
 bytesize = "1.1.0"
-clap = { version = "3.2.20", features = ["derive", "env"] }
+clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -17,7 +17,7 @@ base64 = "0.13.1"
 bytes = "1.3.0"
 bytesize = "1.1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
-clap = { version = "3.2.20", features = ["wrap_help", "env", "derive"] }
+clap = { version = "3.2.24", features = ["wrap_help", "env", "derive"] }
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 headers = "0.3.8"

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -130,6 +130,7 @@ macro_rules! sqlfunc {
                 }
             }
 
+            #[allow(clippy::extra_unused_lifetimes)]
             pub fn $fn_name<$lt>($param_name: $input_ty) -> $output_ty {
                 $body
             }

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -15,7 +15,7 @@ http = "0.2.8"
 hyper = { version = "0.14.23", features = ["http1", "server"] }
 include_dir = "0.7.3"
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "tracing_"] }
-prometheus = { version = "0.13.3", default-features = false, features = ["process"] }
+prometheus = { version = "0.13.3", default-features = false }
 serde = "1.0.152"
 serde_json = { version = "1.0.89" }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -15,7 +15,7 @@ harness = false
 anyhow = "1.0.66"
 byteorder = "1.4.3"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
-clap = { version = "3.2.20", features = ["derive"] }
+clap = { version = "3.2.24", features = ["derive"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 itertools = "0.10.5"
 once_cell = "1.16.0"

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
-clap = { version = "3.2.20", features = ["derive"] }
+clap = { version = "3.2.24", features = ["derive"] }
 crossbeam = "0.8.2"
 mz-avro = { path = "../avro" }
 mz-ccsr = { path = "../ccsr" }

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 [dependencies]
 anyhow = "1.0.66"
 axum = { version = "0.6.7" }
-clap = { version = "3.2.20", features = [ "derive" ] }
+clap = { version = "3.2.24", features = [ "derive" ] }
 dirs = "4.0.0"
 indicatif = "0.17.2"
 mz-build-info = { path = "../build-info" }

--- a/src/mz/src/bin/mz/secrets.rs
+++ b/src/mz/src/bin/mz/secrets.rs
@@ -19,34 +19,48 @@ use serde::{Deserialize, Serialize};
 use mz::api::{get_provider_region_environment, CloudProviderRegion};
 use mz::configuration::ValidProfile;
 
-#[derive(Debug, Subcommand)]
-pub enum SecretCommand {
-    /// Create a new secret
-    Create {
-        /// The name of the secret to create
-        name: String,
+pub use clap_clippy_hack::*;
 
-        #[clap(flatten)]
-        contents: Contents,
-    },
+// Do not add anything but structs/enums with Clap derives in this module!
+//
+// Clap v3 sometimes triggers this warning with subcommands,
+// and its unclear if it will be fixed in v3, and not just
+// in v4. This can't be overridden at the macro level, and instead must be overridden
+// at the module level.
+//
+// TODO(guswynn): remove this when we are using Clap v4.
+#[allow(clippy::almost_swapped)]
+mod clap_clippy_hack {
+    use super::*;
+    #[derive(Debug, Subcommand)]
+    pub enum SecretCommand {
+        /// Create a new secret
+        Create {
+            /// The name of the secret to create
+            name: String,
 
-    /// Delete a secret
-    Delete {
-        /// The name of the secret to create
-        name: String,
-    },
+            #[clap(flatten)]
+            contents: Contents,
+        },
 
-    // List all secrets
-    List,
+        /// Delete a secret
+        Delete {
+            /// The name of the secret to create
+            name: String,
+        },
 
-    /// Update a secret
-    Update {
-        /// The name of the secret to update
-        name: String,
+        // List all secrets
+        List,
 
-        #[clap(flatten)]
-        contents: Contents,
-    },
+        /// Update a secret
+        Update {
+            /// The name of the secret to update
+            name: String,
+
+            #[clap(flatten)]
+            contents: Contents,
+        },
+    }
 }
 
 impl SecretCommand {

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.66"
 async-trait = "0.1.59"
 chrono = { version = "0.4.23", default-features = false }
-clap = { version = "3.2.20", features = ["derive"] }
+clap = { version = "3.2.24", features = ["derive"] }
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 maplit = "1.0.2"

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.59"
-clap = { version = "3.2.20", features = ["env", "derive"] }
+clap = { version = "3.2.24", features = ["env", "derive"] }
 futures-core = "0.3.21"
 http = "0.2.8"
 humantime = { version = "2.1.0", optional = true }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = { version = "1.0.66", optional = true }
 async-trait = { version = "0.1.59", optional = true }
 bytes = { version = "1.3.0", optional = true }
 chrono = { version = "0.4.23", default-features = false, features = ["std"], optional = true }
-clap = { version = "3.2.20", features = ["env"], optional = true }
+clap = { version = "3.2.24", features = ["env"], optional = true }
 ctor = { version = "0.1.26", optional = true }
 either = "1.8.0"
 futures = { version = "0.3.25", optional = true }

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -33,7 +33,7 @@ anyhow = { version = "1.0.66", features = ["backtrace"] }
 async-stream = "0.3.3"
 async-trait = "0.1.59"
 bytes = "1.3.0"
-clap = { version = "3.2.20", features = [ "derive" ] }
+clap = { version = "3.2.24", features = [ "derive" ] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3.25"
 futures-util = "0.3"
@@ -63,7 +63,7 @@ tokio-console = ["mz-ore/tokio-console"]
 [dev-dependencies]
 async-trait = "0.1.59"
 axum = { version = "0.6.7" }
-clap = { version = "3.2.20", features = ["derive", "env"] }
+clap = { version = "3.2.24", features = ["derive", "env"] }
 criterion = { version = "0.4.0", features = ["html_reports"] }
 datadriven = { version = "0.6.0", features = ["async"] }
 futures-task = "0.3.21"

--- a/src/pgtest/Cargo.toml
+++ b/src/pgtest/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 bytes = "1.3.0"
-clap = { version = "3.2.20", features = ["derive"] }
+clap = { version = "3.2.24", features = ["derive"] }
 datadriven = "0.6.0"
 fallible-iterator = "0.2.0"
 mz-ore = { path = "../ore", features = ["cli"] }

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -209,7 +209,7 @@ impl<'a> JsonbRef<'a> {
     /// Panics if this `JsonbRef` was constructed with a [`Datum`] that is not
     /// representable as JSON.
     pub fn to_serde_json(&self) -> serde_json::Value {
-        serde_json::to_value(&JsonbDatum(self.datum))
+        serde_json::to_value(JsonbDatum(self.datum))
             .expect("conversion to serde_json::Value known to be valid")
     }
 }

--- a/src/s3-datagen/Cargo.toml
+++ b/src/s3-datagen/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.66"
 aws-config = { version = "0.53.0", default-features = false, features = ["native-tls"] }
 aws-sdk-s3 = { version = "0.23.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 bytefmt = "0.1.7"
-clap = { version = "3.2.20", features = ["derive"] }
+clap = { version = "3.2.24", features = ["derive"] }
 futures = "0.3.25"
 indicatif = "0.17.2"
 mz-aws-s3-util = { path = "../aws-s3-util" }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.59"
-clap = { version = "3.2.20", features = ["env", "derive"] }
+clap = { version = "3.2.24", features = ["env", "derive"] }
 crossbeam-channel = "0.5.8"
 futures = "0.3.25"
 http = "0.2.8"

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.66"
 bytes = "1.3.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
-clap = { version = "3.2.20", features = ["derive"] }
+clap = { version = "3.2.24", features = ["derive"] }
 fallible-iterator = "0.2.0"
 futures = "0.3.25"
 itertools = "0.10.5"

--- a/src/stash-debug/Cargo.toml
+++ b/src/stash-debug/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.66"
-clap = { version = "3.2.20", features = ["derive", "env"] }
+clap = { version = "3.2.24", features = ["derive", "env"] }
 mz-adapter = { path = "../adapter" }
 mz-build-info = { path = "../build-info" }
 mz-ore = { path = "../ore" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -16,7 +16,7 @@ async-stream = "0.3.3"
 async-trait = "0.1.59"
 bytesize = "1.1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
-clap = { version = "3.2.20", features = ["derive", "env"] }
+clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
 csv-core = { version = "0.1.10" }
 dec = "0.4.8"
@@ -80,7 +80,7 @@ tonic-build = "0.8.2"
 [dev-dependencies]
 async-trait = "0.1.59"
 axum = { version = "0.6.7" }
-clap = { version = "3.2.20", features = ["derive", "env"] }
+clap = { version = "3.2.24", features = ["derive", "env"] }
 datadriven = { version = "0.6.0", features = ["async"] }
 humantime = "2.1.0"
 rocksdb = { version = "0.20.1", default-features = false, features = ["snappy"] }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -18,7 +18,7 @@ aws-types = "0.53.0"
 byteorder = "1.4.3"
 bytes = "1.3.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
-clap = { version = "3.2.20", features = ["derive"] }
+clap = { version = "3.2.24", features = ["derive"] }
 flate2 = "1.0.24"
 futures = "0.3.25"
 globset = "0.4.9"

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -26,7 +26,7 @@ bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
 bytes = { version = "1.3.0" }
 chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x", default-features = false, features = ["alloc", "clock", "serde"] }
-clap = { version = "3.2.20", features = ["derive", "env", "wrap_help"] }
+clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 crossbeam-channel = { version = "0.5.8" }
 crossbeam-deque = { version = "0.8.2" }
@@ -54,7 +54,7 @@ k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }
 kube-client = { version = "0.77.0", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
 kube-core = { version = "0.77.0", default-features = false, features = ["jsonpatch", "schema", "ws"] }
-libc = { version = "0.2.140", features = ["extra_traits", "use_std"] }
+libc = { version = "0.2.142", features = ["extra_traits", "use_std"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 lru = { version = "0.8.1" }
 memchr = { version = "2.5.0", features = ["use_std"] }
@@ -73,7 +73,6 @@ phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 proc-macro2 = { version = "1.0.54", features = ["span-locations"] }
-prometheus = { version = "0.13.3", default-features = false, features = ["process"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 prost-reflect = { version = "0.9.2", default-features = false, features = ["serde"] }
 prost-types = { version = "0.11.2" }
@@ -92,7 +91,7 @@ serde_json = { version = "1.0.89", features = ["alloc", "arbitrary_precision", "
 sha2 = { version = "0.10.6" }
 smallvec = { version = "1.10.0", default-features = false, features = ["const_generics", "serde", "union", "write"] }
 syn = { version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
-textwrap = { version = "0.15.0", default-features = false, features = ["terminal_size"] }
+textwrap = { version = "0.16.0", default-features = false, features = ["terminal_size"] }
 time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
 tokio = { version = "1.27.0", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
@@ -123,7 +122,7 @@ byteorder = { version = "1.4.3" }
 bytes = { version = "1.3.0" }
 cc = { version = "1.0.78", default-features = false, features = ["parallel"] }
 chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x", default-features = false, features = ["alloc", "clock", "serde"] }
-clap = { version = "3.2.20", features = ["derive", "env", "wrap_help"] }
+clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 crossbeam-channel = { version = "0.5.8" }
 crossbeam-deque = { version = "0.8.2" }
@@ -151,7 +150,7 @@ k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }
 kube-client = { version = "0.77.0", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
 kube-core = { version = "0.77.0", default-features = false, features = ["jsonpatch", "schema", "ws"] }
-libc = { version = "0.2.140", features = ["extra_traits", "use_std"] }
+libc = { version = "0.2.142", features = ["extra_traits", "use_std"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 lru = { version = "0.8.1" }
 memchr = { version = "2.5.0", features = ["use_std"] }
@@ -170,7 +169,6 @@ phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 proc-macro2 = { version = "1.0.54", features = ["span-locations"] }
-prometheus = { version = "0.13.3", default-features = false, features = ["process"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 prost-reflect = { version = "0.9.2", default-features = false, features = ["serde"] }
 prost-types = { version = "0.11.2" }
@@ -189,7 +187,7 @@ serde_json = { version = "1.0.89", features = ["alloc", "arbitrary_precision", "
 sha2 = { version = "0.10.6" }
 smallvec = { version = "1.10.0", default-features = false, features = ["const_generics", "serde", "union", "write"] }
 syn = { version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
-textwrap = { version = "0.15.0", default-features = false, features = ["terminal_size"] }
+textwrap = { version = "0.16.0", default-features = false, features = ["terminal_size"] }
 time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
 time-macros = { version = "0.2.6", default-features = false, features = ["formatting", "parsing", "serde"] }
 tokio = { version = "1.27.0", features = ["full", "test-util", "tracing"] }
@@ -208,27 +206,27 @@ uuid = { version = "1.2.2", features = ["serde", "v4", "v5"] }
 zeroize = { version = "1.5.7", features = ["serde"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-byteorder = { version = "1.4.3", default-features = false, features = ["i128"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
-rustix = { version = "0.36.7", features = ["param", "process", "thread"] }
+rustix = { version = "0.37.15", features = ["fs", "termios"] }
 tikv-jemalloc-sys = { version = "0.5.2", features = ["background_threads", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
-byteorder = { version = "1.4.3", default-features = false, features = ["i128"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
-rustix = { version = "0.36.7", features = ["param", "process", "thread"] }
+rustix = { version = "0.37.15", features = ["fs", "termios"] }
 tikv-jemalloc-sys = { version = "0.5.2", features = ["background_threads", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.x86_64-apple-darwin.dependencies]
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
+rustix = { version = "0.37.15", features = ["fs", "termios"] }
 security-framework = { version = "2.7.0", features = ["alpn"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
+rustix = { version = "0.37.15", features = ["fs", "termios"] }
 security-framework = { version = "2.7.0", features = ["alpn"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
Clap v3 is going to be quite annoying going forward. It produces clippy lints that must be allowed at a module-level, which means introducing a new module. This can be cleaned up when: https://github.com/clap-rs/clap/issues/4857#issuecomment-1524206508 is resolved!

Other lints in 1.69 that came up weren't bad!

### Motivation


   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
