### PR TITLE
Explicit error msg for WMR with `linear_chains`

### DIFF
--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -303,17 +303,7 @@ impl MirRelationExpr {
                 let head = body.as_ref();
 
                 if ctx.config.linear_chains {
-                    writeln!(f, "{}With Mutually Recursive", ctx.indent)?;
-                    ctx.indented(|ctx| {
-                        for (id, value) in bindings.iter() {
-                            writeln!(f, "{}cte {} =", ctx.indent, *id)?;
-                            ctx.indented(|ctx| value.fmt_text(f, ctx))?;
-                        }
-                        Ok(())
-                    })?;
-                    write!(f, "{}Return", ctx.indent)?;
-                    self.fmt_attributes(f, ctx)?;
-                    ctx.indented(|ctx| head.fmt_text(f, ctx))?;
+                    unreachable!(); // We exclude this case in `as_explain_single_plan`.
                 } else {
                     write!(f, "{}Return", ctx.indent)?;
                     self.fmt_attributes(f, ctx)?;

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -82,6 +82,7 @@ pub enum ExplainError {
     AnyhowError(anyhow::Error),
     RecursionLimitError(RecursionLimitError),
     SerdeJsonError(serde_json::Error),
+    LinearChainsPlusRecursive,
     UnknownError(String),
 }
 
@@ -103,6 +104,14 @@ impl fmt::Display for ExplainError {
             }
             ExplainError::SerdeJsonError(error) => {
                 write!(f, "{}", error)
+            }
+            ExplainError::LinearChainsPlusRecursive => {
+                write!(
+                    f,
+                    "The linear_chains option is not supported with WITH MUTUALLY RECURSIVE. \
+                If you would like to see added support, then please comment at \
+                https://github.com/MaterializeInc/materialize/issues/19012."
+                )
             }
             ExplainError::UnknownError(error) => {
                 write!(f, "{}", error)

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -753,3 +753,11 @@ Source materialize.public.r
   filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)
 
 EOF
+
+## linear_chains is currently disabled for WMR.
+statement error not supported
+EXPLAIN WITH(linear_chains)
+WITH MUTUALLY RECURSIVE
+    foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
+    bar (a int) as (SELECT a FROM foo)
+SELECT * FROM bar;


### PR DESCRIPTION
This is just a trivial change to print an explicit error msg if the user tries to EXPLAIN a WMR query with the `linear_chains` option, which is not implemented yet. (Before, it was a cryptic error msg that just mentioned shadowing.)

### Motivation

  * This PR prints a more explicit error msg for a recognized bug: https://github.com/MaterializeInc/materialize/issues/19012

### Tips for reviewer


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
