### PR TITLE
ci: Enable various feature flags in CI

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -98,6 +98,12 @@ class Materialized(Service):
         if system_parameter_defaults is None:
             system_parameter_defaults = [
                 "persist_sink_minimum_batch_updates=128",
+                "enable_multi_worker_storage_persist_sink=true",
+                "storage_persist_sink_minimum_batch_updates=100",
+                "persist_pubsub_push_diff_enabled=true",
+                "persist_pubsub_client_enabled=true",
+                "persist_stats_filter_enabled=true",
+                "persist_stats_collection_enabled=true",
             ]
 
         if additional_system_parameter_defaults is not None:


### PR DESCRIPTION
- PubSub
- one-shot monotonic SELECTs

### Motivation

  * This PR fixes a previously unreported bug.
CI was lagging behind the list of feature flags.

### Tips for reviewer
@def- I guess this is what you intended to achieve as a one-off experiment in https://github.com/MaterializeInc/materialize/pull/19221 but as discussed we want to enable feature flags by default in the CI