### PR TITLE
[persist] Fix a copy/paste error on boolean stats

### DIFF
--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -673,7 +673,7 @@ mod impls {
             let value =
                 BooleanArray::new(arrow2::datatypes::DataType::Boolean, value.clone(), None);
             let lower = arrow2::compute::aggregate::min_boolean(&value).unwrap_or_default();
-            let upper = arrow2::compute::aggregate::min_boolean(&value).unwrap_or_default();
+            let upper = arrow2::compute::aggregate::max_boolean(&value).unwrap_or_default();
             PrimitiveStats { lower, upper }
         }
     }
@@ -681,7 +681,7 @@ mod impls {
     impl From<&BooleanArray> for OptionStats<PrimitiveStats<bool>> {
         fn from(value: &BooleanArray) -> Self {
             let lower = arrow2::compute::aggregate::min_boolean(value).unwrap_or_default();
-            let upper = arrow2::compute::aggregate::min_boolean(value).unwrap_or_default();
+            let upper = arrow2::compute::aggregate::max_boolean(value).unwrap_or_default();
             let none = value.validity().map_or(0, |x| x.unset_bits());
             OptionStats {
                 none,


### PR DESCRIPTION
### Motivation

One of two bugs reported in: https://github.com/MaterializeInc/materialize/issues/19338

In support of #18007.

### Tips for reviewer

It would be better if this code had unit test (proptest?) coverage. I think it's probably worth merging this first and following up, though... this bug is simple and tests are complex.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
