### PR TITLE
environmentd: add error structure to http/ws

### DIFF
--- a/doc/user/content/integrations/http-api.md
+++ b/doc/user/content/integrations/http-api.md
@@ -127,7 +127,7 @@ an array of the following:
 Result | JSON value
 ---------------------|------------
 Rows | `{"rows": <2D array of JSON-ified results>, "col_names": <array of text>, "notices": <array of notices>}`
-Error | `{"error": <Error string from execution>, "notices": <array of notices>}`
+Error | `{"error": <Error object from execution>, "notices": <array of notices>}`
 Ok | `{"ok": <tag>, "notices": <array of notices>}`
 
 Each committed statement returns exactly one of these values; e.g. in the case
@@ -170,6 +170,15 @@ type SqlRequest = Simple | Extended;
 interface Notice {
 	message: string;
 	severity: string;
+	detail?: string;
+	hint?: string;
+}
+
+interface Error {
+	message: string;
+	code: string;
+	detail?: string;
+	hint?: string;
 }
 
 type SqlResult =
@@ -182,7 +191,7 @@ type SqlResult =
 	ok: string;
 	notices: Notice[];
 } | {
-	error: string;
+	error: Error;
 	notices: Notice[];
 };
 ```

--- a/doc/user/content/integrations/websocket-api.md
+++ b/doc/user/content/integrations/websocket-api.md
@@ -152,13 +152,27 @@ A notice can appear at any time and contains diagnostic messages that were gener
 The payload has the following structure:
 
 ```
