### PR TITLE
platform-checks: Enable permissions after upgrade

### DIFF
--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -19,9 +19,6 @@ class Check:
     def __init__(self, base_version: MzVersion, rng: Optional[Random]) -> None:
         self.base_version = base_version
         self.rng = rng
-        self._initialize = self.initialize()
-        self._manipulate = self.manipulate()
-        self._validate = self.validate()
 
     def _can_run(self) -> bool:
         return True
@@ -37,6 +34,8 @@ class Check:
 
     def start_initialize(self, e: Executor) -> None:
         if self._can_run():
+            self.current_version = e.current_mz_version
+            self._initialize = self.initialize()
             self._initialize.execute(e)
 
     def join_initialize(self, e: Executor) -> None:
@@ -45,6 +44,8 @@ class Check:
 
     def start_manipulate(self, e: Executor, phase: int) -> None:
         if self._can_run():
+            self.current_version = e.current_mz_version
+            self._manipulate = self.manipulate()
             self._manipulate[phase].execute(e)
 
     def join_manipulate(self, e: Executor, phase: int) -> None:
@@ -53,6 +54,8 @@ class Check:
 
     def start_validate(self, e: Executor) -> None:
         if self._can_run():
+            self.current_version = e.current_mz_version
+            self._validate = self.validate()
             self._validate.execute(e)
 
     def join_validate(self, e: Executor) -> None:

--- a/misc/python/materialize/checks/cloudtest_actions.py
+++ b/misc/python/materialize/checks/cloudtest_actions.py
@@ -1,0 +1,46 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import Optional
+
+from materialize.checks.actions import Action
+from materialize.checks.executors import Executor
+from materialize.cloudtest.k8s.environmentd import EnvironmentdStatefulSet
+from materialize.util import MzVersion, released_materialize_versions
+
+
+class ReplaceEnvironmentdStatefulSet(Action):
+    """Change the image tag of the environmentd stateful set, re-create the definition and replace the existing one."""
+
+    new_tag: Optional[str]
+
+    def __init__(self, new_tag: Optional[str] = None) -> None:
+        self.new_tag = new_tag
+
+    def execute(self, e: Executor) -> None:
+        mz = e.cloudtest_application()
+        stateful_set = [
+            resource
+            for resource in mz.resources
+            if type(resource) == EnvironmentdStatefulSet
+        ]
+        assert len(stateful_set) == 1
+        stateful_set = stateful_set[0]
+
+        stateful_set.tag = self.new_tag
+        stateful_set.replace()
+        e.current_mz_version = (
+            MzVersion.parse_mz(self.new_tag)
+            if self.new_tag
+            else released_materialize_versions()[0]
+        )
+
+    def join(self, e: Executor) -> None:
+        # execute is blocking already
+        pass

--- a/misc/python/materialize/checks/executors.py
+++ b/misc/python/materialize/checks/executors.py
@@ -13,12 +13,16 @@ from typing import Any, Optional
 
 from materialize.cloudtest.application import MaterializeApplication
 from materialize.mzcompose import Composition
-
-# from materialize.cloudtest import
+from materialize.util import MzVersion, released_materialize_versions
 
 
 class Executor:
-    pass
+    # Store the current Materialize version and keep it up-to-date during
+    # upgrades so that actions can depend not just on the base version, but
+    # also on the current version. This enables testing more interesting
+    # scenarios which are still in development and not available a few versions
+    # back already.
+    current_mz_version: MzVersion
 
     def testdrive(self, input: str) -> Any:
         assert False
@@ -71,6 +75,7 @@ class CloudtestExecutor(Executor):
     def __init__(self, application: MaterializeApplication) -> None:
         self.application = application
         self.seed = random.getrandbits(32)
+        self.current_mz_version = released_materialize_versions()[0]
 
     def cloudtest_application(self) -> MaterializeApplication:
         return self.application

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -98,7 +98,7 @@ class ConfigureMz(MzcomposeAction):
         if e.current_mz_version >= MzVersion.parse("0.51.0-dev"):
             input += "ALTER SYSTEM SET enable_ld_rbac_checks TO true;\n"
 
-        if e.current_mz_version >= MzVersion.parse("0.53.0-dev"):
+        if e.current_mz_version >= MzVersion.parse("0.52.0-dev"):
             # Since we already test with RBAC enabled, we have to give materialize
             # user the relevant privileges so the existing tests keep working.
             input += "GRANT CREATE ON DATABASE materialize TO materialize;\n"

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -62,10 +62,11 @@ class StartMz(MzcomposeAction):
                 version_cargo == mz_version
             ), f"Materialize version mismatch, expected {version_cargo}, but got {mz_version}"
 
