### PR TITLE
storage: on boot, keep only the most recent source status history

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6744,6 +6744,9 @@ impl Catalog {
                 ),
                 tcp_user_timeout: Some(self.system_config().pg_replication_tcp_user_timeout()),
             },
+            keep_n_source_status_history_entries: self
+                .system_config()
+                .keep_n_source_status_history_entries(),
         }
     }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -819,6 +819,15 @@ pub const MAX_CONNECTIONS: ServerVar<u32> = ServerVar {
     safe: true,
 };
 
+/// Controls [`mz_storage_client::types::parameters::StorageParameters::keep_n_source_status_history_entries`].
+const KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("keep_n_source_status_history_entries"),
+    value: &5,
+    description: "On reboot, truncate all but the last n entries per ID in the source_status_history collection (Materialize).",
+    internal: true,
+    safe: true,
+};
+
 /// Represents the input to a variable.
 ///
 /// Each variable has different rules for how it handles each style of input.
@@ -1564,6 +1573,7 @@ impl Default for SystemVars {
             .with_var(&ENABLE_ENVELOPE_DEBEZIUM_IN_SUBSCRIBE)
             .with_var(&ENABLE_WITHIN_TIMESTAMP_ORDER_BY_IN_SUBSCRIBE)
             .with_var(&MAX_CONNECTIONS)
+            .with_var(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
     }
 }
 
@@ -1949,6 +1959,10 @@ impl SystemVars {
     /// Returns the `max_connections` configuration parameter.
     pub fn max_connections(&self) -> u32 {
         *self.expect_value(&MAX_CONNECTIONS)
+    }
+
+    pub fn keep_n_source_status_history_entries(&self) -> usize {
+        *self.expect_value(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
     }
 }
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -54,7 +54,7 @@ use mz_persist_client::{PersistClient, PersistLocation, ShardId};
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::{Codec64, Opaque};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
-use mz_repr::{Datum, Diff, GlobalId, RelationDesc, Row, TimestampManipulation};
+use mz_repr::{ColumnName, Datum, Diff, GlobalId, RelationDesc, Row, TimestampManipulation};
 use mz_stash::{self, AppendBatch, StashError, StashFactory, TypedCollection};
 
 use crate::client::{
@@ -1541,8 +1541,10 @@ where
                             // dropped, so that the internal task will stop.
                             self.state.introspection_tokens.insert(id, scraper_token);
                         }
-                        IntrospectionType::SourceStatusHistory
-                        | IntrospectionType::SinkStatusHistory => {
+                        IntrospectionType::SourceStatusHistory => {
+                            self.initialize_source_status_history().await;
+                        }
+                        IntrospectionType::SinkStatusHistory => {
                             // nothing to do: these collections are append only
                         }
                     }
@@ -2520,6 +2522,72 @@ where
             packer.push(Datum::from(data_shard.to_string().as_str()));
             updates.push((row_buf.clone(), 1));
         }
+
+        self.reconcile_managed_collection(id, updates).await;
+    }
+
+    /// Effectively truncates the source status history shard except for the most recent update from
+    /// each ID.
+    async fn initialize_source_status_history(&mut self) {
+        let id = self.state.introspection_ids[&IntrospectionType::SourceStatusHistory];
+
+        let (occurred_at, _) = healthcheck::MZ_SOURCE_STATUS_HISTORY_DESC
+            .get_by_name(&ColumnName::from("occurred_at"))
+            .expect("schema has not changed");
+
+        let (source_id, _) = healthcheck::MZ_SOURCE_STATUS_HISTORY_DESC
+            .get_by_name(&ColumnName::from("source_id"))
+            .expect("schema has not changed");
+
+        let mut rows = vec![];
+
+        match self.state.collections[&id]
+            .write_frontier
+            .elements()
+            .iter()
+            .min()
+        {
+            Some(f) if f > &T::minimum() => {
+                let as_of = f.step_back().unwrap();
+
+                rows.extend(self.snapshot(id, as_of).await.unwrap());
+            }
+            // If collection is closed or the frontier is the minimum, we cannot
+            // or don't need to truncate (respectively).
+            _ => {}
+        }
+
+        let mut most_recent_status = BTreeMap::new();
+
+        for (row, diff) in rows.iter() {
+            mz_ore::soft_assert!(
+                *diff == 1,
+                "only know how to operate over consolidated data"
+            );
+
+            let d = row.unpack();
+            let source_id = d[source_id];
+            let occurred_at = d[occurred_at];
+
+            let (most_recent, unpacked_row) = most_recent_status
+                .entry(source_id)
+                .or_insert((occurred_at.clone(), d.clone()));
+
+            if occurred_at > *most_recent {
+                *most_recent = occurred_at;
+                *unpacked_row = d;
+            }
+        }
+
+        let mut row_buf = Row::default();
+        let updates = most_recent_status
+            .into_iter()
+            .map(|(_, (_, unpacked_row))| {
+                let mut packer = row_buf.packer();
+                packer.extend(unpacked_row.into_iter());
+                (row_buf.clone(), 1)
+            })
+            .collect();
 
         self.reconcile_managed_collection(id, updates).await;
     }

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -18,6 +18,7 @@ message ProtoStorageParameters {
     mz_persist_client.cfg.ProtoPersistParameters persist = 1;
     bool enable_multi_worker_storage_persist_sink = 2;
     ProtoPgReplicationTimeouts pg_replication_timeouts = 3;
+    uint64 keep_n_source_status_history_entries = 4;
 }
 
 message ProtoPgReplicationTimeouts {


### PR DESCRIPTION
Before this commit, the source status history was an append-only shard, meaning it could potentially crash OOM any machine that tried to read all of its contents.

Until we come up with a more principled solution aboout how collections like this should work, truncating the collection on boot seemed like a good idea. However, that seems potentially annoying for support teams handling constantly rebooting clusters; if we instead keep the most recent status from the last epoch, we can maintain a bit of context as to what caused the crash.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
