### PR TITLE
compute/reconcile: don't report dropped collections

### DIFF
--- a/src/compute-client/src/protocol.rs
+++ b/src/compute-client/src/protocol.rs
@@ -98,11 +98,6 @@
 //! The replica must send the required responses to computation commands. This includes commands it
 //! has received in the initialization phase that have not already been responded to.
 //!
-//! The replica may also send [`FrontierUppers`] and [`SubscribeResponse::DroppedAt`] responses
-//! for compute collections that it wasn’t instructed to create through a [`CreateDataflows`]
-//! command. This accounts for replicas reporting the dropping of unneeded collections during
-//! reconciliation ([#16247]). The compute controller should ignore these responses.
-//!
 //! [`ComputeCommand`]: self::command::ComputeCommand
 //! [`CreateTimely`]: self::command::ComputeCommand::CreateTimely
 //! [`CreateInstance`]: self::command::ComputeCommand::CreateInstance
@@ -116,7 +111,6 @@
 //! [`FrontierUppers`]: self::response::ComputeResponse::FrontierUppers
 //! [`Canceled`]: self::response::PeekResponse::Canceled
 //! [`SubscribeResponse::DroppedAt`]: self::response::SubscribeResponse::DroppedAt
-//! [#16247]: https://github.com/MaterializeInc/materialize/issues/16274
 
 pub mod command;
 pub mod history;

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -131,10 +131,6 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// the replica must produce [`SubscribeResponse`]s that report the progress and results of the
     /// subscribes.
     ///
-    /// During the [Initialization Stage], the controller must not send `CreateDataflows` commands
-    /// that instruct the creation of dataflows exporting subscribes. This is a limitation of our
-    /// current implementation that we indend to remove ([#16247]).
-    ///
     /// [`objects_to_build`]: DataflowDescription::objects_to_build
     /// [`source_imports`]: DataflowDescription::source_imports
     /// [`index_imports`]: DataflowDescription::index_imports
@@ -142,7 +138,6 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// [`FrontierUppers`]: super::response::ComputeResponse::FrontierUppers
     /// [`SubscribeResponse`]: super::response::ComputeResponse::SubscribeResponse
     /// [Initialization Stage]: super#initialization-stage
-    /// [#16247]: https://github.com/MaterializeInc/materialize/issues/16247
     CreateDataflows(Vec<DataflowDescription<crate::plan::Plan<T>, CollectionMetadata, T>>),
 
     /// `AllowCompaction` informs the replica about the relaxation of external read capabilities on

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -69,13 +69,11 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     ///
     /// The replica must not send `FrontierUppers` responses for collections that have not
     /// been created previously by a [`CreateDataflows` command] or by a [`CreateInstance`
-    /// command]. An exception are `FrontierUppers` responses that report the empty frontier.
-    /// ([#16247])
+    /// command].
     ///
     /// [`AllowCompaction` command]: super::command::ComputeCommand::AllowCompaction
     /// [`CreateDataflows` command]: super::command::ComputeCommand::CreateDataflows
     /// [`CreateInstance` command]: super::command::ComputeCommand::CreateInstance
-    /// [#16247]: https://github.com/MaterializeInc/materialize/issues/16247
     /// [#16275]: https://github.com/MaterializeInc/materialize/issues/16275
     FrontierUppers(Vec<(GlobalId, Antichain<T>)>),
 
@@ -122,16 +120,13 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     ///   * It must no longer read from its inputs.
     ///   * The replica must not send further `SubscribeResponse`s for that subscribe.
     ///
-    /// The replica must not send [`Batch`] responses for subscribes that have not been
-    /// created previously by a [`CreateDataflows` command]. The replica may send [`DroppedAt`]
-    /// responses for subscribes that have not been created previously by a [`CreateDataflows`
-    /// command]. ([#16247])
+    /// The replica must not send `SubscribeResponse`s for subscribes that have not been
+    /// created previously by a [`CreateDataflows` command].
     ///
     /// [`Batch`]: SubscribeResponse::Batch
     /// [`DroppedAt`]: SubscribeResponse::DroppedAt
     /// [`CreateDataflows` command]: super::command::ComputeCommand::CreateDataflows
     /// [`AllowCompaction` command]: super::command::ComputeCommand::AllowCompaction
-    /// [#16247]: https://github.com/MaterializeInc/materialize/issues/16247
     SubscribeResponse(GlobalId, SubscribeResponse<T>),
 }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -21,7 +21,7 @@ use timely::communication::Allocate;
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::generic::source;
 use timely::dataflow::operators::Operator;
