### PR TITLE
sql: Improve ergonomics of setting current schema

### DIFF
--- a/doc/user/content/sql/set.md
+++ b/doc/user/content/sql/set.md
@@ -25,6 +25,14 @@ _variable&lowbar;value_ | The value to assign to the session variable.
 
 {{% session-variables %}}
 
+## Special Syntax
+
+There are a few session variables that act as aliases for other session variables. 
+
+- `SCHEMA`: `SCHEMA` is an alias for `search_path`. Only one schema can be specified using this syntax. The `TO` and `=` syntax are optional.
+- `NAMES`: `NAMES` is an alias for `client_encoding`. The `TO` and `=` syntax must be omitted.
+- `TIME ZONE`: `TIME ZONE` is an alias for `timezone`. The `TO` and `=` syntax must be omitted.
+
 ## Examples
 
 ### Set active cluster

--- a/doc/user/content/sql/set.md
+++ b/doc/user/content/sql/set.md
@@ -27,7 +27,7 @@ _variable&lowbar;value_ | The value to assign to the session variable.
 
 ## Special Syntax
 
-There are a few session variables that act as aliases for other session variables. 
+There are a few session variables that act as aliases for other session variables.
 
 - `SCHEMA`: `SCHEMA` is an alias for `search_path`. Only one schema can be specified using this syntax. The `TO` and `=` syntax are optional.
 - `NAMES`: `NAMES` is an alias for `client_encoding`. The `TO` and `=` syntax must be omitted.

--- a/doc/user/content/sql/show.md
+++ b/doc/user/content/sql/show.md
@@ -20,6 +20,10 @@ _variable&lowbar;name_ | The name of the session or system variable to display.
 
 {{% session-variables %}}
 
+## Special Syntax
+
+`SHOW SCHEMA` will show the first resolvable schema on the search path, or `NULL` if no such schema exists.
+
 ## System variables
 
 Materialize reserves system variables for region-wide configuration. Although it's possible to `SHOW` system variables, you must [contact us](https://materialize.com/contact/) to change their value (e.g. increasing the maximum number of AWS PrivateLink connections in your region).

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -62,11 +62,11 @@ use mz_sql::plan::{
     SendDiffsPlan, SetVariablePlan, ShowVariablePlan, SourceSinkClusterConfig, SubscribeFrom,
     SubscribePlan, VariableValue, View,
 };
-use mz_sql::session::vars::Var;
 use mz_sql::session::vars::{
     IsolationLevel, OwnedVarInput, VarError, VarInput, CLUSTER_VAR_NAME, DATABASE_VAR_NAME,
     ENABLE_RBAC_CHECKS, TRANSACTION_ISOLATION_VAR_NAME,
 };
+use mz_sql::session::vars::{Var, SCHEMA_ALIAS};
 use mz_ssh_util::keys::SshKeyPairSet;
 use mz_storage_client::controller::{CollectionDescription, DataSource, ReadPolicy, StorageError};
 use mz_storage_client::types::sinks::StorageSinkConnectionBuilder;
