### PR TITLE
storage-client: internal command to update ingestions

### DIFF
--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -325,7 +325,8 @@ impl ShouldHalt for StorageError {
             | StorageError::IngestionInstanceMissing { .. }
             | StorageError::ExportInstanceMissing { .. }
             | StorageError::Generic(_)
-            | StorageError::DataflowError(_) => false,
+            | StorageError::DataflowError(_)
+            | StorageError::InvalidAlterSource { .. } => false,
             StorageError::IOError(e) => e.should_halt(),
         }
     }

--- a/src/storage-client/src/client.proto
+++ b/src/storage-client/src/client.proto
@@ -35,9 +35,11 @@ message ProtoAllowCompaction {
 }
 
 message ProtoCreateSourceCommand {
+    reserved 3;
+    reserved "resume_upper";
     mz_repr.global_id.ProtoGlobalId id = 1;
     mz_storage_client.types.sources.ProtoIngestionDescription description = 2;
-    mz_repr.antichain.ProtoU64Antichain resume_upper = 3;
+    // mz_repr.antichain.ProtoU64Antichain resume_upper = 3;
 }
 
 message ProtoCreateSources {

--- a/src/storage-client/src/client.proto
+++ b/src/storage-client/src/client.proto
@@ -34,16 +34,14 @@ message ProtoAllowCompaction {
     repeated ProtoCompaction collections = 1;
 }
 
-message ProtoCreateSourceCommand {
-    reserved 3;
-    reserved "resume_upper";
+message ProtoRunIngestionCommand {
     mz_repr.global_id.ProtoGlobalId id = 1;
     mz_storage_client.types.sources.ProtoIngestionDescription description = 2;
-    // mz_repr.antichain.ProtoU64Antichain resume_upper = 3;
+    bool update = 3;
 }
 
 message ProtoCreateSources {
-    repeated ProtoCreateSourceCommand sources = 1;
+    repeated ProtoRunIngestionCommand sources = 1;
 }
 
 message ProtoCreateSinkCommand {

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -104,8 +104,8 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     InitializationComplete,
     /// Update storage instance configuration.
     UpdateConfiguration(StorageParameters),
-    /// Create the enumerated sources, each associated with its identifier.
-    CreateSources(Vec<CreateSourceCommand>),
+    /// Run the enumerated sources, each associated with its identifier.
+    RunIngestions(Vec<RunIngestionCommand>),
     /// Enable compaction in storage-managed collections.
     ///
     /// Each entry in the vector names a collection and provides a frontier after which
@@ -116,15 +116,21 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
 
 /// A command that starts ingesting the given ingestion description
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct CreateSourceCommand {
+pub struct RunIngestionCommand {
     /// The id of the storage collection being ingested.
     pub id: GlobalId,
     /// The description of what source type should be ingested and what post-processing steps must
     /// be applied to the data before writing them down into the storage collection
     pub description: IngestionDescription<CollectionMetadata>,
+    /// Whether or not this ingestion command should be allowed to/required to update an existing
+    /// ingestion.
+    ///
+    /// Essentially, if update, the command came from `ALTER SOURCE`; if not, it came from `CREATE
+    /// SOURCE`.
+    pub update: bool,
 }
 
-impl Arbitrary for CreateSourceCommand {
+impl Arbitrary for RunIngestionCommand {
     type Strategy = BoxedStrategy<Self>;
     type Parameters = ();
 
@@ -132,26 +138,33 @@ impl Arbitrary for CreateSourceCommand {
         (
             any::<GlobalId>(),
             any::<IngestionDescription<CollectionMetadata>>(),
+            any::<bool>(),
         )
-            .prop_map(|(id, description)| Self { id, description })
+            .prop_map(|(id, description, update)| Self {
+                id,
+                description,
+                update,
+            })
             .boxed()
     }
 }
 
-impl RustType<ProtoCreateSourceCommand> for CreateSourceCommand {
-    fn into_proto(&self) -> ProtoCreateSourceCommand {
-        ProtoCreateSourceCommand {
+impl RustType<ProtoRunIngestionCommand> for RunIngestionCommand {
+    fn into_proto(&self) -> ProtoRunIngestionCommand {
+        ProtoRunIngestionCommand {
             id: Some(self.id.into_proto()),
             description: Some(self.description.into_proto()),
+            update: self.update,
         }
     }
 
-    fn from_proto(proto: ProtoCreateSourceCommand) -> Result<Self, TryFromProtoError> {
-        Ok(CreateSourceCommand {
-            id: proto.id.into_rust_if_some("ProtoCreateSourceCommand::id")?,
+    fn from_proto(proto: ProtoRunIngestionCommand) -> Result<Self, TryFromProtoError> {
+        Ok(RunIngestionCommand {
+            id: proto.id.into_rust_if_some("ProtoRunIngestionCommand::id")?,
             description: proto
                 .description
-                .into_rust_if_some("ProtoCreateSourceCommand::description")?,
+                .into_rust_if_some("ProtoRunIngestionCommand::description")?,
+            update: proto.update,
         })
     }
 }
@@ -209,14 +222,14 @@ impl RustType<ProtoStorageCommand> for StorageCommand<mz_repr::Timestamp> {
                 StorageCommand::UpdateConfiguration(params) => {
                     UpdateConfiguration(params.into_proto())
                 }
-                StorageCommand::CreateSources(sources) => CreateSources(ProtoCreateSources {
-                    sources: sources.into_proto(),
-                }),
                 StorageCommand::AllowCompaction(collections) => {
                     AllowCompaction(ProtoAllowCompaction {
                         collections: collections.into_proto(),
                     })
                 }
+                StorageCommand::RunIngestions(sources) => CreateSources(ProtoCreateSources {
+                    sources: sources.into_proto(),
+                }),
                 StorageCommand::CreateSinks(sinks) => CreateSinks(ProtoCreateSinks {
                     sinks: sinks.into_proto(),
                 }),
@@ -239,7 +252,7 @@ impl RustType<ProtoStorageCommand> for StorageCommand<mz_repr::Timestamp> {
                 Ok(StorageCommand::UpdateConfiguration(params.into_rust()?))
             }
             Some(CreateSources(ProtoCreateSources { sources })) => {
-                Ok(StorageCommand::CreateSources(sources.into_rust()?))
+                Ok(StorageCommand::RunIngestions(sources.into_rust()?))
             }
             Some(AllowCompaction(ProtoAllowCompaction { collections })) => {
                 Ok(StorageCommand::AllowCompaction(collections.into_rust()?))
@@ -261,8 +274,8 @@ impl Arbitrary for StorageCommand<mz_repr::Timestamp> {
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         Union::new(vec![
             // TODO(guswynn): cluster-unification: also test `CreateTimely` here.
-            proptest::collection::vec(any::<CreateSourceCommand>(), 1..4)
-                .prop_map(StorageCommand::CreateSources)
+            proptest::collection::vec(any::<RunIngestionCommand>(), 1..4)
+                .prop_map(StorageCommand::RunIngestions)
                 .boxed(),
             proptest::collection::vec(any::<CreateSinkCommand<mz_repr::Timestamp>>(), 1..4)
                 .prop_map(StorageCommand::CreateSinks)
@@ -524,8 +537,9 @@ where
                 // until we are required to manage multiple replicas, we can handle
                 // keeping track of state across restarts of storage server(s).
             }
-            StorageCommand::CreateSources(ingestions) => {
+            StorageCommand::RunIngestions(ingestions) => {
                 for ingestion in ingestions {
+                    // TODO: Propagate ingestion.update` into the update.
                     for export_id in ingestion.description.subsource_ids() {
                         let mut frontier = MutableAntichain::new();
                         // TODO(guswynn): cluster-unification: fix this dangerous use of `as`, by

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1522,89 +1522,13 @@ where
             match &description.data_source {
                 DataSource::Ingestion(ingestion) => {
                     let storage_dependencies = description.get_storage_dependencies();
-                    let dependency_since =
-                        self.determine_collection_since_joins(&storage_dependencies)?;
 
-                    // Install read capability for all non-remap subsources on
-                    // remap collection.
-                    //
-                    // N.B. The "main" collection of the source is included in
-                    // `source_exports`.
-                    for id in ingestion.source_exports.keys() {
-                        let collection = self.collection(*id).expect("known to exist");
-
-                        // At the time of collection creation, we did not yet
-                        // have firm guarantees that the since of our
-                        // dependencies was not advanced beyond those of its
-                        // dependents, so we need to patch up the
-                        // implied_capability/since of the collction.
-                        //
-                        // TODO(aljoscha): This comes largely from the fact that
-                        // subsources are created with a `DataSource::Other`, so
-                        // we have no idea (at their creation time) that they
-                        // are a subsource, or that they are a subsource of a
-                        // source where they need a read hold on that
-                        // ingestion's remap collection.
-                        if timely::order::PartialOrder::less_than(
-                            &collection.implied_capability,
-                            &dependency_since,
-                        ) {
-                            assert!(
-                                timely::order::PartialOrder::less_than(
-                                    &dependency_since,
-                                    &collection.write_frontier
-                                ),
-                                "write frontier ({:?}) must be in advance dependency collection's since ({:?})",
-                                collection.write_frontier,
-                                dependency_since,
-                            );
-                            mz_ore::soft_assert!(
-                                matches!(collection.read_policy, ReadPolicy::NoPolicy { .. }),
-                                "subsources should not have external read holds installed until \
-                                their ingestion is created, but {:?} has read policy {:?}",
-                                id,
-                                collection.read_policy
-                            );
-
-                            // This patches up the implied_capability!
-                            self.set_read_policy(vec![(
-                                *id,
-                                ReadPolicy::NoPolicy {
-                                    initial_since: dependency_since.clone(),
-                                },
-                            )]);
-
-                            // We have to re-borrow.
-                            let collection = self.collection(*id).expect("known to exist");
-                            assert!(
-                                collection.implied_capability == dependency_since,
-                                "monkey patching the implied_capability to {:?} did not work, is still {:?}",
-                                dependency_since,
-                                collection.implied_capability,
-                            );
-                        }
-
-                        // Fill in the storage dependencies.
-                        let collection = self.collection_mut(*id).expect("known to exist");
-                        collection
-                            .storage_dependencies
-                            .extend(storage_dependencies.iter().cloned());
-
-                        assert!(
-                            !PartialOrder::less_than(
-                                &collection.read_capabilities.frontier(),
-                                &collection.implied_capability.borrow()
-                            ),
-                            "{id}: at this point, there can be no read holds for any time that is not \
-                            beyond the implied capability \
-                            but we have implied_capability {:?}, read_capabilities {:?}",
-                            collection.implied_capability,
-                            collection.read_capabilities,
-                        );
-
-                        let read_hold = collection.implied_capability.clone();
-                        self.install_read_capabilities(*id, &storage_dependencies, read_hold)?;
-                    }
+                    self.install_dependency_read_holds(
+                        // N.B. The "main" collection of the source is included in
+                        // `source_exports`.
+                        ingestion.source_exports.keys().cloned(),
+                        &storage_dependencies,
+                    )?;
                 }
                 DataSource::Introspection(_) | DataSource::Progress | DataSource::Other => {
                     // No since to patch up and no read holds to install on
@@ -2038,10 +1962,7 @@ where
 
             let mut new_read_capability = policy.frontier(collection.write_frontier.borrow());
 
-            if timely::order::PartialOrder::less_equal(
-                &collection.implied_capability,
-                &new_read_capability,
-            ) {
+            if PartialOrder::less_equal(&collection.implied_capability, &new_read_capability) {
                 let mut update = ChangeBatch::new();
                 update.extend(new_read_capability.iter().map(|time| (time.clone(), 1)));
                 std::mem::swap(&mut collection.implied_capability, &mut new_read_capability);
@@ -2073,10 +1994,7 @@ where
                     .read_policy
                     .frontier(collection.write_frontier.borrow());
 
-                if timely::order::PartialOrder::less_equal(
-                    &collection.implied_capability,
-                    &new_read_capability,
-                ) {
+                if PartialOrder::less_equal(&collection.implied_capability, &new_read_capability) {
                     let mut update = ChangeBatch::new();
                     update.extend(new_read_capability.iter().map(|time| (time.clone(), 1)));
                     std::mem::swap(&mut collection.implied_capability, &mut new_read_capability);
@@ -2101,10 +2019,7 @@ where
                     export.read_policy.frontier(export.write_frontier.borrow())
                 };
 
-                if timely::order::PartialOrder::less_equal(
-                    &export.read_capability,
-                    &new_read_capability,
-                ) {
+                if PartialOrder::less_equal(&export.read_capability, &new_read_capability) {
                     let mut update = ChangeBatch::new();
                     update.extend(new_read_capability.iter().map(|time| (time.clone(), 1)));
                     std::mem::swap(&mut export.read_capability, &mut new_read_capability);
@@ -3125,6 +3040,86 @@ where
             self.clear_from_shard_finalization_register(finalized_shards)
                 .await;
         }
+    }
+
+    /// On each element of `collections`, install a read hold on all of the `storage_dependencies`.
+    fn install_dependency_read_holds<I: Iterator<Item = GlobalId>>(
+        &mut self,
+        collections: I,
+        storage_dependencies: &[GlobalId],
+    ) -> Result<(), StorageError> {
+        let dependency_since = self.determine_collection_since_joins(storage_dependencies)?;
+        for id in collections {
+            let collection = self.collection(id).expect("known to exist");
+
+            // At the time of collection creation, we did not yet
+            // have firm guarantees that the since of our
+            // dependencies was not advanced beyond those of its
+            // dependents, so we need to patch up the
+            // implied_capability/since of the collction.
+            //
+            // TODO(aljoscha): This comes largely from the fact that
+            // subsources are created with a `DataSource::Other`, so
+            // we have no idea (at their creation time) that they
+            // are a subsource, or that they are a subsource of a
+            // source where they need a read hold on that
+            // ingestion's remap collection.
+            if PartialOrder::less_than(&collection.implied_capability, &dependency_since) {
+                assert!(
+                    PartialOrder::less_than(&dependency_since, &collection.write_frontier),
+                    "write frontier ({:?}) must be in advance dependency collection's since ({:?})",
+                    collection.write_frontier,
+                    dependency_since,
+                );
+                mz_ore::soft_assert!(
+                    matches!(collection.read_policy, ReadPolicy::NoPolicy { .. }),
+                    "subsources should not have external read holds installed until \
+                                    their ingestion is created, but {:?} has read policy {:?}",
+                    id,
+                    collection.read_policy
+                );
+
+                // This patches up the implied_capability!
+                self.set_read_policy(vec![(
+                    id,
+                    ReadPolicy::NoPolicy {
+                        initial_since: dependency_since.clone(),
+                    },
+                )]);
+
+                // We have to re-borrow.
+                let collection = self.collection(id).expect("known to exist");
+                assert!(
+                    collection.implied_capability == dependency_since,
+                    "monkey patching the implied_capability to {:?} did not work, is still {:?}",
+                    dependency_since,
+                    collection.implied_capability,
+                );
+            }
+
+            // Fill in the storage dependencies.
+            let collection = self.collection_mut(id).expect("known to exist");
+            collection
+                .storage_dependencies
+                .extend(storage_dependencies.iter().cloned());
+
+            assert!(
+                !PartialOrder::less_than(
+                    &collection.read_capabilities.frontier(),
+                    &collection.implied_capability.borrow()
+                ),
+                "{id}: at this point, there can be no read holds for any time that is not \
+                                beyond the implied capability \
+                                but we have implied_capability {:?}, read_capabilities {:?}",
+                collection.implied_capability,
+                collection.read_capabilities,
+            );
+
+            let read_hold = collection.implied_capability.clone();
+            self.install_read_capabilities(id, storage_dependencies, read_hold)?;
+        }
+
+        Ok(())
     }
 
     /// Converts an `IngestionDescription<()>` into `IngestionDescription<CollectionMetadata>`.

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1653,7 +1653,7 @@ where
                         );
                     }
 
-                    let desc = IngestionDescription {
+                    let description = IngestionDescription {
                         source_imports,
                         source_exports,
                         ingestion_metadata,
@@ -1662,8 +1662,6 @@ where
                         instance_id: ingestion.instance_id,
                         remap_collection_id: ingestion.remap_collection_id,
                     };
-                    let mut calc = desc.create_calc(&self.persist).await;
-                    let resume_upper = calc.calculate_resumption_frontier().await;
 
                     // Fetch the client for this ingestion's instance.
                     let client = self
@@ -1674,11 +1672,7 @@ where
                             storage_instance_id: ingestion.instance_id,
                             ingestion_id: id,
                         })?;
-                    let augmented_ingestion = CreateSourceCommand {
-                        id,
-                        description: desc,
-                        resume_upper,
-                    };
+                    let augmented_ingestion = CreateSourceCommand { id, description };
 
                     client.send(StorageCommand::CreateSources(vec![augmented_ingestion]));
                 }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -979,6 +979,10 @@ pub enum StorageError {
     },
     /// Dataflow was not able to process a request
     DataflowError(DataflowError),
+    /// Response to an invalid/unsupported `ALTER SOURCE` command.
+    ///
+    /// n.b. when returning this error, you should log details about the error.
+    InvalidAlterSource { id: GlobalId },
     /// The controller API was used in some invalid way. This usually indicates
     /// a bug.
     InvalidUsage(String),
@@ -1000,6 +1004,7 @@ impl Error for StorageError {
             Self::ExportInstanceMissing { .. } => None,
             Self::IOError(err) => Some(err),
             Self::DataflowError(err) => Some(err),
+            Self::InvalidAlterSource { .. } => None,
             Self::InvalidUsage(_) => None,
             Self::Generic(err) => err.source(),
         }
@@ -1057,6 +1062,9 @@ impl fmt::Display for StorageError {
             // N.B. For these errors, the underlying error is reported in `source()`, and it
             // is the responsibility of the caller to print the chain of errors, when desired.
             Self::DataflowError(_err) => write!(f, "dataflow failed to process request",),
+            Self::InvalidAlterSource { id } => {
+                write!(f, "{id} cannot be altered in the requested way")
+            }
             Self::InvalidUsage(err) => write!(f, "invalid usage: {}", err),
             Self::Generic(err) => std::fmt::Display::fmt(err, f),
         }

--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -142,7 +142,7 @@ struct RehydrationTask<T> {
     /// A channel upon which responses from the storage replica are delivered.
     response_tx: UnboundedSender<StorageResponse<T>>,
     /// The sources that have been observed.
-    sources: BTreeMap<GlobalId, CreateSourceCommand<T>>,
+    sources: BTreeMap<GlobalId, CreateSourceCommand>,
     /// The exports that have been observed.
     sinks: BTreeMap<GlobalId, CreateSinkCommand<T>>,
     /// The upper frontier information received.

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -78,7 +78,6 @@ use anyhow::Context;
 use crossbeam_channel::TryRecvError;
 use differential_dataflow::lattice::Lattice;
 use fail::fail_point;
-use mz_ore::halt;
 use mz_ore::now::NowFn;
 use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
@@ -977,13 +976,8 @@ impl<'w, A: Allocate> Worker<'w, A> {
             .collect::<BTreeSet<_>>();
         let mut stale_exports = self.storage_state.exports.keys().collect::<BTreeSet<_>>();
 
-        // First, we collect all "drop commands". These are `AllowCompaction`
-        // commands that compact to the empty since. Then, later, we make sure
-        // we retain only those `Create*` commands that are not dropped. We
-        // assume that the `AllowCompaction` command is ordered after the
-        // `Create*` commands but don't assert that.
-        // WIP: Should we assert?
         let mut drop_commands = BTreeSet::new();
+        let mut running_ingestion_descriptions = self.storage_state.ingestions.clone();
 
         for command in &mut commands {
             match command {
@@ -991,12 +985,33 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     panic!("CreateTimely must be captured before")
                 }
                 StorageCommand::AllowCompaction(sinces) => {
+                    // collect all "drop commands". These are `AllowCompaction`
+                    // commands that compact to the empty since. Then, later, we make sure
+                    // we retain only those `Create*` commands that are not dropped. We
+                    // assume that the `AllowCompaction` command is ordered after the
+                    // `Create*` commands but don't assert that.
+                    // WIP: Should we assert?
                     let drops = sinces.drain_filter_swapping(|(_id, since)| since.is_empty());
                     drop_commands.extend(drops.map(|(id, _since)| id));
                 }
+                StorageCommand::CreateSources(ingestions) => {
+                    // Ensure that ingestions are forward-rolling alter compatible.
+                    for ingestion in ingestions {
+                        let prev = running_ingestion_descriptions
+                            .insert(ingestion.id, ingestion.description.clone());
+
+                        if let Some(prev_ingest) = prev {
+                            // If the new ingestion is not exactly equal to the currently running
+                            // ingestion, we must either track that we need to synthesize an update
+                            // command to change the ingestion, or panic.
+                            prev_ingest
+                                .alter_compatible(ingestion.id, &ingestion.description)
+                                .expect("only alter compatible ingestions permitted");
+                        }
+                    }
+                }
                 StorageCommand::InitializationComplete
                 | StorageCommand::UpdateConfiguration(_)
-                | StorageCommand::CreateSources(_)
                 | StorageCommand::CreateSinks(_) => (),
             }
         }


### PR DESCRIPTION
As part of `ALTER SOURCE`, we will need the ability to redescribe and restart an ingestion. Note that this is just prep work for making this accessible later, so nothing to test and we will make sure these code paths are thoroughly exercised once they're connected to the adapter.

### Motivation

This PR adds a known-desirable feature. Part of #15832

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
