### PR TITLE
pgtest: fix range test file

### DIFF
--- a/test/pgtest/range.pt
+++ b/test/pgtest/range.pt
@@ -1,10 +1,16 @@
 # test that our range types' binary functions have the same implementation/results as PG
 
 send
+Parse {"query": "DROP TABLE IF EXISTS int4range_values"}
+Bind
+Execute
 Parse {"query": "CREATE TABLE int4range_values (a int4range)"}
 Bind
 Execute
 Parse {"query": "INSERT INTO int4range_values VALUES ('[,1)'), ('[,1]'), ('[,)'), ('[,]'), ('(,1)'), ('(,1]'), ('(,)'), ('(,]'), ('[-1,1)'), ('[-1,1]'), ('(-1,1)'), ('(-1,1]'), ('[0,0)'), ('[0,0]'), ('(0,0)'), ('(0,0]'), ('[1,)'), ('[1,]'), ('(1,)'), ('(1,]')"}
+Bind
+Execute
+Parse {"query": "DROP TABLE IF EXISTS int4range_test_values"}
 Bind
 Execute
 Parse {"query": "CREATE TABLE int4range_test_values (v int4range)"}
@@ -13,10 +19,16 @@ Execute
 Parse {"query": "INSERT INTO int4range_test_values VALUES ('empty'), ('(,)'), ('(,1)'), ('(-1,)'), ('[-1,1)'), ('[-99,-50)'), ('[50,99)')"}
 Bind
 Execute
+Parse {"query": "DROP TABLE IF EXISTS numrange_values"}
+Bind
+Execute
 Parse {"query": "CREATE TABLE numrange_values (a numrange)"}
 Bind
 Execute
 Parse {"query": "INSERT INTO numrange_values VALUES ('[,1)'), ('[,1]'), ('[,)'), ('[,]'), ('(,1)'), ('(,1]'), ('(,)'), ('(,]'), ('[-1,1)'), ('[-1,1]'), ('(-1,1)'), ('(-1,1]'), ('[0,0)'), ('[0,0]'), ('(0,0)'), ('(0,0]'), ('[1,)'), ('[1,]'), ('(1,)'), ('(1,]')"}
+Bind
+Execute
+Parse {"query": "DROP TABLE IF EXISTS numrange_test_values"}
 Bind
 Execute
 Parse {"query": "CREATE TABLE numrange_test_values (v numrange)"}
@@ -33,10 +45,16 @@ ReadyForQuery
 ----
 ParseComplete
 BindComplete
+CommandComplete {"tag":"DROP TABLE"}
+ParseComplete
+BindComplete
 CommandComplete {"tag":"CREATE TABLE"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"INSERT 0 20"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"DROP TABLE"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"CREATE TABLE"}
@@ -45,10 +63,16 @@ BindComplete
 CommandComplete {"tag":"INSERT 0 7"}
 ParseComplete
 BindComplete
+CommandComplete {"tag":"DROP TABLE"}
+ParseComplete
+BindComplete
 CommandComplete {"tag":"CREATE TABLE"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"INSERT 0 20"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"DROP TABLE"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"CREATE TABLE"}
@@ -91,86 +115,86 @@ ReadyForQuery
 ParseComplete
 BindComplete
 DataRow {"fields":["empty","{empty}"]}
