### PR TITLE
mzcompose: Principled handling of lists of prior versions

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -39,7 +39,7 @@ pytest-split==0.8.0
 pyyaml==6.0
 requests==2.28.1
 scipy==1.10.0
-semver==3.0.0.dev4
+semver==3.0.0
 shtab==1.5.8
 sqlparse==0.4.4
 toml==0.10.2

--- a/misc/python/materialize/checks/cloudtest_actions.py
+++ b/misc/python/materialize/checks/cloudtest_actions.py
@@ -12,7 +12,7 @@ from typing import Optional
 from materialize.checks.actions import Action
 from materialize.checks.executors import Executor
 from materialize.cloudtest.k8s.environmentd import EnvironmentdStatefulSet
-from materialize.util import MzVersion, released_materialize_versions
+from materialize.util import MzVersion
 
 
 class ReplaceEnvironmentdStatefulSet(Action):
@@ -38,7 +38,7 @@ class ReplaceEnvironmentdStatefulSet(Action):
         e.current_mz_version = (
             MzVersion.parse_mz(self.new_tag)
             if self.new_tag
-            else released_materialize_versions()[0]
+            else MzVersion.parse_cargo()
         )
 
     def join(self, e: Executor) -> None:

--- a/misc/python/materialize/checks/executors.py
+++ b/misc/python/materialize/checks/executors.py
@@ -13,7 +13,7 @@ from typing import Any, Optional
 
 from materialize.cloudtest.application import MaterializeApplication
 from materialize.mzcompose import Composition
-from materialize.util import MzVersion, released_materialize_versions
+from materialize.util import MzVersion
 
 
 class Executor:
@@ -75,7 +75,7 @@ class CloudtestExecutor(Executor):
     def __init__(self, application: MaterializeApplication) -> None:
         self.application = application
         self.seed = random.getrandbits(32)
-        self.current_mz_version = released_materialize_versions()[0]
+        self.current_mz_version = MzVersion.parse_cargo()
 
     def cloudtest_application(self) -> MaterializeApplication:
         return self.application

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -18,15 +18,12 @@ from materialize.checks.mzcompose_actions import (
     UseClusterdCompute,
 )
 from materialize.checks.scenarios import Scenario
-from materialize.util import MzVersion, released_materialize_versions
+from materialize.util import MzVersion
+from materialize.version_list import VersionsFromDocs
 
-released_versions = released_materialize_versions()
-
-# Usually, the latest patch version of the current release
-last_version = released_versions[0]
-
-# Usually, the last patch version of the previous release
-previous_version = released_versions[1]
+version_list = VersionsFromDocs()
+released_versions = version_list.all_versions()
+previous_version, last_version = version_list.minor_versions()[-2:]
 
 
 class UpgradeEntireMz(Scenario):
@@ -119,23 +116,23 @@ class UpgradeEntireMzFourVersions(Scenario):
     """Test upgrade X-4 -> X-3 -> X-2 -> X-1 -> X"""
 
     def base_version(self) -> MzVersion:
