### PR TITLE
sql: Add multi-role grant/revoke privilege stmt

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/grant-privilege.svg
+++ b/doc/user/layouts/partials/sql-grammar/grant-privilege.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="495" height="475">
+<svg xmlns="http://www.w3.org/2000/svg" width="495" height="519">
    <polygon points="9 61 1 57 1 65"/>
    <polygon points="17 61 9 57 9 65"/>
    <rect x="31" y="47" width="70" height="32" rx="10"/>
@@ -79,30 +79,38 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="345" y="361">CLUSTER</text>
-   <rect x="65" y="409" width="104" height="32"/>
-   <rect x="63" y="407" width="104" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="73" y="427">object_name</text>
-   <rect x="189" y="409" width="40" height="32" rx="10"/>
-   <rect x="187"
-         y="407"
+   <rect x="25" y="453" width="104" height="32"/>
+   <rect x="23" y="451" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="33" y="471">object_name</text>
+   <rect x="149" y="453" width="40" height="32" rx="10"/>
+   <rect x="147"
+         y="451"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="197" y="427">TO</text>
-   <rect x="269" y="441" width="70" height="32" rx="10"/>
-   <rect x="267"
-         y="439"
+   <text class="terminal" x="157" y="471">TO</text>
+   <rect x="229" y="485" width="70" height="32" rx="10"/>
+   <rect x="227"
+         y="483"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="277" y="459">GROUP</text>
-   <rect x="379" y="409" width="88" height="32"/>
-   <rect x="377" y="407" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="387" y="427">role_name</text>
+   <text class="terminal" x="237" y="503">GROUP</text>
+   <rect x="359" y="453" width="88" height="32"/>
+   <rect x="357" y="451" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="367" y="471">role_name</text>
+   <rect x="359" y="409" width="24" height="32" rx="10"/>
+   <rect x="357"
+         y="407"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="367" y="427">,</text>
    <path class="line"
-         d="m17 61 h2 m0 0 h10 m70 0 h10 m20 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m20 44 h10 m40 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m66 0 h10 m0 0 h50 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m56 0 h10 m0 0 h60 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m76 0 h10 m0 0 h40 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m98 0 h10 m0 0 h18 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m82 0 h10 m0 0 h34 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m84 0 h10 m0 0 h32 m22 -296 l2 0 m2 0 l2 0 m2 0 l2 0 m-452 362 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m104 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m20 -32 h10 m88 0 h10 m3 0 h-3"/>
-   <polygon points="485 423 493 419 493 427"/>
-   <polygon points="485 423 477 419 477 427"/>
+         d="m17 61 h2 m0 0 h10 m70 0 h10 m20 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m20 44 h10 m40 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m66 0 h10 m0 0 h50 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m56 0 h10 m0 0 h60 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m76 0 h10 m0 0 h40 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m98 0 h10 m0 0 h18 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m82 0 h10 m0 0 h34 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m84 0 h10 m0 0 h32 m22 -296 l2 0 m2 0 l2 0 m2 0 l2 0 m-492 406 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m104 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m40 -32 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m23 44 h-3"/>
+   <polygon points="485 467 493 463 493 471"/>
+   <polygon points="485 467 477 463 477 471"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/revoke-privilege.svg
+++ b/doc/user/layouts/partials/sql-grammar/revoke-privilege.svg
@@ -1,108 +1,116 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="503" height="475">
-   <polygon points="9 61 1 57 1 65"/>
-   <polygon points="17 61 9 57 9 65"/>
-   <rect x="31" y="47" width="78" height="32" rx="10"/>
-   <rect x="29"
+<svg xmlns="http://www.w3.org/2000/svg" width="515" height="519">
+   <polygon points="11 61 3 57 3 65"/>
+   <polygon points="19 61 11 57 11 65"/>
+   <rect x="33" y="47" width="78" height="32" rx="10"/>
+   <rect x="31"
          y="45"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="65">REVOKE</text>
-   <rect x="149" y="47" width="76" height="32"/>
-   <rect x="147" y="45" width="76" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="157" y="65">privilege</text>
-   <rect x="149" y="3" width="24" height="32" rx="10"/>
-   <rect x="147"
+   <text class="terminal" x="41" y="65">REVOKE</text>
+   <rect x="151" y="47" width="76" height="32"/>
+   <rect x="149" y="45" width="76" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="159" y="65">privilege</text>
+   <rect x="151" y="3" width="24" height="32" rx="10"/>
+   <rect x="149"
          y="1"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="157" y="21">,</text>
