### PR TITLE
mzcompose: Allow Mzcompose to start containers with 'latest' tag

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -132,6 +132,7 @@ class Materialized(Service):
         self.default_storage_size = (
             default_size
             if image
+            and "latest" not in image
             and MzVersion.parse_mz(image.split(":")[1]) < MzVersion.parse("0.41.0")
             else "1"
             if default_size == 1


### PR DESCRIPTION
'latest' containers are used by the feature-benchmark, but mzcompose previously required that the tag contains a valid version number or a ValueError exception would be thrown when attempting to parse it.


### Motivation
This PR fixes a previously unreported bug.

Feature benchmark was failing.