### PR TITLE
pg_catalog: Add pg_tablespace table

### DIFF
--- a/doc/user/content/sql/system-catalog/pg_catalog.md
+++ b/doc/user/content/sql/system-catalog/pg_catalog.md
@@ -29,6 +29,7 @@ system catalog](https://www.postgresql.org/docs/current/catalogs.html):
   * [`pg_roles`](https://www.postgresql.org/docs/current/view-pg-roles.html)
   * [`pg_settings`](https://www.postgresql.org/docs/current/view-pg-settings.html)
   * [`pg_tables`](https://www.postgresql.org/docs/current/view-pg-tables.html)
+  * [`pg_tablespace`](https://www.postgresql.org/docs/current/catalog-pg-tablespace.html)
   * [`pg_type`](https://www.postgresql.org/docs/current/catalog-pg-type.html)
   * [`pg_views`](https://www.postgresql.org/docs/current/view-pg-views.html)
   * [`pg_authid`](https://www.postgresql.org/docs/current/catalog-pg-authid.html)

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2975,6 +2975,24 @@ LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 WHERE c.relkind IN ('r', 'p')",
 };
 
+pub const PG_TABLESPACE: BuiltinView = BuiltinView {
+    name: "pg_tablespace",
+    schema: PG_CATALOG_SCHEMA,
+    sql: "CREATE VIEW pg_catalog.pg_tablespace AS
+    SELECT oid, spcname, spcowner, spcacl, spcoptions
+    FROM (
+        VALUES (
+            --These are the same defaults CockroachDB uses.
+            0::pg_catalog.oid,
+            'pg_default'::pg_catalog.text,
+            NULL::pg_catalog.oid,
+            NULL::pg_catalog.text[],
+            NULL::pg_catalog.text[]
+        )
+    ) AS _ (oid, spcname, spcowner, spcacl, spcoptions)
+",
+};
+
 pub const PG_ACCESS_METHODS: BuiltinView = BuiltinView {
     name: "pg_am",
     schema: PG_CATALOG_SCHEMA,
@@ -3754,6 +3772,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&PG_AUTH_MEMBERS),
         Builtin::View(&PG_CONSTRAINT),
         Builtin::View(&PG_TABLES),
+        Builtin::View(&PG_TABLESPACE),
         Builtin::View(&PG_ACCESS_METHODS),
         Builtin::View(&PG_AUTHID),
         Builtin::View(&PG_ROLES),

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -597,6 +597,10 @@ pg_tables
 VIEW
 materialize
 pg_catalog
+pg_tablespace
+VIEW
+materialize
+pg_catalog
 pg_type
 VIEW
 materialize

--- a/test/sqllogictest/pg_catalog_tablespace.slt
+++ b/test/sqllogictest/pg_catalog_tablespace.slt
@@ -1,0 +1,18 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+# Start from a pristine server
+reset-server
+
+query ITTTT
+SELECT * FROM pg_tablespace ORDER BY oid
+----
+0 pg_default NULL NULL NULL

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -156,3 +156,12 @@ name                nullable    type
  member             false       oid
  grantor            false       oid
  admin_option       false       boolean
+
+> SHOW COLUMNS FROM pg_tablespace
+name                nullable    type
+------------------------------------------------------------
+ oid                false       oid
+ spcname            false       text
+ spcowner           true        oid
+ spcacl             true        text[]
+ spcoptions         true        text[]


### PR DESCRIPTION
### Motivation

Makes progress towards #9720 

This PR adds the [`pg_tablespace`](https://www.postgresql.org/docs/current/catalog-pg-tablespace.html) catalog table, which is required to support DataGrip. Materialize doesn't support Tablespaces, the defaults I added in the view are the same ones that CockroachDB uses. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds support for the `pg_catalog.pg_tablespaces` table, with default values. Note: Materialize does not support Tablespaces, adding this table is to support tools that require it exists.
