### PR TITLE
persist: update rollup task cadence + make dynamic

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6915,6 +6915,7 @@ impl Catalog {
             stats_filter_enabled: Some(config.persist_stats_filter_enabled()),
             pubsub_client_enabled: Some(config.persist_pubsub_client_enabled()),
             pubsub_push_diff_enabled: Some(config.persist_pubsub_push_diff_enabled()),
+            rollup_threshold: Some(config.persist_rollup_threshold()),
         }
     }
 

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -26,6 +26,7 @@ message ProtoPersistParameters {
     optional bool pubsub_client_enabled = 10;
     optional bool pubsub_push_diff_enabled = 11;
     mz_proto.ProtoDuration consensus_tcp_user_timeout = 12;
+    optional uint64 rollup_threshold = 13;
 }
 
 message ProtoRetryParameters {

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -16,7 +16,6 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use mz_build_info::BuildInfo;
-use mz_ore::cast::CastFrom;
 use mz_ore::now::NowFn;
 use mz_persist::cfg::{BlobKnobs, ConsensusKnobs};
 use mz_persist::retry::Retry;
@@ -142,9 +141,9 @@ impl PersistConfig {
                 consensus_connect_timeout: RwLock::new(Self::DEFAULT_CRDB_CONNECT_TIMEOUT),
                 consensus_tcp_user_timeout: RwLock::new(Self::DEFAULT_CRDB_TCP_USER_TIMEOUT),
                 gc_blob_delete_concurrency_limit: AtomicUsize::new(32),
-                state_versions_recent_live_diffs_limit: AtomicUsize::new(usize::cast_from(
-                    30 * Self::NEED_ROLLUP_THRESHOLD,
-                )),
+                state_versions_recent_live_diffs_limit: AtomicUsize::new(
+                    30 * Self::DEFAULT_ROLLUP_THRESHOLD,
+                ),
                 usage_state_fetch_concurrency_limit: AtomicUsize::new(8),
                 sink_minimum_batch_updates: AtomicUsize::new(
                     Self::DEFAULT_SINK_MINIMUM_BATCH_UPDATES,
@@ -158,6 +157,7 @@ impl PersistConfig {
                 stats_filter_enabled: AtomicBool::new(Self::DEFAULT_STATS_FILTER_ENABLED),
                 pubsub_client_enabled: AtomicBool::new(Self::DEFAULT_PUBSUB_CLIENT_ENABLED),
                 pubsub_push_diff_enabled: AtomicBool::new(Self::DEFAULT_PUBSUB_PUSH_DIFF_ENABLED),
+                rollup_threshold: AtomicUsize::new(Self::DEFAULT_ROLLUP_THRESHOLD),
             }),
             compaction_enabled: !compaction_disabled,
             compaction_concurrency_limit: 5,
@@ -230,6 +230,8 @@ impl PersistConfig {
     pub const DEFAULT_PUBSUB_CLIENT_ENABLED: bool = false;
     /// Default value for [`DynamicConfig::pubsub_push_diff_enabled`].
     pub const DEFAULT_PUBSUB_PUSH_DIFF_ENABLED: bool = true;
+    /// Default value for [`DynamicConfig::rollup_threshold`].
+    pub const DEFAULT_ROLLUP_THRESHOLD: usize = 128;
 
     /// Default value for [`PersistConfig::sink_minimum_batch_updates`].
     pub const DEFAULT_SINK_MINIMUM_BATCH_UPDATES: usize = 0;
@@ -246,9 +248,6 @@ impl PersistConfig {
     // MIGRATION: Remove this once we remove the ReaderState <->
     // ProtoReaderState migration.
     pub(crate) const DEFAULT_READ_LEASE_DURATION: Duration = Duration::from_secs(60 * 15);
-
-    // Tuning notes: Picked arbitrarily.
-    pub(crate) const NEED_ROLLUP_THRESHOLD: u64 = 128;
 
     // TODO: Get rid of this in favor of using PersistParameters at the
     // relevant callsites.
@@ -328,6 +327,7 @@ pub struct DynamicConfig {
     stats_filter_enabled: AtomicBool,
     pubsub_client_enabled: AtomicBool,
     pubsub_push_diff_enabled: AtomicBool,
+    rollup_threshold: AtomicUsize,
 
     // NB: These parameters are not atomically updated together in LD.
     // We put them under a single RwLock to reduce the cost of reads
@@ -531,6 +531,12 @@ impl DynamicConfig {
         self.pubsub_push_diff_enabled.load(Self::LOAD_ORDERING)
     }
 
+    /// Determines how often to write rollups, assigning a maintenance task
+    /// after `rollup_threshold` seqnos have passed since the last rollup.
+    pub fn rollup_threshold(&self) -> usize {
+        self.rollup_threshold.load(Self::LOAD_ORDERING)
+    }
+
     /// The maximum number of concurrent state fetches during usage computation.
     pub fn usage_state_fetch_concurrency_limit(&self) -> usize {
         self.usage_state_fetch_concurrency_limit
@@ -615,6 +621,8 @@ pub struct PersistParameters {
     pub pubsub_client_enabled: Option<bool>,
     /// Configures [`DynamicConfig::pubsub_push_diff_enabled`]
     pub pubsub_push_diff_enabled: Option<bool>,
+    /// Configures [`DynamicConfig::rollup_threshold`]
+    pub rollup_threshold: Option<usize>,
 }
 
 impl PersistParameters {
@@ -635,6 +643,7 @@ impl PersistParameters {
             stats_filter_enabled: self_stats_filter_enabled,
             pubsub_client_enabled: self_pubsub_client_enabled,
             pubsub_push_diff_enabled: self_pubsub_push_diff_enabled,
+            rollup_threshold: self_rollup_threshold,
         } = self;
         let Self {
             blob_target_size: other_blob_target_size,
@@ -649,6 +658,7 @@ impl PersistParameters {
             stats_filter_enabled: other_stats_filter_enabled,
             pubsub_client_enabled: other_pubsub_client_enabled,
             pubsub_push_diff_enabled: other_pubsub_push_diff_enabled,
+            rollup_threshold: other_rollup_threshold,
         } = other;
         if let Some(v) = other_blob_target_size {
             *self_blob_target_size = Some(v);
@@ -686,6 +696,9 @@ impl PersistParameters {
         if let Some(v) = other_pubsub_push_diff_enabled {
             *self_pubsub_push_diff_enabled = Some(v)
         }
+        if let Some(v) = other_rollup_threshold {
+            *self_rollup_threshold = Some(v)
+        }
     }
 
     /// Return whether all parameters are unset.
@@ -707,6 +720,7 @@ impl PersistParameters {
             stats_filter_enabled,
             pubsub_client_enabled,
             pubsub_push_diff_enabled,
+            rollup_threshold,
         } = self;
         blob_target_size.is_none()
             && compaction_minimum_timeout.is_none()
@@ -720,6 +734,7 @@ impl PersistParameters {
             && stats_filter_enabled.is_none()
             && pubsub_client_enabled.is_none()
             && pubsub_push_diff_enabled.is_none()
+            && rollup_threshold.is_none()
     }
 
     /// Applies the parameter values to persist's in-memory config object.
@@ -742,6 +757,7 @@ impl PersistParameters {
             stats_filter_enabled,
             pubsub_client_enabled,
             pubsub_push_diff_enabled,
+            rollup_threshold,
         } = self;
         if let Some(blob_target_size) = blob_target_size {
             cfg.dynamic
@@ -811,6 +827,11 @@ impl PersistParameters {
                 .pubsub_push_diff_enabled
                 .store(*pubsub_push_diff_enabled, DynamicConfig::STORE_ORDERING);
         }
+        if let Some(rollup_threshold) = rollup_threshold {
+            cfg.dynamic
+                .rollup_threshold
+                .store(*rollup_threshold, DynamicConfig::STORE_ORDERING);
+        }
     }
 }
 
@@ -831,6 +852,7 @@ impl RustType<ProtoPersistParameters> for PersistParameters {
             stats_filter_enabled: self.stats_filter_enabled.into_proto(),
             pubsub_client_enabled: self.pubsub_client_enabled.into_proto(),
             pubsub_push_diff_enabled: self.pubsub_push_diff_enabled.into_proto(),
+            rollup_threshold: self.rollup_threshold.into_proto(),
         }
     }
 
@@ -850,6 +872,7 @@ impl RustType<ProtoPersistParameters> for PersistParameters {
             stats_filter_enabled: proto.stats_filter_enabled.into_rust()?,
             pubsub_client_enabled: proto.pubsub_client_enabled.into_rust()?,
             pubsub_push_diff_enabled: proto.pubsub_push_diff_enabled.into_rust()?,
+            rollup_threshold: proto.rollup_threshold.into_rust()?,
         })
     }
 }

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -535,6 +535,11 @@ impl DynamicConfig {
 
     /// Determines how often to write rollups, assigning a maintenance task
     /// after `rollup_threshold` seqnos have passed since the last rollup.
+    ///
+    /// Tuning note: in the absence of a long reader seqno hold, and with
+    /// incremental GC, this threshold will determine about how many live
+    /// diffs are held in Consensus. Lowering this value decreases the live
+    /// diff count at the cost of more maintenance work + blob writes.
     pub fn rollup_threshold(&self) -> usize {
         self.rollup_threshold.load(Self::LOAD_ORDERING)
     }

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -243,6 +243,8 @@ impl PersistConfig {
         clamp: Duration::from_secs(16),
     };
 
+    pub(crate) const DEFAULT_FALLBACK_ROLLUP_THRESHOLD_MULTIPLIER: usize = 3;
+
     // Move this to a PersistConfig field when we actually have read leases.
     //
     // MIGRATION: Remove this once we remove the ReaderState <->

--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -365,7 +365,7 @@ where
 
                 let maintenance = RoutineMaintenance {
                     garbage_collection,
-                    write_rollup: state.need_rollup(),
+                    write_rollup: state.need_rollup(cfg),
                 };
 
                 ApplyCmdResult::Committed((diff, state, work_ret, maintenance))

--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -365,7 +365,7 @@ where
 
                 let maintenance = RoutineMaintenance {
                     garbage_collection,
-                    write_rollup: state.need_rollup(cfg),
+                    write_rollup: state.need_rollup(cfg.dynamic.rollup_threshold()),
                 };
 
                 ApplyCmdResult::Committed((diff, state, work_ret, maintenance))

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1110,6 +1110,7 @@ pub struct ShardsMetrics {
     rollup_count: mz_ore::metrics::UIntGaugeVec,
     largest_batch_size: mz_ore::metrics::UIntGaugeVec,
     seqnos_held: mz_ore::metrics::UIntGaugeVec,
+    seqnos_since_last_rollup: mz_ore::metrics::IntGaugeVec,
     gc_seqno_held_parts: mz_ore::metrics::UIntGaugeVec,
     gc_live_diffs: mz_ore::metrics::UIntGaugeVec,
     gc_finished: mz_ore::metrics::IntCounterVec,
@@ -1330,6 +1331,7 @@ pub struct ShardMetrics {
     pub update_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     pub rollup_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     pub seqnos_held: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    pub seqnos_since_last_rollup: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     pub gc_seqno_held_parts: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     pub gc_live_diffs: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     pub usage_current_state_batches_bytes: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
@@ -1386,6 +1388,9 @@ impl ShardMetrics {
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
             seqnos_held: shards_metrics
                 .seqnos_held
+                .get_delete_on_drop_gauge(vec![shard.clone()]),
+            seqnos_since_last_rollup: shards_metrics
+                .seqnos_since_last_rollup
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
             gc_seqno_held_parts: shards_metrics
                 .gc_seqno_held_parts

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1110,7 +1110,7 @@ pub struct ShardsMetrics {
     rollup_count: mz_ore::metrics::UIntGaugeVec,
     largest_batch_size: mz_ore::metrics::UIntGaugeVec,
     seqnos_held: mz_ore::metrics::UIntGaugeVec,
-    seqnos_since_last_rollup: mz_ore::metrics::IntGaugeVec,
+    seqnos_since_last_rollup: mz_ore::metrics::UIntGaugeVec,
     gc_seqno_held_parts: mz_ore::metrics::UIntGaugeVec,
     gc_live_diffs: mz_ore::metrics::UIntGaugeVec,
     gc_finished: mz_ore::metrics::IntCounterVec,
@@ -1201,6 +1201,11 @@ impl ShardsMetrics {
             seqnos_held: registry.register(metric!(
                 name: "mz_persist_shard_seqnos_held",
                 help: "maximum count of gc-ineligible states by shard",
+                var_labels: ["shard"],
+            )),
+            seqnos_since_last_rollup: registry.register(metric!(
+                name: "mz_persist_shard_seqnos_since_last_rollup",
+                help: "count of seqnos since last rollup",
                 var_labels: ["shard"],
             )),
             gc_seqno_held_parts: registry.register(metric!(

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -2320,9 +2320,10 @@ pub(crate) mod tests {
         );
 
         // and ensure that after a fallback point, we assign every seqno work
-        let fallback_seqno = SeqNo(u64::cast_from(
-            rollup_seqno.0 * PersistConfig::DEFAULT_FALLBACK_ROLLUP_THRESHOLD_MULTIPLIER,
-        ));
+        let fallback_seqno = SeqNo(
+            rollup_seqno.0
+                * u64::cast_from(PersistConfig::DEFAULT_FALLBACK_ROLLUP_THRESHOLD_MULTIPLIER),
+        );
         state.seqno = fallback_seqno;
         assert_eq!(
             state.need_rollup(ROLLUP_THRESHOLD).expect("rollup"),

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1469,6 +1469,7 @@ pub(crate) mod tests {
     use proptest::prelude::*;
     use proptest::strategy::ValueTree;
 
+    use crate::internal::paths::RollupId;
     use crate::internal::trace::tests::any_trace;
     use crate::InvalidUsage::{InvalidBounds, InvalidEmptyTimeInterval};
 

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1350,9 +1350,10 @@ where
         ret
     }
 
-    pub fn need_rollup(&self) -> Option<SeqNo> {
+    pub fn need_rollup(&self, cfg: &PersistConfig) -> Option<SeqNo> {
         let (latest_rollup_seqno, _) = self.latest_rollup();
-        if self.seqno.0.saturating_sub(latest_rollup_seqno.0) > PersistConfig::NEED_ROLLUP_THRESHOLD
+        if self.seqno.0.saturating_sub(latest_rollup_seqno.0)
+            > u64::cast_from(cfg.dynamic.rollup_threshold())
         {
             Some(self.seqno)
         } else {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1350,11 +1350,9 @@ where
         ret
     }
 
-    pub fn need_rollup(&self, cfg: &PersistConfig) -> Option<SeqNo> {
+    pub fn need_rollup(&self, threshold: usize) -> Option<SeqNo> {
         let (latest_rollup_seqno, _) = self.latest_rollup();
-        if self.seqno.0.saturating_sub(latest_rollup_seqno.0)
-            > u64::cast_from(cfg.dynamic.rollup_threshold())
-        {
+        if self.seqno.0.saturating_sub(latest_rollup_seqno.0) > u64::cast_from(threshold) {
             Some(self.seqno)
         } else {
             None

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -273,6 +273,12 @@ impl StateVersions {
 
                 shard_metrics.set_since(new_state.since());
                 shard_metrics.set_upper(new_state.upper());
+                shard_metrics.seqnos_since_last_rollup.set(
+                    new_state
+                        .seqno
+                        .0
+                        .saturating_sub(new_state.latest_rollup().0 .0),
+                );
                 shard_metrics
                     .spine_batch_count
                     .set(u64::cast_from(new_state.spine_batch_count()));

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -820,6 +820,14 @@ const PERSIST_PUBSUB_PUSH_DIFF_ENABLED: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
+/// Controls [`mz_persist_client::cfg::DynamicConfig::rollup_threshold`].
+const PERSIST_ROLLUP_THRESHOLD: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("persist_rollup_threshold"),
+    value: &PersistConfig::DEFAULT_ROLLUP_THRESHOLD,
+    description: "The number of seqnos between rollups.",
+    internal: true,
+};
+
 /// Boolean flag indicating that the remote configuration was synchronized at
 /// least once with the persistent [SessionVars].
 pub static CONFIG_HAS_SYNCED_ONCE: ServerVar<bool> = ServerVar {
@@ -1658,6 +1666,7 @@ impl SystemVars {
             .with_var(&PERSIST_STATS_FILTER_ENABLED)
             .with_var(&PERSIST_PUBSUB_CLIENT_ENABLED)
             .with_var(&PERSIST_PUBSUB_PUSH_DIFF_ENABLED)
+            .with_var(&PERSIST_ROLLUP_THRESHOLD)
             .with_var(&METRICS_RETENTION)
             .with_var(&UNSAFE_MOCK_AUDIT_EVENT_TIMESTAMP)
             .with_var(&ENABLE_LD_RBAC_CHECKS)
@@ -2103,6 +2112,11 @@ impl SystemVars {
     /// Returns the `persist_pubsub_push_diff_enabled` configuration parameter.
     pub fn persist_pubsub_push_diff_enabled(&self) -> bool {
         *self.expect_value(&PERSIST_PUBSUB_PUSH_DIFF_ENABLED)
+    }
+
+    /// Returns the `persist_rollup_threshold` configuration parameter.
+    pub fn persist_rollup_threshold(&self) -> usize {
+        *self.expect_value(&PERSIST_ROLLUP_THRESHOLD)
     }
 
     /// Returns the `metrics_retention` configuration parameter.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

1) Makes our rollup threshold configurable via LD
2) Makes `need_rollup` trigger every `rollup_threshold` past the latest rollup seqno, but not for every seqno greater than the threshold

This latter change will be important when we [stop writing rollups in GC](https://github.com/MaterializeInc/materialize/issues/18419), so CaS operations don't get redundantly assigned rollup work once the threshold is hit.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
