### PR TITLE
coverage: Fix unit test coverage

### DIFF
--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-import multiprocessing
 import os
 
 from materialize import ROOT, spawn, ui
@@ -96,12 +95,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "--lcov",
             "--output-path",
             "coverage/cargotest.lcov",
-            # This can cause intermittent coverage problems, but
-            # single-threaded is too slow:
-            # https://github.com/rust-lang/rust/issues/91092
-            f"--test-threads={multiprocessing.cpu_count()}",
             "--profile=coverage",
-            "--no-fail-fast",
+            # We still want a coverage report on crash
+            "--ignore-run-fail",
         ]
         try:
             spawn.runv(cmd + args.args, env=env)

--- a/ci/test/coverage_report.sh
+++ b/ci/test/coverage_report.sh
@@ -25,7 +25,6 @@ buildkite-agent artifact upload junit_coverage*.xml
 ci_unimportant_heading "Create coverage report"
 REPORT=coverage_without_unittests_"$BUILDKITE_BUILD_ID"
 REPORT_UNITTESTS=coverage_with_unittests_"$BUILDKITE_BUILD_ID"
-head -n1 coverage/cargotest.lcov # TODO(def-) Check if this matches the expected path
 find coverage -name '*.lcov' -exec sed -i "s#SF:/var/lib/buildkite-agent/builds/buildkite-.*/materialize/coverage/#SF:#" {} +
 find coverage -name '*.lcov' -not -name 'cargotest.lcov' -exec genhtml -o "$REPORT" {} +
 find coverage -name '*.lcov' -exec genhtml -o "$REPORT_UNITTESTS" {} +

--- a/misc/python/materialize/cli/ci_coverage_pr_report.py
+++ b/misc/python/materialize/cli/ci_coverage_pr_report.py
@@ -127,14 +127,14 @@ def get_report(coverage: Coverage) -> str:
     it gets any more complex.
     """
     try:
-        # Remove lines which are only covered in unit tests as sindicated by a
+        # Remove lines which are only covered in unit tests as indicated by a
         # negative line count
         for file, lines in coverage.items():
             with open(file, "r+") as f:
                 content = f.readlines()
                 f.seek(0)
                 for i, line in enumerate(content):
-                    if (lines.get(i + 1) or 0) < 0:
+                    if (lines.get(i + 1) or 0) >= 0:
                         f.write(line)
                 f.truncate()
 
@@ -159,7 +159,11 @@ def get_report(coverage: Coverage) -> str:
                 content = f.readlines()
                 f.seek(0)
                 for i, line in enumerate(content):
-                    if (lines.get(i + 1) or 0) > 0:
+                    # If a line has "None" marker, then it can't be covered, print it out.
+                    # If a line has positive or negative coverage then it is
+                    # covered in normal tests or unit tests, print it out.
+                    # All remaining lines can be covered, but are not covered.
+                    if lines.get(i + 1) is None or (lines.get(i + 1) or 0) != 0:
                         f.write(line)
                 f.truncate()
 


### PR DESCRIPTION
Issues seen in https://buildkite.com/materialize/coverage/builds/74#0187c6f1-6555-420f-b752-34d5fc148ef3

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
