### PR TITLE
ci: Reduce sqlsmith/sqlancer nightly runtimes to 50 min

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -601,7 +601,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
-          args: [--max-joins=1, --runtime=3300]
+          args: [--max-joins=1, --runtime=3000]
 
   - id: sqlsmith-explain
     label: "SQLsmith explain"
@@ -612,7 +612,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
-          args: [--max-joins=15, --explain-only, --runtime=3300]
+          args: [--max-joins=15, --explain-only, --runtime=3000]
 
   - id: sqlancer-pqs
     label: "SQLancer PQS"
@@ -623,7 +623,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
-          args: [--runtime=3300, --oracle=PQS, --no-qpg]
+          args: [--runtime=3000, --oracle=PQS, --no-qpg]
 
   - id: sqlancer-norec
     label: "SQLancer NoREC"
@@ -634,7 +634,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
-          args: [--runtime=3300, --oracle=NOREC]
+          args: [--runtime=3000, --oracle=NOREC]
 
   - id: sqlancer-query-partitioning
     label: "SQLancer QueryPartitioning"
@@ -645,7 +645,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
-          args: [--runtime=3300, --oracle=QUERY_PARTITIONING]
+          args: [--runtime=3000, --oracle=QUERY_PARTITIONING]
 
   - id: sqlancer-having
     label: "SQLancer Having"
@@ -656,7 +656,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
-          args: [--runtime=3300, --oracle=HAVING]
+          args: [--runtime=3000, --oracle=HAVING]
 
   - id: crdb-restarts
     label: "CRDB rolling restarts"


### PR DESCRIPTION
Sometimes they time out during cleanup, let's see if this is enough. We want the total time to stay under 1 hour for cost reasons

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
