### PR TITLE
pg sources: propagate running status to all subsources

### DIFF
--- a/test/pg-cdc-resumption/verify-data.td
+++ b/test/pg-cdc-resumption/verify-data.td
@@ -21,3 +21,7 @@ contains:Source error
 
 ! SELECT * FROM alter_fail_drop_col;
 contains:has been altered
+
+# Ensure non-definite errors are cleared.
+> SELECT COUNT(*) = 0 FROM mz_internal.mz_source_statuses WHERE error LIKE '%Connection refused%';
+true


### PR DESCRIPTION
We previously only adjusted the primary source's health status to running on entering the replication loop; subsources were only set to running once they produced data. However, if recovering from an error, and the subsource had already produced all of its data, nothing would ever return it to the running state.

Instead, we should update the health status of subsources, as well.

This change has a counter-intuitive interaction with definite errors (subsources can be permanently wedged in an error state, but still show their health status as running),  but:
- This occurs only in an uncommon case where users fix their schemas
- Whether we're ingesting data is a somewhat orthogonal concern to whether or not you can query the subsource, I guess.

I confirmed that this behavior resolves the issue, which fails with this PR's change to `pg-cdc-resumption` on `main` but succeeds on this branch, namely the `disconnect_pg_during_replication` subtest.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
