### PR TITLE
environmentd: Add boostrap role to startup

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -196,6 +196,7 @@ def main() -> int:
                 f"--adapter-stash-url={args.postgres}?options=--search_path=adapter",
                 f"--storage-stash-url={args.postgres}?options=--search_path=storage",
                 f"--environment-id={environment_id}",
+                "--bootstrap-role=materialize",
                 *args.args,
             ]
         elif args.program == "sqllogictest":

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -196,7 +196,7 @@ def main() -> int:
                 f"--adapter-stash-url={args.postgres}?options=--search_path=adapter",
                 f"--storage-stash-url={args.postgres}?options=--search_path=storage",
                 f"--environment-id={environment_id}",
-                "--local-bootstrap-role=materialize",
+                "--bootstrap-role=materialize",
                 *args.args,
             ]
         elif args.program == "sqllogictest":

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -196,7 +196,7 @@ def main() -> int:
                 f"--adapter-stash-url={args.postgres}?options=--search_path=adapter",
                 f"--storage-stash-url={args.postgres}?options=--search_path=storage",
                 f"--environment-id={environment_id}",
-                "--bootstrap-role=materialize",
+                "--local-bootstrap-role=materialize",
                 *args.args,
             ]
         elif args.program == "sqllogictest":

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -183,7 +183,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             ]
         if self._meets_minimum_version("0.53.0"):
             args += [
-                "--bootstrap-role",
+                "--local-bootstrap-role",
                 "materialize",
             ]
         container = V1Container(

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -181,6 +181,11 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
                     release_mode=self.release_mode,
                 ),
             ]
+        if self._meets_minimum_version("0.53.0"):
+            args += [
+                "--bootstrap-role",
+                "materialize",
+            ]
         container = V1Container(
             name="environmentd",
             image=self.image(

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -183,7 +183,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             ]
         if self._meets_minimum_version("0.53.0"):
             args += [
-                "--local-bootstrap-role",
+                "--bootstrap-role",
                 "materialize",
             ]
         container = V1Container(

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -89,6 +89,7 @@ class Materialized(Service):
             # use Composition.override.
             "MZ_LOG_FILTER",
             "CLUSTERD_LOG_FILTER",
+            "BOOTSTRAP_ROLE=materialize",
             *environment_extra,
         ]
 
@@ -147,8 +148,6 @@ class Materialized(Service):
             "--orchestrator-process-tcp-proxy-listen-addr=0.0.0.0",
             "--orchestrator-process-prometheus-service-discovery-directory=/mzdata/prometheus",
         ]
-
-        environment += ["BOOTSTRAP_ROLE=materialize"]
 
         command += options
 

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -89,7 +89,7 @@ class Materialized(Service):
             # use Composition.override.
             "MZ_LOG_FILTER",
             "CLUSTERD_LOG_FILTER",
-            "BOOTSTRAP_ROLE=materialize",
+            "LOCAL_BOOTSTRAP_ROLE=materialize",
             *environment_extra,
         ]
 

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -89,7 +89,7 @@ class Materialized(Service):
             # use Composition.override.
             "MZ_LOG_FILTER",
             "CLUSTERD_LOG_FILTER",
-            "LOCAL_BOOTSTRAP_ROLE=materialize",
+            "BOOTSTRAP_ROLE=materialize",
             *environment_extra,
         ]
 

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -148,6 +148,8 @@ class Materialized(Service):
             "--orchestrator-process-prometheus-service-discovery-directory=/mzdata/prometheus",
         ]
 
