### PR TITLE
storage: add WITH (DISK) support to upsert sources

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -176,6 +176,18 @@ steps:
     agents:
       queue: linux-x86_64
 
+  - id: upsert
+    label: Upsert
+    depends_on: build-x86_64
+    timeout_in_minutes: 30
+    inputs: [test/upsert]
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: upsert
+    agents:
+      queue: linux-x86_64
+
   - id: kafka-persistence
     label: Kafka persistence
     depends_on: build-x86_64

--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -102,6 +102,7 @@ use mz_service::grpc::GrpcServer;
 use mz_service::secrets::SecretsReaderCliArgs;
 use mz_storage_client::client::proto_storage_server::ProtoStorageServer;
 use mz_storage_client::types::connections::ConnectionContext;
+use mz_storage_client::types::instances::StorageInstanceContext;
 
 const BUILD_INFO: BuildInfo = build_info!();
 
@@ -160,6 +161,11 @@ struct Args {
     // === Tracing options. ===
     #[clap(flatten)]
     tracing: TracingCliArgs,
+
+    // === Other options. ===
+    /// A scratch directory that can be used for ephemeral storage.
+    #[clap(long, env = "SCRATCH_DIRECTORY", value_name = "PATH")]
+    scratch_directory: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -274,6 +280,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             args.aws_external_id,
             secrets_reader,
         ),
+        StorageInstanceContext::new(args.scratch_directory).await?,
     )?;
     info!(
         "listening for storage controller connections on {}",

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -461,7 +461,6 @@ where
 
         Box::pin(stream)
     }
-
     /// Provisions a replica with the service orchestrator.
     async fn provision_replica(
         &self,

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -90,6 +90,7 @@
 use std::collections::BTreeMap;
 use std::mem;
 use std::num::NonZeroI64;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -124,6 +125,7 @@ use mz_storage_client::client::{
     ProtoStorageCommand, ProtoStorageResponse, StorageCommand, StorageResponse,
 };
 use mz_storage_client::controller::StorageController;
+use mz_storage_client::types::instances::StorageInstanceContext;
 
 pub mod clusters;
 
@@ -152,6 +154,8 @@ pub struct ControllerConfig {
     pub postgres_factory: StashFactory,
     /// The metrics registry.
     pub metrics_registry: MetricsRegistry,
+    /// The directory of instance storage.
+    pub scratch_directory: Option<PathBuf>,
 }
 
 /// Responses that [`Controller`] can produce.
@@ -229,6 +233,9 @@ pub struct Controller<T = mz_repr::Timestamp> {
     metrics_tx: UnboundedSender<(ReplicaId, Vec<ServiceProcessMetrics>)>,
     /// Receiver for the channel over which replica metrics are sent.
     metrics_rx: Peekable<UnboundedReceiverStream<(ReplicaId, Vec<ServiceProcessMetrics>)>>,
+
+    /// Additional context to pass through to cluster instances.
+    pub instance_context: StorageInstanceContext,
 }
 
 impl<T> Controller<T> {
@@ -336,6 +343,9 @@ where
 {
     /// Creates a new controller.
     pub async fn new(config: ControllerConfig, envd_epoch: NonZeroI64) -> Self {
+        let instance_context = StorageInstanceContext::new(config.scratch_directory)
+            .await
+            .expect("failed to create instance context");
         let storage_controller = mz_storage_client::controller::Controller::new(
             config.build_info,
             config.storage_stash_url,
@@ -345,6 +355,7 @@ where
             &config.postgres_factory,
             envd_epoch,
             config.metrics_registry.clone(),
+            instance_context.clone(),
         )
         .await;
 
@@ -365,6 +376,7 @@ where
             metrics_tasks: BTreeMap::new(),
             metrics_tx,
             metrics_rx: UnboundedReceiverStream::new(metrics_rx).peekable(),
+            instance_context,
         }
     }
 }

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -365,6 +365,13 @@ pub struct Args {
         env = "ORCHESTRATOR_PROCESS_PROMETHEUS_SERVICE_DISCOVERY_DIRECTORY"
     )]
     orchestrator_process_prometheus_service_discovery_directory: Option<PathBuf>,
+    /// A scratch directory that orchestrated processes can use for ephemeral storage.
+    #[clap(
+        long,
+        env = "ORCHESTRATOR_PROCESS_SCRATCH_DIRECTORY",
+        value_name = "PATH"
+    )]
+    orchestrator_process_scratch_directory: Option<PathBuf>,
     /// Whether to use coverage build and collect coverage information. Not to be used for
     /// production, only testing.
     #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_COVERAGE")]
@@ -654,6 +661,13 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         Option<Arc<dyn CloudResourceController>>,
     ) = match args.orchestrator {
         OrchestratorKind::Kubernetes => {
+            if args.orchestrator_process_scratch_directory.is_some() {
+                bail!(
+                    "--orchestrator-process-scratch-directory is \
+                      not currently usable with the kubernetes orchestrator"
+                );
+            }
+
             let orchestrator = Arc::new(
                 runtime
                     .block_on(KubernetesOrchestrator::new(KubernetesOrchestratorConfig {
@@ -710,6 +724,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                                     .orchestrator_process_prometheus_service_discovery_directory,
                             },
                         ),
+                        scratch_directory: args.orchestrator_process_scratch_directory.clone(),
                     }))
                     .context("creating process orchestrator")?,
             );
@@ -725,6 +740,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     );
     let persist_clients = Arc::new(persist_clients);
     let orchestrator = Arc::new(TracingOrchestrator::new(orchestrator, args.tracing.clone()));
