### PR TITLE
ci: Remove build from release qualification pipeline

### DIFF
--- a/ci/release-qualification/pipeline.yml
+++ b/ci/release-qualification/pipeline.yml
@@ -27,14 +27,9 @@ steps:
         required: false
     if: build.source == "ui"
 
-  - id: build-x86_64
-    label: Build x86_64
-    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build x86_64
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-x86_64
-
-  - wait: ~
+  # There is intentionally no build command here since we want to make sure we
+  # use a properly tagged version when testing the upcoming release, and don't
+  # build our own version just for the tests.
 
   - command: bin/ci-builder run stable bin/pyactivate -m materialize.ci_util.trim_pipeline release-qualification
     if: build.source == "ui"

--- a/ci/release-qualification/pipeline.yml
+++ b/ci/release-qualification/pipeline.yml
@@ -27,9 +27,20 @@ steps:
         required: false
     if: build.source == "ui"
 
-  # There is intentionally no build command here since we want to make sure we
-  # use a properly tagged version when testing the upcoming release, and don't
-  # build our own version just for the tests.
+  - id: build-x86_64
+    label: Build x86_64
+    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build x86_64
+    timeout_in_minutes: 60
+    agents:
+      queue: builder-linux-x86_64
+    # Don't build for "trigger_job" source, which indicates that this release
+    # qualification pipeline was triggered automatically by the tests pipeline
+    # because there is a new tag on a v* branch. In this case we want to make
+    # sure we use the exact same version for testing here as was tagged and
+    # will be released, and don't build our own version just for the tests.
+    if: build.source == "ui" || build.source == "schedule"
+
+  - wait: ~
 
   - command: bin/ci-builder run stable bin/pyactivate -m materialize.ci_util.trim_pipeline release-qualification
     if: build.source == "ui"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -651,6 +651,19 @@ steps:
         BUILDKITE_TAG: "$BUILDKITE_TAG"
     coverage: skip
 
+  - id: release-qualification
+    label: Release qualification
+    depends_on: devel-docker-tags
+    trigger: release-qualification
+    async: true
+    build:
+      commit: "$BUILDKITE_COMMIT"
+      branch: "$BUILDKITE_BRANCH"
+      env:
+        BUILDKITE_TAG: "$BUILDKITE_TAG"
+    if: build.tag != "" && build.branch =~ /^v/
+    coverage: skip
+
   - wait: ~
     continue_on_failure: true
 


### PR DESCRIPTION
As suggested by Alexander we want to make sure we use a properly tagged version when testing the upcoming release, and don't build our own version just for the tests.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
