### PR TITLE
mzcompose: Allow --project-name

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -75,6 +75,11 @@ For additional details on mzcompose, consult doc/developer/mzbuild.md.""",
         action="store_true",
         help="bind container ports to the same host ports rather than choosing random host ports",
     )
+    parser.add_argument(
+        "--project-name",
+        metavar="PROJECT_NAME",
+        help="Use a different project name than the directory name",
+    )
     mzbuild.Repository.install_arguments(parser)
 
     # Docker Compose arguments that we explicitly ban. Since we don't support
@@ -138,7 +143,10 @@ def load_composition(args: argparse.Namespace) -> mzcompose.Composition:
     repo = mzbuild.Repository.from_arguments(ROOT, args)
     try:
         return mzcompose.Composition(
-            repo, name=args.find or Path.cwd().name, preserve_ports=args.preserve_ports
+            repo,
+            name=args.find or Path.cwd().name,
+            preserve_ports=args.preserve_ports,
+            project_name=args.project_name,
         )
     except mzcompose.UnknownCompositionError as e:
         if args.find:

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -84,11 +84,13 @@ class Composition:
         preserve_ports: bool = False,
         silent: bool = False,
         munge_services: bool = True,
+        project_name: Optional[str] = None,
     ):
         self.name = name
         self.description = None
         self.repo = repo
         self.preserve_ports = preserve_ports
+        self.project_name = project_name
         self.silent = silent
         self.workflows: Dict[str, Callable[..., None]] = {}
         self.test_results: OrderedDict[str, Composition.TestResult] = OrderedDict()
@@ -249,6 +251,9 @@ class Composition:
         stderr = None
         if capture_stderr:
             stderr = subprocess.PIPE
+        project_name_args = (
+            ("--project-name", self.project_name) if self.project_name else ()
+        )
 
         try:
             return subprocess.run(
@@ -258,6 +263,7 @@ class Composition:
                     f"-f/dev/fd/{self.file.fileno()}",
                     "--project-directory",
                     self.path,
+                    *project_name_args,
                     *args,
                 ],
                 close_fds=False,


### PR DESCRIPTION
To be able to run a project directory multiple times in parallel

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