+        e.current_mz_version = mz_version
+
 
 class ConfigureMz(MzcomposeAction):
     def __init__(self, scenario: "Scenario") -> None:
-        self.base_version = scenario.base_version()
         self.handle: Optional[Any] = None
 
     def execute(self, e: Executor) -> None:
@@ -86,18 +87,18 @@ class ConfigureMz(MzcomposeAction):
             """
         )
 
-        if self.base_version >= MzVersion(0, 45, 0):
+        if e.current_mz_version >= MzVersion(0, 45, 0):
             # Since we already test with RBAC enabled, we have to give materialize
             # user the relevant attributes so the existing tests keep working.
             input += "ALTER ROLE materialize CREATEROLE CREATEDB CREATECLUSTER;\n"
 
-        if self.base_version >= MzVersion(0, 47, 0):
+        if e.current_mz_version >= MzVersion(0, 47, 0):
             input += "ALTER SYSTEM SET enable_rbac_checks TO true;\n"
 
-        if self.base_version >= MzVersion.parse("0.51.0-dev"):
+        if e.current_mz_version >= MzVersion.parse("0.51.0-dev"):
             input += "ALTER SYSTEM SET enable_ld_rbac_checks TO true;\n"
 
-        if self.base_version >= MzVersion.parse("0.53.0-dev"):
+        if e.current_mz_version >= MzVersion.parse("0.53.0-dev"):
             # Since we already test with RBAC enabled, we have to give materialize
             # user the relevant privileges so the existing tests keep working.
             input += "GRANT CREATE ON DATABASE materialize TO materialize;\n"

--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -17,12 +17,17 @@ from materialize.util import MzVersion
 class Owners(Check):
     def _create_objects(self, role: str, i: int, expensive: bool = False) -> str:
         s = dedent(
-            f"""
+            (
+                f"""
             $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
             GRANT CREATE ON DATABASE materialize TO {role}
             GRANT CREATE ON SCHEMA materialize.public TO {role}
             GRANT CREATE ON CLUSTER default TO {role}
-
+            """
+                if self.current_version >= MzVersion.parse("0.52.0-dev")
+                else ""
+            )
+            + f"""
             $ postgres-execute connection=postgres://{role}@materialized:6875/materialize
             CREATE DATABASE owner_db{i}
             CREATE SCHEMA owner_schema{i}

--- a/misc/python/materialize/checks/pg_cdc.py
+++ b/misc/python/materialize/checks/pg_cdc.py
@@ -140,6 +140,11 @@ class PgCdc(Check):
         return Testdrive(
             dedent(
                 """
+                $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                GRANT SELECT ON postgres_source_tableA TO materialize
+                GRANT SELECT ON postgres_source_tableB TO materialize
+                GRANT SELECT ON postgres_source_tableC TO materialize
+
                 > SELECT f1, max(f2), SUM(LENGTH(f3)) FROM postgres_source_tableA GROUP BY f1;
                 A 800 97350
                 B 800 97350

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -66,11 +66,16 @@ class Scenario:
 
     def run(self) -> None:
         actions = self.actions()
-        # The first action is StartMz, configure it implicitly afterwards
-        actions.insert(1 if isinstance(actions[0], StartMz) else 0, ConfigureMz(self))
+        # Configure implicitly for cloud scenarios
+        if not isinstance(actions[0], StartMz):
+            actions.insert(0, ConfigureMz(self))
         for action in actions:
             action.execute(self.executor)
             action.join(self.executor)
+            # Implicitly call configure to raise version-dependent limits
+            if isinstance(action, StartMz):
+                ConfigureMz(self).execute(self.executor)
+                ConfigureMz(self).join(self.executor)
 
 
 class NoRestartNoUpgrade(Scenario):

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -12,6 +12,7 @@ from typing import List, Optional, Type
 
 from materialize.checks.actions import Action, Initialize, Manipulate, Validate
 from materialize.checks.checks import Check
