### PR TITLE
testdrive: Fortify ubscribe-output.td (take #2)

### DIFF
--- a/test/testdrive/subscribe-output.td
+++ b/test/testdrive/subscribe-output.td
@@ -134,11 +134,10 @@ UPDATE t0 SET value = 4 WHERE key = 1
 > DECLARE c CURSOR FOR SUBSCRIBE t WITH (PROGRESS, SNAPSHOT) WITHIN TIMESTAMP ORDER BY c, b, a
 > FETCH 1 c
 <TIMESTAMP> true <null> <null> <null> <null>
-> FETCH 4 c
+> FETCH 3 c
 <TIMESTAMP> false 1 2 5 -6
 <TIMESTAMP> false 1 4 0 -4
 <TIMESTAMP> false 1 1 2 3
-<TIMESTAMP> true <null> <null> <null> <null>
 > COMMIT
 
 


### PR DESCRIPTION
FETCH N returns "at most N" rows, which causes test flakiness when used in conjunction with WITH PROGRESS, as the timestamp row may or may not be available at the time the FETCH runs and FETCH N will not wait for exactly N rows to become available.

Attempt to fix the test by not waiting for the second timestamp row to be emitted at all. The test already checks with the previous query that at least one timestamp row has been emitted.

Fixes #19267

### Tips for reviewer

@def- if the test continue to flake I will remove the entire thing altogether.