### PR TITLE
explain: further align explain path with oneshot execution path

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2601,7 +2601,6 @@ impl Coordinator {
         plan: ExplainPlan,
         target_cluster: TargetCluster,
     ) -> Result<ExecuteResponse, AdapterError> {
-        use mz_compute_client::plan::Plan;
         use mz_repr::explain::trace_plan;
         use ExplainStage::*;
 
@@ -2702,8 +2701,20 @@ impl Coordinator {
             })?;
 
             let mut dataflow = DataflowDesc::new("explanation".to_string());
-            self.dataflow_builder(cluster_id)
-                .import_view_into_dataflow(&explainee_id, &optimized_plan, &mut dataflow)?;
+            let mut builder = self.dataflow_builder(cluster_id);
+            builder.import_view_into_dataflow(&explainee_id, &optimized_plan, &mut dataflow)?;
+
+            // Resolve all unmaterializable function calls except mz_now(), because we don't yet have a
+            // timestamp.
+            let style = ExprPrepStyle::OneShot {
+                logical_time: EvalTime::Deferred,
+                session,
+            };
+            let state = self.catalog().state();
+            dataflow.visit_children(
+                |r| prep_relation_expr(state, r, style),
+                |s| prep_scalar_expr(state, s, style),
+            )?;
 
             // Execute the `optimize/global` stage.
             catch_unwind(no_errors, "global", || {
@@ -2746,15 +2757,22 @@ impl Coordinator {
                 _ => None,
             };
 
+            if matches!(explainee, Explainee::Query) {
+                // We have the opportunity to name an `until` frontier that will prevent work we needn't perform.
+                // By default, `until` will be `Antichain::new()`, which prevents no updates and is safe.
+                if let Some(as_of) = dataflow.as_of.as_ref() {
+                    if !as_of.is_empty() {
+                        if let Some(next) = as_of.as_option().and_then(|as_of| as_of.checked_add(1))
+                        {
+                            dataflow.until = timely::progress::Antichain::from_elem(next);
+                        }
+                    }
+                }
+            }
+
             // Execute the `optimize/finalize_dataflow` stage.
             let dataflow_plan = catch_unwind(no_errors, "finalize_dataflow", || {
-                Plan::<mz_repr::Timestamp>::finalize_dataflow(
-                    dataflow,
-                    self.catalog()
-                        .system_config()
-                        .enable_monotonic_oneshot_selects(),
-                )
-                .map_err(AdapterError::Internal)
+                self.finalize_dataflow(dataflow, cluster_id)
             })?;
 
             // Trace the resulting plan for the top-level `optimize` path.

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -763,8 +763,13 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM bar;
 
 # Regression test for #19148: support mz_now() on select from indexed table
+# ---
+
 statement ok
-DROP TABLE IF EXISTS t CASCADE;
+DROP SCHEMA IF EXISTS public CASCADE;
+
+statement ok
+CREATE SCHEMA public;
 
 statement ok
 CREATE TABLE t(a TIMESTAMP);
@@ -776,3 +781,21 @@ CREATE DEFAULT INDEX ON t;
 # assert that the query doesn't fail.
 statement ok
 EXPLAIN SELECT * FROM t WHERE a < mz_now();
+
+# Regression test for #19177
+# ---
+
+statement ok
+DROP SCHEMA IF EXISTS public CASCADE;
+
+statement ok
+CREATE SCHEMA public;
+
+statement ok
+CREATE TABLE t1(x text);
+
+statement ok
+CREATE TABLE t2(x text);
+
+statement ok
+EXPLAIN SELECT * FROM t1, t2 WHERE t1.x || mz_internal.mz_session_id()  = t2.x || mz_internal.mz_session_id();


### PR DESCRIPTION
More changes to `sequence_explain_path` to align it with the current code with `sequence_peek_stage`.

### Motivation

  * This PR fixes a recognized bug.

Fixes #19214 (this is a fix for one of the two independently discovered bugs).

### Tips for reviewer

I found quite a few places where the current `sequence_explain_plan` implementation was diverging from the "source of truth" (which at the moment I consider to be `sequence_peek_stage`). I tried to align those, but I will follow up with a design doc that explains the general problem so @MaterializeInc/surfaces and @MaterializeInc/compute can agree on the actual problem and on a long-term solution path. The current solution is not stable because:

1. Nothing stops the two methods from diverging again in the future,
2. In the future, we want to be able to faithfully reproduce the query lifecycle of not only `SELECT`, but also `CREATE INDEX` / `CREATE VIEW` / `CREATE MATERIALIZED VIEW`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