-   <rect x="265" y="47" width="40" height="32"/>
-   <rect x="263" y="45" width="40" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="273" y="65">ON</text>
-   <rect x="345" y="79" width="66" height="32" rx="10"/>
-   <rect x="343"
+   <text class="terminal" x="159" y="21">,</text>
+   <rect x="267" y="47" width="40" height="32"/>
+   <rect x="265" y="45" width="40" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="275" y="65">ON</text>
+   <rect x="347" y="79" width="66" height="32" rx="10"/>
+   <rect x="345"
          y="77"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="353" y="97">TABLE</text>
-   <rect x="345" y="123" width="56" height="32" rx="10"/>
-   <rect x="343"
+   <text class="terminal" x="355" y="97">TABLE</text>
+   <rect x="347" y="123" width="56" height="32" rx="10"/>
+   <rect x="345"
          y="121"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="353" y="141">TYPE</text>
-   <rect x="345" y="167" width="76" height="32" rx="10"/>
-   <rect x="343"
+   <text class="terminal" x="355" y="141">TYPE</text>
+   <rect x="347" y="167" width="76" height="32" rx="10"/>
+   <rect x="345"
          y="165"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="353" y="185">SECRET</text>
-   <rect x="345" y="211" width="116" height="32" rx="10"/>
-   <rect x="343"
+   <text class="terminal" x="355" y="185">SECRET</text>
+   <rect x="347" y="211" width="116" height="32" rx="10"/>
+   <rect x="345"
          y="209"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="353" y="229">CONNECTION</text>
-   <rect x="345" y="255" width="98" height="32" rx="10"/>
-   <rect x="343"
+   <text class="terminal" x="355" y="229">CONNECTION</text>
+   <rect x="347" y="255" width="98" height="32" rx="10"/>
+   <rect x="345"
          y="253"
          width="98"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="353" y="273">DATABASE</text>
-   <rect x="345" y="299" width="82" height="32" rx="10"/>
-   <rect x="343"
+   <text class="terminal" x="355" y="273">DATABASE</text>
+   <rect x="347" y="299" width="82" height="32" rx="10"/>
+   <rect x="345"
          y="297"
          width="82"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="353" y="317">SCHEMA</text>
-   <rect x="345" y="343" width="84" height="32" rx="10"/>
-   <rect x="343"
+   <text class="terminal" x="355" y="317">SCHEMA</text>
+   <rect x="347" y="343" width="84" height="32" rx="10"/>
+   <rect x="345"
          y="341"
          width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="353" y="361">CLUSTER</text>
-   <rect x="53" y="409" width="104" height="32"/>
-   <rect x="51" y="407" width="104" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="61" y="427">object_name</text>
-   <rect x="177" y="409" width="60" height="32" rx="10"/>
-   <rect x="175"
-         y="407"
+   <text class="terminal" x="355" y="361">CLUSTER</text>
+   <rect x="25" y="453" width="104" height="32"/>
+   <rect x="23" y="451" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="33" y="471">object_name</text>
+   <rect x="149" y="453" width="60" height="32" rx="10"/>
+   <rect x="147"
+         y="451"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="185" y="427">FROM</text>
-   <rect x="277" y="441" width="70" height="32" rx="10"/>
-   <rect x="275"
-         y="439"
+   <text class="terminal" x="157" y="471">FROM</text>
+   <rect x="249" y="485" width="70" height="32" rx="10"/>
+   <rect x="247"
+         y="483"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="285" y="459">GROUP</text>
-   <rect x="387" y="409" width="88" height="32"/>
-   <rect x="385" y="407" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="395" y="427">role_name</text>
+   <text class="terminal" x="257" y="503">GROUP</text>
+   <rect x="379" y="453" width="88" height="32"/>
+   <rect x="377" y="451" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="387" y="471">role_name</text>
+   <rect x="379" y="409" width="24" height="32" rx="10"/>
+   <rect x="377"
+         y="407"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="387" y="427">,</text>
    <path class="line"
