### PR TITLE
List replicas in SHOW CLUSTERS

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -610,7 +610,8 @@ SELECT
 FROM
     mz_catalog.mz_clusters mc
         JOIN mz_catalog.mz_cluster_replicas mcr ON mc.id = mcr.cluster_id
-GROUP BY mc.name".to_string();
+GROUP BY mc.name"
+        .to_string();
     ShowSelect::new(scx, query, filter, None, Some(&["name", "replicas"]))
 }
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -599,8 +599,15 @@ pub fn show_clusters<'a>(
     scx: &'a StatementContext<'a>,
     filter: Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let query = "SELECT mz_clusters.name FROM mz_catalog.mz_clusters".to_string();
-
+    let query = "
+SELECT
+    mz_clusters.name,
+    pg_catalog.array_agg(ROW(mz_cluster_replicas.name, mz_cluster_replicas.size) ORDER BY mz_cluster_replicas.name)
+        AS replicas
+FROM
+    mz_catalog.mz_clusters
+        JOIN mz_catalog.mz_cluster_replicas ON mz_clusters.id = mz_cluster_replicas.cluster_id
+GROUP BY mz_clusters.name".to_string();
     ShowSelect::new(scx, query, filter, None, Some(&["name"]))
 }
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -595,20 +595,23 @@ pub fn show_columns<'a>(
     )
 }
 
+// The rationale for which fields to include in the tuples are those
+// that are mandatory when creating a replica as part of the CREATE
+// CLUSTER command, i.e., name and size.
 pub fn show_clusters<'a>(
     scx: &'a StatementContext<'a>,
     filter: Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
     let query = "
 SELECT
-    mz_clusters.name,
-    pg_catalog.array_agg(ROW(mz_cluster_replicas.name, mz_cluster_replicas.size) ORDER BY mz_cluster_replicas.name)
+    mc.name,
+    pg_catalog.string_agg(mcr.name || ' (' || mcr.size || ')', ', ' ORDER BY mcr.name)
         AS replicas
 FROM
-    mz_catalog.mz_clusters
-        JOIN mz_catalog.mz_cluster_replicas ON mz_clusters.id = mz_cluster_replicas.cluster_id
-GROUP BY mz_clusters.name".to_string();
-    ShowSelect::new(scx, query, filter, None, Some(&["name"]))
+    mz_catalog.mz_clusters mc
+        JOIN mz_catalog.mz_cluster_replicas mcr ON mc.id = mcr.cluster_id
+GROUP BY mc.name".to_string();
+    ShowSelect::new(scx, query, filter, None, Some(&["name", "replicas"]))
 }
 
 pub fn show_cluster_replicas<'a>(

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -609,7 +609,7 @@ SELECT
         AS replicas
 FROM
     mz_catalog.mz_clusters mc
-        JOIN mz_catalog.mz_cluster_replicas mcr ON mc.id = mcr.cluster_id
+        LEFT JOIN mz_catalog.mz_cluster_replicas mcr ON mc.id = mcr.cluster_id
 GROUP BY mc.name"
         .to_string();
     ShowSelect::new(scx, query, filter, None, Some(&["name", "replicas"]))

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -143,7 +143,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
 # Introspection tables
 
-> SHOW CLUSTERS LIKE 'cluster2'
+> SELECT name FROM (SHOW CLUSTERS LIKE 'cluster2')
 cluster2
 
 > SELECT name FROM mz_tables WHERE name = 't1';

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -93,15 +93,6 @@ u1  default
 u4  foo
 u7  bar
 
-query TT rowsort
-SELECT name, replicas::text FROM (SHOW CLUSTERS)
-----
-bar  {"(r1,1)","(r2,1)"}
-default  {"(r1,1)"}
-foo  {"(r1,)"}
-mz_introspection  {"(r1,1)"}
-mz_system  {"(r1,1)"}
-
 query T rowsort
 SELECT name FROM (SHOW CLUSTERS LIKE 'd%')
 ----

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -93,17 +93,17 @@ u1  default
 u4  foo
 u7  bar
 
