### PR TITLE
test: Fix the FormatJson scenario in the sql-feature-flags test

### DIFF
--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -744,7 +744,7 @@ impl<'a> StatementContext<'a> {
     }
 
     pub fn require_format_json(&self) -> Result<(), PlanError> {
-        self.require_var_or_unsafe_mode(SystemVars::enable_format_json, "`FORMAT JSON")
+        self.require_var_or_unsafe_mode(SystemVars::enable_format_json, "`FORMAT JSON`")
     }
 
     pub fn finalize_param_types(self) -> Result<Vec<ScalarType>, PlanError> {

--- a/test/sql-feature-flags/mzcompose.py
+++ b/test/sql-feature-flags/mzcompose.py
@@ -13,9 +13,10 @@ import tempfile
 from textwrap import dedent, indent
 
 from materialize.mzcompose import Composition, WorkflowArgumentParser
-from materialize.mzcompose.services import Materialized, Testdrive
+from materialize.mzcompose.services import Materialized, Redpanda, Testdrive
 
 SERVICES = [
+    Redpanda(),
     Materialized(unsafe_mode=False),
     Testdrive(no_reset=True, seed=1),
 ]
@@ -103,6 +104,7 @@ class FeatureTestScenario:
             [
                 # Include the header.
                 header(f"{cls.__name__} (phase 1)", drop_schema=True),
+                cls.initialize(),
                 # We cannot create item #1 when the feature is turned off (default).
                 statement_error(cls.create_item(ordinal=1), cls.feature_error()),
                 # Turn the feature on.
@@ -124,6 +126,7 @@ class FeatureTestScenario:
             [
                 # Include the header.
                 header(f"{cls.__name__} (phase 2)", drop_schema=False),
+                cls.initialize(),
                 # We can query item #1 when the feature is turned on. Ensures
                 # that catalog rehydration ignores SQL-level feature flags.
                 query_ok(cls.query_item(ordinal=1)),
@@ -144,6 +147,11 @@ class FeatureTestScenario:
     def feature_error(cls) -> str:
         """The error expected when the feature is disabled."""
         assert False, "feature_error() must be overriden"
+
+    @classmethod
+    def initialize(cls) -> str:
+        """Any SQL statements that must be executed before the statement under test."""
+        return ""
 
     @classmethod
     def create_item(cls, ordinal: int) -> str:
@@ -200,20 +208,23 @@ class FormatJson(FeatureTestScenario):
         return "`FORMAT JSON` is not enabled"
 
     @classmethod
+    def initialize(cls) -> str:
+        return "> CREATE CONNECTION IF NOT EXISTS kafka_conn_for_format_json TO KAFKA (BROKER '${testdrive.kafka-addr}')"
+
+    @classmethod
     def create_item(cls, ordinal: int) -> str:
         return dedent(
             f"""
-            CREATE CONNECTION kafka_conn_{ordinal:02d}
-                TO KAFKA (BROKER 'foo');
-            CREATE SOURCE data
-                FROM KAFKA CONNECTION kafka_conn (TOPIC 'bar')
-                FORMAT JSON;
+            CREATE SOURCE kafka_source_{ordinal:02d}
+                FROM KAFKA CONNECTION kafka_conn_for_format_json (TOPIC 'bar')
+                FORMAT JSON
+                WITH (SIZE '1');
             """
         )
 
     @classmethod
     def drop_item(cls, ordinal: int) -> str:
-        return f"DROP CONNECTION kafka_conn_{ordinal:02d} CASCADE;"
+        return f"DROP SOURCE kafka_source_{ordinal:02d};"
 
     @classmethod
     def query_item(cls, ordinal: int) -> str:
@@ -223,7 +234,7 @@ class FormatJson(FeatureTestScenario):
 
 
 def run_test(c: Composition, args: argparse.Namespace) -> None:
-    c.up("materialized")
+    c.up("redpanda", "materialized")
     c.up("testdrive", persistent=True)
 
     scenarios = (


### PR DESCRIPTION
- The test framework does not allow CREATE CONNECTION + CREATE SOURCE to be present together in a single line, so move the CREATE CONNECTION to a separate initialization step.

- Use an actual Redpanda instance to ensure that CREATE SOURCE will succeed when appropriate.

### Motivation


  * This PR fixes a previously unreported bug.
Nighlty CI was failking because CREATE CONNECTION  + CREATE SOURCE are 2 statements:

```


[2023-04-26T23:34:32Z] FormatJson-phase1-9fka0g_j:10:1: error: expected one statement, but got 2
--
  | [2023-04-26T23:34:32Z]      \|
  | [2023-04-26T23:34:32Z]    9 \|
  | [2023-04-26T23:34:32Z]   10 \| ! CREATE CONNECTION kafka_conn_01
  | [2023-04-26T23:34:32Z]      \| ^
  | !!! Error Report
```