### PR TITLE
ci: Enable rbac checks by default

### DIFF
--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -26,7 +26,7 @@ SERVICES = [
         # conflict with a Kafka cluster running on the local machine.
         port="30123:30123",
         allow_host_ports=True,
-        extra_environment=[
+        environment_extra=[
             "KAFKA_ADVERTISED_LISTENERS=HOST://localhost:30123,PLAINTEXT://kafka:9092",
             "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=HOST:PLAINTEXT,PLAINTEXT:PLAINTEXT",
         ],

--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -65,6 +65,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 options=test_case.materialized_options,
                 image=test_case.materialized_image,
                 volumes_extra=["secrets:/secrets"],
+                # Disable RBAC checks because of error on "DROP CLUSTER default CASCADE":
+                # InsufficientPrivilege: must be owner of CLUSTER default
+                # TODO: Can dbt connect using mz_system user instead of materialize?
+                additional_system_parameter_defaults={
+                    "enable_rbac_checks": "false",
+                    "enable_ld_rbac_checks": "false",
+                },
             )
             test_args = ["dbt-materialize/tests"]
             if args.k:

--- a/misc/python/materialize/checks/alter_index.py
+++ b/misc/python/materialize/checks/alter_index.py
@@ -52,16 +52,11 @@ class AlterIndex(Check):
         return [
             Testdrive(schema() + dedent(s))
             for s in [
-                (
-                    """
-                $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                """
+                $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER SYSTEM SET enable_index_options = true
                 ALTER SYSTEM SET enable_logical_compaction_window = true
-                """
-                    if self.current_version >= MzVersion(0, 55, 0)
-                    else ""
-                )
-                + """
+
                 > INSERT INTO alter_index_table SELECT 'B' || generate_series FROM generate_series(1,10000);
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "B${kafka-ingest.iteration}"}
@@ -80,6 +75,10 @@ class AlterIndex(Check):
                 $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
                 ALTER INDEX alter_index_table_primary_idx OWNER TO materialize;
                 ALTER INDEX alter_index_source_primary_idx OWNER TO materialize;
+
+                $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                ALTER SYSTEM SET enable_index_options = true
+                ALTER SYSTEM SET enable_logical_compaction_window = true
 
                 > INSERT INTO alter_index_table SELECT 'D' || generate_series FROM generate_series(1,10000);
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000

--- a/misc/python/materialize/checks/alter_index.py
+++ b/misc/python/materialize/checks/alter_index.py
@@ -12,7 +12,6 @@ from typing import List
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
-from materialize.util import MzVersion
 
 
 def schema() -> str:

--- a/misc/python/materialize/checks/json_source.py
+++ b/misc/python/materialize/checks/json_source.py
@@ -24,14 +24,9 @@ class JsonSource(Check):
         return Testdrive(
             dedent(
                 """
-                $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                $[version>=5300] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER SYSTEM SET enable_format_json = true
-                """
-                if self.current_version >= MzVersion(0, 53, 0)
-                else ""
-            )
-            + dedent(
-                """
+                
                 $ kafka-create-topic topic=format-json partitions=1
 
                 $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-json

--- a/misc/python/materialize/checks/json_source.py
+++ b/misc/python/materialize/checks/json_source.py
@@ -26,7 +26,7 @@ class JsonSource(Check):
                 """
                 $[version>=5300] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER SYSTEM SET enable_format_json = true
-                
+
                 $ kafka-create-topic topic=format-json partitions=1
 
                 $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-json

--- a/misc/python/materialize/checks/multiple_partitions.py
+++ b/misc/python/materialize/checks/multiple_partitions.py
@@ -26,7 +26,7 @@ class MultiplePartitions(Check):
             schemas()
             + dedent(
                 """
-                $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER SYSTEM SET enable_create_source_denylist_with_options = true
                 ALTER SYSTEM SET enable_kafka_config_denylist_options = true
 

--- a/misc/python/materialize/checks/multiple_partitions.py
+++ b/misc/python/materialize/checks/multiple_partitions.py
@@ -12,7 +12,6 @@ from typing import List
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
-from materialize.util import MzVersion
 
 
 def schemas() -> str:
@@ -27,15 +26,10 @@ class MultiplePartitions(Check):
             schemas()
             + dedent(
                 """
-                $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
                 ALTER SYSTEM SET enable_create_source_denylist_with_options = true
                 ALTER SYSTEM SET enable_kafka_config_denylist_options = true
-                """
-                if self.current_version >= MzVersion(0, 55, 0)
-                else ""
-            )
-            + dedent(
-                """
+
                 $ kafka-create-topic topic=multiple-partitions-topic
 
                 # ingest A-key entries

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from materialize.checks.actions import Action
 from materialize.checks.executors import Executor
@@ -30,7 +30,7 @@ class StartMz(MzcomposeAction):
         self,
         tag: Optional[MzVersion] = None,
         environment_extra: List[str] = [],
-        system_parameter_defaults: Optional[List[str]] = None,
+        system_parameter_defaults: Optional[Dict[str, str]] = None,
     ) -> None:
         self.tag = tag
         self.environment_extra = environment_extra

--- a/misc/python/materialize/checks/sink.py
+++ b/misc/python/materialize/checks/sink.py
@@ -65,6 +65,11 @@ class SinkUpsert(Check):
             Testdrive(schemas() + dedent(s))
             for s in [
                 """
+                $[version>=5200] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                GRANT SELECT ON sink_source_view TO materialize
+                GRANT USAGE ON CONNECTION kafka_conn TO materialize
+                GRANT USAGE ON CONNECTION csr_conn TO materialize
+
                 $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} repeat=1000
                 {"key1": "I2${kafka-ingest.iteration}"} {"f1": "B${kafka-ingest.iteration}"}
                 {"key1": "U2${kafka-ingest.iteration}"} {"f1": "B${kafka-ingest.iteration}"}
@@ -80,6 +85,11 @@ class SinkUpsert(Check):
                   ENVELOPE DEBEZIUM
                 """,
                 """
+                $[version>=5200] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                GRANT SELECT ON sink_source_view TO materialize
+                GRANT USAGE ON CONNECTION kafka_conn TO materialize
+                GRANT USAGE ON CONNECTION csr_conn TO materialize
+
                 $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} repeat=1000
                 {"key1": "I3${kafka-ingest.iteration}"} {"f1": "C${kafka-ingest.iteration}"}
                 {"key1": "U3${kafka-ingest.iteration}"} {"f1": "C${kafka-ingest.iteration}"}

--- a/misc/python/materialize/checks/sink.py
+++ b/misc/python/materialize/checks/sink.py
@@ -184,7 +184,7 @@ class SinkTables(Check):
             schemas()
             + dedent(
                 """
-                $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER SYSTEM SET enable_table_keys = true;
                 """
                 if self.current_version >= MzVersion(0, 55, 0)

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -466,7 +466,7 @@ async fn migrate(
                             .push(MzAclItem {
                                 grantee: role_id,
                                 grantor: MZ_SYSTEM_ROLE_ID,
-                                acl_mode: AclMode::CREATE,
+                                acl_mode: AclMode::all(),
                             });
                         Some(value)
                     } else {
@@ -483,7 +483,7 @@ async fn migrate(
                             .push(MzAclItem {
                                 grantee: role_id,
                                 grantor: MZ_SYSTEM_ROLE_ID,
-                                acl_mode: AclMode::CREATE,
+                                acl_mode: AclMode::all(),
                             });
                         Some(value)
                     } else {
@@ -500,7 +500,7 @@ async fn migrate(
                             .push(MzAclItem {
                                 grantee: role_id,
                                 grantor: MZ_SYSTEM_ROLE_ID,
-                                acl_mode: AclMode::CREATE,
+                                acl_mode: AclMode::all(),
                             });
                         Some(value)
                     } else {

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -23,6 +23,7 @@ use mz_ore::now::{EpochMillis, NowFn};
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::role_id::RoleId;
 use mz_repr::GlobalId;
+use mz_sql::ast::ObjectType as AstObjectType;
 use mz_sql::catalog::{
     CatalogCluster, CatalogDatabase, CatalogError as SqlCatalogError, CatalogItemType,
     CatalogSchema, RoleAttributes,
@@ -432,7 +433,10 @@ async fn migrate(
                         role: SerializedRole {
                             name: bootstrap_role.clone(),
                             attributes: Some(
-                                RoleAttributes::new().with_create_db().with_create_cluster(),
+                                RoleAttributes::new()
+                                    .with_create_db()
+                                    .with_create_cluster()
+                                    .with_create_role(),
                             ),
                             membership: Some(RoleMembership::new()),
                         },
@@ -466,7 +470,7 @@ async fn migrate(
                             .push(MzAclItem {
                                 grantee: role_id,
                                 grantor: MZ_SYSTEM_ROLE_ID,
-                                acl_mode: AclMode::all(),
+                                acl_mode: rbac::all_object_privileges(AstObjectType::Database),
                             });
                         Some(value)
                     } else {
@@ -483,7 +487,7 @@ async fn migrate(
                             .push(MzAclItem {
                                 grantee: role_id,
                                 grantor: MZ_SYSTEM_ROLE_ID,
-                                acl_mode: AclMode::all(),
+                                acl_mode: rbac::all_object_privileges(AstObjectType::Schema),
                             });
                         Some(value)
                     } else {
@@ -500,7 +504,7 @@ async fn migrate(
                             .push(MzAclItem {
                                 grantee: role_id,
                                 grantor: MZ_SYSTEM_ROLE_ID,
-                                acl_mode: AclMode::all(),
+                                acl_mode: rbac::all_object_privileges(AstObjectType::Cluster),
                             });
                         Some(value)
                     } else {

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -147,7 +147,7 @@ def test_crash_clusterd(mz: MaterializeApplication) -> None:
     mz.testdrive.run(
         input=dedent(
             """
-            $$[version>=5500] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+            $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
             ALTER SYSTEM SET enable_unstable_dependencies = true;
             """
         ),

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -147,7 +147,7 @@ def test_crash_clusterd(mz: MaterializeApplication) -> None:
     mz.testdrive.run(
         input=dedent(
             """
-            $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+            $$[version>=5500] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
             ALTER SYSTEM SET enable_unstable_dependencies = true;
             """
         ),

--- a/test/cloudtest/test_full_testdrive.py
+++ b/test/cloudtest/test_full_testdrive.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+from textwrap import dedent
+
 import pytest
 
 from materialize.cloudtest.application import MaterializeApplication
@@ -14,5 +16,14 @@ from materialize.cloudtest.application import MaterializeApplication
 
 @pytest.mark.long
 def test_full_testdrive(mz: MaterializeApplication) -> None:
+    mz.testdrive.run(
+        input=dedent(
+            """
+            $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+            ALTER SYSTEM SET enable_rbac_checks = true;
+            """
+        ),
+        no_reset=True,
+    )
     mz.testdrive.copy("test/testdrive", "/workdir")
     mz.testdrive.run("testdrive/*.td")

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -49,7 +49,7 @@ disruptions = [
         name="pause-in-materialized-view",
         disruption=lambda c: c.testdrive(
             """
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+$[version>=5500] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_unstable_dependencies = true;
 
 > SET cluster=cluster1

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1038,8 +1038,12 @@ def workflow_test_drop_default_cluster(c: Composition) -> None:
     c.down(destroy_volumes=True)
     c.up("materialized")
 
-    c.sql("DROP CLUSTER default CASCADE")
-    c.sql("CREATE CLUSTER default REPLICAS (default (SIZE '1'))")
+    c.sql("DROP CLUSTER default CASCADE", user="mz_system", port=6877)
+    c.sql(
+        "CREATE CLUSTER default REPLICAS (default (SIZE '1'))",
+        user="mz_system",
+        port=6877,
+    )
 
 
 def workflow_test_resource_limits(c: Composition) -> None:
@@ -1132,7 +1136,10 @@ def workflow_test_system_table_indexes(c: Composition) -> None:
         c.testdrive(
             input=dedent(
                 """
-        > CREATE DEFAULT INDEX ON mz_views;
+        $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+        SET CLUSTER TO DEFAULT;
+        CREATE DEFAULT INDEX ON mz_views;
+
         > SELECT id FROM mz_indexes WHERE id like 'u%';
         u1
     """

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -676,7 +676,7 @@ def workflow_test_github_17177(c: Composition) -> None:
         c.testdrive(
             dedent(
                 """
-            $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+            $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
             ALTER SYSTEM SET enable_repeat_row  = true;
 
             # Set data for test up

--- a/test/cluster/resources/resource-limits.td
+++ b/test/cluster/resources/resource-limits.td
@@ -190,9 +190,6 @@ ALTER SYSTEM SET max_roles = 2;
 > SHOW max_roles
 2
 
-$ postgres-execute connection=mz_system
-ALTER ROLE materialize CREATEROLE
-
 > CREATE ROLE joe
 
 ! CREATE ROLE mike

--- a/test/cluster/resources/resource-limits.td
+++ b/test/cluster/resources/resource-limits.td
@@ -190,6 +190,9 @@ ALTER SYSTEM SET max_roles = 2;
 > SHOW max_roles
 2
 
+$ postgres-execute connection=mz_system
+ALTER ROLE materialize CREATEROLE
+
 > CREATE ROLE joe
 
 ! CREATE ROLE mike
@@ -356,7 +359,8 @@ ALTER SYSTEM SET max_aws_privatelink_connections = 42
 
 > DROP SOURCE mz_source2
 
-> DROP CLUSTER default CASCADE
+$ postgres-execute connection=mz_system
+DROP CLUSTER default CASCADE
 
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_replicas_per_cluster = 100

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -369,7 +369,7 @@ root_scenario: {args.root_scenario}"""
 
     overrides = [
         KafkaService(
-            extra_environment=[
+            environment_extra=[
                 f"KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://{args.external_addr}:9092"
             ]
         ),

--- a/test/feature-benchmark/scenarios_concurrency.py
+++ b/test/feature-benchmark/scenarios_concurrency.py
@@ -134,8 +134,8 @@ class ParallelDataflows(Concurrency):
 
         return Td(
             f"""
-
-> DROP SCHEMA public CASCADE;
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+DROP SCHEMA public CASCADE;
 
 > CREATE SCHEMA public;
 

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -39,8 +39,11 @@ class Generator:
     @classmethod
     def header(cls) -> None:
         print(f"\n#\n# {cls}\n#\n")
-        print("> DROP SCHEMA IF EXISTS public CASCADE;")
-        print(f"> CREATE SCHEMA public /* {cls} */;")
+        print(
+            "$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize"
+        )
+        print("DROP SCHEMA IF EXISTS public CASCADE;")
+        print(f"CREATE SCHEMA public /* {cls} */;")
         print(
             "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}"
         )

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -44,6 +44,7 @@ class Generator:
         )
         print("DROP SCHEMA IF EXISTS public CASCADE;")
         print(f"CREATE SCHEMA public /* {cls} */;")
+        print("GRANT ALL PRIVILEGES ON SCHEMA public TO materialize")
         print(
             "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}"
         )
@@ -1330,7 +1331,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     WORKERS {args.workers}
                 )
             )
-        """
+        """,
+            port=6877,
+            user="mz_system",
         )
 
         c.up("testdrive", persistent=True)

--- a/test/sql-feature-flags/mzcompose.py
+++ b/test/sql-feature-flags/mzcompose.py
@@ -44,6 +44,7 @@ def header(test_name: str, drop_schema: bool) -> str:
             $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
             DROP SCHEMA IF EXISTS public CASCADE;
             CREATE SCHEMA public /* {test_name} */;
+            GRANT ALL PRIVILEGES ON SCHEMA public TO materialize;
             """
         )
     # Create connections.

--- a/test/sql-feature-flags/mzcompose.py
+++ b/test/sql-feature-flags/mzcompose.py
@@ -41,8 +41,9 @@ def header(test_name: str, drop_schema: bool) -> str:
     if drop_schema:
         header += dedent(
             f"""
-            > DROP SCHEMA IF EXISTS public CASCADE;
-            > CREATE SCHEMA public /* {test_name} */;
+            $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+            DROP SCHEMA IF EXISTS public CASCADE;
+            CREATE SCHEMA public /* {test_name} */;
             """
         )
     # Create connections.
@@ -319,9 +320,9 @@ def run_test(c: Composition, args: argparse.Namespace) -> None:
 
         materialized = Materialized(
             unsafe_mode=False,
-            additional_system_parameter_defaults=[
-                "{}=on".format(scenario.feature_name()),
-            ],
+            additional_system_parameter_defaults={
+                scenario.feature_name(): "on",
+            },
         )
 
         with c.override(materialized):
@@ -357,9 +358,9 @@ def run_test(c: Composition, args: argparse.Namespace) -> None:
         # Create MZ config with all features set on by default
         materialized = Materialized(
             unsafe_mode=False,
-            additional_system_parameter_defaults=list(
-                map(lambda scenario: "{}=on".format(scenario.feature_name()), scenarios)
-            ),
+            additional_system_parameter_defaults={
+                scenario.feature_name(): "on" for scenario in scenarios
+            },
         )
         with c.override(materialized):
             c.stop("materialized")

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -204,7 +204,7 @@ SELECT * FROM database_privileges
 ----
 materialize  =U/mz_system
 materialize  mz_system=UC/mz_system
-materialize  materialize=arwdUC/mz_system
+materialize  materialize=UC/mz_system
 
 query TT
 SELECT name, privilege FROM schema_privileges ORDER BY name
@@ -219,14 +219,14 @@ pg_catalog          =U/mz_system
 pg_catalog          mz_system=UC/mz_system
 public              =U/mz_system
 public              mz_system=UC/mz_system
-public              materialize=arwdUC/mz_system
+public              materialize=UC/mz_system
 
 query TT
 SELECT * FROM cluster_privileges ORDER BY name
 ----
 default           =U/mz_system
 default           mz_system=UC/mz_system
-default           materialize=arwdUC/mz_system
+default           materialize=UC/mz_system
 mz_introspection  =U/mz_system
 mz_introspection  mz_system=UC/mz_system
 mz_introspection  mz_introspection=UC/mz_system
@@ -334,8 +334,8 @@ SELECT name, privilege FROM schema_privileges WHERE name = 'public' ORDER BY nam
 public  =U/mz_system
 public  =U/materialize
 public  mz_system=UC/mz_system
+public  materialize=UC/mz_system
 public  materialize=UC/materialize
-public  materialize=arwdUC/mz_system
 
 statement ok
 CREATE SCHEMA sch;

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -204,7 +204,7 @@ SELECT * FROM database_privileges
 ----
 materialize  =U/mz_system
 materialize  mz_system=UC/mz_system
-materialize  materialize=C/mz_system
+materialize  materialize=arwdUC/mz_system
 
 query TT
 SELECT name, privilege FROM schema_privileges ORDER BY name
@@ -219,14 +219,14 @@ pg_catalog          =U/mz_system
 pg_catalog          mz_system=UC/mz_system
 public              =U/mz_system
 public              mz_system=UC/mz_system
-public              materialize=C/mz_system
+public              materialize=arwdUC/mz_system
 
 query TT
 SELECT * FROM cluster_privileges ORDER BY name
 ----
 default           =U/mz_system
 default           mz_system=UC/mz_system
-default           materialize=C/mz_system
+default           materialize=arwdUC/mz_system
 mz_introspection  =U/mz_system
 mz_introspection  mz_system=UC/mz_system
 mz_introspection  mz_introspection=UC/mz_system
@@ -334,8 +334,8 @@ SELECT name, privilege FROM schema_privileges WHERE name = 'public' ORDER BY nam
 public  =U/mz_system
 public  =U/materialize
 public  mz_system=UC/mz_system
-public  materialize=C/mz_system
 public  materialize=UC/materialize
+public  materialize=arwdUC/mz_system
 
 statement ok
 CREATE SCHEMA sch;

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -21,7 +21,7 @@ s2 mz_introspection true false false false
 query TBBBB
 SELECT name, inherit, create_role, create_db, create_cluster FROM mz_roles WHERE id LIKE 'u%'
 ----
-materialize  true  false  true  true
+materialize  true  true  true  true
 
 # Give materialize the CREATEROLE attribute.
 simple conn=mz_system,user=mz_system
@@ -253,20 +253,6 @@ simple conn=mz_system,user=mz_system
 DROP CLUSTER mz_introspection CASCADE;
 ----
 db error: ERROR: system cluster 'mz_introspection' cannot be modified
-
-# TODO: I'm expecting this to fail, why does it succeed in SLT?
-# db error: ERROR: system cluster 'mz_system' cannot be modified
-simple conn=mz_system,user=mz_system
-CREATE CLUSTER REPLICA mz_system.r2 SIZE '1';
-----
-COMPLETE 0
-
-# TODO: I'm expecting this to fail, why does it succeed in SLT?
-# db error: ERROR: system cluster 'mz_system' cannot be modified
-simple conn=mz_system,user=mz_system
-DROP CLUSTER REPLICA mz_system.r1
-----
-COMPLETE 0
 
 simple conn=mz_system,user=mz_system
 SET CLUSTER TO mz_introspection

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -243,3 +243,47 @@ SELECT current_user();
 ----
 db error: ERROR: role u4 was concurrently dropped
 DETAIL: Please disconnect and re-connect with a valid role.
+
+simple conn=mz_system,user=mz_system
+DROP CLUSTER mz_system CASCADE;
+----
+db error: ERROR: system cluster 'mz_system' cannot be modified
+
+simple conn=mz_system,user=mz_system
+DROP CLUSTER mz_introspection CASCADE;
+----
+db error: ERROR: system cluster 'mz_introspection' cannot be modified
+
+# TODO: I'm expecting this to fail, why does it succeed in SLT?
+# db error: ERROR: system cluster 'mz_system' cannot be modified
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA mz_system.r2 SIZE '1';
+----
+COMPLETE 0
+
+# TODO: I'm expecting this to fail, why does it succeed in SLT?
+# db error: ERROR: system cluster 'mz_system' cannot be modified
+simple conn=mz_system,user=mz_system
+DROP CLUSTER REPLICA mz_system.r1
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+SET CLUSTER TO mz_introspection
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE MATERIALIZED VIEW mv1 AS SELECT MIN(1)
+----
+db error: ERROR: system cluster 'mz_introspection' cannot be modified
+
+simple conn=mz_system,user=mz_system
+SET CLUSTER TO mz_system
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE MATERIALIZED VIEW mv1 AS SELECT MIN(1)
+----
+db error: ERROR: system cluster 'mz_system' cannot be modified

--- a/test/storage-usage/mzcompose.py
+++ b/test/storage-usage/mzcompose.py
@@ -227,8 +227,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         c.testdrive(
             dedent(
                 """
-                > DROP SCHEMA IF EXISTS public CASCADE;
-                > CREATE SCHEMA public
+                $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                DROP SCHEMA IF EXISTS public CASCADE;
+                CREATE SCHEMA public;
+                GRANT ALL PRIVILEGES ON SCHEMA public TO materialize;
                 """
             )
         )

--- a/test/testdrive/avro-resolution-no-publish-reader.td
+++ b/test/testdrive/avro-resolution-no-publish-reader.td
@@ -20,7 +20,7 @@ $ kafka-create-topic topic=resolution-no-publish-writer
 $ kafka-ingest format=bytes topic=resolution-no-publish-writer timestamp=1
 \\x00\x00\x00\x00\x01\xf6\x01
 
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 DROP SCHEMA IF EXISTS public CASCADE
 CREATE SCHEMA public
 GRANT CREATE, USAGE ON SCHEMA public TO materialize

--- a/test/testdrive/avro-resolution-no-publish-reader.td
+++ b/test/testdrive/avro-resolution-no-publish-reader.td
@@ -20,8 +20,10 @@ $ kafka-create-topic topic=resolution-no-publish-writer
 $ kafka-ingest format=bytes topic=resolution-no-publish-writer timestamp=1
 \\x00\x00\x00\x00\x01\xf6\x01
 
-> DROP SCHEMA IF EXISTS public CASCADE
-> CREATE SCHEMA public
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+DROP SCHEMA IF EXISTS public CASCADE
+CREATE SCHEMA public
+GRANT CREATE, USAGE ON SCHEMA public TO materialize
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/testdrive/avro-resolution-no-publish-writer.td
+++ b/test/testdrive/avro-resolution-no-publish-writer.td
@@ -18,7 +18,7 @@ $ kafka-create-topic topic=resolution-no-publish-writer
 $ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schema} timestamp=1
 {"f1": 123}
 
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 DROP SCHEMA IF EXISTS public CASCADE
 CREATE SCHEMA public
 GRANT CREATE, USAGE ON SCHEMA public TO materialize

--- a/test/testdrive/avro-resolution-no-publish-writer.td
+++ b/test/testdrive/avro-resolution-no-publish-writer.td
@@ -18,8 +18,10 @@ $ kafka-create-topic topic=resolution-no-publish-writer
 $ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schema} timestamp=1
 {"f1": 123}
 
-> DROP SCHEMA IF EXISTS public CASCADE
-> CREATE SCHEMA public
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+DROP SCHEMA IF EXISTS public CASCADE
+CREATE SCHEMA public
+GRANT CREATE, USAGE ON SCHEMA public TO materialize
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -385,8 +385,9 @@ contains:unknown catalog item 'v'
 > CREATE DATABASE d
 
 # Dropping the public schema is okay, but dropping the catalog schemas is not.
+> DROP SCHEMA public
+
 $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
-DROP SCHEMA public CASCADE
 ALTER SYSTEM SET enable_rbac_checks TO false
 
 ! DROP SCHEMA mz_catalog
@@ -647,15 +648,13 @@ $ psql-execute command="\dt *.test_table"
  tester  | test_table | table | materialize
  tester2 | test_table | table | materialize
 
-# TODO: Reenable when #19388 is fixed
-! CREATE TYPE type1 AS LIST (ELEMENT TYPE = text)
-contains:no schema has been selected to create in
+> CREATE TYPE type1 AS LIST (ELEMENT TYPE = text)
 
-#> SHOW TYPES
-#type1
-#
-#$ psql-execute command="\dT"
-#\      List of data types
-# Schema | Name  | Description
-#--------+-------+-------------
-# public | type1 |
+> SHOW TYPES
+type1
+
+$ psql-execute command="\dT"
+\      List of data types
+ Schema | Name  | Description
+--------+-------+-------------
+ public | type1 |

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -387,7 +387,7 @@ contains:unknown catalog item 'v'
 # Dropping the public schema is okay, but dropping the catalog schemas is not.
 > DROP SCHEMA public
 
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_rbac_checks TO false
 
 ! DROP SCHEMA mz_catalog
@@ -395,7 +395,7 @@ contains:cannot drop schema mz_catalog because it is required by the database sy
 ! DROP SCHEMA pg_catalog
 contains:cannot drop schema pg_catalog because it is required by the database system
 
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_rbac_checks TO true
 
 # Schema names that start with "mz_" or "pg_" are reserved for future use by the

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -385,11 +385,17 @@ contains:unknown catalog item 'v'
 > CREATE DATABASE d
 
 # Dropping the public schema is okay, but dropping the catalog schemas is not.
-> DROP SCHEMA public
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+DROP SCHEMA public CASCADE
+ALTER SYSTEM SET enable_rbac_checks TO false
+
 ! DROP SCHEMA mz_catalog
 contains:cannot drop schema mz_catalog because it is required by the database system
 ! DROP SCHEMA pg_catalog
 contains:cannot drop schema pg_catalog because it is required by the database system
+
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+ALTER SYSTEM SET enable_rbac_checks TO true
 
 # Schema names that start with "mz_" or "pg_" are reserved for future use by the
 # system.
@@ -641,13 +647,15 @@ $ psql-execute command="\dt *.test_table"
  tester  | test_table | table | materialize
  tester2 | test_table | table | materialize
 
-> CREATE TYPE type1 AS LIST (ELEMENT TYPE = text)
+# TODO: Reenable when #19388 is fixed
+! CREATE TYPE type1 AS LIST (ELEMENT TYPE = text)
+contains:no schema has been selected to create in
 
-> SHOW TYPES
-type1
-
-$ psql-execute command="\dT"
-\      List of data types
- Schema | Name  | Description
---------+-------+-------------
- public | type1 |
+#> SHOW TYPES
+#type1
+#
+#$ psql-execute command="\dT"
+#\      List of data types
+# Schema | Name  | Description
+#--------+-------+-------------
+# public | type1 |

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -263,18 +263,27 @@ bar_ind bar <VARIABLE_OUTPUT> {a}
 > DROP CLUSTER clstr CASCADE;
 
 # Test creating indexes on system objects
-> CREATE INDEX sys_ind ON mz_array_types (id)
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+SET CLUSTER TO default
+CREATE INDEX sys_ind ON mz_array_types (id)
+
 > SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON mz_array_types
 sys_ind mz_array_types  <VARIABLE_OUTPUT>   {id}
 > SHOW INDEXES FROM mz_catalog WHERE name = 'sys_ind'
 sys_ind mz_array_types  <VARIABLE_OUTPUT>   {id}
 > SET CLUSTER TO default
-> DROP INDEX sys_ind
+
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+DROP INDEX sys_ind
+ALTER SYSTEM SET enable_rbac_checks TO false
 
 # Test that creating indexes on objects in the mz_internal schema fails
 ! CREATE INDEX illegal_sys_ind ON mz_internal.mz_view_keys (object_id)
 contains:cannot create index with unstable dependencies
+
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+ALTER SYSTEM SET enable_rbac_checks TO true
 
 > SHOW INDEXES IN CLUSTER mz_introspection
 mz_active_peeks_per_worker_s2_primary_idx                   mz_active_peeks_per_worker                   mz_introspection    {id,worker_id}

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -263,7 +263,7 @@ bar_ind bar <VARIABLE_OUTPUT> {a}
 > DROP CLUSTER clstr CASCADE;
 
 # Test creating indexes on system objects
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 SET CLUSTER TO default
 CREATE INDEX sys_ind ON mz_array_types (id)
 
@@ -274,7 +274,7 @@ sys_ind mz_array_types  <VARIABLE_OUTPUT>   {id}
 sys_ind mz_array_types  <VARIABLE_OUTPUT>   {id}
 > SET CLUSTER TO default
 
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 DROP INDEX sys_ind
 ALTER SYSTEM SET enable_rbac_checks TO false
 
@@ -282,7 +282,7 @@ ALTER SYSTEM SET enable_rbac_checks TO false
 ! CREATE INDEX illegal_sys_ind ON mz_internal.mz_view_keys (object_id)
 contains:cannot create index with unstable dependencies
 
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_rbac_checks TO true
 
 > SHOW INDEXES IN CLUSTER mz_introspection

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -100,7 +100,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 f"{replica_name} (SIZE '{materialized.default_replica_size}')"
                 for replica_name in replica_names
             )
-            c.sql(f"CREATE CLUSTER default REPLICAS ({replica_string})", user="mz_system", port=6877)
+            c.sql(
+                f"CREATE CLUSTER default REPLICAS ({replica_string})",
+                user="mz_system",
+                port=6877,
+            )
 
         try:
             junit_report = ci_util.junit_report_filename(c.name)

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -90,7 +90,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         c.up(*dependencies)
 
         if args.replicas > 1:
-            c.sql("DROP CLUSTER default CASCADE")
+            c.sql("DROP CLUSTER default CASCADE", user="mz_system", port=6877)
             # Make sure a replica named 'r1' always exists
             replica_names = [
                 "r1" if replica_id == 0 else f"replica{replica_id}"
@@ -100,7 +100,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 f"{replica_name} (SIZE '{materialized.default_replica_size}')"
                 for replica_name in replica_names
             )
-            c.sql(f"CREATE CLUSTER default REPLICAS ({replica_string})")
+            c.sql(f"CREATE CLUSTER default REPLICAS ({replica_string})", user="mz_system", port=6877)
 
         try:
             junit_report = ci_util.junit_report_filename(c.name)

--- a/test/testdrive/privilege_checks.td
+++ b/test/testdrive/privilege_checks.td
@@ -38,7 +38,7 @@ GRANT CREATE ON SCHEMA materialize.public TO materialize;
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
-contains:permission denied for SCHEMA materialize.public
+contains:permission denied for TABLE materialize.public.t
 
 $ postgres-execute connection=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO materialize;

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -37,7 +37,7 @@ enable_session_rbac_checks          off                     "User facing session
 mz_version                          <VARIES>                "Shows the Materialize server version (Materialize)."
 is_superuser                        off                     "Reports whether the current session is a superuser (PostgreSQL)."
 allowed_cluster_replica_sizes       ""                      "The allowed sizes when creating a new cluster replica (Materialize)."
-enable_rbac_checks                  on                      "User facing global boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
+enable_rbac_checks                  <VARIES>                "User facing global boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
 max_aws_privatelink_connections     0                       "The maximum number of AWS PrivateLink connections in the region, across all schemas (Materialize)."
 max_clusters                        10                      "The maximum number of clusters in the region (Materialize)."
 max_connections                     1000                    "The maximum number of concurrent connections (Materialize)."

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -37,7 +37,7 @@ enable_session_rbac_checks          off                     "User facing session
 mz_version                          <VARIES>                "Shows the Materialize server version (Materialize)."
 is_superuser                        off                     "Reports whether the current session is a superuser (PostgreSQL)."
 allowed_cluster_replica_sizes       ""                      "The allowed sizes when creating a new cluster replica (Materialize)."
-enable_rbac_checks                  <VARIES>                "User facing global boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
+enable_rbac_checks                  on                      "User facing global boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
 max_aws_privatelink_connections     0                       "The maximum number of AWS PrivateLink connections in the region, across all schemas (Materialize)."
 max_clusters                        10                      "The maximum number of clusters in the region (Materialize)."
 max_connections                     1000                    "The maximum number of concurrent connections (Materialize)."

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -37,7 +37,7 @@ enable_session_rbac_checks          off                     "User facing session
 mz_version                          <VARIES>                "Shows the Materialize server version (Materialize)."
 is_superuser                        off                     "Reports whether the current session is a superuser (PostgreSQL)."
 allowed_cluster_replica_sizes       ""                      "The allowed sizes when creating a new cluster replica (Materialize)."
-enable_rbac_checks                  off                     "User facing global boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
+enable_rbac_checks                  on                      "User facing global boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
 max_aws_privatelink_connections     0                       "The maximum number of AWS PrivateLink connections in the region, across all schemas (Materialize)."
 max_clusters                        10                      "The maximum number of clusters in the region (Materialize)."
 max_connections                     1000                    "The maximum number of concurrent connections (Materialize)."

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -14,7 +14,7 @@ mz_system
 mz_introspection
 default
 
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_rbac_checks TO false
 
 ! DROP CLUSTER mz_system CASCADE
@@ -23,7 +23,7 @@ contains:system cluster 'mz_system' cannot be modified
 ! DROP CLUSTER mz_introspection CASCADE
 contains:system cluster 'mz_introspection' cannot be modified
 
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_rbac_checks TO true
 
 ! DROP CLUSTER mz_joe CASCADE
@@ -32,7 +32,7 @@ contains:unknown cluster 'mz_joe'
 ! CREATE CLUSTER mz_joe REPLICAS (r1 (size '1'))
 contains:cluster name "mz_joe" is reserved
 
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_rbac_checks TO false
 
 ! CREATE CLUSTER REPLICA mz_system.r2 SIZE '1';
@@ -41,7 +41,7 @@ contains:system cluster 'mz_system' cannot be modified
 ! DROP CLUSTER REPLICA mz_system.r1
 contains:system cluster 'mz_system' cannot be modified
 
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_rbac_checks TO true
 
 > CREATE MATERIALIZED VIEW mv AS SELECT AVG(50)

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -14,11 +14,17 @@ mz_system
 mz_introspection
 default
 
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+ALTER SYSTEM SET enable_rbac_checks TO false
+
 ! DROP CLUSTER mz_system CASCADE
 contains:system cluster 'mz_system' cannot be modified
 
 ! DROP CLUSTER mz_introspection CASCADE
 contains:system cluster 'mz_introspection' cannot be modified
+
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+ALTER SYSTEM SET enable_rbac_checks TO true
 
 ! DROP CLUSTER mz_joe CASCADE
 contains:unknown cluster 'mz_joe'
@@ -26,11 +32,17 @@ contains:unknown cluster 'mz_joe'
 ! CREATE CLUSTER mz_joe REPLICAS (r1 (size '1'))
 contains:cluster name "mz_joe" is reserved
 
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+ALTER SYSTEM SET enable_rbac_checks TO false
+
 ! CREATE CLUSTER REPLICA mz_system.r2 SIZE '1';
 contains:system cluster 'mz_system' cannot be modified
 
 ! DROP CLUSTER REPLICA mz_system.r1
 contains:system cluster 'mz_system' cannot be modified
+
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+ALTER SYSTEM SET enable_rbac_checks TO true
 
 > CREATE MATERIALIZED VIEW mv AS SELECT AVG(50)
 
@@ -39,8 +51,8 @@ contains:system cluster 'mz_system' cannot be modified
 > SHOW MATERIALIZED VIEWS
 mv default
 
-! CREATE MATERIALIZED VIEW mv1 AS SELECT MIN(1)
-contains:system cluster 'mz_introspection' cannot be modified
+#! CREATE MATERIALIZED VIEW mv1 AS SELECT MIN(1)
+#contains:system cluster 'mz_introspection' cannot be modified
 
 > SET CLUSTER TO mz_system
 
@@ -48,8 +60,8 @@ contains:system cluster 'mz_introspection' cannot be modified
 > SHOW MATERIALIZED VIEWS
 mv default
 
-! CREATE MATERIALIZED VIEW mv1 AS SELECT MIN(1)
-contains:system cluster 'mz_system' cannot be modified
+#! CREATE MATERIALIZED VIEW mv1 AS SELECT MIN(1)
+#contains:system cluster 'mz_system' cannot be modified
 
 > SET CLUSTER TO default
 

--- a/test/upgrade-matrix/nodes.py
+++ b/test/upgrade-matrix/nodes.py
@@ -41,7 +41,7 @@ class BeginVersion(Node):
         # As this action may need start very old Mz versions,
         # we do not use any bootstrap_systme_parameters
         return [
-            StartMz(tag=self.version, system_parameter_defaults=[]),
+            StartMz(tag=self.version, system_parameter_defaults={}),
             ConfigureMz(scenario),
         ]
 

--- a/test/upgrade/check-from-v0.53.0-role.td
+++ b/test/upgrade/check-from-v0.53.0-role.td
@@ -29,10 +29,8 @@ group
 > SELECT role.name AS role, member.name AS member, grantor.name AS grantor FROM mz_role_members membership LEFT JOIN mz_roles role ON membership.role_id = role.id LEFT JOIN mz_roles member ON membership.member = member.id LEFT JOIN mz_roles grantor ON membership.grantor = grantor.id;
 group  joe  mz_system
 
-> DROP ROLE superuser_login;
-
-> DROP ROLE "space role";
-
-> DROP ROLE joe;
-
-> DROP ROLE group;
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+DROP ROLE superuser_login;
+DROP ROLE "space role";
+DROP ROLE joe;
+DROP ROLE group;

--- a/test/upgrade/check-from-v0.53.0-role.td
+++ b/test/upgrade/check-from-v0.53.0-role.td
@@ -29,7 +29,7 @@ group
 > SELECT role.name AS role, member.name AS member, grantor.name AS grantor FROM mz_role_members membership LEFT JOIN mz_roles role ON membership.role_id = role.id LEFT JOIN mz_roles member ON membership.member = member.id LEFT JOIN mz_roles grantor ON membership.grantor = grantor.id;
 group  joe  mz_system
 
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 DROP ROLE superuser_login;
 DROP ROLE "space role";
 DROP ROLE joe;

--- a/test/upgrade/create-in-v0.47.0-role.td
+++ b/test/upgrade/create-in-v0.47.0-role.td
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
-ALTER ROLE materialize CREATEROLE
-
 > CREATE ROLE superuser_login;
 
 > CREATE ROLE "space role";

--- a/test/upgrade/create-in-v0.47.0-role.td
+++ b/test/upgrade/create-in-v0.47.0-role.td
@@ -7,12 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> CREATE ROLE superuser_login;
-
-> CREATE ROLE "space role";
-
-> CREATE ROLE joe;
-
-> CREATE ROLE group;
-
-> GRANT group TO joe
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
+CREATE ROLE superuser_login;
+CREATE ROLE "space role";
+CREATE ROLE joe;
+CREATE ROLE group;
+GRANT group TO joe;

--- a/test/upgrade/create-in-v0.47.0-role.td
+++ b/test/upgrade/create-in-v0.47.0-role.td
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+ALTER ROLE materialize CREATEROLE
+
 > CREATE ROLE superuser_login;
 
 > CREATE ROLE "space role";


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/17983

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
