### PR TITLE
cloudtest: Pass --orchestrator-kubernetes-coverage only if supported

### DIFF
--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -48,10 +48,12 @@ class Application:
         for resource in self.resources:
             resource.create()
 
+    def coverage_mode(self) -> bool:
+        return ui.env_is_truthy("CI_COVERAGE_ENABLED")
+
     def acquire_images(self) -> None:
-        coverage = ui.env_is_truthy("CI_COVERAGE_ENABLED")
         repo = mzbuild.Repository(
-            ROOT, release_mode=self.release_mode, coverage=coverage
+            ROOT, release_mode=self.release_mode, coverage=self.coverage_mode()
         )
         for image in self.images:
             deps = repo.resolve_dependencies([repo.images[image]])
@@ -129,7 +131,10 @@ class MaterializeApplication(Application):
             VpcEndpointsClusterRole(),
             AdminRoleBinding(),
             EnvironmentdStatefulSet(
-                release_mode=release_mode, tag=tag, log_filter=log_filter
+                release_mode=release_mode,
+                tag=tag,
+                log_filter=log_filter,
+                coverage_mode=self.coverage_mode(),
             ),
             self.environmentd,
             self.materialized_alias,

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -71,7 +71,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
         self,
         tag: Optional[str] = None,
         release_mode: bool = True,
-        coverage_mode: bool = True,
+        coverage_mode: bool = False,
         log_filter: Optional[str] = None,
     ) -> None:
         self.tag = tag

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -116,6 +116,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
                         name="CI_COVERAGE_ENABLED",
                         value="1",
                     ),
+                    V1EnvVar(name="MZ_ORCHESTRATOR_KUBERNETES_COVERAGE", value="1"),
                 ]
             )
 
@@ -153,8 +154,6 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             # only supported on newer releases, do not add it here. Add it as a
             # version-gated argument below, using `self._meets_minimum_version`.
         ]
-        if self.coverage_mode:
-            args += ["--orchestrator-kubernetes-coverage"]
         if self.log_filter:
             args += [f"--log-filter={self.log_filter}"]
         if self._meets_minimum_version("0.38.0"):


### PR DESCRIPTION
Use an environment variable so that cloudtest can start Mz versions that do not support --orchestrator-kubernetes-coverage


### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI was failing.