-         d="m17 61 h2 m0 0 h10 m78 0 h10 m20 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m20 44 h10 m40 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m66 0 h10 m0 0 h50 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m56 0 h10 m0 0 h60 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m76 0 h10 m0 0 h40 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m98 0 h10 m0 0 h18 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m82 0 h10 m0 0 h34 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m84 0 h10 m0 0 h32 m22 -296 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 362 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m104 0 h10 m0 0 h10 m60 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m20 -32 h10 m88 0 h10 m3 0 h-3"/>
-   <polygon points="493 423 501 419 501 427"/>
-   <polygon points="493 423 485 419 485 427"/>
+         d="m19 61 h2 m0 0 h10 m78 0 h10 m20 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m20 44 h10 m40 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m66 0 h10 m0 0 h50 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m56 0 h10 m0 0 h60 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m76 0 h10 m0 0 h40 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m98 0 h10 m0 0 h18 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m82 0 h10 m0 0 h34 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m84 0 h10 m0 0 h32 m22 -296 l2 0 m2 0 l2 0 m2 0 l2 0 m-502 406 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m104 0 h10 m0 0 h10 m60 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m40 -32 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m23 44 h-3"/>
+   <polygon points="505 467 513 463 513 471"/>
+   <polygon points="505 467 497 463 497 471"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -214,7 +214,7 @@ format_spec ::=
   'TEXT' |
   'BYTES'
 grant_privilege ::=
-  'GRANT' privilege (',' privilege)* ON ('TABLE'? | 'TYPE' | 'SECRET' | 'CONNECTION' | 'DATABASE' | 'SCHEMA' | 'CLUSTER') object_name 'TO' 'GROUP'? role_name
+  'GRANT' privilege (',' privilege)* ON ('TABLE'? | 'TYPE' | 'SECRET' | 'CONNECTION' | 'DATABASE' | 'SCHEMA' | 'CLUSTER') object_name 'TO' 'GROUP'? role_name ( ',' role_name )*
 grant_role ::=
   'GRANT' role_name 'TO' 'GROUP'? member_name ( ',' member_name )*
 key_strat ::=
@@ -288,7 +288,7 @@ privilege ::=
 reset_session_variable ::=
   'RESET' variable_name
 revoke_privilege ::=
-  'REVOKE' privilege (',' privilege)* ON ('TABLE'? | 'TYPE' | 'SECRET' | 'CONNECTION' | 'DATABASE' | 'SCHEMA' | 'CLUSTER') object_name 'FROM' 'GROUP'? role_name
+  'REVOKE' privilege (',' privilege)* ON ('TABLE'? | 'TYPE' | 'SECRET' | 'CONNECTION' | 'DATABASE' | 'SCHEMA' | 'CLUSTER') object_name 'FROM' 'GROUP'? role_name ( ',' role_name )*
 revoke_role ::=
   'REVOKE' role_name 'FROM' 'GROUP'? member_name ( ',' member_name )*
 rollback ::=

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -104,7 +104,7 @@ use crate::config::{SynchronizedParameters, SystemParameterFrontend};
 use crate::coord::{TargetCluster, DEFAULT_LOGICAL_COMPACTION_WINDOW};
 use crate::session::{PreparedStatement, Session, DEFAULT_DATABASE_NAME};
 use crate::util::{index_sql, ResultExt};
-use crate::{rbac, AdapterError, DUMMY_AVAILABILITY_ZONE};
+use crate::{rbac, AdapterError, ExecuteResponse, DUMMY_AVAILABILITY_ZONE};
 
 use self::builtin::{BuiltinCluster, BuiltinSource};
 
