### PR TITLE
dev-docs: Mention that sccache can be used to speed up compilation

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -452,6 +452,35 @@ For zsh, add the follow to your `~/.zshrc`:
 source /path/to/materialize/misc/completions/zsh/*
 ```
 
+### Compilation Cache
+
+[sccache](https://github.com/mozilla/sccache) can be used to speed up
+compilation by caching results on disk. This is optional, and has
+[limitations](https://github.com/mozilla/sccache#known-caveats) like requiring
+the same absolute paths. For a from-scratch Debug build in the same directory
+you can expect about 40% faster build time. Installation on macOS:
+
+```shell
+brew install sccache
+```
+
+Installation on Linux:
+
+```shell
+cargo install sccache
+```
+
+Then add this fragment in your `~/.cargo/config.toml` (with the actual path via `which sccache`):
+```
+[build]
+rustc-wrapper = "/path/to/sccache"
+```
+
+By default the on-disk cache (`~/.cache/sccache` on Linux,
+`~/Library/Caches/Mozilla.sccache` on macOS) is limited to 10 GB. To change
+this (to 20 GB in this example) set `SCCACHE_CACHE_SIZE="20G"` in your shell
+environment (`~/.zshrc` or `~/.bashrc`).
+
 [Apache Kafka]: https://kafka.apache.org
 [Apache ZooKeeper]: https://zookeeper.apache.org
 [askama]: https://github.com/djc/askama


### PR DESCRIPTION
Following discussion on Slack

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
