### PR TITLE
Better control materialized views' sinces on creation

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1007,7 +1007,7 @@ def workflow_test_bootstrap_vars(c: Composition) -> None:
         Testdrive(no_reset=True),
         Materialized(
             options=[
-                "--system-var-default=allowed_cluster_replica_sizes='1', '2', 'oops'"
+                "--bootstrap-system-parameter=allowed_cluster_replica_sizes='1', '2', 'oops'"
             ],
         ),
     ):
@@ -1019,7 +1019,7 @@ def workflow_test_bootstrap_vars(c: Composition) -> None:
         Testdrive(no_reset=True),
         Materialized(
             environment_extra=[
-                """ MZ_SYSTEM_PARAMETER_DEFAULT=allowed_cluster_replica_sizes='1', '2', 'oops'""".strip()
+                """ MZ_BOOTSTRAP_SYSTEM_PARAMETER=allowed_cluster_replica_sizes='1', '2', 'oops'""".strip()
             ],
         ),
     ):
@@ -1456,8 +1456,6 @@ def workflow_test_mv_source_sink(c: Composition) -> None:
             WORKERS 2
         ));
         SET cluster = cluster1;
-        CREATE TABLE t (a int);
-        CREATE MATERIALIZED VIEW mv AS SELECT * FROM t;
         """
     )
 
@@ -1466,12 +1464,20 @@ def workflow_test_mv_source_sink(c: Composition) -> None:
         (since,) = j["determination"]["since"]["elements"]
         return int(since)
 
-    # Verify that there are no empty frontiers.
-    output = c.sql_query("EXPLAIN TIMESTAMP AS JSON FOR SELECT * FROM t")
-    t_since = extract_since_ts(output[0][0])
-    output = c.sql_query("EXPLAIN TIMESTAMP AS JSON FOR SELECT * FROM mv")
-    mv_since = extract_since_ts(output[0][0])
+    # Currently fails sporadically, so retry a few times to make it fail reliably
+    cursor = c.sql_cursor()
+    for i in range(20):
+        cursor.execute("CREATE TABLE t (a int)")
+        cursor.execute("CREATE MATERIALIZED VIEW mv AS SELECT * FROM t")
 
-    assert (
-        mv_since >= t_since
-    ), f'"since" timestamp of mv ({mv_since}) is less than "since" timestamp of its source table ({t_since})'
+        # Verify that there are no empty frontiers.
+        cursor.execute("EXPLAIN TIMESTAMP AS JSON FOR SELECT * FROM t")
+        t_since = extract_since_ts(cursor.fetchall()[0][0])
+        cursor.execute("EXPLAIN TIMESTAMP AS JSON FOR SELECT * FROM mv")
+        mv_since = extract_since_ts(cursor.fetchall()[0][0])
+
+        assert (
+            mv_since >= t_since
+        ), f'"since" timestamp of mv ({mv_since}) is less than "since" timestamp of its source table ({t_since})'
+
+        cursor.execute("DROP TABLE t CASCADE")


### PR DESCRIPTION
After trying to fix #19151, @def- determined it was still possible to create a materialized view whose dependencies' sinces were in advance of its since.

To resolve this issue, hold back the dependency sinces as far as possible when determining the since for the materialized view, and only permit the sinces to move forward once the view has been created.

I dislike this pattern because it requires manually dropping the read holds, but without something like Go's `defer`, idk how else to accomplish this. @MaterializeInc/surfaces do you all think this is worth jumping through the hoops of adding a "panic if improperly dropped?"

### Motivation

This PR fixes a recognized bug. Fixes #19243

### Tips for reviewer

@def- I took 9e9f895426b3ca9912664a62f41d0e9318b5d0a0 into this PR just to show that the amended test case passes; please feel free to modify as you see fit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
