### PR TITLE
persist: proptest coverage for State proto roundtrip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4326,6 +4326,8 @@ dependencies = [
  "openssl-sys",
  "postgres-openssl",
  "prometheus",
+ "proptest",
+ "proptest-derive",
  "prost",
  "prost-build",
  "protobuf-src",

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -16,6 +16,7 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use mz_ore::now::EpochMillis;
 use mz_persist_types::{Codec, Codec64, Opaque};
+use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp};
 use tracing::instrument;
@@ -26,7 +27,7 @@ use crate::internal::state::Since;
 use crate::{parse_id, GarbageCollector};
 
 /// An opaque identifier for a reader of a persist durable TVC (aka shard).
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct CriticalReaderId(pub(crate) [u8; 16]);
 

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -546,6 +546,7 @@ where
 /// A decoded version of [ProtoStateRollup] for which we have not yet checked
 /// that codecs match the ones in durable state.
 #[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(PartialEq))]
 pub struct UntypedState<T> {
     pub(crate) key_codec: String,
     pub(crate) val_codec: String,
@@ -1030,8 +1031,10 @@ mod tests {
     use bytes::Bytes;
     use mz_build_info::DUMMY_BUILD_INFO;
     use mz_persist::location::SeqNo;
+    use proptest::prelude::*;
 
     use crate::internal::paths::PartialRollupKey;
+    use crate::internal::state::tests::any_state;
     use crate::internal::state::HandleDebugState;
     use crate::internal::state_diff::StateDiff;
     use crate::tests::new_test_client_cache;
@@ -1315,5 +1318,23 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![(SeqNo(1), r1_rollup), (SeqNo(2), r2_rollup)]
         );
+    }
+
+    #[test]
+    fn state_proto_roundtrip() {
+        fn testcase<T: Timestamp + Lattice + Codec64>(state: State<T>) {
+            let before = UntypedState {
+                key_codec: <() as Codec>::codec_name(),
+                val_codec: <() as Codec>::codec_name(),
+                ts_codec: <T as Codec64>::codec_name(),
+                diff_codec: <i64 as Codec64>::codec_name(),
+                state,
+            };
+            let proto = before.into_proto();
+            let after = proto.into_rust().unwrap();
+            assert_eq!(before, after);
+        }
+
+        proptest!(|(state in any_state::<u64>(2))| testcase(state));
     }
 }

