### PR TITLE
sql: Add ALL keyword to grant and revoke stmts

### DIFF
--- a/doc/user/content/sql/grant-privilege.md
+++ b/doc/user/content/sql/grant-privilege.md
@@ -38,6 +38,7 @@ _role_name_   | The role name that is gaining privileges. Use the `PUBLIC` pseud
 **DELETE**    | Allows deleting from an object (requires **SELECT** if a read is necessary). The abbreviation for this privilege is 'd'.
 **CREATE**    | Allows creating a new object within another object. The abbreviation for this privilege is 'C'.
 **USAGE**     | Allows using an object or looking up members of an object. The abbreviation for this privilege is 'U'.
+**ALL**       | All applicable privileges for the provided object type.
 
 ## Details
 
@@ -69,11 +70,15 @@ type for sources, views, and materialized views, or omit the object type.
 ## Examples
 
 ```sql
-GRANT SELECT ON mv TO joe;
+GRANT SELECT ON mv TO joe, mike;
 ```
 
 ```sql
 GRANT USAGE, CREATE ON DATABASE materialize TO joe;
+```
+
+```sql
+GRANT ALL ON CLUSTER dev TO joe;
 ```
 
 ## Related pages

--- a/doc/user/content/sql/revoke-privilege.md
+++ b/doc/user/content/sql/revoke-privilege.md
@@ -33,6 +33,7 @@ _role_name_   | The role name that is losing privileges. Use the `PUBLIC` pseudo
 **DELETE**    | Allows deleting from an object (requires **SELECT** if a read is necessary). The abbreviation for this privilege is 'd'.
 **CREATE**    | Allows creating a new object within another object. The abbreviation for this privilege is 'C'.
 **USAGE**     | Allows using an object or looking up members of an object. The abbreviation for this privilege is 'U'.
+**ALL**       | All applicable privileges for the provided object type.
 
 ## Details
 
@@ -69,12 +70,17 @@ type for sources, views, and materialized views, or omit the object type.
 ## Examples
 
 ```sql
-REVOKE SELECT ON mv FROM joe;
+REVOKE SELECT ON mv FROM joe, mike;
 ```
 
 ```sql
-REVOKE USAGE, CREATE ON DATABASE materialize TO joe;
+REVOKE USAGE, CREATE ON DATABASE materialize FROM joe;
 ```
+
+```sql
+REVOKE ALL ON CLUSTER dev FROM joe;
+```
+
 
 ## Related pages
 

--- a/doc/user/layouts/partials/sql-grammar/grant-privilege.svg
+++ b/doc/user/layouts/partials/sql-grammar/grant-privilege.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="495" height="519">
+<svg xmlns="http://www.w3.org/2000/svg" width="517" height="629">
    <polygon points="9 61 1 57 1 65"/>
    <polygon points="17 61 9 57 9 65"/>
    <rect x="31" y="47" width="70" height="32" rx="10"/>
@@ -9,108 +9,124 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="65">GRANT</text>
-   <rect x="141" y="47" width="76" height="32"/>
-   <rect x="139" y="45" width="76" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="149" y="65">privilege</text>
-   <rect x="141" y="3" width="24" height="32" rx="10"/>
-   <rect x="139"
+   <rect x="161" y="47" width="76" height="32"/>
+   <rect x="159" y="45" width="76" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="169" y="65">privilege</text>
+   <rect x="161" y="3" width="24" height="32" rx="10"/>
+   <rect x="159"
          y="1"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="149" y="21">,</text>