+
     let controller = ControllerConfig {
         build_info: &mz_environmentd::BUILD_INFO,
         orchestrator,
@@ -739,6 +755,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         now: SYSTEM_TIME.clone(),
         postgres_factory: StashFactory::new(&metrics_registry),
         metrics_registry: metrics_registry.clone(),
+        scratch_directory: args.orchestrator_process_scratch_directory,
     };
 
     let cluster_replica_sizes: ClusterReplicaSizeMap = match args.cluster_replica_sizes {

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -286,6 +286,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             command_wrapper: vec![],
             propagate_crashes: config.propagate_crashes,
             tcp_proxy: None,
+            scratch_directory: None,
         }))?,
     );
     // Messing with the clock causes persist to expire leases, causing hangs and
@@ -344,6 +345,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             now: SYSTEM_TIME.clone(),
             postgres_factory,
             metrics_registry: metrics_registry.clone(),
+            scratch_directory: None,
         },
         secrets_controller,
         cloud_resource_controller: None,

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -77,16 +77,16 @@ use mz_ore::metrics::HistogramVecExt;
 use mz_rocksdb::{Options, RocksDBInstance, RocksDBMetrics};
 use prometheus::{HistogramOpts, HistogramVec};
 
-fn metrics_for_tests() -> Result<RocksDBMetrics, anyhow::Error> {
+fn metrics_for_tests() -> Result<Box<RocksDBMetrics>, anyhow::Error> {
     let fake_hist_vec =
         HistogramVec::new(HistogramOpts::new("fake", "fake_help"), &["fake_label"])?;
 
-    Ok(RocksDBMetrics {
+    Ok(Box::new(RocksDBMetrics {
         multi_get_latency: fake_hist_vec.get_delete_on_drop_histogram(vec!["one".to_string()]),
-        multi_get_batch_size: fake_hist_vec.get_delete_on_drop_histogram(vec!["two".to_string()]),
-        write_latency: fake_hist_vec.get_delete_on_drop_histogram(vec!["three".to_string()]),
-        write_batch_size: fake_hist_vec.get_delete_on_drop_histogram(vec!["four".to_string()]),
-    })
+        multi_get_size: fake_hist_vec.get_delete_on_drop_histogram(vec!["two".to_string()]),
+        multi_put_latency: fake_hist_vec.get_delete_on_drop_histogram(vec!["three".to_string()]),
+        multi_put_size: fake_hist_vec.get_delete_on_drop_histogram(vec!["four".to_string()]),
+    }))
 }
 
 #[tokio::test]

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1332,6 +1332,7 @@ pub enum CreateSourceOptionName {
     Size,
     Timeline,
     TimestampInterval,
+    Disk,
 }
 
 impl AstDisplay for CreateSourceOptionName {
@@ -1341,6 +1342,7 @@ impl AstDisplay for CreateSourceOptionName {
             CreateSourceOptionName::Size => "SIZE",
             CreateSourceOptionName::Timeline => "TIMELINE",
             CreateSourceOptionName::TimestampInterval => "TIMESTAMP INTERVAL",
+            CreateSourceOptionName::Disk => "DISK",
         })
     }
 }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -109,6 +109,7 @@ Delimiter
 Desc
 Details
 Discard
+Disk
 Distinct
 Dot
 Double

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2572,7 +2572,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_source_option_name(&mut self) -> Result<CreateSourceOptionName, ParserError> {
-        let name = match self.expect_one_of_keywords(&[IGNORE, SIZE, TIMELINE, TIMESTAMP])? {
+        let name = match self.expect_one_of_keywords(&[IGNORE, SIZE, TIMELINE, TIMESTAMP, DISK])? {
             IGNORE => {
                 self.expect_keyword(KEYS)?;
                 CreateSourceOptionName::IgnoreKeys
@@ -2583,6 +2583,7 @@ impl<'a> Parser<'a> {
                 self.expect_keyword(INTERVAL)?;
                 CreateSourceOptionName::TimestampInterval
             }
+            DISK => CreateSourceOptionName::Disk,
             _ => unreachable!(),
         };
         Ok(name)

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -963,7 +963,7 @@ ALTER INDEX name RESET (property = true)
 parse-statement
 ALTER SOURCE name SET (property = true)
 ----
-error: Expected one of IGNORE or SIZE or TIMELINE or TIMESTAMP, found identifier "property"
+error: Expected one of IGNORE or SIZE or TIMELINE or TIMESTAMP or DISK, found identifier "property"
 ALTER SOURCE name SET (property = true)
                        ^
 
@@ -1464,7 +1464,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (START OFFSET=1, START TIMESTAMP=
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 WITH (START OFFSET="hmm") TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
 ----
-error: Expected one of IGNORE or SIZE or TIMELINE or TIMESTAMP, found START
+error: Expected one of IGNORE or SIZE or TIMELINE or TIMESTAMP or DISK, found START
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 WITH (START OFFSET="hmm") TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
                                                      ^
 
@@ -1696,6 +1696,13 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FO
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR ALL TABLES EXPOSE PROGRESS AS foo.bar WITH (SIZE = 'small')
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], referenced_subsources: Some(All), progress_subsource: Some(Deferred(UnresolvedItemName([Ident("foo"), Ident("bar")]))) })
+
+parse-statement
+CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red') WITH (DISK);
+----
+CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') WITH (DISK)
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Disk, value: None }], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 GRANT admin TO joe

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1705,6 +1705,13 @@ CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') WITH
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Disk, value: None }], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
+CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red') WITH (DISK = true);
+----
+CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') WITH (DISK = true)
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Disk, value: Some(Value(Boolean(true))) }], referenced_subsources: None, progress_subsource: None })
+
+parse-statement
 GRANT admin TO joe
 ----
 GRANT admin TO joe

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -736,6 +736,13 @@ impl<'a> StatementContext<'a> {
         Ok(())
     }
 
