### PR TITLE
storage: bring back StorageController::drop_replica

### DIFF
--- a/src/cluster-client/src/lib.rs
+++ b/src/cluster-client/src/lib.rs
@@ -78,3 +78,6 @@
 #![warn(missing_docs)]
 
 pub mod client;
+
+/// Identifier of a replica.
+pub type ReplicaId = u64;

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -77,7 +77,7 @@ pub mod error;
 pub type ComputeInstanceId = StorageInstanceId;
 
 /// Identifier of a replica.
-pub type ReplicaId = u64;
+pub type ReplicaId = mz_cluster_client::ReplicaId;
 
 /// Identifier of a replica.
 // TODO(#18377): Replace `ReplicaId` with this type.

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -58,7 +58,7 @@ pub struct ClusterConfig {
 pub type ClusterStatus = mz_orchestrator::ServiceStatus;
 
 /// Identifies a cluster replica.
-pub type ReplicaId = mz_compute_client::controller::ReplicaId;
+pub type ReplicaId = mz_cluster_client::ReplicaId;
 
 /// Configures a cluster replica.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -392,9 +392,8 @@ where
         self.deprovision_replica(cluster_id, replica_id).await?;
         self.metrics_tasks.remove(&replica_id);
 
-        // Storage does not support active-active replication and so does not
-        // have an API for dropping replicas.
         self.active_compute().drop_replica(cluster_id, replica_id)?;
+        self.storage.drop_replica(cluster_id, replica_id);
         Ok(())
     }
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -271,6 +271,13 @@ pub trait StorageController: Debug + Send {
     /// storage instance).
     fn connect_replica(&mut self, id: StorageInstanceId, location: ClusterReplicaLocation);
 
+    /// Disconnects the storage instance from the specified replica.
+    fn drop_replica(
+        &mut self,
+        instance_id: StorageInstanceId,
+        replica_id: mz_cluster_client::ReplicaId,
+    );
+
     /// Acquire a mutable reference to the collection state, should it exist.
     fn collection_mut(
         &mut self,
@@ -1109,6 +1116,19 @@ where
             .get_mut(&id)
             .unwrap_or_else(|| panic!("instance {id} does not exist"));
         client.connect(location);
+    }
+
+    fn drop_replica(
+        &mut self,
+        instance_id: StorageInstanceId,
+        _replica_id: mz_cluster_client::ReplicaId,
+    ) {
+        let client = self
+            .state
+            .clients
+            .get_mut(&instance_id)
+            .unwrap_or_else(|| panic!("instance {instance_id} does not exist"));
+        client.reset();
     }
 
     // Add new migrations below and precede them with a short summary of the


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/19254

Note that, just like with the compute controller, we deprovision the replica before we tell the controller, so a finite number of error logs may occur in the meantime.

### Motivation


  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
