### PR TITLE
Fix join visitation

### DIFF
--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -799,3 +799,7 @@ CREATE TABLE t2(x text);
 
 statement ok
 EXPLAIN SELECT * FROM t1, t2 WHERE t1.x || mz_internal.mz_session_id()  = t2.x || mz_internal.mz_session_id();
+
+# Regression test for the join visitation part of #19177
+statement ok
+EXPLAIN SELECT * FROM t1, t2 WHERE t1.x || mz_now()  = t2.x || mz_now();


### PR DESCRIPTION
Fixes the visitation of scalar expressions in MIR's Join. The `implementation` part was not being visited.

This is on top of Alex's PR https://github.com/MaterializeInc/materialize/pull/19223. (The Surfaces part is only what is also present in that PR.)

### Motivation

  * This PR partially fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/19214.
    * The other half is fixed by https://github.com/MaterializeInc/materialize/pull/19223

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
