### PR TITLE
platform-checks: Wait for Pg snapshots to complete when upgrading fro…

### DIFF
--- a/misc/python/materialize/checks/pg_cdc.py
+++ b/misc/python/materialize/checks/pg_cdc.py
@@ -72,9 +72,17 @@ class PgCdc(Check):
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_source_table SELECT 'C', i, REPEAT('C', 1024 - i) FROM generate_series(1,100) AS i;
                 UPDATE postgres_source_table SET f2 = f2 + 100;
-                """,
                 """
-
+                + (
+                    """
+                # Wait until Pg snapshot is complete in order to avoid #18940
+                > SELECT COUNT(*) > 0 FROM postgres_source_tableA
+                true
+                """
+                    if self.base_version < MzVersion.parse("0.46.1")
+                    else ""
+                ),
+                """
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_source_table SELECT 'D', i, REPEAT('D', 1024 - i) FROM generate_series(1,100) AS i;
                 UPDATE postgres_source_table SET f2 = f2 + 100;
@@ -113,7 +121,18 @@ class PgCdc(Check):
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_source_table SELECT 'H', i, REPEAT('X', 1024 - i) FROM generate_series(1,100) AS i;
                 UPDATE postgres_source_table SET f2 = f2 + 100;
-                """,
+                """
+                + (
+                    """
+                # Wait until Pg snapshot is complete in order to avoid #18940
+                > SELECT COUNT(*) > 0 FROM postgres_source_tableB
+                true
+                > SELECT COUNT(*) > 0 FROM postgres_source_tableC
+                true
+                """
+                    if self.base_version < MzVersion.parse("0.46.1")
+                    else ""
+                ),
             ]
         ]
 


### PR DESCRIPTION
…m old Mz version

Relates to #18940

### Motivation

The upgrade test hits a wrong-results situation if it upgrades from a very old Mz version without waiting for the initial Pg snapshot to complete. Since it is not currently known if the bug will be fixed, is fixable or worth fixing, a test workaround is being implemented.


  * This PR fixes a previously unreported bug.
Nightly upgade-matrix is failing.
### Tips for reviewer

@def- , this file already has in-line version checks for two separate issues :-( any ideas on how to organize this better would be much appreciated. As the product ages and continues to accumulate breaking changes or unfixable old-version bugs, we may need to have files with 5 or more ternary if operators and other cruft. 