### PR TITLE
ci: Fix conditional for skipping coverage

### DIFF
--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -28,7 +28,7 @@ export_cov() {
       > coverage/"$BUILDKITE_JOB_ID"-"$(basename "$1")".lcov
 }
 
-if [ -n "${CI_COVERAGE_ENABLED:-}" ] && [ -n "${BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_COVERAGE:-}" ];  then
+if [ -n "${CI_COVERAGE_ENABLED:-}" ] && [ -z "${BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_COVERAGE:-}" ];  then
     ci_unimportant_heading "Generate coverage information"
     run --mz-quiet down --volumes
 


### PR DESCRIPTION
Coverage should run when SKIP_COVERAGE is not set

Follow-up to e31ab4fb45c

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