-use timely::progress::Timestamp;
+use timely::progress::{Antichain, Timestamp};
 use timely::scheduling::{Scheduler, SyncActivator};
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
@@ -525,8 +525,6 @@ impl<'w, A: Allocate> Worker<'w, A> {
             let mut old_compaction = BTreeMap::default();
             // Exported identifiers from dataflows we retain.
             let mut retain_ids = BTreeSet::default();
-            // `as_of` frontiers of collections exported from requested dataflows.
-            let mut new_as_ofs = BTreeMap::default();
 
             // Traverse new commands, sorting out what remediation we can do.
             for command in new_commands.iter() {
@@ -539,7 +537,6 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         for dataflow in dataflows.iter() {
                             let as_of = dataflow.as_of.as_ref().unwrap();
                             let export_ids = dataflow.export_ids().collect::<BTreeSet<_>>();
-                            new_as_ofs.extend(export_ids.iter().map(|id| (*id, as_of.clone())));
 
                             if let Some(old_dataflow) = old_dataflows.get(&export_ids) {
                                 let compatible = old_dataflow.compatible_with(dataflow);
@@ -606,16 +603,17 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 for id in dataflow.export_ids() {
                     // We want to drop anything that has not yet been dropped,
                     // and nothing that has already been dropped.
-                    if old_frontiers.get(&id) != Some(&&timely::progress::Antichain::default()) {
-                        old_compaction.insert(id, timely::progress::Antichain::default());
+                    if old_frontiers.get(&id) != Some(&&Antichain::new()) {
+                        old_compaction.insert(id, Antichain::new());
                     }
                 }
             }
             if !old_compaction.is_empty() {
-                todo_commands.insert(
-                    0,
-                    ComputeCommand::AllowCompaction(old_compaction.into_iter().collect::<Vec<_>>()),
-                );
+                let compactions = old_compaction
+                    .iter()
+                    .map(|(k, v)| (*k, v.clone()))
+                    .collect();
+                todo_commands.insert(0, ComputeCommand::AllowCompaction(compactions));
             }
 
             // Clean up worker-local state.
@@ -633,14 +631,32 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     logger.log(ComputeEvent::Peek(peek.as_log_event(), false));
                 }
             }
-            // We compact away removed frontiers, and so only need to reset ids we continue to use.
-            // We must remember, though, to compensate what already was sent to logging sources.
+
+            // Adjust reported frontiers:
+            //  * For dataflows we continue to use, reset to ensure we report something not before
+            //    the new `as_of` next.
+            //  * For dataflows we drop, set to the empty frontier, to ensure we don't report
+            //    anything for them. This is only needed until we implement #16275.
             for (&id, reported_frontier) in compute_state.reported_frontiers.iter_mut() {
-                let new_reported_frontier = match new_as_ofs.remove(&id) {
-                    Some(lower) => ReportedFrontier::NotReported { lower },
-                    None => ReportedFrontier::new(),
+                let retained = retain_ids.contains(&id);
+                let compaction = old_compaction.remove(&id);
+                let new_reported_frontier = match (retained, compaction) {
+                    (true, Some(new_as_of)) => ReportedFrontier::NotReported { lower: new_as_of },
+                    (true, None) => {
+                        unreachable!("retained dataflows are compacted to the new as_of")
+                    }
+                    (false, Some(new_frontier)) => {
+                        assert!(new_frontier.is_empty());
+                        ReportedFrontier::Reported(new_frontier)
+                    }
+                    (false, None) => {
+                        // Logging dataflows are implicitly retained and don't have a new as_of.
+                        // Reset them to the minimal frontier.
+                        ReportedFrontier::new()
+                    }
                 };
 
+                // Compensate what already was sent to logging sources.
                 if let Some(logger) = &compute_state.compute_logger {
                     if let Some(time) = reported_frontier.logging_time() {
                         logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
@@ -652,10 +668,12 @@ impl<'w, A: Allocate> Worker<'w, A> {
 
                 *reported_frontier = new_reported_frontier;
             }
+
             // Sink tokens should be retained for retained dataflows, and dropped for dropped dataflows.
             compute_state
                 .sink_tokens
                 .retain(|id, _| retain_ids.contains(id));
+
             // We must drop the subscribe response buffer as it is global across all subscribes.
             // If it were broken out by `GlobalId` then we could drop only those of dataflows we drop.
             compute_state.subscribe_response_buffer =

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -630,6 +630,11 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 }
             }
 
+            // Clear the list of dropped collections.
+            // We intended to report their dropping, but the controller does not expect to hear
+            // about them anymore.
+            compute_state.dropped_collections = Default::default();
+
             // Adjust reported frontiers:
             //  * For dataflows we continue to use, reset to ensure we report something not before
             //    the new `as_of` next.


### PR DESCRIPTION
This PR adjusts compute reconciliation to prevent the replica from reporting empty frontiers for collections dropped in the process. During reconciliation, we drop collections/dataflows in two cases:

 1. When old dataflows are replaced by incompatible new dataflows.
 2. When old dataflows are not present in the initialization commands.

In both cases the controller does not expect to hear about the dropping of the old dataflows, so the replica should be silent. This is now ensured by changing the `reported_frontier`s of collections we are going to drop to the empty frontiers. Doing so prevents the frontier reporting logic to try and report the same frontier again when we allow to compact away the old collections.

Note that case (1) mentioned above was already silent prior to this commit, due to some special-casing in `report_dropped_collections`. This special-casing has been replaced with an assert, as we no longer expect `report_dropped_collections` to be called at all for collections dropped during reconciliation.

In addition, the PR does the following less significant things:
* Add a comment to explain why we don't see `DroppedAt` responses for subscribes dropped during reconciliation. This is significant because so far we assumed this would happen, which would have been a bug that #16247 explicitly points out. As it turns out, this bug doesn't actually exist.
* Adjust the compute controller and the compute protocol spec to remove the exceptions we had in place to deal with spurious `FrontierUppers` and `DroppedAt` responses produced during reconciliation.
* Clear the `dropped_collections` list during reconciliation. That we didn't do so previously is almost certainly a bug as it could have been another source of spurious `FrontierUppers` responses.
* Adds a test case that ensures no errors are logged during reconciliation. Unfortunately, I don't think we can do much better than this for testing reconciliation with our current mzcompose framework.

### Motivation

  * This PR fixes a recognized bug.

Fixes #16247.

### Tips for reviewer

Look at the commits separately!

The reconciliation code is tricky. I hope the comments are sufficient in explaining the logic.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
