### PR TITLE
deps: remove personal forks/branches, and add a note about why

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "prost"
 version = "0.11.9"
-source = "git+https://github.com/MaterializeInc/prost?branch=btv#c6a3f885f7d4f1ee0ff96dfc31ff24d052960415"
+source = "git+https://github.com/MaterializeInc/prost#17cc373ba4416f69eef12857a02002838d9fa330"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -6153,7 +6153,7 @@ dependencies = [
 [[package]]
 name = "prost-build"
 version = "0.11.9"
-source = "git+https://github.com/MaterializeInc/prost?branch=btv#c6a3f885f7d4f1ee0ff96dfc31ff24d052960415"
+source = "git+https://github.com/MaterializeInc/prost#17cc373ba4416f69eef12857a02002838d9fa330"
 dependencies = [
  "bytes",
  "heck",
@@ -6174,7 +6174,7 @@ dependencies = [
 [[package]]
 name = "prost-derive"
 version = "0.11.9"
-source = "git+https://github.com/MaterializeInc/prost?branch=btv#c6a3f885f7d4f1ee0ff96dfc31ff24d052960415"
+source = "git+https://github.com/MaterializeInc/prost#17cc373ba4416f69eef12857a02002838d9fa330"
 dependencies = [
  "anyhow",
  "itertools",
@@ -6199,7 +6199,7 @@ dependencies = [
 [[package]]
 name = "prost-types"
 version = "0.11.9"
-source = "git+https://github.com/MaterializeInc/prost?branch=btv#c6a3f885f7d4f1ee0ff96dfc31ff24d052960415"
+source = "git+https://github.com/MaterializeInc/prost#17cc373ba4416f69eef12857a02002838d9fa330"
 dependencies = [
  "prost",
 ]
@@ -7789,7 +7789,7 @@ dependencies = [
 [[package]]
 name = "tonic-build"
 version = "0.8.2"
-source = "git+https://github.com/umanwizard/tonic#76489bf665af99d6e0e83f81648fcac283ea57e1"
+source = "git+https://github.com/MaterializeInc/tonic#76489bf665af99d6e0e83f81648fcac283ea57e1"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,14 +113,19 @@ debug = 1
 #
 # The reasons for each of these overrides are listed in deny.toml.
 [patch.crates-io]
+# IMPORTANT: you should only depend on "main", "master", or an upstream release
+# branch (e.g., "v7.x"). Do *not* depend on a feature/patch branch (e.g.,
+# "fix-thing" or "pr-1234"). Feature/patch branches tend to get rewritten or
+# disappear (e.g., because a PR is force pushed or gets merged), after which
+# point it becomes impossible to build that historical version of Materialize.
 chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x" }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 vte = { git = "https://github.com/alacritty/vte" }
-prost = { git = "https://github.com/MaterializeInc/prost", branch = "btv" }
-prost-build = { git = "https://github.com/MaterializeInc/prost", branch = "btv" }
-prost-derive = { git = "https://github.com/MaterializeInc/prost", branch = "btv" }
-prost-types = { git = "https://github.com/MaterializeInc/prost", branch = "btv" }
-tonic-build = { git = "https://github.com/umanwizard/tonic" }
+prost = { git = "https://github.com/MaterializeInc/prost" }
+prost-build = { git = "https://github.com/MaterializeInc/prost" }
+prost-derive = { git = "https://github.com/MaterializeInc/prost" }
+prost-types = { git = "https://github.com/MaterializeInc/prost" }
+tonic-build = { git = "https://github.com/MaterializeInc/tonic" }

--- a/deny.toml
+++ b/deny.toml
@@ -1,14 +1,15 @@
 [bans]
 multiple-versions = "deny"
-# Do not add exemptions for duplicate dependencies! Duplicate dependencies slow
-# down compilation, bloat the binary, and tickle race conditions in `cargo doc`
-# (see rust-lang/cargo#3613). Submit PRs upstream to remove duplicated
-# transitive dependencies. If necessary, use patch directives in the root
-# Cargo.toml to point at a Materialize-maintained fork that avoids the
-# duplicated transitive dependencies.
+# Try to avoid exemptions for duplicate dependencies! Duplicate dependencies
+# slow down compilation, bloat the binary, and tickle race conditions in `cargo
+# doc` (see rust-lang/cargo#3613).
+#
+# If possible, submit PRs upstream to remove duplicated transitive dependencies.
+# You can use patch directives in the root Cargo.toml to point at a
+# Materialize-maintained fork that avoids the duplicated transitive
+# dependencies.
 skip = [
     # One-time exception for base64 due to its prevalence in the crate graph.
-    # Do NOT add other exceptions to this list.
     { name = "base64", version = "0.13.1" },
     # `syn` is a core crate that a huge part of the ecosystem either directly, or
     # transitively depends on. They just released v2.0 which not all crates have
@@ -225,14 +226,19 @@ allow-git = [
     # it into a release.
     "https://github.com/MaterializeInc/rust-server-sdk",
 
-    # Waiting on https://github.com/awslabs/smithy-rs/pull/2525 to make it into a
-    # release.
-    "https://github.com/parker-timmerman/smithy-rs.git",
-
     # Waiting on https://github.com/tokio-rs/prost/pull/833 to make it into a
     # release.
     "https://github.com/MaterializeInc/prost",
 
-    # Waiting on https://github.com/hyperium/tonic/pull/1398
-    "https://github.com/umanwizard/tonic",
+    # Waiting on https://github.com/hyperium/tonic/pull/1398.
+    "https://github.com/MaterializeInc/tonic",
+
+    # Do not add personal GitHub forks here! Forks must be owned by the
+    # MaterializeInc organization so that maintainership is shared amongst
+    # Materialize employees. If you don't have permissions to create a fork in
+    # the MaterializeInc organization, ask in #eng-infra.
+    #
+    # Personal GitHub repositories are okay for projects where the true upstream
+    # is a personal GitHub account (e.g., frankmcsherry/columnation) rather than
+    # a fork.
 ]

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -74,9 +74,9 @@ phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 proc-macro2 = { version = "1.0.54", features = ["span-locations"] }
-prost = { git = "https://github.com/MaterializeInc/prost", branch = "btv", features = ["no-recursion-limit"] }
+prost = { git = "https://github.com/MaterializeInc/prost", features = ["no-recursion-limit"] }
 prost-reflect = { version = "0.9.2", default-features = false, features = ["serde"] }
-prost-types = { git = "https://github.com/MaterializeInc/prost", branch = "btv" }
+prost-types = { git = "https://github.com/MaterializeInc/prost" }
 quote = { version = "1.0.26" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
@@ -171,9 +171,9 @@ phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 proc-macro2 = { version = "1.0.54", features = ["span-locations"] }
-prost = { git = "https://github.com/MaterializeInc/prost", branch = "btv", features = ["no-recursion-limit"] }
+prost = { git = "https://github.com/MaterializeInc/prost", features = ["no-recursion-limit"] }
 prost-reflect = { version = "0.9.2", default-features = false, features = ["serde"] }
-prost-types = { git = "https://github.com/MaterializeInc/prost", branch = "btv" }
+prost-types = { git = "https://github.com/MaterializeInc/prost" }
 quote = { version = "1.0.26" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }


### PR DESCRIPTION
Maintainership burden can't be shared with personal forks, and personal branches tend to disappear and make old versions of Materialize uncompilable.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
