### PR TITLE
adapter: move peek optimization off coord thread

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -216,14 +216,12 @@ pub enum Message<T = mz_repr::Timestamp> {
         real_time_recency_ts: Timestamp,
         validity: PlanValidity,
     },
-
     // Like Command::Execute, but its context has already been allocated.
     Execute {
         portal_name: String,
         ctx: ExecuteContext,
         span: tracing::Span,
     },
-
     /// Performs any cleanup and logging actions necessary for
     /// finalizing a statement execution.
     RetireExecute {
@@ -233,6 +231,10 @@ pub enum Message<T = mz_repr::Timestamp> {
         ctx: ExecuteContext,
         stmt: Statement<Raw>,
         params: mz_sql::plan::Params,
+    },
+    PeekStageReady {
+        ctx: ExecuteContext,
+        stage: PeekStage,
     },
 }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -332,7 +332,7 @@ impl PeekStage {
 
 #[derive(Debug)]
 pub struct PeekStageValidate {
-    pub plan: mz_sql::plan::SelectPlan,
+    plan: mz_sql::plan::SelectPlan,
     target_cluster: TargetCluster,
 }
 
@@ -374,20 +374,20 @@ pub struct PeekStageTimestamp {
 #[derive(Debug)]
 pub struct PeekStageFinish {
     validity: PlanValidity,
-    pub finishing: RowSetFinishing,
-    pub copy_to: Option<CopyFormat>,
-    pub dataflow: DataflowDescription<OptimizedMirRelationExpr>,
-    pub cluster_id: ClusterId,
-    pub id_bundle: Option<CollectionIdBundle>,
-    pub when: QueryWhen,
-    pub target_replica: Option<ReplicaId>,
-    pub view_id: GlobalId,
-    pub index_id: GlobalId,
-    pub timeline_context: TimelineContext,
-    pub source_ids: BTreeSet<GlobalId>,
-    pub real_time_recency_ts: Option<mz_repr::Timestamp>,
-    pub key: Vec<MirScalarExpr>,
-    pub typ: RelationType,
+    finishing: RowSetFinishing,
+    copy_to: Option<CopyFormat>,
+    dataflow: DataflowDescription<OptimizedMirRelationExpr>,
+    cluster_id: ClusterId,
+    id_bundle: Option<CollectionIdBundle>,
+    when: QueryWhen,
+    target_replica: Option<ReplicaId>,
+    view_id: GlobalId,
+    index_id: GlobalId,
+    timeline_context: TimelineContext,
+    source_ids: BTreeSet<GlobalId>,
+    real_time_recency_ts: Option<mz_repr::Timestamp>,
+    key: Vec<MirScalarExpr>,
+    typ: RelationType,
 }
 
 /// An enum describing which cluster to run a statement on.

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -18,13 +18,15 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use differential_dataflow::lattice::Lattice;
 use maplit::{btreemap, btreeset};
-use mz_compute_client::controller::{ComputeInstanceId, ComputeInstanceRef};
+use mz_compute_client::controller::error::InstanceMissing;
+use mz_compute_client::controller::ComputeInstanceId;
 use mz_compute_client::types::dataflows::{
     BuildDesc, DataflowDesc, DataflowDescription, IndexDesc,
 };
 use mz_compute_client::types::sinks::{
     ComputeSinkConnection, ComputeSinkDesc, PersistSinkConnection,
 };
+use mz_controller::Controller;
 use mz_expr::visit::Visit;
 use mz_expr::{
     CollectionPlan, Id, MapFilterProject, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr,
@@ -51,14 +53,44 @@ use crate::session::{Session, SERVER_MAJOR_VERSION, SERVER_MINOR_VERSION};
 use crate::util::{viewable_variables, ResultExt};
 use crate::{rbac, AdapterError};
 
+/// A reference-less snapshot of a compute instance. There is no guarantee `instance_id` continues
+/// to exist after this has been made.
+#[derive(Debug, Clone)]
+pub struct ComputeInstanceSnapshot {
+    instance_id: ComputeInstanceId,
+    collections: BTreeSet<GlobalId>,
+}
+
+impl ComputeInstanceSnapshot {
+    pub fn new(controller: &Controller, id: ComputeInstanceId) -> Result<Self, InstanceMissing> {
+        controller
+            .compute
+            .instance_ref(id)
+            .map(|instance| ComputeInstanceSnapshot {
+                instance_id: id,
+                collections: BTreeSet::from_iter(instance.collections().map(|(id, _state)| *id)),
+            })
+    }
+
+    /// Return the ID of this compute instance.
+    pub fn instance_id(&self) -> ComputeInstanceId {
+        self.instance_id
+    }
+
+    /// Reports whether the instance contains the indicated collection.
+    pub fn contains_collection(&self, id: &GlobalId) -> bool {
+        self.collections.contains(id)
+    }
+}
+
 /// Borrows of catalog and indexes sufficient to build dataflow descriptions.
-pub struct DataflowBuilder<'a, T> {
+pub struct DataflowBuilder<'a> {
     pub catalog: &'a CatalogState,
     /// A handle to the compute abstraction, which describes indexes by identifier.
     ///
     /// This can also be used to grab a handle to the storage abstraction, through
     /// its `storage_mut()` method.
-    pub compute: ComputeInstanceRef<'a, T>,
+    pub compute: ComputeInstanceSnapshot,
     recursion_guard: RecursionGuard,
 }
 
@@ -88,20 +120,19 @@ pub enum EvalTime {
 
 impl Coordinator {
     /// Creates a new dataflow builder from the catalog and indexes in `self`.
-    pub fn dataflow_builder(
-        &self,
-        instance: ComputeInstanceId,
-    ) -> DataflowBuilder<mz_repr::Timestamp> {
+    pub fn dataflow_builder(&self, instance: ComputeInstanceId) -> DataflowBuilder {
         let compute = self
-            .controller
-            .compute
-            .instance_ref(instance)
+            .instance_snapshot(instance)
             .expect("compute instance does not exist");
-        DataflowBuilder {
-            catalog: self.catalog().state(),
-            compute,
-            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
-        }
+        DataflowBuilder::new(self.catalog().state(), compute)
+    }
+
+    /// Return a reference-less snapshot to the indicated compute instance.
+    pub fn instance_snapshot(
+        &self,
+        id: ComputeInstanceId,
+    ) -> Result<ComputeInstanceSnapshot, InstanceMissing> {
+        ComputeInstanceSnapshot::new(&self.controller, id)
     }
 
     /// Finalizes a dataflow and then broadcasts it to all workers.
@@ -288,24 +319,22 @@ pub fn dataflow_import_id_bundle(
 
 impl CatalogTxn<'_, mz_repr::Timestamp> {
     /// Creates a new dataflow builder from an ongoing catalog transaction.
-    pub fn dataflow_builder(
-        &self,
-        instance: ComputeInstanceId,
-    ) -> DataflowBuilder<mz_repr::Timestamp> {
-        let compute = self
-            .dataflow_client
-            .compute
-            .instance_ref(instance)
+    pub fn dataflow_builder(&self, instance: ComputeInstanceId) -> DataflowBuilder {
+        let snapshot = ComputeInstanceSnapshot::new(self.dataflow_client, instance)
             .expect("compute instance does not exist");
-        DataflowBuilder {
-            catalog: self.catalog,
+        DataflowBuilder::new(self.catalog, snapshot)
+    }
+}
+
+impl<'a> DataflowBuilder<'a> {
+    pub fn new(catalog: &'a CatalogState, compute: ComputeInstanceSnapshot) -> Self {
+        Self {
+            catalog,
             compute,
             recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
         }
     }
-}
 
-impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
     /// Imports the view, source, or table with `id` into the provided
     /// dataflow description.
     fn import_into_dataflow(
@@ -626,7 +655,7 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
     }
 }
 
-impl<'a, T> CheckedRecursion for DataflowBuilder<'a, T> {
+impl<'a> CheckedRecursion for DataflowBuilder<'a> {
     fn recursion_guard(&self) -> &RecursionGuard {
         &self.recursion_guard
     }

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -9,52 +9,46 @@
 
 use std::collections::BTreeSet;
 
-use mz_compute_client::controller::{ComputeInstanceId, ComputeInstanceRef};
+use mz_compute_client::controller::ComputeInstanceId;
 use mz_expr::{CollectionPlan, MirScalarExpr};
-use mz_repr::{GlobalId, TimestampManipulation};
+use mz_repr::GlobalId;
 use mz_transform::IndexOracle;
 
 use crate::catalog::{CatalogItem, CatalogState, Index, Log};
-use crate::coord::dataflows::DataflowBuilder;
+use crate::coord::dataflows::{ComputeInstanceSnapshot, DataflowBuilder};
 use crate::coord::{CollectionIdBundle, Coordinator};
 
 /// Answers questions about the indexes available on a particular compute
 /// instance.
 #[derive(Debug)]
-pub struct ComputeInstanceIndexOracle<'a, T> {
+pub struct ComputeInstanceIndexOracle<'a> {
     catalog: &'a CatalogState,
-    compute: ComputeInstanceRef<'a, T>,
+    compute: ComputeInstanceSnapshot,
 }
 
 impl Coordinator {
     /// Creates a new index oracle for the specified compute instance.
-    pub fn index_oracle(
-        &self,
-        instance: ComputeInstanceId,
-    ) -> ComputeInstanceIndexOracle<mz_repr::Timestamp> {
+    pub fn index_oracle(&self, instance: ComputeInstanceId) -> ComputeInstanceIndexOracle {
         ComputeInstanceIndexOracle {
             catalog: self.catalog().state(),
-            compute: self
-                .controller
-                .compute
-                .instance_ref(instance)
+            compute: ComputeInstanceSnapshot::new(&self.controller, instance)
                 .expect("compute instance does not exist"),
         }
     }
 }
 
-impl<T: Copy> DataflowBuilder<'_, T> {
+impl DataflowBuilder<'_> {
     /// Creates a new index oracle for the same compute instance as the dataflow
     /// builder.
-    pub fn index_oracle(&self) -> ComputeInstanceIndexOracle<T> {
+    pub fn index_oracle(&self) -> ComputeInstanceIndexOracle {
         ComputeInstanceIndexOracle {
             catalog: self.catalog,
-            compute: self.compute,
+            compute: self.compute.clone(),
         }
     }
 }
 
-impl<T: TimestampManipulation> ComputeInstanceIndexOracle<'_, T> {
+impl ComputeInstanceIndexOracle<'_> {
     /// Identifies a bundle of storage and compute collection ids sufficient for
     /// building a dataflow for the identifiers in `ids` out of the indexes
     /// available in this compute instance.
@@ -114,11 +108,11 @@ impl<T: TimestampManipulation> ComputeInstanceIndexOracle<'_, T> {
     pub fn indexes_on(&self, id: GlobalId) -> impl Iterator<Item = (GlobalId, &Index)> {
         self.catalog
             .get_indexes_on(id, self.compute.instance_id())
-            .filter(|(idx_id, _idx)| self.compute.collection(*idx_id).is_ok())
+            .filter(|(idx_id, _idx)| self.compute.contains_collection(idx_id))
     }
 }
 
-impl<T: TimestampManipulation> IndexOracle for ComputeInstanceIndexOracle<'_, T> {
+impl IndexOracle for ComputeInstanceIndexOracle<'_> {
     fn indexes_on(&self, id: GlobalId) -> Box<dyn Iterator<Item = &[MirScalarExpr]> + '_> {
         Box::new(
             ComputeInstanceIndexOracle::indexes_on(self, id)

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -110,6 +110,9 @@ impl Coordinator {
                 self.sequence_execute_single_statement_transaction(ctx, stmt, params)
                     .await;
             }
+            Message::PeekStageReady { ctx, stage } => {
+                self.sequence_peek_stage(ctx, stage).await;
+            }
         }
     }
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -68,19 +68,22 @@ use mz_sql_parser::ast::{
 use mz_ssh_util::keys::SshKeyPairSet;
 use mz_storage_client::controller::{CollectionDescription, DataSource, ReadPolicy, StorageError};
 use mz_storage_client::types::sinks::StorageSinkConnectionBuilder;
-use mz_transform::{EmptyStatisticsOracle, Optimizer};
+use mz_transform::{EmptyStatisticsOracle, Optimizer, StatisticsOracle};
 use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 use tokio::sync::{mpsc, oneshot, OwnedMutexGuard};
 use tracing::instrument::WithSubscriber;
 use tracing::{event, warn, Level};
 
 use crate::catalog::{
-    self, Catalog, CatalogItem, Cluster, ConnCatalog, Connection, DataSourceDesc,
+    self, Catalog, CatalogItem, CatalogState, Cluster, ConnCatalog, Connection, DataSourceDesc,
     StorageSinkConnectionState, UpdatePrivilegeVariant,
 };
 use crate::command::{ExecuteResponse, Response};
 use crate::coord::appends::{Deferred, DeferredPlan, PendingWriteTxn};
-use crate::coord::dataflows::{prep_relation_expr, prep_scalar_expr, EvalTime, ExprPrepStyle};
+use crate::coord::dataflows::{
+    prep_relation_expr, prep_scalar_expr, ComputeInstanceSnapshot, DataflowBuilder, EvalTime,
+    ExprPrepStyle,
+};
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::peek::{FastPathPlan, PlannedPeek};
 use crate::coord::read_policy::SINCE_GRANULARITY;
@@ -1935,11 +1938,8 @@ impl Coordinator {
                     (ctx, PeekStage::Optimize(next))
                 }
                 PeekStage::Optimize(stage) => {
-                    let next = return_if_err!(
-                        self.peek_stage_optimize(ctx.session_mut(), stage).await,
-                        ctx
-                    );
-                    (ctx, PeekStage::Timestamp(next))
+                    self.peek_stage_optimize(ctx, stage).await;
+                    return;
                 }
                 PeekStage::Timestamp(stage) => match self.peek_stage_timestamp(ctx, stage) {
                     Some((ctx, next)) => (ctx, PeekStage::Finish(next)),
@@ -2034,9 +2034,71 @@ impl Coordinator {
         })
     }
 
-    async fn peek_stage_optimize(
-        &mut self,
+    async fn peek_stage_optimize(&mut self, ctx: ExecuteContext, mut stage: PeekStageOptimize) {
+        // Generate data structures that can be moved to another task where we will perform possibly
+        // expensive optimizations.
+        let catalog = self.owned_catalog();
+        let compute = ComputeInstanceSnapshot::new(&self.controller, stage.cluster_id)
+            .expect("compute instance does not exist");
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
+
+        // TODO: Is there a way to avoid making two dataflow_builders (the second is in
+        // optimize_peek)?
+        let id_bundle = self
+            .dataflow_builder(stage.cluster_id)
+            .sufficient_collections(&stage.source_ids);
+        // Although we have added `sources.depends_on()` to the validity already, also add the
+        // sufficient collections for safety.
+        stage.validity.dependency_ids.extend(id_bundle.iter());
+
+        let stats = {
+            match self.determine_timestamp(
+                ctx.session(),
+                &id_bundle,
+                &stage.when,
+                stage.cluster_id,
+                &stage.timeline_context,
+                None,
+            ) {
+                Err(_) => Box::new(EmptyStatisticsOracle),
+                Ok(query_as_of) => self
+                    .statistics_oracle(
+                        ctx.session(),
+                        &stage.source_ids,
+                        query_as_of.timestamp_context.antichain(),
+                        true,
+                    )
+                    .await
+                    .unwrap_or_else(|_| Box::new(EmptyStatisticsOracle)),
+            }
+        };
+
+        mz_ore::task::spawn_blocking(
+            || "optimize peek",
+            move || match Self::optimize_peek(
+                catalog.state(),
+                compute,
+                ctx.session(),
+                stats,
+                id_bundle,
+                stage,
+            ) {
+                Ok(stage) => {
+                    let stage = PeekStage::Timestamp(stage);
+                    // Ignore errors if the coordinator has shut down.
+                    let _ = internal_cmd_tx.send(Message::PeekStageReady { ctx, stage });
+                }
+                Err(err) => ctx.retire(Err(err)),
+            },
+        );
+    }
+
+    fn optimize_peek(
+        catalog: &CatalogState,
+        compute: ComputeInstanceSnapshot,
         session: &Session,
+        stats: Box<dyn StatisticsOracle>,
+        id_bundle: CollectionIdBundle,
         PeekStageOptimize {
             validity,
             source,
@@ -2052,11 +2114,9 @@ impl Coordinator {
             in_immediate_multi_stmt_txn,
         }: PeekStageOptimize,
     ) -> Result<PeekStageTimestamp, AdapterError> {
-        let source = self.view_optimizer.optimize(source)?;
-
-        let id_bundle = self
-            .index_oracle(cluster_id)
-            .sufficient_collections(&source_ids);
+        let optimizer = Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
+        let source = optimizer.optimize(source)?;
+        let mut builder = DataflowBuilder::new(catalog, compute);
 
         // We create a dataflow and optimize it, to determine if we can avoid building it.
         // This can happen if the result optimizes to a constant, or to a `Get` expression
@@ -2069,7 +2129,6 @@ impl Coordinator {
             .collect();
         // The assembled dataflow contains a view and an index of that view.
         let mut dataflow = DataflowDesc::new(format!("oneshot-select-{}", view_id));
-        let mut builder = self.dataflow_builder(cluster_id);
         builder.import_view_into_dataflow(&view_id, &source, &mut dataflow)?;
 
         // Resolve all unmaterializable function calls except mz_now(), because we don't yet have a
@@ -2078,10 +2137,9 @@ impl Coordinator {
             logical_time: EvalTime::Deferred,
             session,
         };
-        let state = self.catalog().state();
         dataflow.visit_children(
-            |r| prep_relation_expr(state, r, style),
-            |s| prep_scalar_expr(state, s, style),
+            |r| prep_relation_expr(catalog, r, style),
+            |s| prep_scalar_expr(catalog, s, style),
         )?;
 
         dataflow.export_index(
@@ -2093,26 +2151,8 @@ impl Coordinator {
             typ.clone(),
         );
 
-        let query_as_of = self
-            .determine_timestamp(
-                session,
-                &id_bundle,
-                &when,
-                cluster_id,
-                &timeline_context,
-                None,
-            )?
-            .timestamp_context
-            .antichain();
-
         // Optimize the dataflow across views, and any other ways that appeal.
-        mz_transform::optimize_dataflow(
-            &mut dataflow,
-            &builder.index_oracle(),
-            self.statistics_oracle(session, &source_ids, query_as_of, true)
-                .await?
-                .as_ref(),
-        )?;
+        mz_transform::optimize_dataflow(&mut dataflow, &builder, &*stats)?;
 
         Ok(PeekStageTimestamp {
             validity,

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -639,6 +639,11 @@ impl<T> ComputeInstanceRef<'_, T> {
     pub fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, CollectionMissing> {
         self.instance.collection(id)
     }
+
+    /// Return an iterator over the installed collections.
+    pub fn collections(&self) -> impl Iterator<Item = (&GlobalId, &CollectionState<T>)> {
+        self.instance.collections_iter()
+    }
 }
 
 /// State maintained about individual compute collections.

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -261,7 +261,7 @@ impl IndexOracle for EmptyIndexOracle {
 }
 
 /// A trait for a type that can estimate statistics about a given `GlobalId`
-pub trait StatisticsOracle: fmt::Debug {
+pub trait StatisticsOracle: fmt::Debug + Send {
     /// Returns a cardinality estimate for the given identifier
     ///
     /// Returning `None` means "no estimate"; returning `Some(0)` means estimating that the shard backing `id` is empty


### PR DESCRIPTION
Move optimization off of the coordinator thread so that slow optimize phases don't block other messages.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a