### PR TITLE
sql: refactor RocksDB tuning enum flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4664,6 +4664,7 @@ dependencies = [
  "tokio",
  "tonic-build",
  "tracing",
+ "uncased",
  "workspace-hack",
 ]
 

--- a/src/rocksdb/Cargo.toml
+++ b/src/rocksdb/Cargo.toml
@@ -27,6 +27,7 @@ tracing = "0.1.37"
 # https://github.com/lz4/lz4/blob/dev/LICENSE
 # https://github.com/facebook/zstd
 rocksdb = { version = "0.21.0", default-features = false, features = ["snappy", "zstd", "lz4"] }
+uncased = "0.9.7"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]


### PR DESCRIPTION
The `String`-valued params weren't ideal, IMO so just converted them to behave like some of the existing enum-style flags.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
