### PR TITLE
cloudtest: Dump stdout/stderr on failed kubectl calls

### DIFF
--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import time
 from datetime import datetime, timedelta
+from textwrap import dedent
 from typing import List, Optional
 
 from pg8000.exceptions import InterfaceError
@@ -70,9 +71,22 @@ class Application:
                 )
 
     def kubectl(self, *args: str) -> str:
-        return subprocess.check_output(
-            ["kubectl", "--context", self.context(), *args]
-        ).decode("ascii")
+        try:
+            return subprocess.check_output(
+                ["kubectl", "--context", self.context(), *args]
+            ).decode("ascii")
+        except subprocess.CalledProcessError as e:
+            print(
+                dedent(
+                    f"""
+                    cmd: {e.cmd}
+                    returncode: {e.returncode}
+                    stdout: {e.stdout}
+                    stderr: {e.stderr}
+                    """
+                )
+            )
+            raise e
 
     def context(self) -> str:
         return "kind-cloudtest"


### PR DESCRIPTION
The CI log was missing useful debugging information in case of failed kubectl calls.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.
We have unexplainable kubectl failures in CI, where the output is not informative:

```


[2023-05-04T00:20:07Z] command terminated with exit code 137
--
  | [2023-05-04T00:20:07Z] F
  | [2023-05-04T00:20:07Z]
  | [2023-05-04T00:20:07Z] =================================== FAILURES ===================================
  | [2023-05-04T00:20:07Z] ______________________________ test_crash_storage ______________________________
  | [2023-05-04T00:20:07Z] Traceback (most recent call last):
  | [2023-05-04T00:20:07Z]   File "/var/lib/buildkite-agent/builds/buildkite-15f2293-i-0833f693a673fdb6c-1/materialize/tests/test/cloudtest/test_crash.py", line 95, in test_crash_storage
  | [2023-05-04T00:20:07Z]     mz.kubectl("exec", pod_name, "--", "bash", "-c", "kill -9 `pidof clusterd` \|\| true")
  | [2023-05-04T00:20:07Z]   File "/var/lib/buildkite-agent/builds/buildkite-15f2293-i-0833f693a673fdb6c-1/materialize/tests/misc/python/materialize/cloudtest/application.py", line 73, in kubectl
  | [2023-05-04T00:20:07Z]     return subprocess.check_output(
  | [2023-05-04T00:20:07Z]   File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
  | [2023-05-04T00:20:07Z]     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  | [2023-05-04T00:20:07Z]   File "/usr/lib/python3.10/subprocess.py", line 524, in run
  | [2023-05-04T00:20:07Z]     raise CalledProcessError(retcode, process.args,
  | [2023-05-04T00:20:07Z] subprocess.CalledProcessError: Command '['kubectl', '--context', 'kind-cloudtest', 'exec', 'pod/cluster-u4-replica-6-0', '--', 'bash', '-c', 'kill -9 `pidof clusterd` \|\| true']' returned non-zero exit status 137.
```

In this case, we are attempting to kill a clusterd on a pod that has already been confirmed as running and the clusterd belongs to a cluster that is confirmed to be running via `SELECT` against a source served by said cluster, so I have no idea why it is failing.
