### PR TITLE
cloud-api: enable Arc in the admin client

### DIFF
--- a/src/cloud-api/src/client.rs
+++ b/src/cloud-api/src/client.rs
@@ -15,6 +15,7 @@
 //!
 //! The [`Client`] requires an [`mz_frontegg_client::client::Client`] as a parameter. The
 //! Frontegg client is used to request and manage the access token.
+use std::sync::Arc;
 
 use reqwest::{Method, RequestBuilder, Url};
 use serde::{de::DeserializeOwned, Deserialize};
@@ -26,7 +27,7 @@ use self::region::Region;
 /// Represents the structure for the client.
 pub struct Client {
     pub(crate) inner: reqwest::Client,
-    pub(crate) auth_client: mz_frontegg_client::client::Client,
+    pub(crate) auth_client: Arc<mz_frontegg_client::client::Client>,
     pub(crate) endpoint: Url,
 }
 

--- a/src/cloud-api/src/config.rs
+++ b/src/cloud-api/src/config.rs
@@ -15,6 +15,7 @@
 //! [`Client`] struct provides methods for interacting with various admin APIs,
 //! such as creating and managing users, or listing passwords.
 //!
+use std::sync::Arc;
 use std::time::Duration;
 
 use once_cell::sync::Lazy;
@@ -29,7 +30,7 @@ pub static DEFAULT_ENDPOINT: Lazy<Url> =
 /// Configures the required parameters of a [`Client`].
 pub struct ClientConfig {
     /// The authorization client to get the authorization token.
-    pub auth_client: mz_frontegg_client::client::Client,
+    pub auth_client: Arc<mz_frontegg_client::client::Client>,
 }
 
 /// A builder for a [`Client`].


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Support `Arc<AdminClient>` as a parameter in the `CloudClient`. The `AdminClient` is made to use with `Arc`, so as far as I understand it should be ok. Otherwise we need one `AdminClient` per `CloudClient`.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
