### PR TITLE
doc/user: add release note about OOM observability

### DIFF
--- a/doc/user/content/releases/v0.52.md
+++ b/doc/user/content/releases/v0.52.md
@@ -27,9 +27,9 @@ mentioning it here."
 
 * Add `reason` to the `mz_internal.mz_cluster_replica_statuses` system catalog
   table. If a cluster replica is in a `not-ready` state, this column provides
-  details on the cause (if available). With this release, the only possible
-  value for `reason` is `oom-killed`, which indicates that a cluster replica is
-  out of memory(OOM).
+  details on the cause (if available). With this release, the only possible non-null
+  value for `reason` is `oom-killed`, which indicates that a cluster replica was killed because it ran
+  out of memory (OOM).
 
 * Add `credits_per_hour` to the `mz_internal.mz_cluster_replica_sizes` system
   catalog table, and rate limit [free trial accounts](/free-trial-faqs/) to 4

--- a/doc/user/content/releases/v0.52.md
+++ b/doc/user/content/releases/v0.52.md
@@ -25,8 +25,15 @@ mentioning it here."
   objects (like `SHOW` commands). This behavior can be disabled via the new
   `auto_route_introspection_queries` [session variable](/sql/set/#other-session-variables).
 
+* Add `reason` to the `mz_internal.mz_cluster_replica_statuses` system catalog
+  table. If a cluster replica is in a `not-ready` state, this column provides
+  details on the cause (if available). With this release, the only possible
+  value for `reason` is `oom-killed`, which indicates that a cluster replica is
+  out of memory(OOM).
+
 * Add `credits_per_hour` to the `mz_internal.mz_cluster_replica_sizes` system
-  table, and rate limit [free trial accounts](/free-trial-faqs/) to 4 credits per hour.
+  catalog table, and rate limit [free trial accounts](/free-trial-faqs/) to 4
+  credits per hour.
 
   To see your current credit consumption rate, measured in credits per hour, run
   the following query:

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -82,12 +82,13 @@ The concept of a linked cluster is not user-facing, and is intentionally undocum
 The `mz_cluster_replica_statuses` table contains a row describing the status
 of each process in each cluster replica in the system.
 
-| Field                | Type                            | Meaning                                                    |
-| -------------------- | ------------------------------- | --------                                                   |
-| `replica_id`         | [`text`]                        | Materialize's unique ID for the cluster replica.           |
-| `process_id`         | [`uint8`]                       | The ID of the process within the cluster replica.          |
-| `status`             | [`text`]                        | The status of the cluster replica: `ready` or `not-ready`. |
-| `updated_at`         | [`timestamp with time zone`]    | The time at which the status was last updated.             |
+| Field                | Type                            | Meaning                                                                      |
+| -------------------- | ------------------------------- | --------                                                                     |
+| `replica_id`         | [`text`]                        | Materialize's unique ID for the cluster replica.                             |
+| `process_id`         | [`uint8`]                       | The ID of the process within the cluster replica.                            |
+| `status`             | [`text`]                        | The status of the cluster replica: `ready` or `not-ready`.                   |
+| `reason`             | [`text`]                        | If the cluster replica is in a `not-ready` state, the reason (if available). |
+| `updated_at`         | [`timestamp with time zone`]    | The time at which the status was last updated.                               |
 
 ### `mz_cluster_replica_utilization`
 


### PR DESCRIPTION
Retroactively adding a release note and patching the docs after #18796.

Linking to #18452, since it'll be helpful to include a troubleshooting query similar to [this one](https://materializeinc.slack.com/archives/C04LQV4KUR4/p1682608422870989) in the guide.