+    pub fn require_upsert_source_disk_available(&self) -> Result<(), PlanError> {
+        self.require_var_or_unsafe_mode(
+            SystemVars::enable_upsert_source_disk,
+            "`WITH (DISK)` syntax",
+        )
+    }
+
     pub fn require_with_mutually_recursive(&self) -> Result<(), PlanError> {
         self.require_var_or_unsafe_mode(
             SystemVars::enable_with_mutually_recursive,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -364,7 +364,8 @@ generate_extracted_config!(
     (IgnoreKeys, bool),
     (Size, String),
     (Timeline, String),
-    (TimestampInterval, Interval)
+    (TimestampInterval, Interval),
+    (Disk, bool)
 );
 
 generate_extracted_config!(
@@ -874,6 +875,15 @@ pub fn plan_create_source(
         conn.table_casts.retain(|pos, _| used_pos.contains(pos));
     }
 
+    let CreateSourceOptionExtracted {
+        size,
+        timeline,
+        timestamp_interval,
+        ignore_keys,
+        disk,
+        seen: _,
+    } = CreateSourceOptionExtracted::try_from(with_options.clone())?;
+
     let (key_desc, value_desc) = encoding.desc()?;
 
     let mut key_envelope = get_key_envelope(include_metadata, &envelope, &encoding)?;
@@ -894,9 +904,10 @@ pub fn plan_create_source(
             let (_before_idx, after_idx) = typecheck_debezium(&value_desc)?;
 
             match mode {
-                DbzMode::Plain => {
-                    UnplannedSourceEnvelope::Upsert(UpsertStyle::Debezium { after_idx })
-                }
+                DbzMode::Plain => UnplannedSourceEnvelope::Upsert {
+                    style: UpsertStyle::Debezium { after_idx },
+                    disk: disk.unwrap_or(false),
+                },
             }
         }
         mz_sql_parser::ast::Envelope::Upsert => {
@@ -911,7 +922,10 @@ pub fn plan_create_source(
             if key_envelope == KeyEnvelope::None {
                 key_envelope = get_unnamed_key_envelope(key_encoding)?;
             }
-            UnplannedSourceEnvelope::Upsert(UpsertStyle::Default(key_envelope))
+            UnplannedSourceEnvelope::Upsert {
+                style: UpsertStyle::Default(key_envelope),
+                disk: disk.unwrap_or(false),
+            }
         }
         mz_sql_parser::ast::Envelope::CdcV2 => {
             scx.require_unsafe_mode("ENVELOPE MATERIALIZE")?;
@@ -924,18 +938,20 @@ pub fn plan_create_source(
         }
     };
 
+    if disk.is_some() {
+        scx.require_unsafe_mode("ON DISK")?;
+        match &envelope {
+            UnplannedSourceEnvelope::Upsert { .. } => {}
+            _ => {
+                bail_unsupported!("ON DISK used with non-UPSERT/DEBEZIUM ENVELOPE");
+            }
+        }
+    }
+
     let metadata_columns = external_connection.metadata_columns();
     let metadata_column_types = external_connection.metadata_column_types();
     let metadata_desc = included_column_desc(metadata_columns.clone());
     let (envelope, mut desc) = envelope.desc(key_desc, value_desc, metadata_desc)?;
-
-    let CreateSourceOptionExtracted {
-        size,
-        timeline,
-        timestamp_interval,
-        ignore_keys,
-        seen: _,
-    } = CreateSourceOptionExtracted::try_from(with_options.clone())?;
 
     if ignore_keys.unwrap_or(false) {
         desc = desc.without_keys();
@@ -4144,6 +4160,7 @@ pub fn plan_alter_source(
                 timeline: timeline_opt,
                 timestamp_interval: timestamp_interval_opt,
                 ignore_keys: ignore_keys_opt,
+                disk: disk_opt,
             } = CreateSourceOptionExtracted::try_from(options)?;
 
             if let Some(value) = size_opt {
@@ -4157,6 +4174,9 @@ pub fn plan_alter_source(
             }
             if let Some(_) = ignore_keys_opt {
                 sql_bail!("Cannot modify the IGNORE KEYS property of a SOURCE.");
+            }
+            if let Some(_) = disk_opt {
+                sql_bail!("Cannot modify the DISK property of a SOURCE.");
             }
         }
         AlterSourceAction::ResetOptions(reset) => {
@@ -4173,6 +4193,9 @@ pub fn plan_alter_source(
                     }
                     CreateSourceOptionName::IgnoreKeys => {
                         sql_bail!("Cannot modify the IGNORE KEYS property of a SOURCE.");
+                    }
+                    CreateSourceOptionName::Disk => {
+                        sql_bail!("Cannot modify the DISK property of a SOURCE.");
                     }
                 }
             }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -520,6 +520,25 @@ const ENABLE_MULTI_WORKER_STORAGE_PERSIST_SINK: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
+/// The default for the `DISK` option in `UPSERT` sources.
+const UPSERT_SOURCE_DISK_DEFAULT: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("upsert_source_disk_default"),
+    value: &false,
+    description: "The default for the `DISK` option in `UPSERT` sources.",
+    internal: true,
+    safe: true,
+};
+
+/// Whether or not the `DISK` option in available `UPSERT` sources.
+const ENABLE_UPSERT_SOURCE_DISK: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_upsert_source_disk"),
+    value: &false,
+    description: "Feature flag indicating availability of the `DISK` \
+                  option in `UPSERT/DEBEZIUM` sources (Materialize).",
+    internal: true,
+    safe: true,
+};
+
 /// Controls the connect_timeout setting when connecting to PG via replication.
 const PG_REPLICATION_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
     name: UncasedStr::new("pg_replication_connect_timeout"),
@@ -1506,6 +1525,8 @@ impl Default for SystemVars {
             .with_var(&MAX_RESULT_SIZE)
             .with_var(&ALLOWED_CLUSTER_REPLICA_SIZES)
             .with_var(&ENABLE_MULTI_WORKER_STORAGE_PERSIST_SINK)
+            .with_var(&UPSERT_SOURCE_DISK_DEFAULT)
+            .with_var(&ENABLE_UPSERT_SOURCE_DISK)
             .with_var(&PERSIST_BLOB_TARGET_SIZE)
             .with_var(&PERSIST_COMPACTION_MINIMUM_TIMEOUT)
             .with_var(&CRDB_CONNECT_TIMEOUT)
@@ -1751,6 +1772,16 @@ impl SystemVars {
     /// Returns the `enable_multi_worker_storage_persist_sink` configuration parameter.
     pub fn enable_multi_worker_storage_persist_sink(&self) -> bool {
         *self.expect_value(&ENABLE_MULTI_WORKER_STORAGE_PERSIST_SINK)
+    }
+
+    /// Returns the `upsert_source_disk_default` configuration parameter.
+    pub fn upsert_source_disk_default(&self) -> bool {
+        *self.expect_value(&UPSERT_SOURCE_DISK_DEFAULT)
+    }
+
+    /// Returns the `enable_upsert_source_disk` configuration parameter.
+    pub fn enable_upsert_source_disk(&self) -> bool {
+        *self.expect_value(&ENABLE_UPSERT_SOURCE_DISK)
     }
 
     /// Returns the `persist_blob_target_size` configuration parameter.

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -871,6 +871,7 @@ impl RunnerInner {
                 command_wrapper: vec![],
                 propagate_crashes: true,
                 tcp_proxy: None,
+                scratch_directory: None,
             })
             .await?,
         );
@@ -900,6 +901,7 @@ impl RunnerInner {
                 now: SYSTEM_TIME.clone(),
                 postgres_factory: postgres_factory.clone(),
                 metrics_registry: metrics_registry.clone(),
+                scratch_directory: None,
             },
             secrets_controller,
             cloud_resource_controller: None,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -43,6 +43,7 @@ use tracing::{debug, info};
 
 use mz_build_info::BuildInfo;
 use mz_cluster_client::client::ClusterReplicaLocation;
+use mz_ore::error::ErrorExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
 use mz_persist_client::cache::PersistClientCache;
@@ -64,6 +65,7 @@ use crate::controller::rehydration::RehydratingStorageClient;
 use crate::healthcheck;
 use crate::metrics::StorageControllerMetrics;
 use crate::types::errors::DataflowError;
+use crate::types::instances::StorageInstanceContext;
 use crate::types::instances::StorageInstanceId;
 use crate::types::parameters::StorageParameters;
 use crate::types::sinks::{
@@ -778,6 +780,8 @@ pub struct StorageControllerState<T: Timestamp + Lattice + Codec64 + TimestampMa
     initialized: bool,
     /// Storage configuration to apply to newly provisioned instances.
     config: StorageParameters,
+    /// Additional context used to validate sources being created.
+    instance_context: StorageInstanceContext,
 }
 
 /// A storage controller for a storage instance.
@@ -934,6 +938,7 @@ impl<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulatio
         now: NowFn,
         factory: &StashFactory,
         envd_epoch: NonZeroI64,
+        instance_context: StorageInstanceContext,
     ) -> Self {
         let tls = mz_postgres_util::make_tls(
             &tokio_postgres::config::Config::from_str(&postgres_url)
@@ -1022,6 +1027,7 @@ impl<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulatio
             clients: BTreeMap::new(),
             initialized: false,
             config: StorageParameters::default(),
+            instance_context,
         }
     }
 }
