### PR TITLE
adapter: optimize peeks before timestamp determination

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -694,7 +694,7 @@ impl Coordinator {
                 tx,
                 finishing,
                 copy_to,
-                source,
+                dataflow,
                 session,
                 cluster_id,
                 when,
@@ -705,6 +705,8 @@ impl Coordinator {
                 source_ids,
                 id_bundle,
                 in_immediate_multi_stmt_txn,
+                key,
+                typ,
             } => {
                 self.sequence_peek_stage(
                     tx,
@@ -712,7 +714,7 @@ impl Coordinator {
                     PeekStage::Finish(PeekStageFinish {
                         finishing,
                         copy_to,
-                        source,
+                        dataflow,
                         cluster_id,
                         when,
                         target_replica,
@@ -723,6 +725,8 @@ impl Coordinator {
                         id_bundle,
                         in_immediate_multi_stmt_txn,
                         real_time_recency_ts: Some(real_time_recency_ts),
+                        key,
+                        typ,
                     }),
                 )
                 .await;


### PR DESCRIPTION
This is in preparation to move optimization off of the main coordinator thread. Before we have a timestamp, we can resolve all unmat fn calls except mz_now. After optimization and getting a timestamp, we again walk the dataflow but can then attempt to resolve mz_now calls. We need to teach DataflowDescription how to walk more fields to cover things like source mfp pushdown.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a