-   <rect x="257" y="47" width="40" height="32"/>
-   <rect x="255" y="45" width="40" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="265" y="65">ON</text>
-   <rect x="337" y="79" width="66" height="32" rx="10"/>
-   <rect x="335"
-         y="77"
+   <text class="terminal" x="169" y="21">,</text>
+   <rect x="141" y="91" width="46" height="32" rx="10"/>
+   <rect x="139"
+         y="89"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="149" y="109">ALL</text>
+   <rect x="227" y="123" width="102" height="32" rx="10"/>
+   <rect x="225"
+         y="121"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="235" y="141">PRIVILEGES</text>
+   <rect x="389" y="47" width="40" height="32"/>
+   <rect x="387" y="45" width="40" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="397" y="65">ON</text>
+   <rect x="45" y="221" width="66" height="32" rx="10"/>
+   <rect x="43"
+         y="219"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="345" y="97">TABLE</text>
-   <rect x="337" y="123" width="56" height="32" rx="10"/>
-   <rect x="335"
-         y="121"
+   <text class="terminal" x="53" y="239">TABLE</text>
+   <rect x="45" y="265" width="56" height="32" rx="10"/>
+   <rect x="43"
+         y="263"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="345" y="141">TYPE</text>
-   <rect x="337" y="167" width="76" height="32" rx="10"/>
-   <rect x="335"
-         y="165"
+   <text class="terminal" x="53" y="283">TYPE</text>
+   <rect x="45" y="309" width="76" height="32" rx="10"/>
+   <rect x="43"
+         y="307"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="345" y="185">SECRET</text>
-   <rect x="337" y="211" width="116" height="32" rx="10"/>
-   <rect x="335"
-         y="209"
+   <text class="terminal" x="53" y="327">SECRET</text>
+   <rect x="45" y="353" width="116" height="32" rx="10"/>
+   <rect x="43"
+         y="351"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="345" y="229">CONNECTION</text>
-   <rect x="337" y="255" width="98" height="32" rx="10"/>
-   <rect x="335"
-         y="253"
+   <text class="terminal" x="53" y="371">CONNECTION</text>
+   <rect x="45" y="397" width="98" height="32" rx="10"/>
+   <rect x="43"
+         y="395"
          width="98"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="345" y="273">DATABASE</text>
-   <rect x="337" y="299" width="82" height="32" rx="10"/>
-   <rect x="335"
-         y="297"
+   <text class="terminal" x="53" y="415">DATABASE</text>
+   <rect x="45" y="441" width="82" height="32" rx="10"/>
+   <rect x="43"
+         y="439"
          width="82"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="345" y="317">SCHEMA</text>
-   <rect x="337" y="343" width="84" height="32" rx="10"/>
-   <rect x="335"
-         y="341"
+   <text class="terminal" x="53" y="459">SCHEMA</text>
+   <rect x="45" y="485" width="84" height="32" rx="10"/>
+   <rect x="43"
+         y="483"
          width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="345" y="361">CLUSTER</text>
-   <rect x="25" y="453" width="104" height="32"/>
-   <rect x="23" y="451" width="104" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="33" y="471">object_name</text>
-   <rect x="149" y="453" width="40" height="32" rx="10"/>
-   <rect x="147"
-         y="451"
+   <text class="terminal" x="53" y="503">CLUSTER</text>
+   <rect x="201" y="189" width="104" height="32"/>
+   <rect x="199" y="187" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="209" y="207">object_name</text>
+   <rect x="325" y="189" width="40" height="32" rx="10"/>
+   <rect x="323"
+         y="187"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="157" y="471">TO</text>
-   <rect x="229" y="485" width="70" height="32" rx="10"/>
-   <rect x="227"
-         y="483"
+   <text class="terminal" x="333" y="207">TO</text>
+   <rect x="405" y="221" width="70" height="32" rx="10"/>
+   <rect x="403"
+         y="219"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="237" y="503">GROUP</text>
-   <rect x="359" y="453" width="88" height="32"/>
-   <rect x="357" y="451" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="367" y="471">role_name</text>
-   <rect x="359" y="409" width="24" height="32" rx="10"/>
-   <rect x="357"
-         y="407"
+   <text class="terminal" x="413" y="239">GROUP</text>
+   <rect x="381" y="595" width="88" height="32"/>
+   <rect x="379" y="593" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="389" y="613">role_name</text>
+   <rect x="381" y="551" width="24" height="32" rx="10"/>
+   <rect x="379"
+         y="549"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="367" y="427">,</text>
+   <text class="terminal" x="389" y="569">,</text>
    <path class="line"
