### PR TITLE
explain: support `mz_now()` on select from indexed table

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -275,7 +275,7 @@ impl Coordinator {
                 self.sequence_copy_rows(tx, session, id, columns, rows);
             }
             Plan::Explain(plan) => {
-                self.sequence_explain(tx, session, plan, depends_on);
+                self.sequence_explain(tx, session, plan, depends_on, target_cluster);
             }
             Plan::Insert(plan) => {
                 self.sequence_insert(tx, session, plan, depends_on).await;

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -761,3 +761,18 @@ WITH MUTUALLY RECURSIVE
     foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
     bar (a int) as (SELECT a FROM foo)
 SELECT * FROM bar;
+
+# Regression test for #19148: support mz_now() on select from indexed table
+statement ok
+DROP TABLE IF EXISTS t CASCADE;
+
+statement ok
+CREATE TABLE t(a TIMESTAMP);
+
+statement ok
+CREATE DEFAULT INDEX ON t;
+
+# EXPLAIN output is time-dependent, so we don't want show the output here, just
+# assert that the query doesn't fail.
+statement ok
+EXPLAIN SELECT * FROM t WHERE a < mz_now();


### PR DESCRIPTION
Opening this for discussion as a possible fix for #19148.

### Motivation

  * This PR fixes a recognized bug.

Fixes #19148 in a somewhat ad-hoc way. Hopefully we can arrive at a more stable solution as an outcome of #18089 and #18496.

### Tips for reviewer

1. I am calling `self.sequence_peek_timestamp` if the explainee is a `Query`.
2. The call hard-codes `when = &QueryWhen::Immediately` and `real_time_recency_ts = None`. I am not aware of contexts where this might be causing explain output that is inconsistent with the `sequence_~` logic.
3. I am also passing an extra `target_cluster: TargetCluster` to `sequence_explain` / `sequence_explain_plan` (this is needed in order to faithfully compute the `cluster_id` for one-shot selects).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - The `EXPLAIN` output now inlines values of unmaterializable functions for fast path plans rendered for the `EXPLAIN OPTIMIZED PLAN` stage and physical plans rendered for the `EXPLAIN PHYSICAL PLAN` stage.
