### PR TITLE
adapter: Enforce max connections at pgwire

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Mutex, MutexGuard};
+use tokio::sync::MutexGuard;
 use tracing::{info, trace, warn};
 use uuid::Uuid;
 
@@ -75,7 +75,7 @@ use mz_sql::plan::{
 };
 use mz_sql::session::user::{INTROSPECTION_USER, SYSTEM_USER};
 use mz_sql::session::vars::{
-    OwnedVarInput, SystemVars, Var, VarError, VarInput, CONFIG_HAS_SYNCED_ONCE,
+    ConnectionCounter, OwnedVarInput, SystemVars, Var, VarError, VarInput, CONFIG_HAS_SYNCED_ONCE,
 };
 use mz_sql::{plan, DEFAULT_SCHEMA};
 use mz_sql_parser::ast::{
@@ -149,7 +149,7 @@ pub const LINKED_CLUSTER_REPLICA_NAME: &str = "linked";
 #[derive(Debug)]
 pub struct Catalog {
     state: CatalogState,
-    storage: Arc<Mutex<storage::Connection>>,
+    storage: Arc<tokio::sync::Mutex<storage::Connection>>,
     transient_revision: u64,
 }
 
@@ -2780,13 +2780,13 @@ impl Catalog {
                 cluster_replica_sizes: config.cluster_replica_sizes,
                 default_storage_cluster_size: config.default_storage_cluster_size,
                 availability_zones: config.availability_zones,
-                system_configuration: SystemVars::default(),
+                system_configuration: SystemVars::new(config.active_connection_count),
                 egress_ips: config.egress_ips,
                 aws_principal_context: config.aws_principal_context,
                 aws_privatelink_availability_zones: config.aws_privatelink_availability_zones,
             },
             transient_revision: 0,
-            storage: Arc::new(Mutex::new(config.storage)),
+            storage: Arc::new(tokio::sync::Mutex::new(config.storage)),
         };
 
         catalog.create_temporary_schema(SYSTEM_CONN_ID, MZ_SYSTEM_ROLE_ID)?;
@@ -4155,6 +4155,7 @@ impl Catalog {
             },
         )
         .await?;
