### PR TITLE
ci: Build before running SLT

### DIFF
--- a/ci/slt/pipeline.yml
+++ b/ci/slt/pipeline.yml
@@ -8,6 +8,15 @@
 # by the Apache License, Version 2.0.
 
 steps:
+  - id: build-x86_64
+    label: Build x86_64
+    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build x86_64
+    timeout_in_minutes: 60
+    agents:
+      queue: builder-linux-x86_64
+
+  - wait: ~
+
   - id: sqllogictest
     label: ":bulb: SQL logic tests"
     timeout_in_minutes: 600


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/sql-logic-tests/builds/5536
```
[2023-05-12T11:32:55Z] Unable to find image 'materialize/ci-builder:UGS65NHDHQZTQGM45VMYFOXC25WBO5RM' locally
[2023-05-12T11:32:55Z] docker: Error response from daemon: manifest for materialize/ci-builder:UGS65NHDHQZTQGM45VMYFOXC25WBO5RM not found: manifest unknown: manifest unknown.
```
It is possible that the build is not available, in other pipelines we trigger build first, which should finish quickly if the build is available already.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