-         d="m17 61 h2 m0 0 h10 m70 0 h10 m20 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m20 44 h10 m40 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m66 0 h10 m0 0 h50 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m56 0 h10 m0 0 h60 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m76 0 h10 m0 0 h40 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m98 0 h10 m0 0 h18 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m82 0 h10 m0 0 h34 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m84 0 h10 m0 0 h32 m22 -296 l2 0 m2 0 l2 0 m2 0 l2 0 m-492 406 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m104 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m40 -32 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m23 44 h-3"/>
-   <polygon points="485 467 493 463 493 471"/>
-   <polygon points="485 467 477 463 477 471"/>
+         d="m17 61 h2 m0 0 h10 m70 0 h10 m40 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m20 44 h92 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m46 0 h10 m20 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m40 -76 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-448 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m66 0 h10 m0 0 h50 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m56 0 h10 m0 0 h60 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m76 0 h10 m0 0 h40 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m98 0 h10 m0 0 h18 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m82 0 h10 m0 0 h34 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m84 0 h10 m0 0 h32 m20 -296 h10 m104 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-178 406 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m23 44 h-3"/>
+   <polygon points="507 609 515 605 515 613"/>
+   <polygon points="507 609 499 605 499 613"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/revoke-privilege.svg
+++ b/doc/user/layouts/partials/sql-grammar/revoke-privilege.svg
@@ -1,116 +1,132 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="515" height="519">
-   <polygon points="11 61 3 57 3 65"/>
-   <polygon points="19 61 11 57 11 65"/>
-   <rect x="33" y="47" width="78" height="32" rx="10"/>
-   <rect x="31"
+<svg xmlns="http://www.w3.org/2000/svg" width="537" height="629">
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="78" height="32" rx="10"/>
+   <rect x="29"
          y="45"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="65">REVOKE</text>
-   <rect x="151" y="47" width="76" height="32"/>
-   <rect x="149" y="45" width="76" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="159" y="65">privilege</text>
-   <rect x="151" y="3" width="24" height="32" rx="10"/>
-   <rect x="149"
+   <text class="terminal" x="39" y="65">REVOKE</text>
+   <rect x="169" y="47" width="76" height="32"/>
+   <rect x="167" y="45" width="76" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="177" y="65">privilege</text>
+   <rect x="169" y="3" width="24" height="32" rx="10"/>
+   <rect x="167"
          y="1"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="159" y="21">,</text>
-   <rect x="267" y="47" width="40" height="32"/>
-   <rect x="265" y="45" width="40" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="275" y="65">ON</text>
-   <rect x="347" y="79" width="66" height="32" rx="10"/>
-   <rect x="345"
-         y="77"
+   <text class="terminal" x="177" y="21">,</text>
+   <rect x="149" y="91" width="46" height="32" rx="10"/>
+   <rect x="147"
+         y="89"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="157" y="109">ALL</text>
+   <rect x="235" y="123" width="102" height="32" rx="10"/>
+   <rect x="233"
+         y="121"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="243" y="141">PRIVILEGES</text>
+   <rect x="397" y="47" width="40" height="32"/>
+   <rect x="395" y="45" width="40" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="405" y="65">ON</text>
+   <rect x="45" y="221" width="66" height="32" rx="10"/>
+   <rect x="43"
+         y="219"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="355" y="97">TABLE</text>
-   <rect x="347" y="123" width="56" height="32" rx="10"/>
-   <rect x="345"
-         y="121"
+   <text class="terminal" x="53" y="239">TABLE</text>
+   <rect x="45" y="265" width="56" height="32" rx="10"/>
+   <rect x="43"
+         y="263"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="355" y="141">TYPE</text>
-   <rect x="347" y="167" width="76" height="32" rx="10"/>
-   <rect x="345"
-         y="165"
+   <text class="terminal" x="53" y="283">TYPE</text>
+   <rect x="45" y="309" width="76" height="32" rx="10"/>
+   <rect x="43"
+         y="307"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="355" y="185">SECRET</text>
-   <rect x="347" y="211" width="116" height="32" rx="10"/>
-   <rect x="345"
-         y="209"
+   <text class="terminal" x="53" y="327">SECRET</text>
+   <rect x="45" y="353" width="116" height="32" rx="10"/>
+   <rect x="43"
+         y="351"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="355" y="229">CONNECTION</text>
-   <rect x="347" y="255" width="98" height="32" rx="10"/>
-   <rect x="345"
-         y="253"
+   <text class="terminal" x="53" y="371">CONNECTION</text>
+   <rect x="45" y="397" width="98" height="32" rx="10"/>
+   <rect x="43"
+         y="395"
          width="98"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="355" y="273">DATABASE</text>
