### PR TITLE
adapter: Remove and fix old migrations

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5187,8 +5187,8 @@ impl Catalog {
                     let membership = RoleMembership::new();
                     let serialized_role = SerializedRole {
                         name: name.clone(),
-                        attributes: Some(attributes.clone()),
-                        membership: Some(membership.clone()),
+                        attributes: attributes.clone(),
+                        membership: membership.clone(),
                     };
                     let id = tx.insert_user_role(serialized_role)?;
                     state.add_to_audit_log(
@@ -7070,18 +7070,16 @@ impl From<ReplicaLocation> for SerializedReplicaLocation {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SerializedRole {
     pub name: String,
-    // TODO(jkosh44): Remove Option when stash consolidation bug is fixed
-    pub attributes: Option<RoleAttributes>,
-    // TODO(jkosh44): Remove Option in v0.49.0
-    pub membership: Option<RoleMembership>,
+    pub attributes: RoleAttributes,
+    pub membership: RoleMembership,
 }
 
 impl From<Role> for SerializedRole {
     fn from(role: Role) -> Self {
         SerializedRole {
             name: role.name,
-            attributes: Some(role.attributes),
-            membership: Some(role.membership),
+            attributes: role.attributes,
+            membership: role.membership,
         }
     }
 }
@@ -7090,8 +7088,8 @@ impl From<&BuiltinRole> for SerializedRole {
     fn from(role: &BuiltinRole) -> Self {
         SerializedRole {
             name: role.name.to_string(),
-            attributes: Some(role.attributes.clone()),
-            membership: Some(RoleMembership::new()),
+            attributes: role.attributes.clone(),
+            membership: RoleMembership::new(),
         }
     }
 }

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -269,7 +269,7 @@ async fn migrate(
                 },
                 SchemaValue {
                     database_id: Some(MATERIALIZE_DATABASE_ID),
-                    database_ns: None,
+                    database_ns: Some(DatabaseNamespace::User),
                     name: "public".into(),
                     owner_id: MZ_SYSTEM_ROLE_ID,
                     privileges: vec![

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -523,6 +523,17 @@ async fn migrate(
                     let mut value = value.clone();
                     value.database_ns = None;
                     Some(value)
+                } else if value.database_id.is_some() && value.database_ns.is_none() {
+                    let mut value = value.clone();
+                    // There are no system databases so we can just assume user namespace.
+                    value.database_ns = Some(DatabaseNamespace::User);
+                    Some(value)
+                } else if value.database_id.is_none() && value.database_ns.is_some() {
+                    // I don't think that anything in the stash was misconfigured like this, but it
+                    // can't hurt to check.
+                    let mut value = value.clone();
+                    value.database_ns = None;
+                    Some(value)
                 } else {
                     None
                 }


### PR DESCRIPTION
This commit removes old migrations. Also, it adds a new migration to fix one of the old migrations. Specifically it does the following:
  - Sets the database namespace to None for schemas in the ambient database.
  - Sets the schema namespace to System for system items.

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
