### PR TITLE
docs/developer: iterate on design doc process

### DIFF
--- a/doc/developer/design/00000000_template.md
+++ b/doc/developer/design/00000000_template.md
@@ -1,99 +1,72 @@
-- Feature name: (Insert name of feature)
+# <Insert Name of Feature>
+
 - Associated: (Insert list of associated epics, issues, or PRs)
 
-# Summary
-[summary]: #summary
+<!--
+Note: Feel free to add or remove sections as needed. However, most design
+docs should at least keep the suggested sections.
+-->
 
-One paragraph to explain the feature: What's wrong, what's the problem, what's the fix, what are the consequences?
+## Context
 
-# Motivation
-[motivation]: #motivation
+<!--
+Bring the reader up to speed enough, such that they can understand the
+following goals and descriptions.
 
-Why are we doing this? What problems does it solve? What use cases does it enable? What is the desired outcome?
+An important reason for this is helping future readers understand the
+assumptions that went into the design, and in turn the goals and design itself.
 
-# Explanation
-[explanation]: #explanation
+Be sure to capture the customer impact/customer problem, which should be the
+motivation for the proposed design!
+-->
 
-Explain the design as if it were part of Materialize and you were teaching the team about it.
-This can mean:
+## Goals
 
-- Introduce new named concepts.
-- Explain the feature using examples that demonstrate product-level changes.
-- Explain how it builds on the current architecture.
-- Explain how engineers and users should think about this change, and how it influences how everyone uses the product.
-- If needed, talk though errors, backwards-compatibility, or migration strategies.
-- Discuss how this affects maintainability, or whether it introduces concepts that might be hard to change in the future.
+<!--
+Enumerate the concrete goals that are in scope for the project.
+-->
 
-# Reference explanation
-[reference-explanation]: #reference-explanation
+## Non-Goals
 
-Focus on the implementation of the feature.
-This is the technical part of the design.
+<!--
+Enumerate potential goals that are explicitly _out_ of scope for the project
+ie. what could we do or what do we want to do in the future - but are not doing
+now.
+-->
 
-- Is it reasonably clear how the feature is implemented?
-- What dependencies does the feature have and introduce?
-- Focus on corner cases.
-- How can we test the feature and protect against regressions?
+## Overview
 
-# Rollout
-[rollout]: #rollout
+<!--
+Brief, high-level overview. A few sentences long, at most a couple of smaller
+paragraphs.
+-->
 
-Describe what steps are necessary to enable this feature for users.
-How do we validate that the feature performs as expected? What monitoring and observability does it require?
+## Detailed description
 
-## Testing and observability
-[testing-and-observability]: #testing-and-observability
+<!--
+Describe the approach in detail. If there is no clear frontrunner, feel free to
+list all approaches in alternatives. If applicable, be sure to call out any new
+testing/validation that will be required.
 
-Testability and explainability are top-tier design concerns!
-Describe how you will test and roll out the implementation.
-When the deliverable is a refactoring, the existing tests may be sufficient.
-When the deliverable is a new feature, new tests are imperative.
+For some features it can be helpful to sketch an implementation. If you're
+working on things that are crossing team boundaries it will be helpful to spell
+out any new interfaces/traits/interactions.
 
-Describe what metrics can be used to monitor and observe the feature.
-What information do we need to expose internally, and what information is interesting to the user?
-How do we expose the information?
+For most new features, you should think about testing, rollout/lifecycle, and
+observability. These things can warrant their own sections.
+-->
 
-Basic guidelines:
+## Alternatives
 
-* Nearly every feature requires either Rust unit tests, sqllogictest tests, or testdrive tests.
-* Features that interact with Kubernetes additionally need a cloudtest test.
-* Features that interact with external systems additionally should be tested manually in a staging environment.
-* Features or changes to performance-critical parts of the system should be load tested.
+<!--
+Similar to the Description section. List of alternative approaches considered,
+pros/cons or why they were not chosen.
+-->
 
-## Lifecycle
-[lifecycle]: #lifecycle
+## Open questions
 