-        return released_versions[3]
+        return released_versions[-4]
 
     def actions(self) -> List[Action]:
         print(
-            f"Upgrading going through {released_versions[3]} -> {released_versions[2]} -> {released_versions[1]} -> {released_versions[0]}"
+            f"Upgrading going through {released_versions[-4]} -> {released_versions[-3]} -> {released_versions[-2]} -> {released_versions[-1]}"
         )
         return [
-            StartMz(tag=released_versions[3]),
+            StartMz(tag=released_versions[-4]),
             Initialize(self),
             KillMz(),
-            StartMz(tag=released_versions[2]),
+            StartMz(tag=released_versions[-3]),
             Manipulate(self, phase=1),
             KillMz(),
-            StartMz(tag=released_versions[1]),
+            StartMz(tag=released_versions[-2]),
             Manipulate(self, phase=2),
             KillMz(),
-            StartMz(tag=released_versions[0]),
+            StartMz(tag=released_versions[-1]),
             KillMz(),
             StartMz(tag=None),
             Validate(self),

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -141,7 +141,7 @@ def describe() -> str:
 
 def fetch() -> str:
     """Fetch from all configured default fetch remotes"""
-    return spawn.capture(["git", "fetch", "--tags", "--force"]).strip()
+    return spawn.capture(["git", "fetch", "--all", "--tags", "--force"]).strip()
 
 
 _fetch = fetch  # renamed because an argument shadows the fetch name in get_tags

--- a/misc/python/materialize/util.py
+++ b/misc/python/materialize/util.py
@@ -14,9 +14,7 @@ import os
 import random
 import subprocess
 from pathlib import Path
-from typing import List
 
-import frontmatter
 from semver import Version
 
 from materialize.mzcompose import Composition
@@ -42,8 +40,7 @@ class MzVersion(Version):
             if not git_hash[0] == "(" or not git_hash[-1] == ")":
                 raise ValueError(f"Invalid mz version string: {version}")
             # Hash ignored
-        # TODO(def-) Remove type ignores when https://github.com/python-semver/python-semver/pull/396 is merged
-        return cls.parse(version)  # type: ignore
+        return cls.parse(version)
 
     @classmethod
     def parse_sql(cls, c: Composition) -> "MzVersion":
@@ -60,30 +57,13 @@ class MzVersion(Version):
         )
         for package in metadata["packages"]:
             if package["name"] == "mz-environmentd":
-                return cls.parse(package["version"])  # type: ignore
+                return cls.parse(package["version"])
         else:
             raise ValueError("No mz-environmentd version found in cargo metadata")
 
+    @classmethod
+    def from_semver(cls, version: Version) -> "MzVersion":
+        return cls.parse(str(version))
+
     def __str__(self) -> str:
         return "v" + super().__str__()