-   <rect x="347" y="299" width="82" height="32" rx="10"/>
-   <rect x="345"
-         y="297"
+   <text class="terminal" x="53" y="415">DATABASE</text>
+   <rect x="45" y="441" width="82" height="32" rx="10"/>
+   <rect x="43"
+         y="439"
          width="82"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="355" y="317">SCHEMA</text>
-   <rect x="347" y="343" width="84" height="32" rx="10"/>
-   <rect x="345"
-         y="341"
+   <text class="terminal" x="53" y="459">SCHEMA</text>
+   <rect x="45" y="485" width="84" height="32" rx="10"/>
+   <rect x="43"
+         y="483"
          width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="355" y="361">CLUSTER</text>
-   <rect x="25" y="453" width="104" height="32"/>
-   <rect x="23" y="451" width="104" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="33" y="471">object_name</text>
-   <rect x="149" y="453" width="60" height="32" rx="10"/>
-   <rect x="147"
-         y="451"
+   <text class="terminal" x="53" y="503">CLUSTER</text>
+   <rect x="201" y="189" width="104" height="32"/>
+   <rect x="199" y="187" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="209" y="207">object_name</text>
+   <rect x="325" y="189" width="60" height="32" rx="10"/>
+   <rect x="323"
+         y="187"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="157" y="471">FROM</text>
-   <rect x="249" y="485" width="70" height="32" rx="10"/>
-   <rect x="247"
-         y="483"
+   <text class="terminal" x="333" y="207">FROM</text>
+   <rect x="425" y="221" width="70" height="32" rx="10"/>
+   <rect x="423"
+         y="219"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="257" y="503">GROUP</text>
-   <rect x="379" y="453" width="88" height="32"/>
-   <rect x="377" y="451" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="387" y="471">role_name</text>
-   <rect x="379" y="409" width="24" height="32" rx="10"/>
-   <rect x="377"
-         y="407"
+   <text class="terminal" x="433" y="239">GROUP</text>
+   <rect x="401" y="595" width="88" height="32"/>
+   <rect x="399" y="593" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="409" y="613">role_name</text>
+   <rect x="401" y="551" width="24" height="32" rx="10"/>
+   <rect x="399"
+         y="549"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="387" y="427">,</text>
+   <text class="terminal" x="409" y="569">,</text>
    <path class="line"
-         d="m19 61 h2 m0 0 h10 m78 0 h10 m20 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m20 44 h10 m40 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m66 0 h10 m0 0 h50 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m56 0 h10 m0 0 h60 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m76 0 h10 m0 0 h40 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m98 0 h10 m0 0 h18 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m82 0 h10 m0 0 h34 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m84 0 h10 m0 0 h32 m22 -296 l2 0 m2 0 l2 0 m2 0 l2 0 m-502 406 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m104 0 h10 m0 0 h10 m60 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m40 -32 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m23 44 h-3"/>
-   <polygon points="505 467 513 463 513 471"/>
-   <polygon points="505 467 497 463 497 471"/>
+         d="m17 61 h2 m0 0 h10 m78 0 h10 m40 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m20 44 h92 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m46 0 h10 m20 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m40 -76 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-456 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m66 0 h10 m0 0 h50 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m56 0 h10 m0 0 h60 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m76 0 h10 m0 0 h40 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m98 0 h10 m0 0 h18 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m82 0 h10 m0 0 h34 m-146 -10 v20 m156 0 v-20 m-156 20 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m84 0 h10 m0 0 h32 m20 -296 h10 m104 0 h10 m0 0 h10 m60 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-178 406 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m23 44 h-3"/>
+   <polygon points="527 609 535 605 535 613"/>
+   <polygon points="527 609 519 605 519 613"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -214,7 +214,7 @@ format_spec ::=
   'TEXT' |
   'BYTES'
 grant_privilege ::=
