### PR TITLE
sql: Prevent modifying privileges of system users

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1509,6 +1509,17 @@ impl CatalogState {
         }
     }
 
+    pub fn ensure_not_system_role(&self, role_id: &RoleId) -> Result<(), Error> {
+        if role_id.is_system() {
+            let role = self.get_role(role_id);
+            Err(Error::new(ErrorKind::ReservedSystemRoleName(
+                role.name().to_string(),
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
     // TODO(mjibson): Is there a way to make this a closure to avoid explicitly
     // passing tx, session, and builtin_table_updates?
     fn add_to_audit_log(
@@ -6905,6 +6916,10 @@ impl Catalog {
 
     pub fn ensure_not_reserved_role(&self, role_id: &RoleId) -> Result<(), Error> {
         self.state.ensure_not_reserved_role(role_id)
+    }
+
+    pub fn ensure_not_system_role(&self, role_id: &RoleId) -> Result<(), Error> {
+        self.state.ensure_not_system_role(role_id)
     }
 
     pub fn ensure_not_reserved_object(

--- a/src/adapter/src/catalog/error.rs
+++ b/src/adapter/src/catalog/error.rs
@@ -46,6 +46,8 @@ pub enum ErrorKind {
     ReservedSchemaName(String),
     #[error("role name {} is reserved", .0.quoted())]
     ReservedRoleName(String),
+    #[error("role name {} is reserved", .0.quoted())]
+    ReservedSystemRoleName(String),
     #[error("cluster name {} is reserved", .0.quoted())]
     ReservedClusterName(String),
     #[error("replica name {} is reserved", .0.quoted())]
@@ -108,6 +110,9 @@ impl Error {
             }
             ErrorKind::ReservedRoleName(_) => {
                 Some("The role \"public\" and the prefixes \"mz_\" and \"pg_\" are reserved for system roles.".into())
+            }
+            ErrorKind::ReservedSystemRoleName(_) => {
+                Some("The role prefixes \"mz_\" and \"pg_\" are reserved for system roles.".into())
             }
             ErrorKind::ReservedClusterName(_) => {
                 Some("The prefixes \"mz_\" and \"pg_\" are reserved for system clusters.".into())

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4032,6 +4032,9 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, AdapterError> {
         self.catalog()
             .ensure_not_reserved_object(&object_id, session.conn_id())?;
+        for grantee in &grantees {
+            self.catalog().ensure_not_system_role(grantee)?;
+        }
 
         let privileges = self
             .catalog()

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -1406,7 +1406,7 @@ t1  mz_system=arwd/mz_system
 ## Test ALL keyword
 
 simple conn=mz_system,user=mz_system
-GRANT ALL ON t1 TO joe, test_role, mz_system
+GRANT ALL ON t1 TO joe, test_role
 ----
 COMPLETE 0
 
@@ -1457,6 +1457,40 @@ query TT
 SELECT name, privilege FROM item_privileges WHERE name = 'v1'
 ----
 v1  mz_system=r/mz_system
+
+## Test system objects
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT on v1 TO mz_introspection
+----
+db error: ERROR: role name "mz_introspection" is reserved
+DETAIL: The role prefixes "mz_" and "pg_" are reserved for system roles.
+
+simple conn=mz_system,user=mz_system
+REVOKE SELECT on v1 FROM mz_introspection
+----
+db error: ERROR: role name "mz_introspection" is reserved
+DETAIL: The role prefixes "mz_" and "pg_" are reserved for system roles.
+
+simple conn=mz_system,user=mz_system
+GRANT INSERT on mz_tables TO joe
+----
+db error: ERROR: system item 'mz_catalog.mz_tables' cannot be modified
+
+simple conn=mz_system,user=mz_system
+REVOKE SELECT on mz_tables FROM joe
+----
+db error: ERROR: system item 'mz_catalog.mz_tables' cannot be modified
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE on CLUSTER mz_system TO JOE
+----
+db error: ERROR: system cluster 'mz_system' cannot be modified
+
+simple conn=mz_system,user=mz_system
+REVOKE USAGE on CLUSTER mz_introspection FROM PUBLIC
+----
+db error: ERROR: system cluster 'mz_introspection' cannot be modified
 
 # Disable rbac checks.
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
This commit prevents anyone from modifying the privileges of system users. Certain system user privileges are required in order for Materialize to work correctly. We don't want to let any superuser revoke them and break Materialize.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
