### PR TITLE
sql: Add support for REASSIGN OWNED statement

### DIFF
--- a/doc/user/content/sql/alter-owner.md
+++ b/doc/user/content/sql/alter-owner.md
@@ -42,6 +42,7 @@ ALTER CLUSTER REPLICA production.r1 OWNER TO admin;
 
 ## See also
 
+- [REASSIGN OWNER](../reassign-owned)
 - [CREATE ROLE](../create-role)
 - [ALTER ROLE](../alter-role)
 - [DROP ROLE](../drop-role)

--- a/doc/user/content/sql/drop-owned.md
+++ b/doc/user/content/sql/drop-owned.md
@@ -37,6 +37,7 @@ DROP OWNED BY joe, george CASCADE;
 
 - [REVOKE PRIVILEGE](../revoke-privilege)
 - [CREATE ROLE](../create-role)
+- [REASSIGN OWNED](../reassign-owned)
 - [DROP CLUSTER](../drop-cluster)
 - [DROP CLUSTER REPLICA](../drop-cluster-replica)
 - [DROP CONNECTION](../drop-connection)

--- a/doc/user/content/sql/reassign-owned.md
+++ b/doc/user/content/sql/reassign-owned.md
@@ -1,0 +1,38 @@
+---
+title: "REASSIGN OWNED"
+description: "`REASSIGN OWNED` reassigns the owner of all the objects from your Materialize instance that are owned by one of the specified roles."
+menu:
+  main:
+    parent: commands
+---
+
+`REASSIGN OWNED` reassigns the owner of all the objects from your Materialize instance that are owned by one of the specified roles.
+
+{{< note >}}
+Unlike [PostgreSQL](https://www.postgresql.org/docs/current/sql-drop-owned.html), Materialize reassigns
+all objects across all databases, including the databases themselves.
+{{< /note >}}
+
+## Syntax
+
+{{< diagram "reassign-owned.svg" >}}
+
+Field | Use
+------|-----
+_old_role_ | The role name whose owned objects will be reassigned.
+_new_role_ | The role name of the new owner of all the objects.
+
+## Examples
+
+```sql
+REASSIGN OWNED BY joe TO mike;
+```
+
+```sql
+REASSIGN OWNED BY joe, george TO mike;
+```
+
+## Related pages
+
+- [ALTER OWNER](../alter-owner)
+- [DROP OWNED](../drop-owned)

--- a/doc/user/layouts/partials/sql-grammar/reassign-owned.svg
+++ b/doc/user/layouts/partials/sql-grammar/reassign-owned.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="491" height="147">
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="92" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">REASSIGN</text>
+   <rect x="143" y="47" width="74" height="32" rx="10"/>
+   <rect x="141"
+         y="45"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="65">OWNED</text>
+   <rect x="237" y="47" width="40" height="32" rx="10"/>
+   <rect x="235"
+         y="45"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="245" y="65">BY</text>
+   <rect x="317" y="47" width="72" height="32"/>
+   <rect x="315" y="45" width="72" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="325" y="65">old_role</text>
+   <rect x="317" y="3" width="24" height="32" rx="10"/>
+   <rect x="315"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="325" y="21">,</text>
+   <rect x="429" y="47" width="40" height="32" rx="10"/>
+   <rect x="427"
+         y="45"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="437" y="65">TO</text>
+   <rect x="385" y="113" width="78" height="32"/>
+   <rect x="383" y="111" width="78" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="393" y="131">new_role</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m92 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m72 0 h10 m-112 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m92 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-92 0 h10 m24 0 h10 m0 0 h48 m20 44 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-128 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m78 0 h10 m3 0 h-3"/>
+   <polygon points="481 127 489 123 489 131"/>
+   <polygon points="481 127 473 123 473 131"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -287,6 +287,8 @@ prepare ::=
   'PREPARE' name 'AS' statement
 privilege ::=
   ('SELECT' | 'INSERT' | 'UPDATE' | 'DELETE' | 'CREATE' | 'USAGE')
+reassign_owned ::=
+  'REASSIGN' 'OWNED' 'BY' old_role (',' old_role)* 'TO' new_role
 reset_session_variable ::=
   'RESET' variable_name
 revoke_privilege ::=

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -329,6 +329,8 @@ pub enum ExecuteResponse {
     Prepare,
     /// A user-requested warning was raised.
     Raised,
+    /// The requested objects were reassigned.
+    ReassignOwned,
     /// The requested privilege was revoked.
     RevokedPrivilege,
     /// The requested role was revoked.
@@ -410,6 +412,7 @@ impl ExecuteResponse {
             }
             Prepare => Some("PREPARE".into()),
             Raised => Some("RAISE".into()),
+            ReassignOwned => Some("REASSIGN OWNED".into()),
             RevokedPrivilege => Some("REVOKE".into()),
             RevokedRole => Some("REVOKE ROLE".into()),
             SendingRows { .. } => None,
@@ -477,6 +480,7 @@ impl ExecuteResponse {
             Insert => vec![Inserted, SendingRows],
             PlanKind::Prepare => vec![ExecuteResponseKind::Prepare],
             PlanKind::Raise => vec![ExecuteResponseKind::Raised],
+            PlanKind::ReassignOwned => vec![ExecuteResponseKind::ReassignOwned],
             RevokePrivilege => vec![RevokedPrivilege],
             RevokeRole => vec![RevokedRole],
             PlanKind::SetVariable | ResetVariable => vec![ExecuteResponseKind::SetVariable],

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -488,7 +488,8 @@ impl Coordinator {
                     | Statement::Insert(_)
                     | Statement::RevokePrivilege(_)
                     | Statement::RevokeRole(_)
-                    | Statement::Update(_) => {
+                    | Statement::Update(_)
+                    | Statement::ReassignOwned(_) => {
                         return tx.send(
                             Err(AdapterError::OperationProhibitsTransaction(
                                 stmt.to_string(),

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -101,7 +101,8 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
         | Plan::GrantRole(_)
         | Plan::RevokeRole(_)
         | Plan::GrantPrivilege(_)
-        | Plan::RevokePrivilege(_) => return TargetCluster::Active,
+        | Plan::RevokePrivilege(_)
+        | Plan::ReassignOwned(_) => return TargetCluster::Active,
     };
 
     // Bail if the user has disabled it via the SessionVar.
@@ -285,7 +286,8 @@ pub fn user_privilege_hack(
         | Plan::RevokeRole(_)
         | Plan::GrantPrivilege(_)
         | Plan::RevokePrivilege(_)
-        | Plan::CopyRows(_) => {
+        | Plan::CopyRows(_)
+        | Plan::ReassignOwned(_) => {
             return Err(AdapterError::Unauthorized(
                 rbac::UnauthorizedError::MzIntrospection {
                     action: plan.name().to_string(),

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -461,6 +461,12 @@ impl Coordinator {
             Plan::AlterOwner(plan) => {
                 tx.send(self.sequence_alter_owner(&mut session, plan).await, session);
             }
+            Plan::ReassignOwned(plan) => {
+                tx.send(
+                    self.sequence_reassign_owned(&mut session, plan).await,
+                    session,
+                );
+            }
         }
     }
 

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -141,6 +141,7 @@ where
         StatementKind::RevokeRole => "revoke_role",
         StatementKind::GrantPrivilege => "grant_privilege",
         StatementKind::RevokePrivilege => "revoke_privilege",
+        StatementKind::ReassignOwned => "reassign_owned",
     }
 }
 

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -32,8 +32,9 @@ use mz_sql::plan::{
     CreateTypePlan, CreateViewPlan, DeallocatePlan, DeclarePlan, DropObjectsPlan, DropOwnedPlan,
     ExecutePlan, ExplainPlan, FetchPlan, GrantPrivilegePlan, GrantRolePlan, InsertPlan,
     MutationKind, PeekPlan, Plan, PlannedRoleAttributes, PreparePlan, RaisePlan, ReadThenWritePlan,
-    ResetVariablePlan, RevokePrivilegePlan, RevokeRolePlan, RotateKeysPlan, SetVariablePlan,
-    ShowCreatePlan, ShowVariablePlan, SourceSinkClusterConfig, StartTransactionPlan, SubscribePlan,
+    ReassignOwnedPlan, ResetVariablePlan, RevokePrivilegePlan, RevokeRolePlan, RotateKeysPlan,
+    SetVariablePlan, ShowCreatePlan, ShowVariablePlan, SourceSinkClusterConfig,
+    StartTransactionPlan, SubscribePlan,
 };
 use mz_sql::session::user::{INTROSPECTION_USER, SYSTEM_USER};
 use mz_sql::session::vars::SystemVars;
@@ -241,6 +242,15 @@ pub fn generate_required_role_membership(plan: &Plan) -> Vec<RoleId> {
     match plan {
         Plan::AlterOwner(AlterOwnerPlan { new_owner, .. }) => vec![*new_owner],
         Plan::DropOwned(DropOwnedPlan { role_ids, .. }) => role_ids.clone(),
+        Plan::ReassignOwned(ReassignOwnedPlan {
+            old_roles,
+            new_role,
+            ..
+        }) => {
+            let mut roles = old_roles.clone();
+            roles.push(*new_role);
+            roles
+        }
         Plan::CreateConnection(_)
         | Plan::CreateDatabase(_)
         | Plan::CreateSchema(_)
@@ -391,7 +401,8 @@ fn generate_required_plan_attribute(plan: &Plan) -> Vec<Attribute> {
         | Plan::Raise(_)
         | Plan::RotateKeys(_)
         | Plan::GrantPrivilege(_)
-        | Plan::RevokePrivilege(_) => Vec::new(),
+        | Plan::RevokePrivilege(_)
+        | Plan::ReassignOwned(_) => Vec::new(),
     }
 }
 
@@ -541,7 +552,8 @@ fn generate_required_ownership(plan: &Plan) -> Vec<ObjectId> {
         | Plan::Raise(_)
         | Plan::GrantRole(_)
         | Plan::RevokeRole(_)
-        | Plan::DropOwned(_) => Vec::new(),
+        | Plan::DropOwned(_)
+        | Plan::ReassignOwned(_) => Vec::new(),
         Plan::CreateIndex(plan) => vec![ObjectId::Item(plan.index.on)],
         Plan::CreateView(CreateViewPlan { replace, .. })
         | Plan::CreateMaterializedView(CreateMaterializedViewPlan { replace, .. }) => replace
@@ -1142,6 +1154,11 @@ fn generate_required_privileges(
             role_ids: _,
             drop_ids: _,
             revokes: _,
+        })
+        | Plan::ReassignOwned(ReassignOwnedPlan {
+            old_roles: _,
+            new_role: _,
+            reassign_ids: _,
         }) => Vec::new(),
     }
 }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -802,6 +802,7 @@ async fn execute_stmt<S: ResultSender>(
         | ExecuteResponse::GrantedRole
         | ExecuteResponse::Inserted(_)
         | ExecuteResponse::Raised
+        | ExecuteResponse::ReassignOwned
         | ExecuteResponse::RevokedPrivilege
         | ExecuteResponse::RevokedRole
         | ExecuteResponse::SetVariable { .. }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1411,6 +1411,7 @@ where
             | ExecuteResponse::Inserted(..)
             | ExecuteResponse::Prepare
             | ExecuteResponse::Raised
+            | ExecuteResponse::ReassignOwned
             | ExecuteResponse::RevokedPrivilege
             | ExecuteResponse::RevokedRole
             | ExecuteResponse::StartedTransaction { .. }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -94,6 +94,7 @@ pub enum Statement<T: AstInfo> {
     RevokeRole(RevokeRoleStatement<T>),
     GrantPrivilege(GrantPrivilegeStatement<T>),
     RevokePrivilege(RevokePrivilegeStatement<T>),
+    ReassignOwned(ReassignOwnedStatement<T>),
 }
 
 impl<T: AstInfo> AstDisplay for Statement<T> {
@@ -153,6 +154,7 @@ impl<T: AstInfo> AstDisplay for Statement<T> {
             Statement::RevokeRole(stmt) => f.write_node(stmt),
             Statement::GrantPrivilege(stmt) => f.write_node(stmt),
             Statement::RevokePrivilege(stmt) => f.write_node(stmt),
+            Statement::ReassignOwned(stmt) => f.write_node(stmt),
         }
     }
 }
@@ -2980,3 +2982,22 @@ impl<T: AstInfo> AstDisplay for RevokePrivilegeStatement<T> {
     }
 }
 impl_display_t!(RevokePrivilegeStatement);
+
+/// `REASSIGN OWNED ...`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ReassignOwnedStatement<T: AstInfo> {
+    /// The roles whose owned objects are being reassigned.
+    pub old_roles: Vec<T::RoleName>,
+    /// The new owner of the objects.
+    pub new_role: T::RoleName,
+}
+
+impl<T: AstInfo> AstDisplay for ReassignOwnedStatement<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("REASSIGN OWNED BY ");
+        f.write_node(&display::comma_separated(&self.old_roles));
+        f.write_str(" TO ");
+        f.write_node(&self.new_role);
+    }
+}
+impl_display_t!(ReassignOwnedStatement);

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -276,6 +276,7 @@ Range
 Raw
 Read
 Real
+Reassign
 Recursive
 References
 Refresh

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -308,6 +308,7 @@ impl<'a> Parser<'a> {
                 Token::Keyword(RAISE) => Ok(self.parse_raise()?),
                 Token::Keyword(GRANT) => Ok(self.parse_grant()?),
                 Token::Keyword(REVOKE) => Ok(self.parse_revoke()?),
+                Token::Keyword(REASSIGN) => Ok(self.parse_reassign_owned()?),
                 Token::Keyword(kw) => parser_err!(
                     self,
                     self.peek_prev_pos(),
@@ -6281,6 +6282,19 @@ impl<'a> Parser<'a> {
     fn expect_role_specification(&mut self) -> Result<Ident, ParserError> {
         let _ = self.parse_keyword(GROUP);
         self.parse_identifier()
+    }
+
+    /// Parse a `REASSIGN OWNED` statement, assuming that the `REASSIGN` token
+    /// has already been consumed.
+    fn parse_reassign_owned(&mut self) -> Result<Statement<Raw>, ParserError> {
+        self.expect_keywords(&[OWNED, BY])?;
+        let old_roles = self.parse_comma_separated(Parser::parse_identifier)?;
+        self.expect_keyword(TO)?;
+        let new_role = self.parse_identifier()?;
+        Ok(Statement::ReassignOwned(ReassignOwnedStatement {
+            old_roles,
+            new_role,
+        }))
     }
 }
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2328,6 +2328,20 @@ REVOKE CREATE ON CLUSTER c FROM joe, mike, yisachar
 RevokePrivilege(RevokePrivilegeStatement { privileges: Privileges([CREATE]), object_type: Cluster, name: Cluster(Ident("c")), roles: [Ident("joe"), Ident("mike"), Ident("yisachar")] })
 
 parse-statement
+REASSIGN OWNED BY joe TO yisachar
+----
+REASSIGN OWNED BY joe TO yisachar
+=>
+ReassignOwned(ReassignOwnedStatement { old_roles: [Ident("joe")], new_role: Ident("yisachar") })
+
+parse-statement
+REASSIGN OWNED BY joe, mike TO yisachar
+----
+REASSIGN OWNED BY joe, mike TO yisachar
+=>
+ReassignOwned(ReassignOwnedStatement { old_roles: [Ident("joe"), Ident("mike")], new_role: Ident("yisachar") })
+
+parse-statement
 DROP OWNED BY joe
 ----
 DROP OWNED BY joe

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -144,6 +144,7 @@ pub enum Plan {
     RevokeRole(RevokeRolePlan),
     GrantPrivilege(GrantPrivilegePlan),
     RevokePrivilege(RevokePrivilegePlan),
+    ReassignOwned(ReassignOwnedPlan),
 }
 
 impl Plan {
@@ -205,6 +206,7 @@ impl Plan {
             StatementKind::Insert => vec![PlanKind::Insert],
             StatementKind::Prepare => vec![PlanKind::Prepare],
             StatementKind::Raise => vec![PlanKind::Raise],
+            StatementKind::ReassignOwned => vec![PlanKind::ReassignOwned],
             StatementKind::ResetVariable => vec![PlanKind::ResetVariable],
             StatementKind::RevokePrivilege => vec![PlanKind::RevokePrivilege],
             StatementKind::RevokeRole => vec![PlanKind::RevokeRole],
@@ -338,6 +340,7 @@ impl Plan {
             Plan::RevokeRole(_) => "revoke role",
             Plan::GrantPrivilege(_) => "grant privilege",
             Plan::RevokePrivilege(_) => "revoke privilege",
+            Plan::ReassignOwned(_) => "reassign owned",
         }
     }
 }
@@ -896,6 +899,16 @@ pub struct RevokePrivilegePlan {
     pub revokees: Vec<RoleId>,
     /// The role that will revoke the privileges.
     pub grantor: RoleId,
+}
+
+#[derive(Debug)]
+pub struct ReassignOwnedPlan {
+    /// The roles whose owned objects are being reassigned.
+    pub old_roles: Vec<RoleId>,
+    /// The new owner of the objects.
+    pub new_role: RoleId,
+    /// All object IDs to reassign.
+    pub reassign_ids: Vec<ObjectId>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -146,6 +146,7 @@ pub fn describe(
         Statement::RevokeRole(stmt) => ddl::describe_revoke_role(&scx, stmt)?,
         Statement::GrantPrivilege(stmt) => ddl::describe_grant_privilege(&scx, stmt)?,
         Statement::RevokePrivilege(stmt) => ddl::describe_revoke_privilege(&scx, stmt)?,
+        Statement::ReassignOwned(stmt) => ddl::describe_reassign_owned(&scx, stmt)?,
 
         // `SHOW` statements.
         Statement::Show(ShowStatement::ShowColumns(stmt)) => {
@@ -282,6 +283,7 @@ pub fn plan(
         Statement::RevokeRole(stmt) => ddl::plan_revoke_role(scx, stmt),
         Statement::GrantPrivilege(stmt) => ddl::plan_grant_privilege(scx, stmt),
         Statement::RevokePrivilege(stmt) => ddl::plan_revoke_privilege(scx, stmt),
+        Statement::ReassignOwned(stmt) => ddl::plan_reassign_owned(scx, stmt),
 
         // DML statements.
         Statement::Copy(stmt) => dml::plan_copy(scx, stmt),

--- a/test/pgtest-mz/notice.pt
+++ b/test/pgtest-mz/notice.pt
@@ -113,9 +113,15 @@ Query {"query": "drop database d1"}
 Query {"query": "set database = dB3"}
 Query {"query": "show database"}
 Query {"query": "drop DATABASE Db3"}
+Query {"query": "create database d4"}
+Query {"query": "set database = d4"}
+Query {"query": "drop owned by materialize"}
 ----
 
 until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ReadyForQuery
@@ -148,6 +154,13 @@ ReadyForQuery {"status":"I"}
 NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"db3\" has been dropped"}]}
 CommandComplete {"tag":"DROP DATABASE"}
 ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE DATABASE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"d4\" has been dropped"}]}
+CommandComplete {"tag":"DROP OWNED"}
+ReadyForQuery {"status":"I"}
 
 # Test dropping active cluster
 send
@@ -160,9 +173,15 @@ Query {"query": "drop cluster c1"}
 Query {"query": "set cluster = cL3"}
 Query {"query": "show cluster"}
 Query {"query": "drop CLUSTER Cl3"}
+Query {"query": "create cluster c4 REPLICAS ()"}
+Query {"query": "set cluster = c4"}
+Query {"query": "drop owned by materialize"}
 ----
 
 until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ReadyForQuery
@@ -194,4 +213,11 @@ CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
 NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active cluster \"cl3\" has been dropped"}]}
 CommandComplete {"tag":"DROP CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active cluster \"c4\" has been dropped"}]}
+CommandComplete {"tag":"DROP OWNED"}
 ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -2366,6 +2366,147 @@ DROP OWNED BY PUBLIC;
 db error: ERROR: role name "public" is reserved
 DETAIL: The role "public" and the prefixes "mz_" and "pg_" are reserved for system roles.
 
+# Test REASSIGN OWNED
+
+statement ok
+CREATE DATABASE db
+
+query T
+SELECT mz_roles.name
+  FROM mz_databases
+  LEFT JOIN mz_roles ON mz_databases.owner_id = mz_roles.id
+  WHERE mz_databases.name = 'db'
+----
+materialize
+
+statement ok
+CREATE SCHEMA s
+
+query T
+SELECT mz_roles.name
+  FROM mz_schemas
+  LEFT JOIN mz_roles ON mz_schemas.owner_id = mz_roles.id
+  WHERE mz_schemas.name = 's'
+----
+materialize
+
+statement ok
+CREATE TABLE t ();
+
+query T
+SELECT mz_roles.name
+  FROM mz_tables
+  LEFT JOIN mz_roles ON mz_tables.owner_id = mz_roles.id
+  WHERE mz_tables.name = 't'
+----
+materialize
+
+simple conn=joe,user=joe
+CREATE TABLE t1 ();
+----
+COMPLETE 0
+
+query T
+SELECT mz_roles.name
+  FROM mz_tables
+  LEFT JOIN mz_roles ON mz_tables.owner_id = mz_roles.id
+  WHERE mz_tables.name = 't1'
+----
+joe
+
+statement ok
+CREATE CLUSTER c REPLICAS (replica1 (SIZE '1'));
+
+query T
+SELECT mz_roles.name
+  FROM mz_clusters
+  LEFT JOIN mz_roles ON mz_clusters.owner_id = mz_roles.id
+  WHERE mz_clusters.name = 'c'
+----
+materialize
+
+query T
+SELECT mz_roles.name
+  FROM mz_cluster_replicas
+  LEFT JOIN mz_roles ON mz_cluster_replicas.owner_id = mz_roles.id
+  WHERE mz_cluster_replicas.name = 'replica1'
+----
+materialize
+
+simple conn=mz_system,user=mz_system
+REASSIGN OWNED BY materialize, joe TO group1;
+----
+COMPLETE 0
+
+query T
+SELECT mz_roles.name
+  FROM mz_databases
+  LEFT JOIN mz_roles ON mz_databases.owner_id = mz_roles.id
+  WHERE mz_databases.name = 'db'
+----
+group1
+
+query T
+SELECT mz_roles.name
+  FROM mz_schemas
+  LEFT JOIN mz_roles ON mz_schemas.owner_id = mz_roles.id
+  WHERE mz_schemas.name = 's'
+----
+group1
+
+query T
+SELECT mz_roles.name
+  FROM mz_tables
+  LEFT JOIN mz_roles ON mz_tables.owner_id = mz_roles.id
+  WHERE mz_tables.name = 't'
+----
+group1
+
+query T
+SELECT mz_roles.name
+  FROM mz_tables
+  LEFT JOIN mz_roles ON mz_tables.owner_id = mz_roles.id
+  WHERE mz_tables.name = 't1'
+----
+group1
+
+query T
+SELECT mz_roles.name
+  FROM mz_clusters
+  LEFT JOIN mz_roles ON mz_clusters.owner_id = mz_roles.id
+  WHERE mz_clusters.name = 'c'
+----
+group1
+
+query T
+SELECT mz_roles.name
+  FROM mz_cluster_replicas
+  LEFT JOIN mz_roles ON mz_cluster_replicas.owner_id = mz_roles.id
+  WHERE mz_cluster_replicas.name = 'replica1'
+----
+group1
+
+## Test reassigning system objects
+
+simple conn=mz_system,user=mz_system
+REASSIGN OWNED BY mz_system TO materialize;
+----
+db error: ERROR: cannot reassign objects owned by role "mz_system" because they are required by the database system
+
+## Test reassigning PUBLIC objects
+
+simple conn=mz_system,user=mz_system
+REASSIGN OWNED BY PUBLIC TO materialize;
+----
+db error: ERROR: role name "public" is reserved
+DETAIL: The role "public" and the prefixes "mz_" and "pg_" are reserved for system roles.
+
+simple conn=mz_system,user=mz_system
+REASSIGN OWNED BY materialize TO PUBLIC;
+----
+db error: ERROR: role name "public" is reserved
+DETAIL: The role "public" and the prefixes "mz_" and "pg_" are reserved for system roles.
+
 # Disable rbac checks.
 
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
This commit adds support for the REASSIGN OWNED statement. The REASSIGN
OWNED statement allows you to reassign the owner of all objects owned
by one or more specified users.

Resolves #19164

### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer

This PR builds off of https://github.com/MaterializeInc/materialize/pull/19175. Only the most recent commit adds anything new.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This release adds the REASSIGN OWNED SQL statement. This statement reassigns the owner of all objects owned by one or more users.
