### PR TITLE
zippy: Restart CRDB on failure

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -488,6 +488,7 @@ class Cockroach(Service):
         setup_materialize: bool = True,
         in_memory: bool = False,
         healthcheck: Optional[ServiceHealthcheck] = None,
+        restart: str = "no",
     ):
         volumes = []
 
@@ -526,6 +527,7 @@ class Cockroach(Service):
                 "volumes": volumes,
                 "init": True,
                 "healthcheck": healthcheck,
+                "restart": restart,
             },
         )
 

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -36,7 +36,7 @@ SERVICES = [
     SchemaRegistry(),
     Debezium(),
     Postgres(),
-    Cockroach(setup_materialize=True),
+    Cockroach(),
     Minio(setup_materialize=True),
     # Those two are overriden below
     Materialized(),
@@ -136,7 +136,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     random.seed(args.seed)
 
     with c.override(
-        Cockroach(image=f"cockroachdb/cockroach:{args.cockroach_tag}"),
+        Cockroach(
+            image=f"cockroachdb/cockroach:{args.cockroach_tag}",
+            # Workaround for #19276
+            restart="on-failure:5",
+            setup_materialize=True,
+        ),
         Testdrive(
             no_reset=True,
             seed=1,


### PR DESCRIPTION
During long-running Zippy tests, CRDB terminates with the following error:

 * FATAL: disk stall detected: unable to sync log files within 20s

As attempts to address the root cause have all failed, we will try restarting the CRDB container up to 5 times to see if this will allow Zippy to complete Release Qualification tests successfully.

Fixes: #19276

### Motivation

  * This PR fixes a previously unreported bug.

Release Qualification was failing sporadically.