### PR TITLE
cloudtest: improve debugging of testdrive failures

### DIFF
--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -73,8 +73,8 @@ class Application:
     def kubectl(self, *args: str) -> str:
         try:
             return subprocess.check_output(
-                ["kubectl", "--context", self.context(), *args]
-            ).decode("ascii")
+                ["kubectl", "--context", self.context(), *args], text=True
+            )
         except subprocess.CalledProcessError as e:
             print(
                 dedent(

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 import os
-import subprocess
 from typing import Optional
 
 from kubernetes.client import V1Container, V1EnvVar, V1ObjectMeta, V1Pod, V1PodSpec
@@ -51,34 +50,27 @@ class Testdrive(K8sPod):
         seed: Optional[int] = None,
     ) -> None:
         wait(condition="condition=Ready", resource="pod/testdrive")
-        subprocess.run(
-            [
-                "kubectl",
-                "--context",
-                self.context(),
-                "exec",
-                "-it",
-                "testdrive",
-                "--",
-                "testdrive",
-                "--materialize-url=postgres://materialize:materialize@environmentd:6875/materialize",
-                "--materialize-internal-url=postgres://materialize:materialize@environmentd:6877/materialize",
-                "--kafka-addr=redpanda:9092",
-                "--schema-registry-url=http://redpanda:8081",
-                "--default-timeout=300s",
-                "--var=replicas=1",
-                "--var=default-storage-size=1",
-                "--var=default-replica-size=1",
-                *([f"--aws-region={self.aws_region}"] if self.aws_region else []),
-                # S3 sources are not compatible with Minio unfortunately
-                # "--aws-endpoint=http://minio-service.default:9000",
-                # "--aws-access-key-id=minio",
-                # "--aws-secret-access-key=minio123",
-                *(["--no-reset"] if no_reset else []),
-                *([f"--seed={seed}"] if seed else []),
-                *args,
-            ],
-            check=True,
+        self.kubectl(
+            "exec",
+            "-it",
+            "testdrive",
+            "--",
+            "testdrive",
+            "--materialize-url=postgres://materialize:materialize@environmentd:6875/materialize",
+            "--materialize-internal-url=postgres://materialize:materialize@environmentd:6877/materialize",
+            "--kafka-addr=redpanda:9092",
+            "--schema-registry-url=http://redpanda:8081",
+            "--default-timeout=300s",
+            "--var=replicas=1",
+            "--var=default-storage-size=1",
+            "--var=default-replica-size=1",
+            *([f"--aws-region={self.aws_region}"] if self.aws_region else []),
+            # S3 sources are not compatible with Minio unfortunately
+            # "--aws-endpoint=http://minio-service.default:9000",
+            # "--aws-access-key-id=minio",
+            # "--aws-secret-access-key=minio123",
+            *(["--no-reset"] if no_reset else []),
+            *([f"--seed={seed}"] if seed else []),
+            *args,
             input=input,
-            text=True,
         )


### PR DESCRIPTION
- make sure that running testdrive goes through K8sResource.kubectl()
- catch CalledProcessError when running kubectl and print all information available from the exception

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

Some cloudtest CI failures are impossible to debug.
### Tips for reviewer

View with whitespace changes suppressed