-  'GRANT' privilege (',' privilege)* ON ('TABLE'? | 'TYPE' | 'SECRET' | 'CONNECTION' | 'DATABASE' | 'SCHEMA' | 'CLUSTER') object_name 'TO' 'GROUP'? role_name ( ',' role_name )*
+  'GRANT' ((privilege (',' privilege)*) | 'ALL' 'PRIVILEGES'? ) ON ('TABLE'? | 'TYPE' | 'SECRET' | 'CONNECTION' | 'DATABASE' | 'SCHEMA' | 'CLUSTER') object_name 'TO' 'GROUP'? role_name ( ',' role_name )*
 grant_role ::=
   'GRANT' role_name 'TO' 'GROUP'? member_name ( ',' member_name )*
 key_strat ::=
@@ -288,7 +288,7 @@ privilege ::=
 reset_session_variable ::=
   'RESET' variable_name
 revoke_privilege ::=
-  'REVOKE' privilege (',' privilege)* ON ('TABLE'? | 'TYPE' | 'SECRET' | 'CONNECTION' | 'DATABASE' | 'SCHEMA' | 'CLUSTER') object_name 'FROM' 'GROUP'? role_name ( ',' role_name )*
+  'REVOKE' ((privilege (',' privilege)*) | 'ALL' 'PRIVILEGES'? ) ON ('TABLE'? | 'TYPE' | 'SECRET' | 'CONNECTION' | 'DATABASE' | 'SCHEMA' | 'CLUSTER') object_name 'FROM' 'GROUP'? role_name ( ',' role_name )*
 revoke_role ::=
   'REVOKE' role_name 'FROM' 'GROUP'? member_name ( ',' member_name )*
 rollback ::=

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2882,11 +2882,29 @@ impl AstDisplay for Privilege {
 }
 impl_display!(Privilege);
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PrivilegeSpecification {
+    All,
+    Privileges(Vec<Privilege>),
+}
+
+impl AstDisplay for PrivilegeSpecification {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            PrivilegeSpecification::All => f.write_str("ALL"),
+            PrivilegeSpecification::Privileges(privileges) => {
+                f.write_node(&display::comma_separated(privileges))
+            }
+        }
+    }
+}
+impl_display!(PrivilegeSpecification);
+
 /// `GRANT ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GrantPrivilegeStatement<T: AstInfo> {
     /// The privileges being granted on an object.
-    pub privileges: Vec<Privilege>,
+    pub privileges: PrivilegeSpecification,
     /// The type of object.
     ///
     /// Note: For views, materialized views, and sources this will be [`ObjectType::Table`].
@@ -2900,7 +2918,7 @@ pub struct GrantPrivilegeStatement<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for GrantPrivilegeStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("GRANT ");
-        f.write_node(&display::comma_separated(&self.privileges));
+        f.write_node(&self.privileges);
         f.write_str(" ON ");
         f.write_node(&self.object_type);
         f.write_str(" ");
