### PR TITLE
Update differential-dataflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "columnation"
 version = "0.1.0"
-source = "git+https://github.com/frankmcsherry/columnation#bfd9e2a953768887138e56f10f9be13e27ef175a"
+source = "git+https://github.com/frankmcsherry/columnation#eb8e20c10e748dcbfe6266be8e24e14422d3de0f"
 dependencies = [
  "paste",
 ]
@@ -1682,7 +1682,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#cc88469a4834faa179725d52e2beb7ab677bdb37"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#438804d98d1888416ef20288570b804bdba8bea9"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1759,7 +1759,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#cc88469a4834faa179725d52e2beb7ab677bdb37"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#438804d98d1888416ef20288570b804bdba8bea9"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7417,7 +7417,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#134842aa6e1cce36a1d68bec3d79c1c3781cd11e"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#432ef57fae761f1e4773833b0474b41f1efe7e7c"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7435,12 +7435,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#134842aa6e1cce36a1d68bec3d79c1c3781cd11e"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#432ef57fae761f1e4773833b0474b41f1efe7e7c"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#134842aa6e1cce36a1d68bec3d79c1c3781cd11e"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#432ef57fae761f1e4773833b0474b41f1efe7e7c"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7456,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#134842aa6e1cce36a1d68bec3d79c1c3781cd11e"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#432ef57fae761f1e4773833b0474b41f1efe7e7c"
 dependencies = [
  "columnation",
  "serde",
@@ -7465,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#134842aa6e1cce36a1d68bec3d79c1c3781cd11e"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#432ef57fae761f1e4773833b0474b41f1efe7e7c"
 
 [[package]]
 name = "tiny-keccak"

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -227,6 +227,10 @@ mod columnation {
         {
             self.region.reserve(regions.map(|r| r.region.len()).sum());
         }
+
+        fn heap_size(&self, callback: impl FnMut(usize, usize)) {
+            self.region.heap_size(callback)
+        }
     }
 }
 

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -333,6 +333,32 @@ GROUP BY round;
 ----
 0  10
 
+## Regression test for https://github.com/MaterializeInc/materialize/issues/18759
+## Test a WMR query with a delta join.
+query III
+WITH MUTUALLY RECURSIVE
+    c1 (f1 INTEGER, f2 INTEGER, f3 INTEGER) AS (
+        SELECT * FROM (VALUES (0, 0, 0))
+        UNION ALL (
+            SELECT
+                a1.f1 + 1 AS f1,
+                a1.f2 + 1 AS f2,
+                a1.f3 + 1 AS f3
+            FROM
+                c1 AS a1,
+                (
+                    SELECT *
+                    FROM c1 AS a1
+                    LEFT JOIN c1 AS a2 USING (f2)
+                    WHERE a1.f1 < 100 AND a2.f2 IS NULL
+                ) AS a2
+            WHERE a1 . f1 < 100
+        )
+    )
+SELECT * FROM c1;
+----
+0  0  0
+
 ## Regression test for https://github.com/MaterializeInc/materialize/issues/18949
 ## Test the situation when a WMR cte has an inner WMR whose body ends with an arrangement.
 query I


### PR DESCRIPTION
This is to pick up https://github.com/TimelyDataflow/differential-dataflow/pull/386

Also includes a regression test for #18759.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/18759.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
