### PR TITLE
storage: dont allow other sources/sinks to be scheduled on linked clusters

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1415,6 +1415,11 @@ fn source_sink_cluster_config(
             if !is_storage_cluster(scx, cluster) {
                 sql_bail!("cannot create {ty} in cluster containing indexes or materialized views");
             }
+
+            // We also don't allow more objects to be added to a cluster that is already
+            // linked to another object.
+            ensure_cluster_is_not_linked(scx, cluster.id())?;
+
             Ok(SourceSinkClusterConfig::Existing { id: in_cluster.id })
         }
         (None, Some(size)) => Ok(SourceSinkClusterConfig::Linked { size }),

--- a/test/testdrive/linked-clusters.td
+++ b/test/testdrive/linked-clusters.td
@@ -85,8 +85,13 @@ materialize_public_lg2  linked  4
 > SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) WHERE cluster = 'materialize_public_lg2'
 materialize_public_lg2  linked  ${arg.default-storage-size}
 
+# Create a connection for use in sinks.
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}')
+
 # Test that linked clusters cannot be dropped, nor can their replicas be
-# dropped, nor can new replicas be created, nor can they run queries.
+# dropped, nor can new replicas be created, nor can they run queries,
+# nor can new sources be scheduled on them.
 ! DROP CLUSTER materialize_public_lg2 CASCADE
 contains:cannot modify linked cluster "materialize_public_lg2"
 ! DROP CLUSTER REPLICA materialize_public_lg2.linked
@@ -97,6 +102,12 @@ contains:cannot create more than one replica of a cluster containing sources or 
 contains:cannot modify linked cluster "materialize_public_lg2"
 ! CREATE INDEX IN CLUSTER materialize_public_lg2 ON v (a)
 contains:cannot modify linked cluster "materialize_public_lg2"
+! CREATE SOURCE lg_bad IN CLUSTER "materialize_public_lg1" FROM LOAD GENERATOR COUNTER
+contains:cannot modify linked cluster "materialize_public_lg1"
+! CREATE SINK snk_bad IN CLUSTER "materialize_public_lg1" FROM v
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk-bad-${testdrive.seed}')
+  FORMAT JSON ENVELOPE DEBEZIUM
+contains:cannot modify linked cluster "materialize_public_lg1"
 > SET cluster = materialize_public_lg2
 ! SELECT 1
 contains:cannot execute queries on cluster containing sources or sinks
@@ -118,10 +129,6 @@ mz_system
 default                 r1      ${arg.default-replica-size}
 mz_introspection        r1      1
 mz_system               r1      1
-
-# Create a connection for use in sinks.
-> CREATE CONNECTION kafka_conn
-  TO KAFKA (BROKER '${testdrive.kafka-addr}')
 
 # Test that creating a sink without an explicit size creates a linked cluster
 # with the default size. (Unsafe mode only.)


### PR DESCRIPTION

### Motivation

  * This PR fixes a recognized bug.

fixes: https://github.com/MaterializeInc/cloud/issues/6430

### Tips for reviewer

I will add 
```
SELECT id AS erroneous_id, name AS erroneous_object, mz_sources.cluster_id AS erroneous_linked_cluster, links.object_id AS real_linked_object FROM mz_sources JOIN mz_internal.mz_cluster_links AS links ON links.cluster_id = mz_sources.cluster_id WHERE links.object_id != mz_sources.id;
```

as sql that needs to be run on all envs to the next release process (and notes about how to mitigate it)


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
