### PR TITLE
adapter: Allow more kinds of queries to be run on the `mz_introspection` cluster

### DIFF
--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -94,9 +94,10 @@ pub fn check_cluster_restrictions(
         return Ok(());
     }
 
-    // Allows explain queries.
-    if let Plan::Explain(_) = plan {
-        return Ok(());
+    // Only continue, and check restrictions, if a Plan would run some computation on the cluster.
+    match plan {
+        Plan::Subscribe(_) | Plan::Peek(_) | Plan::ReadThenWrite(_) => (),
+        _ => return Ok(()),
     }
 
     // Collect any items that are not allowed to be run on the introspection cluster.

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -72,9 +72,7 @@ impl Coordinator {
         {
             return tx.send(Err(e), session);
         }
-        if let Err(e) =
-            introspection::check_cluster_restrictions(&session_catalog, &plan)
-        {
+        if let Err(e) = introspection::check_cluster_restrictions(&session_catalog, &plan) {
             return tx.send(Err(e), session);
         }
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -73,7 +73,7 @@ impl Coordinator {
             return tx.send(Err(e), session);
         }
         if let Err(e) =
-            introspection::check_cluster_restrictions(&session_catalog, &plan, &depends_on)
+            introspection::check_cluster_restrictions(&session_catalog, &plan)
         {
             return tx.send(Err(e), session);
         }

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -258,15 +258,11 @@ materialize.public.mv CREATE␠MATERIALIZED␠VIEW␠"materialize"."public"."mv"
 
 # Test: SHOW CREATE MATERIALIZED VIEW as mz_introspection
 
-
-statement ok
-SET cluster = mz_introspection
-
-statement error querying the following items "materialize\.public\.mv" is not allowed from the "mz_introspection" cluster\nHINT: Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query.
+simple conn=mz_introspection,user=mz_introspection
 SHOW CREATE MATERIALIZED VIEW mv
-
-statement ok
-RESET cluster
+----
+materialize.public.mv,CREATE MATERIALIZED VIEW "materialize"."public"."mv" IN CLUSTER "default" AS SELECT 1
+COMPLETE 1
 
 # Test: SHOW MATERIALIZED VIEWS
 

--- a/test/sqllogictest/operator.slt
+++ b/test/sqllogictest/operator.slt
@@ -129,17 +129,11 @@ SHOW CREATE VIEW ADDER
 materialize.public.adder
 CREATE VIEW "materialize"."public"."adder" AS SELECT 2 + 2
 
-
-# Test: Show user view on mz_introspection
-
-statement ok
-SET cluster = mz_introspection
-
-statement error querying the following items "materialize\.public\.adder" is not allowed from the "mz_introspection" cluster\nHINT: Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query.
+simple conn=mz_introspection,user=mz_introspection
 SHOW CREATE VIEW ADDER
-
-statement ok
-RESET cluster
+----
+materialize.public.adder,CREATE VIEW "materialize"."public"."adder" AS SELECT 2 + 2
+COMPLETE 1
 
 statement ok
 CREATE VIEW MULTIPLIER AS SELECT 2 OPERATOR(*) 2;

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -310,3 +310,38 @@ Used Indexes:
   - mz_internal.mz_source_status_history_ind
 
 EOF
+
+# Querying user objects should not be allowed from the introspection cluster.
+
+statement ok
+CREATE CLUSTER foo REPLICAS (r1 (SIZE '1'));
+
+statement ok
+SET CLUSTER TO foo;
+
+statement ok
+CREATE TABLE bar ( key text, val bigint );
+
+statement ok
+SET CLUSTER TO mz_introspection;
+
+statement error querying the following items "materialize\.public\.bar" is not allowed from the "mz_introspection" cluster\nHINT: Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query.
+SELECT key FROM bar;
+
+# But inspecting those objects, e.g. checking what indexes exist, should be allowed.
+statement ok
+SHOW INDEXES on bar;
+
+statement ok
+SET CLUSTER TO mz_introspection;
+
+statement ok
+DROP CLUSTER foo CASCADE;
+
+# Creating views with the mz_introspection cluster active should be allowed though.
+statement ok
+CREATE VIEW keys AS ( SELECT key FROM bar );
+
+# But creating materialized views, which install resources, should not be allowed.
+statement error system cluster 'mz_introspection' cannot be modified
+CREATE MATERIALIZED VIEW live_keys AS ( SELECT key FROM bar );

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -342,6 +342,13 @@ DROP CLUSTER foo CASCADE;
 statement ok
 CREATE VIEW keys AS ( SELECT key FROM bar );
 
-# But creating materialized views, which install resources, should not be allowed.
+# But creating objects that install resources, should not be allowed.
+
 statement error system cluster 'mz_introspection' cannot be modified
 CREATE MATERIALIZED VIEW live_keys AS ( SELECT key FROM bar );
+
+statement error system cluster 'mz_introspection' cannot be modified
+CREATE CLUSTER REPLICA mz_introspection.backup SIZE '1';
+
+statement error system cluster 'mz_introspection' cannot be modified
+CREATE INDEX i_keys ON bar (key);

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -30,13 +30,8 @@ $ kafka-ingest topic=data format=avro schema=${writer-schema}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${writer-schema}'
 
-# Not allowed to query user objects from mz_introspection.
 > SET CLUSTER TO mz_introspection
-! SHOW INDEXES ON data
-contains: querying the following items "materialize.public.data" is not allowed from the "mz_introspection" cluster
-
-> CREATE CLUSTER my_cluster REPLICAS (r1 (size '1'))
-> SET CLUSTER TO my_cluster
+> SHOW INDEXES ON data
 
 > SHOW INDEXES ON data
 name    on  cluster key
@@ -46,7 +41,7 @@ name    on  cluster key
 # Sources can have default indexes added
 > CREATE DEFAULT INDEX ON data
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON data
 name                on      cluster             key
 -------------------------------------------------------------------------------------------
@@ -70,7 +65,7 @@ position         name
 # Views do not have indexes automatically created
 > CREATE VIEW data_view as SELECT * from data
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON data_view
 name    on  cluster key
 --------------------------------------------------------------------------
@@ -79,7 +74,7 @@ name    on  cluster key
 # Views can have default indexes added
 > CREATE DEFAULT INDEX ON data_view
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 ---------------------------------------------------------------------------------------------------
@@ -90,7 +85,7 @@ data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
 > CREATE MATERIALIZED VIEW matv AS
   SELECT b, sum(a) FROM data GROUP BY b
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON matv
 name    on  cluster key
 --------------------------------------------------------------------------
@@ -99,7 +94,7 @@ name    on  cluster key
 # Materialized views can have default indexes added
 > CREATE DEFAULT INDEX ON matv
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON matv
 name                on      cluster             key
 --------------------------------------------------------------------------------------------
@@ -109,7 +104,7 @@ matv_primary_idx    matv    <VARIABLE_OUTPUT>   {b}
 # IF NOT EXISTS prevents adding multiple default indexes
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 -------------------------------------------------------------------------------------------------
@@ -119,7 +114,7 @@ data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
 # Additional default indexes have the same structure as the first
 > CREATE DEFAULT INDEX ON matv
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON matv
 name                on      cluster             key
 ------------------------------------------------------------------------------------------------
@@ -130,7 +125,7 @@ matv_primary_idx1   matv    <VARIABLE_OUTPUT>   {b}
 # Default indexes can be named
 > CREATE DEFAULT INDEX named_idx ON data_view
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 -----------------------------------------------------------------------------------------------
@@ -144,7 +139,7 @@ named_idx               data_view   <VARIABLE_OUTPUT>   {a,b}
 # Indexes with specified columns can be automatically named
 > CREATE INDEX ON data_view(a)
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON data_view
 name            on          cluster             key
 -------------------------------------------------------------------------------------------
@@ -157,7 +152,7 @@ data_view_a_idx data_view   <VARIABLE_OUTPUT>   {a}
 > CREATE INDEX ON data_view(b, a)
 > CREATE INDEX ON data_view(b - a, a)
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 -----------------------------------------------------------------------------------------------
@@ -171,7 +166,7 @@ data_view_expr_a_idx    data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 # Indexes can be both explicitly named and explicitly structured
 > CREATE INDEX named_idx ON data_view (b - a, a)
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON data_view
 name        on          cluster             key
 ---------------------------------------------------------------------------------------------
@@ -184,7 +179,7 @@ named_idx   data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 > CREATE INDEX data_view_primary_idx ON data_view (b - a, a)
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON data_view
 name                    on          cluster             key
 ------------------------------------------------------------------------------------------------------
@@ -204,7 +199,7 @@ materialize.public.data_view_primary_idx "CREATE INDEX \"data_view_primary_idx\"
 > CREATE DEFAULT INDEX ON foo
 > CREATE INDEX ON foo (a + b)
 > CREATE INDEX ON foo (substr(z, 3))
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON foo
 foo_primary_idx foo <VARIABLE_OUTPUT>   {a,b,z}
 foo_expr_idx    foo <VARIABLE_OUTPUT>   "{a + b}"
@@ -226,7 +221,7 @@ contains:cannot show indexes on materialize.public.foo_primary_idx because it is
 
 > CREATE CLUSTER clstr REPLICAS (r1 (SIZE '1'))
 > CREATE DEFAULT INDEX IN CLUSTER clstr ON foo;
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES IN CLUSTER clstr WHERE on = 'foo'
 foo_primary_idx1    foo clstr   {a,b,z}
 
@@ -237,7 +232,7 @@ foo_primary_idx1    foo clstr   {a,b,z}
 > DROP TABLE foo CASCADE
 > DROP SOURCE data CASCADE
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 
 ! SHOW INDEXES FROM public ON foo
 contains:Cannot specify both FROM and ON
@@ -250,7 +245,7 @@ contains:unknown schema 'nonexistent'
 > CREATE TABLE bar ();
 > CREATE INDEX bar_ind ON bar ();
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES
 bar_ind bar <VARIABLE_OUTPUT> {}
 > SET CLUSTER TO default
@@ -260,13 +255,12 @@ bar_ind bar <VARIABLE_OUTPUT> {}
 > CREATE TABLE foo.bar (a INT)
 > CREATE INDEX bar_ind ON foo.bar (a)
 
-> SET CLUSTER TO my_cluster
+> SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON foo.bar
 bar_ind bar <VARIABLE_OUTPUT> {a}
 > SET CLUSTER TO default
 
 > DROP CLUSTER clstr CASCADE;
-> DROP CLUSTER my_cluster CASCADE;
 
 # Test creating indexes on system objects
 > CREATE INDEX sys_ind ON mz_array_types (id)


### PR DESCRIPTION

### Motivation

#18312 restricted queries that depend on non-system objects, from being run on the `mz_introspection` cluster. The changes it introduced though were too restrictive. This PR relaxes those restrictions, allowing any query to run on mz_introspection, as long as it's not a `SELECT` or `SUBSCRIBE`.

### Tips for reviewer

I think I gated against the correct `Plan`s, but two I was unsure about were `Plan::Fetch` and `Plan::Insert`. I'm not sure if we also want to prevent those from running on `mz_introspection`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
