### PR TITLE
pg sources: support complex identifiers in table names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4893,6 +4893,7 @@ dependencies = [
  "mz-rocksdb",
  "mz-secrets",
  "mz-service",
+ "mz-sql-parser",
  "mz-storage-client",
  "mz-timely-util",
  "num_cpus",

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -49,6 +49,7 @@ mz-repr = { path = "../repr" }
 mz-rocksdb = { path = "../rocksdb" }
 mz-secrets = { path = "../secrets" }
 mz-service = { path = "../service" }
+mz-sql-parser = { path = "../sql-parser" }
 mz-storage-client = { path = "../storage-client" }
 mz-timely-util = { path = "../timely-util" }
 once_cell = { version = "1.16.0" }

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -79,6 +79,14 @@ CREATE TABLE "таблица" ("колона" TEXT);
 ALTER TABLE "таблица" REPLICA IDENTITY FULL;
 INSERT INTO "таблица" VALUES ('стойност');
 
+CREATE TABLE """literal_quotes""" (a TEXT);
+ALTER TABLE """literal_quotes""" REPLICA IDENTITY FULL;
+INSERT INTO """literal_quotes""" VALUES ('v');
+
+CREATE TABLE "select" (a TEXT);
+ALTER TABLE "select" REPLICA IDENTITY FULL;
+INSERT INTO "select" VALUES ('v');
+
 CREATE TABLE escaped_text_table (f1 TEXT, f2 TEXt);
 ALTER TABLE escaped_text_table REPLICA IDENTITY FULL;
 INSERT INTO escaped_text_table VALUES ('escaped\ntext\twith\nnewlines\tand\ntabs', 'more\tescaped\ntext');
@@ -246,7 +254,9 @@ regex: the following columns contain unsupported types:\npostgres\.public\.anoth
     "таблица",
     "escaped_text_table",
     conflict_schema.conflict_table AS public.conflict_table,
-    "space table"
+    "space table",
+    """literal_quotes""",
+    "select"
   );
 
 $ set-regex match=\d+ replacement=<NUMBER>
@@ -263,9 +273,11 @@ no_replica_identity   subsource <null>
 nonpk_table           subsource <null>
 nulls_table           subsource <null>
 pk_table              subsource <null>
+select                subsource <null>
 "space table"         subsource <null>
 trailing_space_nopk   subsource <null>
 trailing_space_pk     subsource <null>
+"\"literal_quotes\""  subsource <null>
 types_table           subsource <null>
 utf<NUMBER>_table     subsource <null>
 таблица               subsource <null>
@@ -350,6 +362,12 @@ contains: SOURCE materialize.public.conflict_table is a subsource and cannot be 
 
 > SELECT * FROM conflict_table;
 234
+
+> SELECT * FROM """literal_quotes"""
+v
+
+> SELECT * FROM "select"
+v
 
 #
 # Confirm that the new sources can be used to build upon


### PR DESCRIPTION
We previously relied on debug printing names to format the target of our snapshotting COPY; however, that does not work with quoted identifiers. However, using non-debug printing is also insufficient because it doesn't properly escape e.g. quoted identifiers.

To properly print the names, we can use logic from the parser, which has these rules encoded; namely Ident's ast string.

### Motivation

This PR fixes a previously unreported bug.

Creating a subsource with a name containing quotes, e.g. `"select"`, or `"""literal_quotes"""` would throw a syntax error because we debug-printed the name, which contains slashes, which are interpreted in ways we didn't intend in the `COPY` command.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix a bug that prevented users from ingesting PostgreSQL tables that contained quotes (e.g. `"""table"""`) or needed to be quoted (e.g. `"select"`).
