### PR TITLE
adapter: export `last_sse_time` from LD as a Prometheus metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "launchdarkly-server-sdk"
 version = "1.0.0"
-source = "git+https://github.com/MaterializeInc/rust-server-sdk#dcda26dad12a871795a6958ef238536c27c67164"
+source = "git+https://github.com/MaterializeInc/rust-server-sdk#5c36592edc75b620482a92e6991147aee7baf2d8"
 dependencies = [
  "built",
  "chrono",

--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -7,18 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::{
-    collections::BTreeMap,
-    sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use derivative::Derivative;
 use launchdarkly_server_sdk as ld;
 use prometheus::IntCounter;
 use tokio::time;
 
-use mz_ore::{metric, metrics::MetricsRegistry};
+use mz_ore::{
+    metric,
+    metrics::{MetricsRegistry, UIntGauge},
+    now::NowFn,
+};
 use mz_sql::catalog::{CloudProvider, EnvironmentId};
 
 use super::SynchronizedParameters;
@@ -39,6 +39,8 @@ pub struct SystemParameterFrontend {
     ld_key_map: BTreeMap<String, String>,
     /// Frontend metrics.
     ld_metrics: Metrics,
+    /// Function to return the current time.
+    now_fn: NowFn,
 }
 
 impl SystemParameterFrontend {
@@ -48,6 +50,7 @@ impl SystemParameterFrontend {
         registry: &MetricsRegistry,
         ld_sdk_key: &str,
         ld_key_map: BTreeMap<String, String>,
+        now_fn: NowFn,
     ) -> Result<Self, anyhow::Error> {
         let ld_metrics = Metrics::register_into(registry);
         let ld_config = ld::ConfigBuilder::new(ld_sdk_key)
@@ -55,15 +58,9 @@ impl SystemParameterFrontend {
                 let last_known_time_seconds = ld_metrics.last_known_time_seconds.clone();
                 let last_cse_time_seconds = ld_metrics.last_cse_time_seconds.clone();
                 Arc::new(move |result| {
-                    if let Ok(t_next) = u64::try_from(result.time_from_server / 1000) {
-                        let t_curr = last_known_time_seconds.get();
-                        if t_next > t_curr {
-                            last_known_time_seconds.inc_by(t_next - t_curr);
-                        }
-                        let t_curr = last_cse_time_seconds.get();
-                        if t_next > t_curr {
-                            last_cse_time_seconds.inc_by(t_next - t_curr);
-                        }
+                    if let Ok(ts) = u64::try_from(result.time_from_server / 1000) {
+                        last_known_time_seconds.set(ts);
+                        last_cse_time_seconds.set(ts);
                     } else {
                         tracing::warn!("Cannot convert time_from_server / 1000 from u128 to u64");
                     }
@@ -101,6 +98,7 @@ impl SystemParameterFrontend {
             ld_ctx,
             ld_key_map,
             ld_metrics,
+            now_fn,
         })
     }
 
@@ -116,18 +114,10 @@ impl SystemParameterFrontend {
         // received in a Prometheus metric.
         self.ld_client.start_with_default_executor_and_callback({
             let last_sse_time_seconds = self.ld_metrics.last_sse_time_seconds.clone();
+            let now_fn = self.now_fn.clone();
             Arc::new(move |_ev| {
-                if let Ok(t_next) = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .map(|duration| duration.as_secs())
-                {
-                    let t_curr = last_sse_time_seconds.get();
-                    if t_next > t_curr {
-                        last_sse_time_seconds.inc_by(t_next - t_curr);
-                    }
-                } else {
-                    tracing::warn!("Cannot get duration since UNIX_EPOCH as seconds");
-                }
+                let ts = now_fn() / 1000;
+                last_sse_time_seconds.set(ts);
             })
         });
 
@@ -178,9 +168,9 @@ impl SystemParameterFrontend {
 #[derive(Debug, Clone)]
 struct Metrics {
     // TODO: remove this in favor of last_cse_time_seconds.
-    pub last_known_time_seconds: IntCounter,
-    pub last_cse_time_seconds: IntCounter,
-    pub last_sse_time_seconds: IntCounter,
+    pub last_known_time_seconds: UIntGauge,
+    pub last_cse_time_seconds: UIntGauge,
+    pub last_sse_time_seconds: UIntGauge,
     pub params_changed: IntCounter,
 }
 

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -341,6 +341,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         let ld_key_map = config.launchdarkly_key_map;
         let env_id = config.environment_id.clone();
         let metrics_registry = config.metrics_registry.clone();
+        let now = config.now.clone();
         // The `SystemParameterFrontend::new` call needs to be wrapped in a
         // spawn_blocking call because the LaunchDarkly SDK initialization uses
         // `reqwest::blocking::client`. This should be revisited after the SDK
@@ -353,6 +354,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
                     &metrics_registry,
                     ld_sdk_key.as_str(),
                     ld_key_map,
+                    now,
                 )
             },
         )


### PR DESCRIPTION
Export a metric under `mz_parameter_frontend_last_sse_time_seconds` in order to track the last known time when a server-side event (SSE) from the LaunchDarkly server was received in the LaunchDarkly client running in `config/frontend.rs`.

### Motivation

  * This PR adds a known-desirable feature.

Implements the missing LaunchDarkly observability discussed in #18941 (see [comment 1](https://github.com/MaterializeInc/materialize/issues/18941#issuecomment-1539390098) / [comment 2](https://github.com/MaterializeInc/materialize/issues/18941#issuecomment-1537686151)).

### Tips for reviewer

The commit also duplicates the `mz_parameter_frontend_last_known_time_seconds` metric under `mz_parameter_frontend_last_cse_time_seconds` for naming consistency (it records events sent from the LaunchDarkly client to the server). The original metric can be removed after we update the Grafana dashboards in the next release.

I suggest to close #18941 once we deploy this. The new metric and Grafana dashboard widgets should allow us to catch the a similar LaunchDarkly issues, at which point we can open a follow-up issue and investigate further.

I tested this manually with the image from this PR on `staging` to verify that the metrics is exported and that it reports values as expected (the value is updated at least once every 3 mins by the corresponding `SSE::Comment` message).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
