### PR TITLE
dbt-materialize: release v1.4.1

### DIFF
--- a/doc/user/content/releases/v0.52.md
+++ b/doc/user/content/releases/v0.52.md
@@ -65,3 +65,10 @@ mentioning it here."
 * Fix a bug where the `before` field was still required in the schema of change
   events for Kafka sources using [`ENVELOPE DEBEZIUM`](https://materialize.com/docs/sql/create-source/#debezium-envelope)
   {{% gh 18844 %}}.
+
+#### Known issues
+
+* v0.52 inadvertently broke compatibility with dbt-materialize <= v1.4.0. Please
+  upgrade to dbt-materialize v1.4.1, which contains a workaround.
+
+  v0.53 of Materialize will restore compatibility with dbt-materialize v1.4.0.

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,13 +1,10 @@
 # dbt-materialize Changelog
 
-## Unreleased
+## 1.4.1 - 2023-04-28
 
-* **Breaking change.** Automatically run introspection queries in the
-    `mz_introspection` cluster via the new `auto_route_introspection_queries`
-    session variable, instead of hardcoding the cluster on connection.
-
-  This change requires [Materialize >=0.49.0](https://materialize.com/docs/releases/v0.49/).
-  **Users of older versions should pin `dbt-materialize` to `v1.4.0`.**
+* Let Materialize automatically run introspection queries in the
+  `mz_introspection` cluster via the new `auto_route_introspection_queries`
+  session variable, instead of hardcoding the cluster on connection.
 
 ## 1.4.0 - 2023-02-03
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.4.0"
+version = "1.4.1"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.4.0",
+    version="1.4.1",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.52.0 inadvertently broke dbt-materialize v1.4.0, by disallowing (most) `CREATE VIEW` statements on `mz_introspection`. Fortunately, there is an easy workaround that we can release as dbt-materialize v1.4.1, which is to rely on the new `auto_route_introspection_queries` behavior in the dbt adapter, rather than explicitly setting the cluster to `mz_introspection`.

There remains, I think, a glitch in dbt-materialize v1.4.1, which is that it *requires* that you have a cluster named `default`, as the cluster named in the connection profile is not actually used as the cluster parameter for the session, but only as the default `IN CLUSTER` cluster for any created indexes or materialized views.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug discovered on Slack.


### Tips for reviewer

I'm not sure whether we should release this with the outstanding cluster bug mentioned in the description or not.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
