### PR TITLE
storage: allow WITH(DISK) even when enable_create_source_denylist_with_options is off

### DIFF
--- a/test/testdrive/disk-feature-flag.td
+++ b/test/testdrive/disk-feature-flag.td
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that with `enable_create_source_denylist_with_options` off, if
+# `enable_upsert_source_disk` is on, we can use `WITH(DISK)`.
+# Note that `WITH(DISK)` is not tested in `test/testdrive`, so we use a source
+# type that will show that we allow the with option overall, but fail later on in
+# `plan_create_source`.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_create_source_denylist_with_options = false
+ALTER SYSTEM SET enable_upsert_source_disk = true
+
+! CREATE SOURCE lg FROM LOAD GENERATOR COUNTER
+  WITH (DISK)
+contains:ON DISK used with non-UPSERT/DEBEZIUM ENVELOPE not yet supported
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_upsert_source_disk = false
+
+! CREATE SOURCE lg FROM LOAD GENERATOR COUNTER
+  WITH (DISK)
+contains:CREATE SOURCE...WITH (DISK..) is not supported


### PR DESCRIPTION
`enable_upsert_source_disk` enables a new with option, but this if statement prevents using `DISK` in staging/production, where enable_create_source_denylist_with_options is off. The intention of the former feature is to allow (some) customers to use this feature in production, so this had to be cleaned up!

### Motivation


  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
https://github.com/MaterializeInc/materialize/issues/17067
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
