### PR TITLE
testdrive: Fortify subscribe-output.td

### DIFF
--- a/test/testdrive/subscribe-output.td
+++ b/test/testdrive/subscribe-output.td
@@ -260,7 +260,7 @@ DELETE FROM t2 WHERE key = 1
 > FETCH 1 c
 <TIMESTAMP> true <null> <null> <null>
 
-> FETCH ALL c
+> FETCH 2 FROM c
 <TIMESTAMP> false upsert 2 3
 <TIMESTAMP> true <null> <null> <null>
 


### PR DESCRIPTION
The test used FETCH ALL, which is not deterministic as ALL means the data that is available as of the FETCH, which may or may not include a progress marker.

Switch to FETCH 2 to make sure the test will block until the expected progress marker is emitted by the cursor.

### Motivation

  * This PR fixes a previously unreported bug.

Nightly CI was failing.

@andrewrodriguez-m FYI