@@ -1439,6 +1445,11 @@ where
                         let metadata = self.collection(id)?.collection_metadata.clone();
                         source_imports.insert(id, metadata);
                     }
+
+                    ingestion
+                        .desc
+                        .validate_against_context(&self.state.instance_context)
+                        .map_err(|e| StorageError::InvalidUsage(e.to_string_with_causes()))?;
 
                     // The ingestion metadata is simply the collection metadata of the collection with
                     // the associated ingestion
@@ -2253,13 +2264,21 @@ where
         postgres_factory: &StashFactory,
         envd_epoch: NonZeroI64,
         metrics_registry: MetricsRegistry,
+        initialize_context: StorageInstanceContext,
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
         Self {
             build_info,
-            state: StorageControllerState::new(postgres_url, tx, now, postgres_factory, envd_epoch)
-                .await,
+            state: StorageControllerState::new(
+                postgres_url,
+                tx,
+                now,
+                postgres_factory,
+                envd_epoch,
+                initialize_context,
+            )
+            .await,
             internal_response_queue: rx,
             persist_location,
             persist: persist_clients,

--- a/src/storage-client/src/types/instances.rs
+++ b/src/storage-client/src/types/instances.rs
@@ -10,9 +10,10 @@
 //! Types related to storage instances.
 
 use std::fmt;
+use std::path::PathBuf;
 use std::str::FromStr;
 
-use anyhow::bail;
+use anyhow::{bail, Context, Error};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -94,6 +95,38 @@ impl RustType<ProtoStorageInstanceId> for StorageInstanceId {
             None => Err(TryFromProtoError::missing_field(
                 "ProtoStorageInstanceId::kind",
             )),
+        }
+    }
+}
+
+/// Extra context for a storage instance.
+/// This is extra information that is used when rendering source
+/// and sinks that is not tied to the source/connection configuration itself.
+#[derive(Debug, Clone)]
+pub struct StorageInstanceContext {
+    /// A directory that can be used for scratch work.
+    pub scratch_directory: Option<PathBuf>,
+}
+
+impl StorageInstanceContext {
+    pub async fn new(scratch_directory: Option<PathBuf>) -> Result<StorageInstanceContext, Error> {
+        if let Some(scratch_directory) = &scratch_directory {
+            tokio::fs::create_dir_all(scratch_directory)
+                .await
+                .with_context(|| {
+                    format!(
+                        "creating scratch directory: {}",
+                        scratch_directory.display()
+                    )
+                })?;
+        }
+        Ok(Self { scratch_directory })
+    }
+
+    /// Constructs a new connection context for usage in tests.
+    pub fn for_tests() -> StorageInstanceContext {
+        Self {
+            scratch_directory: None,
         }
     }
 }

