### PR TITLE
persist: metrics for watch vs sleep resolving next_listen_batch

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1787,6 +1787,8 @@ pub struct LockMetrics {
 pub struct WatchMetrics {
     pub(crate) listen_woken_via_watch: IntCounter,
     pub(crate) listen_woken_via_sleep: IntCounter,
+    pub(crate) listen_resolved_via_watch: IntCounter,
+    pub(crate) listen_resolved_via_sleep: IntCounter,
     pub(crate) snapshot_woken_via_watch: IntCounter,
     pub(crate) snapshot_woken_via_sleep: IntCounter,
     pub(crate) notify_sent: IntCounter,
@@ -1807,6 +1809,14 @@ impl WatchMetrics {
             listen_woken_via_sleep: registry.register(metric!(
                 name: "mz_persist_listen_woken_via_sleep",
                 help: "count of listen next batches wakes via sleep",
+            )),
+            listen_resolved_via_watch: registry.register(metric!(
+                name: "mz_persist_listen_resolved_via_watch",
+                help: "count of listen next batches resolved via watch notify",
+            )),
+            listen_resolved_via_sleep: registry.register(metric!(
+                name: "mz_persist_listen_resolved_via_sleep",
+                help: "count of listen next batches resolved via sleep",
             )),
             snapshot_woken_via_watch: registry.register(metric!(
                 name: "mz_persist_snapshot_woken_via_watch",

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -949,7 +949,13 @@ where
             }
 
             seqno = match self.machine.next_listen_batch(frontier) {
-                Ok(b) => return b,
+                Ok(b) => {
+                    match &wake {
+                        Wake::Watch(_) => self.metrics.watch.listen_resolved_via_watch.inc(),
+                        Wake::Sleep(_) => self.metrics.watch.listen_resolved_via_sleep.inc(),
+                    }
+                    return b;
+                }
                 Err(seqno) => seqno,
             };
 


### PR DESCRIPTION
We had metrics for how many times watch vs sleep woke up the listen, but it's at least as interesting to know which was the one to cause the call to resolve.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