+from materialize.checks.cloudtest_actions import ReplaceEnvironmentdStatefulSet
 from materialize.checks.executors import Executor
 from materialize.checks.mzcompose_actions import ConfigureMz
 from materialize.checks.mzcompose_actions import (
@@ -73,7 +74,9 @@ class Scenario:
             action.execute(self.executor)
             action.join(self.executor)
             # Implicitly call configure to raise version-dependent limits
-            if isinstance(action, StartMz):
+            if isinstance(action, StartMz) or isinstance(
+                action, ReplaceEnvironmentdStatefulSet
+            ):
                 ConfigureMz(self).execute(self.executor)
                 ConfigureMz(self).join(self.executor)
 

--- a/misc/python/materialize/checks/sink.py
+++ b/misc/python/materialize/checks/sink.py
@@ -96,6 +96,11 @@ class SinkUpsert(Check):
         return Testdrive(
             dedent(
                 """
+                $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                GRANT SELECT ON sink_source_view TO materialize
+                GRANT USAGE ON CONNECTION kafka_conn TO materialize
+                GRANT USAGE ON CONNECTION csr_conn TO materialize
+
                 > SELECT * FROM sink_source_view;
                 I2 B 1000
                 I3 C 1000

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -11,7 +11,6 @@ from typing import List, Optional
 
 import pytest
 
-from materialize import util
 from materialize.checks.actions import Action, Initialize, Manipulate, Validate
 from materialize.checks.all_checks import *  # noqa: F401 F403
 from materialize.checks.checks import Check
@@ -20,9 +19,9 @@ from materialize.checks.scenarios import Scenario
 from materialize.cloudtest.application import MaterializeApplication
 from materialize.cloudtest.k8s.environmentd import EnvironmentdStatefulSet
 from materialize.cloudtest.wait import wait
-from materialize.util import MzVersion
+from materialize.util import MzVersion, released_materialize_versions
 
-LAST_RELEASED_VERSION = str(util.released_materialize_versions()[0])
+LAST_RELEASED_VERSION = str(released_materialize_versions()[0])
 
 
 class ReplaceEnvironmentdStatefulSet(Action):

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -14,38 +14,14 @@ import pytest
 from materialize.checks.actions import Action, Initialize, Manipulate, Validate
 from materialize.checks.all_checks import *  # noqa: F401 F403
 from materialize.checks.checks import Check
-from materialize.checks.executors import CloudtestExecutor, Executor
+from materialize.checks.cloudtest_actions import ReplaceEnvironmentdStatefulSet
+from materialize.checks.executors import CloudtestExecutor
 from materialize.checks.scenarios import Scenario
 from materialize.cloudtest.application import MaterializeApplication
-from materialize.cloudtest.k8s.environmentd import EnvironmentdStatefulSet
 from materialize.cloudtest.wait import wait
 from materialize.util import MzVersion, released_materialize_versions
 
 LAST_RELEASED_VERSION = str(released_materialize_versions()[0])
-
-
-class ReplaceEnvironmentdStatefulSet(Action):
-    """Change the image tag of the environmentd stateful set, re-create the definition and replace the existing one."""
-
-    def __init__(self, new_tag: Optional[str] = None) -> None:
-        self.new_tag = new_tag
-
-    def execute(self, e: Executor) -> None:
-        mz = e.cloudtest_application()
-        stateful_set = [
-            resource
-            for resource in mz.resources
-            if type(resource) == EnvironmentdStatefulSet
-        ]
-        assert len(stateful_set) == 1
-        stateful_set = stateful_set[0]
-
-        stateful_set.tag = self.new_tag
-        stateful_set.replace()
-
-    def join(self, e: Executor) -> None:
-        # execute is blocking already
-        pass
 
 
 class CloudtestUpgrade(Scenario):

--- a/test/upgrade-matrix/nodes.py
+++ b/test/upgrade-matrix/nodes.py
@@ -10,7 +10,7 @@
 from typing import List, Optional
 
 from materialize.checks.actions import Action, Initialize, Manipulate, Validate
-from materialize.checks.mzcompose_actions import KillMz, StartMz
+from materialize.checks.mzcompose_actions import ConfigureMz, KillMz, StartMz
 from materialize.checks.scenarios import Scenario
 from materialize.util import MzVersion
 
@@ -40,7 +40,10 @@ class BeginVersion(Node):
     def actions(self, scenario: Scenario) -> List[Action]:
         # As this action may need start very old Mz versions,
         # we do not use any bootstrap_systme_parameters
-        return [StartMz(tag=self.version, bootstrap_system_parameters=[])]
+        return [
+            StartMz(tag=self.version, bootstrap_system_parameters=[]),
+            ConfigureMz(scenario),
+        ]
 
 
 class EndVersion(Node):


### PR DESCRIPTION
to a version which will check RBAC

The alternative would have been to disable checking permissions until X-4 version supports it fully, which delays testing too much.

Failing in nightly currently: https://buildkite.com/materialize/nightlies/builds/2316

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