-{"severity": <"warning"|"notice"|"debug"|"info"|"log">, "message": <informational message>}
+{
+    "message": <informational message>,
+    "severity": <"warning"|"notice"|"debug"|"info"|"log">,
+    "detail": <optional error detail>,
+    "hint": <optional error hint>,
+}
 ```
 
 #### `Error`
 
 Executing a statement resulted in an error.
-The payload is a `string` containing the error.
+The payload has the following structure:
+
+```
+{
+    "message": <informational message>,
+    "code": <error code>,
+    "detail": <optional error detail>,
+    "hint": <optional error hint>,
+}
+```
 
 #### `CommandComplete`
 
@@ -203,15 +217,24 @@ interface Extended {
 type SqlRequest = Simple | Extended;
 
 interface Notice {
-    message: string;
-    severity: string;
+	message: string;
+	severity: string;
+	detail?: string;
+	hint?: string;
+}
+
+interface Error {
+	message: string;
+	code: string;
+	detail?: string;
+	hint?: string;
 }
 
 type WebSocketResult =
     | { type: "ReadyForQuery"; payload: string }
     | { type: "Notice"; payload: Notice }
     | { type: "CommandComplete"; payload: string }
-    | { type: "Error"; payload: string }
+    | { type: "Error"; payload: Error }
     | { type: "Rows"; payload: string[] }
     | { type: "Row"; payload: any[] }
     ;

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -21,7 +21,8 @@ use http::StatusCode;
 use itertools::izip;
 use mz_adapter::session::{EndTransactionAction, RowBatchStream, TransactionStatus};
 use mz_adapter::{
-    AdapterNotice, ExecuteResponse, ExecuteResponseKind, PeekResponseUnary, SessionClient,
+    AdapterError, AdapterNotice, ExecuteResponse, ExecuteResponseKind, PeekResponseUnary,
+    SessionClient,
 };
 use mz_interchange::encode::TypedDatum;
 use mz_interchange::json::ToJson;
@@ -33,6 +34,7 @@ use mz_sql::ast::{Raw, Statement, StatementKind};
 use mz_sql::plan::Plan;
 use serde::{Deserialize, Serialize};
 use tokio::time;
+use tokio_postgres::error::SqlState;
 use tracing::warn;
 use tungstenite::protocol::frame::coding::CloseCode;
 
@@ -141,7 +143,7 @@ async fn run_ws(state: &WsState, mut ws: WebSocket) {
         // Figure out if we need to send an error, any notices, but always the ready message.
         let err = match run_ws_request(req, &mut client, &mut ws).await {
             Ok(()) => None,
-            Err(err) => Some(WebSocketResponse::Error(err.to_string())),
+            Err(err) => Some(WebSocketResponse::Error(err.into())),
         };
 
         // After running our request, there are several messages we need to send in a
@@ -207,6 +209,8 @@ async fn forward_notices(
             severity: Severity::for_adapter_notice(&notice)
                 .as_str()
                 .to_lowercase(),
+            detail: notice.detail(),
+            hint: notice.hint(),
         })
     });
 
@@ -290,8 +294,7 @@ pub enum SqlResult {
     },
     /// The query returned an error.
     Err {
-        /// The error message.
-        error: String,
+        error: SqlError,
         // Any notices generated during execution of the query.
         notices: Vec<Notice>,
     },
@@ -312,9 +315,9 @@ impl SqlResult {
         }
     }
 
-    fn err(client: &mut SessionClient, msg: impl std::fmt::Display) -> SqlResult {
+    fn err(client: &mut SessionClient, error: impl Into<SqlError>) -> SqlResult {
         SqlResult::Err {
-            error: msg.to_string(),
+            error: error.into(),
             notices: make_notices(client),
         }
     }
@@ -328,6 +331,51 @@ impl SqlResult {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct SqlError {
+    pub message: String,
+    pub code: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+}
+
+impl From<AdapterError> for SqlError {
+    fn from(err: AdapterError) -> Self {
+        SqlError {
+            message: err.to_string(),
+            // TODO: Move codes out of pgwire so they can be shared here.
+            code: SqlState::INTERNAL_ERROR.code().to_string(),
+            detail: err.detail(),
+            hint: err.hint(),
+        }
+    }
+}
+
+impl From<String> for SqlError {
+    fn from(message: String) -> Self {
+        SqlError {
+            message,
+            code: SqlState::INTERNAL_ERROR.code().to_string(),
+            detail: None,
+            hint: None,
+        }
+    }
+}
+
+impl From<&str> for SqlError {
+    fn from(value: &str) -> Self {
+        SqlError::from(value.to_string())
+    }
+}
+
+impl From<anyhow::Error> for SqlError {
+    fn from(value: anyhow::Error) -> Self {
+        SqlError::from(value.to_string())
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type", content = "payload")]
 pub enum WebSocketResponse {
     ReadyForQuery(String),
@@ -335,13 +383,17 @@ pub enum WebSocketResponse {
     Rows(Vec<String>),
     Row(Vec<serde_json::Value>),
     CommandComplete(String),
-    Error(String),
+    Error(SqlError),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Notice {
     message: String,
     severity: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
 }
 
 impl Notice {
@@ -466,7 +518,7 @@ impl ResultSender for WebSocket {
                             }
                         }
                         Some(PeekResponseUnary::Error(err)) => {
-                            break (true, vec![WebSocketResponse::Error(err)])
+                            break (true, vec![WebSocketResponse::Error(err.into())])
                         }
                         Some(PeekResponseUnary::Canceled) => {
                             break (
@@ -867,6 +919,8 @@ fn make_notices(client: &mut SessionClient) -> Vec<Notice> {
             severity: Severity::for_adapter_notice(&notice)
                 .as_str()
                 .to_lowercase(),
+            detail: notice.detail(),
+            hint: notice.hint(),
         })
         .collect()
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1059,9 +1059,9 @@ fn test_max_statement_batch_size() {
         let msg: WebSocketResponse = serde_json::from_str(&msg).unwrap();
         match msg {
             WebSocketResponse::Error(err) => assert!(
-                err.contains("statement batch size cannot exceed"),
+                err.message.contains("statement batch size cannot exceed"),
                 "error should indicate that the statement was too large: {}",
-                err
+                err.message,
             ),
             msg @ WebSocketResponse::ReadyForQuery(_)
             | msg @ WebSocketResponse::Notice(_)

--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -33,7 +33,7 @@ http
 {"query":"select 1; select * from noexist;"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"error":"unknown catalog item 'noexist'","notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"error":{"message":"unknown catalog item 'noexist'","code":"XX000"},"notices":[]}]}
 
 # CREATEs should work when provided alone.
 http
@@ -54,7 +54,7 @@ http
 {"query":"create view v1 as select 1; create view v2 as select 1"}
 ----
 200 OK
-{"results":[{"error":"CREATE VIEW v1 AS SELECT 1 cannot be run inside a transaction block","notices":[]}]}
+{"results":[{"error":{"message":"CREATE VIEW v1 AS SELECT 1 cannot be run inside a transaction block","code":"XX000"},"notices":[]}]}
 
 # Syntax errors fail the request.
 http
@@ -117,25 +117,25 @@ http
 {"query":"begin; select 1/0; commit; select 2;"}
 ----
 200 OK
-{"results":[{"ok":"BEGIN","notices":[]},{"error":"division by zero","notices":[]}]}
+{"results":[{"ok":"BEGIN","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
 http
 {"query":"begin; select 1; commit; select 1/0;"}
 ----
 200 OK
-{"results":[{"ok":"BEGIN","notices":[]},{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"COMMIT","notices":[]},{"error":"division by zero","notices":[]}]}
+{"results":[{"ok":"BEGIN","notices":[]},{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"COMMIT","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
 http
 {"query":"select 1/0; begin; select 2; commit;"}
 ----
 200 OK
-{"results":[{"error":"division by zero","notices":[]}]}
+{"results":[{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
 http
 {"query":"select 1; begin; select 1/0; commit;"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"BEGIN","notices":[]},{"error":"division by zero","notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"BEGIN","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
 # Txns w/ writes
 
@@ -144,7 +144,7 @@ http
 {"query":"insert into t values (1); select 1/0; insert into t values (2)"}
 ----
 200 OK
-{"results":[{"ok":"INSERT 0 1","notices":[]},{"error":"division by zero","notices":[]}]}
+{"results":[{"ok":"INSERT 0 1","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
  # Values not successfully written due to aborted txn
 http
@@ -158,7 +158,7 @@ http
 {"query":"begin; insert into t values (1); commit; insert into t values (2); select 1/0;"}
 ----
 200 OK
-{"results":[{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"COMMIT","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"error":"division by zero","notices":[]}]}
+{"results":[{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"COMMIT","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
 http
 {"query":"select * from t;"}
@@ -221,7 +221,7 @@ http
 {"query":"select $1"}
 ----
 200 OK
-{"results":[{"error":"request supplied 0 parameters, but SELECT $1 requires 1","notices":[]}]}
+{"results":[{"error":{"message":"request supplied 0 parameters, but SELECT $1 requires 1","code":"XX000"},"notices":[]}]}
 
 http
 {"query":"subscribe (select * from t)"}
@@ -305,14 +305,14 @@ http
 {"queries":[{"query":"select $1 as col","params":["1","2"]}]}
 ----
 200 OK
-{"results":[{"error":"request supplied 2 parameters, but SELECT $1 AS col requires 1","notices":[]}]}
+{"results":[{"error":{"message":"request supplied 2 parameters, but SELECT $1 AS col requires 1","code":"XX000"},"notices":[]}]}
 
 # Too few parameters
 http
 {"queries":[{"query":"select $1+$2::int as col","params":["1"]}]}
 ----
 200 OK
-{"results":[{"error":"request supplied 1 parameters, but SELECT $1 + ($2)::int4 AS col requires 2","notices":[]}]}
+{"results":[{"error":{"message":"request supplied 1 parameters, but SELECT $1 + ($2)::int4 AS col requires 2","code":"XX000"},"notices":[]}]}
 
 # NaN
 http
@@ -367,14 +367,14 @@ http
 {"queries":[{"query":"insert into t values (1);","params":[]},{"query":"select 1/0;","params":[]}]}
 ----
 200 OK
-{"results":[{"ok":"INSERT 0 1","notices":[]},{"error":"division by zero","notices":[]}]}
+{"results":[{"ok":"INSERT 0 1","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
 # Errors prevent commit + further execution
 http
 {"queries":[{"query":"begin;","params":[]},{"query":"insert into t values (1);","params":[]},{"query":"select 1/0;","params":[]},{"query":"select * from t","params":[]},{"query":"commit","params":[]}]}
 ----
 200 OK
-{"results":[{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"error":"division by zero","notices":[]}]}
+{"results":[{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
 # Requires explicit commit in explicit txn
 http
@@ -394,7 +394,7 @@ http
 {"queries":[{"query":"insert into t values ($1);","params":["1"]},{"query":"begin;","params":[]},{"query":"insert into t values ($1);","params":["2"]},{"query":"insert into t values ($1);","params":["3"]},{"query":"commit;","params":[]},{"query":"select 1/0","params":[]}]}
 ----
 200 OK
-{"results":[{"ok":"INSERT 0 1","notices":[]},{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"COMMIT","notices":[]},{"error":"division by zero","notices":[]}]}
+{"results":[{"ok":"INSERT 0 1","notices":[]},{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"COMMIT","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
 http
 {"queries":[{"query":"select * from t","params":[]}]}
@@ -406,7 +406,7 @@ http
 {"queries":[{"query":"insert into t values ($1);","params":["4"]},{"query":"begin;","params":[]},{"query":"select 1/0;","params":[]},{"query":"commit;","params":[]}]}
 ----
 200 OK
-{"results":[{"ok":"INSERT 0 1","notices":[]},{"ok":"BEGIN","notices":[]},{"error":"division by zero","notices":[]}]}
+{"results":[{"ok":"INSERT 0 1","notices":[]},{"ok":"BEGIN","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
 http
 {"queries":[{"query":"select * from t","params":[]}]}
@@ -419,3 +419,10 @@ http
 ----
 400 Bad Request
 unsupported via this API: SUBSCRIBE (SELECT * FROM t)
+
+# Test detail and hint error fields.
+http
+{"query":"CREATE MATERIALIZED VIEW _now AS SELECT now()"}
+----
+200 OK
+{"results":[{"error":{"message":"cannot materialize call to current_timestamp","code":"XX000","detail":"See: https://materialize.com/docs/sql/functions/now_and_mz_now/","hint":"Try using `mz_now()` here instead."},"notices":[]}]}

--- a/src/environmentd/tests/testdata/http/ws
+++ b/src/environmentd/tests/testdata/http/ws
@@ -10,13 +10,13 @@
 ws-text
 {"query": "bad sql"}
 ----
-{"type":"Error","payload":"Expected a keyword at the beginning of a statement, found identifier \"bad\""}
+{"type":"Error","payload":{"message":"Expected a keyword at the beginning of a statement, found identifier \"bad\"","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text
 {"queries": [{"query": "bad sql"}]}
 ----
-{"type":"Error","payload":"Expected a keyword at the beginning of a statement, found identifier \"bad\""}
+{"type":"Error","payload":{"message":"Expected a keyword at the beginning of a statement, found identifier \"bad\"","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text
@@ -84,19 +84,19 @@ ws-text
 ws-text
 {"queries": [{"query": ""}]}
 ----
-{"type":"Error","payload":"each query must contain exactly 1 statement, but \"\" contains 0"}
+{"type":"Error","payload":{"message":"each query must contain exactly 1 statement, but \"\" contains 0","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text
 {"queries": [{"query": "select $1"}]}
 ----
-{"type":"Error","payload":"request supplied 0 parameters, but SELECT $1 requires 1"}
+{"type":"Error","payload":{"message":"request supplied 0 parameters, but SELECT $1 requires 1","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text
 {"queries": [{"query": "select $1::int", "params": []}]}
 ----
-{"type":"Error","payload":"request supplied 0 parameters, but SELECT ($1)::int4 requires 1"}
+{"type":"Error","payload":{"message":"request supplied 0 parameters, but SELECT ($1)::int4 requires 1","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text
@@ -110,13 +110,13 @@ ws-text
 ws-text
 {"queries": [{"query": "select $1::int", "params": ["z"]}]}
 ----
-{"type":"Error","payload":"unable to decode parameter: invalid input syntax for type integer: invalid digit found in string: \"z\""}
+{"type":"Error","payload":{"message":"unable to decode parameter: invalid input syntax for type integer: invalid digit found in string: \"z\"","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text
 {"queries": [{"query": "select $1::int", "params": [2]}]}
 ----
-{"type":"Error","payload":"data did not match any variant of untagged enum SqlRequest"}
+{"type":"Error","payload":{"message":"data did not match any variant of untagged enum SqlRequest","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text
@@ -141,20 +141,20 @@ ws-text
 ws-text
 {"query": "CREATE VIEW v AS SELECT 1"}
 ----
-{"type":"Error","payload":"CREATE VIEW v AS SELECT 1 cannot be run inside a transaction block"}
+{"type":"Error","payload":{"message":"CREATE VIEW v AS SELECT 1 cannot be run inside a transaction block","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"E"}
 
 ws-text
 {"query": "CREATE VIEW v AS SELECT 1"}
 ----
-{"type":"Error","payload":"current transaction is aborted, commands ignored until end of transaction block"}
+{"type":"Error","payload":{"message":"current transaction is aborted, commands ignored until end of transaction block","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"E"}
 
 
 ws-text
 {"query": "SELECT 2"}
 ----
-{"type":"Error","payload":"current transaction is aborted, commands ignored until end of transaction block"}
+{"type":"Error","payload":{"message":"current transaction is aborted, commands ignored until end of transaction block","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"E"}
 
 ws-text
@@ -169,7 +169,7 @@ ws-text
 ws-text
 {"query": "SUBSCRIBE v"}
 ----
-{"type":"Error","payload":"unknown catalog item 'v'"}
+{"type":"Error","payload":{"message":"unknown catalog item 'v'","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text
@@ -190,7 +190,7 @@ ws-text
 {"type":"Rows","payload":["mz_timestamp","mz_diff","column1"]}
 {"type":"Row","payload":["18446744073709551615",1,1]}
 {"type":"CommandComplete","payload":"SUBSCRIBE"}
-{"type":"Error","payload":"SUBSCRIBE in transactions must be the only read statement"}
+{"type":"Error","payload":{"message":"SUBSCRIBE in transactions must be the only read statement","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text rows=2 fixtimestamp=true


### PR DESCRIPTION
This is a backward incompatible change to both endpoints. WS is experimental so there's no issue. HTTP is not, so this is a breaking change for it.

Error codes live in postgres and will need to be migrated to some common location later.

 Fixes MaterializeInc/database-issues#5715

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - **Breaking change.** Change the HTTP and WebSocket errors to be structured objects instead of strings.