-
-
-def released_materialize_versions() -> List[MzVersion]:
-    """Returns all released Materialize versions.
-
-    The list is determined from the release notes files in the user
-    documentation. Only versions that declare `released: true` in their
-    frontmatter are considered.
-
-    The list is returned in version order with newest versions first.
-    """
-    files = Path(ROOT / "doc" / "user" / "content" / "releases").glob("v*.md")
-    versions = []
-    for f in files:
-        base = f.stem
-        metadata = frontmatter.load(f)
-        if metadata.get("released", False):
-            patch = metadata.get("patch", 0)
-            versions.append(MzVersion.parse_mz(f"{base}.{patch}"))
-    versions.sort(reverse=True)
-    return versions

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -1,0 +1,109 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+import os
+from pathlib import Path
+from typing import List
+
+import frontmatter
+
+from materialize.git import get_version_tags
+from materialize.util import MzVersion
+
+ROOT = Path(os.environ["MZ_ROOT"])
+
+
+class VersionList:
+    def __init__(self) -> None:
+        self.versions: List[MzVersion]
+        assert False
+
+    def all_versions(self) -> List[MzVersion]:
+        return self.versions
+
+    def minor_versions(self) -> List[MzVersion]:
+        """Return the latest patch version for every minor version."""
+        minor_versions = {}
+        for version in self.versions:
+            minor_versions[f"{version.major}.{version.minor}"] = version
+
+        assert len(minor_versions) > 0
+        return sorted(minor_versions.values())
+
+    def patch_versions(self, minor_version: MzVersion) -> List[MzVersion]:
+        """Return all patch versions within the given minor version."""
+        patch_versions = []
+        for version in self.versions:
+            if (
+                version.major == minor_version.major
+                and version.minor == minor_version.minor
+            ):
+                patch_versions.append(version)
+
+        assert len(patch_versions) > 0
+        return sorted(patch_versions)
+
+
+class VersionsFromGit(VersionList):
+    """Materialize versions as tagged in Git.
+
+    >>> len(VersionsFromGit().all_versions()) > 0
+    True
+
+    >>> len(VersionsFromGit().minor_versions()) > 0
+    True
+
+    >>> len(VersionsFromGit().patch_versions(minor_version=MzVersion.parse("0.52.0")))
+    5
+
+    >>> min(VersionsFromGit().all_versions())
+    MzVersion(major=0, minor=1, patch=0, prerelease='rc', build=None)
+    """
+
+    def __init__(self) -> None:
+        self.versions = [MzVersion.from_semver(t) for t in get_version_tags(fetch=True)]
+        self.versions.sort()
+
+
+class VersionsFromDocs(VersionList):
+    """Materialize versions as listed in doc/user/content/versions
+
+    Only versions that declare `versiond: true` in their
+    frontmatter are considered.
+
+    >>> len(VersionsFromDocs().all_versions()) > 0
+    True
+
+    >>> len(VersionsFromDocs().minor_versions()) > 0
+    True
+
+    >>> len(VersionsFromDocs().patch_versions(minor_version=MzVersion.parse("0.52.0")))
+    5
+
+    >>> min(VersionsFromDocs().all_versions())
+    MzVersion(major=0, minor=27, patch=0, prerelease=None, build=None)
+    """
+
+    def __init__(self) -> None:
+        files = Path(ROOT / "doc" / "user" / "content" / "releases").glob("v*.md")
+        self.versions = []
+        for f in files:
+            base = f.stem
+            metadata = frontmatter.load(f)
+            if not metadata.get("released", False):
+                continue
+
+            current_patch = metadata.get("patch", 0)
+
+            for patch in range(current_patch + 1):
+                self.versions.append(MzVersion.parse_mz(f"{base}.{patch}"))
+
+        assert len(self.versions) > 0
+        self.versions.sort()

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -19,16 +19,17 @@ from materialize.checks.executors import CloudtestExecutor
 from materialize.checks.scenarios import Scenario
 from materialize.cloudtest.application import MaterializeApplication
 from materialize.cloudtest.wait import wait
-from materialize.util import MzVersion, released_materialize_versions
+from materialize.util import MzVersion
+from materialize.version_list import VersionsFromDocs
 
-LAST_RELEASED_VERSION = str(released_materialize_versions()[0])
+LAST_RELEASED_VERSION = VersionsFromDocs().minor_versions()[-1]
 
 
 class CloudtestUpgrade(Scenario):
     """A Platform Checks scenario that performs an upgrade in cloudtest/K8s"""
 
     def base_version(self) -> MzVersion:
-        return MzVersion.parse_mz(LAST_RELEASED_VERSION)
+        return LAST_RELEASED_VERSION
 
     def actions(self) -> List[Action]:
         return [
@@ -44,7 +45,7 @@ class CloudtestUpgrade(Scenario):
 def test_upgrade(aws_region: Optional[str]) -> None:
     """Test upgrade from the last released verison to the current source by running all the Platform Checks"""
 
-    mz = MaterializeApplication(tag=LAST_RELEASED_VERSION, aws_region=aws_region)
+    mz = MaterializeApplication(tag=str(LAST_RELEASED_VERSION), aws_region=aws_region)
     wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
 
     executor = CloudtestExecutor(application=mz)

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -51,7 +51,7 @@ from materialize.mzcompose.services import (
     Testdrive,
     Zookeeper,
 )
-from materialize.util import released_materialize_versions
+from materialize.version_list import VersionsFromDocs
 
 #
 # Global feature benchmark thresholds and termination conditions
@@ -179,7 +179,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--other-tag",
         metavar="TAG",
         type=str,
-        default=os.getenv("OTHER_TAG", str(released_materialize_versions()[0])),
+        default=os.getenv("OTHER_TAG", str(VersionsFromDocs().all_versions()[-1])),
         help="'Other' Materialize container tag to benchmark. If not provided, the last released Mz version will be used.",
     )
 

