### PR TITLE
storage: add a marketing based load generator

### DIFF
--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -269,20 +269,21 @@ SELECT * from bids;
 
 ### Creating a marketing load generator
 
-To create a load generator source that simulates an online marketing campaing: 
+To create a load generator source that simulates an online marketing campaign:
 
 ```sql
-CREATE SOURCE marketing 
+CREATE SOURCE marketing
   FROM LOAD GENERATOR MARKETING
-  FOR ALL TABLES 
+  FOR ALL TABLES
   WITH (SIZE = '3xsmall');
 ```
 
 To display the created subsources:
 
-```
+```sql
 SHOW SOURCES;
 ```
+
 ```nofmt
           name          |      type      | size
 ------------------------+----------------+------
@@ -292,11 +293,11 @@ SHOW SOURCES;
  customers              | subsource      |
  impressions            | subsource      |
  leads                  | subsource      |
- marketing              | load-generator | 1
+ marketing              | load-generator | 3xsmall
  marketing_progress     | subsource      |
 ```
 
-To find all impressions and clicks associated with a campaign over the last 30 days: 
+To find all impressions and clicks associated with a campaign over the last 30 days:
 
 ```sql
 WITH
@@ -318,6 +319,7 @@ SELECT campaign_id, sum(impressions) AS impressions, sum(clicks) AS clicks
 FROM impression_rollup LEFT JOIN click_rollup USING(id)
 GROUP BY campaign_id;
 ```
+
 ```nofmt
  campaign_id | impressions | clicks
 -------------+-------------+--------
@@ -431,6 +433,7 @@ The smallest source size (`3xsmall`) is a resonable default to get started. For 
 - [`CREATE SOURCE`](../)
 
 [`bigint`]: /sql/types/bigint
+[`numeric`]: /sql/types/numeric
 [`text`]: /sql/types/text
 [`timestamp with time zone`]: /sql/types/timestamp
 [feature request]: https://github.com/MaterializeInc/materialize/issues/new?assignees=&labels=A-integration&template=02-feature.yml

--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -110,6 +110,63 @@ The organizations, users, and accounts are fixed at the time the source
 is created. Each tick interval, either a new auction is started, or a new bid
 is placed in the currently ongoing auction.
 
