### PR TITLE
doc/user: polish v0.52 release notes

### DIFF
--- a/doc/user/content/releases/v0.48.md
+++ b/doc/user/content/releases/v0.48.md
@@ -59,8 +59,17 @@ shipping in v0.48 -— so mentioning it here."
 
 * Stop silently ignoring `NULL` keys in sources using `ENVELOPE UPSERT` {{% gh 6350 %}}.
   The new behavior is to throw an error when trying to query the source. To
-  recover an errored source, the upstream system must emit a record with a `NULL`
-  value and a `NULL` key.
+  recover an errored source, the upstream Kafka broker must emit a record with
+  a `NULL` value and a `NULL` key to force a retraction. As an example, you can use [`kcat`](https://docs.confluent.io/platform/current/clients/kafkacat-usage.html)
+  to produce an empty message:
+
+  ```bash
+  echo ":" | kcat -b $BROKER -t $TOPIC -Z -K: \
+    -X security.protocol=SASL_SSL \
+    -X sasl.mechanisms=SCRAM-SHA-256 \
+    -X sasl.username=$KAFKA_USERNAME \
+    -X sasl.password=$KAFKA_PASSWORD
+  ```
 
 * Fix a bug that prevented the correct parsing of connection settings specified
   using the [`-c` option](https://www.postgresql.org/docs/current/app-psql.html)

--- a/doc/user/content/releases/v0.48.md
+++ b/doc/user/content/releases/v0.48.md
@@ -57,11 +57,12 @@ shipping in v0.48 -— so mentioning it here."
   `error` column reports the full error message, and other helpful suggestions
   are added under `details`.
 
-* Stop silently ignoring `NULL` keys in sources using `ENVELOPE UPSERT` {{% gh 6350 %}}.
-  The new behavior is to throw an error when trying to query the source. To
-  recover an errored source, the upstream Kafka broker must emit a record with
-  a `NULL` value and a `NULL` key to force a retraction. As an example, you can use [`kcat`](https://docs.confluent.io/platform/current/clients/kafkacat-usage.html)
-  to produce an empty message:
+* Stop silently ignoring `NULL` keys in sources using `ENVELOPE UPSERT` {{% gh
+  6350 %}}. The new behavior is to throw an error when trying to query the
+  source. To recover an errored source, you must produce a record with a `NULL`
+  value and a `NULL` key to the topic, to force a retraction. As an example,
+  you can use [`kcat`](https://docs.confluent.io/platform/current/clients/kafkacat-usage.html) to
+  produce an empty message:
 
   ```bash
   echo ":" | kcat -b $BROKER -t $TOPIC -Z -K: \

--- a/doc/user/content/releases/v0.51.md
+++ b/doc/user/content/releases/v0.51.md
@@ -2,6 +2,7 @@
 title: "Materialize v0.51"
 date: 2023-04-19
 released: true
+patch: 1
 ---
 
 ## v0.51.0

--- a/doc/user/content/releases/v0.51.md
+++ b/doc/user/content/releases/v0.51.md
@@ -14,11 +14,11 @@ patch: 1
   option:
 
   ```sql
-	CREATE SOURCE mz_source
-	  FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
-	  FOR SCHEMAS (public, finance)
-	  WITH (SIZE = '3xsmall');
-	```
+  CREATE SOURCE mz_source
+    FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
+    FOR SCHEMAS (public, finance)
+    WITH (SIZE = '3xsmall');
+  ```
 
   With this option, only tables that are part of the publication _and_
   namespaced with the specified schema(s) will be replicated.

--- a/doc/user/content/releases/v0.52.md
+++ b/doc/user/content/releases/v0.52.md
@@ -1,11 +1,67 @@
 ---
 title: "Materialize v0.52"
 date: 2023-04-26
-released: false
+released: true
+patch: 3
 ---
 
 ## v0.52.0
 
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
+#### Sources and sinks
+
+* Allow reading from all non-errored subsources in the [PostgreSQL source](/sql/create-source/postgres/),
+  when a source error occurs. Prior to this release, if Materialize encountered
+  an error during replication for _any_ table, it'd block reads from _all_
+  replicated tables associated with the source.
+
+#### SQL
+
+[//]: # "NOTE(morsapaes) This feature was released in v0.49, but is only
+considered production-ready after the changes shipping in v0.52 -— so
+mentioning it here."
+
+* Automatically run introspection queries in the [`mz_introspection` cluster](/sql/show-clusters/#mz_introspection-system-cluster),
+  which has several indexes installed to speed up queries using system catalog
+  objects (like `SHOW` commands). This behavior can be disabled via the new
+  `auto_route_introspection_queries` [session variable](/sql/set/#other-session-variables).
+
+* Add `credits_per_hour` to the `mz_internal.mz_cluster_replica_sizes` system
+  table, and rate limit [free trial accounts](/free-trial-faqs/) to 4 credits per hour.
+
+  To see your current credit consumption rate, measured in credits per hour, run
+  the following query:
+
+  ```sql
+  SELECT sum(s.credits_per_hour) AS credit_consumption_rate
+    FROM mz_cluster_replicas r
+    JOIN mz_internal.mz_cluster_replica_sizes s ON r.size = s.size;
+  ```
+
+* Add default privileges to databases objects. Each object-specific system table
+  now has a `privileges` column that specifies the privileges belonging to the
+  object. This is part of the work to enable **Role-based access control**
+  (RBAC) {{% gh 11579 %}}.
+
+  It's important to note that privileges cannot currently be modified, and are
+  not considered when executing statements. This functionality will be added in
+  a future release.
+
+* Add the [`GRANT PRIVILEGE`](/sql/grant-privilege) and [`REVOKE PRIVILEGE`](/sql/revoke-privilege)
+  commands, which allow granting/revoking privileges on a database object. To
+  ensure compatibility with PostgreSQL, sources, views and materialized views
+  must specify `TABLE` as the object type, or omit it altogether.
+
+  This is part of the work to enable **Role-based access control** (RBAC) in a
+  future release {{% gh 11579 %}}.
+
+#### Bug fixes and other improvements
+
+* **Breaking change.** Change the type of `id` in the `mz_schemas` and
+    `mz_databases` system catalog tables from integer to string, for
+    consistency with the rest of the catalog. This change should have no user
+    impact, but please [let us know](https://support.materialize.com) if you
+    run into any issues.
+
+* Fix a bug where the `before` field was still required in the schema of change
+  events for Kafka sources using [`ENVELOPE DEBEZIUM`](https://materialize.com/docs/sql/create-source/#debezium-envelope)
+  {{% gh 18844 %}}.

--- a/doc/user/content/releases/v0.53.md
+++ b/doc/user/content/releases/v0.53.md
@@ -1,0 +1,11 @@
+---
+title: "Materialize v0.53"
+date: 2023-05-10
+released: false
+---
+
+## v0.53.0
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -88,6 +88,23 @@ Note that:
 
 - Using this envelope is required to consume [log compacted topics](https://docs.confluent.io/platform/current/kafka/design.html#log-compaction).
 
+#### Null keys
+
+If a message with a `NULL` key is detected, Materialize sets the source into an
+error state. To recover the errored source, the upstream Kafka broker must emit
+a record with a `NULL` value and a `NULL` key to force a retraction.
+
+As an example, you can use [`kcat`](https://docs.confluent.io/platform/current/clients/kafkacat-usage.html)
+to produce an empty message:
+
+```bash
+echo ":" | kcat -b $BROKER -t $TOPIC -Z -K: \
+  -X security.protocol=SASL_SSL \
+  -X sasl.mechanisms=SCRAM-SHA-256 \
+  -X sasl.username=$KAFKA_USERNAME \
+  -X sasl.password=$KAFKA_PASSWORD
+```
+
 ### Using Debezium
 
 {{< debezium-json >}}

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -91,8 +91,8 @@ Note that:
 #### Null keys
 
 If a message with a `NULL` key is detected, Materialize sets the source into an
-error state. To recover the errored source, the upstream Kafka broker must emit
-a record with a `NULL` value and a `NULL` key to force a retraction.
+error state. To recover an errored source, you must produce a record with a
+`NULL` value and a `NULL` key to the topic, to force a retraction.
 
 As an example, you can use [`kcat`](https://docs.confluent.io/platform/current/clients/kafkacat-usage.html)
 to produce an empty message:

--- a/doc/user/content/sql/grant-privilege.md
+++ b/doc/user/content/sql/grant-privilege.md
@@ -6,10 +6,16 @@ menu:
     parent: commands
 ---
 
-`GRANT` grants privileges on a database object.
+`GRANT` grants privileges on a database object. The `PUBLIC` pseudo-role can
+be used to indicate that the privileges should be granted to all roles
+(including roles that might not exist yet).
+
+Privileges are cumulative: revoking a privilege from `PUBLIC` does not mean all
+roles have lost that privilege, if certain roles were explicitly granted that
+privilege.
 
 {{< warning >}}
-Currently, roles have limited functionality in Materialize. This is part of the
+Currently, privileges have limited functionality in Materialize. This is part of the
 work to enable **Role-based access control** (RBAC) in a future release {{% gh 11579 %}}.
 {{< /warning >}}
 
@@ -25,7 +31,7 @@ work to enable **Role-based access control** (RBAC) in a future release {{% gh 1
 Field         | Use
 --------------|--------------------------------------------------
 _object_name_ | The object that privileges are being granted on.
-_role_name_   | The role name that is gaining privileges.
+_role_name_   | The role name that is gaining privileges. Use the `PUBLIC` pseudo-role to grant privileges to all roles.
 **SELECT**    | Allows reading rows from an object. The abbreviation for this privilege is 'r' (read).
 **INSERT**    | Allows inserting into an object. The abbreviation for this privilege is 'a' (append).
 **UPDATE**    | Allows updating an object (requires **SELECT** if a read is necessary). The abbreviation for this privilege is 'w' (write).
@@ -35,35 +41,32 @@ _role_name_   | The role name that is gaining privileges.
 
 ## Details
 
-For Views, Materialized Views, and Sources, the object type of 'TABLE' must be specified. This is
-for PostgreSQL compatibility.
+The following table describes which privileges are applicable to which objects:
 
-The following tables describes which privileges are applicable on which objects:
+| Object type           | All privileges |
+|-----------------------|----------------|
+| `DATABASE`            | UC             |
+| `SCHEMA`              | UC             |
+| `TABLE`               | arwd           |
+| (`VIEW`)              | r              |
+| (`MATERIALIZED VIEW`) | r              |
+| `INDEX`               |                |
+| `TYPE`                | U              |
+| (`SOURCE`)            | r              |
+| `SINK`                |                |
+| `CONNECTION`          | U              |
+| `SECRET`              | U              |
+| `CLUSTER`             | UC             |
 
-| Object Type          | All Privileges |
-|----------------------|----------------|
-| `DATABASE`           | UC             |
-| `SCHEMA`             | UC             |
-| `TABLE`              | arwd           |
-| `VIEW`               | r              |
-| `MATERIALIZED  VIEW` | r              |
-| `INDEX`              |                |
-| `TYPE`               | U              |
-| `SOURCE`             | r              |
-| `SINK`               |                |
-| `CONNECTION`         | U              |
-| `SECRET`             | U              |
-| `CLUSTER`            | UC             |
+### Compatibility
 
-The keyword `PUBLIC` can be used as the _role_name_. This psuedo-role indicates that these
-privileges are being granted to all roles, even those that don't exist yet.
-Note: Privileges are cumulative. Revoking a privilege from `PUBLIC` does not mean all roles have
-lost that privilege, if certain roles were explicitly granted that privilege.
+For PostgreSQL compatibility reasons, you must specify `TABLE` as the object
+type for sources, views, and materialized views, or omit the object type.
 
 ## Examples
 
 ```sql
-GRANT SELECT ON TABLE t TO joe;
+GRANT SELECT ON mv TO joe;
 ```
 
 ```sql

--- a/doc/user/content/sql/revoke-privilege.md
+++ b/doc/user/content/sql/revoke-privilege.md
@@ -1,18 +1,19 @@
 ---
 title: "REVOKE PRIVILEGE"
-description: "`REVOK` revokes privileges on a database object."
+description: "`REVOKE` revokes privileges from a database object."
 menu:
   main:
     parent: commands
 ---
 
-`REVOKE` revokes privileges on a database object.
+`REVOKE` revokes privileges from a database object. The `PUBLIC` pseudo-role can
+be used to indicate that the privileges should be revoked from all roles
+(including roles that might not exist yet).
 
 {{< warning >}}
-Currently, roles have limited functionality in Materialize. This is part of the
+Currently, privileges have limited functionality in Materialize. This is part of the
 work to enable **Role-based access control** (RBAC) in a future release {{% gh 11579 %}}.
 {{< /warning >}}
-
 
 ## Syntax
 
@@ -24,8 +25,8 @@ work to enable **Role-based access control** (RBAC) in a future release {{% gh 1
 
 Field         | Use
 --------------|--------------------------------------------------
-_object_name_ | The object that privileges are being granted on.
-_role_name_   | The role name that is gaining privileges.
+_object_name_ | The object that privileges are being revoked from.
+_role_name_   | The role name that is losing privileges. Use the `PUBLIC` pseudo-role to revoke privileges from all roles.
 **SELECT**    | Allows reading rows from an object. The abbreviation for this privilege is 'r' (read).
 **INSERT**    | Allows inserting into an object. The abbreviation for this privilege is 'a' (append).
 **UPDATE**    | Allows updating an object (requires **SELECT** if a read is necessary). The abbreviation for this privilege is 'w' (write).
@@ -35,33 +36,37 @@ _role_name_   | The role name that is gaining privileges.
 
 ## Details
 
-For Views, Materialized Views, and Sources, the object type of 'TABLE' must be specified. This is
-for PostgreSQL compatibility.
+The following tables describes which privileges are applicable to which objects:
 
-The following tables describes which privileges are applicable on which objects:
+{{< note >}}
+For PostgreSQL compatibility reasons, you must specify `TABLE` as the object
+type for sources, views, and materialized views, or omit the object type.
+{{</ note >}}
 
-| Object Type          | All Privileges |
-|----------------------|----------------|
-| `DATABASE`           | UC             |
-| `SCHEMA`             | UC             |
-| `TABLE`              | arwd           |
-| `VIEW`               | r              |
-| `MATERIALIZED  VIEW` | r              |
-| `INDEX`              |                |
-| `TYPE`               | U              |
-| `SOURCE`             | r              |
-| `SINK`               |                |
-| `CONNECTION`         | U              |
-| `SECRET`             | U              |
-| `CLUSTER`            | UC             |
+| Object type           | All privileges |
+|-----------------------|----------------|
+| `DATABASE`            | UC             |
+| `SCHEMA`              | UC             |
+| `TABLE`               | arwd           |
+| (`VIEW`)              | r              |
+| (`MATERIALIZED VIEW`) | r              |
+| `INDEX`               |                |
+| `TYPE`                | U              |
+| (`SOURCE`)            | r              |
+| `SINK`                |                |
+| `CONNECTION`          | U              |
+| `SECRET`              | U              |
+| `CLUSTER`             | UC             |
 
-The keyword `PUBLIC` can be used as the _role_name_. This pseudo-role indicates that these
-privileges are being revoked from all roles, even those that don't exist yet.
+### Compatibility
+
+For PostgreSQL compatibility reasons, you must specify `TABLE` as the object
+type for sources, views, and materialized views, or omit the object type.
 
 ## Examples
 
 ```sql
-REVOKE SELECT ON TABLE t FROM joe;
+REVOKE SELECT ON mv FROM joe;
 ```
 
 ```sql


### PR DESCRIPTION
Release notes for v0.52. 🤸 

Touches #18917 (but doesn't close it).

## Tips for reviewer

* Skipping #18796 until retention is enabled and this feature is more useful for self-guided observability (see [this comment](https://github.com/MaterializeInc/materialize/pull/18796#pullrequestreview-1388202550)).
* Skipping #18873 and #18877, since these are fixes to expected behaviour and RBAC isn't exposed to users yet.
* Didn't add a release note for #18853, though it was backported to `v0.51.1` and was unearthed in a user mishap. My understanding is that the change is an improvement, but the actual underlying cause is lack of documentation around ACL requirements for Kafka sources and sinks (#18848).

### Other

* After #18539, `mz_internal.mz_source_statuses` includes progress subsources, which clutters the output. Suggesting that we add a condition to exclude them. @sploiselle
* Now that #18709 and #18831 were merged, we can document range types (#17340). @MaterializeInc/docs 
* We made an effort to remove mentions to sales from the documentation (and replaced them with "contact our team"), so my pettiness is having a hard time dealing with [this error message](https://github.com/jkosh44/materialize/blob/3ae00911ce98e9e91d8782183c426e337468cb30/src/adapter/src/error.rs#L321). @jkosh44 