### PR TITLE
qa: increase test coverage of some system vars

### DIFF
--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -3062,7 +3062,6 @@ impl Value for str {
     }
 }
 
-// The same as the above impl, but works in `SystemVar`s.
 impl Value for String {
     fn type_name() -> String {
         "string".to_string()

--- a/test/testdrive/disk-feature-flag.td
+++ b/test/testdrive/disk-feature-flag.td
@@ -26,3 +26,14 @@ ALTER SYSTEM SET enable_upsert_source_disk = false
 ! CREATE SOURCE lg FROM LOAD GENERATOR COUNTER
   WITH (DISK)
 contains:CREATE SOURCE...WITH (DISK..) is not supported
+
+# The following test that we don't crash envd with bad parameters, and instead just fallback
+# to safe parameters.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET upsert_rocksdb_universal_compaction_ratio = 50;
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET upsert_rocksdb_universal_compaction_ratio;
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET upsert_rocksdb_parallelism = -1;
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET upsert_rocksdb_parallelism

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -170,3 +170,11 @@ postgres
 contains:parameter "IntervalStyle" can only be set to "postgres"
 
 > SET intervalstyle = 'postgres';
+
+# Test some other parameter value codepaths, like `Option<String>` here
+> SET cluster_replica = ''
+
+> SET cluster_replica = 'r1'
+
+! SET cluster_replica = 1, 2
+contains:parameter "cluster_replica" requires a "optional string" value


### PR DESCRIPTION
@def- this is the followups you asked for in https://github.com/MaterializeInc/materialize/pull/19176!

Note that i didnt do https://github.com/MaterializeInc/materialize/pull/19176#discussion_r1195762781, because I am currently testing the viability of level compaction, and will delete the universal option afterwards

### Motivation


   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

