### PR TITLE
mzcompose: Allow Mzcompose to start containers with 'devel' or 'unsta…

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -133,6 +133,8 @@ class Materialized(Service):
             default_size
             if image
             and "latest" not in image
+            and "devel" not in image
+            and "unstable" not in image
             and MzVersion.parse_mz(image.split(":")[1]) < MzVersion.parse("0.41.0")
             else "1"
             if default_size == 1


### PR DESCRIPTION
…ble' tags

Those tags do not carry version information so MzVersion.parse() should not be called on them.

### Motivation

  * This PR fixes a previously unreported bug.

The cloud canary CI job was failing.

### Tips for reviewer

Indeed @def- was right in the original PR that there could be more tags to skip rather than just "latest" but at that time I could not think of any.