### PR TITLE
storage: bounded memory upsert snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4951,6 +4951,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "bincode",
  "bytes",
  "bytesize",
  "chrono",
@@ -5004,6 +5005,7 @@ dependencies = [
  "rdkafka",
  "regex",
  "rocksdb",
+ "seahash",
  "serde",
  "serde_json",
  "sha2",
@@ -6653,6 +6655,12 @@ name = "scratch"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96311ef4a16462c757bb6a39152c40f58f31cd2602a40fceb937e2bc34e6cbab"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -184,18 +184,46 @@ impl Options {
     }
 }
 
+/// The result type for `multi_get`.
+#[derive(Debug)]
+pub struct MultiGetResult {
+    /// The number of keys we fetched.
+    pub processed_gets: u64,
+}
+
+/// The result type for individual gets.
+#[derive(Debug, Default, Clone)]
+pub struct GetResult<V> {
+    /// The previous value, if there was one.
+    pub value: Option<V>,
+    /// The size of `value` as persisted, if there was one.
+    /// Useful for users keeping track of statistics.
+    pub size: Option<u64>,
+}
+
+/// The result type for `multi_put`.
+#[derive(Debug)]
+pub struct MultiPutResult {
+    /// The number of keys we put or deleted.
+    pub processed_puts: u64,
+    /// The total size of values we put into the database.
+    /// Does not contain any information about deletes.
+    pub size_written: u64,
+}
+
 #[derive(Debug)]
 enum Command<K, V> {
     MultiGet {
         batch: Vec<K>,
         // Scratch vector to return results in.
-        results_scratch: Vec<Option<V>>,
+        results_scratch: Vec<GetResult<V>>,
         response_sender: oneshot::Sender<
             Result<
                 (
+                    MultiGetResult,
                     // The batch scratch vector being given back.
                     Vec<K>,
-                    Vec<Option<V>>,
+                    Vec<GetResult<V>>,
                 ),
                 Error,
             >,
@@ -204,7 +232,7 @@ enum Command<K, V> {
     MultiPut {
         batch: Vec<(K, Option<V>)>,
         // Scratch vector to return results in.
-        response_sender: oneshot::Sender<Result<Vec<(K, Option<V>)>, Error>>,
+        response_sender: oneshot::Sender<Result<(MultiPutResult, Vec<(K, Option<V>)>), Error>>,
     },
     Shutdown {
         done_sender: oneshot::Sender<()>,
@@ -212,7 +240,6 @@ enum Command<K, V> {
 }
 
 /// An async wrapper around RocksDB.
-#[derive(Clone)]
 pub struct RocksDBInstance<K, V> {
     tx: mpsc::Sender<Command<K, V>>,
 
@@ -222,7 +249,7 @@ pub struct RocksDBInstance<K, V> {
 
     // Scratch vector to return results from the RocksDB thread
     // during `MultiGet`.
-    multi_get_results_scratch: Vec<Option<V>>,
+    multi_get_results_scratch: Vec<GetResult<V>>,
 
     // Scratch vector to send updates to the RocksDB thread
     // during `MultiPut`.
@@ -289,10 +316,14 @@ where
     /// For each _unique_ key in `gets`, place the stored value (if any) in `results_out`.
     ///
     /// Panics if `gets` and `results_out` are not the same length.
-    pub async fn multi_get<'r, G, R>(&mut self, gets: G, results_out: R) -> Result<u64, Error>
+    pub async fn multi_get<'r, G, R>(
+        &mut self,
+        gets: G,
+        results_out: R,
+    ) -> Result<MultiGetResult, Error>
     where
         G: IntoIterator<Item = K>,
-        R: IntoIterator<Item = &'r mut Option<V>>,
+        R: IntoIterator<Item = &'r mut GetResult<V>>,
     {
         let mut multi_get_vec = std::mem::take(&mut self.multi_get_scratch);
         let mut results_vec = std::mem::take(&mut self.multi_get_results_scratch);
@@ -303,7 +334,7 @@ where
         if multi_get_vec.is_empty() {
             self.multi_get_scratch = multi_get_vec;
             self.multi_get_results_scratch = results_vec;
-            return Ok(0);
+            return Ok(MultiGetResult { processed_gets: 0 });
         }
 
         let (tx, rx) = oneshot::channel();
@@ -318,15 +349,13 @@ where
 
         // We also unwrap all rocksdb errors here.
         match rx.await.map_err(|_| Error::RocksDBThreadGoneAway)? {
-            Ok(mut results) => {
-                let size = u64::cast_from(results.1.len());
-
-                for (place, get) in results_out.into_iter().zip_eq(results.1.drain(..)) {
+            Ok((ret, get_scratch, mut results_scratch)) => {
+                for (place, get) in results_out.into_iter().zip_eq(results_scratch.drain(..)) {
                     *place = get;
                 }
-                self.multi_get_scratch = results.0;
-                self.multi_get_results_scratch = results.1;
-                Ok(size)
+                self.multi_get_scratch = get_scratch;
+                self.multi_get_results_scratch = results_scratch;
+                Ok(ret)
             }
             Err(e) => {
                 // Note we don't attempt to preserve the scratch allocations here.
@@ -338,7 +367,7 @@ where
     /// For each key in puts, store the given value, or delete it if
     /// the value is `None`. If the same `key` appears multiple times,
     /// the last value for the key wins.
-    pub async fn multi_put<P>(&mut self, puts: P) -> Result<u64, Error>
+    pub async fn multi_put<P>(&mut self, puts: P) -> Result<MultiPutResult, Error>
     where
         P: IntoIterator<Item = (K, Option<V>)>,
     {
@@ -348,10 +377,11 @@ where
         multi_put_vec.extend(puts);
         if multi_put_vec.is_empty() {
             self.multi_put_scratch = multi_put_vec;
-            return Ok(0);
+            return Ok(MultiPutResult {
+                processed_puts: 0,
+                size_written: 0,
+            });
         }
-
-        let size = u64::cast_from(multi_put_vec.len());
 
         let (tx, rx) = oneshot::channel();
         self.tx
@@ -364,9 +394,9 @@ where
 
         // We also unwrap all rocksdb errors here.
         match rx.await.map_err(|_| Error::RocksDBThreadGoneAway)? {
-            Ok(scratch) => {
+            Ok((ret, scratch)) => {
                 self.multi_put_scratch = scratch;
-                Ok(size)
+                Ok(ret)
             }
             Err(e) => {
                 // Note we don't attempt to preserve the allocation here.
@@ -403,7 +433,9 @@ fn rocksdb_core_loop<K, V, M>(
     V: Serialize + DeserializeOwned + Send + Sync + 'static,
     M: Deref<Target = RocksDBMetrics> + Send + 'static,
 {
-    let db: DB = match DB::open(&options.as_rocksdb_options(&tuning_config), &instance_path) {
+    let rocksdb_options = options.as_rocksdb_options(&tuning_config);
+
+    let db: DB = match DB::open(&rocksdb_options, &instance_path) {
         Ok(db) => {
             drop(creation_error_tx);
             db
@@ -416,6 +448,8 @@ fn rocksdb_core_loop<K, V, M>(
     };
     let wo = options.as_rocksdb_write_options();
 
+    use bincode::Options;
+    let enc_opts = bincode::DefaultOptions::new().allow_trailing_bytes();
     while let Some(cmd) = cmd_rx.blocking_recv() {
         match cmd {
             Command::Shutdown { done_sender } => {
@@ -441,21 +475,34 @@ fn rocksdb_core_loop<K, V, M>(
                     Ok(gets) => {
                         metrics.multi_get_latency.observe(latency.as_secs_f64());
                         metrics.multi_get_size.observe(f64::cast_lossy(batch_size));
+                        let result = MultiGetResult {
+                            processed_gets: gets.len().try_into().unwrap(),
+                        };
+
                         for previous_value in gets {
-                            let previous_value = match previous_value
-                                .map(|v| bincode::deserialize(&v))
-                                .transpose()
-                            {
-                                Ok(v) => v,
-                                Err(e) => {
-                                    let _ = response_sender.send(Err(Error::DecodeError(e)));
-                                    return;
+                            let (previous_value, size) = match previous_value {
+                                Some(previous_value) => {
+                                    match enc_opts.deserialize(&previous_value) {
+                                        Ok(value) => (
+                                            Some(value),
+                                            Some(u64::cast_from(previous_value.len())),
+                                        ),
+                                        Err(e) => {
+                                            let _ =
+                                                response_sender.send(Err(Error::DecodeError(e)));
+                                            return;
+                                        }
+                                    }
                                 }
+                                None => (None, None),
                             };
-                            results_scratch.push(previous_value);
+                            results_scratch.push(GetResult {
+                                value: previous_value,
+                                size,
+                            });
                         }
 
-                        let _ = response_sender.send(Ok((batch, results_scratch)));
+                        let _ = response_sender.send(Ok((result, batch, results_scratch)));
                     }
                     Err(e) => {
                         let _ = response_sender.send(Err(Error::RocksDB(e)));
@@ -471,16 +518,21 @@ fn rocksdb_core_loop<K, V, M>(
                 let mut writes = rocksdb::WriteBatch::default();
                 let mut encode_buf = Vec::new();
 
+                let mut ret = MultiPutResult {
+                    processed_puts: 0,
+                    size_written: 0,
+                };
                 // TODO(guswynn): sort by key before writing.
                 for (key, value) in batch.drain(..) {
+                    ret.processed_puts += 1;
+
                     match value {
                         Some(update) => {
                             encode_buf.clear();
-                            match bincode::serialize_into::<&mut Vec<u8>, _>(
-                                &mut encode_buf,
-                                &update,
-                            ) {
-                                Ok(()) => {}
+                            match enc_opts
+                                .serialize_into::<&mut Vec<u8>, _>(&mut encode_buf, &update)
+                            {
+                                Ok(()) => ret.size_written += u64::cast_from(encode_buf.len()),
                                 Err(e) => {
                                     let _ = response_sender.send(Err(Error::DecodeError(e)));
                                     return;
@@ -498,7 +550,7 @@ fn rocksdb_core_loop<K, V, M>(
                         let latency = now.elapsed();
                         metrics.multi_put_latency.observe(latency.as_secs_f64());
                         metrics.multi_put_size.observe(f64::cast_lossy(batch_size));
-                        let _ = response_sender.send(Ok(batch));
+                        let _ = response_sender.send(Ok((ret, batch)));
                     }
                     Err(e) => {
                         let _ = response_sender.send(Err(Error::RocksDB(e)));

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -102,12 +102,15 @@ async fn basic() -> Result<(), anyhow::Error> {
     )
     .await?;
 
-    let mut ret = vec![None; 1];
+    let mut ret = vec![Default::default(); 1];
     instance
         .multi_get(vec!["one".to_string()], ret.iter_mut())
         .await?;
 
-    assert_eq!(ret.split_off(0), vec![None]);
+    assert_eq!(
+        ret.into_iter().map(|v| v.value).collect::<Vec<_>>(),
+        vec![None]
+    );
 
     instance
         .multi_put(vec![
@@ -117,12 +120,15 @@ async fn basic() -> Result<(), anyhow::Error> {
         ])
         .await?;
 
-    let mut ret = vec![None; 2];
+    let mut ret = vec![Default::default(); 2];
     instance
         .multi_get(vec!["one".to_string(), "two".to_string()], ret.iter_mut())
         .await?;
 
-    assert_eq!(ret.split_off(0), vec![Some("onev".to_string()), None]);
+    assert_eq!(
+        ret.into_iter().map(|v| v.value).collect::<Vec<_>>(),
+        vec![Some("onev".to_string()), None]
+    );
 
     instance
         .multi_put(vec![
@@ -132,13 +138,13 @@ async fn basic() -> Result<(), anyhow::Error> {
         ])
         .await?;
 
-    let mut ret = vec![None; 2];
+    let mut ret = vec![Default::default(); 2];
     instance
         .multi_get(vec!["one".to_string(), "two".to_string()], ret.iter_mut())
         .await?;
 
     assert_eq!(
-        ret.split_off(0),
+        ret.into_iter().map(|v| v.value).collect::<Vec<_>>(),
         vec![Some("onev".to_string()), Some("twov2".to_string())]
     );
 

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -108,7 +108,9 @@ async fn basic() -> Result<(), anyhow::Error> {
         .await?;
 
     assert_eq!(
-        ret.into_iter().map(|v| v.value).collect::<Vec<_>>(),
+        ret.into_iter()
+            .map(|v| v.map(|v| v.value))
+            .collect::<Vec<_>>(),
         vec![None]
     );
 
@@ -126,7 +128,9 @@ async fn basic() -> Result<(), anyhow::Error> {
         .await?;
 
     assert_eq!(
-        ret.into_iter().map(|v| v.value).collect::<Vec<_>>(),
+        ret.into_iter()
+            .map(|v| v.map(|v| v.value))
+            .collect::<Vec<_>>(),
         vec![Some("onev".to_string()), None]
     );
 
@@ -144,7 +148,9 @@ async fn basic() -> Result<(), anyhow::Error> {
         .await?;
 
     assert_eq!(
-        ret.into_iter().map(|v| v.value).collect::<Vec<_>>(),
+        ret.into_iter()
+            .map(|v| v.map(|v| v.value))
+            .collect::<Vec<_>>(),
         vec![Some("onev".to_string()), Some("twov2".to_string())]
     );
 

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -99,6 +99,7 @@ async fn basic() -> Result<(), anyhow::Error> {
         Options::defaults_with_env(rocksdb::Env::new()?),
         RocksDBTuningParameters::default(),
         metrics_for_tests()?,
+        bincode::DefaultOptions::new(),
     )
     .await?;
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -16,6 +16,7 @@ async-stream = "0.3.3"
 async-trait = "0.1.68"
 bytes = { version = "1.3.0", features = ["serde"] }
 bytesize = "1.1.0"
+bincode = "1"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
@@ -61,6 +62,7 @@ rand = "0.8.5"
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = { version = "1.7.0" }
 rocksdb = { version = "0.21.0", default-features = false, features = ["snappy"] }
+seahash = "4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 sha2 = "0.10.6"

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -30,7 +30,9 @@ use timely::dataflow::Scope;
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::{Antichain, Timestamp};
 
-use crate::render::upsert::types::{InMemoryHashMap, UpsertState, UpsertStateBackend};
+use crate::render::upsert::types::{
+    upsert_bincode_opts, InMemoryHashMap, UpsertState, UpsertStateBackend,
+};
 use crate::source::types::UpsertMetrics;
 use crate::storage_state::StorageInstanceContext;
 
@@ -178,6 +180,9 @@ where
                         mz_rocksdb::Options::defaults_with_env(env),
                         tuning,
                         rocksdb_metrics,
+                        // For now, just use the same config as the one used for
+                        // merging snapshots.
+                        upsert_bincode_opts(),
                     )
                     .await
                     .unwrap(),

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -265,7 +265,6 @@ where
                     for ((key, value), ts, diff) in data.drain(..) {
                         // In the first phase we consolidate updates from our output that are not beyond
                         // resume_upper, in-place in `state`.
-                        #[allow(clippy::as_conversions)]
                         if !resume_upper.less_equal(&ts) {
                             update_buf.push((key, value, diff));
                             batch_key_counter.insert(key);
@@ -312,7 +311,8 @@ where
                     .try_into()
                     .unwrap_or_else(|e: std::num::TryFromIntError| {
                         tracing::warn!(
-                            "rehydration_total metric overflowed and is innacurate: {}",
+                            "rehydration_total metric overflowed or is negative \
+                            and is innacurate: {}. Defaulting to 0",
                             e.display_with_causes(),
                         );
 
@@ -334,8 +334,7 @@ where
             // antichain since we have dropped its token.
         }
 
-        // A re-usable buffer of changes, per key. This is
-        // an `IndexMap` because it has to be `drain`-able
+        // A re-usable buffer of changes, per key. This is an `IndexMap` because it has to be `drain`-able
         // and have a consistent iteration order.
         let mut commands_state: indexmap::IndexMap<_, types::UpsertValueAndSize> =
             indexmap::IndexMap::new();

--- a/src/storage/src/render/upsert/rocksdb.rs
+++ b/src/storage/src/render/upsert/rocksdb.rs
@@ -10,7 +10,10 @@
 use itertools::Itertools;
 use mz_rocksdb::RocksDBInstance;
 
-use crate::render::upsert::types::UpsertState;
+use crate::render::upsert::types::{
+    upsert_bincode_opts, BincodeOpts, GetStats, MergeStats, PutStats, PutValue, StateValue,
+    UpsertState, UpsertValueAndSize,
+};
 use crate::render::upsert::{UpsertKey, UpsertValue};
 
 /// The maximum batch size we will write to rocksdb.
@@ -23,51 +26,186 @@ pub const BATCH_SIZE: usize = 1024;
 /// A `UpsertState` implementation backed by RocksDB.
 /// This is currently untested, and simply compiles.
 pub struct RocksDB {
-    rocksdb: RocksDBInstance<UpsertKey, UpsertValue>,
+    inner: Inner,
+
+    // Bincode options and buffer used
+    // in `merge_snapshot_chunk`.
+    bincode_opts: BincodeOpts,
+    bincode_buffer: Vec<u8>,
+
+    // We need to iterator over `merges` in `merge_snapshot_chunk`
+    // twice, so we have a scratch vector for this.
+    merge_scratch: Vec<(UpsertKey, UpsertValue, mz_repr::Diff)>,
+    // "mini-upsert" map used in `merge_snapshot_chunk`, plus a
+    // scratch vector for calling `multi_get`
+    merge_upsert_scratch: indexmap::IndexMap<UpsertKey, UpsertValueAndSize>,
+    multi_get_scratch: Vec<UpsertKey>,
 }
 
 impl RocksDB {
-    pub fn new(rocksdb: RocksDBInstance<UpsertKey, UpsertValue>) -> Self {
-        Self { rocksdb }
+    pub fn new(rocksdb: RocksDBInstance<UpsertKey, StateValue>) -> Self {
+        Self {
+            inner: Inner { rocksdb },
+            bincode_opts: upsert_bincode_opts(),
+            bincode_buffer: Vec::new(),
+            merge_scratch: Vec::new(),
+            merge_upsert_scratch: indexmap::IndexMap::new(),
+            multi_get_scratch: Vec::new(),
+        }
     }
 }
 
 #[async_trait::async_trait(?Send)]
 impl UpsertState for RocksDB {
-    async fn multi_put<P>(&mut self, puts: P) -> Result<u64, anyhow::Error>
-    where
-        P: IntoIterator<Item = (UpsertKey, Option<UpsertValue>)>,
-    {
-        let mut puts = puts.into_iter().peekable();
+    const SNAPSHOT_BATCH_SIZE: usize = BATCH_SIZE;
 
-        if puts.peek().is_some() {
-            let mut total_size = 0;
-            let puts = puts.chunks(BATCH_SIZE);
-            for puts in puts.into_iter() {
-                total_size += self.rocksdb.multi_put(puts).await?;
+    // Note that this does NOT use RocksDB's native merge functionality, which would be more
+    // performant. This is because:
+    // - We don't have proof we need that performance.
+    // - This implementation is wildly simpler, as the RocksDB merge api is quite difficult to use
+    // properly
+    //
+    // Additionally:
+    // - Keeping track of stats is way easier this way
+    // - The implementation is uses the exact same "mini-upsert" technique used in the upsert
+    // operator.
+    async fn merge_snapshot_chunk<M>(&mut self, merges: M) -> Result<MergeStats, anyhow::Error>
+    where
+        M: IntoIterator<Item = (UpsertKey, UpsertValue, mz_repr::Diff)>,
+    {
+        let mut merges = merges.into_iter().peekable();
+
+        self.merge_scratch.clear();
+        self.merge_upsert_scratch.clear();
+        self.multi_get_scratch.clear();
+
+        let mut stats = MergeStats::default();
+
+        if merges.peek().is_some() {
+            self.merge_scratch.extend(merges);
+            self.merge_upsert_scratch.extend(
+                self.merge_scratch
+                    .iter()
+                    .map(|(k, _, _)| (*k, UpsertValueAndSize::default())),
+            );
+            self.multi_get_scratch
+                .extend(self.merge_upsert_scratch.iter().map(|(k, _)| *k));
+            self.inner
+                .rocksdb
+                .multi_get(
+                    self.multi_get_scratch.drain(..),
+                    self.merge_upsert_scratch.iter_mut().map(|(_, v)| v),
+                )
+                .await?;
+
+            for (key, value, diff) in self.merge_scratch.drain(..) {
+                stats.updates += 1;
+                let entry = self.merge_upsert_scratch.get_mut(&key).unwrap();
+                let val = entry.value.get_or_insert_with(Default::default);
+
+                if val.merge_update(value, diff, self.bincode_opts, &mut self.bincode_buffer) {
+                    entry.value = None;
+                }
             }
-            Ok(total_size)
-        } else {
-            Ok(0)
+
+            // Note we do 1 `multi_get` and 1 `multi_put` while processing a _batch of updates_.
+            // Within the batch, we effectively consolidate each key, before persisting that
+            // consolidated value. Easy!!
+            let p_stats = self
+                .inner
+                .multi_put_inner(self.merge_upsert_scratch.drain(..).map(|(k, v)| {
+                    (
+                        k,
+                        v.value,
+                        v.size.map(|v| v.try_into().expect("less than i64 size")),
+                    )
+                }))
+                .await?;
+
+            stats.values_diff = p_stats.values_diff;
+            stats.size_diff = p_stats.size_diff;
         }
+        Ok(stats)
     }
 
-    async fn multi_get<'r, G, R>(&mut self, gets: G, results_out: R) -> Result<u64, anyhow::Error>
+    async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
+    where
+        P: IntoIterator<Item = (UpsertKey, PutValue)>,
+    {
+        self.inner
+            .multi_put_inner(
+                puts.into_iter()
+                    .map(|(k, put)| (k, put.value.map(|v| v.into()), put.previous_persisted_size)),
+            )
+            .await
+    }
+
+    async fn multi_get<'r, G, R>(
+        &mut self,
+        gets: G,
+        results_out: R,
+    ) -> Result<GetStats, anyhow::Error>
     where
         G: IntoIterator<Item = UpsertKey>,
-        R: IntoIterator<Item = &'r mut Option<UpsertValue>>,
+        R: IntoIterator<Item = &'r mut UpsertValueAndSize>,
     {
+        let mut g_stats = GetStats::default();
         let mut gets = gets.into_iter().peekable();
         if gets.peek().is_some() {
-            let mut total_size = 0;
             let gets = gets.chunks(BATCH_SIZE);
             let results_out = results_out.into_iter().chunks(BATCH_SIZE);
             for (gets, results_out) in gets.into_iter().zip_eq(results_out.into_iter()) {
-                total_size += self.rocksdb.multi_get(gets, results_out).await?;
+                let stats = self.inner.rocksdb.multi_get(gets, results_out).await?;
+                g_stats.processed_gets += stats.processed_gets;
             }
-            Ok(total_size)
-        } else {
-            Ok(0)
         }
+        Ok(g_stats)
+    }
+}
+
+/// A inner struct for `RocksDB` that lets us define an `&mut self` private method
+/// (`multi_put_inner`) that only uses the `rocksdb` field. If Rust had view types,
+/// we wouldn't need this.
+struct Inner {
+    rocksdb: RocksDBInstance<UpsertKey, StateValue>,
+}
+
+impl Inner {
+    async fn multi_put_inner<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
+    where
+        P: IntoIterator<Item = (UpsertKey, Option<StateValue>, Option<i64>)>,
+    {
+        let mut puts = puts.into_iter().peekable();
+
+        let mut p_stats = PutStats::default();
+
+        if puts.peek().is_some() {
+            let puts = puts.chunks(BATCH_SIZE);
+            for puts in puts.into_iter() {
+                let stats = self
+                    .rocksdb
+                    .multi_put(puts.map(|(k, put, previous_persisted_size)| {
+                        match (&put, previous_persisted_size) {
+                            (Some(_), Some(ps)) => {
+                                p_stats.size_diff -= ps;
+                            }
+                            (None, Some(ps)) => {
+                                p_stats.size_diff -= ps;
+                                p_stats.values_diff -= 1;
+                            }
+                            (Some(_), None) => {
+                                p_stats.values_diff += 1;
+                            }
+                            (None, None) => {}
+                        }
+                        (k, put)
+                    }))
+                    .await?;
+                p_stats.processed_puts += stats.processed_puts;
+                let size: i64 = stats.size_written.try_into().expect("less than i64 size");
+                p_stats.size_diff += size;
+            }
+        }
+        Ok(p_stats)
     }
 }

--- a/src/storage/src/render/upsert/rocksdb.rs
+++ b/src/storage/src/render/upsert/rocksdb.rs
@@ -11,10 +11,9 @@ use itertools::Itertools;
 use mz_rocksdb::RocksDBInstance;
 
 use crate::render::upsert::types::{
-    upsert_bincode_opts, BincodeOpts, GetStats, MergeStats, PutStats, PutValue, StateValue,
-    UpsertState, UpsertValueAndSize,
+    GetStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize,
 };
-use crate::render::upsert::{UpsertKey, UpsertValue};
+use crate::render::upsert::UpsertKey;
 
 /// The maximum batch size we will write to rocksdb.
 ///
@@ -23,121 +22,65 @@ use crate::render::upsert::{UpsertKey, UpsertValue};
 // TODO(guswynn|moulimukherjee): Make this configurable.
 pub const BATCH_SIZE: usize = 1024;
 
-/// A `UpsertState` implementation backed by RocksDB.
+/// A `UpsertStateBackend` implementation backed by RocksDB.
 /// This is currently untested, and simply compiles.
 pub struct RocksDB {
-    inner: Inner,
-
-    // Bincode options and buffer used
-    // in `merge_snapshot_chunk`.
-    bincode_opts: BincodeOpts,
-    bincode_buffer: Vec<u8>,
-
-    // We need to iterator over `merges` in `merge_snapshot_chunk`
-    // twice, so we have a scratch vector for this.
-    merge_scratch: Vec<(UpsertKey, UpsertValue, mz_repr::Diff)>,
-    // "mini-upsert" map used in `merge_snapshot_chunk`, plus a
-    // scratch vector for calling `multi_get`
-    merge_upsert_scratch: indexmap::IndexMap<UpsertKey, UpsertValueAndSize>,
-    multi_get_scratch: Vec<UpsertKey>,
+    rocksdb: RocksDBInstance<UpsertKey, StateValue>,
 }
 
 impl RocksDB {
     pub fn new(rocksdb: RocksDBInstance<UpsertKey, StateValue>) -> Self {
-        Self {
-            inner: Inner { rocksdb },
-            bincode_opts: upsert_bincode_opts(),
-            bincode_buffer: Vec::new(),
-            merge_scratch: Vec::new(),
-            merge_upsert_scratch: indexmap::IndexMap::new(),
-            multi_get_scratch: Vec::new(),
-        }
+        Self { rocksdb }
     }
 }
 
 #[async_trait::async_trait(?Send)]
-impl UpsertState for RocksDB {
+impl UpsertStateBackend for RocksDB {
     const SNAPSHOT_BATCH_SIZE: usize = BATCH_SIZE;
-
-    // Note that this does NOT use RocksDB's native merge functionality, which would be more
-    // performant. This is because:
-    // - We don't have proof we need that performance.
-    // - This implementation is wildly simpler, as the RocksDB merge api is quite difficult to use
-    // properly
-    //
-    // Additionally:
-    // - Keeping track of stats is way easier this way
-    // - The implementation is uses the exact same "mini-upsert" technique used in the upsert
-    // operator.
-    async fn merge_snapshot_chunk<M>(&mut self, merges: M) -> Result<MergeStats, anyhow::Error>
-    where
-        M: IntoIterator<Item = (UpsertKey, UpsertValue, mz_repr::Diff)>,
-    {
-        let mut merges = merges.into_iter().peekable();
-
-        self.merge_scratch.clear();
-        self.merge_upsert_scratch.clear();
-        self.multi_get_scratch.clear();
-
-        let mut stats = MergeStats::default();
-
-        if merges.peek().is_some() {
-            self.merge_scratch.extend(merges);
-            self.merge_upsert_scratch.extend(
-                self.merge_scratch
-                    .iter()
-                    .map(|(k, _, _)| (*k, UpsertValueAndSize::default())),
-            );
-            self.multi_get_scratch
-                .extend(self.merge_upsert_scratch.iter().map(|(k, _)| *k));
-            self.inner
-                .rocksdb
-                .multi_get(
-                    self.multi_get_scratch.drain(..),
-                    self.merge_upsert_scratch.iter_mut().map(|(_, v)| v),
-                )
-                .await?;
-
-            for (key, value, diff) in self.merge_scratch.drain(..) {
-                stats.updates += 1;
-                let entry = self.merge_upsert_scratch.get_mut(&key).unwrap();
-                let val = entry.value.get_or_insert_with(Default::default);
-
-                if val.merge_update(value, diff, self.bincode_opts, &mut self.bincode_buffer) {
-                    entry.value = None;
-                }
-            }
-
-            // Note we do 1 `multi_get` and 1 `multi_put` while processing a _batch of updates_.
-            // Within the batch, we effectively consolidate each key, before persisting that
-            // consolidated value. Easy!!
-            let p_stats = self
-                .inner
-                .multi_put_inner(self.merge_upsert_scratch.drain(..).map(|(k, v)| {
-                    (
-                        k,
-                        v.value,
-                        v.size.map(|v| v.try_into().expect("less than i64 size")),
-                    )
-                }))
-                .await?;
-
-            stats.values_diff = p_stats.values_diff;
-            stats.size_diff = p_stats.size_diff;
-        }
-        Ok(stats)
-    }
 
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
-        P: IntoIterator<Item = (UpsertKey, PutValue)>,
+        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue>)>,
     {
-        self.inner
-            .multi_put_inner(
-                puts.into_iter()
-                    .map(|(k, put)| (k, put.value.map(|v| v.into()), put.previous_persisted_size)),
-            )
-            .await
+        let mut p_stats = PutStats::default();
+        let mut puts = puts.into_iter().peekable();
+
+        if puts.peek().is_some() {
+            let puts = puts.chunks(BATCH_SIZE);
+            for puts in puts.into_iter() {
+                let stats = self
+                    .rocksdb
+                    .multi_put(puts.map(
+                        |(
+                            k,
+                            PutValue {
+                                value,
+                                previous_persisted_size,
+                            },
+                        )| {
+                            match (&value, previous_persisted_size) {
+                                (Some(_), Some(ps)) => {
+                                    p_stats.size_diff -= ps;
+                                }
+                                (None, Some(ps)) => {
+                                    p_stats.size_diff -= ps;
+                                    p_stats.values_diff -= 1;
+                                }
+                                (Some(_), None) => {
+                                    p_stats.values_diff += 1;
+                                }
+                                (None, None) => {}
+                            }
+                            (k, value)
+                        },
+                    ))
+                    .await?;
+                p_stats.processed_puts += stats.processed_puts;
+                let size: i64 = stats.size_written.try_into().expect("less than i64 size");
+                p_stats.size_diff += size;
+            }
+        }
+        Ok(p_stats)
     }
 
     async fn multi_get<'r, G, R>(
@@ -155,57 +98,10 @@ impl UpsertState for RocksDB {
             let gets = gets.chunks(BATCH_SIZE);
             let results_out = results_out.into_iter().chunks(BATCH_SIZE);
             for (gets, results_out) in gets.into_iter().zip_eq(results_out.into_iter()) {
-                let stats = self.inner.rocksdb.multi_get(gets, results_out).await?;
+                let stats = self.rocksdb.multi_get(gets, results_out).await?;
                 g_stats.processed_gets += stats.processed_gets;
             }
         }
         Ok(g_stats)
-    }
-}
-
-/// A inner struct for `RocksDB` that lets us define an `&mut self` private method
-/// (`multi_put_inner`) that only uses the `rocksdb` field. If Rust had view types,
-/// we wouldn't need this.
-struct Inner {
-    rocksdb: RocksDBInstance<UpsertKey, StateValue>,
-}
-
-impl Inner {
-    async fn multi_put_inner<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
-    where
-        P: IntoIterator<Item = (UpsertKey, Option<StateValue>, Option<i64>)>,
-    {
-        let mut puts = puts.into_iter().peekable();
-
-        let mut p_stats = PutStats::default();
-
-        if puts.peek().is_some() {
-            let puts = puts.chunks(BATCH_SIZE);
-            for puts in puts.into_iter() {
-                let stats = self
-                    .rocksdb
-                    .multi_put(puts.map(|(k, put, previous_persisted_size)| {
-                        match (&put, previous_persisted_size) {
-                            (Some(_), Some(ps)) => {
-                                p_stats.size_diff -= ps;
-                            }
-                            (None, Some(ps)) => {
-                                p_stats.size_diff -= ps;
-                                p_stats.values_diff -= 1;
-                            }
-                            (Some(_), None) => {
-                                p_stats.values_diff += 1;
-                            }
-                            (None, None) => {}
-                        }
-                        (k, put)
-                    }))
-                    .await?;
-                p_stats.processed_puts += stats.processed_puts;
-                let size: i64 = stats.size_written.try_into().expect("less than i64 size");
-                p_stats.size_diff += size;
-            }
-        }
-        Ok(p_stats)
     }
 }

--- a/src/storage/src/render/upsert/rocksdb.rs
+++ b/src/storage/src/render/upsert/rocksdb.rs
@@ -45,8 +45,6 @@ impl RocksDB {
 
 #[async_trait::async_trait(?Send)]
 impl UpsertStateBackend for RocksDB {
-    const SNAPSHOT_BATCH_SIZE: usize = BATCH_SIZE;
-
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
         P: IntoIterator<Item = (UpsertKey, PutValue<StateValue>)>,

--- a/src/storage/src/render/upsert/types.rs
+++ b/src/storage/src/render/upsert/types.rs
@@ -7,84 +7,477 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! This module defines the `UpsertState` trait and various implementations.
+//! This trait is the way the `upsert` operator interacts with various state backings.
+//!
+//! Because its a complex trait with a somewhat leaky abstraction, it warrants a high-level
+//! description, explaining the complexity. The trait has 3 methods:
+//!
+//! ## `multi_get`
+//! `multi_get` returns the current value for a (unique) set of keys. To keep implementations
+//! efficient, the set of keys is an iterator, and results are written back into another parallel
+//! iterator. In addition to returning the current values, implementations must also return the
+//! _size_ of those values _as they are stored within the implementation_. Implementations are
+//! required to chunk large iterators if they need to operate over smaller batches.
+//!
+//! ## `multi_put`
+//! Update or delete values for a set of keys. To keep implementations efficient, the set
+//! of updates is an iterator. Implementations are also required to return the difference
+//! in values and total size after processing the updates. To simplify this (and because
+//! in the `upsert` usecase we have this data readily available), the updates are input
+//! with the size of the current value (if any) that was returned from a previous `multi_get`.
+//! Implementations are required to chunk large iterators if they need to operate over smaller
+//! batches.
+//!
+//! ## `merge_snapshot_chunk`
+//! The most complicated method, this method requires implementations to consolidate a _chunk_ of
+//! updates into their state. This method effectively asks implementations to implement the logic in
+//! <https://docs.rs/differential-dataflow/latest/differential_dataflow/consolidation/fn.consolidate.html>,
+//! but under the assumption that the set of updates is a valid upsert `Collection`. Note that this
+//! allows implementations to do this a memory-efficient (or even, _memory-bounded) way. Because
+//! this is non-trivial, this module provides `StateValue`, which implements some of the core logic
+//! required to do this. `StateValue::merge_update` has more information about this.
+//!
+//! `merge_snapshot_chunk` has to return stats about the number of values and size of the state,
+//! just like `multi_put`.
+//!
+//! Another curiosity is that implementation can assume that `merge_snapshot_chunk` is called with
+//! a set of updates with a number of keys not greater than `UpsertState::SNAPSHOT_BATCH_SIZE`. This
+//! is different than `multi_put` and `multi_get` purely because it simplifies the way that the `upsert`
+//! operator handles snapshots.
+//!
+//!
+//! # A note on state size
+//!
+//! The `UpsertState` trait requires implementations report _relatively accurate_ information about
+//! how the state size changes over time. Note that it does NOT ask the implementations to give
+//! accurate information about actual resource consumption (like disk space including space
+//! amplification), and instead is just asking about the size of the values, after they have been
+//! encoded. For implementations like `RocksDB`, these may be highly accurate (it literally
+//! reports the encoded size as written to the RocksDB API, and for others like the
+//! `InMemoryHashMap`, they may be rough estimates of actual memory usage. See
+//! `StateValue::memory_size` for more information.
+//!
+//! Note also that after snapshot consolidation, additional space may be used if `StateValue` is
+//! used.
+
+use std::collections::hash_map;
+use std::num::Wrapping;
 use std::sync::Arc;
 use std::time::Instant;
 
+use bincode::Options;
 use itertools::Itertools;
-use mz_ore::cast::CastLossy;
+use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::collections::HashMap;
 
 use crate::render::upsert::{UpsertKey, UpsertValue};
 use crate::source::metrics::UpsertSharedMetrics;
 
+/// The default set of `bincode` options used for consolidating
+/// upsert snapshots (and writing values to RocksDB).
+pub type BincodeOpts = bincode::config::WithOtherTrailing<
+    bincode::config::DefaultOptions,
+    bincode::config::AllowTrailing,
+>;
+
+/// Build the default `BincodeOpts`.
+pub fn upsert_bincode_opts() -> BincodeOpts {
+    bincode::DefaultOptions::new().allow_trailing_bytes()
+}
+
+pub type UpsertValueAndSize = mz_rocksdb::GetResult<StateValue>;
+
+#[derive(Clone, Debug)]
+pub struct PutValue {
+    pub value: Option<UpsertValue>,
+    pub previous_persisted_size: Option<i64>,
+}
+
+/// In any `UpsertState` implementation, we need to support 2 modes:
+/// - Normal operation
+/// - Consolidation of snapshots (during rehydration).
+///
+/// This struct (and `Snapshotting`) is effectively a helper to simplify the logic that
+/// individual `UpsertState` implementations need to do to manage these 2 modes.
+///
+/// Normal operation is easy, we just store an ordinary `UpsertValue`, and allow the implementer
+/// to store it any way they want. During consolidation of snapshots, the logic is more complex.
+/// See the docs on `StateValue::merge_update` for more information.
+///
+/// This struct is not part of the `UpsertState` public API, but implementing that API without
+/// using it is considered hard-mode.
+#[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
+pub enum StateValue {
+    Snapshotting(Snapshotting),
+    Decoded(UpsertValue),
+}
+
+/// A value as produced during consolidation of a snapshot.
+#[derive(Clone, Default, serde::Serialize, serde::Deserialize, Debug)]
+pub struct Snapshotting {
+    value_xor: Vec<u8>,
+    len_sum: Wrapping<i64>,
+    checksum_sum: Wrapping<i64>,
+    diff_sum: Wrapping<i64>,
+}
+
+impl From<UpsertValue> for StateValue {
+    fn from(uv: UpsertValue) -> Self {
+        Self::Decoded(uv)
+    }
+}
+
+impl StateValue {
+    /// We use a XOR trick in order to accumulate the snapshot without having to store the full
+    /// unconsolidated history in memory. For all (value, diff) updates of a key we track:
+    /// - diff_sum = SUM(diff)
+    /// - checksum_sum = SUM(checksum(bincode(value)) * diff)
+    /// - len_sum = SUM(len(bincode(value)) * diff)
+    /// - value_xor = XOR(bincode(value))
+    ///
+    /// ## Correctness
+    ///
+    /// The method is correct because a well formed upsert snapshot will have for each key:
+    /// - Zero or one updates of the form (cur_value, +1)
+    /// - Zero or more pairs of updates of the form (prev_value, +1), (prev_value, -1)
+    ///
+    /// We are interested in extracting the cur_value of each key and discard all prev_values
+    /// that might be included in the stream. Since the history of prev_values always comes in
+    /// pairs, computing the XOR of those is always going to cancel their effects out. Also,
+    /// since XOR is commutative this property is true independent of the order. The same is
+    /// true for the summations of the length and checksum since the sum will contain the
+    /// unrelated values zero times.
+    ///
+    /// Therefore the accumulators will end up precisely in one of two states:
+    /// 1. diff == 0, checksum == 0, value == [0..] => the key is not present
+    /// 2. diff == 1, checksum == checksum(cur_value) value == cur_value => the key is present
+    ///
+    /// ## Robustness
+    ///
+    /// In the absense of bugs, accumulating the diff and checksum is not required since we know
+    /// that a well formed snapshot always satisfies XOR(bincode(values)) == bincode(cur_value).
+    /// However bugs may happen and so storing 16 more bytes per key to have a very high
+    /// guarantee that we're not decoding garbage is more than worth it.
+    /// The main key->value used to store previous values.
+    #[allow(clippy::as_conversions)]
+    pub fn merge_update(
+        &mut self,
+        value: UpsertValue,
+        diff: mz_repr::Diff,
+        bincode_opts: BincodeOpts,
+        bincode_buffer: &mut Vec<u8>,
+    ) -> bool {
+        if let Self::Snapshotting(Snapshotting {
+            value_xor,
+            len_sum,
+            checksum_sum,
+            diff_sum,
+        }) = self
+        {
+            bincode_buffer.clear();
+            bincode_opts
+                .serialize_into(&mut *bincode_buffer, &value)
+                .unwrap();
+            let len = i64::try_from(bincode_buffer.len()).unwrap();
+
+            *diff_sum += diff;
+            *len_sum += len.wrapping_mul(diff);
+            // Truncation is fine (using `as`) as this is just a checksum
+            *checksum_sum += (seahash::hash(&*bincode_buffer) as i64).wrapping_mul(diff);
+
+            // XOR of even diffs cancel out, so we only do it if diff is odd
+            if diff.abs() % 2 == 1 {
+                if value_xor.len() < bincode_buffer.len() {
+                    value_xor.resize(bincode_buffer.len(), 0);
+                }
+                for (acc, val) in value_xor.iter_mut().zip(bincode_buffer.drain(..)) {
+                    *acc ^= val;
+                }
+            }
+
+            return diff_sum.0 == 0 && checksum_sum.0 == 0 && value_xor.iter().all(|&x| x == 0);
+        } else {
+            panic!("`merge_update` called after snapshot consolidation")
+        }
+    }
+
+    /// After consolidation of a snapshot, we assume that all values in the `UpsertState` implementation
+    /// are `Self::Snapshotting`, with a `diff_sum` of 1. Afterwards, if we need to retract one of
+    /// these values, we need to assert that its in this correct state, the mutate it to its
+    /// `Decoded` state, so the `upsert` operator can use it.
+    #[allow(clippy::as_conversions)]
+    pub fn ensure_decoded(&mut self, bincode_opts: BincodeOpts) {
+        match self {
+            StateValue::Snapshotting(Snapshotting {
+                value_xor,
+                len_sum,
+                checksum_sum,
+                diff_sum,
+            }) => match diff_sum.0 {
+                1 => {
+                    let len = usize::try_from(len_sum.0).expect("invalid upsert state");
+                    let value = &value_xor[..len];
+                    // Truncation is fine (using `as`) as this is just a checksum
+                    assert_eq!(
+                        checksum_sum.0,
+                        seahash::hash(value_xor) as i64,
+                        "invalid upsert state"
+                    );
+                    *self = Self::Decoded(bincode_opts.deserialize(value).unwrap());
+                }
+                0 => {
+                    assert_eq!(len_sum.0, 0, "invalid upsert state");
+                    assert_eq!(checksum_sum.0, 0, "invalid upsert state");
+                    assert!(value_xor.iter().all(|&x| x == 0), "invalid upsert state");
+                }
+                _ => panic!("invalid upsert state"),
+            },
+            _ => {}
+        }
+    }
+
+    /// Pull out the `Decoded` value for a `StateValue`, after `ensure_decoded` has been called.
+    pub fn to_decoded(self) -> UpsertValue {
+        match self {
+            Self::Decoded(v) => v,
+            _ => panic!("called `to_decoded without calling `ensure_decoded`"),
+        }
+    }
+
+    /// The size of a `StateValue`, in memory. This is:
+    /// 1. only used in the `InMemoryHashMap` implementation.
+    /// 2. An estimate (it only looks at value sizes, and not errors)
+    ///
+    /// Other implementations may use more accurate accounting.
+    pub fn memory_size(&self) -> u64 {
+        match self {
+            // similar to `Row::byte_len`, we add the heap size and the size of the value itself.
+            Self::Snapshotting(Snapshotting { value_xor, .. }) => {
+                u64::cast_from(value_xor.len()) + u64::cast_from(std::mem::size_of::<Self>())
+            }
+
+            Self::Decoded(Ok(row)) => {
+                // `Row::byte_len` includes the size of `Row`, which is also in `Self`, so we
+                // subtract it.
+                u64::cast_from(row.byte_len()) + u64::cast_from(std::mem::size_of::<Self>())
+                    - u64::cast_from(std::mem::size_of::<mz_repr::Row>())
+            }
+            Self::Decoded(Err(_)) => {
+                // Assume errors are rare enough to not move the needle.
+                0
+            }
+        }
+    }
+}
+
+impl Default for StateValue {
+    fn default() -> Self {
+        Self::Snapshotting(Snapshotting::default())
+    }
+}
+
+/// Statistics for a single call to `merge_snapshot_chunk`.
+#[derive(Clone, Default, Debug)]
+pub struct MergeStats {
+    /// The number of updates processed.
+    pub updates: u64,
+    /// The aggregated number of values inserted or deleted into `state`
+    pub values_diff: i64,
+    /// The total aggregated size of values inserted, deleted, or updated in `state`.
+    /// If the current call to `merge_snapshot_chunk` deletes a lot of values,
+    /// or updates values to smaller ones, this can be negative!
+    pub size_diff: i64,
+}
+
+impl std::ops::AddAssign for MergeStats {
+    fn add_assign(&mut self, rhs: Self) {
+        self.updates += rhs.updates;
+        self.values_diff += rhs.values_diff;
+        self.size_diff += rhs.size_diff;
+    }
+}
+
+/// Statistics for a single call to `multi_put`.
+#[derive(Clone, Default, Debug)]
+pub struct PutStats {
+    /// The number of puts/deletes processed
+    pub processed_puts: u64,
+    /// The aggregated number of values inserted or deleted into `state`
+    pub values_diff: i64,
+    /// The total aggregated size of values inserted, deleted, or updated in `state`.
+    /// If the current call to `multi_put` deletes a lot of values,
+    /// or updates values to smaller ones, this can be negative!
+    pub size_diff: i64,
+}
+
+/// Statistics for a single call to `multi_get`.
+#[derive(Clone, Default, Debug)]
+pub struct GetStats {
+    /// The number of puts/deletes processed
+    pub processed_gets: u64,
+}
+
 /// A trait that defines the fundamental primitives required by a state-backing of
 /// the `upsert` operator.
 #[async_trait::async_trait(?Send)]
 pub trait UpsertState {
+    /// Unlike `multi_get` and `multi_put`, which require the implementer
+    /// to chunk large iterators as they please, `merge_snapshot_chunk` allows
+    /// the implementer to specify their preferred batch size. This batch size
+    /// refers to the number of keys being merged into the state.
+    ///
+    /// This is different from `multi_get` and `multi_put` because snapshots
+    /// are merged from asynchronous, batched timely iterators, as opposed to normal
+    /// sync iterators.
+    const SNAPSHOT_BATCH_SIZE: usize;
+    /// Merge and consolidate the following updates into the state, during snapshotting.
+    ///
+    /// After an ensure snapshot has been `merged`, all values must be in the correct state
+    /// (as determined by `StateValue::ensure_decoded`, and `merge_snapshot_chunk` must NOT
+    /// be called again.
+    async fn merge_snapshot_chunk<P>(&mut self, puts: P) -> Result<MergeStats, anyhow::Error>
+    where
+        P: IntoIterator<Item = (UpsertKey, UpsertValue, mz_repr::Diff)>;
+
     /// Insert or delete for all `puts` keys, prioritizing the last value for
     /// repeated keys.
-    ///
-    /// Returns the size of the `puts`.
-    async fn multi_put<P>(&mut self, puts: P) -> Result<u64, anyhow::Error>
+    async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
-        P: IntoIterator<Item = (UpsertKey, Option<UpsertValue>)>;
+        P: IntoIterator<Item = (UpsertKey, PutValue)>;
 
     /// Get the `gets` keys, which must be unique, placing the results in `results_out`.
     ///
-    /// Returns the size of the `gets`.
-    ///
     /// Panics if `gets` and `results_out` are not the same length.
-    async fn multi_get<'r, G, R>(&mut self, gets: G, results_out: R) -> Result<u64, anyhow::Error>
+    async fn multi_get<'r, G, R>(
+        &mut self,
+        gets: G,
+        results_out: R,
+    ) -> Result<GetStats, anyhow::Error>
     where
         G: IntoIterator<Item = UpsertKey>,
-        R: IntoIterator<Item = &'r mut Option<UpsertValue>>;
+        R: IntoIterator<Item = &'r mut UpsertValueAndSize>;
 }
 
-/// A `HashMap` with an extra scratch vector used to
+/// A `HashMap` with additional scratch space used in some
+/// methods.
 pub struct InMemoryHashMap {
-    state: HashMap<UpsertKey, UpsertValue>,
+    state: HashMap<UpsertKey, StateValue>,
+
+    // Bincode options and buffer used
+    // in `merge_snapshot_chunk`.
+    bincode_opts: BincodeOpts,
+    bincode_buffer: Vec<u8>,
 }
 
 impl Default for InMemoryHashMap {
     fn default() -> Self {
         Self {
             state: HashMap::new(),
+            bincode_opts: upsert_bincode_opts(),
+            bincode_buffer: Vec::new(),
         }
     }
 }
 
 #[async_trait::async_trait(?Send)]
 impl UpsertState for InMemoryHashMap {
-    async fn multi_put<P>(&mut self, puts: P) -> Result<u64, anyhow::Error>
+    const SNAPSHOT_BATCH_SIZE: usize = 1;
+    async fn merge_snapshot_chunk<P>(&mut self, puts: P) -> Result<MergeStats, anyhow::Error>
     where
-        P: IntoIterator<Item = (UpsertKey, Option<UpsertValue>)>,
+        P: IntoIterator<Item = (UpsertKey, UpsertValue, mz_repr::Diff)>,
     {
-        let mut size = 0;
-        for (key, value) in puts {
-            match value {
+        let mut stats = MergeStats::default();
+        for (key, value, diff) in puts {
+            stats.updates += 1;
+
+            let entry = self.state.entry(key);
+            let current_size: i64 = match &entry {
+                hash_map::Entry::Occupied(o) => o
+                    .get()
+                    .memory_size()
+                    .try_into()
+                    .expect("less than i64 size"),
+                hash_map::Entry::Vacant(_) => {
+                    stats.values_diff += 1;
+                    0
+                }
+            };
+            let current_value = entry.or_insert_with(Default::default);
+
+            if current_value.merge_update(value, diff, self.bincode_opts, &mut self.bincode_buffer)
+            {
+                stats.values_diff -= 1;
+                stats.size_diff -= current_size;
+                self.state.remove(&key);
+            } else {
+                stats.size_diff -= current_size;
+                let current_size: i64 = current_value
+                    .memory_size()
+                    .try_into()
+                    .expect("less than i64 size");
+                stats.size_diff += current_size
+            }
+        }
+
+        Ok(stats)
+    }
+
+    async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
+    where
+        P: IntoIterator<Item = (UpsertKey, PutValue)>,
+    {
+        let mut stats = PutStats::default();
+        for (key, p_value) in puts {
+            stats.processed_puts += 1;
+            match p_value.value {
                 Some(value) => {
-                    self.state.insert(key, value);
+                    let decoded_value = StateValue::Decoded(value);
+                    let size: i64 = decoded_value
+                        .memory_size()
+                        .try_into()
+                        .expect("less than i64 size");
+                    match p_value.previous_persisted_size {
+                        Some(previous_size) => {
+                            stats.size_diff -= previous_size;
+                            stats.size_diff += size;
+                        }
+                        None => {
+                            stats.values_diff += 1;
+                            stats.size_diff += size;
+                        }
+                    }
+                    self.state.insert(key, decoded_value);
                 }
                 None => {
+                    if let Some(previous_size) = p_value.previous_persisted_size {
+                        stats.size_diff -= previous_size;
+                        stats.values_diff -= 1;
+                    }
                     self.state.remove(&key);
                 }
             }
-            size += 1;
         }
-        Ok(size)
+        Ok(stats)
     }
 
-    async fn multi_get<'r, G, R>(&mut self, gets: G, results_out: R) -> Result<u64, anyhow::Error>
+    async fn multi_get<'r, G, R>(
+        &mut self,
+        gets: G,
+        results_out: R,
+    ) -> Result<GetStats, anyhow::Error>
     where
         G: IntoIterator<Item = UpsertKey>,
-        R: IntoIterator<Item = &'r mut Option<UpsertValue>>,
+        R: IntoIterator<Item = &'r mut UpsertValueAndSize>,
     {
-        let mut size = 0;
+        let mut stats = GetStats::default();
         for (key, result_out) in gets.into_iter().zip_eq(results_out) {
-            *result_out = self.state.get(&key).cloned();
-            size += 1;
+            stats.processed_gets += 1;
+            let value = self.state.get(&key).cloned();
+            let size = value.as_ref().map(|v| v.memory_size());
+            *result_out = UpsertValueAndSize { value, size };
         }
-        Ok(size)
+        Ok(stats)
     }
 }
 
@@ -105,34 +498,58 @@ impl<S> UpsertState for StatsState<S>
 where
     S: UpsertState,
 {
-    async fn multi_put<P>(&mut self, puts: P) -> Result<u64, anyhow::Error>
+    const SNAPSHOT_BATCH_SIZE: usize = S::SNAPSHOT_BATCH_SIZE;
+    async fn merge_snapshot_chunk<P>(&mut self, puts: P) -> Result<MergeStats, anyhow::Error>
     where
-        P: IntoIterator<Item = (UpsertKey, Option<UpsertValue>)>,
+        P: IntoIterator<Item = (UpsertKey, UpsertValue, mz_repr::Diff)>,
     {
         let now = Instant::now();
-        let size = self.inner.multi_put(puts).await?;
+        let stats = self.inner.merge_snapshot_chunk(puts).await?;
+        self.metrics
+            .merge_snapshot_latency
+            .observe(now.elapsed().as_secs_f64());
+        self.metrics
+            .merge_snapshot_updates
+            .observe(f64::cast_lossy(stats.updates));
+        Ok(stats)
+    }
+
+    async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
+    where
+        P: IntoIterator<Item = (UpsertKey, PutValue)>,
+    {
+        let now = Instant::now();
+        let stats = self.inner.multi_put(puts).await?;
 
         self.metrics
             .multi_put_latency
             .observe(now.elapsed().as_secs_f64());
-        self.metrics.multi_put_size.observe(f64::cast_lossy(size));
+        self.metrics
+            .multi_put_size
+            .observe(f64::cast_lossy(stats.processed_puts));
 
-        Ok(size)
+        Ok(stats)
     }
 
-    async fn multi_get<'r, G, R>(&mut self, gets: G, results_out: R) -> Result<u64, anyhow::Error>
+    async fn multi_get<'r, G, R>(
+        &mut self,
+        gets: G,
+        results_out: R,
+    ) -> Result<GetStats, anyhow::Error>
     where
         G: IntoIterator<Item = UpsertKey>,
-        R: IntoIterator<Item = &'r mut Option<UpsertValue>>,
+        R: IntoIterator<Item = &'r mut UpsertValueAndSize>,
     {
         let now = Instant::now();
-        let size = self.inner.multi_get(gets, results_out).await?;
+        let stats = self.inner.multi_get(gets, results_out).await?;
 
         self.metrics
             .multi_get_latency
             .observe(now.elapsed().as_secs_f64());
-        self.metrics.multi_get_size.observe(f64::cast_lossy(size));
+        self.metrics
+            .multi_get_size
+            .observe(f64::cast_lossy(stats.processed_gets));
 
-        Ok(size)
+        Ok(stats)
     }
 }

--- a/src/storage/src/render/upsert/types.rs
+++ b/src/storage/src/render/upsert/types.rs
@@ -342,16 +342,6 @@ pub struct GetStats {
 /// the `upsert` operator.
 #[async_trait::async_trait(?Send)]
 pub trait UpsertStateBackend {
-    /// Unlike `multi_get` and `multi_put`, which require the implementer
-    /// to chunk large iterators as they please, `merge_snapshot_chunk` allows
-    /// the implementer to specify their preferred batch size. This batch size
-    /// refers to the number of keys being merged into the state.
-    ///
-    /// This is different from `multi_get` and `multi_put` because snapshots
-    /// are merged from asynchronous, batched timely iterators, as opposed to normal
-    /// sync iterators.
-    const SNAPSHOT_BATCH_SIZE: usize;
-
     /// Insert or delete for all `puts` keys, prioritizing the last value for
     /// repeated keys.
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
@@ -387,8 +377,6 @@ impl Default for InMemoryHashMap {
 
 #[async_trait::async_trait(?Send)]
 impl UpsertStateBackend for InMemoryHashMap {
-    const SNAPSHOT_BATCH_SIZE: usize = 1;
-
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
         P: IntoIterator<Item = (UpsertKey, PutValue<StateValue>)>,

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -42,5 +42,5 @@ pub mod types;
 pub use kafka::KafkaSourceReader;
 pub(crate) use source_reader_pipeline::health_operator;
 pub use source_reader_pipeline::{
-    create_raw_source, RawSourceCreationConfig, SourceCreationParams,
+    create_raw_source, RawSourceCreationConfig, SourceCreationParams, SourceStatistics,
 };

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -94,6 +94,8 @@ use crate::statistics::{SourceStatisticsMetrics, StorageStatistics};
 /// prevent hot restart loops.
 const SUSPEND_AND_RESTART_DELAY: Duration = Duration::from_secs(30);
 
+pub type SourceStatistics = StorageStatistics<SourceStatisticsUpdate, SourceStatisticsMetrics>;
+
 /// Shared configuration information for all source types. This is used in the
 /// `create_raw_source` functions, which produce raw sources.
 #[derive(Clone)]
@@ -129,7 +131,7 @@ pub struct RawSourceCreationConfig {
     /// A handle to the persist client cache
     pub persist_clients: Arc<PersistClientCache>,
     /// Place to share statistics updates with storage state.
-    pub source_statistics: StorageStatistics<SourceStatisticsUpdate, SourceStatisticsMetrics>,
+    pub source_statistics: SourceStatistics,
     /// Enables reporting the remap operator's write frontier.
     pub shared_remap_upper: Rc<RefCell<Antichain<mz_repr::Timestamp>>>,
     /// Configuration parameters, possibly from LaunchDarkly

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -486,6 +486,7 @@ impl OffsetCommitMetrics {
 pub struct UpsertMetrics {
     pub(crate) rehydration_latency: DeleteOnDropGauge<'static, AtomicF64, Vec<String>>,
     pub(crate) rehydration_total: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    pub(crate) rehydration_updates: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     pub(crate) shared: Arc<UpsertSharedMetrics>,
     pub(crate) rocksdb: Arc<mz_rocksdb::RocksDBMetrics>,
 }
@@ -501,6 +502,9 @@ impl UpsertMetrics {
                 .get_delete_on_drop_gauge(vec![source_id_s.clone(), worker_id.clone()]),
             rehydration_total: base
                 .rehydration_total
+                .get_delete_on_drop_gauge(vec![source_id_s.clone(), worker_id.clone()]),
+            rehydration_updates: base
+                .rehydration_updates
                 .get_delete_on_drop_gauge(vec![source_id_s, worker_id]),
             shared: base.shared(&source_id),
             rocksdb: base.rocksdb(&source_id),

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -187,6 +187,7 @@ impl<'handle, T: Timestamp, D: Container, P: Pull<BundleCore<T, D>>> Future
             return Poll::Ready(Some(Event::Progress(frontier.clone())));
         } else if frontier.is_empty() {
             // If the frontier is empty and is not pending it means that there is no more data left
+            println!("EMPTY FRONTIER");
             return Poll::Ready(None);
         };
         drop(shared_frontiers);

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from materialize import ci_util
 from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import (
+    Clusterd,
     Kafka,
     Materialized,
     SchemaRegistry,
@@ -26,12 +27,35 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
-    Materialized(),
+    Materialized(
+        options=[
+            "--orchestrator-process-scratch-directory=/mzdata/source_data",
+        ],
+        additional_system_parameter_defaults={
+            "upsert_source_disk_default": "true",
+            "enable_unmanaged_cluster_replicas": "true",
+        },
+    ),
     Testdrive(),
+    Clusterd(
+        name="clusterd1",
+        options=[
+            "--scratch-directory=/mzdata/source_data",
+        ],
+    ),
 ]
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    for name in [
+        "rehydration",
+        "testdrive",
+    ]:
+        with c.test_case(name):
+            c.workflow(name)
+
+
+def workflow_testdrive(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Run testdrive."""
     parser.add_argument(
         "--kafka-default-partitions",
@@ -67,9 +91,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     materialized = Materialized(
         default_size=args.default_size,
         options=[
-            "--orchestrator-process-scratch-directory=/mzdata/source_data"
-            "--system-var-default=upsert_source_disk_default=true"
+            "--orchestrator-process-scratch-directory=/mzdata/source_data",
         ],
+        additional_system_parameter_defaults={"upsert_source_disk_default": "true"},
     )
 
     with c.override(testdrive, materialized):
@@ -102,3 +126,55 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             ci_util.upload_junit_report(
                 "testdrive", Path(__file__).parent / junit_report
             )
+
+
+def workflow_rehydration(c: Composition) -> None:
+    """Test creating sources in a remote clusterd process."""
+
+    c.down(destroy_volumes=True)
+
+    dependencies = [
+        "materialized",
+        "zookeeper",
+        "kafka",
+        "schema-registry",
+        "clusterd1",
+    ]
+
+    c.up("materialized")
+    c.run("testdrive", "rehydration/01-setup.td")
+
+    for (style, mz) in [
+        (
+            "with DISK",
+            Materialized(
+                options=[
+                    "--orchestrator-process-scratch-directory=/mzdata/source_data",
+                ],
+                additional_system_parameter_defaults={
+                    "upsert_source_disk_default": "true"
+                },
+            ),
+        ),
+        ("without DISK", Materialized()),
+    ]:
+
+        with c.override(
+            mz,
+            Testdrive(no_reset=True, consistent_seed=True),
+        ):
+            print(f"Running rehydration workflow {style}")
+
+            c.up(*dependencies)
+
+            c.run("testdrive", "rehydration/02-source-setup.td")
+
+            c.kill("materialized")
+            c.kill("clusterd1")
+            c.up("materialized")
+            c.up("clusterd1")
+
+            c.run("testdrive", "rehydration/03-after-rehydration.td")
+
+        c.run("testdrive", "rehydration/04-reset.td")
+        c.kill("clusterd1")

--- a/test/upsert/rehydration/01-setup.td
+++ b/test/upsert/rehydration/01-setup.td
@@ -1,0 +1,18 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE CLUSTER storage_cluster REPLICAS (
+    r1 (
+      STORAGECTL ADDRESSES ['clusterd1:2100'],
+      STORAGE ADDRESSES ['clusterd1:2103'],
+      COMPUTECTL ADDRESSES ['clusterd1:2101'],
+      COMPUTE ADDRESSES ['clusterd1:2102'],
+      WORKERS 4
+    )
+  )

--- a/test/upsert/rehydration/02-source-setup.td
+++ b/test/upsert/rehydration/02-source-setup.td
@@ -1,0 +1,73 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-create-topic topic=upsert
+
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"} {"f1": "fish", "f2": 1000}
+{"key": "bird1"} {"f1":"goose", "f2": 1}
+{"key": "birdmore"} {"f1":"geese", "f2": 2}
+{"key": "mammal1"} {"f1": "moose", "f2": 1}
+{"key": "bird1"}
+{"key": "birdmore"} {"f1":"geese", "f2": 56}
+{"key": "mammalmore"} {"f1": "moose", "f2": 42}
+{"key": "mammal1"}
+{"key": "mammalmore"} {"f1":"moose", "f2": 2}
+
+> CREATE CONNECTION conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+
+> CREATE CONNECTION c_conn
+  FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}'
+
+> CREATE SOURCE upsert
+  IN CLUSTER storage_cluster
+  FROM KAFKA CONNECTION conn (TOPIC
+  'testdrive-upsert-${testdrive.seed}'
+  )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION c_conn
+  ENVELOPE UPSERT
+
+> SELECT * from upsert
+key           f1       f2
+---------------------------
+fish          fish     1000
+birdmore      geese    56
+mammalmore    moose    2
+
+# NOTE: These queries are slow to succeed because the default metrics scraping
+# interval is 30 seconds.
+#
+# Ensure that statistics are correctly updated
+> SELECT
+    SUM(u.envelope_state_bytes) > 0,
+    SUM(u.envelope_state_count)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+  GROUP BY s.name
+  ORDER BY s.name
+true 3

--- a/test/upsert/rehydration/03-after-rehydration.td
+++ b/test/upsert/rehydration/03-after-rehydration.td
@@ -1,0 +1,122 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+# Ensure we rehydrate properly
+> SELECT * from upsert
+key           f1       f2
+---------------------------
+fish          fish     1000
+birdmore      geese    56
+mammalmore    moose    2
+
+# Ensure that statistics are correctly updated. Note that the
+# byte count could be lower or higher than before restarting,
+# as rehydration has to store values differently.
+> SELECT
+    SUM(u.envelope_state_bytes) > 0,
+    SUM(u.envelope_state_count)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+  GROUP BY s.name
+  ORDER BY s.name
+true 3
+
+# Save the size of the rehydrated state.
+$ set-from-sql var=rehydrated-state-bytes
+SELECT
+    (SUM(u.envelope_state_bytes))::text
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+
+# Ensure we process updates correctly.
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"} {"f1": "longerfish", "f2": 9000}
+
+> SELECT * from upsert
+key           f1                  f2
+--------------------------------------
+fish          longerfish          9000
+birdmore      geese               56
+mammalmore    moose               2
+
+# Wait for the value's new stats to propagate. We can't
+# just check that the `longerfish` value is larger here,
+# because the rehydrated value may be more costly. This
+# means we have to do this in 2 steps, like this.
+#
+# This is also != because different implementations use
+# space differently during rehydration and normal operation.
+> SELECT
+    SUM(u.envelope_state_bytes) != ${rehydrated-state-bytes},
+    SUM(u.envelope_state_count)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+  GROUP BY s.name
+  ORDER BY s.name
+true 3
+
+$ set-from-sql var=state-bytes
+SELECT
+    (SUM(u.envelope_state_bytes))::text
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"} {"f1": "MUCHMUCHMUCHLONGERVALUE", "f2": 9000}
+
+> SELECT
+    SUM(u.envelope_state_bytes) > ${state-bytes},
+    SUM(u.envelope_state_count)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+  GROUP BY s.name
+  ORDER BY s.name
+true 3
+
+
+# Ensure deletes work.
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"}
+
+> SELECT * from upsert
+key           f1                  f2
+--------------------------------------
+birdmore      geese               56
+mammalmore    moose               2
+
+> SELECT
+    SUM(u.envelope_state_count)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+  GROUP BY s.name
+  ORDER BY s.name
+2

--- a/test/upsert/rehydration/04-reset.td
+++ b/test/upsert/rehydration/04-reset.td
@@ -1,0 +1,8 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.


### PR DESCRIPTION
This replaces: https://github.com/MaterializeInc/materialize/pull/18912

This pr is a complex one: at a high level, other than tests, there are 4 things going on:

- A new method on `UpsertState` that asks implementation to consolidate _batches of updates (including diffs)_ in place. In the case of the rocksdb implementation, this does in fact mean _bounded-memory_
  - There is significant machinery around plugging this api in.
- A large amount of machinery to maintain the the statistics added in https://github.com/MaterializeInc/materialize/pull/19044. 
  - This requires some copied code between the implementations, as they store values encoded differently.
- The actual consolidation logic. Instead of storing a `Key->List[Update]`, we instead leverage the power of `xor`, as described below. Note that this logic is primarily encapsulated in the `StateValue` struct, and is used by both implementations.
- The fairly complex rocksdb implementation of the new API. I intended this to be a simple as possible, but it is still a significant lift.


As for the xor logic itself, this description is copied directly from @petrosagg in the original base of this pr (https://github.com/MaterializeInc/materialize/pull/18912):

This makes recovering the upsert snapshot use memory proportinal to the
number of keys as opposed to the current method that uses memory
proportional to the total number of updates.

We use a XOR trick in order to accumulate the snapshot without having to
store the full unconsolidated history in memory. For all (value, diff)
updates of a key we track:
- diff_sum = SUM(diff)
- value_accum = XOR(bincode(value))
- checksum_accum = XOR(checksum(bincode(value)))

The method is correct because a well formed upsert snapshot will have
for each key:
- Zero or one updates of the form (cur_value, +1)
- Zero or more pairs of updates of the form (prev_value, +1), (prev_value, -1)

We are interested in extracting the cur_value of each key and discard
all prev_values that might be included in the stream. Since the history
of prev_values always comes in pairs, computing the XOR of those is
always going to cancel their effects out. Also, since XOR is commutative
this property is true independent of the order.

Therefore the accumulators will end up precisely in one of two states:
1. diff == 0, checksum == 0, value == [0..] => the key is not present
2. diff == 1, checksum == checksum(cur_value) value == cur_value => the
   key is present

In the absense of bugs, accumulating the diff and checksum is not
required since we know that a well formed snapshot always satisfies
XOR(bincode(values)) == bincode(cur_value). However bugs may happen and
so storing 16 more bytes per key to have a very high guarantee that
we're not decoding garbage is more than worth it.

### Motivation

  * This PR adds a known-desirable feature.
 
 Part of: https://github.com/MaterializeInc/materialize/issues/17067

### Tips for reviewer

The bottom commit all the logic. The top commit contains additional tests.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
in notion
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