+        let active_connection_count = Arc::new(std::sync::Mutex::new(ConnectionCounter::new(0)));
         let secrets_reader = Arc::new(InMemorySecretsController::new());
         let (catalog, _, _, _) = Catalog::open(Config {
             storage,
@@ -4176,6 +4177,7 @@ impl Catalog {
             // when debugging, no reaping
             storage_usage_retention_period: None,
             connection_context: None,
+            active_connection_count,
         })
         .await?;
         Ok(catalog)

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytesize::ByteSize;
-use mz_sql::session::vars::ConnectionCounter;
 use serde::Deserialize;
 
 use mz_build_info::BuildInfo;
@@ -25,6 +24,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_repr::GlobalId;
 use mz_secrets::SecretsReader;
 use mz_sql::catalog::EnvironmentId;
+use mz_sql::session::vars::ConnectionCounter;
 
 use crate::catalog::storage;
 use crate::config::SystemParameterFrontend;

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytesize::ByteSize;
+use mz_sql::session::vars::ConnectionCounter;
 use serde::Deserialize;
 
 use mz_build_info::BuildInfo;
@@ -74,6 +75,8 @@ pub struct Config<'a> {
     /// TODO(migration): delete in version v.51 (released in v0.49 + 1
     /// additional release)
     pub connection_context: Option<mz_storage_client::types::connections::ConnectionContext>,
+    /// Global connection limit and count
+    pub active_connection_count: Arc<std::sync::Mutex<ConnectionCounter>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -78,7 +78,6 @@ use derivative::Derivative;
 use fail::fail_point;
 use futures::StreamExt;
 use itertools::Itertools;
-use mz_sql::session::vars::ConnectionCounter;
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, watch, OwnedMutexGuard};
@@ -110,6 +109,7 @@ use mz_sql::ast::{CreateSourceStatement, CreateSubsourceStatement, Raw, Statemen
 use mz_sql::catalog::EnvironmentId;
 use mz_sql::names::Aug;
 use mz_sql::plan::{CopyFormat, Params, QueryWhen};
+use mz_sql::session::vars::ConnectionCounter;
 use mz_storage_client::controller::{
     CollectionDescription, CreateExportToken, DataSource, StorageError,
 };

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -30,9 +30,7 @@ use mz_sql::plan::{
     AbortTransactionPlan, CommitTransactionPlan, CopyRowsPlan, CreateRolePlan, Params, Plan,
     TransactionType,
 };
-use mz_sql::session::vars::{
-    EndTransactionAction, OwnedVarInput, SystemVars, Var, MAX_CONNECTIONS,
-};
+use mz_sql::session::vars::{EndTransactionAction, OwnedVarInput};
 
 use crate::client::ConnectionId;
 use crate::command::{
@@ -209,22 +207,6 @@ impl Coordinator {
         cancel_tx: Arc<watch::Sender<Canceled>>,
         tx: oneshot::Sender<Response<StartupResponse>>,
     ) {
-        if !session.user().is_superuser() {
-            if let Err(e) = self.validate_resource_limit(
-                self.active_conns.len(),
-                1,
-                SystemVars::max_connections,
-                "connection",
-                MAX_CONNECTIONS.name(),
-            ) {
-                let _ = tx.send(Response {
-                    result: Err(e),
-                    session,
-                });
-                return;
-            }
-        }
-
         if self
             .catalog()
             .try_get_role_by_name(&session.user().name)

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -85,10 +85,11 @@ use std::net::{Ipv4Addr, SocketAddr};
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{bail, Context};
+use mz_sql::session::vars::ConnectionCounter;
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
 use rand::seq::SliceRandom;
 use tokio::sync::oneshot;
@@ -364,6 +365,8 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         None
     };
 
+    let active_connection_count = Arc::new(Mutex::new(ConnectionCounter::new(0)));
+
     // Initialize adapter.
     let segment_client = config.segment_api_key.map(mz_segment::Client::new);
     let (adapter_handle, adapter_client) = mz_adapter::serve(mz_adapter::Config {
@@ -389,6 +392,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         system_parameter_frontend: system_parameter_frontend.clone(),
         aws_account_id: config.aws_account_id,
         aws_privatelink_availability_zones: config.aws_privatelink_availability_zones,
+        active_connection_count: Arc::clone(&active_connection_count),
     })
     .await?;
 
@@ -406,6 +410,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
             frontegg: config.frontegg.clone(),
             metrics: metrics.clone(),
             internal: false,
+            active_connection_count: Arc::clone(&active_connection_count),
         });
         server::serve(sql_conns, sql_server)
     });
@@ -427,6 +432,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
             frontegg: None,
             metrics,
             internal: true,
+            active_connection_count: Arc::clone(&active_connection_count),
         });
         server::serve(internal_sql_conns, internal_sql_server)
     });

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -89,7 +89,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{bail, Context};
-use mz_sql::session::vars::ConnectionCounter;
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
 use rand::seq::SliceRandom;
 use tokio::sync::oneshot;
@@ -110,6 +109,7 @@ use mz_ore::tracing::TracingHandle;
 use mz_persist_client::usage::StorageUsageClient;
 use mz_secrets::SecretsController;
 use mz_sql::catalog::EnvironmentId;
+use mz_sql::session::vars::ConnectionCounter;
 use mz_storage_client::types::connections::ConnectionContext;
 
 use crate::http::{HttpConfig, HttpServer, InternalHttpConfig, InternalHttpServer};

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -457,20 +457,20 @@ impl Server {
         config
     }
 
