### PR TITLE
stash: Port initialization to Protobuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chrono"
 version = "0.4.24"
-source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#895d3b867ff318b5866cad7684d26279a45bc114"
+source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#35b145bd0ca721b5926e36f047eec8e1060372c0"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -3426,6 +3426,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "prometheus",
+ "proptest",
  "prost",
  "rand",
  "rdkafka",
@@ -4748,6 +4749,8 @@ dependencies = [
  "mz-storage-client",
  "once_cell",
  "paste",
+ "proptest",
+ "proptest-derive",
  "prost",
  "protobuf-native",
  "rdkafka",
@@ -4863,6 +4866,7 @@ dependencies = [
  "once_cell",
  "postgres-openssl",
  "prometheus",
+ "prost",
  "prost-build",
  "protobuf-src",
  "rand",
@@ -6093,9 +6097,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.3"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -6103,9 +6107,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.2"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8b442418ea0822409d9e7d047cbf1e7e9e1760b172bf9982cf29d517c93511"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
@@ -6125,9 +6129,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.0"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -6151,11 +6155,10 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.2"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "bytes",
  "prost",
 ]
 
@@ -8504,6 +8507,7 @@ dependencies = [
  "hashbrown",
  "hyper",
  "indexmap",
+ "itertools",
  "k8s-openapi",
  "kube",
  "kube-client",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -74,6 +74,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }
 datadriven = "0.6.0"
+proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
 
 [[bench]]
 name = "catalog"

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -49,6 +49,9 @@ use crate::{catalog, rbac};
 
 use super::{SerializedCatalogItem, SerializedReplicaLocation, SerializedReplicaLogging};
 
+pub mod objects;
+pub mod stash;
+
 const USER_VERSION: &str = "user_version";
 
 const MATERIALIZE_DATABASE_ID: u64 = 1;

--- a/src/adapter/src/catalog/storage/objects.rs
+++ b/src/adapter/src/catalog/storage/objects.rs
@@ -1,0 +1,254 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use mz_controller::clusters::ClusterId;
+use mz_ore::now::EpochMillis;
+use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
+use mz_repr::role_id::RoleId;
+use mz_sql::catalog::RoleAttributes;
+use mz_sql::names::{DatabaseId, SchemaId};
+use mz_stash::objects::proto;
+
+/// [`StashType`] is a trait that is generally used for converting catalog types, e.g.
+/// [`DatabaseId`] into the corresponding type that we serialize into the stash, e.g.
+/// [`proto::DatabaseId`].
+///
+/// While we store serialized protobufs in the Stash, that is more of an implementation detail than
+/// a public interface, which is why we don't use the helpers from the `mz_proto` crate.
+pub trait StashType: Sized {
+    type Stash: ::prost::Message;
+
+    fn into_stash(self) -> Self::Stash;
+    fn from_stash(stash: Self::Stash) -> Result<Self, anyhow::Error>;
+}
+
+impl StashType for AclMode {
+    type Stash = proto::AclMode;
+
+    fn into_stash(self) -> Self::Stash {
+        proto::AclMode {
+            bitflags: self.bits(),
+        }
+    }
+
+    fn from_stash(stash: Self::Stash) -> Result<Self, anyhow::Error> {
+        AclMode::from_bits(stash.bitflags)
+            .ok_or_else(|| anyhow::anyhow!("Invalid AclMode from Stash {stash:?}"))
+    }
+}
+
+impl StashType for MzAclItem {
+    type Stash = proto::MzAclItem;
+
+    fn into_stash(self) -> Self::Stash {
+        proto::MzAclItem {
+            grantee: Some(self.grantee.into_stash()),
+            grantor: Some(self.grantor.into_stash()),
+            acl_mode: Some(self.acl_mode.into_stash()),
+        }
+    }
+
+    fn from_stash(stash: Self::Stash) -> Result<Self, anyhow::Error> {
+        let grantee = stash
+            .grantee
+            .map(RoleId::from_stash)
+            .ok_or_else(|| anyhow::anyhow!("Invalid MzAclItem, missing grantee"))??;
+        let grantor = stash
+            .grantor
+            .map(RoleId::from_stash)
+            .ok_or_else(|| anyhow::anyhow!("Invalid MzAclItem, missing grantor"))??;
+        let acl_mode = stash
+            .acl_mode
+            .map(AclMode::from_stash)
+            .ok_or_else(|| anyhow::anyhow!("Invalid MzAclItem, missing acl_mode"))??;
+
+        Ok(MzAclItem {
+            grantee,
+            grantor,
+            acl_mode,
+        })
+    }
+}
+
+impl StashType for RoleAttributes {
+    type Stash = proto::RoleAttributes;
+
+    fn into_stash(self) -> Self::Stash {
+        let RoleAttributes {
+            inherit,
+            create_role,
+            create_db,
+            create_cluster,
+            ..
+        } = self;
+
+        proto::RoleAttributes {
+            inherit,
+            create_role,
+            create_db,
+            create_cluster,
+        }
+    }
+
+    fn from_stash(stash: Self::Stash) -> Result<Self, anyhow::Error> {
+        let proto::RoleAttributes {
+            inherit,
+            create_cluster,
+            create_role,
+            create_db,
+        } = stash;
+
+        let mut attributes = RoleAttributes::new();
+
+        attributes.inherit = inherit;
+        attributes.create_cluster = create_cluster;
+        attributes.create_role = create_role;
+        attributes.create_db = create_db;
+
+        Ok(attributes)
+    }
+}
+
+impl StashType for RoleId {
+    type Stash = proto::RoleId;
+
+    fn into_stash(self) -> Self::Stash {
+        let value = match self {
+            RoleId::User(id) => proto::role_id::Value::User(id),
+            RoleId::System(id) => proto::role_id::Value::System(id),
+            RoleId::Public => proto::role_id::Value::Public(Default::default()),
+        };
+
+        proto::RoleId { value: Some(value) }
+    }
+
+    fn from_stash(stash: Self::Stash) -> Result<Self, anyhow::Error> {
+        match stash.value {
+            Some(proto::role_id::Value::User(id)) => Ok(RoleId::User(id)),
+            Some(proto::role_id::Value::System(id)) => Ok(RoleId::System(id)),
+            Some(proto::role_id::Value::Public(_)) => Ok(RoleId::Public),
+            None => Err(anyhow::anyhow!("Invalid RoleId, found None value")),
+        }
+    }
+}
+
+impl StashType for DatabaseId {
+    type Stash = proto::DatabaseId;
+
+    fn into_stash(self) -> Self::Stash {
+        let value = match self {
+            DatabaseId::User(id) => proto::database_id::Value::User(id),
+            DatabaseId::System(id) => proto::database_id::Value::System(id),
+        };
+
+        proto::DatabaseId { value: Some(value) }
+    }
+
+    fn from_stash(stash: Self::Stash) -> Result<Self, anyhow::Error> {
+        match stash.value {
+            Some(proto::database_id::Value::User(id)) => Ok(DatabaseId::User(id)),
+            Some(proto::database_id::Value::System(id)) => Ok(DatabaseId::System(id)),
+            None => Err(anyhow::anyhow!("Invalid DatabaseId, found None value")),
+        }
+    }
+}
+
+impl StashType for SchemaId {
+    type Stash = proto::SchemaId;
+
+    fn into_stash(self) -> Self::Stash {
+        let value = match self {
+            SchemaId::User(id) => proto::schema_id::Value::User(id),
+            SchemaId::System(id) => proto::schema_id::Value::System(id),
+        };
+
+        proto::SchemaId { value: Some(value) }
+    }
+
+    fn from_stash(stash: Self::Stash) -> Result<Self, anyhow::Error> {
+        match stash.value {
+            Some(proto::schema_id::Value::User(id)) => Ok(SchemaId::User(id)),
+            Some(proto::schema_id::Value::System(id)) => Ok(SchemaId::System(id)),
+            None => Err(anyhow::anyhow!("Invalid SchemaId, found None value")),
+        }
+    }
+}
+
+impl StashType for ClusterId {
+    type Stash = proto::ClusterId;
+
+    fn into_stash(self) -> Self::Stash {
+        let value = match self {
+            ClusterId::User(id) => proto::cluster_id::Value::User(id),
+            ClusterId::System(id) => proto::cluster_id::Value::System(id),
+        };
+
+        proto::ClusterId { value: Some(value) }
+    }
+
+    fn from_stash(stash: Self::Stash) -> Result<Self, anyhow::Error> {
+        match stash.value {
+            Some(proto::cluster_id::Value::User(id)) => Ok(ClusterId::User(id)),
+            Some(proto::cluster_id::Value::System(id)) => Ok(ClusterId::System(id)),
+            None => Err(anyhow::anyhow!("Invalid ClusterId, found None value")),
+        }
+    }
+}
+
+impl StashType for EpochMillis {
+    type Stash = proto::EpochMillis;
+
+    fn into_stash(self) -> Self::Stash {
+        proto::EpochMillis { millis: self }
+    }
+
+    fn from_stash(stash: Self::Stash) -> Result<Self, anyhow::Error> {
+        Ok(stash.millis)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn proptest_role_attributes_roundtrips(attrs: RoleAttributes) {
+            let stash = attrs.clone().into_stash();
+            let after = RoleAttributes::from_stash(stash).expect("roundtrip");
+
+            prop_assert_eq!(attrs, after);
+        }
+
+        #[test]
+        fn proptest_role_id_roundtrips(role_id: RoleId) {
+            let stash = role_id.clone().into_stash();
+            let after = RoleId::from_stash(stash).expect("roundtrip");
+
+            prop_assert_eq!(role_id, after);
+        }
+
+        #[test]
+        fn proptest_database_id_roundtrips(id: DatabaseId) {
+            let stash = id.clone().into_stash();
+            let after = DatabaseId::from_stash(stash).expect("roundtrip");
+
+            prop_assert_eq!(id, after);
+        }
+
+        #[test]
+        fn proptest_schema_id_roundtrips(id: SchemaId) {
+            let stash = id.clone().into_stash();
+            let after = SchemaId::from_stash(stash).expect("roundtrip");
+
+            prop_assert_eq!(id, after);
+        }
+    }
+}

--- a/src/adapter/src/catalog/storage/stash.rs
+++ b/src/adapter/src/catalog/storage/stash.rs
@@ -1,0 +1,607 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+
+use itertools::max;
+
+use mz_controller::clusters::ClusterId;
+use mz_ore::now::EpochMillis;
+use mz_repr::adt::mz_acl_item::AclMode;
+use mz_repr::role_id::RoleId;
+use mz_sql::catalog::RoleAttributes;
+use mz_sql::names::{DatabaseId, SchemaId, PUBLIC_ROLE_NAME};
+use mz_stash::objects::proto;
+use mz_stash::{StashError, Transaction, TypedCollection, STASH_VERSION};
+
+use super::objects::StashType;
+use crate::catalog::builtin::{MZ_INTROSPECTION_ROLE, MZ_SYSTEM_ROLE};
+use crate::catalog::storage::{MZ_INTROSPECTION_ROLE_ID, MZ_SYSTEM_ROLE_ID};
+use crate::rbac;
+
+/// The key used within the "config" collection where we store the Stash version.
+const USER_VERSION: &str = "user_version";
+
+const ROLES_COLLECTION: TypedCollection<proto::RoleKey, proto::RoleValue> =
+    TypedCollection::new("role");
+const DATABASES_COLLECTION: TypedCollection<proto::DatabaseKey, proto::DatabaseValue> =
+    TypedCollection::new("database");
+const SCHEMAS_COLLECTION: TypedCollection<proto::SchemaKey, proto::SchemaValue> =
+    TypedCollection::new("schema");
+const CLUSTER_COLLECTION: TypedCollection<proto::ClusterKey, proto::ClusterValue> =
+    TypedCollection::new("compute_instance");
+const CLUSTER_REPLICA_COLLECTION: TypedCollection<
+    proto::ClusterReplicaKey,
+    proto::ClusterReplicaValue,
+> = TypedCollection::new("compute_replicas");
+const AUDIT_LOG_COLLECTION: TypedCollection<proto::AuditLogKey, ()> =
+    TypedCollection::new("audit_log");
+const CONFIG_COLLETION: TypedCollection<proto::ConfigKey, proto::ConfigValue> =
+    TypedCollection::new("config");
+const ID_ALLOCATOR_COLLECTION: TypedCollection<proto::IdAllocKey, proto::IdAllocValue> =
+    TypedCollection::new("id_alloc");
+
+const USER_ID_ALLOC_KEY: &str = "user";
+const SYSTEM_ID_ALLOC_KEY: &str = "system";
+const DATABASE_ID_ALLOC_KEY: &str = "database";
+const SCHEMA_ID_ALLOC_KEY: &str = "schema";
+const USER_ROLE_ID_ALLOC_KEY: &str = "user_role";
+const USER_CLUSTER_ID_ALLOC_KEY: &str = "user_compute";
+const SYSTEM_CLUSTER_ID_ALLOC_KEY: &str = "system_compute";
+const REPLICA_ID_ALLOC_KEY: &str = "replica";
+const AUDIT_LOG_ID_ALLOC_KEY: &str = "auditlog";
+const STORAGE_USAGE_ID_ALLOC_KEY: &str = "storage_usage";
+
+const DEFAULT_USER_CLUSTER_ID: ClusterId = ClusterId::User(1);
+const DEFAULT_USER_CLUSTER_NAME: &str = "default";
+
+const DEFAULT_REPLICA_ID: u64 = 1;
+const DEFAULT_REPLICA_NAME: &str = "r1";
+
+const MATERIALIZE_DATABASE_ID_VAL: u64 = 1;
+const MATERIALIZE_DATABASE_ID: DatabaseId = DatabaseId::System(MATERIALIZE_DATABASE_ID_VAL);
+
+const MZ_CATALOG_SCHEMA_ID: u64 = 1;
+const PG_CATALOG_SCHEMA_ID: u64 = 2;
+const PUBLIC_SCHEMA_ID: u64 = 3;
+const MZ_INTERNAL_SCHEMA_ID: u64 = 4;
+const INFORMATION_SCHEMA_ID: u64 = 5;
+
+#[derive(Debug, Clone)]
+pub struct InitializeOptions {
+    default_cluster_replica_size: String,
+    default_availability_zone: String,
+    bootstrap_role: Option<String>,
+}
+
+impl InitializeOptions {
+    pub fn new(size: String, zone: String) -> Self {
+        InitializeOptions {
+            default_cluster_replica_size: size,
+            default_availability_zone: zone,
+            bootstrap_role: None,
+        }
+    }
+
+    pub fn with_role(mut self, bootstrap_role: String) -> Self {
+        self.bootstrap_role = Some(bootstrap_role);
+        self
+    }
+}
+
+/// Initializes the Stash with some default objects.
+///
+/// Note: We should only use the latest types here from the `super::objects` module, we should
+/// __not__ use any versioned protos, e.g. `objects_v15`.
+pub async fn initialize(
+    tx: &mut Transaction<'_>,
+    options: InitializeOptions,
+    now: EpochMillis,
+) -> Result<(), StashError> {
+    // During initialization we need to allocate IDs for certain things. We'll track what IDs we've
+    // allocated, persisting the "next ids" at the end.
+    let mut id_allocator = IdAllocator::new();
+
+    // Collect audit events so we can commit them once at the very end.
+    let mut audit_events = vec![];
+
+    // If provided, generate a new Id and attributes for the bootstrap role.
+    //
+    // Note: Make sure we do this _after_ initializing the ID_ALLOCATOR_COLLECTION.
+    let bootstrap_role = if let Some(role) = &options.bootstrap_role {
+        let user_id = id_allocator.allocate(USER_ID_ALLOC_KEY.to_string());
+        let role_id = RoleId::User(user_id);
+        let role_val = proto::RoleValue {
+            name: role.to_string(),
+            attributes: Some(
+                RoleAttributes::new()
+                    .with_create_db()
+                    .with_create_cluster()
+                    .into_stash(),
+            ),
+            membership: Some(proto::RoleMembership::default()),
+        };
+
+        audit_events.push((
+            proto::audit_log_event_v1::EventType::Create,
+            proto::audit_log_event_v1::ObjectType::Role,
+            proto::audit_log_event_v1::Details::IdNameV1(proto::audit_log_event_v1::IdNameV1 {
+                id: role_id.to_string(),
+                name: role.to_string(),
+            }),
+        ));
+
+        Some((role_id.into_stash(), role_val))
+    } else {
+        None
+    };
+
+    ROLES_COLLECTION
+        .initialize(
+            tx,
+            [
+                (
+                    proto::RoleKey {
+                        id: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+                    },
+                    proto::RoleValue {
+                        name: MZ_SYSTEM_ROLE.name.to_string(),
+                        attributes: Some(MZ_SYSTEM_ROLE.attributes.clone().into_stash()),
+                        membership: Some(proto::RoleMembership::default()),
+                    },
+                ),
+                (
+                    proto::RoleKey {
+                        id: Some(MZ_INTROSPECTION_ROLE_ID.into_stash()),
+                    },
+                    proto::RoleValue {
+                        name: MZ_INTROSPECTION_ROLE.name.to_string(),
+                        attributes: Some(MZ_INTROSPECTION_ROLE.attributes.clone().into_stash()),
+                        membership: Some(proto::RoleMembership::default()),
+                    },
+                ),
+                (
+                    proto::RoleKey {
+                        id: Some(RoleId::Public.into_stash()),
+                    },
+                    proto::RoleValue {
+                        name: PUBLIC_ROLE_NAME.as_str().to_lowercase(),
+                        attributes: Some(proto::RoleAttributes::default()),
+                        membership: Some(proto::RoleMembership::default()),
+                    },
+                ),
+            ]
+            .into_iter()
+            // Optionally insert a privilege for the bootstrap role.
+            .chain(bootstrap_role.as_ref().map(|(role_id, role_val)| {
+                let key = proto::RoleKey {
+                    id: Some(role_id.clone()),
+                };
+                (key, role_val.clone())
+            })),
+        )
+        .await?;
+
+    let mut db_privileges = vec![
+        proto::MzAclItem {
+            grantee: Some(RoleId::Public.into_stash()),
+            grantor: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+            acl_mode: Some(AclMode::USAGE.into_stash()),
+        },
+        rbac::owner_privilege(mz_sql_parser::ast::ObjectType::Database, MZ_SYSTEM_ROLE_ID)
+            .into_stash(),
+    ];
+    // Optionally add a privilege for the bootstrap role.
+    if let Some((role_id, _)) = &bootstrap_role {
+        db_privileges.push(proto::MzAclItem {
+            grantee: Some(role_id.clone()),
+            grantor: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+            acl_mode: Some(AclMode::CREATE.into_stash()),
+        })
+    };
+
+    DATABASES_COLLECTION
+        .initialize(
+            tx,
+            [(
+                proto::DatabaseKey {
+                    id: Some(MATERIALIZE_DATABASE_ID.into_stash()),
+                },
+                proto::DatabaseValue {
+                    name: "materialize".into(),
+                    owner_id: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+                    privileges: db_privileges,
+                },
+            )],
+        )
+        .await?;
+    audit_events.push((
+        proto::audit_log_event_v1::EventType::Create,
+        proto::audit_log_event_v1::ObjectType::Database,
+        proto::audit_log_event_v1::Details::IdNameV1(proto::audit_log_event_v1::IdNameV1 {
+            id: MATERIALIZE_DATABASE_ID.to_string(),
+            name: "materialize".to_string(),
+        }),
+    ));
+
+    let schema_privileges = vec![
+        rbac::default_catalog_privilege(mz_sql_parser::ast::ObjectType::Schema).into_stash(),
+        rbac::owner_privilege(mz_sql_parser::ast::ObjectType::Schema, MZ_SYSTEM_ROLE_ID)
+            .into_stash(),
+    ];
+
+    let mz_catalog_schema_key = proto::SchemaKey {
+        id: Some(SchemaId::System(MZ_CATALOG_SCHEMA_ID).into_stash()),
+    };
+    let mz_catalog_schema = proto::SchemaValue {
+        database_id: None,
+        name: "mz_catalog".to_string(),
+        owner_id: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+        privileges: schema_privileges.clone(),
+    };
+
+    let pg_catalog_schema_key = proto::SchemaKey {
+        id: Some(SchemaId::System(PG_CATALOG_SCHEMA_ID).into_stash()),
+    };
+    let pg_catalog_schema = proto::SchemaValue {
+        database_id: None,
+        name: "pg_catalog".to_string(),
+        owner_id: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+        privileges: schema_privileges.clone(),
+    };
+
+    let mz_internal_schema_key = proto::SchemaKey {
+        id: Some(SchemaId::System(MZ_INTERNAL_SCHEMA_ID).into_stash()),
+    };
+    let mz_internal_schema = proto::SchemaValue {
+        database_id: None,
+        name: "mz_internal".to_string(),
+        owner_id: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+        privileges: schema_privileges.clone(),
+    };
+
+    let information_schema_key = proto::SchemaKey {
+        id: Some(SchemaId::System(INFORMATION_SCHEMA_ID).into_stash()),
+    };
+    let information_schema = proto::SchemaValue {
+        database_id: None,
+        name: "information_schema".to_string(),
+        owner_id: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+        privileges: schema_privileges.clone(),
+    };
+
+    let public_schema_key = proto::SchemaKey {
+        id: Some(SchemaId::System(PUBLIC_SCHEMA_ID).into_stash()),
+    };
+    let public_schema = proto::SchemaValue {
+        database_id: Some(MATERIALIZE_DATABASE_ID.into_stash()),
+        name: "public".to_string(),
+        owner_id: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+        privileges: vec![
+            proto::MzAclItem {
+                grantee: Some(RoleId::Public.into_stash()),
+                grantor: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+                acl_mode: Some(AclMode::USAGE.into_stash()),
+            },
+            rbac::owner_privilege(mz_sql_parser::ast::ObjectType::Schema, MZ_SYSTEM_ROLE_ID)
+                .into_stash(),
+        ]
+        .into_iter()
+        // Optionally add the bootstrap role to the public schema.
+        .chain(
+            bootstrap_role
+                .as_ref()
+                .map(|(role_id, _)| proto::MzAclItem {
+                    grantee: Some(role_id.clone()),
+                    grantor: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+                    acl_mode: Some(AclMode::CREATE.into_stash()),
+                }),
+        )
+        .collect(),
+    };
+
+    SCHEMAS_COLLECTION
+        .initialize(
+            tx,
+            [
+                (mz_catalog_schema_key, mz_catalog_schema),
+                (pg_catalog_schema_key, pg_catalog_schema),
+                (public_schema_key, public_schema),
+                (mz_internal_schema_key, mz_internal_schema),
+                (information_schema_key, information_schema),
+            ],
+        )
+        .await?;
+    audit_events.push((
+        proto::audit_log_event_v1::EventType::Create,
+        proto::audit_log_event_v1::ObjectType::Schema,
+        proto::audit_log_event_v1::Details::SchemaV2(proto::audit_log_event_v1::SchemaV2 {
+            id: PUBLIC_SCHEMA_ID.to_string(),
+            name: "public".to_string(),
+            database_name: "materialize".to_string(),
+        }),
+    ));
+
+    let mut cluster_privileges = vec![
+        proto::MzAclItem {
+            grantee: Some(RoleId::Public.into_stash()),
+            grantor: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+            acl_mode: Some(AclMode::USAGE.into_stash()),
+        },
+        rbac::owner_privilege(mz_sql_parser::ast::ObjectType::Cluster, MZ_SYSTEM_ROLE_ID)
+            .into_stash(),
+    ];
+
+    // Optionally add a privilege for the bootstrap role.
+    if let Some((role_id, _)) = &bootstrap_role {
+        cluster_privileges.push(proto::MzAclItem {
+            grantee: Some(role_id.clone()),
+            grantor: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+            acl_mode: Some(AclMode::CREATE.into_stash()),
+        });
+    };
+
+    CLUSTER_COLLECTION
+        .initialize(
+            tx,
+            [(
+                proto::ClusterKey {
+                    id: Some(DEFAULT_USER_CLUSTER_ID.into_stash()),
+                },
+                proto::ClusterValue {
+                    name: DEFAULT_USER_CLUSTER_NAME.to_string(),
+                    linked_object_id: None,
+                    owner_id: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+                    privileges: cluster_privileges,
+                },
+            )],
+        )
+        .await?;
+    audit_events.push((
+        proto::audit_log_event_v1::EventType::Create,
+        proto::audit_log_event_v1::ObjectType::Cluster,
+        proto::audit_log_event_v1::Details::IdNameV1(proto::audit_log_event_v1::IdNameV1 {
+            id: DEFAULT_USER_CLUSTER_ID.to_string(),
+            name: DEFAULT_USER_CLUSTER_NAME.to_string(),
+        }),
+    ));
+
+    CLUSTER_REPLICA_COLLECTION
+        .initialize(
+            tx,
+            [(
+                proto::ClusterReplicaKey {
+                    id: Some(proto::ReplicaId {
+                        value: DEFAULT_REPLICA_ID,
+                    }),
+                },
+                proto::ClusterReplicaValue {
+                    cluster_id: Some(DEFAULT_USER_CLUSTER_ID.into_stash()),
+                    name: DEFAULT_REPLICA_NAME.to_string(),
+                    config: Some(proto::ReplicaConfig {
+                        location: Some(proto::replica_config::Location::Managed(
+                            proto::replica_config::ManagedLocation {
+                                size: options.default_cluster_replica_size.clone(),
+                                availability_zone: options.default_availability_zone,
+                                az_user_specified: false,
+                            },
+                        )),
+                        logging: Some(proto::replica_config::Logging {
+                            log_logging: false,
+                            interval: Some(proto::Duration::from_secs(1)),
+                        }),
+                        idle_arrangement_merge_effort: None,
+                    }),
+                    owner_id: Some(MZ_SYSTEM_ROLE_ID.into_stash()),
+                },
+            )],
+        )
+        .await?;
+    audit_events.push((
+        proto::audit_log_event_v1::EventType::Create,
+        proto::audit_log_event_v1::ObjectType::Clusterreplica,
+        proto::audit_log_event_v1::Details::CreateClusterReplicaV1(
+            proto::audit_log_event_v1::CreateClusterReplicaV1 {
+                cluster_id: DEFAULT_USER_CLUSTER_ID.to_string(),
+                cluser_name: "default".to_string(),
+                replica_name: "default".to_string(),
+                replica_id: DEFAULT_REPLICA_ID.to_string(),
+                logical_size: options.default_cluster_replica_size,
+            },
+        ),
+    ));
+
+    // Allocate an ID for each audit log event.
+    let mut audit_events_with_id = Vec::with_capacity(audit_events.len());
+    for (ty, obj, details) in audit_events {
+        let id = id_allocator.allocate(AUDIT_LOG_ID_ALLOC_KEY.to_string());
+        audit_events_with_id.push((id, ty, obj, details));
+    }
+
+    // Push all of our events onto the audit log.
+    AUDIT_LOG_COLLECTION
+        .initialize(
+            tx,
+            audit_events_with_id
+                .into_iter()
+                .map(|(id, ty, obj, details)| {
+                    let event = proto::audit_log_key::Event::V1(proto::AuditLogEventV1 {
+                        id,
+                        event_type: ty.into(),
+                        object_type: obj.into(),
+                        user: None,
+                        occurred_at: Some(now.into_stash()),
+                        details: Some(details),
+                    });
+                    (proto::AuditLogKey { event: Some(event) }, ())
+                }),
+        )
+        .await?;
+
+    ID_ALLOCATOR_COLLECTION
+        .initialize(
+            tx,
+            [
+                (
+                    proto::IdAllocKey {
+                        name: USER_ID_ALLOC_KEY.to_string(),
+                    },
+                    proto::IdAllocValue {
+                        next_id: id_allocator.next_id(USER_ID_ALLOC_KEY),
+                    },
+                ),
+                (
+                    proto::IdAllocKey {
+                        name: SYSTEM_ID_ALLOC_KEY.to_string(),
+                    },
+                    proto::IdAllocValue {
+                        next_id: id_allocator.next_id(SYSTEM_ID_ALLOC_KEY),
+                    },
+                ),
+                (
+                    proto::IdAllocKey {
+                        name: DATABASE_ID_ALLOC_KEY.to_string(),
+                    },
+                    proto::IdAllocValue {
+                        next_id: MATERIALIZE_DATABASE_ID_VAL + 1,
+                    },
+                ),
+                (
+                    proto::IdAllocKey {
+                        name: SCHEMA_ID_ALLOC_KEY.to_string(),
+                    },
+                    proto::IdAllocValue {
+                        next_id: max(&[
+                            MZ_CATALOG_SCHEMA_ID,
+                            PG_CATALOG_SCHEMA_ID,
+                            PUBLIC_SCHEMA_ID,
+                            MZ_INTERNAL_SCHEMA_ID,
+                            INFORMATION_SCHEMA_ID,
+                        ])
+                        .expect("known to be non-empty")
+                            + 1,
+                    },
+                ),
+                (
+                    proto::IdAllocKey {
+                        name: USER_ROLE_ID_ALLOC_KEY.to_string(),
+                    },
+                    proto::IdAllocValue {
+                        next_id: id_allocator.next_id(USER_ROLE_ID_ALLOC_KEY),
+                    },
+                ),
+                (
+                    proto::IdAllocKey {
+                        name: USER_CLUSTER_ID_ALLOC_KEY.to_string(),
+                    },
+                    proto::IdAllocValue {
+                        next_id: DEFAULT_USER_CLUSTER_ID.inner_id() + 1,
+                    },
+                ),
+                (
+                    proto::IdAllocKey {
+                        name: SYSTEM_CLUSTER_ID_ALLOC_KEY.to_string(),
+                    },
+                    proto::IdAllocValue {
+                        next_id: id_allocator.next_id(SYSTEM_CLUSTER_ID_ALLOC_KEY),
+                    },
+                ),
+                (
+                    proto::IdAllocKey {
+                        name: REPLICA_ID_ALLOC_KEY.to_string(),
+                    },
+                    proto::IdAllocValue {
+                        next_id: DEFAULT_REPLICA_ID + 1,
+                    },
+                ),
+                (
+                    proto::IdAllocKey {
+                        name: AUDIT_LOG_ID_ALLOC_KEY.to_string(),
+                    },
+                    proto::IdAllocValue {
+                        next_id: id_allocator.next_id(AUDIT_LOG_ID_ALLOC_KEY),
+                    },
+                ),
+                (
+                    proto::IdAllocKey {
+                        name: STORAGE_USAGE_ID_ALLOC_KEY.to_string(),
+                    },
+                    proto::IdAllocValue {
+                        next_id: id_allocator.next_id(STORAGE_USAGE_ID_ALLOC_KEY),
+                    },
+                ),
+            ],
+        )
+        .await?;
+
+    // Set our initial version.
+    CONFIG_COLLETION
+        .initialize(
+            tx,
+            [(
+                proto::ConfigKey {
+                    key: USER_VERSION.to_string(),
+                },
+                proto::ConfigValue {
+                    value: STASH_VERSION,
+                },
+            )],
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// A small struct which keeps track of what Ids we've used during initialization.
+#[derive(Debug, Clone)]
+struct IdAllocator {
+    ids: BTreeMap<String, u64>,
+}
+
+impl IdAllocator {
+    const DEFAULT_ID: u64 = 1;
+
+    pub fn new() -> Self {
+        IdAllocator {
+            ids: BTreeMap::default(),
+        }
+    }
+
+    /// For a given key, returns the current value and bumps the allocator.
+    pub fn allocate(&mut self, key: String) -> u64 {
+        let next_id = self.ids.entry(key).or_insert(Self::DEFAULT_ID);
+        let copy = *next_id;
+        *next_id = next_id
+            .checked_add(1)
+            .expect("allocated more than u64::MAX ids!");
+        copy
+    }
+
+    /// Gets the next ID, without bumping the allocator.
+    pub fn next_id(&self, key: &str) -> u64 {
+        self.ids.get(key).copied().unwrap_or(Self::DEFAULT_ID)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::IdAllocator;
+
+    #[test]
+    fn smoke_test_id_allocator() {
+        let mut allocator = IdAllocator::new();
+
+        assert_eq!(allocator.allocate("a".to_string()), 1);
+        assert_eq!(allocator.next_id("a"), 2);
+
+        assert_eq!(allocator.next_id("b"), 1);
+        assert_eq!(allocator.allocate("b".to_string()), 1);
+        assert_eq!(allocator.next_id("b"), 2);
+    }
+}

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -39,6 +39,8 @@ mz-sql-parser = { path = "../sql-parser" }
 mz-storage-client = { path = "../storage-client" }
 paste = "1.0"
 protobuf-native = "0.2.1"
+proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
+proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = "1.7.0"

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, Instant};
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
+use proptest_derive::Arbitrary;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -373,7 +374,7 @@ pub trait CatalogSchema {
 // TODO(jkosh44) When https://github.com/MaterializeInc/materialize/issues/17824 is implemented
 //  then switch this to a bitflag (https://docs.rs/bitflags/latest/bitflags/)
 /// Attributes belonging to a [`CatalogRole`].
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Arbitrary)]
 pub struct RoleAttributes {
     /// Indicates whether the role has inheritance of privileges.
     pub inherit: bool,

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -15,6 +15,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use once_cell::sync::Lazy;
+use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use uncased::UncasedStr;
 
@@ -677,7 +678,9 @@ impl AstInfo for Aug {
 }
 
 /// The identifier for a schema.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Arbitrary,
+)]
 pub enum SchemaId {
     User(u64),
     System(u64),
@@ -725,7 +728,9 @@ impl FromStr for SchemaId {
 }
 
 /// The identifier for a database.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Arbitrary,
+)]
 pub enum DatabaseId {
     User(u64),
     System(u64),

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -18,6 +18,7 @@ mz-ore = { path = "../ore", features = ["metrics", "network", "async", "test"] }
 mz-postgres-util = { path = "../postgres-util" }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 prometheus = { version = "0.13.3", default-features = false }
+prost = { version = "0.11.9", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 serde = "1.0.152"
 serde_json = "1.0.89"
@@ -38,7 +39,7 @@ tokio = { version = "1.24.2", features = ["macros"] }
 anyhow = "1.0.66"
 md-5 = "0.10.5"
 protobuf-src = "1.1.0"
-prost-build = "0.11.2"
+prost-build = "0.11.9"
 serde = "1.0.152"
 serde_json = "1.0.89"
 

--- a/src/stash/build.rs
+++ b/src/stash/build.rs
@@ -192,6 +192,19 @@ fn main() -> anyhow::Result<()> {
     prost_build::Config::new()
         .btree_map(["."])
         .bytes(["."])
+        .message_attribute(".", "#[derive(Eq, PartialOrd, Ord)]")
+        // Note(parkmycar): This is annoying, but we need to manually specify each oneof so we can
+        // get them to implement Eq, PartialEq, and Ord. If you define a new oneof you should add
+        // it here.
+        .enum_attribute("CatalogItem.value", "#[derive(Eq, PartialOrd, Ord)]")
+        .enum_attribute("GlobalId.value", "#[derive(Eq, PartialOrd, Ord)]")
+        .enum_attribute("ClusterId.value", "#[derive(Eq, PartialOrd, Ord)]")
+        .enum_attribute("DatabaseId.value", "#[derive(Eq, PartialOrd, Ord)]")
+        .enum_attribute("SchemaId.value", "#[derive(Eq, PartialOrd, Ord)]")
+        .enum_attribute("RoleId.value", "#[derive(Eq, PartialOrd, Ord)]")
+        .enum_attribute("ReplicaConfig.location", "#[derive(Eq, PartialOrd, Ord)]")
+        .enum_attribute("AuditLogEventV1.details", "#[derive(Eq, PartialOrd, Ord)]")
+        .enum_attribute("AuditLogKey.event", "#[derive(Eq, PartialOrd, Ord)]")
         .compile_protos(
             &paths,
             &[ /*

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "objects.proto",
-    "md5": "aa1f2da91fafd7943362f6771ecb7ba0"
+    "md5": "aa1d990e3074bb020ded0bb4636b740e"
   },
   {
     "name": "objects_v15.proto",
-    "md5": "abaa1cc4c19ce465f34d34414cc129d2"
+    "md5": "8f15a7d60f6ac006ca87840f7de9d26e"
   }
 ]

--- a/src/stash/protos/objects.proto
+++ b/src/stash/protos/objects.proto
@@ -146,7 +146,9 @@ message ServerConfigurationValue {
 }
 
 message AuditLogKey {
-
+    oneof event {
+        AuditLogEventV1 v1 = 1;
+    }
 }
 
 // ---- Common Types
@@ -248,10 +250,16 @@ message ReplicaConfig {
         Duration interval = 2;
     }
 
+    message MergeEffort {
+        uint32 effort = 1;
+    }
+
     oneof location {
         UnmanagedLocation unmanaged = 1;
         ManagedLocation managed = 2;
     }
+    Logging logging = 3;
+    MergeEffort idle_arrangement_merge_effort = 4;
 }
 
 message RoleId {
@@ -290,7 +298,7 @@ message MzAclItem {
 }
 
 
-message AuditLogEvent {
+message AuditLogEventV1 {
     enum EventType {
         EVENT_TYPE_UNKNOWN = 0;
         EVENT_TYPE_CREATE = 1;
@@ -413,10 +421,14 @@ message AuditLogEvent {
         string database_name = 3;
     }
 
+    message User {
+        string value = 1;
+    }
+
     uint64 id = 1;
     EventType event_type = 2;
     ObjectType object_type = 3;
-    string user = 4;
+    User user = 4;
     EpochMillis occurred_at = 5;
     oneof details {
         CreateClusterReplicaV1 create_cluster_replica_v1 = 6;

--- a/src/stash/protos/objects_v15.proto
+++ b/src/stash/protos/objects_v15.proto
@@ -146,7 +146,9 @@ message ServerConfigurationValue {
 }
 
 message AuditLogKey {
-
+    oneof event {
+        AuditLogEventV1 v1 = 1;
+    }
 }
 
 // ---- Common Types
@@ -248,10 +250,16 @@ message ReplicaConfig {
         Duration interval = 2;
     }
 
+    message MergeEffort {
+        uint32 effort = 1;
+    }
+
     oneof location {
         UnmanagedLocation unmanaged = 1;
         ManagedLocation managed = 2;
     }
+    Logging logging = 3;
+    MergeEffort idle_arrangement_merge_effort = 4;
 }
 
 message RoleId {
@@ -290,7 +298,7 @@ message MzAclItem {
 }
 
 
-message AuditLogEvent {
+message AuditLogEventV1 {
     enum EventType {
         EVENT_TYPE_UNKNOWN = 0;
         EVENT_TYPE_CREATE = 1;
@@ -413,10 +421,14 @@ message AuditLogEvent {
         string database_name = 3;
     }
 
+    message User {
+        string value = 1;
+    }
+
     uint64 id = 1;
     EventType event_type = 2;
     ObjectType object_type = 3;
-    string user = 4;
+    User user = 4;
     EpochMillis occurred_at = 5;
     oneof details {
         CreateClusterReplicaV1 create_cluster_replica_v1 = 6;

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -88,11 +88,21 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use timely::progress::Antichain;
 
+pub mod objects;
+
 mod postgres;
 mod transaction;
+mod upgrade;
 
 pub use crate::postgres::{DebugStashFactory, Stash, StashFactory};
 pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
+
+/// The current version of the [`Stash`].
+///
+/// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
+/// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
+/// change, we need to bump this version.
+pub const STASH_VERSION: u64 = 14;
 
 pub type Diff = i64;
 pub type Timestamp = i64;

--- a/src/stash/src/objects.rs
+++ b/src/stash/src/objects.rs
@@ -1,0 +1,20 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! The current types that are serialized in the Stash.
+
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/objects.rs"));
+}
+
+impl proto::Duration {
+    pub const fn from_secs(secs: u64) -> proto::Duration {
+        proto::Duration { secs, nanos: 0 }
+    }
+}

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -1,0 +1,73 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+
+use super::InternalStashError;
+use crate::{StashError, Transaction, TypedCollection};
+
+pub enum MigrationAction<K1, K2, V2> {
+    /// Deletes the provided key.
+    Delete(K1),
+    /// Inserts the provided key-value pair. The key must not currently exist!
+    Insert(K2, V2),
+    /// Update the key-value pair for the provided key.
+    Update(K1, (K2, V2)),
+}
+
+/// TODO(parkmycar): Once the Stash / the [`crate::Data`] trait uses [`prost`], get rid of this.
+pub trait DataProto: ::prost::Message + std::cmp::Ord + Default + Send + Sync {}
+impl<T: ::prost::Message + std::cmp::Ord + Default + Send + Sync> DataProto for T {}
+
+impl<K, V> TypedCollection<K, V>
+where
+    K: DataProto,
+    V: DataProto,
+{
+    /// Provided a closure, will migrate a [`TypedCollection`] of types `K` and `V` to types `K2`
+    /// and `V2`.
+    ///
+    /// TODO(parkmycar): Fill in this implementation in a future PR.
+    #[allow(clippy::unused_async)]
+    pub async fn migrate_to<K2, V2>(
+        &self,
+        _tx: &mut Transaction<'_>,
+        _f: impl for<'a> FnOnce(&'a BTreeMap<K, V>) -> Vec<MigrationAction<K, K2, V2>>,
+    ) -> Result<(), StashError>
+    where
+        K2: DataProto,
+        V2: DataProto,
+    {
+        Err(StashError {
+            inner: InternalStashError::Other("unimplemented".to_string()),
+        })
+    }
+
+    /// Initializes a [`TypedCollection`] with the values provided in `values`.
+    ///
+    /// # Panics
+    /// * If the [`TypedCollection`] is not empty.
+    pub async fn initialize(
+        &self,
+        tx: &mut Transaction<'_>,
+        values: impl IntoIterator<Item = (K, V)>,
+    ) -> Result<(), StashError> {
+        self.migrate_to(tx, |entries| {
+            assert!(entries.is_empty());
+
+            values
+                .into_iter()
+                .map(|(key, val)| MigrationAction::Insert(key, val))
+                .collect()
+        })
+        .await?;
+
+        Ok(())
+    }
+}

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -50,6 +50,7 @@ globset = { version = "0.4.9", features = ["serde1"] }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["raw"] }
 hyper = { version = "0.14.25", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
+itertools = { version = "0.10.5" }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }
 kube-client = { version = "0.77.0", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
@@ -73,9 +74,9 @@ phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 proc-macro2 = { version = "1.0.54", features = ["span-locations"] }
-prost = { version = "0.11.3", features = ["no-recursion-limit"] }
+prost = { version = "0.11.9", features = ["no-recursion-limit"] }
 prost-reflect = { version = "0.9.2", default-features = false, features = ["serde"] }
-prost-types = { version = "0.11.2" }
+prost-types = { version = "0.11.9" }
 quote = { version = "1.0.26" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
@@ -146,6 +147,7 @@ globset = { version = "0.4.9", features = ["serde1"] }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["raw"] }
 hyper = { version = "0.14.25", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
+itertools = { version = "0.10.5" }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }
 kube-client = { version = "0.77.0", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
@@ -169,9 +171,9 @@ phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 proc-macro2 = { version = "1.0.54", features = ["span-locations"] }
-prost = { version = "0.11.3", features = ["no-recursion-limit"] }
+prost = { version = "0.11.9", features = ["no-recursion-limit"] }
 prost-reflect = { version = "0.9.2", default-features = false, features = ["serde"] }
-prost-types = { version = "0.11.2" }
+prost-types = { version = "0.11.9" }
 quote = { version = "1.0.26" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }


### PR DESCRIPTION
### Motivation

* Makes progress towards: #17466 

This PR re-writes the [first migration](https://github.com/MaterializeInc/materialize/blob/main/src/adapter/src/catalog/storage.rs#L86-L509), which is used to initialize the Stash, with the new protobuf types.

The code in this PR isn't yet called, nor is it tested. What's tricky is we can't test it until the Stash itself uses protobuf, and we can't migrate it to protobuf until we have all of this supporting code. So to prevent having one huge PR I've opted to land a few unused changes first, then in the PR that moves the Stash to proto I'll add tests.

### Tips for reviewer

* What really needs the most attention is `fn stash(...)` in `initialize.rs` and to make sure it does everything that currently the [first migration](https://github.com/MaterializeInc/materialize/blob/main/src/adapter/src/catalog/storage.rs#L86-L509) does.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
