### PR TITLE
persist: add SQL to expose shard internals for debugging and QA

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -516,7 +516,7 @@ impl ExecuteResponse {
             DropObjects => vec![DroppedObject],
             DropOwned => vec![DroppedOwned],
             PlanKind::EmptyQuery => vec![ExecuteResponseKind::EmptyQuery],
-            Explain | Peek | ShowAllVariables | ShowCreate | ShowVariable => {
+            Explain | Peek | ShowAllVariables | ShowCreate | ShowVariable | InspectShard => {
                 vec![CopyTo, SendingRows]
             }
             Execute | ReadThenWrite => vec![Deleted, Inserted, SendingRows, Updated],

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -64,6 +64,7 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
         | Plan::ShowAllVariables
         | Plan::ShowCreate(_)
         | Plan::ShowVariable(_)
+        | Plan::InspectShard(_)
         | Plan::SetVariable(_)
         | Plan::ResetVariable(_)
         | Plan::SetTransaction(_)
@@ -286,6 +287,7 @@ pub fn user_privilege_hack(
         | Plan::AlterSystemReset(_)
         | Plan::AlterSystemResetAll(_)
         | Plan::AlterOwner(_)
+        | Plan::InspectShard(_)
         | Plan::ReadThenWrite(_)
         | Plan::Raise(_)
         | Plan::RotateKeys(_)

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -200,6 +200,11 @@ impl Coordinator {
                 let result = self.sequence_show_variable(ctx.session(), plan);
                 ctx.retire(result);
             }
+            Plan::InspectShard(plan) => {
+                // TODO: Ideally, this await would happen off the main thread.
+                let result = self.sequence_inspect_shard(ctx.session(), plan).await;
+                ctx.retire(result);
+            }
             Plan::SetVariable(plan) => {
                 let result = self.sequence_set_variable(ctx.session_mut(), plan);
                 ctx.retire(result);

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -31,10 +31,11 @@ use mz_sql::plan::{
     CreateSecretPlan, CreateSinkPlan, CreateSourcePlan, CreateSourcePlans, CreateTablePlan,
     CreateTypePlan, CreateViewPlan, DeallocatePlan, DeclarePlan, DropObjectsPlan, DropOwnedPlan,
     ExecutePlan, ExplainPlan, FetchPlan, GrantPrivilegesPlan, GrantRolePlan, InsertPlan,
-    MutationKind, PeekPlan, Plan, PlannedRoleAttributes, PreparePlan, RaisePlan, ReadThenWritePlan,
-    ReassignOwnedPlan, ResetVariablePlan, RevokePrivilegesPlan, RevokeRolePlan, RotateKeysPlan,
-    SetTransactionPlan, SetVariablePlan, ShowCreatePlan, ShowVariablePlan, SideEffectingFunc,
-    SourceSinkClusterConfig, StartTransactionPlan, SubscribePlan, UpdatePrivilege,
+    InspectShardPlan, MutationKind, PeekPlan, Plan, PlannedRoleAttributes, PreparePlan, RaisePlan,
+    ReadThenWritePlan, ReassignOwnedPlan, ResetVariablePlan, RevokePrivilegesPlan, RevokeRolePlan,
+    RotateKeysPlan, SetTransactionPlan, SetVariablePlan, ShowCreatePlan, ShowVariablePlan,
+    SideEffectingFunc, SourceSinkClusterConfig, StartTransactionPlan, SubscribePlan,
+    UpdatePrivilege,
 };
 use mz_sql::session::user::{INTROSPECTION_USER, SYSTEM_USER};
 use mz_sql::session::vars::SystemVars;
@@ -327,6 +328,7 @@ pub fn generate_required_role_membership(
         | Plan::ShowAllVariables
         | Plan::ShowCreate(_)
         | Plan::ShowVariable(_)
+        | Plan::InspectShard(_)
         | Plan::SetVariable(_)
         | Plan::ResetVariable(_)
         | Plan::SetTransaction(_)
@@ -430,6 +432,7 @@ fn generate_required_plan_attribute(plan: &Plan) -> Vec<Attribute> {
         | Plan::ShowAllVariables
         | Plan::ShowCreate(_)
         | Plan::ShowVariable(_)
+        | Plan::InspectShard(_)
         | Plan::SetVariable(_)
         | Plan::ResetVariable(_)
         | Plan::SetTransaction(_)
@@ -590,6 +593,7 @@ fn generate_required_ownership(plan: &Plan) -> Vec<ObjectId> {
         | Plan::ShowAllVariables
         | Plan::ShowVariable(_)
         | Plan::SetVariable(_)
+        | Plan::InspectShard(_)
         | Plan::ResetVariable(_)
         | Plan::SetTransaction(_)
         | Plan::StartTransaction(_)
@@ -1211,6 +1215,7 @@ fn generate_required_privileges(
         | Plan::EmptyQuery
         | Plan::ShowAllVariables
         | Plan::ShowVariable(ShowVariablePlan { name: _ })
+        | Plan::InspectShard(InspectShardPlan { id: _ })
         | Plan::SetVariable(SetVariablePlan {
             name: _,
             value: _,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1865,6 +1865,20 @@ impl AstDisplay for ShowVariableStatement {
 }
 impl_display!(ShowVariableStatement);
 
+/// `INSPECT SHARD <id>`
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct InspectShardStatement {
+    pub id: String,
+}
+
+impl AstDisplay for InspectShardStatement {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("INSPECT SHARD ");
+        f.write_str(&self.id);
+    }
+}
+impl_display!(InspectShardStatement);
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ShowObjectType<T: AstInfo> {
     MaterializedView {
@@ -2916,6 +2930,7 @@ pub enum ShowStatement<T: AstInfo> {
     ShowCreateIndex(ShowCreateIndexStatement<T>),
     ShowCreateConnection(ShowCreateConnectionStatement<T>),
     ShowVariable(ShowVariableStatement),
+    InspectShard(InspectShardStatement),
 }
 
 impl<T: AstInfo> AstDisplay for ShowStatement<T> {
@@ -2931,6 +2946,7 @@ impl<T: AstInfo> AstDisplay for ShowStatement<T> {
             ShowStatement::ShowCreateIndex(stmt) => f.write_node(stmt),
             ShowStatement::ShowCreateConnection(stmt) => f.write_node(stmt),
             ShowStatement::ShowVariable(stmt) => f.write_node(stmt),
+            ShowStatement::InspectShard(stmt) => f.write_node(stmt),
         }
     }
 }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -174,6 +174,7 @@ Inherit
 Inline
 Inner
 Insert
+Inspect
 Int
 Integer
 Intersect
@@ -322,6 +323,7 @@ Serializable
 Service
 Session
 Set
+Shard
 Show
 Sink
 Sinks

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -308,6 +308,7 @@ impl<'a> Parser<'a> {
                 Token::Keyword(GRANT) => Ok(self.parse_grant()?),
                 Token::Keyword(REVOKE) => Ok(self.parse_revoke()?),
                 Token::Keyword(REASSIGN) => Ok(self.parse_reassign_owned()?),
+                Token::Keyword(INSPECT) => Ok(Statement::Show(self.parse_inspect()?)),
                 Token::Keyword(kw) => parser_err!(
                     self,
                     self.peek_prev_pos(),
@@ -5488,6 +5489,12 @@ impl<'a> Parser<'a> {
         } else {
             Ok(None)
         }
+    }
+
+    fn parse_inspect(&mut self) -> Result<ShowStatement<Raw>, ParserError> {
+        self.expect_keyword(SHARD)?;
+        let id = self.parse_literal_string()?;
+        Ok(ShowStatement::InspectShard(InspectShardStatement { id }))
     }
 
     fn parse_table_and_joins(&mut self) -> Result<TableWithJoins<Raw>, ParserError> {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -113,6 +113,7 @@ pub enum Plan {
     ShowAllVariables,
     ShowCreate(ShowCreatePlan),
     ShowVariable(ShowVariablePlan),
+    InspectShard(InspectShardPlan),
     SetVariable(SetVariablePlan),
     ResetVariable(ResetVariablePlan),
     SetTransaction(SetTransactionPlan),
@@ -239,6 +240,7 @@ impl Plan {
                 PlanKind::ShowVariable,
                 PlanKind::ShowCreate,
                 PlanKind::ShowAllVariables,
+                PlanKind::InspectShard,
             ],
             StatementKind::StartTransaction => vec![PlanKind::StartTransaction],
             StatementKind::Subscribe => vec![PlanKind::Subscribe],
@@ -288,6 +290,7 @@ impl Plan {
             Plan::ShowAllVariables => "show all variables",
             Plan::ShowCreate(_) => "show create",
             Plan::ShowVariable(_) => "show variable",
+            Plan::InspectShard(_) => "inspect shard",
             Plan::SetVariable(_) => "set variable",
             Plan::ResetVariable(_) => "reset variable",
             Plan::SetTransaction(_) => "set transaction",
@@ -647,6 +650,11 @@ pub struct DropOwnedPlan {
 #[derive(Debug)]
 pub struct ShowVariablePlan {
     pub name: String,
+}
+
+#[derive(Debug)]
+pub struct InspectShardPlan {
+    pub id: GlobalId,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1519,6 +1519,7 @@ fn plan_set_expr(
                     show::show_objects(qcx.scx, stmt)?.plan_hir(qcx)
                 }
                 ShowStatement::ShowVariable(_) => sql_bail!("unsupported SHOW statement"),
+                ShowStatement::InspectShard(_) => sql_bail!("unsupported INSPECT statement"),
             }
         }
     }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -215,6 +215,9 @@ pub fn describe(
 
         // Other statements.
         Statement::Raise(stmt) => raise::describe_raise(&scx, stmt)?,
+        Statement::Show(ShowStatement::InspectShard(stmt)) => {
+            scl::describe_inspect_shard(&scx, stmt)?
+        }
     };
 
     let desc = desc.with_params(scx.finalize_param_types()?);
@@ -350,6 +353,7 @@ pub fn plan(
 
         // Other statements.
         Statement::Raise(stmt) => raise::plan_raise(scx, stmt),
+        Statement::Show(ShowStatement::InspectShard(stmt)) => scl::plan_inspect_shard(scx, stmt),
     };
 
     if let Ok(plan) = &plan {

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -485,6 +485,20 @@ pub trait StorageController: Debug + Send {
     /// initial state and the controller can reconcile (i.e. drop) any unclaimed
     /// resources.
     async fn reconcile_state(&mut self);
+
+    /// Exposes the internal state of the data shard for debugging and QA.
+    ///
+    /// We'll be thoughtful about making unnecessary changes, but the **output
+    /// of this method needs to be gated from users**, so that it's not subject
+    /// to our backward compatibility guarantees.
+    ///
+    /// TODO: Ideally this would return `impl Serialize` so the caller can do
+    /// with it what they like, but that doesn't work in traits yet. The
+    /// workaround (an associated type) doesn't work because persist doesn't
+    /// want to make the type public. In the meantime, move the `serde_json`
+    /// call from the single user into this method.
+    async fn inspect_persist_state(&self, id: GlobalId)
+        -> Result<serde_json::Value, anyhow::Error>;
 }
 
 /// Compaction policies for collections maintained by `Controller`.
@@ -2409,6 +2423,22 @@ where
 
     async fn reconcile_state(&mut self) {
         self.reconcile_state_inner().await
+    }
+
+    async fn inspect_persist_state(
+        &self,
+        id: GlobalId,
+    ) -> Result<serde_json::Value, anyhow::Error> {
+        let collection = &self.collection(id)?.collection_metadata;
+        let client = self
+            .persist
+            .open(collection.persist_location.clone())
+            .await?;
+        let shard_state = client
+            .inspect_shard::<Self::Timestamp>(&collection.data_shard)
+            .await?;
+        let json_state = serde_json::to_value(shard_state)?;
+        Ok(json_state)
     }
 }
 


### PR DESCRIPTION
This adds an mz_system only `INSPECT SHARD <id>` command for debugging and QA.

Example:

```
materialize=> INSPECT SHARD 'u1';
state
------------------
{"batches": ... }
(1 row)
```

As discussed in https://github.com/MaterializeInc/materialize/issues/19102#issuecomment-1540789978, it's possible but tricky to make this work in a way that lets us use normal SQL jsonb operators on it. This first version chooses to do the strait forward implementation, which pushes any processing of the json into the client. If this command proves to be sufficiently useful and this limitation proves to be a sufficiently annoying papercut, then we can revisit.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