@@ -6860,6 +6860,15 @@ fn enable_features_required_for_catalog_open(session_catalog: &mut ConnCatalog) 
 pub enum UpdatePrivilegeVariant {
     Grant,
     Revoke,
+}
+
+impl From<UpdatePrivilegeVariant> for ExecuteResponse {
+    fn from(variant: UpdatePrivilegeVariant) -> Self {
+        match variant {
+            UpdatePrivilegeVariant::Grant => ExecuteResponse::GrantedPrivilege,
+            UpdatePrivilegeVariant::Revoke => ExecuteResponse::RevokedPrivilege,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -963,13 +963,13 @@ fn generate_required_privileges(
         Plan::GrantPrivilege(GrantPrivilegePlan {
             acl_mode: _,
             object_id,
-            grantee: _,
+            grantees: _,
             grantor: _,
         })
         | Plan::RevokePrivilege(RevokePrivilegePlan {
             acl_mode: _,
             object_id,
-            revokee: _,
+            revokees: _,
             grantor: _,
         }) => match object_id {
             ObjectId::ClusterReplica((cluster_id, _)) => {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2893,8 +2893,8 @@ pub struct GrantPrivilegeStatement<T: AstInfo> {
     pub object_type: ObjectType,
     /// The name of the object.
     pub name: T::ObjectName,
-    /// The role that will granted the privileges.
-    pub role: T::RoleName,
+    /// The roles that will granted the privileges.
+    pub roles: Vec<T::RoleName>,
 }
 
 impl<T: AstInfo> AstDisplay for GrantPrivilegeStatement<T> {
@@ -2906,7 +2906,7 @@ impl<T: AstInfo> AstDisplay for GrantPrivilegeStatement<T> {
         f.write_str(" ");
         f.write_node(&self.name);
         f.write_str(" TO ");
-        f.write_node(&self.role);
+        f.write_node(&display::comma_separated(&self.roles));
     }
 }
 impl_display_t!(GrantPrivilegeStatement);
@@ -2922,8 +2922,8 @@ pub struct RevokePrivilegeStatement<T: AstInfo> {
     pub object_type: ObjectType,
     /// The name of the object.
     pub name: T::ObjectName,
-    /// The role that will have privileges revoked.
-    pub role: T::RoleName,
+    /// The roles that will have privileges revoked.
+    pub roles: Vec<T::RoleName>,
 }
 
 impl<T: AstInfo> AstDisplay for RevokePrivilegeStatement<T> {
@@ -2935,7 +2935,7 @@ impl<T: AstInfo> AstDisplay for RevokePrivilegeStatement<T> {
         f.write_str(" ");
         f.write_node(&self.name);
         f.write_str(" FROM ");
-        f.write_node(&self.role);
+        f.write_node(&display::comma_separated(&self.roles));
     }
 }
 impl_display_t!(RevokePrivilegeStatement);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5970,12 +5970,12 @@ impl<'a> Parser<'a> {
                 }
                 let name = self.parse_object_name(object_type)?;
                 self.expect_keyword(TO)?;
-                let role = self.parse_identifier()?;
+                let roles = self.parse_comma_separated(Parser::parse_identifier)?;
                 Ok(Statement::GrantPrivilege(GrantPrivilegeStatement {
                     privileges,
                     object_type,
                     name,
-                    role,
+                    roles,
                 }))
             }
             None => {
@@ -6028,12 +6028,12 @@ impl<'a> Parser<'a> {
                 }
                 let name = self.parse_object_name(object_type)?;
                 self.expect_keyword(FROM)?;
-                let role = self.parse_identifier()?;
+                let roles = self.parse_comma_separated(Parser::parse_identifier)?;
                 Ok(Statement::RevokePrivilege(RevokePrivilegeStatement {
                     privileges,
                     object_type,
                     name,
-                    role,
+                    roles,
                 }))
             }
             None => {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1954,7 +1954,7 @@ GRANT USAGE, CREATE ON CLUSTER foo TO joe
 ----
 GRANT USAGE, CREATE ON CLUSTER foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE, CREATE], object_type: Cluster, name: Cluster(Ident("foo")), role: Ident("joe") })
+GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE, CREATE], object_type: Cluster, name: Cluster(Ident("foo")), roles: [Ident("joe")] })
 
 parse-statement
 GRANT USAGE, CREATE ON CLUSTER REPLICA foo.r TO joe
@@ -1968,28 +1968,28 @@ GRANT CREATE ON DATABASE foo TO joe
 ----
 GRANT CREATE ON DATABASE foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [CREATE], object_type: Database, name: Database(UnresolvedDatabaseName(Ident("foo"))), role: Ident("joe") })
+GrantPrivilege(GrantPrivilegeStatement { privileges: [CREATE], object_type: Database, name: Database(UnresolvedDatabaseName(Ident("foo"))), roles: [Ident("joe")] })
 
 parse-statement
 GRANT USAGE ON SCHEMA foo TO joe
 ----
 GRANT USAGE ON SCHEMA foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Schema, name: Schema(UnresolvedSchemaName([Ident("foo")])), role: Ident("joe") })
+GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Schema, name: Schema(UnresolvedSchemaName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE foo TO joe
 ----
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [SELECT, INSERT, UPDATE, DELETE], object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), role: Ident("joe") })
+GrantPrivilege(GrantPrivilegeStatement { privileges: [SELECT, INSERT, UPDATE, DELETE], object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 GRANT USAGE ON foo TO joe
 ----
 GRANT USAGE ON TABLE foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), role: Ident("joe") })
+GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 GRANT USAGE ON SINK foo TO joe
@@ -2017,14 +2017,14 @@ GRANT USAGE ON SECRET foo TO joe
 ----
 GRANT USAGE ON SECRET foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Secret, name: Item(UnresolvedItemName([Ident("foo")])), role: Ident("joe") })
+GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Secret, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 GRANT USAGE ON CONNECTION foo TO joe
 ----
 GRANT USAGE ON CONNECTION foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Connection, name: Item(UnresolvedItemName([Ident("foo")])), role: Ident("joe") })
+GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Connection, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 GRANT SELECT ON VIEW foo TO joe
@@ -2046,3 +2046,129 @@ GRANT FAKE ON TABLE t TO joe
 error: Expected TO, found ON
 GRANT FAKE ON TABLE t TO joe
            ^
+
+parse-statement
+GRANT SELECT, INSERT ON t TO joe, mike
+----
+GRANT SELECT, INSERT ON TABLE t TO joe, mike
+=>
+GrantPrivilege(GrantPrivilegeStatement { privileges: [SELECT, INSERT], object_type: Table, name: Item(UnresolvedItemName([Ident("t")])), roles: [Ident("joe"), Ident("mike")] })
+
+parse-statement
+GRANT USAGE ON DATABASE d TO joe, mike
+----
+GRANT USAGE ON DATABASE d TO joe, mike
+=>
+GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Database, name: Database(UnresolvedDatabaseName(Ident("d"))), roles: [Ident("joe"), Ident("mike")] })
+
+parse-statement
+REVOKE USAGE, CREATE ON CLUSTER foo FROM joe
+----
+REVOKE USAGE, CREATE ON CLUSTER foo FROM joe
+=>
+RevokePrivilege(RevokePrivilegeStatement { privileges: [USAGE, CREATE], object_type: Cluster, name: Cluster(Ident("foo")), roles: [Ident("joe")] })
+
+parse-statement
+REVOKE USAGE, CREATE ON CLUSTER REPLICA foo.r FROM joe
+----
+error: Unsupported REVOKE on CLUSTER REPLICA
+REVOKE USAGE, CREATE ON CLUSTER REPLICA foo.r FROM joe
+                                ^
+
+parse-statement
+REVOKE CREATE ON DATABASE foo FROM joe
+----
+REVOKE CREATE ON DATABASE foo FROM joe
+=>
+RevokePrivilege(RevokePrivilegeStatement { privileges: [CREATE], object_type: Database, name: Database(UnresolvedDatabaseName(Ident("foo"))), roles: [Ident("joe")] })
+
+parse-statement
+REVOKE USAGE ON SCHEMA foo FROM joe
+----
+REVOKE USAGE ON SCHEMA foo FROM joe
+=>
+RevokePrivilege(RevokePrivilegeStatement { privileges: [USAGE], object_type: Schema, name: Schema(UnresolvedSchemaName([Ident("foo")])), roles: [Ident("joe")] })
+
+parse-statement
+REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLE foo FROM joe
+----
+REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLE foo FROM joe
+=>
+RevokePrivilege(RevokePrivilegeStatement { privileges: [SELECT, INSERT, UPDATE, DELETE], object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
+
+parse-statement
+REVOKE USAGE ON foo FROM joe
+----
+REVOKE USAGE ON TABLE foo FROM joe
+=>
+RevokePrivilege(RevokePrivilegeStatement { privileges: [USAGE], object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
+
+parse-statement
+REVOKE USAGE ON SINK foo FROM joe
+----
+error: Unsupported REVOKE on SINK
+REVOKE USAGE ON SINK foo FROM joe
+                ^
+
+parse-statement
+REVOKE USAGE ON SOURCE foo FROM joe
+----
+error: For object type SOURCE, you must specify 'TABLE' or omit the object type
+REVOKE USAGE ON SOURCE foo FROM joe
+                ^
+
+parse-statement
+REVOKE USAGE ON INDEX foo FROM joe
+----
+error: Unsupported REVOKE on INDEX
+REVOKE USAGE ON INDEX foo FROM joe
+                ^
+
+parse-statement
+REVOKE USAGE ON SECRET foo FROM joe
+----
+REVOKE USAGE ON SECRET foo FROM joe
+=>
+RevokePrivilege(RevokePrivilegeStatement { privileges: [USAGE], object_type: Secret, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
+
+parse-statement
+REVOKE USAGE ON CONNECTION foo FROM joe
+----
+REVOKE USAGE ON CONNECTION foo FROM joe
+=>
+RevokePrivilege(RevokePrivilegeStatement { privileges: [USAGE], object_type: Connection, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
+
+parse-statement
+REVOKE SELECT ON VIEW foo FROM joe
+----
+error: For object type VIEW, you must specify 'TABLE' or omit the object type
+REVOKE SELECT ON VIEW foo FROM joe
+                 ^
+
+parse-statement
+REVOKE SELECT ON MATERIALIZED VIEW foo FROM joe
+----
+error: For object type MATERIALIZED VIEW, you must specify 'TABLE' or omit the object type
+REVOKE SELECT ON MATERIALIZED VIEW foo FROM joe
+                              ^
+
+parse-statement
+REVOKE FAKE ON TABLE t FROM joe
+----
+error: Expected FROM, found ON
+REVOKE FAKE ON TABLE t FROM joe
+            ^
+
+parse-statement
+REVOKE SELECT, INSERT ON t FROM joe, mike
+----
+REVOKE SELECT, INSERT ON TABLE t FROM joe, mike
+=>
+RevokePrivilege(RevokePrivilegeStatement { privileges: [SELECT, INSERT], object_type: Table, name: Item(UnresolvedItemName([Ident("t")])), roles: [Ident("joe"), Ident("mike")] })
+
+parse-statement
+REVOKE USAGE ON DATABASE d FROM joe, mike
+----
+REVOKE USAGE ON DATABASE d FROM joe, mike
+=>
+RevokePrivilege(RevokePrivilegeStatement { privileges: [USAGE], object_type: Database, name: Database(UnresolvedDatabaseName(Ident("d"))), roles: [Ident("joe"), Ident("mike")] })

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -863,8 +863,8 @@ pub struct GrantPrivilegePlan {
     pub acl_mode: AclMode,
     /// The ID of the object.
     pub object_id: ObjectId,
-    /// The role that will granted the privileges.
-    pub grantee: RoleId,
+    /// The roles that will granted the privileges.
+    pub grantees: Vec<RoleId>,
     /// The role that is granting the privileges.
     pub grantor: RoleId,
 }
@@ -875,8 +875,8 @@ pub struct RevokePrivilegePlan {
     pub acl_mode: AclMode,
     /// The ID of the object.
     pub object_id: ObjectId,
-    /// The role that will have privileges revoked.
-    pub revokee: RoleId,
+    /// The roles that will have privileges revoked.
+    pub revokees: Vec<RoleId>,
     /// The role that will revoke the privileges.
     pub grantor: RoleId,
 }

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -1342,6 +1342,66 @@ GRANT SELECT ON DATABASE t TO joe
 statement error invalid privilege types USAGE for TABLE
 GRANT SELECT, USAGE ON TABLE t TO joe
 
+## Test multiple roles
+
+simple conn=mz_system,user=mz_system
+CREATE TABLE t1 (a INT);
+----
+COMPLETE 0
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't1'
+----
+t1  mz_system=arwd/mz_system
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON t1 TO joe, other
+----
+COMPLETE 0
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't1'
+----
+t1  joe=r/mz_system
+t1  other=r/mz_system
+t1  mz_system=arwd/mz_system
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT, INSERT ON t1 TO test_role, other
+----
+COMPLETE 0
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't1'
+----
+t1  joe=r/mz_system
+t1  other=ar/mz_system
+t1  test_role=ar/mz_system
+t1  mz_system=arwd/mz_system
+
+simple conn=mz_system,user=mz_system
+REVOKE INSERT ON t1 FROM joe, test_role, other
+----
+COMPLETE 0
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't1'
+----
+t1  joe=r/mz_system
+t1  other=r/mz_system
+t1  test_role=r/mz_system
+t1  mz_system=arwd/mz_system
+
+simple conn=mz_system,user=mz_system
+REVOKE SELECT ON t1 FROM joe, test_role, other
+----
+COMPLETE 0
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't1'
+----
+t1  mz_system=arwd/mz_system
+
 # Disable rbac checks.
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;


### PR DESCRIPTION
This commit adds the ability to specify multiple roles in a GRANT/REVOKE privilege statement.

Resolves #18972

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release allows users to specify multiple roles in `GRANT`/`REVOKE` privilege statements.
