### PR TITLE
Update mz_internal.mz_cluster_replica_history

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -138,6 +138,8 @@ created and (if applicable) dropped.
 | Field              | Type                         | Meaning                                                                                                                                   |
 |--------------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | `replica_id`       | [`text`]                     | The ID of a cluster replica.                                                                                                              |
+| `cluster_name`     | [`text`]                     | The name of the cluster associated with the replica.                                                                                      |
+| `replica_name`     | [`text`]                     | The name of the replica.                                                                                                                  |
 | `size`             | [`text`]                     | The size of the cluster replica. Corresponds to [`mz_cluster_replica_sizes.size`](#mz_cluster_replica_sizes).                             |
 | `created_at`       | [`timestamp with time zone`] | The time at which the replica was created.                                                                                                |
 | `dropped_at`       | [`timestamp with time zone`] | The time at which the replica was dropped, or `NULL` if it still exists.                                                                  |

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -135,15 +135,15 @@ extant cluster replicas.
 The `mz_cluster_replica_history` gives the times each replica was
 created and (if applicable) dropped.
 
-| Field              | Type                         | Meaning                                                                                                                                   |
-|--------------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| `replica_id`       | [`text`]                     | The ID of a cluster replica.                                                                                                              |
-| `cluster_name`     | [`text`]                     | The name of the cluster associated with the replica.                                                                                      |
-| `replica_name`     | [`text`]                     | The name of the replica.                                                                                                                  |
-| `size`             | [`text`]                     | The size of the cluster replica. Corresponds to [`mz_cluster_replica_sizes.size`](#mz_cluster_replica_sizes).                             |
-| `created_at`       | [`timestamp with time zone`] | The time at which the replica was created.                                                                                                |
-| `dropped_at`       | [`timestamp with time zone`] | The time at which the replica was dropped, or `NULL` if it still exists.                                                                  |
-| `credits_per_hour` | [`numeric`]                  | The number of compute credits consumed per hour. Corresponds to [`mz_cluster_replica_sizes.credtis_per_hour`](#mz_cluster_replica_sizes). |
+| Field                 | Type                         | Meaning                                                                                                                                   |
+|-----------------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `internal_replica_id` | [`text`]                     | An internal identifier of a cluster replica. Guaranteed to be unique, but not guaranteed to correspond to any user-facing replica ID.     |
+| `cluster_name`        | [`text`]                     | The name of the cluster associated with the replica.                                                                                      |
+| `replica_name`        | [`text`]                     | The name of the replica.                                                                                                                  |
+| `size`                | [`text`]                     | The size of the cluster replica. Corresponds to [`mz_cluster_replica_sizes.size`](#mz_cluster_replica_sizes).                             |
+| `created_at`          | [`timestamp with time zone`] | The time at which the replica was created.                                                                                                |
+| `dropped_at`          | [`timestamp with time zone`] | The time at which the replica was dropped, or `NULL` if it still exists.                                                                  |
+| `credits_per_hour`    | [`numeric`]                  | The number of compute credits consumed per hour. Corresponds to [`mz_cluster_replica_sizes.credtis_per_hour`](#mz_cluster_replica_sizes). |
 
 ### `mz_sessions`
 

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -3260,13 +3260,7 @@ pub const MZ_CLUSTER_REPLICA_HISTORY: BuiltinView = BuiltinView {
                 WHERE object_type = 'cluster-replica' AND event_type = 'drop'
             )
         SELECT
-            -- [btv] We have two notions of replica ID: the old one,
-            -- which is only present in `mz_audit_events`, and
-            -- the new one. We convert from old to new by
-            -- prepending with `u` here,
-            -- so as to not leak implementation details of `mz_audit_events`
-            -- into this more-broadly-useful view.
-            'u' || creates.replica_id AS replica_id,
+            creates.replica_id AS internal_replica_id,
             creates.size,
             creates.cluster_name,
             creates.replica_name,

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -159,11 +159,11 @@ SELECT occurred_at::text = '1970-01-01 00:00:00.666+00' FROM mz_audit_events ORD
 ----
 false
 
-query TTBBBT
-SELECT replica_id, size, created_at IS NOT NULL, dropped_at IS NOT NULL, created_at < dropped_at, credits_per_hour FROM mz_internal.mz_cluster_replica_history ORDER BY created_at
+query TTTTBBBT
+SELECT replica_id, cluster_name, replica_name, size, created_at IS NOT NULL, dropped_at IS NOT NULL, created_at < dropped_at, credits_per_hour FROM mz_internal.mz_cluster_replica_history ORDER BY created_at
 ----
-1  1  true  false  NULL  1
-4  1  true  true  true  1
-5  1  true  true  true  1
-6  2  true  true  true  1
-7  1  true  false  NULL  1
+u1  default  r1  1  true  false  NULL  1
+u4  foo  r  1  true  true  true  1
+u5  materialize_public_s  linked  1  true  true  true  1
+u6  materialize_public_s  linked  2  true  true  true  1
+u7  materialize_public_multiplex  linked  1  true  false  NULL  1

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -160,10 +160,10 @@ SELECT occurred_at::text = '1970-01-01 00:00:00.666+00' FROM mz_audit_events ORD
 false
 
 query TTTTBBBT
-SELECT replica_id, cluster_name, replica_name, size, created_at IS NOT NULL, dropped_at IS NOT NULL, created_at < dropped_at, credits_per_hour FROM mz_internal.mz_cluster_replica_history ORDER BY created_at
+SELECT internal_replica_id, cluster_name, replica_name, size, created_at IS NOT NULL, dropped_at IS NOT NULL, created_at < dropped_at, credits_per_hour FROM mz_internal.mz_cluster_replica_history ORDER BY created_at
 ----
-u1  default  r1  1  true  false  NULL  1
-u4  foo  r  1  true  true  true  1
-u5  materialize_public_s  linked  1  true  true  true  1
-u6  materialize_public_s  linked  2  true  true  true  1
-u7  materialize_public_multiplex  linked  1  true  false  NULL  1
+1  default  r1  1  true  false  NULL  1
+4  foo  r  1  true  true  true  1
+5  materialize_public_s  linked  1  true  true  true  1
+6  materialize_public_s  linked  2  true  true  true  1
+7  materialize_public_multiplex  linked  1  true  false  NULL  1


### PR DESCRIPTION
Fixes two issues with this view.

First, we were surfacing an "old-style" replica ID, which is an implementation detail of `mz_audit_events`. To get the corresponding publicly-relevant "new-style" replica ID, we now prepend it with "u".

Second, we need to include `replica_name` and `cluster_name` in this view, since in general users won't be able to get those by joining against `mz_clusters` and `mz_cluster_replicas`, in the case where the cluster or replica has already been dropped.

See full discussion [here](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1684175174531589).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improve the relevance of the information in `mz_cluster_replica_history`.