### PR TITLE
coverage: Also use clusterd binary when running SLT

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -57,9 +57,10 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
     mkdir -p coverage/
     chmod 777 coverage/
     # Not all tests contain all of these containers:
+    mzcompose cp sqllogictest:/usr/local/bin/sqllogictest coverage/ || true
+    mzcompose cp sqllogictest:/usr/local/bin/clusterd coverage/ || true
     mzcompose cp materialized:/usr/local/bin/environmentd coverage/ || true
     mzcompose cp materialized:/usr/local/bin/clusterd coverage/ || true
-    mzcompose cp sqllogictest:/usr/local/bin/sqllogictest coverage/ || true
     mzcompose cp testdrive:/usr/local/bin/testdrive coverage/ || true
 fi
 


### PR DESCRIPTION
As noticed in https://github.com/MaterializeInc/materialize/pull/18966

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
