### PR TITLE
frontegg-client: implements the remove fn + list roles + missing TODOs

### DIFF
--- a/src/frontegg-client/src/client.rs
+++ b/src/frontegg-client/src/client.rs
@@ -33,6 +33,7 @@ use crate::config::{ClientBuilder, ClientConfig};
 use crate::error::{ApiError, Error};
 
 pub mod app_password;
+pub mod role;
 pub mod user;
 
 const AUTH_PATH: [&str; 5] = ["identity", "resources", "auth", "v1", "api-token"];
@@ -183,6 +184,7 @@ impl Client {
             None => {
                 // No auth available in the client, request a new one.
                 req = self.build_request(Method::POST, AUTH_PATH);
+
                 let authentication_request = AuthenticationRequest {
                     client_id: &self.app_password.client_id.to_string(),
                     secret: &self.app_password.secret_key.to_string(),
@@ -193,6 +195,7 @@ impl Client {
 
         // Do the request.
         let res: AuthenticationResponse = self.send_unauthenticated_request(req).await?;
+
         *auth = Some(Auth {
             token: res.access_token.clone(),
             // Refresh twice as frequently as we need to, to be safe.

--- a/src/frontegg-client/src/client/app_password.rs
+++ b/src/frontegg-client/src/client/app_password.rs
@@ -77,8 +77,10 @@ impl Client {
         #[derive(Debug, Deserialize)]
         struct AppPassword {
             /// The client ID embedded in the app password.
+            #[serde(rename = "clientId")]
             client_id: Uuid,
             /// The secret key embedded in the app password.
+            #[serde(rename = "secret")]
             secret_key: Uuid,
         }
 

--- a/src/frontegg-client/src/client/role.rs
+++ b/src/frontegg-client/src/client/role.rs
@@ -1,0 +1,76 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! This module implements the client's functions for interacting with the
+//! Frontegg users API.
+
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+
+use crate::client::Client;
+use crate::error::Error;
+use crate::parse::Paginated;
+
+const ROLES_PATH: [&str; 5] = ["frontegg", "identity", "resources", "roles", "v2"];
+
+/// `Role` represents the Frontegg role structure.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Role {
+    /// A unique identifier for the role.
+    pub id: String,
+    /// The identifier of the vendor associated with the role.
+    pub vendor_id: String,
+    /// The optional identifier of the tenant associated with the role.
+    pub tenant_id: Option<String>,
+    /// A unique key associated with the role.
+    pub key: String,
+    /// The name of the role.
+    pub name: String,
+    /// A description of the role.
+    pub description: String,
+    /// A boolean indicating whether this role is a default one.
+    pub is_default: bool,
+    /// A boolean indicating whether this role was the first one assigned to a user.
+    pub first_user_role: bool,
+    /// A string representing the date and time in ISO 8601 when the role was created.
+    ///
+    /// E.g.: 2023-04-26T08:37:03.000Z
+    pub created_at: String,
+    /// A string representing the date and time in ISO 8601 when the role was last updated.
+    ///
+    /// E.g.: 2023-04-26T08:37:03.000Z
+    pub updated_at: String,
+    /// A vector of strings representing the permissions associated with the role.
+    pub permissions: Vec<String>,
+    /// An integer representing the level of the role.
+    pub level: i32,
+}
+
+impl Client {
+    /// Lists all available roles.
+    pub async fn list_roles(&self) -> Result<Vec<Role>, Error> {
+        let mut roles = vec![];
+        let mut page = 0;
+
+        loop {
+            let req = self.build_request(Method::GET, ROLES_PATH);
+            let req = req.query(&[("_limit", "50"), ("_offset", &*page.to_string())]);
+            let res: Paginated<Role> = self.send_request(req).await?;
+            for role in res.items {
+                roles.push(role);
+            }
+            page += 1;
+            if page >= res.metadata.total_pages {
+                break;
+            }
+        }
+        Ok(roles)
+    }
+}


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

The motivation for this pull request is:
1. Implements the `remove` user function for Frontegg.
2. Implements the`list` roles function for Frontegg.
3. Do missing documentation TODOs
4. Fix an issue in the AppPassword structure.

All of them appeared after integrating the `frontegg-client` with `mz`. 


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
