### PR TITLE
persist: regression test for #19366

### DIFF
--- a/src/persist-types/proptest-regressions/stats.txt
+++ b/src/persist-types/proptest-regressions/stats.txt
@@ -14,3 +14,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc dbeaf5be7c581d2a5eb4959b72b1ffc1b9a980160516e2f9a5753dbac0385ec7 # shrinks to x = "߿®"
+cc cf0b08c15f4e230cbb1424d6c70c968b4c05d2cc1789ea858edf62b07b80d9fd # shrinks to a = false, b = true


### PR DESCRIPTION
We merged #19366 without a regression test to get it into this week's release candidate, so circling back here and adding test coverage that would have caught it. The bug was a copy-paste error in generating stats for bool columns.

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