+        environment += ["BOOTSTRAP_ROLE=materialize"]
+
         command += options
 
         config: ServiceConfig = {}

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4067,7 +4067,7 @@ impl Catalog {
                 default_cluster_replica_size: "1".into(),
                 builtin_cluster_replica_size: "1".into(),
                 default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
-                local_bootstrap_role: None,
+                bootstrap_role: None,
             },
         )
         .await?;

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4067,7 +4067,7 @@ impl Catalog {
                 default_cluster_replica_size: "1".into(),
                 builtin_cluster_replica_size: "1".into(),
                 default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
-                bootstrap_role: None,
+                local_bootstrap_role: None,
             },
         )
         .await?;

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4067,6 +4067,7 @@ impl Catalog {
                 default_cluster_replica_size: "1".into(),
                 builtin_cluster_replica_size: "1".into(),
                 default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
+                bootstrap_role: None,
             },
         )
         .await?;

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -421,14 +421,14 @@ async fn migrate(
             txn.configs
                 .insert(USER_VERSION.to_string(), ConfigValue { value: 0 })?;
 
-            if let Some(bootstrap_role) = &bootstrap_args.bootstrap_role {
+            if let Some(local_bootstrap_role) = &bootstrap_args.local_bootstrap_role {
                 let role_id =
                     RoleId::User(txn.get_and_increment_id(USER_ROLE_ID_ALLOC_KEY.to_string())?);
                 txn.roles.insert(
                     RoleKey { id: role_id },
                     RoleValue {
                         role: SerializedRole {
-                            name: bootstrap_role.clone(),
+                            name: local_bootstrap_role.clone(),
                             attributes: Some(
                                 RoleAttributes::new().with_create_db().with_create_cluster(),
                             ),
@@ -445,7 +445,7 @@ async fn migrate(
                             ObjectType::Role,
                             EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
                                 id: role_id.to_string(),
-                                name: bootstrap_role.clone(),
+                                name: local_bootstrap_role.clone(),
                             }),
                             None,
                             now,
@@ -968,7 +968,7 @@ pub struct BootstrapArgs {
     pub default_cluster_replica_size: String,
     pub builtin_cluster_replica_size: String,
     pub default_availability_zone: String,
-    pub bootstrap_role: Option<String>,
+    pub local_bootstrap_role: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -445,7 +445,7 @@ async fn migrate(
                             ObjectType::Role,
                             EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
                                 id: role_id.to_string(),
-                                name: "materialize".into(),
+                                name: bootstrap_role.clone(),
                             }),
                             None,
                             now,

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -421,14 +421,14 @@ async fn migrate(
             txn.configs
                 .insert(USER_VERSION.to_string(), ConfigValue { value: 0 })?;
 
-            if let Some(local_bootstrap_role) = &bootstrap_args.local_bootstrap_role {
+            if let Some(bootstrap_role) = &bootstrap_args.bootstrap_role {
                 let role_id =
                     RoleId::User(txn.get_and_increment_id(USER_ROLE_ID_ALLOC_KEY.to_string())?);
                 txn.roles.insert(
                     RoleKey { id: role_id },
                     RoleValue {
                         role: SerializedRole {
-                            name: local_bootstrap_role.clone(),
+                            name: bootstrap_role.clone(),
                             attributes: Some(
                                 RoleAttributes::new().with_create_db().with_create_cluster(),
                             ),
@@ -445,7 +445,7 @@ async fn migrate(
                             ObjectType::Role,
                             EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
                                 id: role_id.to_string(),
-                                name: local_bootstrap_role.clone(),
+                                name: bootstrap_role.clone(),
                             }),
                             None,
                             now,
@@ -968,7 +968,7 @@ pub struct BootstrapArgs {
     pub default_cluster_replica_size: String,
     pub builtin_cluster_replica_size: String,
     pub default_availability_zone: String,
-    pub local_bootstrap_role: Option<String>,
+    pub bootstrap_role: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -163,6 +163,15 @@ pub struct Args {
     #[clap(long, env = "UNSAFE_MODE")]
     unsafe_mode: bool,
 
+    /// If set, a role with the provided name will be created with `CREATEDB` and `CREATECLUSTER`
+    /// attributes. It will also have `CREATE` privileges on the `materialize` database,
+    /// `materialize.public` schema, and `default` cluster.
+    ///
+    /// This option is meant for local development and testing to simplify the initial process of
+    /// granting attributes and privileges to some default role.
+    #[clap(long, env = "BOOTSTRAP_ROLE")]
+    bootstrap_role: Option<String>,
+
     // === Connection options. ===
     /// The address on which to listen for untrusted SQL connections.
     ///
@@ -796,6 +805,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             .map(|kv| (kv.key, kv.value))
             .collect(),
         config_sync_loop_interval: args.config_sync_loop_interval,
+        bootstrap_role: args.bootstrap_role,
     }))?;
 
     metrics.start_time_environmentd.set(

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -163,15 +163,6 @@ pub struct Args {
     #[clap(long, env = "UNSAFE_MODE")]
     unsafe_mode: bool,
 
-    /// If set, a role with the provided name will be created with `CREATEDB` and `CREATECLUSTER`
-    /// attributes. It will also have `CREATE` privileges on the `materialize` database,
-    /// `materialize.public` schema, and `default` cluster.
-    ///
-    /// This option is meant for local development and testing to simplify the initial process of
-    /// granting attributes and privileges to some default role.
-    #[clap(long, env = "BOOTSTRAP_ROLE")]
-    bootstrap_role: Option<String>,
-
     // === Connection options. ===
     /// The address on which to listen for untrusted SQL connections.
     ///
@@ -386,6 +377,14 @@ pub struct Args {
         default_value_if("orchestrator", Some("process"), Some("clusterd"))
     )]
     clusterd_image: Option<String>,
+    /// If set, a role with the provided name will be created with `CREATEDB` and `CREATECLUSTER`
+    /// attributes. It will also have `CREATE` privileges on the `materialize` database,
+    /// `materialize.public` schema, and `default` cluster.
+    ///
+    /// This option is meant for local development and testing to simplify the initial process of
+    /// granting attributes and privileges to some default role.
+    #[clap(long, env = "BOOTSTRAP_ROLE")]
+    bootstrap_role: Option<String>,
 
     // === Storage options. ===
     /// Where the persist library should store its blob data.

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -402,7 +402,7 @@ pub struct Args {
     #[clap(long, env = "ADAPTER_STASH_URL", value_name = "POSTGRES_URL")]
     adapter_stash_url: String,
 
-    // === Cloud options. ===
+    // === Bootstrap options. ===
     #[clap(
         long,
         env = "ENVIRONMENT_ID",

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -163,15 +163,6 @@ pub struct Args {
     #[clap(long, env = "UNSAFE_MODE")]
     unsafe_mode: bool,
 
-    /// If set, a role with the provided name will be created with `CREATEDB` and `CREATECLUSTER`
-    /// attributes. It will also have `CREATE` privileges on the `materialize` database,
-    /// `materialize.public` schema, and `default` cluster.
-    ///
-    /// This option is meant for local development and testing to simplify the initial process of
-    /// granting attributes and privileges to some default role.
-    #[clap(long, env = "BOOTSTRAP_ROLE")]
-    bootstrap_role: Option<String>,
-
     // === Connection options. ===
     /// The address on which to listen for untrusted SQL connections.
     ///
@@ -526,6 +517,16 @@ pub struct Args {
     // === Tracing options. ===
     #[clap(flatten)]
     tracing: TracingCliArgs,
+
+    // === Testing options. ===
+    /// If set, a role with the provided name will be created with `CREATEDB` and `CREATECLUSTER`
+    /// attributes. It will also have `CREATE` privileges on the `materialize` database,
+    /// `materialize.public` schema, and `default` cluster.
+    ///
+    /// This option is meant for local development and testing to simplify the initial process of
+    /// granting attributes and privileges to some default role.
+    #[clap(long, env = "LOCAL_BOOTSTRAP_ROLE")]
+    local_bootstrap_role: Option<String>,
 }
 
 #[derive(ArgEnum, Debug, Clone)]
@@ -805,7 +806,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             .map(|kv| (kv.key, kv.value))
             .collect(),
         config_sync_loop_interval: args.config_sync_loop_interval,
-        bootstrap_role: args.bootstrap_role,
+        local_bootstrap_role: args.local_bootstrap_role,
     }))?;
 
     metrics.start_time_environmentd.set(

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -163,6 +163,15 @@ pub struct Args {
     #[clap(long, env = "UNSAFE_MODE")]
     unsafe_mode: bool,
 
+    /// If set, a role with the provided name will be created with `CREATEDB` and `CREATECLUSTER`
+    /// attributes. It will also have `CREATE` privileges on the `materialize` database,
+    /// `materialize.public` schema, and `default` cluster.
+    ///
+    /// This option is meant for local development and testing to simplify the initial process of
+    /// granting attributes and privileges to some default role.
+    #[clap(long, env = "BOOTSTRAP_ROLE")]
+    bootstrap_role: Option<String>,
+
     // === Connection options. ===
     /// The address on which to listen for untrusted SQL connections.
     ///
@@ -517,16 +526,6 @@ pub struct Args {
     // === Tracing options. ===
     #[clap(flatten)]
     tracing: TracingCliArgs,
-
-    // === Testing options. ===
-    /// If set, a role with the provided name will be created with `CREATEDB` and `CREATECLUSTER`
-    /// attributes. It will also have `CREATE` privileges on the `materialize` database,
-    /// `materialize.public` schema, and `default` cluster.
-    ///
-    /// This option is meant for local development and testing to simplify the initial process of
-    /// granting attributes and privileges to some default role.
-    #[clap(long, env = "LOCAL_BOOTSTRAP_ROLE")]
-    local_bootstrap_role: Option<String>,
 }
 
 #[derive(ArgEnum, Debug, Clone)]
@@ -806,7 +805,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             .map(|kv| (kv.key, kv.value))
             .collect(),
         config_sync_loop_interval: args.config_sync_loop_interval,
-        local_bootstrap_role: args.local_bootstrap_role,
+        bootstrap_role: args.bootstrap_role,
     }))?;
 
     metrics.start_time_environmentd.set(

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -128,6 +128,8 @@ pub struct Config {
     // === Special modes. ===
     /// Whether to permit usage of unsafe features.
     pub unsafe_mode: bool,
+    /// What role, if any, should be initially created with elevated privileges.
+    pub bootstrap_role: Option<String>,
 
     // === Connection options. ===
     /// The IP address and port to listen for pgwire connections on.
@@ -146,6 +148,8 @@ pub struct Config {
     pub tls: Option<TlsConfig>,
     /// Frontegg JWT authentication configuration.
     pub frontegg: Option<FronteggAuthentication>,
+
+    // === Connection options. ===
     /// Configuration for source and sink connections created by the storage
     /// layer. This can include configuration for external
     /// sources.
@@ -211,8 +215,6 @@ pub struct Config {
     // === Testing options. ===
     /// A now generation function for mocking time.
     pub now: NowFn,
-    /// What role, if any, should be initially created with elevated privileges.
-    pub local_bootstrap_role: Option<String>,
 }
 
 /// Configures TLS encryption for connections.
@@ -316,7 +318,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
                 .choose(&mut rand::thread_rng())
                 .cloned()
                 .unwrap_or_else(|| mz_adapter::DUMMY_AVAILABILITY_ZONE.into()),
-            local_bootstrap_role: config.local_bootstrap_role,
+            bootstrap_role: config.bootstrap_role,
         },
     )
     .await?;

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -165,7 +165,7 @@ pub struct Config {
     /// The PostgreSQL URL for the adapter stash.
     pub adapter_stash_url: String,
 
-    // === Cloud options. ===
+    // === Bootstrap options. ===
     /// The cloud ID of this environment.
     pub environment_id: EnvironmentId,
     /// Availability zones in which storage and compute resources may be

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -128,8 +128,6 @@ pub struct Config {
     // === Special modes. ===
     /// Whether to permit usage of unsafe features.
     pub unsafe_mode: bool,
-    /// What role, if any, should be initially created with elevated privileges.
-    pub bootstrap_role: Option<String>,
 
     // === Connection options. ===
     /// The IP address and port to listen for pgwire connections on.
@@ -148,8 +146,6 @@ pub struct Config {
     pub tls: Option<TlsConfig>,
     /// Frontegg JWT authentication configuration.
     pub frontegg: Option<FronteggAuthentication>,
-
-    // === Connection options. ===
     /// Configuration for source and sink connections created by the storage
     /// layer. This can include configuration for external
     /// sources.
@@ -215,6 +211,8 @@ pub struct Config {
     // === Testing options. ===
     /// A now generation function for mocking time.
     pub now: NowFn,
+    /// What role, if any, should be initially created with elevated privileges.
+    pub local_bootstrap_role: Option<String>,
 }
 
 /// Configures TLS encryption for connections.
@@ -318,7 +316,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
                 .choose(&mut rand::thread_rng())
                 .cloned()
                 .unwrap_or_else(|| mz_adapter::DUMMY_AVAILABILITY_ZONE.into()),
-            bootstrap_role: config.bootstrap_role,
+            local_bootstrap_role: config.local_bootstrap_role,
         },
     )
     .await?;

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -128,6 +128,8 @@ pub struct Config {
     // === Special modes. ===
     /// Whether to permit usage of unsafe features.
     pub unsafe_mode: bool,
+    /// What role, if any, should be initially created with elevated privileges.
+    pub bootstrap_role: Option<String>,
 
     // === Connection options. ===
     /// The IP address and port to listen for pgwire connections on.
@@ -316,6 +318,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
                 .choose(&mut rand::thread_rng())
                 .cloned()
                 .unwrap_or_else(|| mz_adapter::DUMMY_AVAILABILITY_ZONE.into()),
+            bootstrap_role: config.bootstrap_role,
         },
     )
     .await?;

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -128,8 +128,6 @@ pub struct Config {
     // === Special modes. ===
     /// Whether to permit usage of unsafe features.
     pub unsafe_mode: bool,
-    /// What role, if any, should be initially created with elevated privileges.
-    pub bootstrap_role: Option<String>,
 
     // === Connection options. ===
     /// The IP address and port to listen for pgwire connections on.
@@ -205,6 +203,8 @@ pub struct Config {
     /// An invertible map from system parameter names to LaunchDarkly feature
     /// keys to use when propagating values from the latter to the former.
     pub launchdarkly_key_map: BTreeMap<String, String>,
+    /// What role, if any, should be initially created with elevated privileges.
+    pub bootstrap_role: Option<String>,
 
     // === Tracing options. ===
     /// The metrics registry to use.

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -135,6 +135,7 @@ pub struct Config {
     builtin_cluster_replica_size: String,
     propagate_crashes: bool,
     enable_tracing: bool,
+    bootstrap_role: Option<String>,
 }
 
 impl Default for Config {
@@ -153,6 +154,7 @@ impl Default for Config {
             builtin_cluster_replica_size: "1".to_string(),
             propagate_crashes: false,
             enable_tracing: false,
+            bootstrap_role: Some("materialize".into()),
         }
     }
 }
@@ -230,6 +232,11 @@ impl Config {
 
     pub fn with_enable_tracing(mut self, enable_tracing: bool) -> Self {
         self.enable_tracing = enable_tracing;
+        self
+    }
+
+    pub fn with_bootstrap_role(mut self, bootstrap_role: Option<String>) -> Self {
+        self.bootstrap_role = bootstrap_role;
         self
     }
 }
@@ -368,6 +375,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         launchdarkly_sdk_key: None,
         launchdarkly_key_map: Default::default(),
         config_sync_loop_interval: None,
+        bootstrap_role: config.bootstrap_role,
     }))?;
     let server = Server {
         inner,

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -135,7 +135,7 @@ pub struct Config {
     builtin_cluster_replica_size: String,
     propagate_crashes: bool,
     enable_tracing: bool,
-    local_bootstrap_role: Option<String>,
+    bootstrap_role: Option<String>,
 }
 
 impl Default for Config {
@@ -154,7 +154,7 @@ impl Default for Config {
             builtin_cluster_replica_size: "1".to_string(),
             propagate_crashes: false,
             enable_tracing: false,
-            local_bootstrap_role: Some("materialize".into()),
+            bootstrap_role: Some("materialize".into()),
         }
     }
 }
@@ -235,8 +235,8 @@ impl Config {
         self
     }
 
-    pub fn with_local_bootstrap_role(mut self, bootstrap_role: Option<String>) -> Self {
-        self.local_bootstrap_role = bootstrap_role;
+    pub fn with_bootstrap_role(mut self, bootstrap_role: Option<String>) -> Self {
+        self.bootstrap_role = bootstrap_role;
         self
     }
 }
@@ -375,7 +375,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         launchdarkly_sdk_key: None,
         launchdarkly_key_map: Default::default(),
         config_sync_loop_interval: None,
-        local_bootstrap_role: config.local_bootstrap_role,
+        bootstrap_role: config.bootstrap_role,
     }))?;
     let server = Server {
         inner,

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -135,7 +135,7 @@ pub struct Config {
     builtin_cluster_replica_size: String,
     propagate_crashes: bool,
     enable_tracing: bool,
-    bootstrap_role: Option<String>,
+    local_bootstrap_role: Option<String>,
 }
 
 impl Default for Config {
@@ -154,7 +154,7 @@ impl Default for Config {
             builtin_cluster_replica_size: "1".to_string(),
             propagate_crashes: false,
             enable_tracing: false,
-            bootstrap_role: Some("materialize".into()),
+            local_bootstrap_role: Some("materialize".into()),
         }
     }
 }
@@ -235,8 +235,8 @@ impl Config {
         self
     }
 
-    pub fn with_bootstrap_role(mut self, bootstrap_role: Option<String>) -> Self {
-        self.bootstrap_role = bootstrap_role;
+    pub fn with_local_bootstrap_role(mut self, bootstrap_role: Option<String>) -> Self {
+        self.local_bootstrap_role = bootstrap_role;
         self
     }
 }
@@ -375,7 +375,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         launchdarkly_sdk_key: None,
         launchdarkly_key_map: Default::default(),
         config_sync_loop_interval: None,
-        bootstrap_role: config.bootstrap_role,
+        local_bootstrap_role: config.local_bootstrap_role,
     }))?;
     let server = Server {
         inner,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -911,6 +911,7 @@ impl RunnerInner {
             launchdarkly_sdk_key: None,
             launchdarkly_key_map: Default::default(),
             config_sync_loop_interval: None,
+            bootstrap_role: Some("materialize".into()),
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -911,7 +911,7 @@ impl RunnerInner {
             launchdarkly_sdk_key: None,
             launchdarkly_key_map: Default::default(),
             config_sync_loop_interval: None,
-            bootstrap_role: Some("materialize".into()),
+            local_bootstrap_role: Some("materialize".into()),
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -911,7 +911,7 @@ impl RunnerInner {
             launchdarkly_sdk_key: None,
             launchdarkly_key_map: Default::default(),
             config_sync_loop_interval: None,
-            local_bootstrap_role: Some("materialize".into()),
+            bootstrap_role: Some("materialize".into()),
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -397,6 +397,7 @@ impl Usage {
                 default_cluster_replica_size: "1".into(),
                 builtin_cluster_replica_size: "1".into(),
                 default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
+                bootstrap_role: None,
             },
         )
         .await?;

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -397,7 +397,7 @@ impl Usage {
                 default_cluster_replica_size: "1".into(),
                 builtin_cluster_replica_size: "1".into(),
                 default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
-                local_bootstrap_role: None,
+                bootstrap_role: None,
             },
         )
         .await?;

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -397,7 +397,7 @@ impl Usage {
                 default_cluster_replica_size: "1".into(),
                 builtin_cluster_replica_size: "1".into(),
                 default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
-                bootstrap_role: None,
+                local_bootstrap_role: None,
             },
         )
         .await?;

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -87,7 +87,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 2  create  schema  {"database_name":"materialize","id":"3","name":"public"}  NULL
 3  create  cluster  {"id":"u1","name":"default"}  NULL
 4  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","logical_size":"1","replica_id":"1","replica_name":"r1"}  NULL
-5  create  role  {"id":"u1","name":"materialize"}  materialize
+5  create  role  {"id":"u1","name":"materialize"}  NULL
 6  create  database  {"id":"u2","name":"test"}  materialize
 7  create  schema  {"database_name":"test","id":"u6","name":"public"}  materialize
 8  create  schema  {"database_name":"test","id":"u7","name":"sc1"}  materialize

--- a/test/sqllogictest/privileges.slt
+++ b/test/sqllogictest/privileges.slt
@@ -189,6 +189,7 @@ SELECT * FROM database_privileges
 ----
 materialize  =U/mz_system
 materialize  mz_system=UC/mz_system
+materialize  materialize=C/mz_system
 
 query TT
 SELECT * FROM schema_privileges ORDER BY name
@@ -203,12 +204,14 @@ pg_catalog          =U/mz_system
 pg_catalog          mz_system=UC/mz_system
 public              =U/mz_system
 public              mz_system=UC/mz_system
+public              materialize=C/mz_system
 
 query TT
 SELECT * FROM cluster_privileges ORDER BY name
 ----
 default           =U/mz_system
 default           mz_system=UC/mz_system
+default           materialize=C/mz_system
 mz_introspection  =U/mz_system
 mz_introspection  mz_system=UC/mz_system
 mz_introspection  mz_introspection=UC/mz_system
@@ -315,6 +318,7 @@ SELECT * FROM schema_privileges WHERE name = 'public' ORDER BY name
 public  =U/mz_system
 public  =U/materialize
 public  mz_system=UC/mz_system
+public  materialize=C/mz_system
 public  materialize=UC/materialize
 
 statement ok

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -21,7 +21,7 @@ s2 mz_introspection true false false false
 query TBBBB
 SELECT name, inherit, create_role, create_db, create_cluster FROM mz_roles WHERE id LIKE 'u%'
 ----
-materialize  true  false  false  false
+materialize  true  false  true  true
 
 # Give materialize the CREATEROLE attribute.
 simple conn=mz_system,user=mz_system
@@ -56,7 +56,7 @@ SELECT name, inherit, create_role, create_db, create_cluster FROM mz_roles
 ----
 rj  true  false  false  false
 mz_system  true  true  true  true
-materialize  true  true  false  false
+materialize  true  true  true  true
 mz_introspection  true  false  false  false
 
 # Dropping multiple roles should not have any effect if one of the role names


### PR DESCRIPTION
This commit adds the concept of a bootstrap role to startup. If a bootstrap role is specified when starting Materialize, and it's the first time that this instance of Materialize has been started, then a bootstrap role will be created with the given name that has elevated privileges. The role will have the `CREATEDB` and `CREATECLUSTER` attribute, and the `CREATE` privilege on the `materialize` database, the `materialize.public` schema, and the `default` cluster. The purpose of this role is to make testing and local development easier when RBAC is enabled.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
