### PR TITLE
Various coverage improvements

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -60,6 +60,7 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
     mzcompose cp materialized:/usr/local/bin/environmentd coverage/ || true
     mzcompose cp materialized:/usr/local/bin/clusterd coverage/ || true
     mzcompose cp sqllogictest:/usr/local/bin/sqllogictest coverage/ || true
+    mzcompose cp testdrive:/usr/local/bin/testdrive coverage/ || true
 fi
 
 ci_uncollapsed_heading ":docker: Running \`mzcompose run ${run_args[*]}\`"

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -40,7 +40,7 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
         find . -name '*.profraw' -delete
 
         ARGS=()
-        for program in clusterd environmentd sqllogictest; do
+        for program in clusterd environmentd sqllogictest testdrive; do
             if [ -f coverage/"$program" ]; then
                 export_cov coverage/"$program"
                 ARGS+=("-a" coverage/"$BUILDKITE_JOB_ID"-"$program".lcov)

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -34,7 +34,7 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
     if [ -n "$(find . -name '*.profraw')" ]; then
         # Workaround for "invalid instrumentation profile data (file header is corrupt)"
         find . -name '*.profraw' | while read -r i; do
-            bin/ci-builder run stable rust-profdata show "$i" > /dev/null || rm "$i"
+            bin/ci-builder run stable rust-profdata show "$i" > /dev/null || rm "$i" || true
         done
         find . -name '*.profraw' -exec bin/ci-builder run stable rust-profdata merge -sparse -o coverage/"$BUILDKITE_JOB_ID".profdata {} +
         find . -name '*.profraw' -delete

--- a/misc/python/materialize/cli/ci_coverage_pr_report.py
+++ b/misc/python/materialize/cli/ci_coverage_pr_report.py
@@ -16,7 +16,7 @@ from typing import Dict, Optional
 
 import junit_xml
 
-from materialize import ROOT, ci_util
+from materialize import ROOT, ci_util, ui
 
 # - None value indicates that this line is interesting, but we don't know yet
 #   if it can actually be covered.
@@ -138,14 +138,16 @@ def get_report(coverage: Coverage) -> str:
                         f.write(line)
                 f.truncate()
 
-        subprocess.run(
-            ["git", "config", "user.email", "coverage@materialize.com"],
-            check=True,
-        )
-        subprocess.run(
-            ["git", "config", "user.name", "Code Coverage"],
-            check=True,
-        )
+        # Only set user for CI, not when testing this script locally
+        if ui.env_is_truthy("CI"):
+            subprocess.run(
+                ["git", "config", "user.email", "coverage@materialize.com"],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Code Coverage"],
+                check=True,
+            )
         subprocess.run(
             ["git", "commit", "--allow-empty", "-a", "-m", "Covered in unit test only"],
             check=True,


### PR DESCRIPTION
Noticed as part of https://github.com/MaterializeInc/materialize/pull/19050/, but want to submit now already. Working run with these changes was https://buildkite.com/materialize/coverage/builds/83

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
