### PR TITLE
ci: Fix python error when junit report upload failed

### DIFF
--- a/misc/python/materialize/ci_util/__init__.py
+++ b/misc/python/materialize/ci_util/__init__.py
@@ -71,7 +71,8 @@ def upload_junit_report(suite: str, junit_report: Path) -> None:
         )
     except Exception as e:
         print(f"Got exception when uploading analytics: {e}")
-    print(res.status_code, res.text)
+    else:
+        print(res.status_code, res.text)
 
 
 def get_artifacts() -> Any:


### PR DESCRIPTION
Noticed in https://buildkite.com/materialize/tests/builds/55619#018823e1-0fb0-4e6d-b075-e1b387c15ed9

```
UnboundLocalError: local variable 'res' referenced before assignment
```

Comes from https://github.com/MaterializeInc/materialize/pull/14997

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
