### PR TITLE
Don't push literal errors past Negate

### DIFF
--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -472,6 +472,9 @@ impl Typecheck {
     /// It should be linear in the size of the AST.
     ///
     /// ??? should we also compute keys and return a `RelationType`?
+    ///   ggevay: Checking keys would have the same problem as checking nullability: key inference
+    ///   is very heuristic (even more so than nullability inference), so it's almost impossible to
+    ///   reliably keep it stable across transformations.
     pub fn typecheck<'a>(
         &self,
         expr: &'a MirRelationExpr,

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -822,3 +822,32 @@ Explained Query:
           Get l2
 
 EOF
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/19179
+statement ok
+with
+  v1 as (
+    WITH
+            creates AS
+            (
+                SELECT
+                    details ->> 'logical_size' AS size,
+                    details ->> 'replica_id' AS replica_id,
+                    occurred_at
+                FROM mz_catalog.mz_audit_events
+                WHERE
+                    object_type = 'cluster-replica' AND event_type = 'create'
+            )
+        SELECT
+            mz_internal.mz_error_if_null(
+                    mz_cluster_replica_sizes.credits_per_hour, 'Replica of unknown size'
+                )
+                AS credits_per_hour
+        FROM
+            creates
+                LEFT JOIN
+                    mz_internal.mz_cluster_replica_sizes
+                    ON mz_cluster_replica_sizes.size = creates.size
+  )
+select * from v1
+WHERE credits_per_hour > credits_per_hour;


### PR DESCRIPTION
This addresses #19179, although [it's not fixing the problem in its full generality](https://github.com/MaterializeInc/materialize/issues/17189#issuecomment-1547391011). With this PR, we won't push predicates with literal errors down through a `Negate`. The new code is similar to the `let (retained, pushdown) =` in the  `Map` case.

### Motivation

  * This PR partially fixes a recognized bug: #19179

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
