### PR TITLE
sql: implement the age(...) function

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -611,6 +611,9 @@ message ProtoBinaryFunc {
         google.protobuf.Empty uuid_generate_v5 = 183;
         google.protobuf.Empty mz_acl_item_contains_privilege = 184;
         google.protobuf.Empty parse_ident = 185;
+        google.protobuf.Empty age_timestamp = 186;
+        google.protobuf.Empty age_timestamp_tz = 187;
+        google.protobuf.Empty age_current = 188;
     }
 }
 

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -613,7 +613,6 @@ message ProtoBinaryFunc {
         google.protobuf.Empty parse_ident = 185;
         google.protobuf.Empty age_timestamp = 186;
         google.protobuf.Empty age_timestamp_tz = 187;
-        google.protobuf.Empty age_current = 188;
     }
 }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -830,32 +830,6 @@ fn age_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalErro
     Ok(Datum::from(age))
 }
 
-fn age_current<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    // The function to get the current time always returns a timestamp with a timezone.
-    let a_ts = a.unwrap_timestamptz();
-
-    // Note: We truncate a_ts to the current day to match Postgres semantics, which takes the age
-    // from the current day, at midnight.
-
-    let age = match b {
-        Datum::Timestamp(b_ts) => {
-            let date = a_ts.to_naive().truncate_day();
-            let date = CheckedTimestamp::try_from(date)?;
-            let age = date.age(&b_ts)?;
-            age
-        }
-        Datum::TimestampTz(b_ts) => {
-            let date = a_ts.truncate_day();
-            let date = CheckedTimestamp::try_from(date)?;
-            let age = date.age(&b_ts)?;
-            age
-        }
-        d => panic!("Expected Timestamp or TimestampTz, got {d:?}"),
-    };
-
-    Ok(Datum::from(age))
-}
-
 fn sub_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_timestamp() - b.unwrap_timestamp())
 }