@@ -1646,6 +1646,33 @@ impl Coordinator {
         session: &Session,
         plan: ShowVariablePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
+        if &plan.name == SCHEMA_ALIAS {
+            let schemas = self.catalog.resolve_search_path(session);
+            let schema = schemas.first();
+            return match schema {
+                Some((database_spec, schema_spec)) => {
+                    let schema_name = &self
+                        .catalog
+                        .get_schema(database_spec, schema_spec, session.conn_id())
+                        .name()
+                        .schema;
+                    let row = Row::pack_slice(&[Datum::String(schema_name)]);
+                    Ok(send_immediate_rows(vec![row]))
+                }
+                None => {
+                    session.add_notice(AdapterNotice::NoResolvableSearchPathSchema {
+                        search_path: session
+                            .vars()
+                            .search_path()
+                            .into_iter()
+                            .map(|schema| schema.to_string())
+                            .collect(),
+                    });
+                    Ok(send_immediate_rows(vec![Row::pack_slice(&[Datum::Null])]))
+                }
+            };
+        }
+
         let variable = session
             .vars()
             .get(&plan.name)
@@ -1653,6 +1680,23 @@ impl Coordinator {
 
         if variable.visible(session.user()) && (variable.safe() || self.catalog().unsafe_mode()) {
             let row = Row::pack_slice(&[Datum::String(&variable.value())]);
+            if variable.name() == DATABASE_VAR_NAME
+                && matches!(
+                    self.catalog().resolve_database(&variable.value()),
+                    Err(CatalogError::UnknownDatabase(_))
+                )
+            {
+                let name = variable.value();
+                session.add_notice(AdapterNotice::DatabaseDoesNotExist { name });
+            } else if variable.name() == CLUSTER_VAR_NAME
+                && matches!(
+                    self.catalog().resolve_cluster(&variable.value()),
+                    Err(CatalogError::UnknownCluster(_))
+                )
+            {
+                let name = variable.value();
+                session.add_notice(AdapterNotice::ClusterDoesNotExist { name });
+            }
             Ok(send_immediate_rows(vec![row]))
         } else {
             Err(AdapterError::VarError(VarError::UnknownParameter(

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -109,7 +109,7 @@ impl AdapterNotice {
         match self {
             AdapterNotice::DatabaseDoesNotExist { name: _ } => Some("Create the database with CREATE DATABASE or pick an extant database with SET DATABASE = name. List available databases with SHOW DATABASES.".into()),
             AdapterNotice::ClusterDoesNotExist { name: _ } => Some("Create the cluster with CREATE CLUSTER or pick an extant cluster with SET CLUSTER = name. List available clusters with SHOW CLUSTERS.".into()),
-            AdapterNotice::NoResolvableSearchPathSchema { search_path: _ } => Some("Create a schema with CREATE SCHEMA or pick an extant schema with SET SCHEMA = name. List available schemas with SHOW SCHEMAS".into()),
+            AdapterNotice::NoResolvableSearchPathSchema { search_path: _ } => Some("Create a schema with CREATE SCHEMA or pick an extant schema with SET SCHEMA = name. List available schemas with SHOW SCHEMAS.".into()),
             AdapterNotice::DroppedActiveDatabase { name: _ } => Some("Choose a new active database by executing SET DATABASE = <name>.".into()),
             AdapterNotice::DroppedActiveCluster { name: _ } => Some("Choose a new active cluster by executing SET CLUSTER = <name>.".into()),
             AdapterNotice::ClusterReplicaStatusChanged { status, .. } => {

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -43,6 +43,9 @@ pub enum AdapterNotice {
     ClusterDoesNotExist {
         name: String,
     },
+    NoResolvableSearchPathSchema {
+        search_path: Vec<String>,
+    },
     ExistingTransactionInProgress,
     ExplicitTransactionControlInImplicitTransaction,
     UserRequested {
@@ -106,6 +109,7 @@ impl AdapterNotice {
         match self {
             AdapterNotice::DatabaseDoesNotExist { name: _ } => Some("Create the database with CREATE DATABASE or pick an extant database with SET DATABASE = name. List available databases with SHOW DATABASES.".into()),
             AdapterNotice::ClusterDoesNotExist { name: _ } => Some("Create the cluster with CREATE CLUSTER or pick an extant cluster with SET CLUSTER = name. List available clusters with SHOW CLUSTERS.".into()),
+            AdapterNotice::NoResolvableSearchPathSchema { search_path: _ } => Some("Create a schema with CREATE SCHEMA or pick an extant schema with SET SCHEMA = name. List available schemas with SHOW SCHEMAS".into()),
             AdapterNotice::DroppedActiveDatabase { name: _ } => Some("Choose a new active database by executing SET DATABASE = <name>.".into()),
             AdapterNotice::DroppedActiveCluster { name: _ } => Some("Choose a new active cluster by executing SET CLUSTER = <name>.".into()),
             AdapterNotice::ClusterReplicaStatusChanged { status, .. } => {
@@ -143,6 +147,13 @@ impl fmt::Display for AdapterNotice {
             }
             AdapterNotice::ClusterDoesNotExist { name } => {
                 write!(f, "cluster {} does not exist", name.quoted())
+            }
+            AdapterNotice::NoResolvableSearchPathSchema { search_path } => {
+                write!(
+                    f,
+                    "no schema on the search path exists: {}",
+                    search_path.join(", ")
+                )
             }
             AdapterNotice::ExistingTransactionInProgress => {
                 write!(f, "there is already a transaction in progress")

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -412,6 +412,7 @@ impl ErrorResponse {
             AdapterNotice::ObjectAlreadyExists { .. } => SqlState::DUPLICATE_OBJECT,
             AdapterNotice::DatabaseDoesNotExist { .. } => SqlState::WARNING,
             AdapterNotice::ClusterDoesNotExist { .. } => SqlState::WARNING,
+            AdapterNotice::NoResolvableSearchPathSchema { .. } => SqlState::WARNING,
             AdapterNotice::ExistingTransactionInProgress => SqlState::ACTIVE_SQL_TRANSACTION,
             AdapterNotice::ExplicitTransactionControlInImplicitTransaction => {
                 SqlState::NO_ACTIVE_SQL_TRANSACTION
@@ -571,6 +572,7 @@ impl Severity {
             AdapterNotice::ObjectAlreadyExists { .. } => Severity::Notice,
             AdapterNotice::DatabaseDoesNotExist { .. } => Severity::Notice,
             AdapterNotice::ClusterDoesNotExist { .. } => Severity::Notice,
+            AdapterNotice::NoResolvableSearchPathSchema { .. } => Severity::Notice,
             AdapterNotice::ExistingTransactionInProgress => Severity::Warning,
             AdapterNotice::ExplicitTransactionControlInImplicitTransaction => Severity::Warning,
             AdapterNotice::UserRequested { severity } => match severity {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4988,14 +4988,18 @@ impl<'a> Parser<'a> {
                     variable = Ident::new("client_encoding");
                     normal = true;
                 }
-                Ok(SCHEMA) => {
-                    variable = Ident::new("search_path");
-                    normal = true;
-                }
                 _ => {}
             }
         }
-        if normal {
+        if variable.as_str().parse() == Ok(SCHEMA) {
+            variable = Ident::new("search_path");
+            let to = self.parse_set_variable_value()?;
+            Ok(Statement::SetVariable(SetVariableStatement {
+                local: modifier == Some(LOCAL),
+                variable,
+                to: SetVariableTo::Values(vec![to]),
+            }))
+        } else if normal {
             let to = self.parse_set_variable_to()?;
             Ok(Statement::SetVariable(SetVariableStatement {
                 local: modifier == Some(LOCAL),

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -544,3 +544,38 @@ DISCARD BAD
 error: Expected one of ALL or PLANS or SEQUENCES or TEMP or TEMPORARY, found identifier "bad"
 DISCARD BAD
         ^
+
+parse-statement
+SET SCHEMA TO 'public'
+----
+SET search_path = 'public'
+=>
+SetVariable(SetVariableStatement { local: false, variable: Ident("search_path"), to: Values([Literal(String("public"))]) })
+
+parse-statement
+SET schema = 'public'
+----
+SET search_path = 'public'
+=>
+SetVariable(SetVariableStatement { local: false, variable: Ident("search_path"), to: Values([Literal(String("public"))]) })
+
+parse-statement
+SET LOCAL schema = 'public'
+----
+SET LOCAL search_path = 'public'
+=>
+SetVariable(SetVariableStatement { local: true, variable: Ident("search_path"), to: Values([Literal(String("public"))]) })
+
+parse-statement
+SET SESSION schema = 'public'
+----
+SET search_path = 'public'
+=>
+SetVariable(SetVariableStatement { local: false, variable: Ident("search_path"), to: Values([Literal(String("public"))]) })
+
+parse-statement
+SET SESSION schema = public, private
+----
+error: Expected end of statement, found comma
+SET SESSION schema = public, private
+                           ^

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -31,6 +31,7 @@ use crate::plan::{
     FetchPlan, Plan, PlanError, PreparePlan, ResetVariablePlan, SetVariablePlan, ShowVariablePlan,
     VariableValue,
 };
+use crate::session::vars::SCHEMA_ALIAS;
 
 pub fn describe_set_variable(
     _: &StatementContext,
@@ -98,6 +99,8 @@ pub fn describe_show_variable(
             .with_column("name", ScalarType::String.nullable(false))
             .with_column("setting", ScalarType::String.nullable(false))
             .with_column("description", ScalarType::String.nullable(false))
+    } else if variable.as_str() == SCHEMA_ALIAS {
+        RelationDesc::empty().with_column(variable.as_str(), ScalarType::String.nullable(true))
     } else {
         RelationDesc::empty().with_column(variable.as_str(), ScalarType::String.nullable(false))
     };

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -229,6 +229,8 @@ const INTERVAL_STYLE: ServerVar<str> = ServerVar {
 const MZ_VERSION_NAME: &UncasedStr = UncasedStr::new("mz_version");
 const IS_SUPERUSER_NAME: &UncasedStr = UncasedStr::new("is_superuser");
 
+// Schema can be used an alias for a search path with a single element.
+pub const SCHEMA_ALIAS: &UncasedStr = UncasedStr::new("schema");
 static DEFAULT_SEARCH_PATH: Lazy<Vec<Ident>> = Lazy::new(|| vec![Ident::new(DEFAULT_SCHEMA)]);
 static SEARCH_PATH: Lazy<ServerVar<Vec<Ident>>> = Lazy::new(|| ServerVar {
     name: UncasedStr::new("search_path"),

--- a/test/pgtest-mz/notice.pt
+++ b/test/pgtest-mz/notice.pt
@@ -55,6 +55,18 @@ ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
 ----
 NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"database \"nonexistant\" does not exist"}]}
 CommandComplete {"tag":"SET"}
@@ -111,31 +123,6 @@ CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
-
-# Test dropping active database
-send
-Query {"query": "create database d1"}
-Query {"query": "create database d2"}
-Query {"query": "create database DB3"}
-Query {"query": "set database = d1"}
-Query {"query": "drop database d2"}
-Query {"query": "drop database d1"}
-Query {"query": "set database = dB3"}
-Query {"query": "show database"}
-Query {"query": "drop DATABASE Db3"}
-----
-
-until
-ReadyForQuery
-ReadyForQuery
-ReadyForQuery
-ReadyForQuery
-ReadyForQuery
-ReadyForQuery
-ReadyForQuery
-ReadyForQuery
-ReadyForQuery
-----
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
 RowDescription {"fields":[{"name":"schema"}]}
@@ -166,6 +153,64 @@ ReadyForQuery {"status":"I"}
 NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"cluster \"nonexistant2\" does not exist"}]}
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"cluster"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"cluster \"nonexistant2\" does not exist"}]}
+DataRow {"fields":["nonexistant2"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"cluster"}]}
+DataRow {"fields":["default"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# Test dropping active database
+send
+Query {"query": "create database d1"}
+Query {"query": "create database d2"}
+Query {"query": "create database DB3"}
+Query {"query": "set database = d1"}
+Query {"query": "drop database d2"}
+Query {"query": "drop database d1"}
+Query {"query": "set database = dB3"}
+Query {"query": "show database"}
+Query {"query": "drop DATABASE Db3"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE DATABASE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE DATABASE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE DATABASE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP DATABASE"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"d1\" has been dropped"}]}
+CommandComplete {"tag":"DROP DATABASE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"database"}]}
+DataRow {"fields":["db3"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"db3\" has been dropped"}]}
+CommandComplete {"tag":"DROP DATABASE"}
+ReadyForQuery {"status":"I"}
 
 # Test dropping active cluster
 send
@@ -191,27 +236,25 @@ ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ----
-RowDescription {"fields":[{"name":"cluster"}]}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"cluster \"nonexistant2\" does not exist"}]}
-DataRow {"fields":["nonexistant2"]}
-CommandComplete {"tag":"SELECT 1"}
+CommandComplete {"tag":"CREATE CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP CLUSTER"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active cluster \"c1\" has been dropped"}]}
+CommandComplete {"tag":"DROP CLUSTER"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
 RowDescription {"fields":[{"name":"cluster"}]}
-DataRow {"fields":["default"]}
+DataRow {"fields":["cl3"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"CREATE DATABASE"}
-ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"CREATE DATABASE"}
-ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"CREATE DATABASE"}
-ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"SET"}
-ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"DROP DATABASE"}
-ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"d1\" has been dropped"}]}
-CommandComplete {"tag":"DROP DATABASE"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active cluster \"cl3\" has been dropped"}]}
+CommandComplete {"tag":"DROP CLUSTER"}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest-mz/notice.pt
+++ b/test/pgtest-mz/notice.pt
@@ -16,6 +16,18 @@ Query {"query": "set database = 'materialize'"}
 Query {"query": "show database"}
 Query {"query": "set database = default"}
 Query {"query": "show database"}
+Query {"query": "set schema = nonexistant"}
+Query {"query": "show schema"}
+Query {"query": "set schema = public"}
+Query {"query": "show schema"}
+Query {"query": "set SCHEMA = NONexistant2"}
+Query {"query": "set schema = \"nonexistant3\""}
+Query {"query": "set schema = \"public\""}
+Query {"query": "show schema"}
+Query {"query": "set schema = 'public'"}
+Query {"query": "show schema"}
+Query {"query": "set schema = default"}
+Query {"query": "show schema"}
 Query {"query": "set cluster = nonexistant"}
 Query {"query": "show cluster"}
 Query {"query": "set CLUSTER = NONexistant2"}
@@ -48,6 +60,7 @@ NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
 RowDescription {"fields":[{"name":"database"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"database \"nonexistant\" does not exist"}]}
 DataRow {"fields":["nonexistant"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
@@ -81,25 +94,22 @@ RowDescription {"fields":[{"name":"database"}]}
 DataRow {"fields":["materialize"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"cluster \"nonexistant\" does not exist"}]}
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
-RowDescription {"fields":[{"name":"cluster"}]}
-DataRow {"fields":["nonexistant"]}
-CommandComplete {"tag":"SELECT 1"}
-ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"cluster \"nonexistant2\" does not exist"}]}
-CommandComplete {"tag":"SET"}
-ReadyForQuery {"status":"I"}
-RowDescription {"fields":[{"name":"cluster"}]}
-DataRow {"fields":["nonexistant2"]}
+RowDescription {"fields":[{"name":"schema"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"no schema on the search path exists: nonexistant"}]}
+DataRow {"fields":["NULL"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
-RowDescription {"fields":[{"name":"cluster"}]}
-DataRow {"fields":["default"]}
+RowDescription {"fields":[{"name":"schema"}]}
+DataRow {"fields":["public"]}
 CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
 
 # Test dropping active database
@@ -126,27 +136,35 @@ ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ----
-CommandComplete {"tag":"CREATE DATABASE"}
-ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"CREATE DATABASE"}
-ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"CREATE DATABASE"}
-ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"DROP DATABASE"}
-ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"d1\" has been dropped"}]}
-CommandComplete {"tag":"DROP DATABASE"}
-ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"SET"}
-ReadyForQuery {"status":"I"}
-RowDescription {"fields":[{"name":"database"}]}
-DataRow {"fields":["db3"]}
+RowDescription {"fields":[{"name":"schema"}]}
+DataRow {"fields":["public"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"db3\" has been dropped"}]}
-CommandComplete {"tag":"DROP DATABASE"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"schema"}]}
+DataRow {"fields":["public"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"schema"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"no schema on the search path exists: default"}]}
+DataRow {"fields":["NULL"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"cluster \"nonexistant\" does not exist"}]}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"cluster"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"cluster \"nonexistant\" does not exist"}]}
+DataRow {"fields":["nonexistant"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"cluster \"nonexistant2\" does not exist"}]}
+CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
 
 # Test dropping active cluster
