### PR TITLE
persist: set tcp user timeout for CRDB connections

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6898,6 +6898,7 @@ impl Catalog {
             blob_target_size: Some(config.persist_blob_target_size()),
             compaction_minimum_timeout: Some(config.persist_compaction_minimum_timeout()),
             consensus_connect_timeout: Some(config.crdb_connect_timeout()),
+            consensus_tcp_user_timeout: Some(config.crdb_tcp_user_timeout()),
             sink_minimum_batch_updates: Some(config.persist_sink_minimum_batch_updates()),
             storage_sink_minimum_batch_updates: Some(
                 config.storage_persist_sink_minimum_batch_updates(),

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -25,6 +25,7 @@ message ProtoPersistParameters {
     optional bool stats_filter_enabled = 7;
     optional bool pubsub_client_enabled = 10;
     optional bool pubsub_push_diff_enabled = 11;
+    mz_proto.ProtoDuration consensus_tcp_user_timeout = 12;
 }
 
 message ProtoRetryParameters {

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -219,7 +219,7 @@ impl PersistConfig {
     /// Default value for [`DynamicConfig::consensus_connect_timeout`].
     pub const DEFAULT_CRDB_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
     /// Default value for [`DynamicConfig::consensus_tcp_user_timeout`].
-    pub const DEFAULT_CRDB_TCP_USER_TIMEOUT: Duration = Duration::from_secs(15);
+    pub const DEFAULT_CRDB_TCP_USER_TIMEOUT: Duration = Duration::from_secs(30);
     /// Default value for [`DynamicConfig::stats_audit_percent`].
     pub const DEFAULT_STATS_AUDIT_PERCENT: usize = 0;
     /// Default value for [`DynamicConfig::stats_collection_enabled`].

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -157,6 +157,8 @@ pub trait ConsensusKnobs: std::fmt::Debug + Send + Sync {
     fn connection_pool_ttl_stagger(&self) -> Duration;
     /// Time to wait for a connection to be made before trying.
     fn connect_timeout(&self) -> Duration;
+    /// TCP user timeout for connection to [Consensus].
+    fn tcp_user_timeout(&self) -> Duration;
 }
 
 impl ConsensusConfig {

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -146,6 +146,9 @@ impl PostgresConsensusConfig {
             fn connect_timeout(&self) -> Duration {
                 Duration::MAX
             }
+            fn tcp_user_timeout(&self) -> Duration {
+                Duration::MAX
+            }
         }
 
         let config = PostgresConsensusConfig::new(
@@ -175,6 +178,7 @@ impl PostgresConsensus {
     pub async fn open(config: PostgresConsensusConfig) -> Result<Self, ExternalError> {
         let mut pg_config: Config = config.url.parse()?;
         pg_config.connect_timeout(config.knobs.connect_timeout());
+        pg_config.tcp_user_timeout(config.knobs.tcp_user_timeout());
         let tls = make_tls(&pg_config)?;
 
         let manager = Manager::from_config(

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -147,7 +147,7 @@ impl PostgresConsensusConfig {
                 Duration::MAX
             }
             fn tcp_user_timeout(&self) -> Duration {
-                Duration::MAX
+                Duration::ZERO
             }
         }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -664,6 +664,20 @@ const CRDB_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
     safe: true,
 };
 
+/// Controls the TCP user timeout to Cockroach.
+///
+/// Used by persist as [`mz_persist_client::cfg::DynamicConfig::consensus_tcp_user_timeout`].
+const CRDB_TCP_USER_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("crdb_tcp_user_timeout"),
+    value: &PersistConfig::DEFAULT_CRDB_TCP_USER_TIMEOUT,
+    description:
+        "The TCP timeout for connections to CockroachDB. Specifies the amount of time that \
+        transmitted data may remain unacknowledged before the TCP connection is forcibly \
+        closed.",
+    internal: true,
+    safe: true,
+};
+
 /// The maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
 const DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<usize> = ServerVar {
     name: UncasedStr::new("dataflow_max_inflight_bytes"),
@@ -1666,6 +1680,7 @@ impl SystemVars {
             .with_var(&PERSIST_BLOB_TARGET_SIZE)
             .with_var(&PERSIST_COMPACTION_MINIMUM_TIMEOUT)
             .with_var(&CRDB_CONNECT_TIMEOUT)
+            .with_var(&CRDB_TCP_USER_TIMEOUT)
             .with_var(&DATAFLOW_MAX_INFLIGHT_BYTES)
             .with_var(&PERSIST_SINK_MINIMUM_BATCH_UPDATES)
             .with_var(&STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
@@ -2040,6 +2055,11 @@ impl SystemVars {
     /// Returns the `crdb_connect_timeout` configuration parameter.
     pub fn crdb_connect_timeout(&self) -> Duration {
         *self.expect_value(&CRDB_CONNECT_TIMEOUT)
+    }
+
+    /// Returns the `crdb_tcp_user_timeout` configuration parameter.
+    pub fn crdb_tcp_user_timeout(&self) -> Duration {
+        *self.expect_value(&CRDB_TCP_USER_TIMEOUT)
     }
 
     /// Returns the `dataflow_max_inflight_bytes` configuration parameter.
@@ -3216,6 +3236,7 @@ fn is_persist_config_var(name: &str) -> bool {
     name == PERSIST_BLOB_TARGET_SIZE.name()
         || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
         || name == CRDB_CONNECT_TIMEOUT.name()
+        || name == CRDB_TCP_USER_TIMEOUT.name()
         || name == PERSIST_SINK_MINIMUM_BATCH_UPDATES.name()
         || name == STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES.name()
         || name == PERSIST_NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF.name()


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

The last API call timeout we need in persist! This sets a TCP user timeout on our Consensus connections, so that the client (really the OS managing the TCP socket) will proactively kill a connection if it does not get a packet back from the server for the specified time. This is useful to prevent socket hangs for busy connections, and avoids the need for sketchier app-level timeouts which don't have a clear time bound.

The proposed value is 30s, which should be ample time for CRDB to respond with literally any packet. Without this, if the connection were transparently lost, we could be waiting for ~16 minutes for TCP to kill the connection after `tcp_retries2` had been attempted.

User timeouts are often paired with keep-alives (I will forever link https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/ everywhere I go), but I don't think we really need keep-alives, whose goal is to keep idle connections healthy, as we [frequently cycle our connections](https://github.com/MaterializeInc/materialize/pull/16229) to the point where we shouldn't have unused / idle connections.

cc @mjibson this should be useful for the stash connection as well


### Motivation

  * This PR adds a known-desirable feature.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
