### PR TITLE
Fix nightly tests after unsafe mode removal

### DIFF
--- a/misc/python/materialize/checks/alter_index.py
+++ b/misc/python/materialize/checks/alter_index.py
@@ -64,14 +64,19 @@ class AlterIndex(Check):
         return [
             Testdrive(schema() + dedent(s))
             for s in [
-                """
-                > INSERT INTO alter_index_table SELECT 'B' || generate_series FROM generate_series(1,10000);
-                $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
-                {"f1": "B${kafka-ingest.iteration}"}
-
+                (
+                    """
                 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER SYSTEM SET enable_index_options = true
                 ALTER SYSTEM SET enable_logical_compaction_window = true
+                """
+                    if self.current_version >= MzVersion(0, 55, 0)
+                    else ""
+                )
+                + """
+                > INSERT INTO alter_index_table SELECT 'B' || generate_series FROM generate_series(1,10000);
+                $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
+                {"f1": "B${kafka-ingest.iteration}"}
 
                 > ALTER INDEX alter_index_table_primary_idx SET (LOGICAL COMPACTION WINDOW = '1ms');
                 > ALTER INDEX alter_index_source_primary_idx SET (LOGICAL COMPACTION WINDOW = '1ms');

--- a/misc/python/materialize/checks/json_source.py
+++ b/misc/python/materialize/checks/json_source.py
@@ -24,13 +24,18 @@ class JsonSource(Check):
         return Testdrive(
             dedent(
                 """
+                $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                ALTER SYSTEM SET enable_format_json = true
+                """
+                if self.current_version >= MzVersion(0, 53, 0)
+                else ""
+            )
+            + dedent(
+                """
                 $ kafka-create-topic topic=format-json partitions=1
 
                 $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-json
                 "object":{"a":"b","c":"d"}
-
-                $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-                ALTER SYSTEM SET enable_format_json = true
 
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
 

--- a/misc/python/materialize/checks/multiple_partitions.py
+++ b/misc/python/materialize/checks/multiple_partitions.py
@@ -12,6 +12,7 @@ from typing import List
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
+from materialize.util import MzVersion
 
 
 def schemas() -> str:
@@ -29,8 +30,12 @@ class MultiplePartitions(Check):
                 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER SYSTEM SET enable_create_source_denylist_with_options = true
                 ALTER SYSTEM SET enable_kafka_config_denylist_options = true
-
-
+                """
+                if self.current_version >= MzVersion(0, 55, 0)
+                else ""
+            )
+            + dedent(
+                """
                 $ kafka-create-topic topic=multiple-partitions-topic
 
                 # ingest A-key entries

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -131,11 +131,12 @@ class UseClusterdCompute(MzcomposeAction):
             else "STORAGECTL ADDRESS 'clusterd_compute_1:2100'"
         )
 
-        c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = on;",
-            port=6877,
-            user="mz_system",
-        )
+        if self.base_version >= MzVersion(0, 55, 0):
+            c.sql(
+                "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = on;",
+                port=6877,
+                user="mz_system",
+            )
 
         c.sql(
             f"""

--- a/misc/python/materialize/checks/sink.py
+++ b/misc/python/materialize/checks/sink.py
@@ -12,6 +12,7 @@ from typing import List
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
+from materialize.util import MzVersion
 
 
 def schemas() -> str:
@@ -185,7 +186,12 @@ class SinkTables(Check):
                 """
                 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER SYSTEM SET enable_table_keys = true;
-
+                """
+                if self.current_version >= MzVersion(0, 55, 0)
+                else ""
+            )
+            + dedent(
+                """
                 > CREATE TABLE sink_large_transaction_table (f1 INTEGER, f2 TEXT, PRIMARY KEY (f1));
                 > CREATE DEFAULT INDEX ON sink_large_transaction_table;
 

--- a/test/kafka-multi-broker/01-init.td
+++ b/test/kafka-multi-broker/01-init.td
@@ -44,6 +44,9 @@ $ kafka-ingest format=avro topic=kafka-multi-broker schema=${schema} timestamp=6
     URL '${testdrive.schema-registry-url}'
   );
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_kafka_config_denylist_options = true
+
 > CREATE SINK multi_broker_sink
   FROM kafka_multi_broker
   INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR = 2, PARTITION COUNT = 2, TOPIC 'testdrive-kafka-multi-broker-sink-${testdrive.seed}')


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/19120

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
