### PR TITLE
tests: Use json to extract timestamps from EXPLAIN TIMESTAMP

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-import re
+import json
 import time
 from textwrap import dedent
 from threading import Thread
@@ -357,25 +357,16 @@ def workflow_test_github_15535(c: Composition) -> None:
     print("Sleeping to wait for frontier updates")
     time.sleep(10)
 
-    def extract_frontiers(output: str) -> Tuple[str, str]:
-        since_re = re.compile("^\s+since:\[(?P<frontier>.*)\]")
-        upper_re = re.compile("^\s+upper:\[(?P<frontier>.*)\]")
-        since = None
-        upper = None
-        for line in output.splitlines():
-            if match := since_re.match(line):
-                since = match.group("frontier").strip()
-            elif match := upper_re.match(line):
-                upper = match.group("frontier").strip()
-
-        assert since is not None, "since not found in EXPLAIN TIMESTAMP output"
-        assert upper is not None, "upper not found in EXPLAIN TIMESTAMP output"
-        return (since, upper)
+    def extract_frontiers(output: str) -> Tuple[int, int]:
+        j = json.loads(output)
+        (upper,) = j["determination"]["upper"]["elements"]
+        (since,) = j["determination"]["since"]["elements"]
+        return (upper, since)
 
     # Verify that there are no empty frontiers.
-    output = c.sql_query("EXPLAIN TIMESTAMP FOR SELECT * FROM mv")
+    output = c.sql_query("EXPLAIN TIMESTAMP AS JSON FOR SELECT * FROM mv")
     mv_since, mv_upper = extract_frontiers(output[0][0])
-    output = c.sql_query("EXPLAIN TIMESTAMP FOR SELECT * FROM t")
+    output = c.sql_query("EXPLAIN TIMESTAMP AS JSON FOR SELECT * FROM t")
     t_since, t_upper = extract_frontiers(output[0][0])
 
     assert mv_since, "mv has empty since frontier"
@@ -1471,16 +1462,14 @@ def workflow_test_mv_source_sink(c: Composition) -> None:
     )
 
     def extract_since_ts(output: str) -> int:
-        since_re = re.compile("^\s+since:\[(?P<ts>[0-9]*) \(.*\)\]")
-        for line in output.splitlines():
-            if match := since_re.match(line):
-                return int(match.group("ts"))
-        assert False, f"No since timestamp found in {output}"
+        j = json.loads(output)
+        (since,) = j["determination"]["since"]["elements"]
+        return int(since)
 
     # Verify that there are no empty frontiers.
-    output = c.sql_query("EXPLAIN TIMESTAMP FOR SELECT * FROM t")
+    output = c.sql_query("EXPLAIN TIMESTAMP AS JSON FOR SELECT * FROM t")
     t_since = extract_since_ts(output[0][0])
-    output = c.sql_query("EXPLAIN TIMESTAMP FOR SELECT * FROM mv")
+    output = c.sql_query("EXPLAIN TIMESTAMP AS JSON FOR SELECT * FROM mv")
     mv_since = extract_since_ts(output[0][0])
 
     assert (


### PR DESCRIPTION
Less brittle than regex

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