--- a/src/storage-client/src/types/sources.proto
+++ b/src/storage-client/src/types/sources.proto
@@ -76,6 +76,7 @@ message ProtoUpsertEnvelope {
     ProtoUpsertStyle style = 1;
     repeated uint64 key_indices = 2;
     uint64 source_arity = 3;
+    bool disk = 4;
 }
 
 message ProtoUpsertStyle {

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -386,11 +386,12 @@ where
                     };
                     let upsert = crate::render::upsert::upsert(
                         &upsert_input,
-                        upsert_envelope.key_indices.clone(),
+                        upsert_envelope.clone(),
                         resume_upper,
                         previous,
                         previous_token,
                         base_source_config,
+                        &storage_state.instance_context,
                     );
 
                     let (upsert_ok, upsert_err) = upsert.inner.ok_err(split_ok_err);

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -145,6 +145,11 @@ where
     );
 
     if upsert_envelope.disk {
+        tracing::info!(
+            "timely-{} rendering {} with rocksdb-backed upsert state",
+            source_config.worker_id,
+            source_config.id
+        );
         let rocksdb_metrics = Arc::clone(&upsert_metrics.rocksdb);
         let rocksdb_dir = instance_context
             .scratch_directory
@@ -172,6 +177,11 @@ where
             },
         )
     } else {
+        tracing::info!(
+            "timely-{} rendering {} with memory-backed upsert state",
+            source_config.worker_id,
+            source_config.id
+        );
         upsert_inner(
             input,
             upsert_envelope.key_indices,

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -32,6 +32,8 @@ use timely::progress::{Antichain, Timestamp};
 use crate::source::types::UpsertMetrics;
 use mz_repr::{Datum, DatumVec, Diff, Row};
 use mz_storage_client::types::errors::{DataflowError, EnvelopeError, UpsertError};
+use mz_storage_client::types::instances::StorageInstanceContext;
+use mz_storage_client::types::sources::UpsertEnvelope;
 use mz_timely_util::builder_async::{Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder};
 
 use self::types::{InMemoryHashMap, StatsState, UpsertState};
@@ -126,14 +128,76 @@ impl<H: Digest> Hasher for DigestHasher<H> {
 /// and the collection of the previous output of this operator.
 pub(crate) fn upsert<G: Scope, O: timely::ExchangeData + Ord>(
     input: &Collection<G, (UpsertKey, Option<UpsertValue>, O), Diff>,
-    mut key_indices: Vec<usize>,
+    upsert_envelope: UpsertEnvelope,
     resume_upper: Antichain<G::Timestamp>,
     previous: Collection<G, Result<Row, DataflowError>, Diff>,
     previous_token: Option<Rc<dyn Any>>,
     source_config: crate::source::RawSourceCreationConfig,
+    instance_context: &StorageInstanceContext,
 ) -> Collection<G, Result<Row, DataflowError>, Diff>
 where
     G::Timestamp: TotalOrder,
+{
+    let upsert_metrics = UpsertMetrics::new(
+        &source_config.base_metrics,
+        source_config.id,
+        source_config.worker_id,
+    );
+
+    if upsert_envelope.disk {
+        let rocksdb_metrics = Arc::clone(&upsert_metrics.rocksdb);
+        let rocksdb_dir = instance_context
+            .scratch_directory
+            .as_ref()
+            .expect("instance directory to be there if rendering an ON DISK source")
+            .join(source_config.id.to_string())
+            .join(source_config.worker_id.to_string());
+        upsert_inner(
+            input,
+            upsert_envelope.key_indices,
+            resume_upper,
+            previous,
+            previous_token,
+            upsert_metrics,
+            move || async move {
+                rocksdb::RocksDB::new(
+                    mz_rocksdb::RocksDBInstance::new(
+                        &rocksdb_dir,
+                        mz_rocksdb::Options::new_with_defaults().unwrap(),
+                        rocksdb_metrics,
+                    )
+                    .await
+                    .unwrap(),
+                )
+            },
+        )
+    } else {
+        upsert_inner(
+            input,
+            upsert_envelope.key_indices,
+            resume_upper,
+            previous,
+            previous_token,
+            upsert_metrics,
+            || async { InMemoryHashMap::default() },
+        )
+    }
+}
+
+fn upsert_inner<G: Scope, O: timely::ExchangeData + Ord, F, Fut, US>(
+    input: &Collection<G, (UpsertKey, Option<UpsertValue>, O), Diff>,
+    mut key_indices: Vec<usize>,
+    resume_upper: Antichain<G::Timestamp>,
+    previous: Collection<G, Result<Row, DataflowError>, Diff>,
+    previous_token: Option<Rc<dyn Any>>,
+    upsert_metrics: UpsertMetrics,
+    state: F,
+) -> Collection<G, Result<Row, DataflowError>, Diff>
+where
+    G::Timestamp: TotalOrder,
+    F: FnOnce() -> Fut + 'static,
+    Fut: std::future::Future<Output = US>,
+    US: UpsertState,
 {
     // Sort key indices to ensure we can construct the key by iterating over the datums of the row
     key_indices.sort_unstable();
@@ -163,11 +227,6 @@ where
     );
     let (mut output_handle, output) = builder.new_output();
 
-    let upsert_metrics = UpsertMetrics::new(
-        &source_config.base_metrics,
-        source_config.id,
-        source_config.worker_id,
-    );
     let upsert_shared_metrics = Arc::clone(&upsert_metrics.shared);
     builder.build(move |caps| async move {
         let mut output_cap = caps.into_element();
@@ -201,7 +260,7 @@ where
         consolidation::consolidate(&mut snapshot);
 
         // The main key->value used to store previous values.
-        let mut state = StatsState::new(InMemoryHashMap::default(), upsert_shared_metrics);
+        let mut state = StatsState::new(state().await, upsert_shared_metrics);
 
         // A re-usable buffer of changes, per key. This is
         // an `IndexMap` because it has to be `drain`-able

--- a/src/storage/src/render/upsert/rocksdb.rs
+++ b/src/storage/src/render/upsert/rocksdb.rs
@@ -27,6 +27,12 @@ pub struct RocksDB {
     rocksdb: RocksDBInstance<UpsertKey, UpsertValue>,
 }
 
+impl RocksDB {
+    pub fn new(rocksdb: RocksDBInstance<UpsertKey, UpsertValue>) -> Self {
+        Self { rocksdb }
+    }
+}
+
 #[async_trait::async_trait(?Send)]
 impl UpsertState for RocksDB {
     async fn multi_put<P>(&mut self, puts: P) -> Result<u64, anyhow::Error>

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -20,6 +20,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_storage_client::client::StorageClient;
 use mz_storage_client::client::{StorageCommand, StorageResponse};
 use mz_storage_client::types::connections::ConnectionContext;
+use mz_storage_client::types::instances::StorageInstanceContext;
 use timely::worker::Worker as TimelyWorker;
 
 use crate::sink::SinkBaseMetrics;
@@ -34,6 +35,8 @@ pub struct Config {
     pub now: NowFn,
     /// Configuration for source and sink connection.
     pub connection_context: ConnectionContext,
+    /// Other configuration for storage instances.
+    pub instance_context: StorageInstanceContext,
 
     /// Metrics for sources.
     pub source_metrics: SourceBaseMetrics,
@@ -55,6 +58,7 @@ pub fn serve(
     generic_config: mz_cluster::server::ClusterConfig,
     now: NowFn,
     connection_context: ConnectionContext,
+    instance_context: StorageInstanceContext,
 ) -> Result<
     (
         TimelyContainerRef<StorageCommand, StorageResponse, Thread>,
@@ -70,6 +74,7 @@ pub fn serve(
     let config = Config {
         now,
         connection_context,
+        instance_context,
         source_metrics,
         sink_metrics,
         decode_metrics,
@@ -110,6 +115,7 @@ impl mz_cluster::types::AsRunnableWorker<StorageCommand, StorageResponse> for Co
             config.sink_metrics,
             config.now.clone(),
             config.connection_context,
+            config.instance_context,
             persist_clients,
         )
         .run();

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -501,6 +501,7 @@ pub struct UpsertMetrics {
     pub(crate) rehydration_latency: DeleteOnDropGauge<'static, AtomicF64, Vec<String>>,
     pub(crate) rehydration_total: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     pub(crate) shared: Arc<UpsertSharedMetrics>,
+    pub(crate) rocksdb: Arc<mz_rocksdb::RocksDBMetrics>,
 }
 
 impl UpsertMetrics {
@@ -516,6 +517,7 @@ impl UpsertMetrics {
                 .rehydration_total
                 .get_delete_on_drop_gauge(vec![source_id_s, worker_id]),
             shared: base.shared(&source_id),
+            rocksdb: base.rocksdb(&source_id),
         }
     }
 }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -98,6 +98,7 @@ use mz_storage_client::client::{SinkStatisticsUpdate, SourceStatisticsUpdate};
 use mz_storage_client::client::{StorageCommand, StorageResponse};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::connections::ConnectionContext;
+use mz_storage_client::types::instances::StorageInstanceContext;
 use mz_storage_client::types::sinks::{MetadataFilled, StorageSinkDesc};
 use mz_storage_client::types::sources::{IngestionDescription, SourceData};
 
@@ -149,6 +150,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
         sink_metrics: SinkBaseMetrics,
         now: NowFn,
         connection_context: ConnectionContext,
+        instance_context: StorageInstanceContext,
         persist_clients: Arc<PersistClientCache>,
     ) -> Self {
         // It is very important that we only create the internal control
@@ -204,6 +206,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
             timely_worker_index: timely_worker.index(),
             timely_worker_peers: timely_worker.peers(),
             connection_context,
+            instance_context,
             persist_clients,
             sink_tokens: BTreeMap::new(),
             sink_write_frontiers: BTreeMap::new(),
@@ -261,6 +264,8 @@ pub struct StorageState {
     pub timely_worker_peers: usize,
     /// Configuration for source and sink connections.
     pub connection_context: ConnectionContext,
+    /// Other configuration for sources and sinks.
+    pub instance_context: StorageInstanceContext,
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
     /// This is intentionally shared between workers
     pub persist_clients: Arc<PersistClientCache>,

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -232,6 +232,7 @@ where
                     sink_metrics,
                     SYSTEM_TIME.clone(),
                     connection_context,
+                    mz_storage_client::types::instances::StorageInstanceContext::for_tests(),
                     Arc::clone(&persist_clients),
                 )
             };

--- a/test/upsert/kafka-upsert-debezium-sources.td
+++ b/test/upsert/kafka-upsert-debezium-sources.td
@@ -1,0 +1,229 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# must be a subset of the keys in the rows
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "id", "type": "long"}
+    ]
+  }
+
+$ set schema={
+    "type" : "record",
+    "name" : "envelope",
+    "fields" : [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {
+                  "name": "id",
+                  "type": "long"
+              },
+              {
+                "name": "creature",
+                "type": "string"
+              }]
+           },
+           "null"
+         ]
+      },
+      { "name": "op", "type": "string" },
+      {
+        "name": "after",
+        "type": ["row", "null"]
+      },
+      {
+        "name": "source",
+        "type": {
+          "type": "record",
+          "name": "Source",
+          "namespace": "io.debezium.connector.mysql",
+          "fields": [
+            {
+              "name": "file",
+              "type": "string"
+            },
+            {
+              "name": "pos",
+              "type": "long"
+            },
+            {
+              "name": "row",
+              "type": "int"
+            },
+            {
+              "name": "snapshot",
+              "type": [
+                {
+                  "type": "boolean",
+                  "connect.default": false
+                },
+                "null"
+              ],
+              "default": false
+            }
+          ],
+          "connect.name": "io.debezium.connector.mysql.Source"
+        }
+      }
+    ]
+  }
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+$ kafka-create-topic topic=dbzupsert partitions=1
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
+{"id": 1} {"before": {"row": {"id": 1, "creature": "fish"}}, "after": {"row": {"id": 1, "creature": "mudskipper"}}, "op": "u", "source": {"file": "binlog1", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+{"id": 1} {"before": {"row": {"id": 1, "creature": "mudskipper"}}, "after": {"row": {"id": 1, "creature": "salamander"}}, "op": "u", "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+{"id": 1} {"before": {"row": {"id": 1, "creature": "salamander"}}, "after": {"row": {"id": 1, "creature": "lizard"}}, "op": "u", "source": {"file": "binlog3", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+
+! CREATE SOURCE doin_upsert
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM ${arg.impl}
+contains:ENVELOPE [DEBEZIUM] UPSERT requires that KEY FORMAT be specified
+
+> CREATE SOURCE doin_upsert
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM ${arg.impl}
+
+> SELECT * FROM doin_upsert
+id creature
+-----------
+1  lizard
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=2
+{"id": 1} {"before": {"row": {"id": 1, "creature": "lizard"}}, "after": {"row": {"id": 1, "creature": "dino"}}, "op": "u", "source": {"file": "binlog4", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+
+> SELECT * FROM doin_upsert
+id creature
+-----------
+1  dino
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=3
+{"id": 2} {"before": null, "after": {"row": {"id": 2, "creature": "archeopteryx"}}, "op": "c", "source": {"file": "binlog5", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+{"id": 2} {"before": {"row": {"id": 2, "creature": "archeopteryx"}}, "after": {"row": {"id": 2, "creature": "velociraptor"}}, "op": "u", "source": {"file": "binlog6", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+
+> SELECT * FROM doin_upsert ORDER BY creature
+id creature
+------------
+1  dino
+2  velociraptor
+
+# test duplicates
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=4
+{"id": 3} {"before": {"row": {"id": 3, "creature": "protoceratops"}}, "after": {"row": {"id": 3, "creature": "triceratops"}}, "op": "u", "source": {"file": "binlog7", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+{"id": 3} {"before": {"row": {"id": 3, "creature": "protoceratops"}}, "after": {"row": {"id": 3, "creature": "triceratops"}}, "op": "u", "source": {"file": "binlog8", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+
+> SELECT * FROM doin_upsert WHERE id = 3
+id creature
+-----------
+3  triceratops
+
+# test removal and reinsertion
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=5
+{"id": 4} {"before": null, "after": {"row": {"id": 4, "creature": "moros"}}, "op": "c", "source": {"file": "binlog9", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+
+> SELECT creature FROM doin_upsert WHERE id = 4
+creature
+--------
+moros
+
+# [btv] uncomment if we bring back classic debezium mode
+# ! CREATE SOURCE doin_upsert_metadata
+#   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+#   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+#   INCLUDE OFFSET
+#   ENVELOPE DEBEZIUM
+# contains:INCLUDE OFFSET with Debezium requires UPSERT semantics
+
+> CREATE SOURCE doin_upsert_metadata
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  INCLUDE PARTITION, OFFSET AS test_kafka_offset
+  ENVELOPE DEBEZIUM ${arg.impl}
+
+> SELECT * FROM doin_upsert_metadata WHERE id = 4
+id creature partition test_kafka_offset
+---------------------------------------
+4  moros    0         8
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=6
+{"id": 4} {"before": {"row": {"id": 4, "creature": "trex"}}, "after": null, "op": "d", "source": {"file": "binlog10", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+
+> SELECT creature FROM doin_upsert WHERE id = 4
+creature
+--------
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=7
+{"id": 4} {"before": {"row": {"id": 4, "creature": "trex"}}, "after": {"row": {"id": 4, "creature": "chicken"}}, "op": "u", "source": {"file": "binlog11", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+
+> SELECT creature FROM doin_upsert WHERE id = 4
+creature
+--------
+chicken
+
+> SELECT * FROM doin_upsert WHERE id = 3
+id creature
+-----------
+3  triceratops
+
+# Test that `WITH (START OFFSET=<whatever>)` works
+> CREATE SOURCE upsert_fast_forward
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET = [6], TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM ${arg.impl}
+
+> SELECT * FROM upsert_fast_forward WHERE id = 3
+id creature
+-----------
+3  triceratops
+
+# test include metadata
+> CREATE SOURCE upsert_metadata
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  INCLUDE OFFSET, PARTITION
+  ENVELOPE DEBEZIUM ${arg.impl}
+
+> SELECT * FROM upsert_metadata
+id   creature      offset  partition
+------------------------------------
+1    dino          3       0
+2    velociraptor  5       0
+3    triceratops   7       0
+4    chicken       10      0
+
+# test include metadata respects metadata order
+> CREATE SOURCE upsert_metadata_reordered
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  INCLUDE PARTITION, OFFSET
+  ENVELOPE DEBEZIUM ${arg.impl}
+
+> SELECT * FROM upsert_metadata_reordered
+id   creature      partition  offset
+------------------------------------
+1    dino          0          3
+2    velociraptor  0          5
+3    triceratops   0          7
+4    chicken       0          10

--- a/test/upsert/kafka-upsert-debezium-sources.td
+++ b/test/upsert/kafka-upsert-debezium-sources.td
@@ -98,13 +98,13 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
 ! CREATE SOURCE doin_upsert
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM ${arg.impl}
+  ENVELOPE DEBEZIUM
 contains:ENVELOPE [DEBEZIUM] UPSERT requires that KEY FORMAT be specified
 
 > CREATE SOURCE doin_upsert
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE DEBEZIUM ${arg.impl}
+  ENVELOPE DEBEZIUM
 
 > SELECT * FROM doin_upsert
 id creature
@@ -160,7 +160,7 @@ moros
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE PARTITION, OFFSET AS test_kafka_offset
-  ENVELOPE DEBEZIUM ${arg.impl}
+  ENVELOPE DEBEZIUM
 
 > SELECT * FROM doin_upsert_metadata WHERE id = 4
 id creature partition test_kafka_offset
@@ -191,7 +191,7 @@ id creature
 > CREATE SOURCE upsert_fast_forward
   FROM KAFKA CONNECTION kafka_conn (START OFFSET = [6], TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE DEBEZIUM ${arg.impl}
+  ENVELOPE DEBEZIUM
 
 > SELECT * FROM upsert_fast_forward WHERE id = 3
 id creature
@@ -203,7 +203,7 @@ id creature
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE OFFSET, PARTITION
-  ENVELOPE DEBEZIUM ${arg.impl}
+  ENVELOPE DEBEZIUM
 
 > SELECT * FROM upsert_metadata
 id   creature      offset  partition
@@ -218,7 +218,7 @@ id   creature      offset  partition
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE PARTITION, OFFSET
-  ENVELOPE DEBEZIUM ${arg.impl}
+  ENVELOPE DEBEZIUM
 
 > SELECT * FROM upsert_metadata_reordered
 id   creature      partition  offset

--- a/test/upsert/mzcompose
+++ b/test/upsert/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -66,7 +66,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     materialized = Materialized(
         default_size=args.default_size,
-        options=["--orchestrator-process-scratch-directory=/mzdata/source_data"],
+        options=[
+            "--orchestrator-process-scratch-directory=/mzdata/source_data"
+            "--bootstrap-system-parameter=upsert_source_disk_default=true"
+        ],
     )
 
     with c.override(testdrive, materialized):
@@ -93,7 +96,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 f"--var=replicas={args.replicas}",
                 f"--var=default-replica-size={materialized.default_replica_size}",
                 f"--var=default-storage-size={materialized.default_storage_size}",
-                "--var=impl=WITH (DISK)",
                 *args.files,
             )
         finally:

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -1,0 +1,102 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This mzcompose currently tests `UPSERT` sources with `DISK` configured.
+# TODO(guswynn): move ALL upsert-related tests into this directory.
+
+from pathlib import Path
+
+from materialize import ci_util
+from materialize.mzcompose import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services import (
+    Kafka,
+    Materialized,
+    SchemaRegistry,
+    Testdrive,
+    Zookeeper,
+)
+
+SERVICES = [
+    Zookeeper(),
+    Kafka(),
+    SchemaRegistry(),
+    Materialized(),
+    Testdrive(),
+]
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    """Run testdrive."""
+    parser.add_argument(
+        "--kafka-default-partitions",
+        type=int,
+        metavar="N",
+        help="set the default number of kafka partitions per topic",
+    )
+    parser.add_argument(
+        "--default-size",
+        type=int,
+        default=Materialized.Size.DEFAULT_SIZE,
+        help="Use SIZE 'N-N' for replicas and SIZE 'N' for sources",
+    )
+
+    parser.add_argument("--replicas", type=int, default=1, help="use multiple replicas")
+
+    parser.add_argument(
+        "files",
+        nargs="*",
+        default=["*.td"],
+        help="run against the specified files",
+    )
+    args = parser.parse_args()
+
+    dependencies = ["materialized", "zookeeper", "kafka", "schema-registry"]
+
+    testdrive = Testdrive(
+        forward_buildkite_shard=True,
+        kafka_default_partitions=args.kafka_default_partitions,
+        validate_postgres_stash="materialized",
+    )
+
+    materialized = Materialized(
+        default_size=args.default_size,
+        options=["--orchestrator-process-scratch-directory=/mzdata/source_data"],
+    )
+
+    with c.override(testdrive, materialized):
+        c.up(*dependencies)
+
+        if args.replicas > 1:
+            c.sql("DROP CLUSTER default CASCADE")
+            # Make sure a replica named 'r1' always exists
+            replica_names = [
+                "r1" if replica_id == 0 else f"replica{replica_id}"
+                for replica_id in range(0, args.replicas)
+            ]
+            replica_string = ",".join(
+                f"{replica_name} (SIZE '{materialized.default_replica_size}')"
+                for replica_name in replica_names
+            )
+            c.sql(f"CREATE CLUSTER default REPLICAS ({replica_string})")
+
+        try:
+            junit_report = ci_util.junit_report_filename(c.name)
+            c.run(
+                "testdrive",
+                f"--junit-report={junit_report}",
+                f"--var=replicas={args.replicas}",
+                f"--var=default-replica-size={materialized.default_replica_size}",
+                f"--var=default-storage-size={materialized.default_storage_size}",
+                "--var=impl=WITH (DISK)",
+                *args.files,
+            )
+        finally:
+            ci_util.upload_junit_report(
+                "testdrive", Path(__file__).parent / junit_report
+            )


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/17067

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

- The top commit is just basic tests. @philip-stoev my plan to eventually move all upsert-related tests into this new mzcompose, and test both backends there. I wanted to keep this pr manageable. I also added this new composition to the tests ci pipeline.
- The bottom commit is the meat of the implementation; It contains:
  -  Support for `WITH (ON DISK)` in `CREATE SOURCE` (note that `ON DISK = true/false` are explicitly banned for clarity, and simplifying migrations in the future.
  - `--instance-directory` is the new optional plan required to use this feature. This is forward to `clusterd` from `envd`. Naming (and the naming of `InstanceContext`) isn't great, and I'm not attached to anything specific here)
  - The rest of the changes are mostly boilerplate piping things through. Note that error handling is lackluster, but thats a separate task in the epic. The non `ON DISK` flow is left unchanged.
  - Note that this is behind `--unsafe-mode`. Next step is to change this to an LD flag. This will happen in a followup pr, to avoid too much noise in one pr.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
   (see notion)
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

