### PR TITLE
cloudtest: Fortify test_missing_secret (take #2)

### DIFF
--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -137,6 +137,9 @@ def test_missing_secret(mz: MaterializeApplication) -> None:
             FROM POSTGRES CONNECTION pg_conn_with_deleted_secret
             (PUBLICATION 'mz_source')
             FOR ALL TABLES;
+
+          > SELECT COUNT(*) > 0 FROM t1;
+          true
      """
         )
     )


### PR DESCRIPTION
Apparently waiting for the pod to become ready is not enough to guarantee that the clusterd process is in fact running.

Make sure the process is indeed running by running a SELECT against a source served by the cluster. clusterd must positively be running if/when the SELECT returns.

### Motivation

  * This PR fixes a previously unreported bug.

Ci cloudtest kept failing even in the face of previous fix attempts.