### PR TITLE
rbac: Give mz_introspection role more privileges

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -3485,10 +3485,14 @@ pub static MZ_INTROSPECTION_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {
 
 pub static MZ_SYSTEM_CLUSTER: Lazy<BuiltinCluster> = Lazy::new(|| BuiltinCluster {
     name: &*SYSTEM_USER.name,
-    privileges: vec![rbac::owner_privilege(
-        ObjectType::Cluster,
-        MZ_SYSTEM_ROLE_ID,
-    )],
+    privileges: vec![
+        MzAclItem {
+            grantee: MZ_INTROSPECTION_ROLE_ID,
+            grantor: MZ_SYSTEM_ROLE_ID,
+            acl_mode: AclMode::USAGE,
+        },
+        rbac::owner_privilege(ObjectType::Cluster, MZ_SYSTEM_ROLE_ID),
+    ],
 });
 
 pub static MZ_SYSTEM_CLUSTER_REPLICA: Lazy<BuiltinClusterReplica> =

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -541,6 +541,7 @@ async fn migrate(
                 if &cluster_value.name == MZ_SYSTEM_CLUSTER.name
                     && !cluster_value
                         .privileges
+                        .as_ref()
                         .map(|privilege| privilege.contains(&mz_introspection_privilege))
                         .unwrap_or(false)
                 {

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -541,16 +541,13 @@ async fn migrate(
                 if &cluster_value.name == MZ_SYSTEM_CLUSTER.name
                     && !cluster_value
                         .privileges
-                        .as_ref()
-                        .expect("cluster privileges not migrated")
-                        .contains(&mz_introspection_privilege)
+                        .map(|privilege| privilege.contains(&mz_introspection_privilege))
+                        .unwrap_or(false)
                 {
                     let mut cluster_value = cluster_value.clone();
-                    cluster_value
-                        .privileges
-                        .as_mut()
-                        .expect("cluster privilege not migrated")
-                        .push(mz_introspection_privilege);
+                    let mut privileges = cluster_value.privileges.take().unwrap_or_default();
+                    privileges.push(mz_introspection_privilege);
+                    cluster_value.privileges = Some(privileges);
                     Some(cluster_value)
                 } else {
                     None

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -231,6 +231,7 @@ mz_introspection  =U/mz_system
 mz_introspection  mz_system=UC/mz_system
 mz_introspection  mz_introspection=UC/mz_system
 mz_system         mz_system=UC/mz_system
+mz_system         mz_introspection=U/mz_system
 
 ### The materialize privilege comes from the views created above
 query T


### PR DESCRIPTION
This commit gives the mz_introspection role USAGE privileges on the mz_system cluster. The mz_introspection role uses the mz_system cluster for various activities in cloud, such as the prometheus SQL exporter.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
