### PR TITLE
ci: Add stack overflow to the list of errors extracted from the logs

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -30,6 +30,7 @@ ERROR_RE = re.compile(
     | [Oo]ut\ [Oo]f\ [Mm]emory
     | cannot\ migrate\ from\ catalog
     | halting\ process: # Rust unwrap
+    | fatal runtime error: # stack overflow
     | \[SQLsmith\] # Unknown errors are logged
     | \[SQLancer\] # Unknown errors are logged
     # From src/testdrive/src/action/sql.rs


### PR DESCRIPTION
Make sure lines of the following form:

fatal runtime error: stack overflow

are extracted and presented as Buildkite annotations

### Motivation

  * This PR fixes a previously unreported bug.

A CI failure was not detected and reported by the ci_logged_errors_detect.py

https://buildkite.com/materialize/nightlies/builds/2387#018826ed-3aa1-475c-97fd-515a8e97e8e7