### PR TITLE
Increase timeout for proptest_stash_migrate_json_to_proto

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,6 +17,10 @@ filter = "package(mz-environmentd)"
 threads-required = 8
 slow-timeout = { period = "120s", terminate-after = 2 }
 
+[[profile.default.overrides]]
+filter = "package(mz-stash) and test(proptest_stash_migrate_json_to_proto)"
+slow-timeout = { period = "120s", terminate-after = 2 }
+
 [profile.ci]
 junit = { path = "junit_cargo-test.xml" }
 fail-fast = false


### PR DESCRIPTION
Seen to timeout sporadically: https://buildkite.com/materialize/tests/builds/55918#01884260-ff44-4135-87dc-0a3aad49091d
```
[2023-05-22T07:44:19Z] TIMEOUT [ 120.008s] mz-stash upgrade::json_to_proto::tests::proptest_stash_migrate_json_to_proto
```
Test was recently introduced in 4e800d563eb CC @parker-timmerman Is this test expected to run that long or is something else wrong?

Fixes: https://github.com/MaterializeInc/materialize/issues/19396

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
