### PR TITLE
Update RocksDB version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease 0.2.4",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -1009,7 +1009,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chrono"
 version = "0.4.24"
-source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#eb927846b6a840ff26690c8762d5b1f90a37882b"
+source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#ada0629bb45cf08e9ff72f0ac18fe5eb43d628cb"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -6022,16 +6022,6 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b83ec2d0af5c5c556257ff52c9f98934e243b9fd39604bfb2a9b75ec2e97f18"
-dependencies = [
- "proc-macro2",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "prettyplease"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
@@ -6142,8 +6132,7 @@ dependencies = [
 [[package]]
 name = "prost"
 version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+source = "git+https://github.com/MaterializeInc/prost?branch=btv#c6a3f885f7d4f1ee0ff96dfc31ff24d052960415"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -6152,8 +6141,7 @@ dependencies = [
 [[package]]
 name = "prost-build"
 version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+source = "git+https://github.com/MaterializeInc/prost?branch=btv#c6a3f885f7d4f1ee0ff96dfc31ff24d052960415"
 dependencies = [
  "bytes",
  "heck",
@@ -6162,11 +6150,11 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease 0.1.9",
+ "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn 1.0.107",
+ "syn 2.0.12",
  "tempfile",
  "which",
 ]
@@ -6174,8 +6162,7 @@ dependencies = [
 [[package]]
 name = "prost-derive"
 version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+source = "git+https://github.com/MaterializeInc/prost?branch=btv#c6a3f885f7d4f1ee0ff96dfc31ff24d052960415"
 dependencies = [
  "anyhow",
  "itertools",
@@ -6200,8 +6187,7 @@ dependencies = [
 [[package]]
 name = "prost-types"
 version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+source = "git+https://github.com/MaterializeInc/prost?branch=btv#c6a3f885f7d4f1ee0ff96dfc31ff24d052960415"
 dependencies = [
  "prost",
 ]
@@ -7791,14 +7777,13 @@ dependencies = [
 [[package]]
 name = "tonic-build"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c6fd7c2581e36d63388a9e04c350c21beb7a8b059580b2e93993c526899ddc"
+source = "git+https://github.com/umanwizard/tonic#76489bf665af99d6e0e83f81648fcac283ea57e1"
 dependencies = [
- "prettyplease 0.1.9",
+ "prettyplease",
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
+version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -797,12 +797,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
+ "prettyplease 0.2.4",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.107",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -1008,10 +1009,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chrono"
 version = "0.4.24"
-source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#35b145bd0ca721b5926e36f047eec8e1060372c0"
+source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#eb927846b6a840ff26690c8762d5b1f90a37882b"
 dependencies = [
  "iana-time-zone",
- "num-integer",
  "num-traits",
  "serde",
  "winapi",
@@ -3043,11 +3043,11 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.10.0+7.9.2"
+version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe4d5874f5ff2bc616e55e8c6086d478fcda13faf9495768a4aa1c22042d30b"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
- "bindgen 0.64.0",
+ "bindgen 0.65.1",
  "bzip2-sys",
  "cc",
  "glob",
@@ -6031,6 +6031,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.12",
+]
+
+[[package]]
 name = "priority-queue"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6152,7 +6162,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.1.9",
  "prost",
  "prost-types",
  "regex",
@@ -6488,9 +6498,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015439787fce1e75d55f279078d33ff14b4af5d93d995e8838ee4631301c8a99"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -7784,7 +7794,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c6fd7c2581e36d63388a9e04c350c21beb7a8b059580b2e93993c526899ddc"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.1.9",
  "proc-macro2",
  "prost-build",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,3 +119,8 @@ postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 vte = { git = "https://github.com/alacritty/vte" }
+prost = { git = "https://github.com/MaterializeInc/prost", branch = "btv" }
+prost-build = { git = "https://github.com/MaterializeInc/prost", branch = "btv" }
+prost-derive = { git = "https://github.com/MaterializeInc/prost", branch = "btv" }
+prost-types = { git = "https://github.com/MaterializeInc/prost", branch = "btv" }
+tonic-build = { git = "https://github.com/umanwizard/tonic" }

--- a/deny.toml
+++ b/deny.toml
@@ -228,4 +228,11 @@ allow-git = [
     # Waiting on https://github.com/awslabs/smithy-rs/pull/2525 to make it into a
     # release.
     "https://github.com/parker-timmerman/smithy-rs.git",
+
+    # Waiting on https://github.com/tokio-rs/prost/pull/833 to make it into a
+    # release.
+    "https://github.com/MaterializeInc/prost",
+
+    # Waiting on https://github.com/hyperium/tonic/pull/1398
+    "https://github.com/umanwizard/tonic",
 ]

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -30,7 +30,7 @@ mz-timely-util = { path = "../timely-util" }
 once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
 regex = "1.7.0"
-rocksdb = { version = "0.20.1", default-features = false, features = ["snappy"] }
+rocksdb = { version = "0.21.0", default-features = false, features = ["snappy"] }
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }

--- a/src/rocksdb/Cargo.toml
+++ b/src/rocksdb/Cargo.toml
@@ -26,7 +26,7 @@ tracing = "0.1.37"
 # https://github.com/google/snappy/blob/main/COPYING
 # https://github.com/lz4/lz4/blob/dev/LICENSE
 # https://github.com/facebook/zstd
-rocksdb = { version = "0.20.1", default-features = false, features = ["snappy", "zstd", "lz4"] }
+rocksdb = { version = "0.21.0", default-features = false, features = ["snappy", "zstd", "lz4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -59,7 +59,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = { version = "1.7.0" }
-rocksdb = { version = "0.20.1", default-features = false, features = ["snappy"] }
+rocksdb = { version = "0.21.0", default-features = false, features = ["snappy"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 sha2 = "0.10.6"

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -74,9 +74,9 @@ phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 proc-macro2 = { version = "1.0.54", features = ["span-locations"] }
-prost = { version = "0.11.9", features = ["no-recursion-limit"] }
+prost = { git = "https://github.com/MaterializeInc/prost", branch = "btv", features = ["no-recursion-limit"] }
 prost-reflect = { version = "0.9.2", default-features = false, features = ["serde"] }
-prost-types = { version = "0.11.9" }
+prost-types = { git = "https://github.com/MaterializeInc/prost", branch = "btv" }
 quote = { version = "1.0.26" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
@@ -171,9 +171,9 @@ phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 proc-macro2 = { version = "1.0.54", features = ["span-locations"] }
-prost = { version = "0.11.9", features = ["no-recursion-limit"] }
+prost = { git = "https://github.com/MaterializeInc/prost", branch = "btv", features = ["no-recursion-limit"] }
 prost-reflect = { version = "0.9.2", default-features = false, features = ["serde"] }
-prost-types = { version = "0.11.9" }
+prost-types = { git = "https://github.com/MaterializeInc/prost", branch = "btv" }
 quote = { version = "1.0.26" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
@@ -189,7 +189,7 @@ serde_json = { version = "1.0.89", features = ["alloc", "arbitrary_precision", "
 sha2 = { version = "0.10.6" }
 smallvec = { version = "1.10.0", default-features = false, features = ["const_generics", "serde", "union", "write"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.12", features = ["full", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.12", features = ["extra-traits", "full", "visit-mut"] }
 textwrap = { version = "0.16.0", default-features = false, features = ["terminal_size"] }
 time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
 time-macros = { version = "0.2.6", default-features = false, features = ["formatting", "parsing", "serde"] }


### PR DESCRIPTION
The current main is not building for me on an up-to-date Arch Linux, because I have gcc 13, which is not supported by our current RocksDB. This update includes
https://github.com/facebook/rocksdb/commit/88edfbfb5e1cac228f7cc31fbec24bb637fe54b1
through
https://github.com/rust-rocksdb/rust-rocksdb/commit/d44de09925c16757480e0676832c7123a86c7216
and it fixes the build on my machine.

See
https://materializeinc.slack.com/archives/CM7ATT65S/p1684318187564809

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

Btw. is it ok that the set of features specified when importing RocksDB is different in the different importing crates? I think cargo unions these sets, but maybe it's still better to make them the same? (I'm really not an expert on these things, so just asking.)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