--- a/test/upgrade-matrix/mzcompose.py
+++ b/test/upgrade-matrix/mzcompose.py
@@ -46,10 +46,8 @@ from materialize.mzcompose.services import (
     Redpanda,
 )
 from materialize.mzcompose.services import Testdrive as TestdriveService
-from materialize.util import MzVersion, released_materialize_versions
-
-# All released Materialize versions, in order from most to least recent.
-all_versions = released_materialize_versions()
+from materialize.util import MzVersion
+from materialize.version_list import VersionsFromDocs
 
 SERVICES = [
     Cockroach(setup_materialize=True),
@@ -138,7 +136,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     executor = MzcomposeExecutor(composition=c)
 
-    versions = list(reversed([v for v in all_versions if v >= args.min_version]))
+    versions = list(
+        [v for v in VersionsFromDocs().minor_versions() if v >= args.min_version]
+    )
     print(
         "--- Testing upgrade scenarios involving the following versions: "
         + " ".join([str(v) for v in versions])

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -25,10 +25,11 @@ from materialize.mzcompose.services import (
     Testdrive,
     Zookeeper,
 )
-from materialize.util import MzVersion, released_materialize_versions
+from materialize.util import MzVersion
+from materialize.version_list import VersionsFromDocs
 
-# All released Materialize versions, in order from most to least recent.
-all_versions = released_materialize_versions()
+version_list = VersionsFromDocs()
+all_versions = version_list.all_versions()
 
 mz_options: Dict[MzVersion, str] = {}
 
@@ -71,25 +72,8 @@ SERVICES = [
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    """Test upgrades from various versions."""
+    """Test upgrades from previous versions."""
 
-    parser.add_argument(
-        "--min-version",
-        metavar="VERSION",
-        type=MzVersion.parse,
-        default=MzVersion.parse("0.39.0"),
-        help="the minimum version to test from",
-    )
-    parser.add_argument(
-        "--most-recent",
-        metavar="N",
-        # Usually, the 2 most-recent versions will be:
-        # - the previous patch version of the current release
-        # - the last patch version of the previous release
-        default=2,
-        type=int,
-        help="limit testing to the N most recent versions",
-    )
     parser.add_argument(
         "--tests",
         choices=["all", "non-ssl", "ssl"],
@@ -101,10 +85,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     args = parser.parse_args()
 
-    tested_versions = [v for v in all_versions if v >= args.min_version]
-    if args.most_recent is not None:
-        tested_versions = tested_versions[: args.most_recent]
-    tested_versions.reverse()
+    tested_versions = version_list.minor_versions()[-2:]
 
     if args.tests in ["all", "non-ssl"]:
         for version in tested_versions:
@@ -131,7 +112,7 @@ def test_upgrade_from_version(
     filter: str,
     style: str = "",
 ) -> None:
-    print(f"===>>> Testing upgrade from Materialize {from_version} to current_source.")
+    print(f"+++ Testing upgrade from Materialize {from_version} to current_source.")
 
     # If we are testing vX.Y.Z, the glob should include all patch versions 0 to Z
     prior_patch_versions = []


### PR DESCRIPTION
Previously, it was not possible to distinguish between the version list as maintained in the docs and the version list maintained as Git tags.

Furthermore, it was not possible to distinguish between minor and patch versions, which is important when targeting specific upgrade sequences.

This commit refactors mzcompose.util.get_released_versions() into a set of classes and functions that allow those distinctions to be made.

This commit does not change the behavior of the existing upgrade tests but a follow-up commit will take advantage of this refactor in full.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

This refactoring is in required in order to support the upgrade scenarios in https://www.notion.so/materialize/Product-Upgrade-Paths-when-Testing-b6a3caf3a8424acfb440d455dbcf0e9a which require differentating between minor and patch versions.