### PR TITLE
storage: dont use http proxies for csr-over-ssh

### DIFF
--- a/src/ccsr/src/client.rs
+++ b/src/ccsr/src/client.rs
@@ -10,6 +10,7 @@
 use std::collections::BTreeSet;
 use std::error::Error;
 use std::fmt;
+use std::sync::Arc;
 
 use anyhow::bail;
 use reqwest::{Method, Url};
@@ -19,20 +20,29 @@ use serde::{Deserialize, Serialize};
 use crate::config::Auth;
 
 /// An API client for a Confluent-compatible schema registry.
-#[derive(Debug)]
 pub struct Client {
     inner: reqwest::Client,
-    url: Url,
+    url: Arc<dyn Fn() -> Url + Send + Sync + 'static>,
     auth: Option<Auth>,
+}
+
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Client")
+            .field("inner", &self.inner)
+            .field("url", &"...")
+            .field("auth", &self.auth)
+            .finish()
+    }
 }
 
 impl Client {
     pub(crate) fn new(
         inner: reqwest::Client,
-        url: Url,
+        url: Arc<dyn Fn() -> Url + Send + Sync + 'static>,
         auth: Option<Auth>,
     ) -> Result<Self, anyhow::Error> {
-        if url.cannot_be_a_base() {
+        if url().cannot_be_a_base() {
             bail!("cannot construct a CCSR client with a cannot-be-a-base URL");
         }
         Ok(Client { inner, url, auth })
@@ -43,7 +53,7 @@ impl Client {
         P: IntoIterator,
         P::Item: AsRef<str>,
     {
-        let mut url = self.url.clone();
+        let mut url = (self.url)();
         url.path_segments_mut()
             .expect("constructor validated URL can be a base")
             .clear()

--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -589,14 +589,16 @@ impl CsrConnection {
                 // computed for every request. This ensures that, if the tunnel
                 // fails and restarts at a new address, requests will start
                 // using the new tunnel address.
-                client_config = client_config.add_proxy(mz_ccsr::Proxy::custom(move |url| {
+
+                let remote_url = self.url.clone();
+                client_config = client_config.dynamic_url(move || {
                     let addr = ssh_tunnel.local_addr();
-                    let mut url = url.clone();
+                    let mut url = remote_url.clone();
                     url.set_host(Some(&addr.ip().to_string()))
                         .expect("cannot fail");
                     url.set_port(Some(addr.port())).expect("cannot fail");
-                    Some(url)
-                }));
+                    url
+                });
             }
             Tunnel::AwsPrivatelink(connection) => {
                 assert!(connection.port.is_none());


### PR DESCRIPTION
`reqwest` `Proxy`s require the schema-registry http server is configured to be a proxy. This is not true for Redpanda. This pr reverts this change, and goes back to a (now dynamic) url override scheme

### Motivation


  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
