### PR TITLE
sql: Fix panic on correlated casts

### DIFF
--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -922,11 +922,9 @@ pub fn plan_hypothetical_cast(
     Some(
         plan_cast(&ecx, ccx, col_expr, to)
             .ok()?
+            // TODO(jkosh44) Support casts that have correlated implementations.
             .lower_uncorrelated()
-            .expect(
-                "lower_uncorrelated should not fail given that there is no correlation \
-                in the input col_expr",
-            ),
+            .ok()?,
     )
 }
 

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -919,13 +919,11 @@ pub fn plan_hypothetical_cast(
 
     // Determine the `ScalarExpr` required to cast our column to the target
     // component type.
-    Some(
-        plan_cast(&ecx, ccx, col_expr, to)
-            .ok()?
-            // TODO(jkosh44) Support casts that have correlated implementations.
-            .lower_uncorrelated()
-            .ok()?,
-    )
+    plan_cast(&ecx, ccx, col_expr, to)
+        .ok()?
+        // TODO(jkosh44) Support casts that have correlated implementations.
+        .lower_uncorrelated()
+        .ok()
 }
 
 /// Plans a cast between [`ScalarType`]s, specifying which types of casts are

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -929,3 +929,9 @@ query T
 SELECT c::int[] FROM array_t2;
 ----
 NULL
+
+query error CAST does not support casting from mz_aclitem\[\] to text\[\]
+SELECT privileges::text[] FROM mz_views;
+
+query error CAST does not support casting from regproc list to text list
+SELECT (LIST[1299::regproc]::regproc list)::text list


### PR DESCRIPTION
Previously if a cast from one type to another type was implemented using SQL, and the SQL contained a SELECT or other correlated expression, then the cast would cause a panic in certain situations. The panic would happen if the cast was involved in any of the following casts:

- String to Array
- String to List
- String to Map
- String to Range
- Record to Record
- Array to Array
- List to List

These casts incorrectly assumed that the cast implementation did not contain a correlated expression.

This commit removes the panic from these casts, but does not actually implement the casts.

Fixes #19052

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
