### PR TITLE
cloud-api: fixes region and environments requests

### DIFF
--- a/src/cloud-api/src/client.rs
+++ b/src/cloud-api/src/client.rs
@@ -24,6 +24,8 @@ use serde::Deserialize;
 use crate::client::region::Region;
 use crate::error::{ApiError, Error};
 
+use self::cloud_provider::CloudProvider;
+
 /// Represents the structure for the client.
 pub struct Client {
     pub(crate) inner: reqwest::Client,
@@ -69,7 +71,28 @@ impl Client {
     }
 
     /// Builds a request towards the `Client`'s endpoint
+    /// The function requires a [CloudProvider] as parameter
+    /// since it contains the api url (region controller url)
+    /// to interact with the region.
     async fn build_region_request<P>(
+        &self,
+        method: Method,
+        path: P,
+        cloud_provider: CloudProvider,
+    ) -> Result<RequestBuilder, Error>
+    where
+        P: IntoIterator,
+        P::Item: AsRef<str>,
+    {
+        self.build_request(method, path, cloud_provider.api_url)
+            .await
+    }
+
+    /// Builds a request towards the `Client`'s endpoint.
+    /// The function requires a [Region] as parameter
+    /// since it contains the environment controller url
+    /// to interact with the environment.
+    async fn build_environment_request<P>(
         &self,
         method: Method,
         path: P,

--- a/src/cloud-api/src/client/environment.rs
+++ b/src/cloud-api/src/client/environment.rs
@@ -43,7 +43,7 @@ impl Client {
     pub async fn get_environment(&self, region: Region) -> Result<Environment, Error> {
         // Send request to the subdomain
         let req = self
-            .build_region_request(Method::GET, ["api", "environment"], region)
+            .build_environment_request(Method::GET, ["api", "environment"], region)
             .await?;
 
         let environments: Vec<Environment> = self.send_request(req).await?;
@@ -78,7 +78,7 @@ impl Client {
         &self,
         version: Option<String>,
         environmentd_extra_args: Vec<String>,
-        region: Region,
+        cloud_provider: CloudProvider,
     ) -> Result<Region, Error> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -98,16 +98,24 @@ impl Client {
         };
 
         let req = self
-            .build_region_request(Method::POST, ["api", "environmentassignment"], region)
+            .build_region_request(
+                Method::POST,
+                ["api", "environmentassignment"],
+                cloud_provider,
+            )
             .await?;
         let req = req.json(&body);
         self.send_request(req).await
     }
 
     /// Deletes an environment in a particular region for the current user
-    pub async fn delete_environment(&self, region: Region) -> Result<Region, Error> {
+    pub async fn delete_environment(&self, cloud_provider: CloudProvider) -> Result<Region, Error> {
         let req = self
-            .build_region_request(Method::DELETE, ["api", "environmentassignment"], region)
+            .build_region_request(
+                Method::DELETE,
+                ["api", "environmentassignment"],
+                cloud_provider,
+            )
             .await?;
         self.send_request(req).await
     }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR fixes the way the `cloud-api` client was doing requests towards regions and environment. Before it was using the environment controller url (wrongly) to request information about the region.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

The name of the functions are a bit tricky. E.g. It receives a `CloudProvider` as parameter but the call is towards the Region controller url.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