@@ -1999,7 +1973,6 @@ pub enum BinaryFunc {
     AddDateTime,
     AddTimeInterval,
     AddNumeric,
-    AgeCurrent,
     AgeTimestamp,
     AgeTimestampTz,
     BitAndInt16,
@@ -2204,7 +2177,6 @@ impl BinaryFunc {
             BinaryFunc::AddTimeInterval => Ok(add_time_interval(a, b)),
             BinaryFunc::AddNumeric => add_numeric(a, b),
             BinaryFunc::AddInterval => add_interval(a, b),
-            BinaryFunc::AgeCurrent => age_current(a, b),
             BinaryFunc::AgeTimestamp => age_timestamp(a, b),
             BinaryFunc::AgeTimestampTz => age_timestamptz(a, b),
             BinaryFunc::BitAndInt16 => Ok(bit_and_int16(a, b)),
@@ -2503,7 +2475,7 @@ impl BinaryFunc {
             AddInterval | SubInterval | SubTimestamp | SubTimestampTz | MulInterval
             | DivInterval => ScalarType::Interval.nullable(in_nullable),
 
-            AgeCurrent | AgeTimestamp | AgeTimestampTz => ScalarType::Interval.nullable(in_nullable),
+            AgeTimestamp | AgeTimestampTz => ScalarType::Interval.nullable(in_nullable),
 
             AddTimestampInterval
             | SubTimestampInterval
@@ -2653,7 +2625,6 @@ impl BinaryFunc {
             | AddDateTime
             | AddTimeInterval
             | AddNumeric
-            | AgeCurrent
             | AgeTimestamp
             | AgeTimestampTz
             | BitAndInt16
@@ -2967,7 +2938,6 @@ impl BinaryFunc {
             | RangeDifference => true,
             ToCharTimestamp
             | ToCharTimestampTz
-            | AgeCurrent
             | AgeTimestamp
             | AgeTimestampTz
             | DateBinTimestamp
@@ -3160,9 +3130,7 @@ impl BinaryFunc {
             | BinaryFunc::IsRegexpMatch { .. } => (false, false),
             BinaryFunc::ToCharTimestamp | BinaryFunc::ToCharTimestampTz => (false, false),
             BinaryFunc::DateBinTimestamp | BinaryFunc::DateBinTimestampTz => (true, true),
-            BinaryFunc::AgeTimestamp | BinaryFunc::AgeTimestampTz | BinaryFunc::AgeCurrent => {
-                (true, true)
-            }
+            BinaryFunc::AgeTimestamp | BinaryFunc::AgeTimestampTz => (true, true),
             // TODO: can these ever be treated as monotone? It's safe to treat the unary versions
             // as monotone in some cases, but only when extracting specific parts.
             BinaryFunc::ExtractInterval
@@ -3262,7 +3230,6 @@ impl fmt::Display for BinaryFunc {
             BinaryFunc::AddDateTime => f.write_str("+"),
             BinaryFunc::AddDateInterval => f.write_str("+"),
             BinaryFunc::AddTimeInterval => f.write_str("+"),
-            BinaryFunc::AgeCurrent => f.write_str("age"),
             BinaryFunc::AgeTimestamp => f.write_str("age"),
             BinaryFunc::AgeTimestampTz => f.write_str("age"),
             BinaryFunc::BitAndInt16 => f.write_str("&"),
@@ -3477,7 +3444,6 @@ impl Arbitrary for BinaryFunc {
             Just(BinaryFunc::AddDateTime).boxed(),
             Just(BinaryFunc::AddTimeInterval).boxed(),
             Just(BinaryFunc::AddNumeric).boxed(),
-            Just(BinaryFunc::AgeCurrent).boxed(),
             Just(BinaryFunc::AgeTimestamp).boxed(),
             Just(BinaryFunc::AgeTimestampTz).boxed(),
             Just(BinaryFunc::BitAndInt16).boxed(),
@@ -3685,7 +3651,6 @@ impl RustType<ProtoBinaryFunc> for BinaryFunc {
             BinaryFunc::AddDateTime => AddDateTime(()),
             BinaryFunc::AddTimeInterval => AddTimeInterval(()),
             BinaryFunc::AddNumeric => AddNumeric(()),
-            BinaryFunc::AgeCurrent => AgeCurrent(()),
             BinaryFunc::AgeTimestamp => AgeTimestamp(()),
             BinaryFunc::AgeTimestampTz => AgeTimestampTz(()),
             BinaryFunc::BitAndInt16 => BitAndInt16(()),
@@ -3883,7 +3848,6 @@ impl RustType<ProtoBinaryFunc> for BinaryFunc {
                 AddDateTime(()) => Ok(BinaryFunc::AddDateTime),
                 AddTimeInterval(()) => Ok(BinaryFunc::AddTimeInterval),
                 AddNumeric(()) => Ok(BinaryFunc::AddNumeric),
-                AgeCurrent(()) => Ok(BinaryFunc::AgeCurrent),
                 AgeTimestamp(()) => Ok(BinaryFunc::AgeTimestamp),
                 AgeTimestampTz(()) => Ok(BinaryFunc::AgeTimestampTz),
                 BitAndInt16(()) => Ok(BinaryFunc::BitAndInt16),
@@ -7627,54 +7591,6 @@ mod test {
             .unwrap()
             .try_into()
             .unwrap()
-    }
-
-    #[test]
-    fn age_current_truncates() {
-        let now = NaiveDateTime::new(
-            NaiveDate::from_ymd_opt(2023, 06, 01).unwrap(),
-            NaiveTime::from_hms_opt(1, 25, 12).unwrap(),
-        );
-        let now: DateTime<Utc> = DateTime::from_utc(now, Utc);
-        let now_ts = Datum::TimestampTz(CheckedTimestamp::from_timestamplike(now).unwrap());
-
-        // The user specified timestamp is only precise to the day, so we should truncate.
-        let day_prec = NaiveDateTime::new(
-            NaiveDate::from_ymd_opt(2022, 05, 30).unwrap(),
-            NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
-        );
-        let day_prec_ts = Datum::Timestamp(CheckedTimestamp::from_timestamplike(day_prec).unwrap());
-        let day_age = age_current(now_ts.clone(), day_prec_ts)
-            .unwrap()
-            .unwrap_interval();
-
-        assert_eq!(day_age, Interval::new(12, 2, 0));
-
-        // The user specified timestamp is only precise to the hour, so we should truncate.
-        let hour_prec = NaiveDateTime::new(
-            NaiveDate::from_ymd_opt(2022, 05, 30).unwrap(),
-            NaiveTime::from_hms_opt(12, 0, 0).unwrap(),
-        );
-        let hour_prec_ts =
-            Datum::Timestamp(CheckedTimestamp::from_timestamplike(hour_prec).unwrap());
-        let hour_age = age_current(now_ts.clone(), hour_prec_ts)
-            .unwrap()
-            .unwrap_interval();
-
-        assert_eq!(hour_age, Interval::new(12, 1, 43_200_000_000));
-
-        // The user specified timestamp is only precise to the minute, so we should truncate.
-        let minute_prec = NaiveDateTime::new(
-            NaiveDate::from_ymd_opt(2022, 05, 30).unwrap(),
-            NaiveTime::from_hms_opt(12, 15, 0).unwrap(),
-        );
-        let minute_prec_ts =
-            Datum::Timestamp(CheckedTimestamp::from_timestamplike(minute_prec).unwrap());
-        let minute_age = age_current(now_ts.clone(), minute_prec_ts)
-            .unwrap()
-            .unwrap_interval();
-
-        assert_eq!(minute_age, Interval::new(12, 1, 45_840_000_000));
     }
 
     // Tests that `UnaryFunc::output_type` are consistent with

--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -756,23 +756,28 @@ mod test {
         )
         .unwrap();
 
+        let years = HIGH_DATE.year() - LOW_DATE.year();
+        let months = years * 12;
+
         // Test high - low.
         let result = high.age(&low).unwrap();
-        assert_eq!(result, Interval::new(3202272, 0, 0));
+        assert_eq!(result, Interval::new(months, 0, 0));
 
         // Test low - high.
         let result = low.age(&high).unwrap();
-        assert_eq!(result, Interval::new(-3202272, 0, 0));
+        assert_eq!(result, Interval::new(-months, 0, 0));
     }
 
     proptest! {
         #[test]
+        #[cfg_attr(miri, ignore)] // slow
         fn test_age_naive(a: CheckedTimestamp<NaiveDateTime>, b: CheckedTimestamp<NaiveDateTime>) {
             let result = a.age(&b);
             prop_assert!(result.is_ok());
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)] // slow
         fn test_age_utc(a: CheckedTimestamp<DateTime<Utc>>, b: CheckedTimestamp<DateTime<Utc>>) {
             let result = a.age(&b);
             prop_assert!(result.is_ok());

--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -551,13 +551,13 @@ impl<T: TimestampLike> CheckedTimestamp<T> {
 
             // Flip sign if necessary.
             if a < b {
-                nanos = -nanos;
-                seconds = -seconds;
-                minutes = -minutes;
-                hours = -hours;
-                days = -days;
-                months = -months;
-                years = -years;
+                nanos = nanos.checked_neg()?;
+                seconds = seconds.checked_neg()?;
+                minutes = minutes.checked_neg()?;
+                hours = hours.checked_neg()?;
+                days = days.checked_neg()?;
+                months = months.checked_neg()?;
+                years = years.checked_neg()?;
             }
 
             // Carry negative fields into the next higher field.
@@ -592,22 +592,22 @@ impl<T: TimestampLike> CheckedTimestamp<T> {
 
             // Revert the sign back, if we flipped it originally.
             if a < b {
-                nanos = -nanos;
-                seconds = -seconds;
-                minutes = -minutes;
-                hours = -hours;
-                days = -days;
-                months = -months;
-                years = -years;
+                nanos = nanos.checked_neg()?;
+                seconds = seconds.checked_neg()?;
+                minutes = minutes.checked_neg()?;
+                hours = hours.checked_neg()?;
+                days = days.checked_neg()?;
+                months = months.checked_neg()?;
+                years = years.checked_neg()?;
             }
 
             let months = i32::try_from(years * MONTHS_PER_YEAR + months).ok()?;
             let days = i32::try_from(days).ok()?;
             let micros = Duration::nanoseconds(
                 nanos
-                    + (seconds * NANOSECONDS_PER_SECOND)
-                    + (minutes * NANOSECONDS_PER_MINUTE)
-                    + (hours * NANOSECONDS_PER_HOUR),
+                    .checked_add(seconds.checked_mul(NANOSECONDS_PER_SECOND)?)?
+                    .checked_add(minutes.checked_mul(NANOSECONDS_PER_MINUTE)?)?
+                    .checked_add(hours.checked_mul(NANOSECONDS_PER_HOUR)?)?,
             )
             .num_microseconds()?;
 

--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -6,6 +6,14 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+//
+// Portions of this file are derived from `timestamp.c` in the Postgres project.
+// The original source code was retrieved on June 1, 2023 from:
+//
+//     https://github.com/postgres/postgres/blob/REL_15_3/src/backend/utils/adt/timestamp.c
+//
+// The original source code is subject to the terms of the PostgreSQL license, a copy
+// of which can be found in the LICENSE file at the root of this repository.
 
 //! Methods for checked timestamp operations.
 

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -2939,10 +2939,10 @@ pub fn arb_datum() -> BoxedStrategy<PropDatum> {
         add_arb_duration(chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap())
             .prop_map(PropDatum::Time)
             .boxed(),
-        add_arb_duration(chrono::NaiveDateTime::from_timestamp_opt(0, 0).unwrap())
+        arb_naive_date_time()
             .prop_map(|t| PropDatum::Timestamp(CheckedTimestamp::from_timestamplike(t).unwrap()))
             .boxed(),
-        add_arb_duration(chrono::Utc.timestamp_opt(0, 0).unwrap())
+        arb_utc_date_time()
             .prop_map(|t| PropDatum::TimestampTz(CheckedTimestamp::from_timestamplike(t).unwrap()))
             .boxed(),
         arb_interval().prop_map(PropDatum::Interval).boxed(),
@@ -2964,6 +2964,16 @@ pub fn arb_datum() -> BoxedStrategy<PropDatum> {
         ])
     })
     .boxed()
+}
+
+/// Generates an arbitrary [`NaiveDateTime`].
+pub fn arb_naive_date_time() -> impl Strategy<Value = NaiveDateTime> {
+    add_arb_duration(chrono::NaiveDateTime::from_timestamp_opt(0, 0).unwrap())
+}
+
+/// Generates an arbitrary [`DateTime`] in [`Utc`].
+pub fn arb_utc_date_time() -> impl Strategy<Value = DateTime<Utc>> {
+    add_arb_duration(chrono::Utc.timestamp_opt(0, 0).unwrap())
 }
 
 fn arb_array_dimension() -> BoxedStrategy<ArrayDimension> {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2403,6 +2403,24 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         "atanh" => Scalar {
             params!(Float64) => UnaryFunc::Atanh(func::Atanh) => Float64, 2467;
         },
+        "age" => Scalar {
+            params!(Timestamp, Timestamp) => BinaryFunc::AgeTimestamp => Interval, 2058;
+            params!(TimestampTz, TimestampTz) => BinaryFunc::AgeTimestampTz => Interval, 1199;
+            params!(Timestamp) => Operation::unary(|_ecx, ts| {
+                Ok(HirScalarExpr::CallBinary {
+                    func: BinaryFunc::AgeCurrent,
+                    expr1: Box::new(HirScalarExpr::CallUnmaterializable(UnmaterializableFunc::CurrentTimestamp)),
+                    expr2: Box::new(ts),
+                })
+            }) => Interval, 2059;
+            params!(TimestampTz) => Operation::unary(|_ecx, ts| {
+                Ok(HirScalarExpr::CallBinary {
+                    func: BinaryFunc::AgeCurrent,
+                    expr1: Box::new(HirScalarExpr::CallUnmaterializable(UnmaterializableFunc::CurrentTimestamp)),
+                    expr2: Box::new(ts),
+                })
+            }) => Interval, 1386;
+        },
         "timezone" => Scalar {
             params!(String, Timestamp) => BinaryFunc::TimezoneTimestamp => TimestampTz, 2069;
             params!(String, TimestampTz) => BinaryFunc::TimezoneTimestampTz => Timestamp, 1159;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2406,20 +2406,6 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         "age" => Scalar {
             params!(Timestamp, Timestamp) => BinaryFunc::AgeTimestamp => Interval, 2058;
             params!(TimestampTz, TimestampTz) => BinaryFunc::AgeTimestampTz => Interval, 1199;
-            params!(Timestamp) => Operation::unary(|_ecx, ts| {
-                Ok(HirScalarExpr::CallBinary {
-                    func: BinaryFunc::AgeCurrent,
-                    expr1: Box::new(HirScalarExpr::CallUnmaterializable(UnmaterializableFunc::CurrentTimestamp)),
-                    expr2: Box::new(ts),
-                })
-            }) => Interval, 2059;
-            params!(TimestampTz) => Operation::unary(|_ecx, ts| {
-                Ok(HirScalarExpr::CallBinary {
-                    func: BinaryFunc::AgeCurrent,
-                    expr1: Box::new(HirScalarExpr::CallUnmaterializable(UnmaterializableFunc::CurrentTimestamp)),
-                    expr2: Box::new(ts),
-                })
-            }) => Interval, 1386;
         },
         "timezone" => Scalar {
             params!(String, Timestamp) => BinaryFunc::TimezoneTimestamp => TimestampTz, 2069;

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -1405,13 +1405,8 @@ SELECT age('2001-04-10 22:06:45', '1957-06-13')
 ----
 43 years 9 months 27 days 22:06:45
 
-query B
-SELECT age('1957-06-13') - age(now(), '1957-06-13') = interval '0s'
-----
-true
-
 query T
-select age('2017-12-10'::timestamptz, '2017-12-01'::timestamptz)
+SELECT age('2017-12-10'::timestamptz, '2017-12-01'::timestamptz)
 ----
 9 days
 
@@ -1419,3 +1414,23 @@ query T
 SELECT age('2017-12-10 04:05:01.555'::timestamp, '2017-12-10 04:05:01.550'::timestamp);
 ----
 00:00:00.005
+
+query T
+SELECT age('0001-06-01 08:10:56.555'::timestamp, '9999-12-10 04:05:01.550'::timestamp);
+----
+-9998 years -6 months -8 days -19:54:04.995
+
+query B
+SELECT age('2020-04-05'::date + '03:00'::time, '2020-04-05'::date + '02:00'::time) = '1 hour'::interval;
+----
+true
+
+query T
+SELECT age(to_timestamp(-210833720368), to_timestamp(8200000000000));
+----
+-266528 years -8 months -17 days -12:06:08
+
+query T
+SELECT age(to_timestamp(8200000000000), to_timestamp(-210833720368));
+----
+266528 years 8 months 17 days 12:06:08

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -1397,3 +1397,25 @@ SELECT justify_interval(interval '2147483647 months -30 days 1440 hrs');
 
 query error interval out of range
 SELECT justify_interval(interval '-2147483648 months 30 days -1440 hrs');
+
+# TIMESTAMP/DATE builtins.
+
+query T
+SELECT age('2001-04-10 22:06:45', '1957-06-13')
+----
+43 years 9 months 27 days 22:06:45
+
+query B
+SELECT age('1957-06-13') - age(now(), '1957-06-13') = interval '0s'
+----
+true
+
+query T
+select age('2017-12-10'::timestamptz, '2017-12-01'::timestamptz)
+----
+9 days
+
+query T
+SELECT age('2017-12-10 04:05:01.555'::timestamp, '2017-12-10 04:05:01.550'::timestamp);
+----
+00:00:00.005


### PR DESCRIPTION
### Motivation

Fixes #14449 

This PR implements the [`age(ts, ts)`](https://www.postgresql.org/docs/current/functions-datetime.html) function from Postgres.

Specifically we support the following:

1. `age(timestamp, timestamp)`
2. `age(timestamptz, timestamptz)`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds support for the [`age(...)`](https://www.postgresql.org/docs/current/functions-datetime.html) builtin function.