-    pub fn connect<T>(&self, tls: T) -> Result<postgres::Client, anyhow::Error>
+    pub fn connect<T>(&self, tls: T) -> Result<postgres::Client, postgres::Error>
     where
         T: MakeTlsConnect<Socket> + Send + 'static,
         T::TlsConnect: Send,
         T::Stream: Send,
         <T::TlsConnect as TlsConnect<Socket>>::Future: Send,
     {
-        Ok(self.pg_config().connect(tls)?)
+        self.pg_config().connect(tls)
     }
 
     pub async fn connect_async<T>(
         &self,
         tls: T,
-    ) -> Result<(tokio_postgres::Client, tokio::task::JoinHandle<()>), anyhow::Error>
+    ) -> Result<(tokio_postgres::Client, tokio::task::JoinHandle<()>), postgres::Error>
     where
         T: MakeTlsConnect<Socket> + Send + 'static,
         T::TlsConnect: Send,

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -28,7 +28,7 @@ use tracing::{debug, warn, Instrument};
 use mz_adapter::session::{
     EndTransactionAction, InProgressRows, Portal, PortalState, RowBatchStream, TransactionStatus,
 };
-use mz_adapter::{AdapterNotice, AdapterError, ExecuteResponse, PeekResponseUnary, RowsFuture};
+use mz_adapter::{AdapterError, AdapterNotice, ExecuteResponse, PeekResponseUnary, RowsFuture};
 use mz_frontegg_auth::{Authentication as FronteggAuthentication, Claims};
 use mz_ore::cast::CastFrom;
 use mz_ore::netio::AsyncReady;
@@ -40,8 +40,7 @@ use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{FetchDirection, Ident, Raw, Statement};
 use mz_sql::plan::{CopyFormat, ExecuteTimeout, StatementDesc};
 use mz_sql::session::user::{ExternalUserMetadata, User, INTERNAL_USER_NAMES};
-use mz_sql::session::vars::{VarInput, ConnectionCounter};
-
+use mz_sql::session::vars::{ConnectionCounter, VarInput};
 
 use crate::codec::FramedConn;
 use crate::message::{

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -13,10 +13,14 @@ use std::convert::TryFrom;
 use std::future::Future;
 use std::iter;
 use std::mem;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 use byteorder::{ByteOrder, NetworkEndian};
 use futures::future::{pending, BoxFuture, FutureExt};
 use itertools::izip;
+use mz_adapter::AdapterError;
+use mz_sql::session::vars::ConnectionCounter;
 use postgres::error::SqlState;
 use tokio::io::{self, AsyncRead, AsyncWrite};
 use tokio::select;
@@ -83,6 +87,11 @@ pub struct RunParams<'a, A> {
     /// Whether this is an internal server that permits access to restricted
     /// system resources.
     pub internal: bool,
+    /// During handling the query, did we increment the connection count. Used
+    /// during connection teardown to determine if we need to decrement the count.
+    pub incremented_connection_count: &'a mut bool,
+    /// Global connection limit and count
+    pub active_connection_count: Arc<Mutex<ConnectionCounter>>,
 }
 
 /// Runs a pgwire connection to completion.
@@ -104,6 +113,8 @@ pub async fn run<'a, A>(
         mut params,
         frontegg,
         internal,
+        incremented_connection_count,
+        active_connection_count,
     }: RunParams<'a, A>,
 ) -> Result<(), io::Error>
 where
@@ -242,6 +253,30 @@ where
     session
         .vars_mut()
         .end_transaction(EndTransactionAction::Commit);
