### PR TITLE
frontegg-client: enables authentication using email and password

### DIFF
--- a/src/frontegg-client/src/client.rs
+++ b/src/frontegg-client/src/client.rs
@@ -37,7 +37,9 @@ pub mod app_password;
 pub mod role;
 pub mod user;
 
-const AUTH_PATH: [&str; 5] = ["identity", "resources", "auth", "v1", "api-token"];
+const CREDENTIALS_AUTH_PATH: [&str; 5] = ["identity", "resources", "auth", "v1", "user"];
+const APP_PASSWORD_AUTH_PATH: [&str; 5] = ["identity", "resources", "auth", "v1", "api-token"];
+
 const REFRESH_AUTH_PATH: [&str; 7] = [
     "identity",
     "resources",
@@ -59,7 +61,14 @@ struct AuthenticationResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct AuthenticationRequest<'a> {
+struct CredentialsAuthenticationRequest<'a> {
+    email: &'a str,
+    password: &'a str,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AppPasswordAuthenticationRequest<'a> {
     client_id: &'a str,
     secret: &'a str,
 }
@@ -78,6 +87,31 @@ pub(crate) struct Auth {
     refresh_token: String,
 }
 
+/// Representation of the two possible ways to authenticate a user.
+///
+/// The usage of [Authentication::AppPassword] is more favorable
+/// and recommended. App-passwords can be created for a particular
+/// usage and be removed at any time. While the user credentials
+/// may have a broader impact.
+pub enum Authentication {
+    /// Legitimate email and password that will remain in use to identify
+    /// the user throughout the client's existence.
+    Credentials(Credentials),
+    /// A singular, legitimate app password that will remain in use to identify
+    /// the user throughout the client's existence.
+    AppPassword(AppPassword),
+}
+
+/// Representation of a user's credentials.
+/// They are the same as a user needs to
+/// log in to Materialize's console.
+pub struct Credentials {
+    /// User's email to authenticate with Materialize console
+    pub email: String,
+    /// User's password to authenticate with Materialize console
+    pub password: String,
+}
+
 /// An API client for Frontegg.
 ///
 /// The API client is designed to be wrapped in an [`Arc`] and used from
@@ -87,7 +121,7 @@ pub(crate) struct Auth {
 /// [`Arc`]: std::sync::Arc
 pub struct Client {
     pub(crate) inner: reqwest::Client,
-    pub(crate) app_password: AppPassword,
+    pub(crate) authentication: Authentication,
     pub(crate) endpoint: Url,
     pub(crate) auth: Mutex<Option<Auth>>,
 }
@@ -183,14 +217,27 @@ impl Client {
                 }
             }
             None => {
-                // No auth available in the client, request a new one.
-                req = self.build_request(Method::POST, AUTH_PATH);
+                match &self.authentication {
+                    Authentication::Credentials(credentials) => {
+                        // No auth available in the client, request a new one.
+                        req = self.build_request(Method::POST, CREDENTIALS_AUTH_PATH);
 
-                let authentication_request = AuthenticationRequest {
-                    client_id: &self.app_password.client_id.to_string(),
-                    secret: &self.app_password.secret_key.to_string(),
-                };
-                req = req.json(&authentication_request);
+                        let authentication_request = CredentialsAuthenticationRequest {
+                            email: &credentials.email,
+                            password: &credentials.password,
+                        };
+                        req = req.json(&authentication_request);
+                    }
+                    Authentication::AppPassword(app_password) => {
+                        req = self.build_request(Method::POST, APP_PASSWORD_AUTH_PATH);
+
+                        let authentication_request = AppPasswordAuthenticationRequest {
+                            client_id: &app_password.client_id.to_string(),
+                            secret: &app_password.secret_key.to_string(),
+                        };
+                        req = req.json(&authentication_request);
+                    }
+                }
             }
         }
 

--- a/src/frontegg-client/src/config.rs
+++ b/src/frontegg-client/src/config.rs
@@ -22,11 +22,10 @@
 
 use std::time::Duration;
 
-use mz_frontegg_auth::AppPassword;
 use once_cell::sync::Lazy;
 use reqwest::Url;
 
-use crate::client::Client;
+use crate::client::{Authentication, Client};
 
 /// The default endpoint the client will use to issue the requests. Currently
 /// points to Materialize admin endpoint.
@@ -40,7 +39,7 @@ pub static DEFAULT_ENDPOINT: Lazy<Url> = Lazy::new(|| {
 pub struct ClientConfig {
     /// A singular, legitimate app password that will remain in use to identify
     /// the user throughout the client's existence.
-    pub app_password: AppPassword,
+    pub authentication: Authentication,
 }
 
 /// A builder for a [`Client`].
@@ -75,7 +74,7 @@ impl ClientBuilder {
             .unwrap();
         Client {
             inner,
-            app_password: config.app_password,
+            authentication: config.authentication,
             endpoint: self.endpoint,
             auth: Default::default(),
         }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

The motivation for this PR is to enable authentication using email and password. It is a feature needed by `mz` to login a user without using the web browser.

Currently the `frontegg-client` supports to authenticate using AppPasswords, so I've added an enum `Authentication` that could be an `AppPassword` or `Credentials`, and support for each type of request.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Maybe using an enum wasn't the best decision and could use another approach/structure.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
