### PR TITLE
sql: consolidate vars Option implementations

### DIFF
--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2182,7 +2182,7 @@ pub trait Var: fmt::Debug {
     fn description(&self) -> &'static str;
 
     /// Returns the name of the type of this variable.
-    fn type_name(&self) -> &'static str;
+    fn type_name(&self) -> String;
 
     /// Indicates wither the [`Var`] is visible for the given [`User`].
     ///
@@ -2260,8 +2260,8 @@ where
         self.description
     }
 
-    fn type_name(&self) -> &'static str {
-        V::TYPE_NAME
+    fn type_name(&self) -> String {
+        V::type_name()
     }
 
     fn visible(&self, user: &User) -> bool {
@@ -2348,8 +2348,8 @@ where
         self.parent.description()
     }
 
-    fn type_name(&self) -> &'static str {
-        V::TYPE_NAME
+    fn type_name(&self) -> String {
+        V::type_name()
     }
 
     fn visible(&self, user: &User) -> bool {
@@ -2510,8 +2510,8 @@ where
         self.parent.description()
     }
 
-    fn type_name(&self) -> &'static str {
-        V::TYPE_NAME
+    fn type_name(&self) -> String {
+        V::type_name()
     }
 
     fn visible(&self, user: &User) -> bool {
@@ -2536,8 +2536,8 @@ impl Var for BuildInfo {
         "Shows the Materialize server version (Materialize)."
     }
 
-    fn type_name(&self) -> &'static str {
-        str::TYPE_NAME
+    fn type_name(&self) -> String {
+        str::type_name()
     }
 
     fn visible(&self, _: &User) -> bool {
@@ -2562,8 +2562,8 @@ impl Var for User {
         "Reports whether the current session is a superuser (PostgreSQL)."
     }
 
-    fn type_name(&self) -> &'static str {
-        bool::TYPE_NAME
+    fn type_name(&self) -> String {
+        bool::type_name()
     }
 
     fn visible(&self, _: &User) -> bool {
@@ -2578,7 +2578,7 @@ impl Var for User {
 /// A value that can be stored in a session or server variable.
 pub trait Value: ToOwned + Send + Sync {
     /// The name of the value type.
-    const TYPE_NAME: &'static str;
+    fn type_name() -> String;
     /// Parses a value of this type from a [`VarInput`].
     fn parse(input: VarInput) -> Result<Self::Owned, ()>;
     /// Formats this value as a flattened string.
@@ -2597,7 +2597,9 @@ fn extract_single_value(input: VarInput) -> Result<&str, ()> {
 }
 
 impl Value for bool {
-    const TYPE_NAME: &'static str = "boolean";
+    fn type_name() -> String {
+        "boolean".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<Self, ()> {
         let s = extract_single_value(input)?;
@@ -2617,7 +2619,9 @@ impl Value for bool {
 }
 
 impl Value for i32 {
-    const TYPE_NAME: &'static str = "integer";
+    fn type_name() -> String {
+        "integer".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<i32, ()> {
         let s = extract_single_value(input)?;
@@ -2630,7 +2634,9 @@ impl Value for i32 {
 }
 
 impl Value for u32 {
-    const TYPE_NAME: &'static str = "unsigned integer";
+    fn type_name() -> String {
+        "unsigned integer".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<u32, ()> {
         let s = extract_single_value(input)?;
@@ -2643,7 +2649,9 @@ impl Value for u32 {
 }
 
 impl Value for mz_repr::Timestamp {
-    const TYPE_NAME: &'static str = "mz-timestamp";
+    fn type_name() -> String {
+        "mz-timestamp".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<mz_repr::Timestamp, ()> {
         let s = extract_single_value(input)?;
@@ -2656,7 +2664,9 @@ impl Value for mz_repr::Timestamp {
 }
 
 impl Value for usize {
-    const TYPE_NAME: &'static str = "unsigned integer";
+    fn type_name() -> String {
+        "unsigned integer".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<usize, ()> {
         let s = extract_single_value(input)?;
@@ -2669,7 +2679,9 @@ impl Value for usize {
 }
 
 impl Value for Numeric {
-    const TYPE_NAME: &'static str = "numeric";
+    fn type_name() -> String {
+        "numeric".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<Self::Owned, ()> {
         let s = extract_single_value(input)?;
@@ -2699,7 +2711,9 @@ const SEC_TO_DAY: u64 = 60u64 * 60 * 24;
 const MICRO_TO_MILLI: u32 = 1000u32;
 
 impl Value for Duration {
-    const TYPE_NAME: &'static str = "duration";
+    fn type_name() -> String {
+        "duration".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<Duration, ()> {
         let s = extract_single_value(input)?;
@@ -2828,7 +2842,9 @@ fn test_value_duration() {
 }
 
 impl Value for str {
-    const TYPE_NAME: &'static str = "string";
+    fn type_name() -> String {
+        "string".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<String, ()> {
         let s = extract_single_value(input)?;
@@ -2842,7 +2858,9 @@ impl Value for str {
 
 // The same as the above impl, but works in `SystemVar`s.
 impl Value for String {
-    const TYPE_NAME: &'static str = "string";
+    fn type_name() -> String {
+        "string".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<String, ()> {
         let s = extract_single_value(input)?;
@@ -2855,7 +2873,9 @@ impl Value for String {
 }
 
 impl Value for Vec<String> {
-    const TYPE_NAME: &'static str = "string list";
+    fn type_name() -> String {
+        "string list".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<Vec<String>, ()> {
         match input {
@@ -2880,7 +2900,9 @@ impl Value for Vec<String> {
 }
 
 impl Value for Vec<Ident> {
-    const TYPE_NAME: &'static str = "identifier list";
+    fn type_name() -> String {
+        "identifier list".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<Vec<Ident>, ()> {
         let holder;
@@ -2901,52 +2923,20 @@ impl Value for Vec<Ident> {
     }
 }
 
-impl Value for Option<String> {
-    const TYPE_NAME: &'static str = "optional string";
+// Implement `Value` for `Option<V>` for any owned `V`.
+impl<V> Value for Option<V>
+where
+    V: Value + Clone + ToOwned<Owned = V>,
+{
+    fn type_name() -> String {
+        format!("optional {}", V::type_name())
+    }
 
-    fn parse(input: VarInput) -> Result<Option<String>, ()> {
+    fn parse(input: VarInput) -> Result<Option<V>, ()> {
         let s = extract_single_value(input)?;
         match s {
             "" => Ok(None),
-            _ => Ok(Some(s.to_string())),
-        }
-    }
-
-    fn format(&self) -> String {
-        match self {
-            Some(s) => s.format(),
-            None => "".into(),
-        }
-    }
-}
-
-impl Value for Option<mz_repr::Timestamp> {
-    const TYPE_NAME: &'static str = "optional unsigned integer";
-
-    fn parse(input: VarInput) -> Result<Option<mz_repr::Timestamp>, ()> {
-        let s = extract_single_value(input)?;
-        match s {
-            "" => Ok(None),
-            _ => <mz_repr::Timestamp as Value>::parse(VarInput::Flat(s)).map(Some),
-        }
-    }
-
-    fn format(&self) -> String {
-        match self {
-            Some(s) => s.format(),
-            None => "".into(),
-        }
-    }
-}
-
-impl Value for Option<i32> {
-    const TYPE_NAME: &'static str = "optional signed integer";
-
-    fn parse(input: VarInput) -> Result<Option<i32>, ()> {
-        let s = extract_single_value(input)?;
-        match s {
-            "" => Ok(None),
-            _ => <i32 as Value>::parse(VarInput::Flat(s)).map(Some),
+            _ => <V as Value>::parse(VarInput::Flat(s)).map(Some),
         }
     }
 
@@ -3032,7 +3022,9 @@ impl ClientSeverity {
 }
 
 impl Value for ClientSeverity {
-    const TYPE_NAME: &'static str = "string";
+    fn type_name() -> String {
+        "string".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<Self::Owned, ()> {
         let s = extract_single_value(input)?;
@@ -3092,7 +3084,9 @@ impl TimeZone {
 }
 
 impl Value for TimeZone {
-    const TYPE_NAME: &'static str = "string";
+    fn type_name() -> String {
+        "string".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<Self::Owned, ()> {
         let s = extract_single_value(input)?;
@@ -3145,7 +3139,9 @@ impl IsolationLevel {
 }
 
 impl Value for IsolationLevel {
-    const TYPE_NAME: &'static str = "string";
+    fn type_name() -> String {
+        "string".to_string()
+    }
 
     fn parse(input: VarInput) -> Result<Self::Owned, ()> {
         let s = extract_single_value(input)?;


### PR DESCRIPTION
Cleanup from https://github.com/MaterializeInc/materialize/pull/19176

### Motivation

   * This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