-query T rowsort
-SHOW CLUSTERS
+query TT rowsort
+SELECT name, replicas::text FROM (SHOW CLUSTERS)
 ----
-mz_system
-mz_introspection
-bar
-default
-foo
+bar  {"(r1,1)","(r2,1)"}
+default  {"(r1,1)"}
+foo  {"(r1,)"}
+mz_introspection  {"(r1,1)"}
+mz_system  {"(r1,1)"}
 
 query T rowsort
-SHOW CLUSTERS LIKE 'd%'
+SELECT name FROM (SHOW CLUSTERS LIKE 'd%')
 ----
 default
 

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -59,7 +59,7 @@ u1  default  false  NULL  NULL
 
 
 query T rowsort
-SHOW CLUSTERS
+SELECT name FROM (SHOW CLUSTERS)
 ----
 mz_system
 mz_introspection

--- a/test/sqllogictest/show_clusters.slt
+++ b/test/sqllogictest/show_clusters.slt
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test for `SHOW CLUSTERS`.
+
+mode standard
+
+# Start from a pristine state
+reset-server
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_unmanaged_cluster_replicas = on;
+----
+COMPLETE 0
+
+statement ok
+CREATE CLUSTER foo REPLICAS ()
+
+statement ok
+CREATE CLUSTER bar REPLICAS (r1 (SIZE '1'), r2 (SIZE '1'))
+
+query TT rowsort
+SELECT name, replicas FROM (SHOW CLUSTERS)
+----
+bar
+r1 (1), r2 (1)
+default
+r1 (1)
+foo
+NULL
+mz_introspection
+r1 (1)
+mz_system
+r1 (1)

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -165,17 +165,28 @@ Used Indexes:
 
 EOF
 
