### PR TITLE
test: fix feature flags for more nightly tests

### DIFF
--- a/misc/python/materialize/checks/multiple_partitions.py
+++ b/misc/python/materialize/checks/multiple_partitions.py
@@ -27,15 +27,10 @@ class MultiplePartitions(Check):
             schemas()
             + dedent(
                 """
-                $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
                 ALTER SYSTEM SET enable_create_source_denylist_with_options = true
                 ALTER SYSTEM SET enable_kafka_config_denylist_options = true
-                """
-                if self.current_version >= MzVersion(0, 55, 0)
-                else ""
-            )
-            + dedent(
-                """
+
                 $ kafka-create-topic topic=multiple-partitions-topic
 
                 # ingest A-key entries


### PR DESCRIPTION
Fix another round of nightly test failures.

### Motivation

This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
