### PR TITLE
adapter: Fix AS OF panics in transactions

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2229,7 +2229,7 @@ impl Coordinator {
         // OF or we're inside an explicit transaction. The latter case is
         // necessary to support PG's `BEGIN` semantics, whose behavior can
         // depend on whether or not reads have occurred in the txn.
-        if when == &QueryWhen::Immediately {
+        if when.is_transactional() {
             session.add_transaction_ops(TransactionOps::Peeks(
                 determination.timestamp_context.clone(),
             ))?;

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2229,12 +2229,13 @@ impl Coordinator {
         // OF or we're inside an explicit transaction. The latter case is
         // necessary to support PG's `BEGIN` semantics, whose behavior can
         // depend on whether or not reads have occurred in the txn.
-        if matches!(session.transaction(), &TransactionStatus::InTransaction(_))
-            || when == &QueryWhen::Immediately
-        {
+        if when == &QueryWhen::Immediately {
             session.add_transaction_ops(TransactionOps::Peeks(
                 determination.timestamp_context.clone(),
             ))?;
+        } else if matches!(session.transaction(), &TransactionStatus::InTransaction(_)) {
+            // If the query uses AS OF, then ignore the timestamp.
+            session.add_transaction_ops(TransactionOps::Peeks(TimestampContext::NoTimestamp))?;
         }
 
         let in_immediate_multi_stmt_txn = session.transaction().is_in_multi_statement_transaction()

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1035,6 +1035,13 @@ impl QueryWhen {
             }
         }
     }
+    /// Returns whether the selected timestamp should be tracked within the current transaction.
+    pub fn is_transactional(&self) -> bool {
+        match self {
+            QueryWhen::Immediately | QueryWhen::Freshest => true,
+            QueryWhen::AtLeastTimestamp(_) | QueryWhen::AtTimestamp(_) => false,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -611,3 +611,38 @@ SELECT * FROM rtr
 ----
 1
 1
+
+statement ok
+DELETE FROM t
+
+# AS OF should work in the middle of a transaction
+
+statement ok
+BEGIN
+
+query T
+SELECT * FROM t AS OF AT LEAST 1683131452106;
+----
+
+# Give t a chance to advance.
+statement ok
+SELECT mz_internal.mz_sleep(2)
+
+query T
+SELECT * FROM t AS OF AT LEAST 1683131452106;
+----
+
+query T
+SELECT * FROM t;
+----
+
+# Give t a chance to advance.
+statement ok
+SELECT mz_internal.mz_sleep(2)
+
+query T
+SELECT * FROM t AS OF AT LEAST 1683131452106;
+----
+
+statement ok
+COMMIT


### PR DESCRIPTION
Previously, executing `AS OF` in a read only transaction could trigger a panic. This was because the timestamp selected for the `AS OF` would conflict with timestamps selected in previous queries.

This commit fixes this panic by not comparing the timestamp used in `AS OF` queries against the timestamps of other queries in the same transaction.

Fixes #19180
Fixes #19178

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
