### PR TITLE
persist: enable pushdown feature flags in CI

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -98,6 +98,9 @@ class Materialized(Service):
         if system_parameter_defaults is None:
             system_parameter_defaults = [
                 "persist_sink_minimum_batch_updates=128",
+                "persist_stats_filter_enabled=true",
+                "persist_stats_collection_enabled=true",
+                "persist_stats_audit_percent=100",
             ]
 
         if additional_system_parameter_defaults is not None:


### PR DESCRIPTION
Both of these flags are "additive" in the sense that the "off" state does nothing, as opposed to executing some other codepath. This gets us performance coverage of the new code (e.g. in feature benchmarks). Combined with the "audit" feature, which we already enabled previously in CI, we automatically get correctness coverage of both the stats and interpret paths for anything already covered by existing CI tests.

This is no substitute, of course, for dedicated test coverage, but we don't lose anything by CI not exercising the "off" case and we gain a lot. Concretely, this is exactly how we found the bug fixed in #19128.

Touches #12684

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
