### PR TITLE
release: bump to version v0.55.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3656,7 +3656,7 @@ dependencies = [
 
 [[package]]
 name = "mz-clusterd"
-version = "0.54.0-dev"
+version = "0.55.0-dev"
 dependencies = [
  "anyhow",
  "axum",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "0.54.0-dev"
+version = "0.55.0-dev"
 dependencies = [
  "anyhow",
  "askama",
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "mz-persist-client"
-version = "0.54.0-dev"
+version = "0.55.0-dev"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-clusterd"
 description = "Materialize's cluster server."
-version = "0.54.0-dev"
+version = "0.55.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "0.54.0-dev"
+version = "0.55.0-dev"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition.workspace = true

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-persist-client"
 description = "Client for Materialize pTVC durability system"
-version = "0.54.0-dev"
+version = "0.55.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
### Motivation

Bump dev version

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
