### PR TITLE
upgrade-matrix: Fix failure with 4-1 default storage size on v0.40.0

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -22,6 +22,7 @@ from materialize.mzcompose import (
     ServiceHealthcheck,
     loader,
 )
+from materialize.util import MzVersion
 
 DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.0.5"
 
@@ -128,7 +129,14 @@ class Materialized(Service):
         if propagate_crashes:
             command += ["--orchestrator-process-propagate-crashes"]
 
-        self.default_storage_size = "1" if default_size == 1 else f"{default_size}-1"
+        self.default_storage_size = (
+            default_size
+            if image
+            and MzVersion.parse_mz(image.split(":")[1]) < MzVersion.parse("0.41.0")
+            else "1"
+            if default_size == 1
+            else f"{default_size}-1"
+        )
 
         self.default_replica_size = (
             "1" if default_size == 1 else f"{default_size}-{default_size}"


### PR DESCRIPTION
Noticed in nightly: https://buildkite.com/materialize/nightlies/builds/2385#01882505-7756-422d-965f-a7c3d5eb6584

environmentd: default storage host size is unknown

Introduced in https://github.com/MaterializeInc/materialize/pull/17662. Reproduced with `bin/mzcompose --find upgrade-matrix down && bin/mzcompose --find upgrade-matrix run default --seed=01882455-2429-4514-a2c6-7b688fdf3158`

I checked and it seems to work fine starting with v0.41.0.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
