### PR TITLE
pg_catalog: Add missing columns to pg_roles

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -3001,6 +3001,8 @@ pub const PG_ROLES: BuiltinView = BuiltinView {
     '********'::pg_catalog.text AS rolpassword,
     r.rolvaliduntil,
     r.rolbypassrls,
+    --Note: this is NULL because Materialize doesn't support Role-specific config values.
+    NULL::pg_catalog.text[] as rolconfig,
     r.oid AS oid
 FROM pg_catalog.pg_authid r",
 };


### PR DESCRIPTION
### Motivation

Makes progress towards #9720 

This PR adds the `rolconfig` column to the [`pg_roles`](https://www.postgresql.org/docs/current/view-pg-roles.html) catalog table. We don't support Role-specific configuration values so the list is always null. I double checked this behavior with @jkosh44.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds the `rolconfig` column to the `pg_catalog.pg_roles` table. The value of this column is always NULL, but allows tools that require the column to work.