-DataRow {"fields":["(,1)","{empty,(,1),[-99,-50),[-1,1)}"]}
-DataRow {"fields":["(,2)","{empty,(,1),[-99,-50),[-1,1)}"]}
-DataRow {"fields":["(,)","{empty,(,1),(,),[-99,-50),[-1,1),[0,),[50,99)}"]}
-DataRow {"fields":["[-1,1)","{empty,[-1,1)}"]}
-DataRow {"fields":["[-1,2)","{empty,[-1,1)}"]}
+DataRow {"fields":["(,1)","{empty,\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["(,2)","{empty,\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["(,)","{empty,\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1)","{empty,\"[-1,1)\"}"]}
+DataRow {"fields":["[-1,2)","{empty,\"[-1,1)\"}"]}
 DataRow {"fields":["[0,1)","{empty}"]}
 DataRow {"fields":["[0,2)","{empty}"]}
-DataRow {"fields":["[1,)","{empty,[50,99)}"]}
-DataRow {"fields":["[2,)","{empty,[50,99)}"]}
+DataRow {"fields":["[1,)","{empty,\"[50,99)\"}"]}
+DataRow {"fields":["[2,)","{empty,\"[50,99)\"}"]}
 CommandComplete {"tag":"SELECT 10"}
 ParseComplete
 BindComplete
-DataRow {"fields":["empty","{empty,(,1),(,),[-99,-50),[-1,1),[0,),[50,99)}"]}
-DataRow {"fields":["(,1)","{(,1),(,)}"]}
-DataRow {"fields":["(,2)","{(,)}"]}
-DataRow {"fields":["(,)","{(,)}"]}
-DataRow {"fields":["[-1,1)","{(,1),(,),[-1,1)}"]}
-DataRow {"fields":["[-1,2)","{(,)}"]}
-DataRow {"fields":["[0,1)","{(,1),(,),[-1,1),[0,)}"]}
-DataRow {"fields":["[0,2)","{(,),[0,)}"]}
-DataRow {"fields":["[1,)","{(,),[0,)}"]}
-DataRow {"fields":["[2,)","{(,),[0,)}"]}
+DataRow {"fields":["empty","{empty,\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["(,2)","{\"(,)\"}"]}
+DataRow {"fields":["(,)","{\"(,)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\"}"]}
+DataRow {"fields":["[-1,2)","{\"(,)\"}"]}
+DataRow {"fields":["[0,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[0,2)","{\"(,)\",\"[0,)\"}"]}
+DataRow {"fields":["[1,)","{\"(,)\",\"[0,)\"}"]}
+DataRow {"fields":["[2,)","{\"(,)\",\"[0,)\"}"]}
 CommandComplete {"tag":"SELECT 10"}
 ParseComplete
 BindComplete
-DataRow {"fields":["(,1)","{(,1),(,),[-99,-50),[-1,1),[0,)}"]}
-DataRow {"fields":["(,2)","{(,1),(,),[-99,-50),[-1,1),[0,)}"]}
-DataRow {"fields":["(,)","{(,1),(,),[-99,-50),[-1,1),[0,),[50,99)}"]}
-DataRow {"fields":["[-1,1)","{(,1),(,),[-1,1),[0,)}"]}
-DataRow {"fields":["[-1,2)","{(,1),(,),[-1,1),[0,)}"]}
-DataRow {"fields":["[0,1)","{(,1),(,),[-1,1),[0,)}"]}
-DataRow {"fields":["[0,2)","{(,1),(,),[-1,1),[0,)}"]}
-DataRow {"fields":["[1,)","{(,),[0,),[50,99)}"]}
-DataRow {"fields":["[2,)","{(,),[0,),[50,99)}"]}
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["(,2)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["(,)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[-1,2)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[0,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[0,2)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[1,)","{\"(,)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[2,)","{\"(,)\",\"[0,)\",\"[50,99)\"}"]}
 CommandComplete {"tag":"SELECT 9"}
 ParseComplete
 BindComplete
-DataRow {"fields":["(,1)","{[50,99)}"]}
-DataRow {"fields":["(,2)","{[50,99)}"]}
-DataRow {"fields":["[-1,1)","{[50,99)}"]}
-DataRow {"fields":["[-1,2)","{[50,99)}"]}
-DataRow {"fields":["[0,1)","{[50,99)}"]}
-DataRow {"fields":["[0,2)","{[50,99)}"]}
+DataRow {"fields":["(,1)","{\"[50,99)\"}"]}
+DataRow {"fields":["(,2)","{\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1)","{\"[50,99)\"}"]}
+DataRow {"fields":["[-1,2)","{\"[50,99)\"}"]}
+DataRow {"fields":["[0,1)","{\"[50,99)\"}"]}
+DataRow {"fields":["[0,2)","{\"[50,99)\"}"]}
 CommandComplete {"tag":"SELECT 6"}
 ParseComplete
 BindComplete
-DataRow {"fields":["[-1,1)","{[-99,-50)}"]}
-DataRow {"fields":["[-1,2)","{[-99,-50)}"]}
-DataRow {"fields":["[0,1)","{[-99,-50)}"]}
-DataRow {"fields":["[0,2)","{[-99,-50)}"]}
-DataRow {"fields":["[1,)","{(,1),[-99,-50),[-1,1)}"]}
-DataRow {"fields":["[2,)","{(,1),[-99,-50),[-1,1)}"]}
+DataRow {"fields":["[-1,1)","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[-1,2)","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[0,1)","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[0,2)","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[1,)","{\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["[2,)","{\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
 CommandComplete {"tag":"SELECT 6"}
 ParseComplete
 BindComplete
-DataRow {"fields":["(,1)","{(,1),(,),[-1,1),[0,),[50,99)}"]}
-DataRow {"fields":["(,2)","{(,),[0,),[50,99)}"]}
-DataRow {"fields":["(,)","{(,),[0,)}"]}
-DataRow {"fields":["[-1,1)","{(,1),(,),[-1,1),[0,),[50,99)}"]}
-DataRow {"fields":["[-1,2)","{(,),[0,),[50,99)}"]}
-DataRow {"fields":["[0,1)","{(,1),(,),[-1,1),[0,),[50,99)}"]}
-DataRow {"fields":["[0,2)","{(,),[0,),[50,99)}"]}
-DataRow {"fields":["[1,)","{(,),[0,)}"]}
-DataRow {"fields":["[2,)","{(,),[0,)}"]}
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(,2)","{\"(,)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(,)","{\"(,)\",\"[0,)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[-1,2)","{\"(,)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[0,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[0,2)","{\"(,)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[1,)","{\"(,)\",\"[0,)\"}"]}
+DataRow {"fields":["[2,)","{\"(,)\",\"[0,)\"}"]}
 CommandComplete {"tag":"SELECT 9"}
 ParseComplete
 BindComplete
-DataRow {"fields":["(,1)","{(,1),(,)}"]}
-DataRow {"fields":["(,2)","{(,1),(,)}"]}
-DataRow {"fields":["(,)","{(,1),(,)}"]}
-DataRow {"fields":["[-1,1)","{(,1),(,),[-99,-50),[-1,1)}"]}
-DataRow {"fields":["[-1,2)","{(,1),(,),[-99,-50),[-1,1)}"]}
-DataRow {"fields":["[0,1)","{(,1),(,),[-99,-50),[-1,1),[0,)}"]}
-DataRow {"fields":["[0,2)","{(,1),(,),[-99,-50),[-1,1),[0,)}"]}
-DataRow {"fields":["[1,)","{(,1),(,),[-99,-50),[-1,1),[0,)}"]}
-DataRow {"fields":["[2,)","{(,1),(,),[-99,-50),[-1,1),[0,)}"]}
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["(,2)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["(,)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["[-1,2)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["[0,1)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[0,2)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[1,)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[2,)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\"}"]}
 CommandComplete {"tag":"SELECT 9"}
 ParseComplete
 BindComplete
-DataRow {"fields":["[1,)","{(,1),[-1,1)}"]}
+DataRow {"fields":["[1,)","{\"(,1)\",\"[-1,1)\"}"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
 
@@ -208,102 +232,102 @@ ReadyForQuery
 ParseComplete
 BindComplete
 DataRow {"fields":["empty","{empty}"]}
-DataRow {"fields":["(,1)","{empty,(,1),[-99,-50),[-1,1)}"]}
-DataRow {"fields":["(,1]","{empty,(,1),[-99,-50),[-1,1)}"]}
-DataRow {"fields":["(,)","{empty,(,1),(,),[-99,-50),[-1,1),(-1,),[50,99)}"]}
-DataRow {"fields":["[-1,1)","{empty,[-1,1)}"]}
-DataRow {"fields":["[-1,1]","{empty,[-1,1)}"]}
+DataRow {"fields":["(,1)","{empty,\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["(,1]","{empty,\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["(,)","{empty,\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1)","{empty,\"[-1,1)\"}"]}
+DataRow {"fields":["[-1,1]","{empty,\"[-1,1)\"}"]}
 DataRow {"fields":["(-1,1)","{empty}"]}
 DataRow {"fields":["(-1,1]","{empty}"]}
 DataRow {"fields":["[0,0]","{empty}"]}
-DataRow {"fields":["[1,)","{empty,[50,99)}"]}
-DataRow {"fields":["(1,)","{empty,[50,99)}"]}
+DataRow {"fields":["[1,)","{empty,\"[50,99)\"}"]}
+DataRow {"fields":["(1,)","{empty,\"[50,99)\"}"]}
 CommandComplete {"tag":"SELECT 11"}
 ParseComplete
 BindComplete
-DataRow {"fields":["empty","{empty,(,1),(,),[-99,-50),[-1,1),(-1,),[50,99)}"]}
-DataRow {"fields":["(,1)","{(,1),(,)}"]}
-DataRow {"fields":["(,1]","{(,)}"]}
-DataRow {"fields":["(,)","{(,)}"]}
-DataRow {"fields":["[-1,1)","{(,1),(,),[-1,1)}"]}
-DataRow {"fields":["[-1,1]","{(,)}"]}
-DataRow {"fields":["(-1,1)","{(,1),(,),[-1,1),(-1,)}"]}
-DataRow {"fields":["(-1,1]","{(,),(-1,)}"]}
-DataRow {"fields":["[0,0]","{(,1),(,),[-1,1),(-1,)}"]}
-DataRow {"fields":["[1,)","{(,),(-1,)}"]}
-DataRow {"fields":["(1,)","{(,),(-1,)}"]}
+DataRow {"fields":["empty","{empty,\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["(,1]","{\"(,)\"}"]}
+DataRow {"fields":["(,)","{\"(,)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\"}"]}
+DataRow {"fields":["[-1,1]","{\"(,)\"}"]}
+DataRow {"fields":["(-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(-1,1]","{\"(,)\",\"(-1,)\"}"]}
+DataRow {"fields":["[0,0]","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["[1,)","{\"(,)\",\"(-1,)\"}"]}
+DataRow {"fields":["(1,)","{\"(,)\",\"(-1,)\"}"]}
 CommandComplete {"tag":"SELECT 11"}
 ParseComplete
 BindComplete
-DataRow {"fields":["(,1)","{(,1),(,),[-99,-50),[-1,1),(-1,)}"]}
-DataRow {"fields":["(,1]","{(,1),(,),[-99,-50),[-1,1),(-1,)}"]}
-DataRow {"fields":["(,)","{(,1),(,),[-99,-50),[-1,1),(-1,),[50,99)}"]}
-DataRow {"fields":["[-1,1)","{(,1),(,),[-1,1),(-1,)}"]}
-DataRow {"fields":["[-1,1]","{(,1),(,),[-1,1),(-1,)}"]}
-DataRow {"fields":["(-1,1)","{(,1),(,),[-1,1),(-1,)}"]}
-DataRow {"fields":["(-1,1]","{(,1),(,),[-1,1),(-1,)}"]}
-DataRow {"fields":["[0,0]","{(,1),(,),[-1,1),(-1,)}"]}
-DataRow {"fields":["[1,)","{(,),(-1,),[50,99)}"]}
-DataRow {"fields":["(1,)","{(,),(-1,),[50,99)}"]}
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(,1]","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(,)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["[-1,1]","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(-1,1]","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["[0,0]","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["[1,)","{\"(,)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(1,)","{\"(,)\",\"(-1,)\",\"[50,99)\"}"]}
 CommandComplete {"tag":"SELECT 10"}
 ParseComplete
 BindComplete
-DataRow {"fields":["(,1)","{[50,99)}"]}
-DataRow {"fields":["(,1]","{[50,99)}"]}
-DataRow {"fields":["[-1,1)","{[50,99)}"]}
-DataRow {"fields":["[-1,1]","{[50,99)}"]}
-DataRow {"fields":["(-1,1)","{[50,99)}"]}
-DataRow {"fields":["(-1,1]","{[50,99)}"]}
-DataRow {"fields":["[0,0]","{[50,99)}"]}
+DataRow {"fields":["(,1)","{\"[50,99)\"}"]}
+DataRow {"fields":["(,1]","{\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1)","{\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1]","{\"[50,99)\"}"]}
+DataRow {"fields":["(-1,1)","{\"[50,99)\"}"]}
+DataRow {"fields":["(-1,1]","{\"[50,99)\"}"]}
+DataRow {"fields":["[0,0]","{\"[50,99)\"}"]}
 CommandComplete {"tag":"SELECT 7"}
 ParseComplete
 BindComplete
-DataRow {"fields":["[-1,1)","{[-99,-50)}"]}
-DataRow {"fields":["[-1,1]","{[-99,-50)}"]}
-DataRow {"fields":["(-1,1)","{[-99,-50)}"]}
-DataRow {"fields":["(-1,1]","{[-99,-50)}"]}
-DataRow {"fields":["[0,0]","{[-99,-50)}"]}
-DataRow {"fields":["[1,)","{(,1),[-99,-50),[-1,1)}"]}
-DataRow {"fields":["(1,)","{(,1),[-99,-50),[-1,1)}"]}
+DataRow {"fields":["[-1,1)","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[-1,1]","{\"[-99,-50)\"}"]}
+DataRow {"fields":["(-1,1)","{\"[-99,-50)\"}"]}
+DataRow {"fields":["(-1,1]","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[0,0]","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[1,)","{\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["(1,)","{\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
 CommandComplete {"tag":"SELECT 7"}
 ParseComplete
 BindComplete
-DataRow {"fields":["(,1)","{(,1),(,),[-1,1),(-1,),[50,99)}"]}
-DataRow {"fields":["(,1]","{(,),(-1,),[50,99)}"]}
-DataRow {"fields":["(,)","{(,),(-1,)}"]}
-DataRow {"fields":["[-1,1)","{(,1),(,),[-1,1),(-1,),[50,99)}"]}
-DataRow {"fields":["[-1,1]","{(,),(-1,),[50,99)}"]}
-DataRow {"fields":["(-1,1)","{(,1),(,),[-1,1),(-1,),[50,99)}"]}
-DataRow {"fields":["(-1,1]","{(,),(-1,),[50,99)}"]}
-DataRow {"fields":["[0,0]","{(,1),(,),[-1,1),(-1,),[50,99)}"]}
-DataRow {"fields":["[1,)","{(,),(-1,)}"]}
-DataRow {"fields":["(1,)","{(,),(-1,)}"]}
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(,1]","{\"(,)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(,)","{\"(,)\",\"(-1,)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1]","{\"(,)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(-1,1]","{\"(,)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[0,0]","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[1,)","{\"(,)\",\"(-1,)\"}"]}
+DataRow {"fields":["(1,)","{\"(,)\",\"(-1,)\"}"]}
 CommandComplete {"tag":"SELECT 10"}
 ParseComplete
 BindComplete
-DataRow {"fields":["(,1)","{(,1),(,)}"]}
-DataRow {"fields":["(,1]","{(,1),(,)}"]}
-DataRow {"fields":["(,)","{(,1),(,)}"]}
-DataRow {"fields":["[-1,1)","{(,1),(,),[-99,-50),[-1,1)}"]}
-DataRow {"fields":["[-1,1]","{(,1),(,),[-99,-50),[-1,1)}"]}
-DataRow {"fields":["(-1,1)","{(,1),(,),[-99,-50),[-1,1),(-1,)}"]}
-DataRow {"fields":["(-1,1]","{(,1),(,),[-99,-50),[-1,1),(-1,)}"]}
-DataRow {"fields":["[0,0]","{(,1),(,),[-99,-50),[-1,1),(-1,)}"]}
-DataRow {"fields":["[1,)","{(,1),(,),[-99,-50),[-1,1),(-1,)}"]}
-DataRow {"fields":["(1,)","{(,1),(,),[-99,-50),[-1,1),(-1,)}"]}
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["(,1]","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["(,)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["[-1,1]","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["(-1,1)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(-1,1]","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["[0,0]","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["[1,)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(1,)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
 CommandComplete {"tag":"SELECT 10"}
 ParseComplete
 BindComplete
-DataRow {"fields":["[1,)","{(,1),[-1,1)}"]}
+DataRow {"fields":["[1,)","{\"(,1)\",\"[-1,1)\"}"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
 
 # test range binary encodings
 send
-Parse {"query": "SELECT * FROM int4range_values;"}
+Parse {"query": "SELECT * FROM int4range_values ORDER BY a;"}
 Bind {"result_formats": [1]}
 Execute
-Parse {"query": "SELECT * FROM numrange_values;"}
+Parse {"query": "SELECT * FROM numrange_values ORDER BY a;"}
 Bind {"result_formats": [1]}
 Execute
 Sync
@@ -317,45 +341,45 @@ BindComplete
 DataRow {"fields":["\u0001"]}
 DataRow {"fields":["\u0001"]}
 DataRow {"fields":["\u0001"]}
-DataRow {"fields":["\u0018"]}
-DataRow {"fields":["\u0018"]}
-DataRow {"fields":["\u0018"]}
-DataRow {"fields":["\u0018"]}
 DataRow {"fields":["\b\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0001"]}
 DataRow {"fields":["\b\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0001"]}
 DataRow {"fields":["\b\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0002"]}
 DataRow {"fields":["\b\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0002"]}
-DataRow {"fields":["\u0012\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0001"]}
-DataRow {"fields":["\u0012\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0001"]}
-DataRow {"fields":["\u0012\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0002"]}
-DataRow {"fields":["\u0012\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0002"]}
+DataRow {"fields":["\u0018"]}
+DataRow {"fields":["\u0018"]}
+DataRow {"fields":["\u0018"]}
+DataRow {"fields":["\u0018"]}
+DataRow {"fields":["[2, 0, 0, 0, 4, 255, 255, 255, 255, 0, 0, 0, 4, 0, 0, 0, 1]"]}
+DataRow {"fields":["[2, 0, 0, 0, 4, 255, 255, 255, 255, 0, 0, 0, 4, 0, 0, 0, 2]"]}
 DataRow {"fields":["\u0002\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0001"]}
 DataRow {"fields":["\u0002\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0001"]}
 DataRow {"fields":["\u0002\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0002"]}
-DataRow {"fields":["[2, 0, 0, 0, 4, 255, 255, 255, 255, 0, 0, 0, 4, 0, 0, 0, 1]"]}
-DataRow {"fields":["[2, 0, 0, 0, 4, 255, 255, 255, 255, 0, 0, 0, 4, 0, 0, 0, 2]"]}
+DataRow {"fields":["\u0012\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0001"]}
+DataRow {"fields":["\u0012\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0001"]}
+DataRow {"fields":["\u0012\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0002"]}
+DataRow {"fields":["\u0012\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0002"]}
 CommandComplete {"tag":"SELECT 20"}
 ParseComplete
 BindComplete
 DataRow {"fields":["\u0001"]}
 DataRow {"fields":["\u0001"]}
 DataRow {"fields":["\u0001"]}
-DataRow {"fields":["\u0018"]}
-DataRow {"fields":["\u0018"]}
-DataRow {"fields":["\u0018"]}
-DataRow {"fields":["\u0018"]}
 DataRow {"fields":["\b\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
 DataRow {"fields":["\b\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
 DataRow {"fields":["\f\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
 DataRow {"fields":["\f\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
-DataRow {"fields":["\u0010\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
-DataRow {"fields":["\u0010\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
-DataRow {"fields":["\u0012\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
-DataRow {"fields":["\u0012\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
-DataRow {"fields":["\u0000\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000@\u0000\u0000\u0000\u0000\u0001\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
+DataRow {"fields":["\u0018"]}
+DataRow {"fields":["\u0018"]}
+DataRow {"fields":["\u0018"]}
+DataRow {"fields":["\u0018"]}
 DataRow {"fields":["\u0002\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000@\u0000\u0000\u0000\u0000\u0001\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
-DataRow {"fields":["\u0004\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000@\u0000\u0000\u0000\u0000\u0001\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
-DataRow {"fields":["[6, 0, 0, 0, 8, 0, 0, 255, 255, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 255, 255, 0, 0, 0, 0]"]}
 DataRow {"fields":["\u0006\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000@\u0000\u0000\u0000\u0000\u0001\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
+DataRow {"fields":["\u0000\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000@\u0000\u0000\u0000\u0000\u0001\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
+DataRow {"fields":["\u0004\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000@\u0000\u0000\u0000\u0000\u0001\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
+DataRow {"fields":["\u0006\u0000\u0000\u0000\b\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\b\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"]}
+DataRow {"fields":["\u0012\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
+DataRow {"fields":["\u0012\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
+DataRow {"fields":["\u0010\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
+DataRow {"fields":["\u0010\u0000\u0000\u0000\n\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"]}
 CommandComplete {"tag":"SELECT 20"}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest/range.pt
+++ b/test/pgtest/range.pt
@@ -1,16 +1,10 @@
 # test that our range types' binary functions have the same implementation/results as PG
 
 send
-Parse {"query": "DROP TABLE IF EXISTS int4range_values"}
-Bind
-Execute
 Parse {"query": "CREATE TABLE int4range_values (a int4range)"}
 Bind
 Execute
 Parse {"query": "INSERT INTO int4range_values VALUES ('[,1)'), ('[,1]'), ('[,)'), ('[,]'), ('(,1)'), ('(,1]'), ('(,)'), ('(,]'), ('[-1,1)'), ('[-1,1]'), ('(-1,1)'), ('(-1,1]'), ('[0,0)'), ('[0,0]'), ('(0,0)'), ('(0,0]'), ('[1,)'), ('[1,]'), ('(1,)'), ('(1,]')"}
-Bind
-Execute
-Parse {"query": "DROP TABLE IF EXISTS int4range_test_values"}
 Bind
 Execute
 Parse {"query": "CREATE TABLE int4range_test_values (v int4range)"}
@@ -19,16 +13,10 @@ Execute
 Parse {"query": "INSERT INTO int4range_test_values VALUES ('empty'), ('(,)'), ('(,1)'), ('(-1,)'), ('[-1,1)'), ('[-99,-50)'), ('[50,99)')"}
 Bind
 Execute
-Parse {"query": "DROP TABLE IF EXISTS numrange_values"}
-Bind
-Execute
 Parse {"query": "CREATE TABLE numrange_values (a numrange)"}
 Bind
 Execute
 Parse {"query": "INSERT INTO numrange_values VALUES ('[,1)'), ('[,1]'), ('[,)'), ('[,]'), ('(,1)'), ('(,1]'), ('(,)'), ('(,]'), ('[-1,1)'), ('[-1,1]'), ('(-1,1)'), ('(-1,1]'), ('[0,0)'), ('[0,0]'), ('(0,0)'), ('(0,0]'), ('[1,)'), ('[1,]'), ('(1,)'), ('(1,]')"}
-Bind
-Execute
-Parse {"query": "DROP TABLE IF EXISTS numrange_test_values"}
 Bind
 Execute
 Parse {"query": "CREATE TABLE numrange_test_values (v numrange)"}
@@ -45,16 +33,10 @@ ReadyForQuery
 ----
 ParseComplete
 BindComplete
-CommandComplete {"tag":"DROP TABLE"}
-ParseComplete
-BindComplete
 CommandComplete {"tag":"CREATE TABLE"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"INSERT 0 20"}
-ParseComplete
-BindComplete
-CommandComplete {"tag":"DROP TABLE"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"CREATE TABLE"}
@@ -63,16 +45,10 @@ BindComplete
 CommandComplete {"tag":"INSERT 0 7"}
 ParseComplete
 BindComplete
-CommandComplete {"tag":"DROP TABLE"}
-ParseComplete
-BindComplete
 CommandComplete {"tag":"CREATE TABLE"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"INSERT 0 20"}
-ParseComplete
-BindComplete
-CommandComplete {"tag":"DROP TABLE"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"CREATE TABLE"}
@@ -104,6 +80,9 @@ Parse {"query": "SELECT a t, array_agg(v ORDER BY v) FROM ( SELECT DISTINCT a FR
 Bind
 Execute
 Parse {"query": "SELECT a t, array_agg(v ORDER BY v) FROM ( SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL ) int4range_values(a), int4range_test_values WHERE a -|- v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT DISTINCT l.v, r.v, l.v < r.v, l.v <= r.v, l.v > r.v, l.v >= r.v, l.v = r.v, l.v <> r.v FROM int4range_test_values AS l, int4range_test_values AS r ORDER BY 1, 2;"}
 Bind
 Execute
 Sync
@@ -196,6 +175,58 @@ ParseComplete
 BindComplete
 DataRow {"fields":["[1,)","{\"(,1)\",\"[-1,1)\"}"]}
 CommandComplete {"tag":"SELECT 1"}
+ParseComplete
+BindComplete
+DataRow {"fields":["empty","empty","f","t","f","t","t","f"]}
+DataRow {"fields":["empty","(,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","(,)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[-99,-50)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[0,)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["(,1)","(,1)","f","t","f","t","t","f"]}
+DataRow {"fields":["(,1)","(,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[-99,-50)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[0,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["(,)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["(,)","(,)","f","t","f","t","t","f"]}
+DataRow {"fields":["(,)","[-99,-50)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","[0,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-99,-50)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","[-99,-50)","f","t","f","t","t","f"]}
+DataRow {"fields":["[-99,-50)","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-99,-50)","[0,)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-99,-50)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-1,1)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","[-99,-50)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","[-1,1)","f","t","f","t","t","f"]}
+DataRow {"fields":["[-1,1)","[0,)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-1,1)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["[0,)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[0,)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[0,)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[0,)","[-99,-50)","f","f","t","t","f","t"]}
+DataRow {"fields":["[0,)","[-1,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[0,)","[0,)","f","t","f","t","t","f"]}
+DataRow {"fields":["[0,)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["[50,99)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","[-99,-50)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","[-1,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","[0,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","[50,99)","f","t","f","t","t","f"]}
+CommandComplete {"tag":"SELECT 49"}
 ReadyForQuery {"status":"I"}
 
 send
@@ -221,6 +252,9 @@ Parse {"query": "SELECT a t, array_agg(v ORDER BY v) FROM ( SELECT DISTINCT a FR
 Bind
 Execute
 Parse {"query": "SELECT a t, array_agg(v ORDER BY v) FROM ( SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL ) numrange_values(a), numrange_test_values WHERE a -|- v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT DISTINCT l.v, r.v, l.v < r.v, l.v <= r.v, l.v > r.v, l.v >= r.v, l.v = r.v, l.v <> r.v FROM numrange_test_values AS l, numrange_test_values AS r ORDER BY 1, 2;"}
 Bind
 Execute
 Sync
@@ -320,6 +354,58 @@ ParseComplete
 BindComplete
 DataRow {"fields":["[1,)","{\"(,1)\",\"[-1,1)\"}"]}
 CommandComplete {"tag":"SELECT 1"}
+ParseComplete
+BindComplete
+DataRow {"fields":["empty","empty","f","t","f","t","t","f"]}
+DataRow {"fields":["empty","(,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","(,)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[-99,-50)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","(-1,)","t","t","f","f","f","t"]}
+DataRow {"fields":["empty","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["(,1)","(,1)","f","t","f","t","t","f"]}
+DataRow {"fields":["(,1)","(,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[-99,-50)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","(-1,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,1)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["(,)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["(,)","(,)","f","t","f","t","t","f"]}
+DataRow {"fields":["(,)","[-99,-50)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","(-1,)","t","t","f","f","f","t"]}
+DataRow {"fields":["(,)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-99,-50)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-99,-50)","[-99,-50)","f","t","f","t","t","f"]}
+DataRow {"fields":["[-99,-50)","[-1,1)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-99,-50)","(-1,)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-99,-50)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-1,1)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","[-99,-50)","f","f","t","t","f","t"]}
+DataRow {"fields":["[-1,1)","[-1,1)","f","t","f","t","t","f"]}
+DataRow {"fields":["[-1,1)","(-1,)","t","t","f","f","f","t"]}
+DataRow {"fields":["[-1,1)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["(-1,)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["(-1,)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["(-1,)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["(-1,)","[-99,-50)","f","f","t","t","f","t"]}
+DataRow {"fields":["(-1,)","[-1,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["(-1,)","(-1,)","f","t","f","t","t","f"]}
+DataRow {"fields":["(-1,)","[50,99)","t","t","f","f","f","t"]}
+DataRow {"fields":["[50,99)","empty","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","(,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","(,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","[-99,-50)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","[-1,1)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","(-1,)","f","f","t","t","f","t"]}
+DataRow {"fields":["[50,99)","[50,99)","f","t","f","t","t","f"]}
+CommandComplete {"tag":"SELECT 49"}
 ReadyForQuery {"status":"I"}
 
 # test range binary encodings


### PR DESCRIPTION
In #18817, I missed an `ORDER BY` and assumed that there was an issue with the binary encoding of `range` types in MZ. However, the only problem was a missing `ORDER BY`, so adding that aligned the test's behavior with PG without modifying an source code.

### Motivation

This PR refactors existing code. Closes #18820

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
