### PR TITLE
sqlsmith ci: Print all queries for panic

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -246,5 +246,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             )
             print(f"From {from_time} until {to_time}")
 
-        shortest_query = min([error["query"] for error in errors], key=len)
-        print(f"Query: {shortest_query}")
+        # The error message indicates a panic, if we happen to get multiple
+        # distinct panics we want to have all the responsible queries instead
+        # of just one:
+        if "server closed the connection unexpectedly" in errors[0]["message"]:
+            for i, error in enumerate(errors, start=1):
+                print(f"Query {i}: {error['query']}")
+        else:
+            shortest_query = min([error["query"] for error in errors], key=len)
+            print(f"Query: {shortest_query}")


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
