### PR TITLE
[persist] Handle MFP's strict expression evaluation

### DIFF
--- a/src/expr/tests/testdata/interpret
+++ b/src/expr/tests/testdata/interpret
@@ -87,7 +87,7 @@ interpret
 ----
 may contain: ["00000" "20000" "2" "80000" <err>]
 
-# Regression test: `or` short circuits even when the first argument throws an error
+# Regression test: `or` may short circuit even when the first argument throws an error
 # Expression: ((((1 / 0) > 0) OR true))
 interpret
 []
@@ -95,4 +95,4 @@ interpret
 (call_variadic or [(call_binary gt (call_binary div_numeric (1 numeric) (0 numeric)) (0 numeric)) true])
 ["string" 300 true false null]
 ----
-may contain: [true]
+may contain: [true <err>]


### PR DESCRIPTION
In #19173, we taught the `ColumnSpecs` interpreter to support AND and OR's non-strict evaluation behaviour.

As part of evaluating an MFP's filters to determine whether it will filter out an entire set of rows, we use `AND` to combine the results of multiple filters. However, MFP's filter evaluation is strict: if any filter errors the overall `evaluate` call will fail. This caused the results of evaluating an MFP with `eval` or the new interpreter to be inconsistent.

Instead of re-implementing AND in a strict way, this changes the abstract interpreter to permit both semantics: now an expression like `<error> AND false` is allowed to _either_ error or return false. Aside from fixing the linked bug, this also makes the interpreter more robust to future changes in the optimizer.

### Motivation

Fixes a known bug: #19338 

### Tips for reviewer

We may merge this quickly to unbreak main, but I'm happy for post-hoc review if anyone has comments on the strategy here. (This feature remains behind a flag, but that flag is now enabled in CI.)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
