### PR TITLE
adapter: re-verify and plan off-thread statements

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -13,7 +13,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
-use anyhow::anyhow;
 use chrono::DurationRound;
 use mz_persist_client::usage::ShardsUsage;
 use rand::{rngs, Rng, SeedableRng};
@@ -36,9 +35,9 @@ use crate::coord::{
     SinkConnectionReady,
 };
 use crate::util::ResultExt;
-use crate::{catalog, AdapterError, AdapterNotice};
+use crate::{catalog, AdapterNotice};
 
-use super::{PeekStage, PeekStageFinish};
+use super::{PeekStage, PeekStageFinish, TransientPlan};
 
 impl Coordinator {
     pub(crate) async fn handle_message(&mut self, msg: Message) {
@@ -89,15 +88,19 @@ impl Coordinator {
             }
             Message::RealTimeRecencyTimestamp {
                 conn_id,
-                transient_revision,
                 real_time_recency_ts,
+                replan,
             } => {
-                self.message_real_time_recency_timestamp(
-                    conn_id,
-                    transient_revision,
-                    real_time_recency_ts,
-                )
-                .await;
+                self.message_real_time_recency_timestamp(conn_id, real_time_recency_ts, replan)
+                    .await;
+            }
+            Message::Replan {
+                tx,
+                session,
+                replan,
+            } => {
+                self.sequence_plan(tx, session, replan.plan, replan.depends_on)
+                    .await;
             }
         }
     }
@@ -654,8 +657,8 @@ impl Coordinator {
     async fn message_real_time_recency_timestamp(
         &mut self,
         conn_id: ConnectionId,
-        transient_revision: u64,
         real_time_recency_ts: mz_repr::Timestamp,
+        replan: TransientPlan,
     ) {
         let real_time_recency_context =
             match self.pending_real_time_recency_timestamp.remove(&conn_id) {
@@ -664,11 +667,17 @@ impl Coordinator {
                 None => return,
             };
 
-        // Re-validate that the catalog hasn't changed.
-        if transient_revision != self.catalog().transient_revision() {
-            // TODO(jkosh44) It would be preferable to re-validate the query instead of blindly failing.
+        if replan.transient_revision != self.catalog().transient_revision() {
+            // Revision change; re plan from the beginning.
             let (tx, session) = real_time_recency_context.take_tx_and_session();
-            return tx.send(Err(AdapterError::Unstructured(anyhow!("Catalog contents have changed mid-query due to concurrent DDL, please re-try query"))), session);
+            self.internal_cmd_tx
+                .send(Message::Replan {
+                    tx,
+                    session,
+                    replan,
+                })
+                .expect("coordinator must exist");
+            return;
         }
 
         match real_time_recency_context {
@@ -703,7 +712,6 @@ impl Coordinator {
                 index_id,
                 timeline_context,
                 source_ids,
-                id_bundle,
                 in_immediate_multi_stmt_txn,
                 key,
                 typ,
@@ -712,6 +720,7 @@ impl Coordinator {
                     tx,
                     session,
                     PeekStage::Finish(PeekStageFinish {
+                        replan,
                         finishing,
                         copy_to,
                         dataflow,
@@ -722,7 +731,6 @@ impl Coordinator {
                         index_id,
                         timeline_context,
                         source_ids,
-                        id_bundle,
                         in_immediate_multi_stmt_txn,
                         real_time_recency_ts: Some(real_time_recency_ts),
                         key,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -232,7 +232,7 @@ impl Coordinator {
                 self.sequence_end_transaction(tx, session, action);
             }
             Plan::Peek(plan) => {
-                self.sequence_peek(tx, session, plan).await;
+                self.sequence_peek(tx, session, plan, depends_on).await;
             }
             Plan::Subscribe(plan) => {
                 tx.send(
@@ -258,13 +258,14 @@ impl Coordinator {
                 self.sequence_copy_rows(tx, session, id, columns, rows);
             }
             Plan::Explain(plan) => {
-                self.sequence_explain(tx, session, plan);
+                self.sequence_explain(tx, session, plan, depends_on);
             }
             Plan::Insert(plan) => {
-                self.sequence_insert(tx, session, plan).await;
+                self.sequence_insert(tx, session, plan, depends_on).await;
             }
             Plan::ReadThenWrite(plan) => {
-                self.sequence_read_then_write(tx, session, plan).await;
+                self.sequence_read_then_write(tx, session, plan, depends_on)
+                    .await;
             }
             Plan::AlterNoop(plan) => {
                 tx.send(

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -222,7 +222,7 @@ impl TryFrom<BTreeSet<String>> for ExplainConfig {
 }
 
 /// The type of object to be explained
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Explainee {
     /// An object that will be served using a dataflow
     Dataflow(GlobalId),

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -603,7 +603,7 @@ pub struct ResetVariablePlan {
     pub name: String,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PeekPlan {
     pub source: MirRelationExpr,
     pub when: QueryWhen,
@@ -650,7 +650,7 @@ pub struct CopyRowsPlan {
     pub rows: Vec<Row>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExplainPlan {
     pub raw_plan: HirRelationExpr,
     pub row_set_finishing: Option<RowSetFinishing>,
@@ -942,7 +942,7 @@ pub struct Type {
 }
 
 /// Specifies when a `Peek` or `Subscribe` should occur.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum QueryWhen {
     /// The peek should occur at the latest possible timestamp that allows the
     /// peek to complete immediately.


### PR DESCRIPTION
Statements that can execute off of the coordinator thread have the potential to become invalidated if their underlying objects or indexes have changed while doing work off of the coordinator thread. Detect this by recording the transient revision and detecting if it changed. Add a common way for statements to re-plan themselves from the beginning when this happens.

RTR already did correct revision checking, but it didn't replan. Teach peek how to check its revision during the finish stage, which will become useful for upcoming off thread optimization.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a