### PR TITLE
orchestrator-k8s: enable Guaranteed QoS for pods

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -644,6 +644,12 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 name: "init".to_string(),
                 image: Some(image),
                 image_pull_policy: Some(self.config.image_pull_policy.to_string()),
+                resources: Some(ResourceRequirements {
+                    // Set both limits and requests to the same values, to ensure a
+                    // `Guaranteed` QoS class for the pod.
+                    limits: Some(limits.clone()),
+                    requests: Some(limits.clone()),
+                }),
                 env: Some(vec![
                     EnvVar {
                         name: "MZ_NAMESPACE".to_string(),
@@ -750,8 +756,10 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                             .collect(),
                     ),
                     resources: Some(ResourceRequirements {
-                        limits: Some(limits),
-                        ..Default::default()
+                        // Set both limits and requests to the same values, to ensure a
+                        // `Guaranteed` QoS class for the pod.
+                        limits: Some(limits.clone()),
+                        requests: Some(limits),
                     }),
                     volume_mounts,
                     env,


### PR DESCRIPTION
This PR makes the kubernetes orchestrator set both the 'limits' and the 'requests' fields of all container resource configurations to the same value. This is to ensure that, if limits are specified, kubernetes assigns the pod to the `Guaranteed` QoS class [1].

A `Guaranteed` QoS class is a pre-condition for enabling the `static` CPU management policy [2], which in turn is a pre-condition for enabling CPU pinning for replica threads (#15044).

Note that we have to specify 'limits' and 'requests' also for the init containers. If we don't, the pods resources are considered unlimited [3].

[1]: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#guaranteed
[2]: https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy
[3]: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resources

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/cloud/issues/3368.

### Tips for reviewer

Re-using the app container limit for the init container might be controversial, but I hope not. AFAICT, we just need to make sure the following is true:
* The init container has _some_ limits configuration and an equal requests configuration.
* The init container's limit is not larger than that of the app container, to ensure the pod can always be scheduled on a pod if there are sufficient resources for the app container.

I assume in most cases the init container's limit could be much lower than the app container's, but it doesn't seem harmful to just use the same limit.

It's also worth pointing out that explicitly setting `requests` is a no-op, as the setting will default to `limits` if you leave it out. I'm just making the default explicit to make clear that we want those values to be the same.

I considered adding a `cloudtest` test to verify that replicas do indeed get the `Guaranteed` QoS level, but of course we don't use CPU/memory limits in testing, so that doesn't work.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