--- a/src/persist-client/src/internal/paths.rs
+++ b/src/persist-client/src/internal/paths.rs
@@ -11,6 +11,7 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use mz_persist::location::SeqNo;
+use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -55,7 +56,7 @@ impl PartId {
 /// Used to reduce the bytes needed to refer to a blob key in memory and in
 /// persistent state, all access to blobs are always within the context of an
 /// individual shard.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct PartialBatchKey(pub(crate) String);
 
 impl PartialBatchKey {
@@ -119,7 +120,7 @@ impl RollupId {
 /// Used to reduce the bytes needed to refer to a blob key in memory and in
 /// persistent state, all access to blobs are always within the context of an
 /// individual shard.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct PartialRollupKey(pub(crate) String);
 
 impl PartialRollupKey {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -24,6 +24,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::now::EpochMillis;
 use mz_persist::location::SeqNo;
 use mz_persist_types::{Codec, Codec64, Opaque};
+use proptest_derive::Arbitrary;
 use semver::Version;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -53,7 +54,7 @@ include!(concat!(
 
 /// A token to disambiguate state commands that could not otherwise be
 /// idempotent.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Arbitrary, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IdempotencyToken(pub(crate) [u8; 16]);
 
 impl std::fmt::Display for IdempotencyToken {
@@ -98,7 +99,7 @@ pub struct LeasedReaderState<T> {
     pub debug: HandleDebugState,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, PartialEq)]
 pub struct OpaqueState(pub [u8; 8]);
 
 #[derive(Clone, Debug, PartialEq)]
@@ -131,7 +132,7 @@ pub struct WriterState<T> {
 }
 
 /// Debugging info for a reader or writer.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, PartialEq)]
 pub struct HandleDebugState {
     /// Hostname of the persist user that registered this writer or reader. For
     /// critical readers, this is the _most recent_ registration.
@@ -141,7 +142,7 @@ pub struct HandleDebugState {
 }
 
 /// A subset of a [HollowBatch] corresponding 1:1 to a blob.
-#[derive(Clone, Debug)]
+#[derive(Arbitrary, Clone, Debug)]
 pub struct HollowBatchPart {
     /// Pointer usable to retrieve the updates.
     pub key: PartialBatchKey,
@@ -291,7 +292,7 @@ impl<'a, T> Iterator for HollowBatchRunIter<'a, T> {
 }
 
 /// A pointer to a rollup stored externally.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Arbitrary, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HollowRollup {
     /// Pointer usable to retrieve the rollup.
     pub key: PartialRollupKey,
@@ -1368,13 +1369,167 @@ impl<T> Determinacy for Upper<T> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use mz_build_info::DUMMY_BUILD_INFO;
     use mz_ore::now::SYSTEM_TIME;
+    use proptest::prelude::*;
 
+    use crate::internal::trace::tests::any_trace;
     use crate::InvalidUsage::{InvalidBounds, InvalidEmptyTimeInterval};
 
     use super::*;
+
+    pub fn any_hollow_batch<T: Arbitrary + Timestamp>() -> impl Strategy<Value = HollowBatch<T>> {
+        Strategy::prop_map(
+            (
+                any::<T>(),
+                any::<T>(),
+                any::<T>(),
+                proptest::collection::vec(any::<HollowBatchPart>(), 0..3),
+                any::<usize>(),
+                any::<bool>(),
+            ),
+            |(t0, t1, since, parts, len, runs)| {
+                let (lower, upper) = if t0 <= t1 {
+                    (Antichain::from_elem(t0), Antichain::from_elem(t1))
+                } else {
+                    (Antichain::from_elem(t1), Antichain::from_elem(t0))
+                };
+                let since = Antichain::from_elem(since);
+                let runs = if runs { vec![parts.len()] } else { vec![] };
+                HollowBatch {
+                    desc: Description::new(lower, upper, since),
+                    parts,
+                    len: len % 10,
+                    runs,
+                }
+            },
+        )
+    }
+
+    pub fn any_leased_reader_state<T: Arbitrary>() -> impl Strategy<Value = LeasedReaderState<T>> {
+        Strategy::prop_map(
+            (
+                any::<SeqNo>(),
+                any::<Option<T>>(),
+                any::<u64>(),
+                any::<u64>(),
+                any::<HandleDebugState>(),
+            ),
+            |(seqno, since, last_heartbeat_timestamp_ms, mut lease_duration_ms, debug)| {
+                // lease_duration_ms of 0 means this state was written by an old
+                // version of code, which means we'll migrate it in the decode
+                // path. Avoid.
+                if lease_duration_ms == 0 {
+                    lease_duration_ms += 1;
+                }
+                LeasedReaderState {
+                    seqno,
+                    since: since.map_or_else(Antichain::new, Antichain::from_elem),
+                    last_heartbeat_timestamp_ms,
+                    lease_duration_ms,
+                    debug,
+                }
+            },
+        )
+    }
+
+    pub fn any_critical_reader_state<T: Arbitrary>() -> impl Strategy<Value = CriticalReaderState<T>>
+    {
+        Strategy::prop_map(
+            (
+                any::<Option<T>>(),
+                any::<OpaqueState>(),
+                any::<String>(),
+                any::<HandleDebugState>(),
+            ),
+            |(since, opaque, opaque_codec, debug)| CriticalReaderState {
+                since: since.map_or_else(Antichain::new, Antichain::from_elem),
+                opaque,
+                opaque_codec,
+                debug,
+            },
+        )
+    }
+
+    pub fn any_writer_state<T: Arbitrary>() -> impl Strategy<Value = WriterState<T>> {
+        Strategy::prop_map(
+            (
+                any::<u64>(),
+                any::<u64>(),
+                any::<IdempotencyToken>(),
+                any::<Option<T>>(),
+                any::<HandleDebugState>(),
+            ),
+            |(
+                last_heartbeat_timestamp_ms,
+                lease_duration_ms,
+                most_recent_write_token,
+                most_recent_write_upper,
+                debug,
+            )| WriterState {
+                last_heartbeat_timestamp_ms,
+                lease_duration_ms,
+                most_recent_write_token,
+                most_recent_write_upper: most_recent_write_upper
+                    .map_or_else(Antichain::new, Antichain::from_elem),
+                debug,
+            },
+        )
+    }
+
+    pub fn any_state<T: Arbitrary + Timestamp + Lattice>(
+        max_trace_batches: usize,
+    ) -> impl Strategy<Value = State<T>> {
+        Strategy::prop_map(
+            (
+                any::<ShardId>(),
+                any::<SeqNo>(),
+                any::<u64>(),
+                any::<String>(),
+                any::<SeqNo>(),
+                proptest::collection::btree_map(any::<SeqNo>(), any::<HollowRollup>(), 1..3),
+                proptest::collection::btree_map(
+                    any::<LeasedReaderId>(),
+                    any_leased_reader_state::<T>(),
+                    1..3,
+                ),
+                proptest::collection::btree_map(
+                    any::<CriticalReaderId>(),
+                    any_critical_reader_state::<T>(),
+                    1..3,
+                ),
+                proptest::collection::btree_map(any::<WriterId>(), any_writer_state::<T>(), 0..3),
+                any_trace::<T>(max_trace_batches),
+            ),
+            |(
+                shard_id,
+                seqno,
+                walltime_ms,
+                hostname,
+                last_gc_req,
+                rollups,
+                leased_readers,
+                critical_readers,
+                writers,
+                trace,
+            )| State {
+                applier_version: semver::Version::new(1, 2, 3),
+                shard_id,
+                seqno,
+                walltime_ms,
+                hostname,
+                collections: StateCollections {
+                    last_gc_req,
+                    rollups,
+                    leased_readers,
+                    critical_readers,
+                    writers,
+                    trace,
+                },
+            },
+        )
+    }
 
     fn hollow<T: Timestamp>(lower: T, upper: T, keys: &[&str], len: usize) -> HollowBatch<T> {
         HollowBatch {

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -25,6 +25,7 @@ use mz_ore::now::EpochMillis;
 use mz_ore::task::RuntimeExt;
 use mz_persist::location::{Blob, SeqNo};
 use mz_persist_types::{Codec, Codec64};
+use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -45,7 +46,7 @@ use crate::internal::watch::StateWatch;
 use crate::{parse_id, GarbageCollector, PersistConfig};
 
 /// An opaque identifier for a reader of a persist durable TVC (aka shard).
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct LeasedReaderId(pub(crate) [u8; 16]);
 

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -14,11 +14,12 @@ use mz_persist_types::columnar::{PartEncoder, Schema};
 use mz_persist_types::part::{Part, PartBuilder};
 use mz_persist_types::stats::StructStats;
 use mz_persist_types::Codec;
+use proptest_derive::Arbitrary;
 
 use crate::internal::encoding::Schemas;
 
 /// Aggregate statistics about data contained in a [Part].
-#[derive(Debug)]
+#[derive(Arbitrary, Debug)]
 pub struct PartStats {
     /// Aggregate statistics about key data contained in a [Part].
     pub key: StructStats,

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -21,6 +21,7 @@ use mz_ore::now::EpochMillis;
 use mz_ore::task::RuntimeExt;
 use mz_persist::location::Blob;
 use mz_persist_types::{Codec, Codec64};
+use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -41,7 +42,7 @@ use crate::internal::state::{HollowBatch, Upper};
 use crate::{parse_id, CpuHeavyRuntime, GarbageCollector, PersistConfig, ShardId};
 
 /// An opaque identifier for a writer of a persist durable TVC (aka shard).
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct WriterId(pub(crate) [u8; 16]);
 

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -14,6 +14,7 @@ arrow2 = { version = "0.16.0", features = ["compute_aggregate", "io_ipc", "io_pa
 bytes = "1.3.0"
 mz-proto = { path = "../proto" }
 parquet2 = { version = "0.17.1", default-features = false }
+proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -380,6 +380,7 @@ mod impls {
     use arrow2::types::simd::Simd;
     use arrow2::types::NativeType;
     use mz_proto::{ProtoType, RustType, TryFromProtoError};
+    use proptest::prelude::*;
 
     use crate::columnar::Data;
     use crate::stats::private::StatsCost;
@@ -1066,6 +1067,23 @@ mod impls {
     primitive_stats_rust_type!(f64, LowerF64, UpperF64);
     primitive_stats_rust_type!(Vec<u8>, LowerBytes, UpperBytes);
     primitive_stats_rust_type!(String, LowerString, UpperString);
+
+    #[allow(unused_parens)]
+    impl Arbitrary for StructStats {
+        type Parameters = ();
+        type Strategy =
+            proptest::strategy::Map<(<usize as Arbitrary>::Strategy), fn((usize)) -> Self>;
+
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            Strategy::prop_map((any::<usize>()), |(len)| {
+                StructStats {
+                    len,
+                    // TODO: Fill in cols with stats.
+                    cols: Default::default(),
+                }
+            })
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -42,6 +42,8 @@ openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 prometheus = { version = "0.13.3", default-features = false }
+proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
+proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.152", features = ["derive"] }

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -18,6 +18,7 @@ use bytes::Bytes;
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::u64_to_usize;
 use mz_proto::RustType;
+use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
@@ -35,7 +36,9 @@ use crate::error::Error;
 /// Read-only requests are assigned the SeqNo of a write, indicating that all
 /// mutating requests up to and including that one are reflected in the read
 /// state.
-#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Arbitrary, Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize,
+)]
 pub struct SeqNo(pub u64);
 
 impl std::fmt::Display for SeqNo {


### PR DESCRIPTION
Mostly a yak shave for #19102 where I wanted to deterministically generate a random State to then compare against the expected JSON version of that state. We can commit the latter as a golden and use it as an example of what the `INSPECT` output looks like.


### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
