### PR TITLE
Ensure MIR join equivalences include typecheckable non-nullable fields

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1902,42 +1902,8 @@ pub fn non_nullable_columns(predicates: &[MirScalarExpr]) -> BTreeSet<usize> {
         // Should that happen, the row would be discarded.
         predicate.non_null_requirements(&mut nonnull_required_columns);
 
-        /*
-        Test for explicit checks that a column is non-null.
-
-        This analysis is ad hoc, and will miss things:
-
-        materialize=> create table a(x int, y int);
-        CREATE TABLE
-        materialize=> explain with(types) select x from a where (y=x and y is not null) or x is not null;
-        Optimized Plan
-        --------------------------------------------------------------------------------------------------------
-        Explained Query:                                                                                      +
-        Project (#0) // { types: "(integer?)" }                                                             +
-        Filter ((#0) IS NOT NULL OR ((#1) IS NOT NULL AND (#0 = #1))) // { types: "(integer?, integer?)" }+
-        Get materialize.public.a // { types: "(integer?, integer?)" }                                   +
-                                                                                  +
-        Source materialize.public.a                                                                           +
-        filter=(((#0) IS NOT NULL OR ((#1) IS NOT NULL AND (#0 = #1))))                                     +
-
-        (1 row)
-        */
-
-        if let MirScalarExpr::CallUnary {
-            func: UnaryFunc::Not(scalar_func::Not),
-            expr,
-        } = predicate
-        {
-            if let MirScalarExpr::CallUnary {
-                func: UnaryFunc::IsNull(scalar_func::IsNull),
-                expr,
-            } = &**expr
-            {
-                if let MirScalarExpr::Column(c) = &**expr {
-                    nonnull_required_columns.insert(*c);
-                }
-            }
-        }
+        // Add any columns that cannot be null for the predicates to pass
+        predicate.rejected_nulls(&mut nonnull_required_columns);
     }
 
     nonnull_required_columns


### PR DESCRIPTION
#18666 introduced an MIR typechecker. This PR is meant to address one of its imprecisions.

Join equivalences use raw `Datum` equality for inner joins, which would equate `NULL`s---when we compile a join from SQL we are careful to avoid hitting this case, but it's not 100% clear that we avoid this in all cases.

The typechecker has code that emits debug-level traces for when a join equivalence class is all nullable fields. But a number of queries---including some that are part of the startup sequence---generate queries that cause these traces to happen.

### Motivation

  * This PR fixes a recognized bug. #18666

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