+
+    if !session.user().is_internal() && !session.user().is_external_admin() {
+        let result = {
+            let mut connections = active_connection_count.lock().expect("lock poisoned");
+            if connections.current >= connections.limit {
+                Err(AdapterError::ResourceExhaustion {
+                    limit_name: "max_connections".into(),
+                    resource_type: "connection".into(),
+                    desired: connections.current.to_string(),
+                    limit: connections.limit.to_string(),
+                    current: (connections.current - 1).to_string(),
+                })
+            } else {
+                connections.current += 1;
+                *incremented_connection_count = true;
+                Ok(())
+            }
+        };
+        if let Err(e) = result {
+            return conn
+                .send(ErrorResponse::from_adapter_error(Severity::Fatal, e))
+                .await;
+        }
+    }
 
     let mut buf = vec![BackendMessage::AuthenticationOk];
     for var in session.vars().notify_set() {

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -19,8 +19,6 @@ use std::sync::Mutex;
 use byteorder::{ByteOrder, NetworkEndian};
 use futures::future::{pending, BoxFuture, FutureExt};
 use itertools::izip;
-use mz_adapter::AdapterError;
-use mz_sql::session::vars::ConnectionCounter;
 use postgres::error::SqlState;
 use tokio::io::{self, AsyncRead, AsyncWrite};
 use tokio::select;
@@ -30,7 +28,7 @@ use tracing::{debug, warn, Instrument};
 use mz_adapter::session::{
     EndTransactionAction, InProgressRows, Portal, PortalState, RowBatchStream, TransactionStatus,
 };
-use mz_adapter::{AdapterNotice, ExecuteResponse, PeekResponseUnary, RowsFuture};
+use mz_adapter::{AdapterNotice, AdapterError, ExecuteResponse, PeekResponseUnary, RowsFuture};
 use mz_frontegg_auth::{Authentication as FronteggAuthentication, Claims};
 use mz_ore::cast::CastFrom;
 use mz_ore::netio::AsyncReady;
@@ -42,7 +40,8 @@ use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{FetchDirection, Ident, Raw, Statement};
 use mz_sql::plan::{CopyFormat, ExecuteTimeout, StatementDesc};
 use mz_sql::session::user::{ExternalUserMetadata, User, INTERNAL_USER_NAMES};
-use mz_sql::session::vars::VarInput;
+use mz_sql::session::vars::{VarInput, ConnectionCounter};
+
 
 use crate::codec::FramedConn;
 use crate::message::{

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -261,9 +261,9 @@ where
                 Err(AdapterError::ResourceExhaustion {
                     limit_name: "max_connections".into(),
                     resource_type: "connection".into(),
-                    desired: connections.current.to_string(),
+                    desired: (connections.current + 1).to_string(),
                     limit: connections.limit.to_string(),
-                    current: (connections.current - 1).to_string(),
+                    current: connections.current.to_string(),
                 })
             } else {
                 connections.current += 1;

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -10,10 +10,11 @@
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use async_trait::async_trait;
-use futures::FutureExt;
+use mz_sql::session::vars::ConnectionCounter;
 use openssl::ssl::{Ssl, SslContext};
 use tokio::io::{self, AsyncRead, AsyncWrite, AsyncWriteExt, Interest, ReadBuf, Ready};
 use tokio_openssl::SslStream;
@@ -48,6 +49,8 @@ pub struct Config {
     /// Whether this is an internal server that permits access to restricted
     /// system resources.
     pub internal: bool,
+    /// Global connection limit and count
+    pub active_connection_count: Arc<Mutex<ConnectionCounter>>,
 }
 
 /// Configures a server's TLS encryption and authentication.
@@ -75,6 +78,7 @@ pub struct Server {
     frontegg: Option<FronteggAuthentication>,
     metrics: Metrics,
     internal: bool,
+    active_connection_count: Arc<Mutex<ConnectionCounter>>,
 }
 
 impl Server {
@@ -86,6 +90,7 @@ impl Server {
             frontegg: config.frontegg,
             metrics: Metrics::new(config.metrics, config.internal),
             internal: config.internal,
+            active_connection_count: config.active_connection_count,
         }
     }
 
@@ -93,7 +98,7 @@ impl Server {
     pub fn handle_connection<A>(
         &self,
         conn: A,
-    ) -> impl Future<Output = Result<(), anyhow::Error>> + 'static
+    ) -> impl Future<Output = Result<(), anyhow::Error>> + 'static + Send
     where
         A: AsyncRead + AsyncWrite + AsyncReady + Send + Sync + Unpin + fmt::Debug + 'static,
     {
@@ -102,84 +107,100 @@ impl Server {
         let tls = self.tls.clone();
         let internal = self.internal;
         let metrics = self.metrics.clone();
-
+        let active_connection_count = Arc::clone(&self.active_connection_count);
+        let active_connection_count2 = Arc::clone(&self.active_connection_count);
         async move {
-            let mut adapter_client = adapter_client?;
-            let conn_id = adapter_client.conn_id();
-            let mut conn = Conn::Unencrypted(conn);
-            loop {
-                let message = codec::decode_startup(&mut conn).await?;
+            let mut incremented_connection_count = false;
+            let result = (|| {
+                let incremented_connection_count = &mut incremented_connection_count;
+                async move {
+                    let mut adapter_client = adapter_client?;
+                    let conn_id = adapter_client.conn_id();
+                    let mut conn = Conn::Unencrypted(conn);
+                    loop {
+                        let message = codec::decode_startup(&mut conn).await?;
 
-                match &message {
-                    Some(message) => trace!("cid={} recv={:?}", conn_id, message),
-                    None => trace!("cid={} recv=<eof>", conn_id),
-                }
+                        match &message {
+                            Some(message) => trace!("cid={} recv={:?}", conn_id, message),
+                            None => trace!("cid={} recv=<eof>", conn_id),
+                        }
 
-                conn = match message {
-                    // Clients sometimes hang up during the startup sequence, e.g.
-                    // because they receive an unacceptable response to an
-                    // `SslRequest`. This is considered a graceful termination.
-                    None => return Ok(()),
+                        conn = match message {
+                            // Clients sometimes hang up during the startup sequence, e.g.
+                            // because they receive an unacceptable response to an
+                            // `SslRequest`. This is considered a graceful termination.
+                            None => return Ok(()),
 
-                    Some(FrontendStartupMessage::Startup { version, params }) => {
-                        let mut conn = FramedConn::new(conn_id, conn);
-                        protocol::run(protocol::RunParams {
-                            tls_mode: tls.as_ref().map(|tls| tls.mode),
-                            adapter_client,
-                            conn: &mut conn,
-                            version,
-                            params,
-                            frontegg: frontegg.as_ref(),
-                            internal,
-                        })
-                        .await?;
-                        conn.flush().await?;
-                        return Ok(());
-                    }
-
-                    Some(FrontendStartupMessage::CancelRequest {
-                        conn_id,
-                        secret_key,
-                    }) => {
-                        adapter_client.cancel_request(conn_id, secret_key);
-                        // For security, the client is not told whether the cancel
-                        // request succeeds or fails.
-                        return Ok(());
-                    }
-
-                    Some(FrontendStartupMessage::SslRequest) => match (conn, &tls) {
-                        (Conn::Unencrypted(mut conn), Some(tls)) => {
-                            trace!("cid={} send=AcceptSsl", conn_id);
-                            conn.write_all(&[ACCEPT_SSL_ENCRYPTION]).await?;
-                            let mut ssl_stream = SslStream::new(Ssl::new(&tls.context)?, conn)?;
-                            if let Err(e) = Pin::new(&mut ssl_stream).accept().await {
-                                let _ = ssl_stream.get_mut().shutdown().await;
-                                return Err(e.into());
+                            Some(FrontendStartupMessage::Startup { version, params }) => {
+                                let mut conn = FramedConn::new(conn_id, conn);
+                                protocol::run(protocol::RunParams {
+                                    tls_mode: tls.as_ref().map(|tls| tls.mode),
+                                    adapter_client,
+                                    conn: &mut conn,
+                                    version,
+                                    params,
+                                    frontegg: frontegg.as_ref(),
+                                    internal,
+                                    incremented_connection_count,
+                                    active_connection_count,
+                                })
+                                .await?;
+                                conn.flush().await?;
+                                return Ok(());
                             }
-                            Conn::Ssl(ssl_stream)
-                        }
-                        (mut conn, _) => {
-                            trace!("cid={} send=RejectSsl", conn_id);
-                            conn.write_all(&[REJECT_ENCRYPTION]).await?;
-                            conn
-                        }
-                    },
 
-                    Some(FrontendStartupMessage::GssEncRequest) => {
-                        trace!("cid={} send=RejectGssEnc", conn_id);
-                        conn.write_all(&[REJECT_ENCRYPTION]).await?;
-                        conn
+                            Some(FrontendStartupMessage::CancelRequest {
+                                conn_id,
+                                secret_key,
+                            }) => {
+                                adapter_client.cancel_request(conn_id, secret_key);
+                                // For security, the client is not told whether the cancel
+                                // request succeeds or fails.
+                                return Ok(());
+                            }
+
+                            Some(FrontendStartupMessage::SslRequest) => match (conn, &tls) {
+                                (Conn::Unencrypted(mut conn), Some(tls)) => {
+                                    trace!("cid={} send=AcceptSsl", conn_id);
+                                    conn.write_all(&[ACCEPT_SSL_ENCRYPTION]).await?;
+                                    let mut ssl_stream =
+                                        SslStream::new(Ssl::new(&tls.context)?, conn)?;
+                                    if let Err(e) = Pin::new(&mut ssl_stream).accept().await {
+                                        let _ = ssl_stream.get_mut().shutdown().await;
+                                        return Err(e.into());
+                                    }
+                                    Conn::Ssl(ssl_stream)
+                                }
+                                (mut conn, _) => {
+                                    trace!("cid={} send=RejectSsl", conn_id);
+                                    conn.write_all(&[REJECT_ENCRYPTION]).await?;
+                                    conn
+                                }
+                            },
+
+                            Some(FrontendStartupMessage::GssEncRequest) => {
+                                trace!("cid={} send=RejectGssEnc", conn_id);
+                                conn.write_all(&[REJECT_ENCRYPTION]).await?;
+                                conn
+                            }
+                        }
                     }
                 }
+            })()
+            .await;
+            if incremented_connection_count {
+                active_connection_count2
+                    .lock()
+                    .expect("poisoned lock")
+                    .current -= 1;
             }
-        }
-        .inspect(move |result| {
             let status = match result {
                 Ok(()) => "success",
                 Err(_) => "error",
             };
             metrics.connection_status(status).inc();
-        })
+            result
+        }
     }
 }
 

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -189,9 +189,7 @@ impl Server {
             })()
             .await;
             if incremented_connection_count {
-                let mut connections = active_connection_count2
-                    .lock()
-                    .expect("poisoned lock");
+                let mut connections = active_connection_count2.lock().expect("poisoned lock");
                 assert_ne!(0, connections.current);
                 connections.current -= 1;
             }

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -189,10 +189,11 @@ impl Server {
             })()
             .await;
             if incremented_connection_count {
-                active_connection_count2
+                let mut connections = active_connection_count2
                     .lock()
-                    .expect("poisoned lock")
-                    .current -= 1;
+                    .expect("poisoned lock");
+                assert_ne!(0, connections.current);
+                connections.current -= 1;
             }
             let status = match result {
                 Ok(()) => "success",

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -14,7 +14,6 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use async_trait::async_trait;
-use mz_sql::session::vars::ConnectionCounter;
 use openssl::ssl::{Ssl, SslContext};
 use tokio::io::{self, AsyncRead, AsyncWrite, AsyncWriteExt, Interest, ReadBuf, Ready};
 use tokio_openssl::SslStream;
@@ -22,6 +21,7 @@ use tracing::trace;
 
 use mz_frontegg_auth::Authentication as FronteggAuthentication;
 use mz_ore::netio::AsyncReady;
+use mz_sql::session::vars::ConnectionCounter;
 
 use crate::codec::{self, FramedConn, ACCEPT_SSL_ENCRYPTION, REJECT_ENCRYPTION};
 use crate::message::FrontendStartupMessage;

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1778,9 +1778,9 @@ impl SystemVars {
     fn propagate_var_change(&mut self, name: &str) {
         if name == MAX_CONNECTIONS.name {
             self.active_connection_count
-            .lock()
-            .expect("lock poisoned")
-            .limit = u64::cast_from(*self.expect_value(&MAX_CONNECTIONS));
+                .lock()
+                .expect("lock poisoned")
+                .limit = u64::cast_from(*self.expect_value(&MAX_CONNECTIONS));
         }
     }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -12,16 +12,19 @@ use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Debug;
+use std::sync::Arc;
 use std::time::Duration;
 
 use const_format::concatcp;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use serde::Serialize;
+use std::sync::Mutex;
 use uncased::UncasedStr;
 
 use mz_build_info::BuildInfo;
 use mz_ore::cast;
+use mz_ore::cast::CastFrom;
 use mz_ore::str::StrExt;
 use mz_persist_client::cfg::PersistConfig;
 use mz_repr::adt::numeric::Numeric;
@@ -1526,26 +1529,49 @@ impl SessionVars {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
+pub struct ConnectionCounter {
+    pub current: u64,
+    pub limit: u64,
+}
+
+impl ConnectionCounter {
+    pub fn new(limit: u64) -> Self {
+        ConnectionCounter { current: 0, limit }
+    }
+}
+
 /// On disk variables.
 ///
 /// See [`SessionVars`] for more details on the Materialize configuration model.
 #[derive(Debug)]
 pub struct SystemVars {
     vars: BTreeMap<&'static UncasedStr, Box<dyn VarMut>>,
+    active_connection_count: Arc<Mutex<ConnectionCounter>>,
 }
 
 impl Clone for SystemVars {
     fn clone(&self) -> Self {
         SystemVars {
             vars: self.vars.iter().map(|(k, v)| (*k, v.clone_var())).collect(),
+            active_connection_count: Arc::clone(&self.active_connection_count),
         }
     }
 }
 
 impl Default for SystemVars {
     fn default() -> Self {
-        SystemVars::empty()
-            .with_var(&CONFIG_HAS_SYNCED_ONCE)
+        Self::new(Arc::new(Mutex::new(ConnectionCounter::new(0))))
+    }
+}
+
+impl SystemVars {
+    pub fn new(active_connection_count: Arc<Mutex<ConnectionCounter>>) -> Self {
+        let vars = SystemVars {
+            vars: Default::default(),
+            active_connection_count,
+        };
+        vars.with_var(&CONFIG_HAS_SYNCED_ONCE)
             .with_var(&MAX_AWS_PRIVATELINK_CONNECTIONS)
             .with_var(&MAX_TABLES)
             .with_var(&MAX_SOURCES)
@@ -1596,14 +1622,6 @@ impl Default for SystemVars {
             .with_var(&ENABLE_WITHIN_TIMESTAMP_ORDER_BY_IN_SUBSCRIBE)
             .with_var(&MAX_CONNECTIONS)
             .with_var(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
-    }
-}
-
-impl SystemVars {
-    fn empty() -> Self {
-        SystemVars {
-            vars: Default::default(),
-        }
     }
 
     fn with_var<V>(mut self, var: &'static ServerVar<V>) -> Self
@@ -1709,10 +1727,19 @@ impl SystemVars {
     /// 2. If `value` does not represent a valid [`SystemVars`] value for
     ///    `name`.
     pub fn set(&mut self, name: &str, input: VarInput) -> Result<bool, VarError> {
-        self.vars
+        let result = self
+            .vars
             .get_mut(UncasedStr::new(name))
             .ok_or_else(|| VarError::UnknownParameter(name.into()))
-            .and_then(|v| v.set(input))
+            .and_then(|v| v.set(input))?;
+
+        if name == MAX_CONNECTIONS.name {
+            self.active_connection_count
+                .lock()
+                .expect("lock poisoned")
+                .limit = u64::cast_from(*self.expect_value(&MAX_CONNECTIONS));
+        }
+        Ok(result)
     }
 
     /// Set the default for this variable. This is the value this
@@ -1739,10 +1766,19 @@ impl SystemVars {
     /// The call will return an error:
     /// 1. If `name` does not refer to a valid [`SystemVars`] field.
     pub fn reset(&mut self, name: &str) -> Result<bool, VarError> {
-        self.vars
+        let result = self
+            .vars
             .get_mut(UncasedStr::new(name))
             .ok_or_else(|| VarError::UnknownParameter(name.into()))
-            .map(|v| v.reset())
+            .map(|v| v.reset())?;
+
+        if name == MAX_CONNECTIONS.name {
+            self.active_connection_count
+                .lock()
+                .expect("lock poisoned")
+                .limit = u64::cast_from(*self.expect_value(&MAX_CONNECTIONS));
+        }
+        Ok(result)
     }
 
     /// Returns the `config_has_synced_once` configuration parameter.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1571,7 +1571,8 @@ impl SystemVars {
             vars: Default::default(),
             active_connection_count,
         };
-        let mut vars = vars.with_var(&CONFIG_HAS_SYNCED_ONCE)
+        let mut vars = vars
+            .with_var(&CONFIG_HAS_SYNCED_ONCE)
             .with_var(&MAX_AWS_PRIVATELINK_CONNECTIONS)
             .with_var(&MAX_TABLES)
             .with_var(&MAX_SOURCES)
@@ -1745,7 +1746,8 @@ impl SystemVars {
     /// variable will be be `reset` to. If no default is set, the static default in the
     /// variable definition is used instead.
     pub fn set_default(&mut self, name: &str, input: VarInput) -> Result<(), VarError> {
-        let result = self.vars
+        let result = self
+            .vars
             .get_mut(UncasedStr::new(name))
             .ok_or_else(|| VarError::UnknownParameter(name.into()))
             .and_then(|v| v.set_default(input))?;
@@ -1784,9 +1786,9 @@ impl SystemVars {
 
     fn refresh_state(&mut self) {
         self.active_connection_count
-        .lock()
-        .expect("lock poisoned")
-        .limit = u64::cast_from(*self.expect_value(&MAX_CONNECTIONS));
+            .lock()
+            .expect("lock poisoned")
+            .limit = u64::cast_from(*self.expect_value(&MAX_CONNECTIONS));
     }
 
     /// Returns the `config_has_synced_once` configuration parameter.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1784,6 +1784,8 @@ impl SystemVars {
         Ok(result)
     }
 
+    /// Refresh the internal state (currently just active_connection_count) when any of
+    /// the system vars that may affect them changes. Today only when MAX_CONNECTIONS changes.
     fn refresh_state(&mut self) {
         self.active_connection_count
             .lock()

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -82,7 +82,7 @@ use std::{
     path::PathBuf,
     process,
     str::FromStr,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use anyhow::Context;
@@ -104,7 +104,7 @@ use mz_ore::{
     now::SYSTEM_TIME,
 };
 use mz_secrets::InMemorySecretsController;
-use mz_sql::catalog::EnvironmentId;
+use mz_sql::{catalog::EnvironmentId, session::vars::ConnectionCounter};
 use mz_stash::{Stash, StashFactory};
 use mz_storage_client::controller as storage;
 
@@ -402,6 +402,7 @@ impl Usage {
         )
         .await?;
         let secrets_reader = Arc::new(InMemorySecretsController::new());
+
         let (_catalog, _, _, last_catalog_version) = Catalog::open(Config {
             storage,
             unsafe_mode: true,
@@ -421,6 +422,7 @@ impl Usage {
             system_parameter_frontend: None,
             storage_usage_retention_period: None,
             connection_context: None,
+            active_connection_count: Arc::new(Mutex::new(ConnectionCounter::new(0))),
         })
         .await?;
 


### PR DESCRIPTION
Fixes #19194. It allows us to error out the connection on connect vs the first query. Also removes the test's flakyness

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
