### PR TITLE
slt: Enable table keys for sqlite tests

### DIFF
--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -31,7 +31,7 @@ sqllogictest \
     test/sqllogictest/transform/*.slt \
     | tee -a target/slt.log
 
-sqllogictest --auto-index-tables --auto-transactions \
+sqllogictest --auto-index-tables --auto-transactions --enable-table-keys \
     -v "$@" \
     test/sqllogictest/sqlite/test \
     | tee -a target/slt.log

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -126,6 +126,9 @@ struct Args {
     /// ported SQLite SLT files. Does not work generally, so don't use it for other tests.
     #[clap(long)]
     auto_transactions: bool,
+    /// Inject `ALTER SYSTEM SET enable_table_keys = true` before running the SLT file.
+    #[clap(long)]
+    enable_table_keys: bool,
 }
 
 #[tokio::main]
@@ -144,6 +147,7 @@ async fn main() -> ExitCode {
         fail_fast: args.fail_fast,
         auto_index_tables: args.auto_index_tables,
         auto_transactions: args.auto_transactions,
+        enable_table_keys: args.enable_table_keys,
     };
 
     if args.rewrite_results {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -981,6 +981,13 @@ impl RunnerInner {
             .await
             .unwrap();
 
+        if config.enable_table_keys {
+            system_client
+                .simple_query("ALTER SYSTEM SET enable_table_keys = true")
+                .await
+                .unwrap();
+        }
+
         Ok(RunnerInner {
             server_addr,
             internal_server_addr,
@@ -1432,6 +1439,7 @@ pub struct RunConfig<'a> {
     pub fail_fast: bool,
     pub auto_index_tables: bool,
     pub auto_transactions: bool,
+    pub enable_table_keys: bool,
 }
 
 fn print_record(config: &RunConfig<'_>, record: &Record) {


### PR DESCRIPTION
So that we don't have to touch the tests, which would be a rather huge change:
https://github.com/def-/sqllogictest/commit/7fad3c9cd88879c19c04c6b66f2471c0e199fd33

Many sqlite tests require --enable-table-keys, so it might make sense to use it for all of them instead of filtering them:
https://buildkite.com/materialize/sql-logic-tests/builds/5546#0188433b-9d55-4b22-930d-b1cddcd626b5

I'll wait for full SLT run on this to see if it fixes all the issues: https://buildkite.com/materialize/sql-logic-tests/builds/5547

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
