### PR TITLE
storage: maybe prevent panic on acquiring sink handle

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1772,14 +1772,14 @@ where
 
     fn drop_sinks_unvalidated(&mut self, identifiers: Vec<GlobalId>) {
         for id in identifiers {
-            let export = match self.export(id) {
-                Ok(export) => export,
-                Err(_) => continue,
-            };
+            // Already removed.
+            if self.export(id).is_err() {
+                continue;
+            }
 
-            let read_capability = export.read_capability.clone();
-            let storage_dependencies = export.storage_dependencies.clone();
-            self.remove_read_capabilities(read_capability, &storage_dependencies);
+            // We don't explicitly call `remove_read_capabilities`! Downgrading the
+            // frontier of the source to `[]` (the empty Antichain), will propagate
+            // to the storage dependencies.
 
             // Remove sink by removing its write frontier and arranging for deprovisioning.
             self.update_write_frontiers(&[(id, Antichain::new())]);
@@ -1916,8 +1916,15 @@ where
                     export.write_frontier = new_upper.clone();
                 }
 
-                let mut new_read_capability =
-                    export.read_policy.frontier(export.write_frontier.borrow());
+                // Ignore read policy for sinks whose write frontiers are closed, which identifies
+                // the sink is being dropped; we need to advance the read frontier to the empty
+                // chain to signal to the dataflow machinery that they should deprovision this
+                // object.
+                let mut new_read_capability = if export.write_frontier.is_empty() {
+                    export.write_frontier.clone()
+                } else {
+                    export.read_policy.frontier(export.write_frontier.borrow())
+                };
 
                 if timely::order::PartialOrder::less_equal(
                     &export.read_capability,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -2156,7 +2156,10 @@ where
             //
             // Note that while collections are dropped, the `client` may already
             // be cleared out, before we do this post-processing!
-            if cluster_id.is_some() && frontier.is_empty() {
+            if cluster_id.is_some()
+                && frontier.is_empty()
+                && self.state.collections.get(&id).is_some()
+            {
                 self.state.pending_source_drops.push(id);
             }
 


### PR DESCRIPTION
[This Sentry panic](https://materializeinc.sentry.io/issues/4131244750/?project=6780145&referrer=github_integration) occurs when the storage state tries to open a sink handle, but the sink has had its read frontier closed.

In triaging this issue, I realized that dropping a sink never resulted in an `AllowCompaction` command for the ID with the empty antichain as the frontier. That meant that the rehydration client never updated the since, and the initial since when re-hydrating a sink would be the last non-empty since it had seen. My hope is that with this PR, we will send the appropriate `AllowCompaction` command and the state will clean itself up.

I do not believe this fix is certain to prevent all instances of this panic, but merging this (after review, natch) as a potential fix would give us more insight if it continues to occur.

### Motivation

This PR fixes a recognized bug. Closes #19099

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
