### PR TITLE
limits test: Allow one more connection

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -76,8 +76,9 @@ class Connections(Generator):
     @classmethod
     def body(cls) -> None:
         print("$ postgres-execute connection=mz_system")
-        # two extra connections for mz_system and the default connection
-        print(f"ALTER SYSTEM SET max_connections = {Connections.COUNT+2};")
+        # three extra connections for mz_system, default connection, and one
+        # since sqlparse 0.4.4
+        print(f"ALTER SYSTEM SET max_connections = {Connections.COUNT+3};")
 
         for i in cls.all():
             print(


### PR DESCRIPTION
I confirmed that bf93cb8e4093dd030c6e838e844e53c6270603e3 is the responsible change, but could not figure out why sqlparse would cause an additional sql connection to be opened. The sqlparse.split result in misc/python/materialize/mzcompose/__init__.py looks the same to me, I didn't see any other uses that would be related.

I checked and manually the number of connection limit is still respected correctly, so this is a test-only issue anyway.

Fixes #19256

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
