### PR TITLE
adapter: correctly terminate all failed Commands

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -103,6 +103,7 @@ pub use crate::catalog::config::{AwsPrincipalContext, ClusterReplicaSizeMap, Con
 pub use crate::catalog::error::{AmbiguousRename, Error, ErrorKind};
 use crate::catalog::storage::{BootstrapArgs, Transaction, MZ_SYSTEM_ROLE_ID};
 use crate::client::ConnectionId;
+use crate::command::CatalogDump;
 use crate::config::{SynchronizedParameters, SystemParameterFrontend};
 use crate::coord::{TargetCluster, DEFAULT_LOGICAL_COMPACTION_WINDOW};
 use crate::session::{PreparedStatement, Session, DEFAULT_DATABASE_NAME};
@@ -6719,8 +6720,8 @@ impl Catalog {
     /// There are no guarantees about the format of the serialized state, except
     /// that the serialized state for two identical catalogs will compare
     /// identically.
-    pub fn dump(&self) -> String {
-        self.state.dump()
+    pub fn dump(&self) -> CatalogDump {
+        CatalogDump::new(self.state.dump())
     }
 
     pub fn config(&self) -> &mz_sql::catalog::CatalogConfig {

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -30,7 +30,10 @@ use mz_repr::{GlobalId, Row, ScalarType};
 use mz_sql::ast::{Raw, Statement};
 use mz_sql::session::user::{User, INTROSPECTION_USER};
 
-use crate::command::{Canceled, Command, ExecuteResponse, Response, StartupResponse};
+use crate::command::{
+    Canceled, CatalogDump, Command, ExecuteResponse, GetVariablesResponse, Response,
+    StartupResponse,
+};
 use crate::error::AdapterError;
 use crate::metrics::Metrics;
 use crate::session::{EndTransactionAction, PreparedStatement, Session, TransactionId};
@@ -409,7 +412,7 @@ impl SessionClient {
     }
 
     /// Dumps the catalog to a JSON string.
-    pub async fn dump_catalog(&mut self) -> Result<String, AdapterError> {
+    pub async fn dump_catalog(&mut self) -> Result<CatalogDump, AdapterError> {
         self.send(|tx, session| Command::DumpCatalog { session, tx })
             .await
     }
@@ -436,7 +439,7 @@ impl SessionClient {
     }
 
     /// Gets the current value of all system variables.
-    pub async fn get_system_vars(&mut self) -> Result<BTreeMap<String, String>, AdapterError> {
+    pub async fn get_system_vars(&mut self) -> Result<GetVariablesResponse, AdapterError> {
         self.send(|tx, session| Command::GetSystemVars { session, tx })
             .await
     }

--- a/src/environmentd/src/http/catalog.rs
+++ b/src/environmentd/src/http/catalog.rs
@@ -17,7 +17,7 @@ use http::StatusCode;
 use crate::http::AuthedClient;
 
 pub async fn handle_internal_catalog(AuthedClient(mut client): AuthedClient) -> impl IntoResponse {
-    match client.dump_catalog().await {
+    match client.dump_catalog().await.map(|c| c.into_string()) {
         Ok(res) => Ok((TypedHeader(ContentType::json()), res)),
         Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
     }


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug: #18282

@mjibson #18282 mentions that all Command messages ignore a failed send, but it looks like over time we've slowly started to use `ClientTransmitter` for them already. This PR "finishes the swing" and uses `ClientTransmitter` for the last couple that are applicable.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
