### PR TITLE
sql: refactor session vars

### DIFF
--- a/src/adapter/src/config/mod.rs
+++ b/src/adapter/src/config/mod.rs
@@ -54,9 +54,11 @@ pub async fn system_parameter_sync(
     loop {
         interval.tick().await;
         backend.pull(&mut params).await;
-        let launchdarkly_enabled =
-            <bool as Value>::parse(VarInput::Flat(&params.get(ENABLE_LAUNCHDARKLY.name())))
-                .expect("This is known to be a bool");
+        let launchdarkly_enabled = <bool as Value>::parse(
+            &ENABLE_LAUNCHDARKLY,
+            VarInput::Flat(&params.get(ENABLE_LAUNCHDARKLY.name())),
+        )
+        .expect("This is known to be a bool");
         if launchdarkly_enabled && frontend.pull(&mut params) {
             backend.push(&mut params).await;
         }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1855,7 +1855,10 @@ impl SystemVars {
             .with_var(&MAX_MATERIALIZED_VIEWS)
             .with_var(&MAX_CLUSTERS)
             .with_var(&MAX_REPLICAS_PER_CLUSTER)
-            .with_var(&MAX_CREDIT_CONSUMPTION_RATE)
+            .with_constrained_var(
+                &MAX_CREDIT_CONSUMPTION_RATE,
+                ValueConstraint::Domain(&NumericNonNegNonNan),
+            )
             .with_var(&MAX_DATABASES)
             .with_var(&MAX_SCHEMAS_PER_DATABASE)
             .with_var(&MAX_OBJECTS_PER_SCHEMA)
@@ -1919,6 +1922,16 @@ impl SystemVars {
 
     pub fn allow_unsafe(&self) -> bool {
         self.allow_unsafe
+    }
+
+    fn with_constrained_var<V>(mut self, var: &'static ServerVar<V>, c: ValueConstraint<V>) -> Self
+    where
+        V: Value + Debug + PartialEq + Clone + 'static,
+        V::Owned: Debug + Send + Clone + Sync,
+    {
+        self.vars
+            .insert(var.name, Box::new(SystemVar::new(var).with_constraint(c)));
+        self
     }
 
     fn expect_value<V>(&self, var: &ServerVar<V>) -> &V
@@ -2419,7 +2432,7 @@ where
 
 impl<V> Var for ServerVar<V>
 where
-    V: Value + Debug + 'static,
+    V: Value + Debug + PartialEq + 'static,
 {
     fn name(&self) -> &'static str {
         self.name.as_str()
@@ -2458,25 +2471,27 @@ where
 #[derive(Debug)]
 struct SystemVar<V>
 where
-    V: Value + Debug + 'static,
-    V::Owned: Debug,
+    V: Value + Debug + PartialEq + 'static,
+    V::Owned: Debug + Clone + Send + Sync,
 {
     persisted_value: Option<V::Owned>,
     dynamic_default: Option<V::Owned>,
     parent: &'static ServerVar<V>,
+    constraints: Vec<ValueConstraint<V>>,
 }
 
 // The derived `Clone` implementation requires `V: Clone`, which is not needed.
 impl<V> Clone for SystemVar<V>
 where
-    V: Value + Debug + 'static,
-    V::Owned: Debug + Clone,
+    V: Value + Debug + PartialEq + 'static,
+    V::Owned: Debug + Clone + Send + Sync,
 {
     fn clone(&self) -> Self {
         SystemVar {
             persisted_value: self.persisted_value.clone(),
             dynamic_default: self.dynamic_default.clone(),
             parent: self.parent,
+            constraints: self.constraints.clone(),
         }
     }
 }
@@ -2484,14 +2499,36 @@ where
 impl<V> SystemVar<V>
 where
     V: Value + Debug + PartialEq + 'static,
-    V::Owned: Debug,
+    V::Owned: Debug + Clone + Send + Sync,
 {
     fn new(parent: &'static ServerVar<V>) -> SystemVar<V> {
         SystemVar {
             persisted_value: None,
             dynamic_default: None,
             parent,
+            constraints: vec![],
         }
+    }
+
+    fn with_constraint(mut self, c: ValueConstraint<V>) -> SystemVar<V> {
+        assert!(
+            !self
+                .constraints
+                .iter()
+                .any(|c| matches!(c, ValueConstraint::ReadOnly | ValueConstraint::Fixed)),
+            "fixed value and read only params do not support any other constraints"
+        );
+        self.constraints.push(c);
+        self
+    }
+
+    fn check_constraints(&self, v: &V::Owned) -> Result<(), VarError> {
+        let cur_v = self.value();
+        for constraint in &self.constraints {
+            constraint.check_constraint(self, cur_v, v)?;
+        }
+
+        Ok(())
     }
 
     fn persisted_value(&self) -> Option<&V> {
@@ -2514,7 +2551,7 @@ where
 impl<V> Var for SystemVar<V>
 where
     V: Value + Debug + PartialEq + 'static,
-    V::Owned: Debug,
+    V::Owned: Debug + Clone + Send + Sync,
 {
     fn name(&self) -> &'static str {
         self.parent.name()
@@ -2564,7 +2601,9 @@ where
 
     fn set(&mut self, input: VarInput) -> Result<bool, VarError> {
         match V::parse(input) {
-            Ok(v) => {
+            Ok(mut v) => {
+                self.check_constraints(&v)?;
+
                 if self.persisted_value() != Some(v.borrow()) {
                     self.persisted_value = Some(v);
                     Ok(true)
@@ -2657,7 +2696,7 @@ impl FeatureFlag {
 #[derive(Debug)]
 struct SessionVar<V>
 where
-    V: Value + Debug + 'static,
+    V: Value + ToOwned + Debug + PartialEq + 'static,
 {
     default_value: &'static V,
     local_value: Option<V::Owned>,
@@ -2671,7 +2710,7 @@ where
 #[derive(Debug)]
 enum ValueConstraint<V>
 where
-    V: ToOwned + Debug + ?Sized + 'static,
+    V: Value + ToOwned + Debug + PartialEq + 'static,
 {
     Fixed,
     ReadOnly,
@@ -2679,17 +2718,55 @@ where
     Domain(&'static dyn DomainConstraint<V>),
 }
 
+impl<V> ValueConstraint<V>
+where
+    V: Value + ToOwned + Debug + PartialEq + 'static,
+{
+    fn check_constraint(
+        &self,
+        var: &(dyn Var + Send + Sync),
+        cur_value: &V,
+        new_value: &V::Owned,
+    ) -> Result<(), VarError> {
+        match self {
+            ValueConstraint::ReadOnly => return Err(VarError::ReadOnlyParameter(var.name())),
+            ValueConstraint::Fixed => {
+                if cur_value != new_value.borrow() {
+                    return Err(VarError::FixedValueParameter(var.into()));
+                }
+            }
+            ValueConstraint::Domain(check) => check.check(var, new_value)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl<V> Clone for ValueConstraint<V>
+where
+    V: Value + ToOwned + Debug + PartialEq + 'static,
+{
+    fn clone(&self) -> Self {
+        match self {
+            ValueConstraint::Fixed => ValueConstraint::Fixed,
+            ValueConstraint::ReadOnly => ValueConstraint::ReadOnly,
+            ValueConstraint::Domain(c) => ValueConstraint::Domain(*c),
+        }
+    }
+}
+
 trait DomainConstraint<V>: Debug + Send + Sync
 where
-    V: Value + Debug + ?Sized + 'static,
+    V: Value + Debug + PartialEq + 'static,
 {
-    // This useless `self` is just to make a trait object
-    fn check(&self, v: &V::Owned) -> Result<(), VarError>;
+    // `self` is make a trait object
+    fn check(&self, var: &(dyn Var + Send + Sync), v: &V::Owned) -> Result<(), VarError>;
 }
 
 impl<V> SessionVar<V>
 where
-    V: Value + Debug + 'static,
+    V: Value + ToOwned + Debug + PartialEq + 'static,
+    V::Owned: Debug + Send + Sync,
 {
     fn new(parent: &'static ServerVar<V>) -> SessionVar<V> {
         SessionVar {
@@ -2755,7 +2832,12 @@ where
     }
 
     fn check_constraints(&self, v: &V::Owned) -> Result<(), VarError> {
-        todo!()
+        let cur_v = self.value();
+        for constraint in &self.constraints {
+            constraint.check_constraint(self, cur_v, v)?;
+        }
+
+        Ok(())
     }
 
     fn reset(&mut self, local: bool) {
@@ -2790,8 +2872,8 @@ where
 
 impl<V> Var for SessionVar<V>
 where
-    V: Value + Debug + 'static,
-    V::Owned: Debug,
+    V: Value + ToOwned + Debug + PartialEq + 'static,
+    V::Owned: Debug + Send + Sync,
 {
     fn name(&self) -> &'static str {
         self.parent.name()
@@ -2965,6 +3047,23 @@ impl Value for usize {
     }
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct NumericNonNegNonNan;
+
+impl DomainConstraint<Numeric> for NumericNonNegNonNan {
+    fn check(&self, var: &(dyn Var + Send + Sync), n: &Numeric) -> Result<(), VarError> {
+        if n.is_nan() || n.is_negative() {
+            Err(VarError::InvalidParameterValue {
+                parameter: var.into(),
+                values: vec![n.to_string()],
+                reason: "only supports non-negative, non-NaN numeric values".to_string(),
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
 impl Value for Numeric {
     fn type_name() -> String {
         "numeric".to_string()
@@ -2972,19 +3071,8 @@ impl Value for Numeric {
 
     fn parse(input: VarInput) -> Result<Self::Owned, ()> {
         let s = extract_single_value(input)?;
-        let n: Numeric = s.parse().map_err(|_| ())?;
-        // TODO(jkosh44) This is a hacky way of of imposing validations on Numerics. Ideally this type
-        //  of validation should be specific to the variable that requires it, not all Numerics.
-        //  Additionally, it should return an InvalidParameterValue error, but this eventually gets
-        //  turned into an InvalidParameterType error. Unfortunately, SystemVars has no way of doing
-        //  this kind of validation.
-        // NaN and negatives are not valid values. Positive infinity is allowed because it's useful
-        // to signify that there is no limit.
-        if n.is_nan() || n.is_negative() {
-            Err(())
-        } else {
-            Ok(n)
-        }
+        let n = s.parse().map_err(|_| ())?;
+        Ok(n)
     }
 
     fn format(&self) -> String {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2373,9 +2373,8 @@ where
     }
 
     fn set(&mut self, input: VarInput) -> Result<bool, VarError> {
-        let mut v = V::parse(self, input)?;
+        let v = V::parse(self, input)?;
 
-        V::canonicalize(&mut v);
         self.check_constraints(&v)?;
 
         if self.persisted_value() != Some(v.borrow()) {
@@ -2647,9 +2646,8 @@ where
 
     /// Parse the input and update the stored value to match.
     fn set(&mut self, input: VarInput, local: bool) -> Result<(), VarError> {
-        let mut v = V::parse(self, input)?;
+        let v = V::parse(self, input)?;
 
-        V::canonicalize(&mut v);
         self.check_constraints(&v)?;
 
         if local {
@@ -2731,6 +2729,7 @@ impl Var for User {
 pub trait Value: ToOwned + Send + Sync {
     /// The name of the value type.
     fn type_name() -> String;
+
     /// Parses a value of this type from a [`VarInput`].
     fn parse<'a>(
         param: &'a (dyn Var + Send + Sync),
@@ -2741,10 +2740,6 @@ pub trait Value: ToOwned + Send + Sync {
     /// The resulting string is guaranteed to be parsable if provided to
     /// [`Value::parse`] as a [`VarInput::Flat`].
     fn format(&self) -> String;
-
-    /// Mutate the provided value into the canonical form that should be stored
-    /// or compared against the stored value.
-    fn canonicalize(_: &mut Self::Owned) {}
 }
 
 fn extract_single_value<'var, 'input: 'var>(
@@ -3052,10 +3047,6 @@ impl Value for String {
 
     fn format(&self) -> String {
         self.to_owned()
-    }
-
-    fn canonicalize(v: &mut Self::Owned) {
-        *v = v.to_ascii_lowercase();
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -66,7 +66,6 @@
 use std::any::Any;
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
-use std::fmt;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -2345,7 +2344,7 @@ impl SystemVars {
 }
 
 /// A `Var` represents a configuration parameter of an arbitrary type.
-pub trait Var: fmt::Debug {
+pub trait Var: Debug {
     /// Returns the name of the configuration parameter.
     fn name(&self) -> &'static str;
 
@@ -2401,7 +2400,7 @@ pub trait VarMut: Var + Send + Sync {
 #[derive(Debug)]
 pub struct ServerVar<V>
 where
-    V: fmt::Debug + ?Sized + 'static,
+    V: Debug + ?Sized + 'static,
 {
     name: &'static UncasedStr,
     value: &'static V,
@@ -2411,7 +2410,7 @@ where
 
 impl<V> Var for ServerVar<V>
 where
-    V: Value + fmt::Debug + ?Sized + 'static,
+    V: Value + Debug + ?Sized + 'static,
 {
     fn name(&self) -> &'static str {
         self.name.as_str()
@@ -2450,8 +2449,8 @@ where
 #[derive(Debug)]
 struct SystemVar<V>
 where
-    V: Value + fmt::Debug + ?Sized + 'static,
-    V::Owned: fmt::Debug,
+    V: Value + Debug + ?Sized + 'static,
+    V::Owned: Debug,
 {
     persisted_value: Option<V::Owned>,
     dynamic_default: Option<V::Owned>,
@@ -2461,8 +2460,8 @@ where
 // The derived `Clone` implementation requires `V: Clone`, which is not needed.
 impl<V> Clone for SystemVar<V>
 where
-    V: Value + fmt::Debug + ?Sized + 'static,
-    V::Owned: fmt::Debug + Clone,
+    V: Value + Debug + ?Sized + 'static,
+    V::Owned: Debug + Clone,
 {
     fn clone(&self) -> Self {
         SystemVar {
@@ -2475,8 +2474,8 @@ where
 
 impl<V> SystemVar<V>
 where
-    V: Value + fmt::Debug + PartialEq + ?Sized + 'static,
-    V::Owned: fmt::Debug,
+    V: Value + Debug + PartialEq + ?Sized + 'static,
+    V::Owned: Debug,
 {
     fn new(parent: &'static ServerVar<V>) -> SystemVar<V> {
         SystemVar {
@@ -2505,8 +2504,8 @@ where
 
 impl<V> Var for SystemVar<V>
 where
-    V: Value + fmt::Debug + PartialEq + ?Sized + 'static,
-    V::Owned: fmt::Debug,
+    V: Value + Debug + PartialEq + ?Sized + 'static,
+    V::Owned: Debug,
 {
     fn name(&self) -> &'static str {
         self.parent.name()
@@ -2531,8 +2530,8 @@ where
 
 impl<V> VarMut for SystemVar<V>
 where
-    V: Value + fmt::Debug + PartialEq + 'static,
-    V::Owned: fmt::Debug + Clone + Send + Sync,
+    V: Value + Debug + PartialEq + 'static,
+    V::Owned: Debug + Clone + Send + Sync,
 {
     fn as_var(&self) -> &dyn Var {
         self
@@ -2649,7 +2648,7 @@ impl FeatureFlag {
 #[derive(Debug)]
 struct SessionVar<V>
 where
-    V: Value + fmt::Debug + ?Sized + 'static,
+    V: Value + Debug + ?Sized + 'static,
 {
     default_value: &'static V,
     local_value: Option<V::Owned>,
@@ -2661,7 +2660,7 @@ where
 
 impl<V> SessionVar<V>
 where
-    V: Value + fmt::Debug + ?Sized + 'static,
+    V: Value + Debug + ?Sized + 'static,
 {
     fn new(parent: &'static ServerVar<V>) -> SessionVar<V> {
         SessionVar {
@@ -2726,8 +2725,8 @@ where
 
 impl<V> Var for SessionVar<V>
 where
-    V: Value + fmt::Debug + ?Sized + 'static,
-    V::Owned: fmt::Debug,
+    V: Value + Debug + ?Sized + 'static,
+    V::Owned: Debug,
 {
     fn name(&self) -> &'static str {
         self.parent.name()

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1768,7 +1768,7 @@ impl DropConnection {
 pub struct SystemVars {
     /// Allows "unsafe" parameters to be set.
     allow_unsafe: bool,
-    vars: BTreeMap<&'static UncasedStr, Box<dyn VarMut>>,
+    vars: BTreeMap<&'static UncasedStr, Box<dyn SystemVarMut>>,
     active_connection_count: Arc<Mutex<ConnectionCounter>>,
 }
 
@@ -2344,7 +2344,7 @@ pub trait Var: Debug {
 
 /// A `Var` with additional methods for mutating the value, as well as
 /// helpers that enable various operations in a `dyn` context.
-pub trait VarMut: Var + Send + Sync {
+pub trait SystemVarMut: Var + Send + Sync {
     /// Upcast to Var, for use with `dyn`.
     fn as_var(&self) -> &dyn Var;
 
@@ -2352,7 +2352,7 @@ pub trait VarMut: Var + Send + Sync {
     fn value_any(&self) -> &(dyn Any + 'static);
 
     /// Clone, but object safe and specialized to `VarMut`.
-    fn clone_var(&self) -> Box<dyn VarMut>;
+    fn clone_var(&self) -> Box<dyn SystemVarMut>;
 
     /// Return whether or not `input` is equal to this var's default value,
     /// if there is one.
@@ -2525,7 +2525,7 @@ where
     }
 }
 
-impl<V> VarMut for SystemVar<V>
+impl<V> SystemVarMut for SystemVar<V>
 where
     V: Value + Debug + PartialEq + 'static,
     V::Owned: Debug + Clone + Send + Sync,
@@ -2539,7 +2539,7 @@ where
         value
     }
 
-    fn clone_var(&self) -> Box<dyn VarMut> {
+    fn clone_var(&self) -> Box<dyn SystemVarMut> {
         Box::new(self.clone())
     }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -294,7 +294,7 @@ const EXTRA_FLOAT_DIGITS: ServerVar<i32> = ServerVar {
 
 const FAILPOINTS: ServerVar<Failpoints> = ServerVar {
     name: UncasedStr::new("failpoints"),
-    value: &Failpoints(Ok(())),
+    value: &Failpoints,
     description: "Allows failpoints to be dynamically activated.",
     internal: false,
 };
@@ -591,9 +591,12 @@ mod upsert_rocksdb {
             "rocksdb_compaction_style".to_string()
         }
 
-        fn parse<'a>(input: VarInput) -> Result<Self::Owned, ()> {
-            let s = extract_single_value(input)?;
-            CompactionStyle::from_str(s).map_err(|_| ())
+        fn parse<'a>(
+            param: &'a (dyn Var + Send + Sync),
+            input: VarInput,
+        ) -> Result<Self::Owned, VarError> {
+            let s = extract_single_value(param, input)?;
+            CompactionStyle::from_str(s).map_err(|_| VarError::InvalidParameterType(param.into()))
         }
 
         fn format(&self) -> String {
@@ -606,9 +609,12 @@ mod upsert_rocksdb {
             "rocksdb_compression_type".to_string()
         }
 
-        fn parse<'a>(input: VarInput) -> Result<Self::Owned, ()> {
-            let s = extract_single_value(input)?;
-            CompressionType::from_str(s).map_err(|_| ())
+        fn parse<'a>(
+            param: &'a (dyn Var + Send + Sync),
+            input: VarInput,
+        ) -> Result<Self::Owned, VarError> {
+            let s = extract_single_value(param, input)?;
+            CompressionType::from_str(s).map_err(|_| VarError::InvalidParameterType(param.into()))
         }
 
         fn format(&self) -> String {
@@ -1357,20 +1363,9 @@ impl SessionVars {
         if name == APPLICATION_NAME.name {
             self.application_name.set(input, local)
         } else if name == CLIENT_ENCODING.name {
-            match extract_single_value(input) {
-                Ok(value) if UncasedStr::new(value) == CLIENT_ENCODING.value => Ok(()),
-                _ => Err(VarError::FixedValueParameter((&*CLIENT_ENCODING).into())),
-            }
+            self.client_encoding.set(input, local)
         } else if name == CLIENT_MIN_MESSAGES.name {
-            if let Ok(_) = ClientSeverity::parse(input) {
-                self.client_min_messages.set(input, local)
-            } else {
-                return Err(VarError::ConstrainedParameter {
-                    parameter: (&CLIENT_MIN_MESSAGES).into(),
-                    values: input.to_vec(),
-                    valid_values: Some(ClientSeverity::valid_values()),
-                });
-            }
+            self.client_min_messages.set(input, local)
         } else if name == CLUSTER.name {
             self.cluster.set(input, local)
         } else if name == CLUSTER_REPLICA.name {
@@ -1378,78 +1373,33 @@ impl SessionVars {
         } else if name == DATABASE.name {
             self.database.set(input, local)
         } else if name == DATE_STYLE.name {
-            let Ok(values) = Vec::<String>::parse(input) else {
-                return Err(VarError::FixedValueParameter((&*DATE_STYLE).into()));
-            };
-            for value in values {
-                let value = UncasedStr::new(value.trim());
-                if value != "ISO" && value != "MDY" {
-                    return Err(VarError::FixedValueParameter((&*DATE_STYLE).into()));
-                }
-            }
-            Ok(())
+            self.date_style.set(input, local)
         } else if name == EXTRA_FLOAT_DIGITS.name {
             self.extra_float_digits.set(input, local)
         } else if name == FAILPOINTS.name {
-            self.failpoints
-                .set(input, local)
-                .expect("failpoint setting always succeeds; errors are passed in OK valued");
-
-            let Failpoints(v) = self.failpoints.value();
-            let r = v.clone();
-            self.failpoints
-                .set(VarInput::Flat(""), local)
-                .expect("empty string always a valid failpoint");
-            r
+            self.failpoints.set(input, local)
         } else if name == INTEGER_DATETIMES.name {
-            Err(VarError::ReadOnlyParameter(INTEGER_DATETIMES.name()))
+            self.integer_datetimes.set(input, local)
         } else if name == INTERVAL_STYLE.name {
-            match extract_single_value(input) {
-                Ok(value) if UncasedStr::new(value) == INTERVAL_STYLE.value => Ok(()),
-                _ => Err(VarError::FixedValueParameter((&*INTERVAL_STYLE).into())),
-            }
+            self.interval_style.set(input, local)
         } else if name == SEARCH_PATH.name {
             self.search_path.set(input, local)
         } else if name == SERVER_VERSION.name {
-            Err(VarError::ReadOnlyParameter(SERVER_VERSION.name()))
+            self.server_version.set(input, local)
         } else if name == SERVER_VERSION_NUM.name {
-            Err(VarError::ReadOnlyParameter(SERVER_VERSION_NUM.name()))
+            self.server_version_num.set(input, local)
         } else if name == SQL_SAFE_UPDATES.name {
             self.sql_safe_updates.set(input, local)
         } else if name == STANDARD_CONFORMING_STRINGS.name {
-            match bool::parse(input) {
-                Ok(value) if value == *STANDARD_CONFORMING_STRINGS.value => Ok(()),
-                Ok(_) => Err(VarError::FixedValueParameter(
-                    (&STANDARD_CONFORMING_STRINGS).into(),
-                )),
-                Err(()) => Err(VarError::InvalidParameterType(
-                    (&STANDARD_CONFORMING_STRINGS).into(),
-                )),
-            }
+            self.standard_conforming_strings.set(input, local)
         } else if name == STATEMENT_TIMEOUT.name {
             self.statement_timeout.set(input, local)
         } else if name == IDLE_IN_TRANSACTION_SESSION_TIMEOUT.name {
             self.idle_in_transaction_session_timeout.set(input, local)
         } else if name == TIMEZONE.name {
-            if let Ok(_) = TimeZone::parse(input) {
-                self.timezone.set(input, local)
-            } else {
-                Err(VarError::ConstrainedParameter {
-                    parameter: (&TIMEZONE).into(),
-                    values: input.to_vec(),
-                    valid_values: None,
-                })
-            }
+            self.timezone.set(input, local)
         } else if name == TRANSACTION_ISOLATION.name {
-            if let Ok(_) = IsolationLevel::parse(input) {
-                self.transaction_isolation.set(input, local)
-            } else {
-                return Err(VarError::ConstrainedParameter {
-                    parameter: (&TRANSACTION_ISOLATION).into(),
-                    values: input.to_vec(),
-                    valid_values: Some(IsolationLevel::valid_values()),
-                });
-            }
+            self.transaction_isolation.set(input, local)
         } else if name == REAL_TIME_RECENCY.name {
             self.real_time_recency.set(input, local)
         } else if name == EMIT_TIMESTAMP_NOTICE.name {
@@ -2594,25 +2544,21 @@ where
     }
 
     fn is_default(&self, input: VarInput) -> Result<bool, VarError> {
-        match V::parse(input) {
-            Ok(v) => Ok(self.parent.value == v.borrow()),
-            Err(()) => Err(VarError::InvalidParameterType(self.parent.into())),
-        }
+        let v = V::parse(self, input)?;
+        Ok(self.parent.value == v.borrow())
     }
 
     fn set(&mut self, input: VarInput) -> Result<bool, VarError> {
-        match V::parse(input) {
-            Ok(v) => {
-                self.check_constraints(&v)?;
+        let mut v = V::parse(self, input)?;
 
-                if self.persisted_value() != Some(v.borrow()) {
-                    self.persisted_value = Some(v);
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-            Err(()) => Err(VarError::InvalidParameterType(self.parent.into())),
+        V::canonicalize(&mut v);
+        self.check_constraints(&v)?;
+
+        if self.persisted_value() != Some(v.borrow()) {
+            self.persisted_value = Some(v);
+            Ok(true)
+        } else {
+            Ok(false)
         }
     }
 
@@ -2626,13 +2572,9 @@ where
     }
 
     fn set_default(&mut self, input: VarInput) -> Result<(), VarError> {
-        match V::parse(input) {
-            Ok(v) => {
-                self.dynamic_default = Some(v);
-                Ok(())
-            }
-            Err(()) => Err(VarError::InvalidParameterType(self.parent.into())),
-        }
+        let v = V::parse(self, input)?;
+        self.dynamic_default = Some(v);
+        Ok(())
     }
 }
 
@@ -2817,20 +2759,18 @@ where
     }
 
     fn set(&mut self, input: VarInput, local: bool) -> Result<(), VarError> {
-        match V::parse(input) {
-            Ok(mut v) => {
-                V::canonicalize(&mut v);
-                self.check_constraints(&v)?;
-                if local {
-                    self.local_value = Some(v);
-                } else {
-                    self.local_value = None;
-                    self.staged_value = Some(v);
-                }
-                Ok(())
-            }
-            Err(()) => Err(VarError::InvalidParameterType(self.parent.into())),
+        let mut v = V::parse(self, input)?;
+
+        V::canonicalize(&mut v);
+        self.check_constraints(&v)?;
+
+        if local {
+            self.local_value = Some(v);
+        } else {
+            self.local_value = None;
+            self.staged_value = Some(v);
         }
+        Ok(())
     }
 
     fn check_constraints(&self, v: &V::Owned) -> Result<(), VarError> {
@@ -2951,7 +2891,10 @@ pub trait Value: ToOwned + Send + Sync {
     /// The name of the value type.
     fn type_name() -> String;
     /// Parses a value of this type from a [`VarInput`].
-    fn parse(input: VarInput) -> Result<Self::Owned, ()>;
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError>;
     /// Formats this value as a flattened string.
     ///
     /// The resulting string is guaranteed to be parsable if provided to
@@ -2963,11 +2906,18 @@ pub trait Value: ToOwned + Send + Sync {
     fn canonicalize(_: &mut Self::Owned) {}
 }
 
-fn extract_single_value(input: VarInput) -> Result<&str, ()> {
+fn extract_single_value<'var, 'input: 'var>(
+    param: &'var (dyn Var + Send + Sync),
+    input: VarInput<'input>,
+) -> Result<&'input str, VarError> {
     match input {
         VarInput::Flat(value) => Ok(value),
         VarInput::SqlSet([value]) => Ok(value),
-        _ => Err(()),
+        VarInput::SqlSet(values) => Err(VarError::InvalidParameterValue {
+            parameter: param.into(),
+            values: values.to_vec(),
+            reason: "expects a single value".to_string(),
+        }),
     }
 }
 
@@ -2976,12 +2926,12 @@ impl Value for bool {
         "boolean".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<Self, ()> {
-        let s = extract_single_value(input)?;
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<Self, VarError> {
+        let s = extract_single_value(param, input)?;
         match s {
             "t" | "true" | "on" => Ok(true),
             "f" | "false" | "off" => Ok(false),
-            _ => Err(()),
+            _ => Err(VarError::InvalidParameterType(param.into())),
         }
     }
 
@@ -2998,9 +2948,10 @@ impl Value for i32 {
         "integer".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<i32, ()> {
-        let s = extract_single_value(input)?;
-        s.parse().map_err(|_| ())
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<i32, VarError> {
+        let s = extract_single_value(param, input)?;
+        s.parse()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))
     }
 
     fn format(&self) -> String {
@@ -3013,9 +2964,10 @@ impl Value for u32 {
         "unsigned integer".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<u32, ()> {
-        let s = extract_single_value(input)?;
-        s.parse().map_err(|_| ())
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<u32, VarError> {
+        let s = extract_single_value(param, input)?;
+        s.parse()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))
     }
 
     fn format(&self) -> String {
@@ -3028,9 +2980,13 @@ impl Value for mz_repr::Timestamp {
         "mz-timestamp".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<mz_repr::Timestamp, ()> {
-        let s = extract_single_value(input)?;
-        s.parse().map_err(|_| ())
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<mz_repr::Timestamp, VarError> {
+        let s = extract_single_value(param, input)?;
+        s.parse()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))
     }
 
     fn format(&self) -> String {
@@ -3043,9 +2999,10 @@ impl Value for usize {
         "unsigned integer".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<usize, ()> {
-        let s = extract_single_value(input)?;
-        s.parse().map_err(|_| ())
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<usize, VarError> {
+        let s = extract_single_value(param, input)?;
+        s.parse()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))
     }
 
     fn format(&self) -> String {
@@ -3075,9 +3032,14 @@ impl Value for Numeric {
         "numeric".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<Self::Owned, ()> {
-        let s = extract_single_value(input)?;
-        let n = s.parse().map_err(|_| ())?;
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        let n = s
+            .parse()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))?;
         Ok(n)
     }
 
@@ -3096,8 +3058,11 @@ impl Value for Duration {
         "duration".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<Duration, ()> {
-        let s = extract_single_value(input)?;
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Duration, VarError> {
+        let s = extract_single_value(param, input)?;
         let s = s.trim();
         // Take all numeric values from [0..]
         let split_pos = s
@@ -3106,7 +3071,9 @@ impl Value for Duration {
             .unwrap_or_else(|| s.chars().count());
 
         // Error if the numeric values don't parse, i.e. there aren't any.
-        let d = s[..split_pos].parse::<u64>().map_err(|_| ())?;
+        let d = s[..split_pos]
+            .parse::<u64>()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))?;
 
         // We've already trimmed end
         let (f, m): (fn(u64) -> Duration, u64) = match s[split_pos..].trim_start() {
@@ -3117,13 +3084,23 @@ impl Value for Duration {
             "min" => (Duration::from_secs, SEC_TO_MIN),
             "h" => (Duration::from_secs, SEC_TO_HOUR),
             "d" => (Duration::from_secs, SEC_TO_DAY),
-            _ => return Err(()),
+            o => {
+                return Err(VarError::InvalidParameterValue {
+                    parameter: param.into(),
+                    values: vec![s.to_string()],
+                    reason: format!("expected us, ms, s, min, h, or d but got {:?}", o),
+                })
+            }
         };
 
         let d = if d == 0 {
             Duration::from_secs(u64::MAX)
         } else {
-            f(d.checked_mul(m).ok_or(())?)
+            f(d.checked_mul(m).ok_or(VarError::InvalidParameterValue {
+                parameter: param.into(),
+                values: vec![s.to_string()],
+                reason: "expected value to fit in u64".to_string(),
+            })?)
         };
         Ok(d)
     }
@@ -3159,7 +3136,7 @@ impl Value for Duration {
 #[test]
 fn test_value_duration() {
     fn inner(t: &'static str, e: Duration, expected_format: Option<&'static str>) {
-        let d = Duration::parse(VarInput::Flat(t)).expect("invalid duration");
+        let d = Duration::parse(&STATEMENT_TIMEOUT, VarInput::Flat(t)).expect("invalid duration");
         assert_eq!(d, e);
         let mut d_format = d.format();
         d_format.retain(|c| !c.is_whitespace());
@@ -3206,7 +3183,7 @@ fn test_value_duration() {
     );
 
     fn errs(t: &'static str) {
-        assert!(Duration::parse(VarInput::Flat(t)).is_err());
+        assert!(Duration::parse(&STATEMENT_TIMEOUT, VarInput::Flat(t)).is_err());
     }
     errs("1 m");
     errs("1 sec");
@@ -3227,8 +3204,8 @@ impl Value for String {
         "string".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<String, ()> {
-        let s = extract_single_value(input)?;
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<String, VarError> {
+        let s = extract_single_value(param, input)?;
         Ok(s.to_owned())
     }
 
@@ -3246,16 +3223,20 @@ impl Value for Vec<String> {
         "string list".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<Vec<String>, ()> {
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Vec<String>, VarError> {
         match input {
-            VarInput::Flat(v) => mz_sql_parser::parser::split_identifier_string(v).map_err(|_| ()),
+            VarInput::Flat(v) => mz_sql_parser::parser::split_identifier_string(v)
+                .map_err(|_| VarError::InvalidParameterType(param.into())),
             // Unlike parsing `Vec<Ident>`, we further split each element.
             // This matches PostgreSQL.
             VarInput::SqlSet(values) => {
                 let mut out = vec![];
                 for v in values {
-                    let idents =
-                        mz_sql_parser::parser::split_identifier_string(v).map_err(|_| ())?;
+                    let idents = mz_sql_parser::parser::split_identifier_string(v)
+                        .map_err(|_| VarError::InvalidParameterType(param.into()))?;
                     out.extend(idents)
                 }
                 Ok(out)
@@ -3283,11 +3264,15 @@ impl Value for Vec<Ident> {
         "identifier list".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<Vec<Ident>, ()> {
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Vec<Ident>, VarError> {
         let holder;
         let values = match input {
             VarInput::Flat(value) => {
-                holder = mz_sql_parser::parser::split_identifier_string(value).map_err(|_| ())?;
+                holder = mz_sql_parser::parser::split_identifier_string(value)
+                    .map_err(|_| VarError::InvalidParameterType(param.into()))?;
                 &holder
             }
             // Unlike parsing `Vec<String>`, we do *not* further split each
@@ -3311,11 +3296,14 @@ where
         format!("optional {}", V::type_name())
     }
 
-    fn parse(input: VarInput) -> Result<Option<V>, ()> {
-        let s = extract_single_value(input)?;
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Option<V>, VarError> {
+        let s = extract_single_value(param, input)?;
         match s {
             "" => Ok(None),
-            _ => <V as Value>::parse(VarInput::Flat(s)).map(Some),
+            _ => <V as Value>::parse(param, VarInput::Flat(s)).map(Some),
         }
     }
 
@@ -3329,51 +3317,46 @@ where
 
 // This unorthodox design lets us escape complex errors from value parsing.
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct Failpoints(Result<(), VarError>);
+struct Failpoints;
 
 impl Value for Failpoints {
     fn type_name() -> String {
         "failpoints config".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<Failpoints, ()> {
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Failpoints, VarError> {
         let values = input.to_vec();
         for mut cfg in values.iter().map(|v| v.trim().split(';')).flatten() {
-            let mut parse_config = || -> Result<(), VarError> {
-                cfg = cfg.trim();
-                if cfg.is_empty() {
-                    return Ok(());
-                }
-                let mut splits = cfg.splitn(2, '=');
-                let failpoint = splits
-                    .next()
-                    .ok_or_else(|| VarError::InvalidParameterValue {
-                        parameter: (&FAILPOINTS).into(),
-                        values: input.to_vec(),
-                        reason: "missing failpxoint name".into(),
-                    })?;
-                let action = splits
-                    .next()
-                    .ok_or_else(|| VarError::InvalidParameterValue {
-                        parameter: (&FAILPOINTS).into(),
-                        values: input.to_vec(),
-                        reason: "missing failpoint action".into(),
-                    })?;
-                fail::cfg(failpoint, action).map_err(|e| VarError::InvalidParameterValue {
-                    parameter: (&FAILPOINTS).into(),
-                    values: input.to_vec(),
-                    reason: e,
-                })?;
-
-                Ok(())
-            };
-
-            if let Err(e) = parse_config() {
-                return Ok(Failpoints(Err(e)));
+            cfg = cfg.trim();
+            if cfg.is_empty() {
+                continue;
             }
+            let mut splits = cfg.splitn(2, '=');
+            let failpoint = splits
+                .next()
+                .ok_or_else(|| VarError::InvalidParameterValue {
+                    parameter: param.into(),
+                    values: input.to_vec(),
+                    reason: "missing failpoint name".into(),
+                })?;
+            let action = splits
+                .next()
+                .ok_or_else(|| VarError::InvalidParameterValue {
+                    parameter: param.into(),
+                    values: input.to_vec(),
+                    reason: "missing failpoint action".into(),
+                })?;
+            fail::cfg(failpoint, action).map_err(|e| VarError::InvalidParameterValue {
+                parameter: param.into(),
+                values: input.to_vec(),
+                reason: e,
+            })?;
         }
 
-        Ok(Failpoints(Ok(())))
+        Ok(Failpoints)
     }
 
     fn format(&self) -> String {
@@ -3459,8 +3442,11 @@ impl Value for ClientSeverity {
         "string".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<Self::Owned, ()> {
-        let s = extract_single_value(input)?;
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
         let s = UncasedStr::new(s);
 
         if s == ClientSeverity::Error.as_str() {
@@ -3485,7 +3471,11 @@ impl Value for ClientSeverity {
         } else if s == ClientSeverity::Debug5.as_str() {
             Ok(ClientSeverity::Debug5)
         } else {
-            Err(())
+            Err(VarError::ConstrainedParameter {
+                parameter: param.into(),
+                values: input.to_vec(),
+                valid_values: Some(ClientSeverity::valid_values()),
+            })
         }
     }
 
@@ -3521,8 +3511,11 @@ impl Value for TimeZone {
         "string".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<Self::Owned, ()> {
-        let s = extract_single_value(input)?;
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
         let s = UncasedStr::new(s);
 
         if s == TimeZone::UTC.as_str() {
@@ -3530,7 +3523,11 @@ impl Value for TimeZone {
         } else if s == "+00:00" {
             Ok(TimeZone::FixedOffset("+00:00"))
         } else {
-            Err(())
+            Err(VarError::ConstrainedParameter {
+                parameter: (&TIMEZONE).into(),
+                values: input.to_vec(),
+                valid_values: None,
+            })
         }
     }
 
@@ -3576,8 +3573,11 @@ impl Value for IsolationLevel {
         "string".to_string()
     }
 
-    fn parse(input: VarInput) -> Result<Self::Owned, ()> {
-        let s = extract_single_value(input)?;
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
         let s = UncasedStr::new(s);
 
         // We don't have any optimizations for levels below Serializable,
@@ -3591,7 +3591,11 @@ impl Value for IsolationLevel {
         } else if s == Self::StrictSerializable.as_str() {
             Ok(Self::StrictSerializable)
         } else {
-            Err(())
+            Err(VarError::ConstrainedParameter {
+                parameter: (&TRANSACTION_ISOLATION).into(),
+                values: input.to_vec(),
+                valid_values: Some(IsolationLevel::valid_values()),
+            })
         }
     }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -3235,6 +3235,10 @@ impl Value for String {
     fn format(&self) -> String {
         self.to_owned()
     }
+
+    fn canonicalize(v: &mut Self::Owned) {
+        *v = v.to_ascii_lowercase();
+    }
 }
 
 impl Value for Vec<String> {
@@ -3268,6 +3272,9 @@ impl Value for Vec<String> {
     fn canonicalize(v: &mut Self::Owned) {
         v.sort();
         v.dedup();
+        for v in v {
+            *v = v.to_ascii_uppercase();
+        }
     }
 }
 

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -287,7 +287,7 @@ COMPLETE 0
 ISO, MDY
 COMPLETE 1
 
-statement error parameter "database" requires a "string" value
+statement error parameter "database" cannot have value "one","two": expects a single value
 set database = one, two
 
 # Test invalid values for float vars
@@ -297,12 +297,12 @@ set database = one, two
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET max_credit_consumption_rate = '-100.5'
 ----
-db error: ERROR: parameter "max_credit_consumption_rate" requires a "numeric" value
+db error: ERROR: parameter "max_credit_consumption_rate" cannot have value "-100.5": only supports non-negative, non-NaN numeric values
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET max_credit_consumption_rate = NaN
 ----
-db error: ERROR: parameter "max_credit_consumption_rate" requires a "numeric" value
+db error: ERROR: parameter "max_credit_consumption_rate" cannot have value "NaN": only supports non-negative, non-NaN numeric values
 
 statement ok
 SET SCHEMA 'non-resolvable-name'

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -24,7 +24,7 @@ cluster_replica                     ""                      "Sets a target clust
 database                            materialize             "Sets the current database (CockroachDB)."
 DateStyle                           "ISO, MDY"              "Sets the display format for date and time values (PostgreSQL)."
 extra_float_digits                  3                       "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."
-failpoints                          ""                      "Allows failpoints to be dynamically activated."
+failpoints                          <omitted>               "Allows failpoints to be dynamically activated."
 integer_datetimes                   on                      "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL)."
 IntervalStyle                       postgres                "Sets the display format for interval values (PostgreSQL)."
 search_path                         public                  "Sets the schema search order for names that are not schema-qualified (PostgreSQL)."
@@ -69,7 +69,7 @@ UTF8
 UTF8
 
 ! SET client_encoding = UTF9
-contains:parameter "client_encoding" can only be set to "UTF8"
+contains:invalid value for parameter "client_encoding": "utf9"
 
 # if its utf8 we let it through
 > SET NAMES 'UTF8';
@@ -135,7 +135,7 @@ contains:invalid value for parameter "TimeZone": "nope"
 contains:invalid value for parameter "transaction_isolation": "read draft"
 
 ! SET integer_datetimes = false
-contains:parameter "integer_datetimes" cannot be changed
+contains:parameter "integer_datetimes" can only be set to "on"
 
 > SET client_min_messages TO ERROR
 > SHOW client_min_messages
@@ -173,7 +173,7 @@ contains:invalid value for parameter "client_min_messages": "invalid"
 postgres
 
 ! SET intervalstyle = 'postgres-legacy'
-contains:parameter "IntervalStyle" can only be set to "postgres"
+contains:invalid value for parameter "IntervalStyle": "postgres-legacy"
 
 > SET intervalstyle = 'postgres';
 
@@ -183,4 +183,4 @@ contains:parameter "IntervalStyle" can only be set to "postgres"
 > SET cluster_replica = 'r1'
 
 ! SET cluster_replica = 1, 2
-contains:parameter "cluster_replica" requires a "optional string" value
+contains:parameter "cluster_replica" cannot have value "1","2": expects a single value


### PR DESCRIPTION
`SessionVars` had greatly diverged from `SystemVars` in structure, as well as just generally having a number of little warts that were unergonomic. Instead bring these two structs into parity with one another and make the module easier/more extensible in the future.

I tinkered on this over the weekend so did not spec out a design doc.

@jkosh44 I'm glad to chat about any of these design decisions; I made some opinionated changes here to simplify things in the long term that are more complex than the `str` comparisons we previously had.

### Motivation

 This PR refactors existing code. Closes #19187

### Tips for reviewer

You should be able to go through commit-by-commit to get a sense of the changes, though there were a few changes that wound up getting reverted in later commits that were too knotted to push down:
- `DateStyle` wound up getting totally refactored because its generic implementation over `Vec<String>` was incredibly annoying to work with.
- There was briefly a "canonicalize" function on the `Value` trait, which wound up being unnecessary after a few add'l refactors + removing the `DateStyle` nonsense.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