+### Marketing
+
+The marketing load generator simulates an marketing organization that is using a machine learning model to send coupons to potential leads. The marketing source will be automatically demuxed
+into multiple subsources when the `CREATE SOURCE` command is executed. This will
+create the following subsources:
+
+  * `customers` describes the customers that the marketing team may target.
+
+    Field     | Type       | Description
+    ----------|------------|------------
+    `id`      | [`bigint`] | A unique identifier for the customer.
+    `email`   | [`text`]   | A customers email.
+    `income`  | [`bigint`] | The customers income in pennies.
+
+  * `impressions` describes online ads that have been seen by a customer.
+
+    Field             | Type                         | Description
+    ------------------|------------------------------|------------
+    `id`              | [`bigint`]                   | A unique identifier for the impression.
+    `customer_id`     | [`bigint`]                   | The identifier of the customer that saw the ad. References `customers.id`.
+    `impression_time` | [`timestamp with time zone`] | The time the ad was seen.
+
+  * `clicks` describes clicks of ads.
+
+    Field             | Type                         | Description
+    ------------------|------------------------------|------------
+    `impression_id`   | [`bigint`]                   | The identifier of the impression that was clicked. References `impressions.id`.
+    `click_time`      | [`timestamp with time zone`] | The time at which the impression was clicked.
+
+  * `leads` describes a potential lead for a purchase.
+
+    Field               | Type                         | Description
+    --------------------|------------------------------|------------
+    `id`                | [`bigint`]                   | A unique identifier for the lead.
+    `customer_id`       | [`bigint`]                   | The identifier of the customer we'd like to convert. References `customers.id`.
+    `created_at`        | [`timestamp with time zone`] | The time the lead was created.
+    `converted_at`      | [`timestamp with time zone`] | The time the lead was converted.
+    `conversion_amount` | [`bigint`]                   | The amount the lead converted for in pennies.
+
+  * `coupons` describes coupons given to leads.
+
+    Field               | Type                         | Description
+    --------------------|------------------------------|------------
+    `id`                | [`bigint`]                   | A unique identifier for the coupon.
+    `lead_id`           | [`bigint`]                   | The identifier of the lead we're attempting to convert. References `leads.id`.
+    `created_at`        | [`timestamp with time zone`] | The time the coupon was created.
+    `amount`            | [`bigint`]                   | The amount the coupon is for in pennies.
+
+  * `conversion_predictions` describes the predictions made by a highly sophisticated machine learning model.
+
+    Field               | Type                         | Description
+    --------------------|------------------------------|------------
+    `lead_id`           | [`bigint`]                   | The identifier of the lead we're attempting to convert. References `leads.id`.
+    `experiement_bucket`| [`text`]                     | Whether the lead is a control or experiment.
+    `created_at`        | [`timestamp with time zone`] | The time the prediction was made.
+    `score`             | [`numeric`]                  | The predicted likelyhood the lead will convert.
+
 ### TPCH
 
 The TPCH load generator implements the [TPC-H benchmark specification](https://www.tpc.org/tpch/default5.asp).

--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -112,7 +112,7 @@ is placed in the currently ongoing auction.
 
 ### Marketing
 
-The marketing load generator simulates an marketing organization that is using a machine learning model to send coupons to potential leads. The marketing source will be automatically demuxed
+The marketing load generator simulates a marketing organization that is using a machine learning model to send coupons to potential leads. The marketing source will be automatically demuxed
 into multiple subsources when the `CREATE SOURCE` command is executed. This will
 create the following subsources:
 
@@ -121,8 +121,8 @@ create the following subsources:
     Field     | Type       | Description
     ----------|------------|------------
     `id`      | [`bigint`] | A unique identifier for the customer.
-    `email`   | [`text`]   | A customers email.
-    `income`  | [`bigint`] | The customers income in pennies.
+    `email`   | [`text`]   | The customer's email.
+    `income`  | [`bigint`] | The customer's income in pennies.
 
   * `impressions` describes online ads that have been seen by a customer.
 
@@ -130,7 +130,7 @@ create the following subsources:
     ------------------|------------------------------|------------
     `id`              | [`bigint`]                   | A unique identifier for the impression.
     `customer_id`     | [`bigint`]                   | The identifier of the customer that saw the ad. References `customers.id`.
-    `impression_time` | [`timestamp with time zone`] | The time the ad was seen.
+    `impression_time` | [`timestamp with time zone`] | The time at which the ad was seen.
 
   * `clicks` describes clicks of ads.
 
@@ -145,8 +145,8 @@ create the following subsources:
     --------------------|------------------------------|------------
     `id`                | [`bigint`]                   | A unique identifier for the lead.
     `customer_id`       | [`bigint`]                   | The identifier of the customer we'd like to convert. References `customers.id`.
-    `created_at`        | [`timestamp with time zone`] | The time the lead was created.
-    `converted_at`      | [`timestamp with time zone`] | The time the lead was converted.
+    `created_at`        | [`timestamp with time zone`] | The time at which the lead was created.
+    `converted_at`      | [`timestamp with time zone`] | The time at which the lead was converted.
     `conversion_amount` | [`bigint`]                   | The amount the lead converted for in pennies.
 
   * `coupons` describes coupons given to leads.
@@ -155,7 +155,7 @@ create the following subsources:
     --------------------|------------------------------|------------
     `id`                | [`bigint`]                   | A unique identifier for the coupon.
     `lead_id`           | [`bigint`]                   | The identifier of the lead we're attempting to convert. References `leads.id`.
-    `created_at`        | [`timestamp with time zone`] | The time the coupon was created.
+    `created_at`        | [`timestamp with time zone`] | The time at which the coupon was created.
     `amount`            | [`bigint`]                   | The amount the coupon is for in pennies.
 
   * `conversion_predictions` describes the predictions made by a highly sophisticated machine learning model.
@@ -163,9 +163,9 @@ create the following subsources:
     Field               | Type                         | Description
     --------------------|------------------------------|------------
     `lead_id`           | [`bigint`]                   | The identifier of the lead we're attempting to convert. References `leads.id`.
-    `experiement_bucket`| [`text`]                     | Whether the lead is a control or experiment.
-    `created_at`        | [`timestamp with time zone`] | The time the prediction was made.
-    `score`             | [`numeric`]                  | The predicted likelyhood the lead will convert.
+    `experiment_bucket`| [`text`]                     | Whether the lead is a control or experiment.
+    `created_at`        | [`timestamp with time zone`] | The time at which the prediction was made.
+    `score`             | [`numeric`]                  | The predicted likelihood the lead will convert.
 
 ### TPCH
 

--- a/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="667" height="759">
+<svg xmlns="http://www.w3.org/2000/svg" width="667" height="803">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -39,186 +39,194 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="391" y="119">FROM LOAD GENERATOR</text>
-   <rect x="112" y="243" width="86" height="32" rx="10"/>
-   <rect x="110"
+   <rect x="104" y="243" width="86" height="32" rx="10"/>
+   <rect x="102"
          y="241"
          width="86"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="120" y="261">AUCTION</text>
-   <rect x="112" y="287" width="88" height="32" rx="10"/>
-   <rect x="110"
+   <text class="terminal" x="112" y="261">AUCTION</text>
+   <rect x="104" y="287" width="88" height="32" rx="10"/>
+   <rect x="102"
          y="285"
          width="88"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="120" y="305">COUNTER</text>
-   <rect x="112" y="331" width="60" height="32" rx="10"/>
-   <rect x="110"
+   <text class="terminal" x="112" y="305">COUNTER</text>
+   <rect x="104" y="331" width="104" height="32" rx="10"/>
+   <rect x="102"
          y="329"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="112" y="349">MARKETING</text>
+   <rect x="104" y="375" width="60" height="32" rx="10"/>
+   <rect x="102"
+         y="373"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="120" y="349">TPCH</text>
-   <rect x="260" y="243" width="26" height="32" rx="10"/>
-   <rect x="258"
+   <text class="terminal" x="112" y="393">TPCH</text>
+   <rect x="268" y="243" width="26" height="32" rx="10"/>
+   <rect x="266"
          y="241"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="268" y="261">(</text>
-   <rect x="326" y="243" width="166" height="32"/>
-   <rect x="324" y="241" width="166" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="334" y="261">load_generator_option</text>
-   <rect x="326" y="199" width="24" height="32" rx="10"/>
-   <rect x="324"
+   <text class="terminal" x="276" y="261">(</text>
+   <rect x="334" y="243" width="166" height="32"/>
+   <rect x="332" y="241" width="166" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="342" y="261">load_generator_option</text>
+   <rect x="334" y="199" width="24" height="32" rx="10"/>
+   <rect x="332"
          y="197"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="334" y="217">,</text>
-   <rect x="532" y="243" width="26" height="32" rx="10"/>
-   <rect x="530"
+   <text class="terminal" x="342" y="217">,</text>
+   <rect x="540" y="243" width="26" height="32" rx="10"/>
+   <rect x="538"
          y="241"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="540" y="261">)</text>
-   <rect x="45" y="397" width="138" height="32" rx="10"/>
+   <text class="terminal" x="548" y="261">)</text>
+   <rect x="45" y="441" width="138" height="32" rx="10"/>
    <rect x="43"
-         y="395"
+         y="439"
          width="138"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="415">FOR ALL TABLES</text>
-   <rect x="45" y="485" width="106" height="32" rx="10"/>
+   <text class="terminal" x="53" y="459">FOR ALL TABLES</text>
+   <rect x="45" y="529" width="106" height="32" rx="10"/>
    <rect x="43"
-         y="483"
+         y="527"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="503">FOR TABLES</text>
-   <rect x="171" y="485" width="26" height="32" rx="10"/>
+   <text class="terminal" x="53" y="547">FOR TABLES</text>
+   <rect x="171" y="529" width="26" height="32" rx="10"/>
    <rect x="169"
-         y="483"
+         y="527"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="179" y="503">(</text>
-   <rect x="237" y="485" width="96" height="32"/>
-   <rect x="235" y="483" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="245" y="503">table_name</text>
-   <rect x="373" y="517" width="40" height="32" rx="10"/>
+   <text class="terminal" x="179" y="547">(</text>
+   <rect x="237" y="529" width="96" height="32"/>
+   <rect x="235" y="527" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="245" y="547">table_name</text>
+   <rect x="373" y="561" width="40" height="32" rx="10"/>
    <rect x="371"
-         y="515"
+         y="559"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="381" y="535">AS</text>
-   <rect x="433" y="517" width="106" height="32"/>
-   <rect x="431" y="515" width="106" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="441" y="535">subsrc_name</text>
-   <rect x="237" y="441" width="24" height="32" rx="10"/>
+   <text class="terminal" x="381" y="579">AS</text>
+   <rect x="433" y="561" width="106" height="32"/>
+   <rect x="431" y="559" width="106" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="441" y="579">subsrc_name</text>
+   <rect x="237" y="485" width="24" height="32" rx="10"/>
    <rect x="235"
-         y="439"
+         y="483"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="245" y="459">,</text>
-   <rect x="599" y="485" width="26" height="32" rx="10"/>
+   <text class="terminal" x="245" y="503">,</text>
+   <rect x="599" y="529" width="26" height="32" rx="10"/>
    <rect x="597"
-         y="483"
+         y="527"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="607" y="503">)</text>
-   <rect x="101" y="599" width="76" height="32" rx="10"/>
+   <text class="terminal" x="607" y="547">)</text>
+   <rect x="101" y="643" width="76" height="32" rx="10"/>
    <rect x="99"
-         y="597"
+         y="641"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="109" y="617">EXPOSE</text>
-   <rect x="197" y="599" width="96" height="32" rx="10"/>
+   <text class="terminal" x="109" y="661">EXPOSE</text>
+   <rect x="197" y="643" width="96" height="32" rx="10"/>
    <rect x="195"
-         y="597"
+         y="641"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="205" y="617">PROGRESS</text>
-   <rect x="313" y="599" width="40" height="32" rx="10"/>
+   <text class="terminal" x="205" y="661">PROGRESS</text>
+   <rect x="313" y="643" width="40" height="32" rx="10"/>
    <rect x="311"
-         y="597"
+         y="641"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="321" y="617">AS</text>
-   <rect x="373" y="599" width="196" height="32"/>
-   <rect x="371" y="597" width="196" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="381" y="617">progress_subsource_name</text>
-   <rect x="255" y="709" width="58" height="32" rx="10"/>
+   <text class="terminal" x="321" y="661">AS</text>
+   <rect x="373" y="643" width="196" height="32"/>
+   <rect x="371" y="641" width="196" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="381" y="661">progress_subsource_name</text>
+   <rect x="255" y="753" width="58" height="32" rx="10"/>
    <rect x="253"
-         y="707"
+         y="751"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="263" y="727">WITH</text>
-   <rect x="333" y="709" width="26" height="32" rx="10"/>
+   <text class="terminal" x="263" y="771">WITH</text>
+   <rect x="333" y="753" width="26" height="32" rx="10"/>
    <rect x="331"
-         y="707"
+         y="751"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="341" y="727">(</text>
-   <rect x="399" y="709" width="48" height="32"/>
-   <rect x="397" y="707" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="407" y="727">field</text>
-   <rect x="467" y="709" width="28" height="32" rx="10"/>
+   <text class="terminal" x="341" y="771">(</text>
+   <rect x="399" y="753" width="48" height="32"/>
+   <rect x="397" y="751" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="407" y="771">field</text>
+   <rect x="467" y="753" width="28" height="32" rx="10"/>
    <rect x="465"
-         y="707"
+         y="751"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="475" y="727">=</text>
-   <rect x="515" y="709" width="38" height="32"/>
-   <rect x="513" y="707" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="523" y="727">val</text>
-   <rect x="399" y="665" width="24" height="32" rx="10"/>
+   <text class="terminal" x="475" y="771">=</text>
+   <rect x="515" y="753" width="38" height="32"/>
+   <rect x="513" y="751" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="523" y="771">val</text>
+   <rect x="399" y="709" width="24" height="32" rx="10"/>
    <rect x="397"
-         y="663"
+         y="707"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="407" y="683">,</text>
-   <rect x="593" y="709" width="26" height="32" rx="10"/>
+   <text class="terminal" x="407" y="727">,</text>
+   <rect x="593" y="753" width="26" height="32" rx="10"/>
    <rect x="591"
-         y="707"
+         y="751"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="601" y="727">)</text>
+   <text class="terminal" x="601" y="771">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-406 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m196 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-531 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m86 0 h10 m0 0 h2 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m60 0 h10 m0 0 h28 m40 -88 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-597 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h442 m-620 0 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v68 m620 0 v-68 m-620 68 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m20 44 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-608 170 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-398 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
-   <polygon points="657 723 665 719 665 727"/>
-   <polygon points="657 723 649 719 649 727"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-406 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m196 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-539 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m86 0 h10 m0 0 h18 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m88 0 h10 m0 0 h16 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m104 0 h10 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m60 0 h10 m0 0 h44 m40 -132 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-605 198 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h442 m-620 0 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v68 m620 0 v-68 m-620 68 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m20 44 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-608 170 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-398 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="657 767 665 763 665 771"/>
+   <polygon points="657 767 649 763 649 771"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -110,7 +110,7 @@ create_source_kafka ::=
 create_source_load_generator ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   ('IN CLUSTER' cluster_name)?
-  'FROM LOAD GENERATOR' ('AUCTION' | 'COUNTER' | 'TPCH')
+  'FROM LOAD GENERATOR' ('AUCTION' | 'COUNTER' | 'MARKETING' | 'TPCH')
   ('(' (load_generator_option) ( ( ',' load_generator_option ) )* ')')?
   (
     'FOR ALL TABLES' |

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1088,6 +1088,7 @@ impl_display_t!(CreateSourceConnection);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum LoadGenerator {
     Counter,
+    Marketing,
     Auction,
     Datums,
     Tpch,
@@ -1097,6 +1098,7 @@ impl AstDisplay for LoadGenerator {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             Self::Counter => f.write_str("COUNTER"),
+            Self::Marketing => f.write_str("MARKETING"),
             Self::Auction => f.write_str("AUCTION"),
             Self::Datums => f.write_str("DATUMS"),
             Self::Tpch => f.write_str("TPCH"),

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -204,6 +204,7 @@ Log
 Logical
 Login
 Map
+Marketing
 Materialize
 Materialized
 Max

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2700,14 +2700,16 @@ impl<'a> Parser<'a> {
             }
             LOAD => {
                 self.expect_keyword(GENERATOR)?;
-                let generator =
-                    match self.expect_one_of_keywords(&[COUNTER, AUCTION, TPCH, DATUMS])? {
-                        COUNTER => LoadGenerator::Counter,
-                        AUCTION => LoadGenerator::Auction,
-                        TPCH => LoadGenerator::Tpch,
-                        DATUMS => LoadGenerator::Datums,
-                        _ => unreachable!(),
-                    };
+                let generator = match self
+                    .expect_one_of_keywords(&[COUNTER, MARKETING, AUCTION, TPCH, DATUMS])?
+                {
+                    COUNTER => LoadGenerator::Counter,
+                    AUCTION => LoadGenerator::Auction,
+                    TPCH => LoadGenerator::Tpch,
+                    DATUMS => LoadGenerator::Datums,
+                    MARKETING => LoadGenerator::Marketing,
+                    _ => unreachable!(),
+                };
                 let options = if self.consume_token(&Token::LParen) {
                     let options =
                         self.parse_comma_separated(Parser::parse_load_generator_option)?;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1278,6 +1278,7 @@ pub(crate) fn load_generator_ast_to_generator(
             }
             LoadGenerator::Counter { max_cardinality }
         }
+        mz_sql_parser::ast::LoadGenerator::Marketing => LoadGenerator::Marketing,
         mz_sql_parser::ast::LoadGenerator::Datums => LoadGenerator::Datums,
         mz_sql_parser::ast::LoadGenerator::Tpch => {
             let LoadGeneratorOptionExtracted { scale_factor, .. } = options.to_vec().try_into()?;
@@ -1322,6 +1323,7 @@ pub(crate) fn load_generator_ast_to_generator(
             database: RawDatabaseSpecifier::Name("mz_load_generators".to_owned()),
             schema: match load_generator {
                 LoadGenerator::Counter { .. } => "counter".into(),
+                LoadGenerator::Marketing => "marketing".into(),
                 LoadGenerator::Auction => "auction".into(),
                 LoadGenerator::Datums => "datums".into(),
                 LoadGenerator::Tpch { .. } => "tpch".into(),

--- a/src/storage-client/src/types/sources.proto
+++ b/src/storage-client/src/types/sources.proto
@@ -212,6 +212,7 @@ message ProtoLoadGeneratorSourceConnection {
         google.protobuf.Empty auction = 3;
         ProtoTpchLoadGenerator tpch = 4;
         google.protobuf.Empty datums = 5;
+        google.protobuf.Empty marketing = 7;
     }
     optional uint64 tick_micros = 2;
 }

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -33,12 +33,15 @@ use crate::source::{RawSourceCreationConfig, SourceMessage, SourceReaderError};
 mod auction;
 mod counter;
 mod datums;
+mod marketing;
 mod tpch;
 
 pub use auction::Auction;
 pub use counter::Counter;
 pub use datums::Datums;
 pub use tpch::Tpch;
+
+use self::marketing::Marketing;
 
 pub fn as_generator(g: &LoadGenerator, tick_micros: Option<u64>) -> Box<dyn Generator> {
     match g {
@@ -47,6 +50,7 @@ pub fn as_generator(g: &LoadGenerator, tick_micros: Option<u64>) -> Box<dyn Gene
             max_cardinality: max_cardinality.clone(),
         }),
         LoadGenerator::Datums => Box::new(Datums {}),
+        LoadGenerator::Marketing => Box::new(Marketing {}),
         LoadGenerator::Tpch {
             count_supplier,
             count_part,

--- a/src/storage/src/source/generator/marketing.rs
+++ b/src/storage/src/source/generator/marketing.rs
@@ -1,0 +1,327 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    iter,
+};
+
+use mz_ore::now::to_datetime;
+use mz_repr::{Datum, Row};
+use mz_storage_client::types::sources::{Generator, GeneratorMessageType};
+use rand::{distributions::Standard, rngs::SmallRng, Rng, SeedableRng};
+
+const CUSTOMERS_OUTPUT: usize = 1;
+const IMPRESSIONS_OUTPUT: usize = 2;
+const CLICK_OUTPUT: usize = 3;
+const LEADS_OUTPUT: usize = 4;
+const COUPONS_OUTPUT: usize = 5;
+const CONVERSIONS_PREDICTIONS_OUTPUT: usize = 6;
+
+const CONTROL: &str = "control";
+const EXPERIMENT: &str = "experiment";
+
+pub struct Marketing {}
+
+// Note that this generator issues retractions; if you change this,
+// `mz_storage_client::types::sources::LoadGenerator::is_monotonic`
+// must be updated.
+impl Generator for Marketing {
+    fn by_seed(
+        &self,
+        now: mz_ore::now::NowFn,
+        seed: Option<u64>,
+    ) -> Box<
+        dyn Iterator<
+            Item = (
+                usize,
+                mz_storage_client::types::sources::GeneratorMessageType,
+                mz_repr::Row,
+                i64,
+            ),
+        >,
+    > {
+        let mut rng: SmallRng = SmallRng::seed_from_u64(seed.unwrap_or_default());
+
+        let mut counter = 0;
+
+        let mut future_updates = FutureUpdates::default();
+        let mut pending: Vec<(usize, Row, i64)> = CUSTOMERS
+            .into_iter()
+            .enumerate()
+            .map(|(id, email)| {
+                let mut customer = Row::with_capacity(3);
+                let mut packer = customer.packer();
+
+                packer.push(Datum::Int64(id.try_into().unwrap()));
+                packer.push(Datum::String(email));
+                packer.push(Datum::Int64(rng.gen_range(5_000_000..10_000_000i64)));
+
+                (CUSTOMERS_OUTPUT, customer, 1)
+            })
+            .collect();
+
+        Box::new(iter::from_fn(move || {
+            if pending.is_empty() {
+                let mut impression = Row::with_capacity(4);
+                let mut packer = impression.packer();
+
+                let impression_id = counter;
+                counter += 1;
+
+                packer.push(Datum::Int64(impression_id));
+                packer.push(Datum::Int64(
+                    rng.gen_range(0..CUSTOMERS.len()).try_into().unwrap(),
+                ));
+                packer.push(Datum::Int64(rng.gen_range(0..20i64)));
+                let impression_time = now();
+                packer.push(Datum::TimestampTz(
+                    to_datetime(impression_time)
+                        .try_into()
+                        .expect("timestamp must fit"),
+                ));
+
+                pending.push((IMPRESSIONS_OUTPUT, impression, 1));
+
+                // 1 in 10 impressions have a click. Making us the
+                // most successful marketing organization in the world.
+                if rng.gen_range(0..10) == 1 {
+                    let mut click = Row::with_capacity(2);
+                    let mut packer = click.packer();
+
+                    let click_time = impression_time + rng.gen_range(20000..40000);
+
+                    packer.push(Datum::Int64(impression_id));
+                    packer.push(Datum::TimestampTz(
+                        to_datetime(click_time)
+                            .try_into()
+                            .expect("timestamp must fit"),
+                    ));
+
+                    future_updates.insert(click_time, (CLICK_OUTPUT, click, 1));
+                }
+
+                let mut updates = future_updates.retrieve(now());
+                pending.append(&mut updates);
+
+                for _ in 0..rng.gen_range(1..2) {
+                    let id = counter;
+                    counter += 1;
+
+                    let mut lead = Lead {
+                        id,
+                        customer_id: rng.gen_range(0..CUSTOMERS.len()).try_into().unwrap(),
+                        created_at: now(),
+                        converted_at: None,
+                        conversion_amount: None,
+                    };
+
+                    pending.push((LEADS_OUTPUT, lead.to_row(), 1));
+
+                    // a highly scientific statistical model
+                    // predicting the likelyhood of a conversion
+                    let score = rng.sample::<f64, _>(Standard);
+                    let label = score > 0.5f64;
+
+                    let bucket = if lead.id % 10 <= 1 {
+                        CONTROL
+                    } else {
+                        EXPERIMENT
+                    };
+
+                    let mut prediction = Row::with_capacity(4);
+                    let mut packer = prediction.packer();
+
+                    packer.push(Datum::Int64(lead.id));
+                    packer.push(Datum::String(bucket));
+                    packer.push(Datum::TimestampTz(
+                        to_datetime(now()).try_into().expect("timestamp must fit"),
+                    ));
+                    packer.push(Datum::Float64(score.into()));
+
+                    pending.push((CONVERSIONS_PREDICTIONS_OUTPUT, prediction, 1));
+
+                    let mut sent_coupon = false;
+                    if !label && bucket == EXPERIMENT {
+                        sent_coupon = true;
+                        let amount = rng.gen_range(500..5000);
+
+                        let mut coupon = Row::with_capacity(4);
+                        let mut packer = coupon.packer();
+
+                        let id = counter;
+                        counter += 1;
+                        packer.push(Datum::Int64(id));
+                        packer.push(Datum::Int64(lead.id));
+                        packer.push(Datum::TimestampTz(
+                            to_datetime(now()).try_into().expect("timestamp must fit"),
+                        ));
+                        packer.push(Datum::Int64(amount));
+
+                        pending.push((COUPONS_OUTPUT, coupon, 1));
+                    }
+
+                    // Decide if a lead will convert. We assume our model is fairly
+                    // accurate and correlates with conversions. We also assume
+                    // that coupons make leads a little more liekly to convert.
+                    let mut converted = rng.sample::<f64, _>(Standard) < score;
+                    if sent_coupon && !converted {
+                        converted = rng.sample::<f64, _>(Standard) < score;
+                    }
+
+                    if converted {
+                        let converted_at = now() + rng.gen_range(1..30);
+
+                        future_updates.insert(converted_at, (LEADS_OUTPUT, lead.to_row(), -1));
+
+                        lead.converted_at = Some(converted_at);
+                        lead.conversion_amount = Some(rng.gen_range(1000..25000));
+
+                        future_updates.insert(converted_at, (LEADS_OUTPUT, lead.to_row(), 1));
+                    }
+                }
+            }
+
+            pending.pop().map(|(output, row, diff)| {
+                let typ = if pending.is_empty() {
+                    GeneratorMessageType::Finalized
+                } else {
+                    GeneratorMessageType::InProgress
+                };
+                (output, typ, row, diff)
+            })
+        }))
+    }
+}
+
+struct Lead {
+    id: i64,
+    customer_id: i64,
+    created_at: u64,
+    converted_at: Option<u64>,
+    conversion_amount: Option<i64>,
+}
+
+impl Lead {
+    fn to_row(&self) -> Row {
+        let mut row = Row::with_capacity(5);
+        let mut packer = row.packer();
+        packer.push(Datum::Int64(self.id));
+        packer.push(Datum::Int64(self.customer_id));
+        packer.push(Datum::TimestampTz(
+            to_datetime(self.created_at)
+                .try_into()
+                .expect("timestamp must fit"),
+        ));
+        packer.push(
+            self.converted_at
+                .map(|converted_at| {
+                    Datum::TimestampTz(
+                        to_datetime(converted_at)
+                            .try_into()
+                            .expect("timestamp must fit"),
+                    )
+                })
+                .unwrap_or(Datum::Null),
+        );
+        packer.push(
+            self.conversion_amount
+                .map(Datum::Int64)
+                .unwrap_or(Datum::Null),
+        );
+
+        row
+    }
+}
+
+const CUSTOMERS: &[&str] = &[
+    "andy.rooney@email.com",
+    "marisa.tomei@email.com",
+    "betty.thomas@email.com",
+    "don.imus@email.com",
+    "chevy.chase@email.com",
+    "george.wendt@email.com",
+    "oscar.levant@email.com",
+    "jack.lemmon@email.com",
+    "ben.vereen@email.com",
+    "alexander.hamilton@email.com",
+    "tommy.lee.jones@email.com",
+    "george.takei@email.com",
+    "norman.mailer@email.com",
+    "casey.kasem@email.com",
+    "sarah.miles@email.com",
+    "john.landis@email.com",
+    "george.c..marshall@email.com",
+    "rita.coolidge@email.com",
+    "al.unser@email.com",
+    "ross.perot@email.com",
+    "mikhail.gorbachev@email.com",
+    "yasmine.bleeth@email.com",
+    "darryl.strawberry@email.com",
+    "bruce.springsteen@email.com",
+    "weird.al.yankovic@email.com",
+    "james.franco@email.com",
+    "jean.smart@email.com",
+    "stevie.nicks@email.com",
+    "robert.merrill@email.com",
+    "todd.bridges@email.com",
+    "sam.cooke@email.com",
+    "bert.convy@email.com",
+    "erica.jong@email.com",
+    "oscar.schindler@email.com",
+    "douglas.fairbanks@email.com",
+    "penny.marshall@email.com",
+    "bram.stoker@email.com",
+    "holly.hunter@email.com",
+    "leontyne.price@email.com",
+    "dick.smothers@email.com",
+    "meredith.baxter@email.com",
+    "carla.bruni@email.com",
+    "joel.mccrea@email.com",
+    "mariette.hartley@email.com",
+    "vince.gill@email.com",
+    "leon.schotter@email.com",
+    "johann.von.goethe@email.com",
+    "john.katz@email.com",
+    "attenborough@email.com",
+    "billy.graham@email.com",
+];
+
+#[derive(Default)]
+struct FutureUpdates {
+    updates: BTreeMap<u64, Vec<(usize, Row, i64)>>,
+}
+
+impl FutureUpdates {
+    /// Schedules a row to be output at a certain time
+    fn insert(&mut self, time: u64, update: (usize, Row, i64)) {
+        match self.updates.entry(time) {
+            Entry::Vacant(v) => {
+                v.insert(vec![update]);
+            }
+            Entry::Occupied(o) => {
+                o.into_mut().push(update);
+            }
+        }
+    }
+
+    /// Returns all rows that are scheduled to be output
+    /// at or before a certain time.
+    fn retrieve(&mut self, time: u64) -> Vec<(usize, Row, i64)> {
+        let mut updates = vec![];
+        while let Some(e) = self.updates.first_entry() {
+            if *e.key() > time {
+                break;
+            }
+
+            updates.append(&mut e.remove());
+        }
+        updates
+    }
+}


### PR DESCRIPTION
### Motivation

Adds a new loadgen type `MARKETING` that will allow us to demo Materialize as a real-time feature store and for real-time monitoring of machine learning models. 

### Tips for reviewer

I didn't add a test-drive file because it wasn't clear to me there was anything I could readily test other than the output of show sources. Maybe that's valuable! Please let me know if I should add one. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
