### PR TITLE
test: move FORMAT JSON tests to json_source.py

### DIFF
--- a/misc/python/materialize/checks/kafka_formats.py
+++ b/misc/python/materialize/checks/kafka_formats.py
@@ -54,11 +54,6 @@ class KafkaFormats(Check):
                   format=protobuf descriptor-file=test.proto message=Value
                 {"key1": "key1A", "key2": "key1B"} {"value1": "value1A", "value2": "value1B"}
 
-                $ kafka-create-topic topic=format-json-bytes partitions=1
-
-                $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-json-bytes
-                "object":{"a":"b","c":"d"}
-
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
                 > CREATE SOURCE format_bytes1
@@ -95,13 +90,6 @@ class KafkaFormats(Check):
                   KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA '${test-schema}'
                   VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA '${test-schema}'
                   INCLUDE KEY
-
-                > CREATE SOURCE format_json1
-                  IN CLUSTER kafka_formats
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-json-bytes-${testdrive.seed}')
-                  KEY FORMAT JSON
-                  VALUE FORMAT JSON
-                  ENVELOPE UPSERT
             """
             )
         )
@@ -148,13 +136,6 @@ class KafkaFormats(Check):
                   VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA '${test-schema}'
                   INCLUDE KEY
 
-                > CREATE SOURCE format_json2
-                  IN CLUSTER kafka_formats
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-json-bytes-${testdrive.seed}')
-                  KEY FORMAT JSON
-                  VALUE FORMAT JSON
-                  ENVELOPE UPSERT
-
                 $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-bytes
                 key2A,key2B:value2A,value2B
 
@@ -162,9 +143,6 @@ class KafkaFormats(Check):
                   key-format=protobuf key-descriptor-file=test.proto key-message=Key
                   format=protobuf descriptor-file=test.proto message=Value
                 {"key1": "key2A", "key2": "key2B"} {"value1": "value2A", "value2": "value2B"}
-
-                $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-json-bytes
-                "array":[1,2,3]
                 """,
                 """
                 $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-bytes
@@ -174,11 +152,6 @@ class KafkaFormats(Check):
                   key-format=protobuf key-descriptor-file=test.proto key-message=Key
                   format=protobuf descriptor-file=test.proto message=Value
                 {"key1": "key3A", "key2": "key3B"} {"value1": "value3A", "value2": "value3B"}
-
-                $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-json-bytes
-                "int":1
-                "float":1.23
-                "str":"hello"
                 """,
             ]
         ]
@@ -210,13 +183,6 @@ class KafkaFormats(Check):
                 key2A key2B value2A value2B
                 key3A key3B value3A value3B
 
-                > SELECT * FROM format_json1 ORDER BY key
-                "\\"array\\"" [1,2,3]
-                "\\"float\\"" 1.23
-                "\\"int\\"" 1
-                "\\"object\\"" "{\\"a\\":\\"b\\",\\"c\\":\\"d\\"}"
-                "\\"str\\"" "\\"hello\\""
-
                 > SELECT * FROM format_text2
                 key1A,key1B value1A,value1B
                 key2A,key2B value2A,value2B
@@ -236,13 +202,6 @@ class KafkaFormats(Check):
                 key1A key1B value1A value1B
                 key2A key2B value2A value2B
                 key3A key3B value3A value3B
-
-                > SELECT * FROM format_json2 ORDER BY key
-                "\\"array\\"" [1,2,3]
-                "\\"float\\"" 1.23
-                "\\"int\\"" 1
-                "\\"object\\"" "{\\"a\\":\\"b\\",\\"c\\":\\"d\\"}"
-                "\\"str\\"" "\\"hello\\""
                 """
             )
         )


### PR DESCRIPTION
Fixes breakage of upgrade tests

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