-query T multiline
-EXPLAIN SELECT name FROM (SHOW CLUSTERS)
-----
-Explained Query (fast path):
-  Project (#0)
-    ReadExistingIndex mz_internal.mz_show_clusters_ind
-
-Used Indexes:
-  - mz_internal.mz_show_clusters_ind
-
-EOF
+# TODO[btv] - We should probably someday
+# optimize `SELECT name FROM (SHOW CLUSTERS)`
+# to do the same thing as `SELECT name FROM mz_clusters`;
+# i.e., just read out of the index we have on the latter table.
+# However, today we cannot do that. It's probably fine in practice
+# as there won't be more than a few dozen clusters/replicas in any
+# real world deployment, so spinning up a dataflow with joins
+# etc. is only mildly bad.
+#
+# See discussion here: https://materializeinc.slack.com/archives/C02PPB50ZHS/p1691531471306959
+#
+# query T multiline
+# EXPLAIN SELECT name FROM (SHOW CLUSTERS)
+# ----
+# Explained Query (fast path):
+#   Project (#0)
+#     ReadExistingIndex mz_internal.mz_show_clusters_ind
+#
+# Used Indexes:
+#   - mz_internal.mz_show_clusters_ind
+#
+# EOF
 
 query T multiline
 EXPLAIN SHOW CLUSTER REPLICAS

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -166,7 +166,7 @@ Used Indexes:
 EOF
 
 query T multiline
-EXPLAIN SHOW CLUSTERS
+EXPLAIN SELECT name FROM (SHOW CLUSTERS)
 ----
 Explained Query (fast path):
   Project (#0)

--- a/test/testdrive/linked-clusters.td
+++ b/test/testdrive/linked-clusters.td
@@ -17,7 +17,7 @@ $ set-sql-timeout duration=1s
 > CREATE MATERIALIZED VIEW v AS SELECT 1 AS a
 
 # Test that only the default replicas exist at start.
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 default
 mz_introspection
 mz_system
@@ -29,7 +29,7 @@ mz_system         r1  1
 # Test that creating a source without an explicit size creates a linked cluster
 # with the default size. (Unsafe mode only.)
 > CREATE SOURCE lg FROM LOAD GENERATOR COUNTER
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 default
 mz_introspection
 mz_system
@@ -44,7 +44,7 @@ materialize_public_lg  linked  ${arg.default-storage-size}
 # Test that creating sources with an explicit size creates linked clusters, each
 # with a replica named "linked" with the size specified in the source.
 > CREATE SOURCE lg1 FROM LOAD GENERATOR COUNTER WITH (SIZE = '1')
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 default
 mz_introspection
 mz_system
@@ -60,7 +60,7 @@ materialize_public_lg1  linked  1
   WHERE s.id LIKE 'u%'
 lg1  materialize_public_lg1
 > CREATE SOURCE lg2 FROM LOAD GENERATOR COUNTER WITH (SIZE = '2')
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 default
 mz_introspection
 mz_system
@@ -121,7 +121,7 @@ contains:cannot execute queries on cluster containing sources or sinks
 # the sources.
 > DROP SOURCE lg1
 > DROP SOURCE lg2
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 default
 mz_introspection
 mz_system
@@ -135,7 +135,7 @@ mz_system               r1      1
 > CREATE SINK snk FROM v
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk-${testdrive.seed}')
   FORMAT JSON ENVELOPE DEBEZIUM
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 default
 mz_introspection
 mz_system
@@ -152,7 +152,7 @@ materialize_public_snk  linked  ${arg.default-storage-size}
 > CREATE SINK snk1 FROM v
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1-${testdrive.seed}')
   FORMAT JSON ENVELOPE DEBEZIUM WITH (SIZE = '1')
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 default
 mz_introspection
 mz_system
@@ -170,7 +170,7 @@ snk1  materialize_public_snk1
 > CREATE SINK snk2 FROM v
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk-${testdrive.seed}')
   FORMAT JSON ENVELOPE DEBEZIUM WITH (SIZE = '2')
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 default
 mz_introspection
 mz_system
@@ -199,7 +199,7 @@ materialize_public_snk2  linked  ${arg.default-storage-size}
 # the sinks.
 > DROP SINK snk1
 > DROP SINK snk2
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 default
 mz_introspection
 mz_system
@@ -219,7 +219,7 @@ mz_system               r1      1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk-${testdrive.seed}')
   FORMAT JSON ENVELOPE DEBEZIUM
 
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 default
 mz_introspection
 mz_system
@@ -243,7 +243,7 @@ materialize_schema2_s1  linked  ${arg.default-storage-size}
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk-${testdrive.seed}')
   FORMAT JSON ENVELOPE DEBEZIUM
 
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 default
 mz_introspection
 mz_system
@@ -266,7 +266,7 @@ materialize_public_S1  linked  ${arg.default-storage-size}
 > CREATE CLUSTER materialize_public_s1 REPLICAS (r1 (SIZE '1'));
 > CREATE SOURCE s1 FROM LOAD GENERATOR COUNTER
 
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 default
 mz_introspection
 mz_system

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -9,7 +9,7 @@
 
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 
-> SHOW CLUSTERS
+> SELECT name FROM (SHOW CLUSTERS)
 mz_system
 mz_introspection
 default


### PR DESCRIPTION
Add an array of replicas to the output of `SHOW CLUSTERS`. My reasoning for wanting to add this is that it is the most commonly useful information about a cluster. There has been some concern that this makes our `SHOW` commands somewhat "denormalized", since we are now duplicating information between `SHOW CLUSTERS` and `SHOW CLUSTER REPLICAS`. However, my personal opinion is that it doesn't matter, because the `SHOW` commands are meant to be broadly useful to users, not to be as mathematically elegant as possible.

The rationale for which fields to include in the tuples are those that are mandatory when creating a replica as part of the `CREATE CLUSTER` command, i.e., name and size.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
* Add replica sizes and names to `SHOW CLUSTERS`
