### PR TITLE
adapter: Limit number of concurrent connections (#19091)

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -30,7 +30,7 @@ use mz_sql::plan::{
     AbortTransactionPlan, CommitTransactionPlan, CopyRowsPlan, CreateRolePlan, Params, Plan,
     TransactionType,
 };
-use mz_sql::session::vars::{EndTransactionAction, OwnedVarInput};
+use mz_sql::session::vars::{EndTransactionAction, OwnedVarInput, SystemVars};
 
 use crate::client::ConnectionId;
 use crate::command::{
@@ -207,6 +207,22 @@ impl Coordinator {
         cancel_tx: Arc<watch::Sender<Canceled>>,
         tx: oneshot::Sender<Response<StartupResponse>>,
     ) {
+        if !session.user().is_superuser() {
+            if let Err(e) = self.validate_resource_limit(
+                self.active_conns.len(),
+                1,
+                SystemVars::max_connections,
+                "a connection",
+                "max connections",
+            ) {
+                let _ = tx.send(Response {
+                    result: Err(e),
+                    session,
+                });
+                return;
+            }
+        }
+
         if self
             .catalog()
             .try_get_role_by_name(&session.user().name)

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -30,7 +30,9 @@ use mz_sql::plan::{
     AbortTransactionPlan, CommitTransactionPlan, CopyRowsPlan, CreateRolePlan, Params, Plan,
     TransactionType,
 };
-use mz_sql::session::vars::{EndTransactionAction, OwnedVarInput, SystemVars};
+use mz_sql::session::vars::{
+    EndTransactionAction, OwnedVarInput, SystemVars, Var, MAX_CONNECTIONS,
+};
 
 use crate::client::ConnectionId;
 use crate::command::{
@@ -212,8 +214,8 @@ impl Coordinator {
                 self.active_conns.len(),
                 1,
                 SystemVars::max_connections,
-                "a connection",
-                "max connections",
+                "connection",
+                MAX_CONNECTIONS.name(),
             ) {
                 let _ = tx.send(Response {
                     result: Err(e),

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1156,10 +1156,10 @@ impl Coordinator {
     }
 
     /// Validate a specific type of resource limit and return an error if that limit is exceeded.
-    fn validate_resource_limit<F>(
+    pub(crate) fn validate_resource_limit<F>(
         &self,
         current_amount: usize,
-        new_amount: i32,
+        new_instances: i64,
         resource_limit: F,
         resource_type: &str,
         limit_name: &str,
@@ -1167,12 +1167,11 @@ impl Coordinator {
     where
         F: Fn(&SystemVars) -> u32,
     {
-        if new_amount <= 0 {
+        if new_instances <= 0 {
             return Ok(());
         }
 
         let limit: i64 = resource_limit(self.catalog().system_config()).into();
-        let new_instances: i64 = new_amount.into();
         let current_amount: Option<i64> = current_amount.try_into().ok();
         let desired =
             current_amount.and_then(|current_amount| current_amount.checked_add(new_instances));

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -3020,7 +3020,7 @@ fn test_max_connections() {
         .unwrap_or_else(|| panic!("expect db error: {}", e));
     assert!(
         e.message()
-            .starts_with("creating a connection would violate max connections limit"),
+            .starts_with("creating connection would violate max_connections limit"),
         "e={}",
         e
     );
@@ -3032,7 +3032,7 @@ fn test_max_connections() {
         .unwrap_or_else(|| panic!("expect db error: {}", e));
     assert!(
         e.message()
-            .starts_with("creating a connection would violate max connections limit"),
+            .starts_with("creating connection would violate max_connections limit"),
         "e={}",
         e
     );

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -3015,13 +3015,27 @@ fn test_max_connections() {
     let mut client2 = server.connect(postgres::NoTls).unwrap();
     let _ = client1.batch_execute("SELECT 1").unwrap();
     let e = client2.batch_execute("SELECT 1").expect_err("expect error");
-    let e = e.as_db_error().unwrap_or_else(|| panic!("expect db error: {}", e));
-    assert!(e.message().starts_with("creating a connection would violate max connections limit"), "e={}", e);
+    let e = e
+        .as_db_error()
+        .unwrap_or_else(|| panic!("expect db error: {}", e));
+    assert!(
+        e.message()
+            .starts_with("creating a connection would violate max connections limit"),
+        "e={}",
+        e
+    );
 
     let mut client3 = server.connect(postgres::NoTls).unwrap();
     let e = client3.batch_execute("SELECT 1").expect_err("expect error");
-    let e = e.as_db_error().unwrap_or_else(|| panic!("expect db error: {}", e));
-    assert!(e.message().starts_with("creating a connection would violate max connections limit"), "e={}", e);
+    let e = e
+        .as_db_error()
+        .unwrap_or_else(|| panic!("expect db error: {}", e));
+    assert!(
+        e.message()
+            .starts_with("creating a connection would violate max connections limit"),
+        "e={}",
+        e
+    );
 
     let mut mz_client2 = server
         .pg_config_internal()

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -775,6 +775,14 @@ pub const ENABLE_WITHIN_TIMESTAMP_ORDER_BY_IN_SUBSCRIBE: ServerVar<bool> = Serve
     safe: true,
 };
 
+pub const MAX_CONNECTIONS: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_connections"),
+    value: &1000,
+    description: "The maximum number of concurrent connections (Materialize).",
+    internal: false,
+    safe: true,
+};
+
 /// Represents the input to a variable.
 ///
 /// Each variable has different rules for how it handles each style of input.
@@ -1515,6 +1523,7 @@ impl Default for SystemVars {
             .with_var(&ENABLE_LAUNCHDARKLY)
             .with_var(&ENABLE_ENVELOPE_UPSERT_IN_SUBSCRIBE)
             .with_var(&ENABLE_WITHIN_TIMESTAMP_ORDER_BY_IN_SUBSCRIBE)
+            .with_var(&MAX_CONNECTIONS)
     }
 }
 
@@ -1875,6 +1884,11 @@ impl SystemVars {
     /// Returns the `enable_within_timestamp_order_by` configuration parameter.
     pub fn enable_within_timestamp_order_by(&self) -> bool {
         *self.expect_value(&ENABLE_WITHIN_TIMESTAMP_ORDER_BY_IN_SUBSCRIBE)
+    }
+
+    /// Returns the `max_connections` configuration parameter.
+    pub fn max_connections(&self) -> u32 {
+        *self.expect_value(&MAX_CONNECTIONS)
     }
 }
 

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -75,6 +75,10 @@ class Generator:
 class Connections(Generator):
     @classmethod
     def body(cls) -> None:
+        print("$ postgres-execute connection=mz_system")
+        # two extra connections for mz_system and the default connection
+        print(f"ALTER SYSTEM SET max_connections = {Connections.COUNT+2};")
+
         for i in cls.all():
             print(
                 f"$ postgres-connect name=conn{i} url=postgres://materialize:materialize@${{testdrive.materialize-sql-addr}}"

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -34,6 +34,7 @@ is_superuser                            off                    "Reports whether 
 max_aws_privatelink_connections         0                      "The maximum number of AWS PrivateLink connections in the region, across all schemas (Materialize)."
 max_clusters                            10                     "The maximum number of clusters in the region (Materialize)."
 max_credit_consumption_rate             1024                   "The maximum rate of credit consumption in a region. Credits are consumed based on the size of cluster replicas in use (Materialize)."
+max_connections                         1000                   "The maximum number of concurrent connections (Materialize)."
 max_databases                           1000                   "The maximum number of databases in the region (Materialize)."
 max_materialized_views                  100                    "The maximum number of materialized views in the region, across all schemas (Materialize)."
 max_objects_per_schema                  1000                   "The maximum number of objects in a schema (Materialize)."


### PR DESCRIPTION
Proposed fix for #18341. Try two: I erroneously set new_instances to #active connections instead of 1

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