@@ -173,25 +191,27 @@ ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ----
-CommandComplete {"tag":"CREATE CLUSTER"}
-ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"CREATE CLUSTER"}
-ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"CREATE CLUSTER"}
-ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"SET"}
-ReadyForQuery {"status":"I"}
-CommandComplete {"tag":"DROP CLUSTER"}
-ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active cluster \"c1\" has been dropped"}]}
-CommandComplete {"tag":"DROP CLUSTER"}
+RowDescription {"fields":[{"name":"cluster"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"cluster \"nonexistant2\" does not exist"}]}
+DataRow {"fields":["nonexistant2"]}
+CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
 RowDescription {"fields":[{"name":"cluster"}]}
-DataRow {"fields":["cl3"]}
+DataRow {"fields":["default"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active cluster \"cl3\" has been dropped"}]}
-CommandComplete {"tag":"DROP CLUSTER"}
+CommandComplete {"tag":"CREATE DATABASE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE DATABASE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE DATABASE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP DATABASE"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"d1\" has been dropped"}]}
+CommandComplete {"tag":"DROP DATABASE"}
 ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -303,3 +303,28 @@ simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET max_credit_consumption_rate = NaN
 ----
 db error: ERROR: parameter "max_credit_consumption_rate" requires a "numeric" value
+
+statement ok
+SET SCHEMA 'non-resolvable-name'
+
+statement ok
+SET SCHEMA TO 'non-resolvable-name'
+
+statement ok
+SET SCHEMA = 'non-resolvable-name'
+
+query T
+SHOW SCHEMA
+----
+NULL
+
+statement ok
+SET SCHEMA TO 'public'
+
+query T
+SHOW SCHEMA
+----
+public
+
+statement error Expected end of statement, found comma
+SET SCHEMA TO public, private, playground


### PR DESCRIPTION
Previously, we followed the PostgreSQL syntax for how to set the current search_path. That is a user could type
`SET search_path = <list-of-schemas>` or `SET schema <single-schema>`. `TO` also works as a replacement for `=` in the first example. Note the lack of an `=` in the second example. The reason PostgreSQL does this is that when using parameter aliases (such as `SCHEMA`) the user has to omit the `=`/`TO`. This differs from how we treat databases and schemas. For those objects users can type
`SET database = <database-name>` or `SET cluster = <cluster-name>` respectively. Many users were confused of the differences between schemas and databases/clusters.

This commit improves the ergonomics of setting the current schema by allowing the syntax `SET schema {= | TO} {ident | string}` which has the same result as `SET schema {string}`. It also adds `SHOW schema` which acts as an alias for `SELECT current_schema()`.

Additionally, `SHOW database`, `SHOW cluster`, and `SHOW schema` emit a notice if they are unable to display a resolvable object.

Resolves #18946

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
