### PR TITLE
ci: Fortify the pg-cdc-resumption scenario

### DIFF
--- a/test/pg-cdc-resumption/mzcompose.py
+++ b/test/pg-cdc-resumption/mzcompose.py
@@ -14,7 +14,7 @@ SERVICES = [
     Materialized(),
     Postgres(),
     Toxiproxy(),
-    Testdrive(no_reset=True),
+    Testdrive(no_reset=True, default_timeout="300s"),
 ]
 
 


### PR DESCRIPTION
When a Pg snapshot is interrupted, the total nume required to detect the interruption, reconnect and re-ingest the snapshot may be more than testdrive's default timeout of 120s.

Increase the timeout to 300s, which causes the sporadic test failures to go away.

### Motivation


  * This PR fixes a previously unreported bug.
The test was sporadically failing in CI.

### Tips for reviewer

Initially I thought that the Pg source is borked forever if it does not return data in 120s, but apparently it does recover if testdrive is given a longer timeout. It takes ~30 seconds for Mz to detect that Pg has been restarted, which left 90s for Mz to re-ingest a snapshot consisting of 1M+ records, which apparently is not enough time.