### PR TITLE
feature-benchmark: Add a scenario with many clusters

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -22,6 +22,7 @@ from scenarios import *  # noqa: F401 F403
 from scenarios import Scenario
 from scenarios_concurrency import *  # noqa: F401 F403
 from scenarios_optbench import *  # noqa: F401 F403
+from scenarios_scale import *  # noqa: F401 F403
 from scenarios_subscribe import *  # noqa: F401 F403
 
 from materialize.feature_benchmark.aggregation import Aggregation, MinAggregation

--- a/test/feature-benchmark/scenarios_scale.py
+++ b/test/feature-benchmark/scenarios_scale.py
@@ -1,0 +1,77 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+
+from materialize.feature_benchmark.measurement_source import MeasurementSource, Td
+from materialize.feature_benchmark.scenario import Scenario
+
+
+class SmallClusters(Scenario):
+    """Materialized views across many small clusters."""
+
+    SCALE = 1.5  # 32 clusters
+    FIXED_SCALE = True
+
+    def benchmark(self) -> MeasurementSource:
+        create = "\n".join(
+            dedent(
+                f"""
+                > DROP CLUSTER IF EXISTS cluster{i} CASCADE;
+
+                > CREATE CLUSTER cluster{i} REPLICAS (r (SIZE '4-1'));
+
+                > CREATE MATERIALIZED VIEW v{i}
+                  IN CLUSTER cluster{i}
+                  AS SELECT COUNT(*) FROM t1;
+
+                > CREATE DEFAULT INDEX ON v{i}
+                """
+            )
+            for i in range(self.n())
+        )
+
+        select = "\n".join(
+            dedent(
+                f"""
+                > SET CLUSTER = cluster{i}
+                > SELECT * FROM v{i}
+                100000
+                """
+            )
+            for i in range(self.n())
+        )
+
+        return Td(
+            dedent(
+                f"""
+                > DROP TABLE IF EXISTS t1 CASCADE;
+                > CREATE TABLE t1 (f1 INTEGER);
+
+                $ postgres-execute connection=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
+                ALTER SYSTEM SET max_clusters = {self.n() + 2};
+                """
+            )
+            + create
+            + dedent(
+                """
+                > INSERT INTO t1
+                  SELECT * FROM generate_series(1, 100000)
+                  /* A */
+                """
+            )
+            + select
+            + dedent(
+                """
+                > SELECT 1
+                  /* B */;
+                1
+                """
+            )
+        )


### PR DESCRIPTION
Create ~30 small clusters and benchmark the time it takes for materialized views installed on all of them to register an insertion into a single common source.

### Motivation

  * This PR adds a feature that has not yet been specified.

The feature benchmark was previously lacking a scenario that exercised any scalability/communication issues in having a single environmentd coordinate many clusters.

This scenario will be important going forward when benchmarking PubSub and various future scalability enhancements in Persist and the coordinator.