-If the design is risky or has the potential to be destabilizing, you should plan to roll the implementation out behind a feature flag.
-List all feature flags, their behavior and when it is safe to change their value.
-Describe the [lifecycle of the feature](https://www.notion.so/Feature-lifecycle-2fb13301803b4b7e9ba0868238bd4cfb).
-Will it start as an alpha feature behind a feature flag?
-What level of testing will be required to promote to beta?
-To stable?
-
-# Drawbacks
-[drawbacks]: #drawbacks
-
-Why should we *not* do this?
-
-# Conclusion and alternatives
-[conclusion-and-alternatives]: #conclusion-and-alternatives
-
-- Why is the design the best to solve the problem?
-- What other designs have been considered, and what were the reasons to not pick any other?
-- What is the impact of not implementing this design?
-
-# Unresolved questions
-[unresolved-questions]: #unresolved-questions
-
-- What questions need to be resolved to finalize the design?
-- What questions will need to be resolved during the implementation of the design?
-- What questions does this design raise that we should address separately?
-
-# Future work
-[future-work]: #future-work
-
-Describe what work should follow from this design, which new aspects it enables, and how it might affect individual parts of Materialize.
-Think in larger terms.
-This section can also serve as a place to dump ideas that are related but not part of the design.
-
-If you can't think of any, please note this down.
+<!--
+Anything currently unanswered that needs specific focus. This section may be
+expanded during the doc meeting as other unknowns are pointed out. These
+questions may be technical, product, or anything in-between.
+-->

--- a/doc/developer/design/00000000_template_compute.md
+++ b/doc/developer/design/00000000_template_compute.md
@@ -1,0 +1,99 @@
+- Feature name: (Insert name of feature)
+- Associated: (Insert list of associated epics, issues, or PRs)
+
+# Summary
+[summary]: #summary
+
+One paragraph to explain the feature: What's wrong, what's the problem, what's the fix, what are the consequences?
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What problems does it solve? What use cases does it enable? What is the desired outcome?
+
+# Explanation
+[explanation]: #explanation
+
+Explain the design as if it were part of Materialize and you were teaching the team about it.
+This can mean:
+
+- Introduce new named concepts.
+- Explain the feature using examples that demonstrate product-level changes.
+- Explain how it builds on the current architecture.
+- Explain how engineers and users should think about this change, and how it influences how everyone uses the product.
+- If needed, talk though errors, backwards-compatibility, or migration strategies.
+- Discuss how this affects maintainability, or whether it introduces concepts that might be hard to change in the future.
+
+# Reference explanation
+[reference-explanation]: #reference-explanation
+
+Focus on the implementation of the feature.
+This is the technical part of the design.
+
+- Is it reasonably clear how the feature is implemented?
+- What dependencies does the feature have and introduce?
+- Focus on corner cases.
+- How can we test the feature and protect against regressions?
+
+# Rollout
+[rollout]: #rollout
+
+Describe what steps are necessary to enable this feature for users.
+How do we validate that the feature performs as expected? What monitoring and observability does it require?
+
+## Testing and observability
+[testing-and-observability]: #testing-and-observability
+
+Testability and explainability are top-tier design concerns!
+Describe how you will test and roll out the implementation.
+When the deliverable is a refactoring, the existing tests may be sufficient.
+When the deliverable is a new feature, new tests are imperative.
+
+Describe what metrics can be used to monitor and observe the feature.
+What information do we need to expose internally, and what information is interesting to the user?
+How do we expose the information?
+
+Basic guidelines:
+
+* Nearly every feature requires either Rust unit tests, sqllogictest tests, or testdrive tests.
+* Features that interact with Kubernetes additionally need a cloudtest test.
+* Features that interact with external systems additionally should be tested manually in a staging environment.
+* Features or changes to performance-critical parts of the system should be load tested.
+
+## Lifecycle
+[lifecycle]: #lifecycle
+
+If the design is risky or has the potential to be destabilizing, you should plan to roll the implementation out behind a feature flag.
+List all feature flags, their behavior and when it is safe to change their value.
+Describe the [lifecycle of the feature](https://www.notion.so/Feature-lifecycle-2fb13301803b4b7e9ba0868238bd4cfb).
+Will it start as an alpha feature behind a feature flag?
+What level of testing will be required to promote to beta?
+To stable?
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Conclusion and alternatives
+[conclusion-and-alternatives]: #conclusion-and-alternatives
+
+- Why is the design the best to solve the problem?
+- What other designs have been considered, and what were the reasons to not pick any other?
+- What is the impact of not implementing this design?
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What questions need to be resolved to finalize the design?
+- What questions will need to be resolved during the implementation of the design?
+- What questions does this design raise that we should address separately?
+
+# Future work
+[future-work]: #future-work
+
+Describe what work should follow from this design, which new aspects it enables, and how it might affect individual parts of Materialize.
+Think in larger terms.
+This section can also serve as a place to dump ideas that are related but not part of the design.
+
+If you can't think of any, please note this down.

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -89,7 +89,8 @@ thinking. Err on the side of writing a design document.
 ### Creation
 
 1. Copy the [template](./00000000_template.md) to a new date-prefixed file in
-   `doc/developer/design` and fill it in.
+   `doc/developer/design` and fill it in. There is a separate template that the
+   COMPUTE team prefers: [template_compute](./00000000_template_compute.md).
 2. Submit a pull request -- this makes it easy for others to add written
    comments.
 3. "Socialize" the design with relevant stakeholders. Typically, there is a

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -70,14 +70,17 @@ Some specific times when you should write a design document:
 
 Definitely write a design document:
 
-1. If it's going to involve multiple people and/or teams coordinating changes.
+1. If the change is large/cross-cutting, e.g., will be spread over multiple PRs
+   and/or multiple teams.
 2. If there are multiple alternative implementations and no clear best option.
 3. If it changes a customer-facing/public API, or a major private API (for
    example, the API for implementing new sinks).
 
 Consider writing a design document:
 
-1. If the change is large/cross-cutting, e.g., will be spread over multiple PRs.
+1. If it's going to involve multiple people and/or teams coordinating changes.
+   You have to use your gut feeling/common sense here. A change that involves
+   two people from the same team might not need a document.
 2. If the change will take more than a week to implement or will proceed in
    phases that need clearly delimited scope.
 

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -146,8 +146,10 @@ Instead, invest in evergreen content. Add comments in the code itself (module
 comments can be particularly valuable) and reference documentation in
 [doc/developer/reference](/doc/developer/reference/README.md). For larger
 components, consider putting together an architecture presentation (see, for
-example, the `persist` lectures); slides and a talk track can be a more
-efficient means of communicating some types of technical content.
+example, the [`persist` lectures
+(internal)](https://www.notion.so/materialize/6f83baae1f5348eb87334a53daa63066));
+slides and a talk track can be a more efficient means of communicating some
+types of technical content.
 
 ## How should you push back on aspects of a design document?
 

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -51,7 +51,7 @@ Some specific times when you should write a design document:
 2. If the change will take more than a week to implement or will proceed in
    phases that need clearly delimited scope.
 3. If there are multiple alternative implementations and no clear best option.
-4. If it's going to involve multiple people coordinating changes.
+4. If it's going to involve multiple people and/or teams coordinating changes.
 5. If it changes a customer-facing/public API, or a major private API (for
    example, the API for implementing new sinks).
 
@@ -66,23 +66,26 @@ thinking. Err on the side of writing a design document.
    `doc/developer/design` and fill it in.
 2. Submit a pull request -- this makes it easy for others to add written
    comments.
-3. Announce that the design doc is ready for review in #eng-announce.
-
-### Discussion
-
-4. Address comments, discuss, and iterate on the document in the PR.
-5. Gather explicit approvals from relevant stakeholders. Typically, there is a
+3. "Socialize" the design with relevant stakeholders. Typically, there is a
    small set of people who have a vested interest in the area the design
-   touches. If it's not clear who that is, ask a TL, EM, or in #eng-general.
+   touches. If it's not clear who that is, ask your TL, EM, or in #eng-general.
+4. (Optional) Announce that the design doc is ready for review in #eng-announce,
+   if you think it's helpful to surface the design to a larger set of people.
+
+### Iteration
+
+5. Address comments, discuss, and iterate on the document in the PR.
+6. Gather explicit approvals from relevant stakeholders. This should be the set
+   of people that you identified at step 3. or folks that noticed your design
+   document from the (optional) announcement.
 
 ### Finalization
 
-6. Announce the intent to close commenting on the design document in
-   #eng-announce. Tag people that should be aware of the design and ask for
-   their feedback.
-7. Allow two business days for any final comments.
-8. If no comments have raised new issues or if no one has asked for additional
-   time to review, merge the design document.
+7. If no comments have raised new issues or if no one has asked for additional
+   time to review, merge the design document. Do _not_ assume _silent
+   consensus_: if you did not hear back from important stakeholders, don't take
+   this as approval. Make sure the relevant people have in fact seen your design
+   and had a chance to object or propose changes.
 
 ## How should you push back on aspects of a design document?
 

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -151,6 +151,20 @@ example, the [`persist` lectures
 slides and a talk track can be a more efficient means of communicating some
 types of technical content.
 
-## How should you push back on aspects of a design document?
+## How should you review a design document?
 
-Consult the draft [Raising an objection about a design](https://rustacean-principles.netlify.app/how_to_rustacean/show_up/raising_an_objection.html) Rustacean doc for guidance.
+As a reviewer, you play a key role in making the design review process a
+pleasant and productive experience:
+
+ - Keep the goals and non-goals outlined above in mind. We need authors and
+   reviewers aligned on the overall expectations for design documents in order
+   for the overall process to be productive.
+ - If you can only provide input on parts of the design doc, point that out
+   explicitly and focus on those areas.
+ - Avoid [bikeshedding](https://bikeshed.com). Bikeshedding can drain the
+   author's energy without adding any value.
+
+If you don't know how to productively push back on aspects of a design
+document, consult the draft [Raising an objection about a
+design](https://rustacean-principles.netlify.app/how_to_rustacean/show_up/raising_an_objection.html)
+Rustacean doc for guidance.

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -1,73 +1,91 @@
+# Design Process
 
-# What's the purpose of a design document?
+## What's the purpose of a design document?
 
-A design doc is a tool for the author to explain and gather feedback on a technical
-decision, providing an opportunity for anything they hadn't thought of to be
-surfaced early on and to have their thinking validated. It also serves as
+A design doc is a tool for the author to explain and gather feedback on a
+technical decision, providing an opportunity for anything they hadn't thought of
+to be surfaced early on and to have their thinking validated. It also serves as
 historical documentation for why a thing was done a certain way. The idea is to
-go slower at the beginning and get everything out on the table so we can go
-fast when implementing.
+go slower at the beginning and get everything out on the table so we can go fast
+when implementing.
 
-Design docs should contain enough information that a coworker could both justify and do the implementation rather than the author: this is a step along the path of transferring the work that makes it more likely "we", collectively, understand what we are looking at.
-It should record enough information that a coworker could review, diagnose, and debug the implementation of the design.
-A great design would have this property, that it acts as a map for understanding and fixing the feature, as well as implementing it.
+Design docs should contain enough information that a coworker could both justify
+and do the implementation rather than the author: this is a step along the path
+of transferring the work that makes it more likely "we", collectively,
+understand what we are looking at. It should record enough information that a
+coworker could review, diagnose, and debug the implementation of the design. A
+great design would have this property, that it acts as a map for understanding
+and fixing the feature, as well as implementing it.
 
-Design docs go hand in hand with a discussion meeting. Asynchronous,
-text-only communication tends to drag out the process and doesn't get the
-same kind of broad feedback as having a short, in-person meeting.
+Design docs go hand in hand with a discussion meeting. Asynchronous, text-only
+communication tends to drag out the process and doesn't get the same kind of
+broad feedback as having a short, in-person meeting.
 
-It's not expected that all questions will be answered prior to the meeting,
-but the meeting should not be an open-ended brainstorming process. There is
-upfront work that goes into the doc (see [template](./00000000_template.md)) to allow for a productive
-meeting, and it's best if attendees have time to read and digest the doc
-prior to the meeting.
+It's not expected that all questions will be answered prior to the meeting, but
+the meeting should not be an open-ended brainstorming process. There is upfront
+work that goes into the doc (see [template](./00000000_template.md)) to allow
+for a productive meeting, and it's best if attendees have time to read and
+digest the doc prior to the meeting.
 
 Note that design doc meetings are not an approval board or review body and the
-process is not design by committee. The author is responsible for driving to
-a conclusion. That doesn't mean that the author is solely responsible for
-making a decision, but does mean that the author is responsible for getting
-the knowledge they need to understand the space (from e.g., talking to peers),
-ensuring that critical concerns or open questions are addressed, and
-determining at what point a good decision has been reached. Not every design
-doc will lead to complete consensus.
+process is not design by committee. The author is responsible for driving to a
+conclusion. That doesn't mean that the author is solely responsible for making a
+decision, but does mean that the author is responsible for getting the knowledge
+they need to understand the space (from e.g., talking to peers), ensuring that
+critical concerns or open questions are addressed, and determining at what point
+a good decision has been reached. Not every design doc will lead to complete
+consensus.
 
 Examples:
 * [Cluster SQL API](https://github.com/MaterializeInc/materialize/pull/10680)
 * [`WITH MUTUALLY RECURSIVE`](https://github.com/MaterializeInc/materialize/pull/16445)
 
-# When should you make a design document?
+## When should you make a design document?
 
-Design docs should be written for all changes where an implementation does not immediately follow from the problem.
+Design docs should be written for all changes where an implementation does not
+immediately follow from the problem.
+
 Some specific times when you should write a design document:
+
 1. If the change is large/cross-cutting, e.g., will be spread over multiple PRs.
-2. If the change will take more than a week to implement or will proceed in phases that need clearly delimited scope.
+2. If the change will take more than a week to implement or will proceed in
+   phases that need clearly delimited scope.
 3. If there are multiple alternative implementations and no clear best option.
 4. If it's going to involve multiple people coordinating changes.
-5. If it changes a customer-facing/public API, or a major private API (for example, the API for implementing new sinks).
+5. If it changes a customer-facing/public API, or a major private API (for
+   example, the API for implementing new sinks).
 
-Many smaller changes do still benefit from a quick design doc to clarify thinking.
-Err on the side of writing a design document.
+Many smaller changes do still benefit from a quick design doc to clarify
+thinking. Err on the side of writing a design document.
 
-# How should you make a design document?
+## How should you make a design document?
 
-## Creation
-1. Copy the [template](./00000000_template.md) to a new date-prefixed file in `doc/developer/design` and fill it in.
-2. Submit a pull request---this makes it easy for others to add written comments.
+### Creation
+
+1. Copy the [template](./00000000_template.md) to a new date-prefixed file in
+   `doc/developer/design` and fill it in.
+2. Submit a pull request -- this makes it easy for others to add written
+   comments.
 3. Announce that the design doc is ready for review in #eng-announce.
 
-## Discussion
+### Discussion
+
 4. Address comments, discuss, and iterate on the document in the PR.
-5. Gather explicit approvals from relevant stakeholders.
-   Typically, there is a small set of people who have a vested interest in the area the design touches.
-   If it's not clear who that is, ask a TL, EM, or in #eng-general.
-6. Keep the design doc open while working on the feature and keep it updated as you're refining the design.
+5. Gather explicit approvals from relevant stakeholders. Typically, there is a
+   small set of people who have a vested interest in the area the design
+   touches. If it's not clear who that is, ask a TL, EM, or in #eng-general.
+6. Keep the design doc open while working on the feature and keep it updated as
+   you're refining the design.
 
-## Finalization
-6. Announce the intent to close commenting on the design document in #eng-announce.
-   Tag people that should be aware of the design and ask for their feedback.
+### Finalization
+
+6. Announce the intent to close commenting on the design document in
+   #eng-announce. Tag people that should be aware of the design and ask for
+   their feedback.
 7. Allow two business days for any final comments.
-8. If no comments have raised new issues or if no one has asked for additional time to review, merge the design document.
+8. If no comments have raised new issues or if no one has asked for additional
+   time to review, merge the design document.
 
-# How should you push back on aspects of a design document?
+## How should you push back on aspects of a design document?
 
 Consult the draft [Raising an objection about a design](https://rustacean-principles.netlify.app/how_to_rustacean/show_up/raising_an_objection.html) Rustacean doc for guidance.

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -107,8 +107,8 @@ thinking. Err on the side of writing a design document.
 3. "Socialize" the design with relevant stakeholders. Typically, there is a
    small set of people who have a vested interest in the area the design
    touches. If it's not clear who that is, ask your TL, EM, or in #eng-general.
-4. (Optional) Announce that the design doc is ready for review in #eng-announce,
-   if you think it's helpful to surface the design to a larger set of people.
+4. Announce that the design doc is ready for review in #eng-announce, if you
+   think it's helpful to surface the design to a larger set of people.
 
 ### Iteration
 

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -40,10 +40,18 @@ Summary of the goals of a design document:
  - Record context and assumptions.
  - Achieve a (reasonable) level of consensus around a design.
  - Record decisions.
- - Document a chosen design and lay out _some_ of the technical details: this
-   is sufficiently vague and requires some _intuition_ from the writer. This
-   point depends on the target audience and the nature of the design/change
-   that is being proposed.
+ - Document a chosen design and lay out _some_ of the technical details.
+
+The last point is intentionally vague and requires some _intuition_ from the
+writer. The appropriate level of technical detail depends on the target
+reviewers and the nature of the design/change that is being proposed.
+
+Ask your tech lead if you are unsure about the right level of technical detail.
+A good rule of thumb is that you should strive for the *minimum* level of
+detail that fully communicates the proposal to your reviewers. Going into too
+much detail has a cost: it takes longer to write the document and longer to
+review the document, plus the finest details are those that are most likely to
+change during implementation.
 
 ## Non-Goals
 

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -9,14 +9,6 @@ historical documentation for why a thing was done a certain way. The idea is to
 go slower at the beginning and get everything out on the table so we can go fast
 when implementing.
 
-Design docs should contain enough information that a coworker could both justify
-and do the implementation rather than the author: this is a step along the path
-of transferring the work that makes it more likely "we", collectively,
-understand what we are looking at. It should record enough information that a
-coworker could review, diagnose, and debug the implementation of the design. A
-great design would have this property, that it acts as a map for understanding
-and fixing the feature, as well as implementing it.
-
 Design docs go hand in hand with a discussion meeting. Asynchronous, text-only
 communication tends to drag out the process and doesn't get the same kind of
 broad feedback as having a short, in-person meeting.
@@ -40,6 +32,34 @@ Examples:
 * [Cluster SQL API](https://github.com/MaterializeInc/materialize/pull/10680)
 * [`WITH MUTUALLY RECURSIVE`](https://github.com/MaterializeInc/materialize/pull/16445)
 
+## Goals
+
+Summary of the goals of a design document:
+
+ - Record context and assumptions.
+ - Achieve a (reasonable) level of consensus around a design.
+ - Record decisions.
+ - Document a chosen design and lay out _some_ of the technical details: this
+   is sufficiently vague and requires some _intuition_ from the writer. This
+   point depends on the target audience and the nature of the design/change
+   that is being proposed.
+
+## Non-Goals
+
+These are not explicitly required for a good design document. You should,
+however, use your own judgement to determine what is and isn't required for
+your specific case.
+
+ - Allow a drive-by commenter without any context to fully understand the
+   design: the intention is that a group of people with common context can come
+   together, understand the design and come to a decision. Some context might
+   be gathered from previous design documents, from reference documentation, or
+   from looking at the code.
+ - Provide a fully spec'ed reference implementation: depending on the topic, it
+   can be very helpful to prepare a prototype. Both for validating the design
+   and for presenting it to others. However, it is not always a required part
+   of the design.
+
 ## When should you make a design document?
 
 Design docs should be written for all changes where an implementation does not
@@ -47,13 +67,18 @@ immediately follow from the problem.
 
 Some specific times when you should write a design document:
 
+Definitely write a design document:
+
+1. If it's going to involve multiple people and/or teams coordinating changes.
+2. If there are multiple alternative implementations and no clear best option.
+3. If it changes a customer-facing/public API, or a major private API (for
+   example, the API for implementing new sinks).
+
+Consider writing a design document:
+
 1. If the change is large/cross-cutting, e.g., will be spread over multiple PRs.
 2. If the change will take more than a week to implement or will proceed in
    phases that need clearly delimited scope.
-3. If there are multiple alternative implementations and no clear best option.
-4. If it's going to involve multiple people and/or teams coordinating changes.
-5. If it changes a customer-facing/public API, or a major private API (for
-   example, the API for implementing new sinks).
 
 Many smaller changes do still benefit from a quick design doc to clarify
 thinking. Err on the side of writing a design document.

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -74,8 +74,6 @@ thinking. Err on the side of writing a design document.
 5. Gather explicit approvals from relevant stakeholders. Typically, there is a
    small set of people who have a vested interest in the area the design
    touches. If it's not clear who that is, ask a TL, EM, or in #eng-general.
-6. Keep the design doc open while working on the feature and keep it updated as
-   you're refining the design.
 
 ### Finalization
 

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -93,7 +93,8 @@ Consider writing a design document:
    phases that need clearly delimited scope.
 
 Many smaller changes do still benefit from a quick design doc to clarify
-thinking. Err on the side of writing a design document.
+thinking. Err on the side of writing a design document. If in doubt, keep it
+short.
 
 ## How should you make a design document?
 
@@ -117,13 +118,36 @@ thinking. Err on the side of writing a design document.
    of people that you identified at step 3. or folks that noticed your design
    document from the (optional) announcement.
 
-### Finalization
+### Request approval
 
 7. If no comments have raised new issues or if no one has asked for additional
    time to review, merge the design document. Do _not_ assume _silent
    consensus_: if you did not hear back from important stakeholders, don't take
    this as approval. Make sure the relevant people have in fact seen your design
    and had a chance to object or propose changes.
+
+## Refinement
+
+If you discover substantial flaws in your design during implementation, update
+the design document, open a PR with the changes, and repeat steps 3-7.
+
+For minor errors, just correct the design document in place in your
+implementation PRs.
+
+Use your judgment as to which scenario applies.
+
+## Finalization
+
+You should **not** maintain the design doc forever. The doc is meant to be a
+point-in-time artifact that describes the historical context for the design.
+Once the described work is complete, you can stop updating the design doc.
+
+Instead, invest in evergreen content. Add comments in the code itself (module
+comments can be particularly valuable) and reference documentation in
+[doc/developer/reference](/doc/developer/reference/README.md). For larger
+components, consider putting together an architecture presentation (see, for
+example, the `persist` lectures); slides and a talk track can be a more
+efficient means of communicating some types of technical content.
 
 ## How should you push back on aspects of a design document?
 

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -28,9 +28,10 @@ critical concerns or open questions are addressed, and determining at what point
 a good decision has been reached. Not every design doc will lead to complete
 consensus.
 
-Examples:
-* [Cluster SQL API](https://github.com/MaterializeInc/materialize/pull/10680)
-* [`WITH MUTUALLY RECURSIVE`](https://github.com/MaterializeInc/materialize/pull/16445)
+Examples (some "in spirit", because the design doc template changed over time):
+* [External Introspection](./20230227_external_introspection.md)
+* [`WITH MUTUALLY RECURSIVE`](./20221204_with_mutually_recursive.md)
+* [Postgres Sources](./20210412_postgres_sources.md)
 
 ## Goals
 


### PR DESCRIPTION
### Motivation

 - Make the process more lightweight
 - Reflect recent discussions around what the goals of the design process should be

This is hopefully iterating us in the right direction, but we should keep iterating when needed. Some of the wording/ideas has been influenced by reading https://www.industrialempathy.com/posts/design-docs-at-google/ and other articles.

The changes are quite small/incremental but there is a light pivot away from trying to provide complete reference implementations in the design towards recording context and decisions, while still also describing the technical design.

Changes to the README each have their own description in the git message (summarized here):
 - don't require design doc PRs to stay open during implementation (motivation: be less prescriptive)
 - clarify lifecycle, give some hints about required approval and where to get it (motivation: this is recording current practice)
 - clearly spell out goals in README, which includes the aforementioned pivot (see Goals below)

I'm copying the Goals/No-Goals that are laid out in `README.md` below:

## Goals

Summary of the goals of a design document:

 - Record context and assumptions.
 - Achieve a (reasonable) level of consensus around a design.
 - Record decisions.
 - Document a chosen design and lay out _some_ of the technical details: this
   is sufficiently vague and requires some _intuition_ from the writer. This
   point depends on the target audience and the nature of the design/change
   that is being proposed.

## Non-Goals

These are not explicitly required for a good design document. You should,
however, use your own judgement to determine what is and isn't required for
your specific case.

 - Allow a drive-by commenter without any context to fully understand the
   design: the intention is that a group of people with common context can come
   together, understand the design and come to a decision. Some context might
   be gathered from previous design documents, from reference documentation, or
   from looking at the code.
 - Provide a fully spec'ed reference implementation: depending on the topic, it
   can be very helpful to prepare a prototype. Both for validating the design
   and for presenting it to others. However, it is not always a required part
   of the design.