### PR TITLE
ore: remove PANIC_ON_HALT

### DIFF
--- a/src/ore/src/process.rs
+++ b/src/ore/src/process.rs
@@ -15,8 +15,6 @@
 
 //! Process utilities.
 
-use std::sync::atomic::AtomicBool;
-
 /// Halts the process.
 ///
 /// `halt` forwards the provided arguments to the [`tracing::warn`] macro, then
@@ -38,26 +36,12 @@ use std::sync::atomic::AtomicBool;
 ///     tap into the existing whole-process retry logic. Use halt judiciously in
 ///     these cases, as restarting a process can be inefficient (e.g., mandatory
 ///     restart backoff, rehydrating expensive state).
-///
-/// If you need to write a Rust libtest test that asserts that a call to halt
-/// has occcurred, see [`PANIC_ON_HALT`].
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "tracing_")))]
 #[cfg(feature = "tracing_")]
 #[macro_export]
 macro_rules! halt {
     ($($arg:expr),* $(,)?) => {{
         $crate::__private::tracing::warn!("halting process: {}", format!($($arg),*));
-        if $crate::process::PANIC_ON_HALT.load(std::sync::atomic::Ordering::SeqCst) {
-            panic!("promoting halt to panic because PANIC_ON_HALT is set");
-        } else {
             ::std::process::exit(2);
-        }
     }}
 }
-
-/// Override the behavior of [`halt`] to panic rather than exiting the process.
-///
-/// Intended for use in Rust libtest tests which want to assert that a halt has
-/// occurred via [`std::panic::catch_unwind`]. The default behavior exits the
-/// test binary itself, which is not testable from within the same process.
-pub static PANIC_ON_HALT: AtomicBool = AtomicBool::new(false);


### PR DESCRIPTION
This was [added in the initial halt! PR][halt] because of a persist unit test's coverage of a halt!, but months later this remains the only usage and it's easy enough to swap in a panic for the halt in `cfg!(test)` at that one callsite.

[halt]: https://github.com/MaterializeInc/materialize/pull/15773#issuecomment-1297978935

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