@@ -2915,7 +2933,7 @@ impl_display_t!(GrantPrivilegeStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RevokePrivilegeStatement<T: AstInfo> {
     /// The privileges being revoked.
-    pub privileges: Vec<Privilege>,
+    pub privileges: PrivilegeSpecification,
     /// The type of object.
     ///
     /// Note: For views, materialized views, and sources this will be [`ObjectType::Table`].
@@ -2929,7 +2947,7 @@ pub struct RevokePrivilegeStatement<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for RevokePrivilegeStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("REVOKE ");
-        f.write_node(&display::comma_separated(&self.privileges));
+        f.write_node(&self.privileges);
         f.write_str(" ON ");
         f.write_node(&self.object_type);
         f.write_str(" ");

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -263,6 +263,7 @@ Prefix
 Prepare
 Primary
 Privatelink
+Privileges
 Progress
 Protobuf
 Publication

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5941,7 +5941,7 @@ impl<'a> Parser<'a> {
     /// Parse a `GRANT` statement, assuming that the `GRANT` token
     /// has already been consumed.
     fn parse_grant(&mut self) -> Result<Statement<Raw>, ParserError> {
-        match self.parse_privileges() {
+        match self.parse_privilege_specification() {
             Some(privileges) => {
                 self.expect_keyword(ON)?;
                 // If the object type is omitted, then it is assumed to be a table.
@@ -5999,7 +5999,7 @@ impl<'a> Parser<'a> {
     /// Parse a `REVOKE` statement, assuming that the `REVOKE` token
     /// has already been consumed.
     fn parse_revoke(&mut self) -> Result<Statement<Raw>, ParserError> {
-        match self.parse_privileges() {
+        match self.parse_privilege_specification() {
             Some(privileges) => {
                 self.expect_keyword(ON)?;
                 // If the object type is omitted, then it is assumed to be a table.
@@ -6223,7 +6223,12 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse one or more privileges separated by a ','.
-    fn parse_privileges(&mut self) -> Option<Vec<Privilege>> {
+    fn parse_privilege_specification(&mut self) -> Option<PrivilegeSpecification> {
+        if self.parse_keyword(ALL) {
+            let _ = self.parse_keyword(PRIVILEGES);
+            return Some(PrivilegeSpecification::All);
+        }
+
         let mut privileges = Vec::new();
         while let Some(privilege) = self.parse_privilege() {
             privileges.push(privilege);
@@ -6235,7 +6240,7 @@ impl<'a> Parser<'a> {
         if privileges.is_empty() {
             None
         } else {
-            Some(privileges)
+            Some(PrivilegeSpecification::Privileges(privileges))
         }
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1996,7 +1996,7 @@ GRANT USAGE, CREATE ON CLUSTER foo TO joe
 ----
 GRANT USAGE, CREATE ON CLUSTER foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE, CREATE], object_type: Cluster, name: Cluster(Ident("foo")), roles: [Ident("joe")] })
+GrantPrivilege(GrantPrivilegeStatement { privileges: Privileges([USAGE, CREATE]), object_type: Cluster, name: Cluster(Ident("foo")), roles: [Ident("joe")] })
 
 parse-statement
 GRANT USAGE, CREATE ON CLUSTER REPLICA foo.r TO joe
@@ -2010,28 +2010,28 @@ GRANT CREATE ON DATABASE foo TO joe
 ----
 GRANT CREATE ON DATABASE foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [CREATE], object_type: Database, name: Database(UnresolvedDatabaseName(Ident("foo"))), roles: [Ident("joe")] })
+GrantPrivilege(GrantPrivilegeStatement { privileges: Privileges([CREATE]), object_type: Database, name: Database(UnresolvedDatabaseName(Ident("foo"))), roles: [Ident("joe")] })
 
 parse-statement
 GRANT USAGE ON SCHEMA foo TO joe
 ----
 GRANT USAGE ON SCHEMA foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Schema, name: Schema(UnresolvedSchemaName([Ident("foo")])), roles: [Ident("joe")] })
+GrantPrivilege(GrantPrivilegeStatement { privileges: Privileges([USAGE]), object_type: Schema, name: Schema(UnresolvedSchemaName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE foo TO joe
 ----
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [SELECT, INSERT, UPDATE, DELETE], object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
+GrantPrivilege(GrantPrivilegeStatement { privileges: Privileges([SELECT, INSERT, UPDATE, DELETE]), object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 GRANT USAGE ON foo TO joe
 ----
 GRANT USAGE ON TABLE foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
+GrantPrivilege(GrantPrivilegeStatement { privileges: Privileges([USAGE]), object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 GRANT USAGE ON SINK foo TO joe
@@ -2059,14 +2059,14 @@ GRANT USAGE ON SECRET foo TO joe
 ----
 GRANT USAGE ON SECRET foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Secret, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
+GrantPrivilege(GrantPrivilegeStatement { privileges: Privileges([USAGE]), object_type: Secret, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 GRANT USAGE ON CONNECTION foo TO joe
 ----
 GRANT USAGE ON CONNECTION foo TO joe
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Connection, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
+GrantPrivilege(GrantPrivilegeStatement { privileges: Privileges([USAGE]), object_type: Connection, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 GRANT SELECT ON VIEW foo TO joe
@@ -2094,21 +2094,36 @@ GRANT SELECT, INSERT ON t TO joe, mike
 ----
 GRANT SELECT, INSERT ON TABLE t TO joe, mike
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [SELECT, INSERT], object_type: Table, name: Item(UnresolvedItemName([Ident("t")])), roles: [Ident("joe"), Ident("mike")] })
+GrantPrivilege(GrantPrivilegeStatement { privileges: Privileges([SELECT, INSERT]), object_type: Table, name: Item(UnresolvedItemName([Ident("t")])), roles: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 GRANT USAGE ON DATABASE d TO joe, mike
 ----
 GRANT USAGE ON DATABASE d TO joe, mike
 =>
-GrantPrivilege(GrantPrivilegeStatement { privileges: [USAGE], object_type: Database, name: Database(UnresolvedDatabaseName(Ident("d"))), roles: [Ident("joe"), Ident("mike")] })
+GrantPrivilege(GrantPrivilegeStatement { privileges: Privileges([USAGE]), object_type: Database, name: Database(UnresolvedDatabaseName(Ident("d"))), roles: [Ident("joe"), Ident("mike")] })
+
+parse-statement
+GRANT ALL ON DATABASE d TO joe, mike
+----
+GRANT ALL ON DATABASE d TO joe, mike
+=>
+GrantPrivilege(GrantPrivilegeStatement { privileges: All, object_type: Database, name: Database(UnresolvedDatabaseName(Ident("d"))), roles: [Ident("joe"), Ident("mike")] })
+
+parse-statement
+GRANT ALL PRIVILEGES ON TYPE t TO joe
+----
+GRANT ALL ON TYPE t TO joe
+=>
+GrantPrivilege(GrantPrivilegeStatement { privileges: All, object_type: Type, name: Item(UnresolvedItemName([Ident("t")])), roles: [Ident("joe")] })
+
 
 parse-statement
 REVOKE USAGE, CREATE ON CLUSTER foo FROM joe
 ----
 REVOKE USAGE, CREATE ON CLUSTER foo FROM joe
 =>
-RevokePrivilege(RevokePrivilegeStatement { privileges: [USAGE, CREATE], object_type: Cluster, name: Cluster(Ident("foo")), roles: [Ident("joe")] })
+RevokePrivilege(RevokePrivilegeStatement { privileges: Privileges([USAGE, CREATE]), object_type: Cluster, name: Cluster(Ident("foo")), roles: [Ident("joe")] })
 
 parse-statement
 REVOKE USAGE, CREATE ON CLUSTER REPLICA foo.r FROM joe
@@ -2122,28 +2137,28 @@ REVOKE CREATE ON DATABASE foo FROM joe
 ----
 REVOKE CREATE ON DATABASE foo FROM joe
 =>
-RevokePrivilege(RevokePrivilegeStatement { privileges: [CREATE], object_type: Database, name: Database(UnresolvedDatabaseName(Ident("foo"))), roles: [Ident("joe")] })
+RevokePrivilege(RevokePrivilegeStatement { privileges: Privileges([CREATE]), object_type: Database, name: Database(UnresolvedDatabaseName(Ident("foo"))), roles: [Ident("joe")] })
 
 parse-statement
 REVOKE USAGE ON SCHEMA foo FROM joe
 ----
 REVOKE USAGE ON SCHEMA foo FROM joe
 =>
-RevokePrivilege(RevokePrivilegeStatement { privileges: [USAGE], object_type: Schema, name: Schema(UnresolvedSchemaName([Ident("foo")])), roles: [Ident("joe")] })
+RevokePrivilege(RevokePrivilegeStatement { privileges: Privileges([USAGE]), object_type: Schema, name: Schema(UnresolvedSchemaName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLE foo FROM joe
 ----
 REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLE foo FROM joe
 =>
-RevokePrivilege(RevokePrivilegeStatement { privileges: [SELECT, INSERT, UPDATE, DELETE], object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
+RevokePrivilege(RevokePrivilegeStatement { privileges: Privileges([SELECT, INSERT, UPDATE, DELETE]), object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 REVOKE USAGE ON foo FROM joe
 ----
 REVOKE USAGE ON TABLE foo FROM joe
 =>
-RevokePrivilege(RevokePrivilegeStatement { privileges: [USAGE], object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
+RevokePrivilege(RevokePrivilegeStatement { privileges: Privileges([USAGE]), object_type: Table, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 REVOKE USAGE ON SINK foo FROM joe
@@ -2171,14 +2186,14 @@ REVOKE USAGE ON SECRET foo FROM joe
 ----
 REVOKE USAGE ON SECRET foo FROM joe
 =>
-RevokePrivilege(RevokePrivilegeStatement { privileges: [USAGE], object_type: Secret, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
+RevokePrivilege(RevokePrivilegeStatement { privileges: Privileges([USAGE]), object_type: Secret, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 REVOKE USAGE ON CONNECTION foo FROM joe
 ----
 REVOKE USAGE ON CONNECTION foo FROM joe
 =>
-RevokePrivilege(RevokePrivilegeStatement { privileges: [USAGE], object_type: Connection, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
+RevokePrivilege(RevokePrivilegeStatement { privileges: Privileges([USAGE]), object_type: Connection, name: Item(UnresolvedItemName([Ident("foo")])), roles: [Ident("joe")] })
 
 parse-statement
 REVOKE SELECT ON VIEW foo FROM joe
@@ -2206,11 +2221,25 @@ REVOKE SELECT, INSERT ON t FROM joe, mike
 ----
 REVOKE SELECT, INSERT ON TABLE t FROM joe, mike
 =>
-RevokePrivilege(RevokePrivilegeStatement { privileges: [SELECT, INSERT], object_type: Table, name: Item(UnresolvedItemName([Ident("t")])), roles: [Ident("joe"), Ident("mike")] })
+RevokePrivilege(RevokePrivilegeStatement { privileges: Privileges([SELECT, INSERT]), object_type: Table, name: Item(UnresolvedItemName([Ident("t")])), roles: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 REVOKE USAGE ON DATABASE d FROM joe, mike
 ----
 REVOKE USAGE ON DATABASE d FROM joe, mike
 =>
-RevokePrivilege(RevokePrivilegeStatement { privileges: [USAGE], object_type: Database, name: Database(UnresolvedDatabaseName(Ident("d"))), roles: [Ident("joe"), Ident("mike")] })
+RevokePrivilege(RevokePrivilegeStatement { privileges: Privileges([USAGE]), object_type: Database, name: Database(UnresolvedDatabaseName(Ident("d"))), roles: [Ident("joe"), Ident("mike")] })
+
+parse-statement
+REVOKE ALL ON DATABASE d FROM joe, mike
+----
+REVOKE ALL ON DATABASE d FROM joe, mike
+=>
+RevokePrivilege(RevokePrivilegeStatement { privileges: All, object_type: Database, name: Database(UnresolvedDatabaseName(Ident("d"))), roles: [Ident("joe"), Ident("mike")] })
+
+parse-statement
+REVOKE ALL PRIVILEGES ON TYPE t FROM joe
+----
+REVOKE ALL ON TYPE t FROM joe
+=>
+RevokePrivilege(RevokePrivilegeStatement { privileges: All, object_type: Type, name: Item(UnresolvedItemName([Ident("t")])), roles: [Ident("joe")] })

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -1402,6 +1402,61 @@ SELECT name, privilege FROM item_privileges WHERE name = 't1'
 ----
 t1  mz_system=arwd/mz_system
 
+## Test ALL keyword
+
+simple conn=mz_system,user=mz_system
+GRANT ALL ON t1 TO joe, test_role, mz_system
+----
+COMPLETE 0
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't1'
+----
+t1  joe=arwd/mz_system
+t1  mz_system=arwd/mz_system
+t1  test_role=arwd/mz_system
+
+simple conn=mz_system,user=mz_system
+REVOKE ALL ON t1 FROM joe, test_role, other
+----
+COMPLETE 0
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 't1'
+----
+t1  mz_system=arwd/mz_system
+
+simple conn=mz_system,user=mz_system
+CREATE VIEW v1 AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v1'
+----
+v1  mz_system=r/mz_system
+
+simple conn=mz_system,user=mz_system
+GRANT ALL ON v1 TO joe
+----
+COMPLETE 0
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v1'
+----
+v1  joe=r/mz_system
+v1  mz_system=r/mz_system
+
+simple conn=mz_system,user=mz_system
+REVOKE ALL ON v1 FROM joe
+----
+COMPLETE 0
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'v1'
+----
+v1  mz_system=r/mz_system
+
 # Disable rbac checks.
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;


### PR DESCRIPTION
This commit adds the ALL keyword to the GRANT and REVOKE privilege statements. ALL is a shorthand for all applicable privileges for the specified object type.

Resolves #19162

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release will add the `ALL` keyword to GRANT and REVOKE privilege statements.
