### PR TITLE
transform: rework `MonotonicFlag` inference to make it `recursion_safe`

### DIFF
--- a/doc/developer/design/20230223_stabilize_with_mutually_recursive.md
+++ b/doc/developer/design/20230223_stabilize_with_mutually_recursive.md
@@ -95,7 +95,7 @@ transformation              | estimate | tracked in
 ----------------------------|----------|-------------------------------------------------
 `canonicalize_mfp`          | &check;  | MaterializeInc/materialize#18123
 `column_knowledge`          | &check;  | MaterializeInc/materialize#18161
-`demand`                    | L?       | MaterializeInc/materialize#18162
+`demand`                    | &check;  | MaterializeInc/materialize#18162
 `filter_fusion`             | &check;  | MaterializeInc/materialize#18123 (depends on type inference)
 `fixpoint`                  | &check;  | MaterializeInc/materialize#16561
 `flatmap_to_map`            | &check;  | MaterializeInc/materialize#18123
@@ -107,7 +107,7 @@ transformation              | estimate | tracked in
 `literal_constraints`       | &check;  | MaterializeInc/materialize#18123
 `literal_lifting`           | &check;  | MaterializeInc/materialize#18165
 `map_fusion`                | &check;  | MaterializeInc/materialize#18123
-`monotonic_flag`            | L?       | MaterializeInc/materialize#18472
+`monotonic_flag`            | &check;  | MaterializeInc/materialize#18472
 `negate_fusion`             | &check;  | MaterializeInc/materialize#18123
 `non_null_requirements`     | &check;  | MaterializeInc/materialize#18166
 `non_nullable`              | &check;  | MaterializeInc/materialize#18123 (somewhat restricted)
@@ -118,7 +118,7 @@ transformation              | estimate | tracked in
 `projection_extraction`     | &check;  | MaterializeInc/materialize#18123
 `projection_lifting`        | &check;  | MaterializeInc/materialize#18168
 `projection_pushdown`       | &check;  | MaterializeInc/materialize#18169
-`reduce_elision`            | M?       | MaterializeInc/materialize#18170
+`reduce_elision`            | &check;  | MaterializeInc/materialize#18170
 `reduce_fusion`             | &check;  | MaterializeInc/materialize#18123
 `reduction_pushdown`        | &check;  | MaterializeInc/materialize#18171
 `redundant_join`            | &check;  | MaterializeInc/materialize#18172

--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -216,9 +216,9 @@ Operator | Meaning | Example
 **Filter** | Removes rows of the input for which some scalar predicates return `false`. | `Filter (#20 < #21)`
 **Join** | Returns combinations of rows from each input whenever some equality predicates are `true`. | `Join on=(#1 = #2)`
 **CrossJoin** | An alias for a `Join` with an empty predicate (emits all combinations). | `CrossJoin`
-**Reduce** | Groups the input rows by some scalar expressions, reduces each groups using some aggregate functions and produce rows containing the group key and aggregate outputs. | `Reduce group_by=[#0] aggregates=[max((#0 * #1))]`
+**Reduce** | Groups the input rows by some scalar expressions, reduces each groups using some aggregate functions, and produce rows containing the group key and aggregate outputs. | `Reduce group_by=[#0] aggregates=[max((#0 * #1))]`
 **Distinct** | Alias for a `Reduce` with an empty aggregate list. | `Distinct`
-**TopK** | Groups the inputs rows by some scalar expressions, sorts each group using the group key, removes the top `offset` rows in each group and returns the next `limit` rows.| `TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 monotonic=false`
+**TopK** | Groups the inputs rows by some scalar expressions, sorts each group using the group key, removes the top `offset` rows in each group, and returns the next `limit` rows.| `TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5`
 **Negate** | Negates the row counts of the input. This is usually used in combination with union to remove rows from the other union input. | `Negate`
 **Threshold** | Removes any rows with negative counts. | `Threshold`
 **Union** | Sums the counts of each row of all inputs. | `Union`
@@ -236,9 +236,9 @@ Operator | Meaning | Example
 **CallTable** | Appends the result of some table function to each row in the input. | `CallTable generate_series(1, 7, 1)`
 **Filter** | Removes rows of the input for which some scalar predicates return false. | `Filter (#20 < #21)`
 **~Join** | Performs one of `INNER` / `LEFT` / `RIGHT` / `FULL OUTER` / `CROSS` join on the two inputs, using the given predicate. | `InnerJoin (#3 = #5)`.
-**Reduce** | Groups the input rows by some scalar expressions, reduces each group using some aggregate functions and produce rows containing the group key and aggregate outputs. In the case where the group key is empty and the input is empty, returns a single row with the aggregate functions applied to the empty input collection. | `Reduce group_by=[#2] aggregates=[min(#0), max(#0)]`
+**Reduce** | Groups the input rows by some scalar expressions, reduces each group using some aggregate functions, and produces rows containing the group key and aggregate outputs. In the case where the group key is empty and the input is empty, returns a single row with the aggregate functions applied to the empty input collection. | `Reduce group_by=[#2] aggregates=[min(#0), max(#0)]`
 **Distinct** | Removes duplicate copies of input rows. | `Distinct`
-**TopK** | Groups the inputs rows by some scalar expressions, sorts each group using the group key, removes the top `offset` rows in each group and returns the next `limit` rows. | `TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5`
+**TopK** | Groups the inputs rows by some scalar expressions, sorts each group using the group key, removes the top `offset` rows in each group, and returns the next `limit` rows. | `TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5`
 **Negate** | Negates the row counts of the input. This is usually used in combination with union to remove rows from the other union input. | `Negate`
 **Threshold** | Removes any rows with negative counts. | `Threshold`
 **Union** | Sums the counts of each row of all inputs. | `Union`

--- a/src/compute-client/src/explain/text.rs
+++ b/src/compute-client/src/explain/text.rs
@@ -603,6 +603,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for HierarchicalPlan {
                 writeln!(f, "{}aggr_funcs=[{}]", ctx.indent, aggr_funcs)?;
                 let skips = separated(", ", &plan.skips);
                 writeln!(f, "{}skips=[{}]", ctx.indent, skips)?;
+                writeln!(f, "{}monotonic", ctx.indent)?;
                 if plan.must_consolidate {
                     writeln!(f, "{}must_consolidate", ctx.indent)?;
                 }

--- a/src/expr-test-util/tests/testdata/rel
+++ b/src/expr-test-util/tests/testdata/rel
@@ -126,7 +126,7 @@ build
 (top_k (get y) [1] [0] 5 1)
 ----
 ----
-TopK group_by=[#1] order_by=[#0 asc nulls_first] limit=5 offset=1 monotonic=false
+TopK group_by=[#1] order_by=[#0 asc nulls_first] limit=5 offset=1
   Get u1
 
 ----
@@ -136,7 +136,7 @@ build
 (top_k (get y) [0 1] [(2 true true)] )
 ----
 ----
-TopK group_by=[#0, #1] order_by=[#2 desc nulls_last] monotonic=false
+TopK group_by=[#0, #1] order_by=[#2 desc nulls_last]
   Get u1
 
 ----

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -572,7 +572,7 @@ impl MirRelationExpr {
                 group_key,
                 aggregates,
                 expected_group_size,
-                monotonic: _, // TODO: monotonic should be an attribute
+                monotonic,
                 input,
             } => {
                 FmtNode {
@@ -589,6 +589,9 @@ impl MirRelationExpr {
                         if aggregates.len() > 0 {
                             let aggregates = separated(", ", aggregates);
                             write!(f, " aggregates=[{}]", aggregates)?;
+                        }
+                        if *monotonic {
+                            write!(f, " monotonic")?;
                         }
                         if let Some(expected_group_size) = expected_group_size {
                             write!(f, " exp_group_size={}", expected_group_size)?;
@@ -625,7 +628,9 @@ impl MirRelationExpr {
                         if offset > &0 {
                             write!(f, " offset={}", offset)?
                         }
-                        write!(f, " monotonic={}", monotonic)?;
+                        if *monotonic {
+                            write!(f, " monotonic")?;
+                        }
                         if let Some(expected_group_size) = expected_group_size {
                             write!(f, " exp_group_size={}", expected_group_size)?;
                         }

--- a/src/transform/src/monotonic.rs
+++ b/src/transform/src/monotonic.rs
@@ -10,8 +10,11 @@
 //! Analysis to identify monotonic collections, especially TopK inputs.
 use std::collections::BTreeSet;
 
+use itertools::zip_eq;
 use mz_expr::visit::VisitChildren;
 use mz_expr::{Id, LocalId, MirRelationExpr, RECURSION_LIMIT};
+use mz_ore::cast::CastFrom;
+use mz_ore::soft_panic_or_log;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 use mz_repr::GlobalId;
 
@@ -120,38 +123,92 @@ impl MonotonicFlag {
                 MirRelationExpr::LetRec {
                     ids,
                     values,
-                    max_iters: _,
+                    max_iters,
                     body,
                 } => {
+                    // Optimistically assume that all bindings were monotonic
+                    // (it is safe to do this as we initialize each binding to
+                    // the empty collection, which is trivially monotonic).
                     for id in ids.iter() {
-                        if locals.contains(id) {
-                            panic!("Shadowing of identifier: {:?}", id);
-                        }
-                    }
-                    // Pessimistically assume all bindings are non-monotonic, and
-                    // iteratively attempt to determine that some may be monotonic.
-                    //
-                    // TODO: This is suboptimal as long as there is one method to
-                    // both report and apply monotonicity information. We need to
-                    // be able to repeatedly report monotonicity information, and
-                    // then apply it subsequently. Ideally we would optimistically
-                    // assume all bindings were monotonic, and iteratively remove
-                    // any that are determined to be non-monotonic; only once this
-                    // concludes can we apply any transformations, however.
-                    // Don't forget to handle `max_iters` when changing to the
-                    // optimistic approach!
-                    let mut added = true;
-                    while added {
-                        added = false;
-                        for (id, value) in ids.iter().zip(&mut *values) {
-                            if !locals.contains(id) && self.apply(value, mon_ids, locals)? {
-                                added = true;
-                                locals.insert(*id);
-                            }
-                        }
+                        let inserted = locals.insert(id.clone());
+                        assert!(inserted, "Shadowing of identifier: {id:?}");
                     }
 
-                    self.apply(body, mon_ids, locals)?
+                    // The following is equivalent to a dataflow analysis on the
+                    // following lattice:
+                    // - The bottom element is `true` / contained in `locals`.
+                    // - The top element is `false` / not present in `locals`.
+                    // - The join operator is boolean `AND`.
+                    // - The meet operator is boolean `OR` (but it's not used).
+                    //
+                    // Sequentially AND locals[id] with the result of descending
+                    // into a clone of values[id]. Repeat until one of the
+                    // following conditions is met:
+                    //
+                    // 1. The locals entries have stabilized at a fixpoint.
+                    // 2. No fixpoint was found after `max_iterations`. If this
+                    //    is the case we reset the locals entries for all
+                    //    recursive CTEs to `false` by removing them from
+                    //    `locals` (pessimistic approximation).
+                    // 3. We reach the user-specified iteration limit of any of
+                    //    the bindings. In this case, we also give up similarly
+                    //    to (2), because we don't want to complicate things
+                    //    with handling different limits per binding.
+                    let min_max_iter = max_iters.into_iter().filter_map(|md| *md).min();
+                    let max_iterations = 100;
+                    let mut curr_iteration = 0;
+                    loop {
+                        // Check for conditions (2) and (3).
+                        if curr_iteration >= max_iterations
+                            || min_max_iter
+                                .map(|min_max_iter| curr_iteration >= min_max_iter.get())
+                                .unwrap_or(false)
+                        {
+                            if curr_iteration > u64::cast_from(ids.len()) {
+                                soft_panic_or_log!(
+                                    "LetRec loop in MonotonicFlag has not converged in |{}|",
+                                    ids.len()
+                                );
+                            }
+
+                            for id in ids.iter() {
+                                locals.remove(id);
+                            }
+                            break;
+                        }
+
+                        // Check for condition (1).
+                        let mut change = false;
+                        for (id, mut value) in zip_eq(ids.iter(), values.iter().cloned()) {
+                            if !self.apply(&mut value, mon_ids, locals)? {
+                                change |= locals.remove(id); // set only if `id` is still present
+                            }
+                        }
+                        if !change {
+                            break;
+                        }
+
+                        curr_iteration += 1;
+                    }
+
+                    // Descend into the values with the locals.
+                    for value in values.iter_mut() {
+                        self.apply(value, mon_ids, locals)?;
+                    }
+
+                    let is_monotonic = self.apply(body, mon_ids, locals)?;
+
+                    // Remove shadowed bindings. This is good hygiene, as
+                    // otherwise with nested LetRec blocks the `loop { ... }`
+                    // above will carry inner LetRec IDs across outer LetRec
+                    // iterations. As a consequence, the "no shadowing"
+                    // assertion at the beginning of this block will fail at the
+                    // inner LetRec for the second outer LetRec iteration.
+                    for id in ids.iter() {
+                        locals.remove(id);
+                    }
+
+                    is_monotonic
                 }
                 // The default behavior.
                 // TODO: check that this is the behavior we want.

--- a/src/transform/tests/testdata/predicate-pushdown
+++ b/src/transform/tests/testdata/predicate-pushdown
@@ -225,7 +225,7 @@ build apply=PredicatePushdown
   [(call_binary gt #1 5)]
 )
 ----
-TopK group_by=[#1] order_by=[#1 desc nulls_first] limit=1 monotonic=false
+TopK group_by=[#1] order_by=[#1 desc nulls_first] limit=1
   Filter (#1 > 5)
     Constant
       - ("a", 1)

--- a/src/transform/tests/testdata/projection-pushdown
+++ b/src/transform/tests/testdata/projection-pushdown
@@ -304,7 +304,7 @@ build apply=ProjectionPushdown
 ----
 Project (#0, #0, #0)
   Project (#2)
-    TopK group_by=[#0] order_by=[#1 asc nulls_first, #2 asc nulls_first] monotonic=false
+    TopK group_by=[#0] order_by=[#1 asc nulls_first, #2 asc nulls_first]
       Get x
 
 build apply=ProjectionPushdown
@@ -318,7 +318,7 @@ build apply=ProjectionPushdown
 ----
 Project (#0, #0)
   Project (#1)
-    TopK order_by=[#0 asc nulls_first] monotonic=false
+    TopK order_by=[#0 asc nulls_first]
       Project (#1, #2)
         Get x
 
@@ -331,7 +331,7 @@ build apply=ProjectionPushdown
         )
     [#2 #1])
 ----
-TopK group_by=[#0] order_by=[#1 asc nulls_first] monotonic=false
+TopK group_by=[#0] order_by=[#1 asc nulls_first]
   Project (#2, #1)
     Get x
 

--- a/src/transform/tests/testdata/topk_fusion
+++ b/src/transform/tests/testdata/topk_fusion
@@ -17,13 +17,13 @@ ok
 build apply=Fusion
 (top_k (top_k (get x) [] [] 3 2) [] [] 1 1)
 ----
-TopK limit=1 offset=3 monotonic=false
+TopK limit=1 offset=3
   Get x
 
 build apply=Fusion
 (top_k (top_k (get x) [0] [#0] 3 2) [0] [#0] 1 1)
 ----
-TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=1 offset=3 monotonic=false
+TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=1 offset=3
   Get x
 
 # outer limit is greater than inner limit plus outer offset
@@ -31,13 +31,13 @@ TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=1 offset=3 monotonic=fals
 build apply=Fusion
 (top_k (top_k (get x) [0] [#0] 3 2) [0] [#0] 10 0)
 ----
-TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=3 offset=2 monotonic=false
+TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=3 offset=2
   Get x
 
 build apply=Fusion
 (top_k (top_k (get x) [0] [#0] 3 2) [0] [#0] 10 1)
 ----
-TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=2 offset=3 monotonic=false
+TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=2 offset=3
   Get x
 
 # outer offset is equal to inner limit
@@ -59,7 +59,7 @@ Constant <empty>
 build apply=Fusion
 (top_k (top_k (get x) [0] [#0] null 2) [0] [#0] 10 1)
 ----
-TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=10 offset=3 monotonic=false
+TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=10 offset=3
   Get x
 
 # both have no limit, but offset
@@ -67,7 +67,7 @@ TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=10 offset=3 monotonic=fal
 build apply=Fusion
 (top_k (top_k (get x) [0] [#0] null 2) [0] [#0] null 1)
 ----
-TopK group_by=[#0] order_by=[#0 asc nulls_first] offset=3 monotonic=false
+TopK group_by=[#0] order_by=[#0 asc nulls_first] offset=3
   Get x
 
 # outer has no limit, but both have offset
@@ -75,7 +75,7 @@ TopK group_by=[#0] order_by=[#0 asc nulls_first] offset=3 monotonic=false
 build apply=Fusion
 (top_k (top_k (get x) [] [#0] 3 2) [] [#0] null 1)
 ----
-TopK order_by=[#0 asc nulls_first] limit=2 offset=3 monotonic=false
+TopK order_by=[#0 asc nulls_first] limit=2 offset=3
   Get x
 
 # outer has no limit and no offset
@@ -83,7 +83,7 @@ TopK order_by=[#0 asc nulls_first] limit=2 offset=3 monotonic=false
 build apply=Fusion
 (top_k (top_k (get x) [] [#0] 3 2) [] [#0] null 0)
 ----
-TopK order_by=[#0 asc nulls_first] limit=3 offset=2 monotonic=false
+TopK order_by=[#0 asc nulls_first] limit=3 offset=2
   Get x
 
 # inner has no limit and no offset
@@ -91,7 +91,7 @@ TopK order_by=[#0 asc nulls_first] limit=3 offset=2 monotonic=false
 build apply=Fusion
 (top_k (top_k (get x) [] [#0] null 0) [] [#0] 3 2)
 ----
-TopK order_by=[#0 asc nulls_first] limit=3 offset=2 monotonic=false
+TopK order_by=[#0 asc nulls_first] limit=3 offset=2
   Get x
 
 # inner has no limit and no offset, and outer has only limit
@@ -99,7 +99,7 @@ TopK order_by=[#0 asc nulls_first] limit=3 offset=2 monotonic=false
 build apply=Fusion
 (top_k (top_k (get x) [] [#0] null 0) [] [#0] 3 0)
 ----
-TopK order_by=[#0 asc nulls_first] limit=3 monotonic=false
+TopK order_by=[#0 asc nulls_first] limit=3
   Get x
 
 # inner has no limit and no offset, and outer has only offset
@@ -107,7 +107,7 @@ TopK order_by=[#0 asc nulls_first] limit=3 monotonic=false
 build apply=Fusion
 (top_k (top_k (get x) [] [#0] null 0) [] [#0] null 1)
 ----
-TopK order_by=[#0 asc nulls_first] offset=1 monotonic=false
+TopK order_by=[#0 asc nulls_first] offset=1
   Get x
 
 # both have no limit and no offset
@@ -115,7 +115,7 @@ TopK order_by=[#0 asc nulls_first] offset=1 monotonic=false
 build apply=Fusion
 (top_k (top_k (get x) [] [#0] null 0) [] [#0] null 0)
 ----
-TopK order_by=[#0 asc nulls_first] monotonic=false
+TopK order_by=[#0 asc nulls_first]
   Get x
 
 # both have limit 0 and no offset
@@ -142,8 +142,8 @@ Constant <empty>
 build
 (top_k (top_k (constant [[5][4][2][3][2][1]] [int32]) [] [] 3 2) [] [] 1 1)
 ----
-TopK limit=1 offset=1 monotonic=false
-  TopK limit=3 offset=2 monotonic=false
+TopK limit=1 offset=1
+  TopK limit=3 offset=2
     Constant
       - (5)
       - (4)
@@ -155,7 +155,7 @@ TopK limit=1 offset=1 monotonic=false
 build apply=Fusion
 (top_k (top_k (constant [[5][4][2][3][2][1]] [int32]) [] [] 3 2) [] [] 1 1)
 ----
-TopK limit=1 offset=3 monotonic=false
+TopK limit=1 offset=3
   Constant
     - (5)
     - (4)
@@ -179,8 +179,8 @@ Constant <empty>
 build apply=Fusion
 (top_k (top_k (constant [[5 4] [3 2] [1 0]] [int32 int32]) [] [#1] 3 2) [] [#0] 1 0)
 ----
-TopK order_by=[#0 asc nulls_first] limit=1 monotonic=false
-  TopK order_by=[#1 asc nulls_first] limit=3 offset=2 monotonic=false
+TopK order_by=[#0 asc nulls_first] limit=1
+  TopK order_by=[#1 asc nulls_first] limit=3 offset=2
     Constant
       - (5, 4)
       - (3, 2)
@@ -189,7 +189,7 @@ TopK order_by=[#0 asc nulls_first] limit=1 monotonic=false
 build apply=Fusion
 (top_k (top_k (constant [[5 4] [3 2] [1 0]] [int32 int32]) [] [#1] 3 2) [] [#1] 1 0)
 ----
-TopK order_by=[#1 asc nulls_first] limit=1 offset=2 monotonic=false
+TopK order_by=[#1 asc nulls_first] limit=1 offset=2
   Constant
     - (5, 4)
     - (3, 2)
@@ -198,8 +198,8 @@ TopK order_by=[#1 asc nulls_first] limit=1 offset=2 monotonic=false
 build apply=Fusion
 (top_k (top_k (constant [[5 4] [3 2] [1 0]] [int32 int32]) [0] [#0] 3 2) [1] [#1] 1 0)
 ----
-TopK group_by=[#1] order_by=[#1 asc nulls_first] limit=1 monotonic=false
-  TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=3 offset=2 monotonic=false
+TopK group_by=[#1] order_by=[#1 asc nulls_first] limit=1
+  TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=3 offset=2
     Constant
       - (5, 4)
       - (3, 2)
@@ -208,8 +208,8 @@ TopK group_by=[#1] order_by=[#1 asc nulls_first] limit=1 monotonic=false
 build apply=Fusion
 (top_k (top_k (constant [[5 4] [3 2] [1 0]] [int32 int32]) [0] [] 3 2) [0] [#1] 1 0)
 ----
-TopK group_by=[#0] order_by=[#1 asc nulls_first] limit=1 monotonic=false
-  TopK group_by=[#0] limit=3 offset=2 monotonic=false
+TopK group_by=[#0] order_by=[#1 asc nulls_first] limit=1
+  TopK group_by=[#0] limit=3 offset=2
     Constant
       - (5, 4)
       - (3, 2)
@@ -220,7 +220,7 @@ TopK group_by=[#0] order_by=[#1 asc nulls_first] limit=1 monotonic=false
 build apply=Fusion
 (top_k (top_k (constant [[5 4] [3 2] [1 0] [1 1]] [int32 int32]) [0] [] 3 1) [0] [] 1 0)
 ----
-TopK group_by=[#0] limit=1 offset=1 monotonic=false
+TopK group_by=[#0] limit=1 offset=1
   Constant
     - (5, 4)
     - (3, 2)
@@ -244,7 +244,7 @@ Constant
 build apply=Fusion
 (top_k (top_k (get x) [0] [(#0 false true)] 3 2) [0] [(#0 false true)] 1 1)
 ----
-TopK group_by=[#0] order_by=[#0 asc nulls_last] limit=1 offset=3 monotonic=false
+TopK group_by=[#0] order_by=[#0 asc nulls_last] limit=1 offset=3
   Get x
 
 # Cannot be fused, because nulls_last differs
@@ -252,8 +252,8 @@ TopK group_by=[#0] order_by=[#0 asc nulls_last] limit=1 offset=3 monotonic=false
 build apply=Fusion
 (top_k (top_k (get x) [0] [(#0 false false)] 3 2) [0] [(#0 false true)] 1 1)
 ----
-TopK group_by=[#0] order_by=[#0 asc nulls_last] limit=1 offset=1 monotonic=false
-  TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=3 offset=2 monotonic=false
+TopK group_by=[#0] order_by=[#0 asc nulls_last] limit=1 offset=1
+  TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=3 offset=2
     Get x
 
 # Cannot be fused, because asc-desc differs
@@ -261,6 +261,6 @@ TopK group_by=[#0] order_by=[#0 asc nulls_last] limit=1 offset=1 monotonic=false
 build apply=Fusion
 (top_k (top_k (get x) [0] [(#0 false false)] 3 2) [0] [(#0 true false)] 1 1)
 ----
-TopK group_by=[#0] order_by=[#0 desc nulls_first] limit=1 offset=1 monotonic=false
-  TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=3 offset=2 monotonic=false
+TopK group_by=[#0] order_by=[#0 desc nulls_first] limit=1 offset=1
+  TopK group_by=[#0] order_by=[#0 asc nulls_first] limit=3 offset=2
     Get x

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -48,7 +48,7 @@ materialize.public.test1:
       Union // { arity: 4 }
         Negate // { arity: 4 }
           Distinct group_by=[#0..=#3] // { arity: 4 }
-            TopK order_by=[#1 asc nulls_last] limit=10 offset=1 monotonic=false // { arity: 4 }
+            TopK order_by=[#1 asc nulls_last] limit=10 offset=1 // { arity: 4 }
               Project (#0..=#2, #4) // { arity: 4 }
                 Map ((#3 + 1)) // { arity: 5 }
                   Union // { arity: 4 }

--- a/test/sqllogictest/attributes/mir_column_types.slt
+++ b/test/sqllogictest/attributes/mir_column_types.slt
@@ -120,7 +120,7 @@ Explained Query:
   Threshold // { types: "(boolean?, bigint)" }
     Union // { types: "(boolean?, bigint)" }
       Negate // { types: "(boolean?, bigint)" }
-        TopK limit=1 monotonic=false // { types: "(boolean?, bigint)" }
+        TopK limit=1 // { types: "(boolean?, bigint)" }
           Project (#1, #2) // { types: "(boolean?, bigint)" }
             Reduce group_by=[#0] aggregates=[min(#1), count(*)] // { types: "(double precision, boolean?, bigint)" }
               Project (#0, #1) // { types: "(double precision, boolean?)" }

--- a/test/sqllogictest/attributes/mir_unique_keys.slt
+++ b/test/sqllogictest/attributes/mir_unique_keys.slt
@@ -109,7 +109,7 @@ Explained Query:
     Union // { keys: "()" }
       Project (#1, #2) // { keys: "([1])" }
         Map (integer_to_double(#0)) // { keys: "([0], [2])" }
-          TopK group_by=[#0] limit=1 monotonic=false // { keys: "([0])" }
+          TopK group_by=[#0] limit=1 // { keys: "([0])" }
             Project (#0, #1) // { keys: "()" }
               Join on=(#0 = #2) type=differential // { keys: "()" }
                 ArrangeBy keys=[[#0]] // { keys: "([0])" }
@@ -165,7 +165,7 @@ Explained Query:
                 Project () // { keys: "()" }
                   Get l0 // { keys: "()" }
     cte l0 =
-      TopK limit=3 monotonic=true // { keys: "()" }
+      TopK limit=3 monotonic // { keys: "()" }
         FlatMap generate_series(1, 100000, 1) // { keys: "()" }
           Constant // { keys: "([])" }
             - ()

--- a/test/sqllogictest/distinct_on.slt
+++ b/test/sqllogictest/distinct_on.slt
@@ -32,7 +32,7 @@ EXPLAIN WITH(arity, join_impls) SELECT DISTINCT ON (c) a FROM abc
 ----
 Explained Query:
   Project (#0) // { arity: 1 }
-    TopK group_by=[#1] limit=1 monotonic=false // { arity: 2 }
+    TopK group_by=[#1] limit=1 // { arity: 2 }
       Project (#0, #2) // { arity: 2 }
         Get materialize.public.abc // { arity: 3 }
 
@@ -43,7 +43,7 @@ EXPLAIN WITH(arity, join_impls) SELECT DISTINCT ON (c) a FROM abc ORDER BY c, b
 ----
 Explained Query:
   Finish order_by=[#2 asc nulls_last, #1 asc nulls_last] output=[#0]
-    TopK group_by=[#2] order_by=[#1 asc nulls_last] limit=1 monotonic=false // { arity: 3 }
+    TopK group_by=[#2] order_by=[#1 asc nulls_last] limit=1 // { arity: 3 }
       Get materialize.public.abc // { arity: 3 }
 
 EOF

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -143,7 +143,7 @@ EXPLAIN DECORRELATED PLAN AS TEXT FOR
 VIEW ov
 ----
 Project (#0, #1)
-  TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 monotonic=false
+  TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
     CrossJoin
       Constant
         - ()
@@ -345,7 +345,7 @@ With
               Get l7
   cte l7 =
     Project (#0, #1)
-      TopK group_by=[#0] limit=1 monotonic=false
+      TopK group_by=[#0] limit=1
         Filter (#2 = #0)
           CrossJoin
             Get l6
@@ -366,7 +366,7 @@ With
               Get l3
   cte l3 =
     Project (#0, #1)
-      TopK group_by=[#0] limit=1 monotonic=false
+      TopK group_by=[#0] limit=1
         Filter (#2 = #0)
           CrossJoin
             Get l2

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -164,7 +164,7 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR
 VIEW ov
 ----
 materialize.public.ov:
-  TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 monotonic=false
+  TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
     Get materialize.public.t
 
 Used Indexes:
@@ -309,7 +309,7 @@ Explained Query:
                 Get l1
   With
     cte l4 =
-      TopK group_by=[#0] limit=1 monotonic=false
+      TopK group_by=[#0] limit=1
         Project (#0, #1)
           Filter (#0) IS NOT NULL
             Join on=(#0 = #2) type=differential
@@ -318,7 +318,7 @@ Explained Query:
                 Filter (#1) IS NOT NULL
                   Get materialize.public.mv
     cte l3 =
-      TopK group_by=[#0] limit=1 monotonic=false
+      TopK group_by=[#0] limit=1
         Project (#0, #1)
           Filter (#0) IS NOT NULL
             Join on=(#0 = #2) type=differential

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -2915,7 +2915,7 @@ Explained Query:
       FlatMap unnest_list(#0) // { arity: 2 }
         Project (#1) // { arity: 1 }
           Map (list[row(1, row(#0))]) // { arity: 2 }
-            TopK limit=1 monotonic=false // { arity: 1 }
+            TopK limit=1 // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Get materialize.public.m3 // { arity: 11 }
 

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -87,7 +87,7 @@ EXPLAIN WITH(arity, join_impls) SELECT state, name FROM
 ----
 Explained Query:
   Project (#1, #0) // { arity: 2 }
-    TopK group_by=[#1] order_by=[#2 desc nulls_first] limit=3 monotonic=false // { arity: 3 }
+    TopK group_by=[#1] order_by=[#2 desc nulls_first] limit=3 // { arity: 3 }
       Get materialize.public.cities // { arity: 3 }
 
 EOF
@@ -114,7 +114,7 @@ Explained Query:
   With
     cte l0 =
       Project (#0, #1) // { arity: 2 }
-        TopK group_by=[#1] order_by=[#2 desc nulls_first] limit=3 monotonic=false // { arity: 3 }
+        TopK group_by=[#1] order_by=[#2 desc nulls_first] limit=3 // { arity: 3 }
           Get materialize.public.cities // { arity: 3 }
 
 EOF
@@ -146,7 +146,7 @@ EXPLAIN WITH(arity, join_impls) SELECT state, COUNT(*) FROM (
 Explained Query:
   Project (#0, #2) // { arity: 2 }
     Map (1) // { arity: 3 }
-      TopK group_by=[#0] order_by=[#1 desc nulls_first] limit=1 monotonic=false // { arity: 2 }
+      TopK group_by=[#0] order_by=[#1 desc nulls_first] limit=1 // { arity: 2 }
         Project (#1, #2) // { arity: 2 }
           Get materialize.public.cities // { arity: 3 }
 
@@ -161,7 +161,7 @@ EXPLAIN WITH(arity, join_impls) SELECT state, name FROM
 ----
 Explained Query:
   Project (#1, #0) // { arity: 2 }
-    TopK group_by=[#1] order_by=[#2 desc nulls_last] limit=3 monotonic=false exp_group_size=1 // { arity: 3 }
+    TopK group_by=[#1] order_by=[#2 desc nulls_last] limit=3 exp_group_size=1 // { arity: 3 }
       Get materialize.public.cities // { arity: 3 }
 
 EOF

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -743,7 +743,7 @@ Explained Query:
                 Get l1 // { arity: 3, types: "(integer?, integer?, integer?)" }
     cte l0 =
       Map (1) // { arity: 1, types: "(integer)" }
-        Distinct // { arity: 0, types: "()" }
+        Distinct monotonic // { arity: 0, types: "()" }
           Union // { arity: 0, types: "()" }
             Project () // { arity: 0, types: "()" }
               Get l0 // { arity: 1, types: "(integer?)" }
@@ -792,7 +792,7 @@ Explained Query:
                 Get l1 // { arity: 3, types: "(boolean?, integer?, integer?)" }
     cte l0 =
       Map (1) // { arity: 1, types: "(integer)" }
-        Distinct // { arity: 0, types: "()" }
+        Distinct monotonic // { arity: 0, types: "()" }
           Union // { arity: 0, types: "()" }
             Project () // { arity: 0, types: "()" }
               Get l0 // { arity: 1, types: "(integer?)" }

--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -42,7 +42,7 @@ Explained Query:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[count(*)] // { arity: 1 }
+      Reduce aggregates=[count(*)] monotonic // { arity: 1 }
         Constant // { arity: 0 }
           - (() x 1000000000)
 

--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -101,11 +101,11 @@ Explained Query:
     Get l0 // { arity: 2 }
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0, #1] // { arity: 2 }
+      Distinct group_by=[#0, #1] monotonic // { arity: 2 }
         Union // { arity: 2 }
-          Distinct group_by=[#0, #1] // { arity: 2 }
+          Distinct group_by=[#0, #1] monotonic // { arity: 2 }
             Union // { arity: 2 }
-              Distinct group_by=[#0, #1] // { arity: 2 }
+              Distinct group_by=[#0, #1] monotonic // { arity: 2 }
                 Union // { arity: 2 }
                   Get l0 // { arity: 2 }
                   Constant // { arity: 2 }

--- a/test/sqllogictest/transform/monotonic.slt
+++ b/test/sqllogictest/transform/monotonic.slt
@@ -1,0 +1,168 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test Common subexpression elimination for Relations.
+# PR https://github.com/MaterializeInc/materialize/pull/7715
+#
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_with_mutually_recursive = true
+----
+COMPLETE 0
+
+statement ok
+CREATE SOURCE counter FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+
+# Properly TopK
+query T multiline
+EXPLAIN SELECT * FROM (SELECT counter FROM counter limit 1);
+----
+Explained Query:
+  TopK limit=1 monotonic
+    Get materialize.public.counter
+
+EOF
+
+# Infer monotonic Reduce operator
+query T multiline
+EXPLAIN SELECT counter % 3, MAX(counter) as sum FROM counter GROUP BY counter % 3;
+----
+Explained Query:
+  Reduce group_by=[(#0 % 3)] aggregates=[max(#0)] monotonic
+    Get materialize.public.counter
+
+EOF
+
+# Propagating monotonicity analysis through materialized views
+
+statement ok
+CREATE MATERIALIZED VIEW v1 AS SELECT DISTINCT counter % 3 as f1 FROM counter GROUP BY counter % 3;
+
+statement ok
+CREATE MATERIALIZED VIEW v2 AS SELECT f1 as counter FROM v1 WHERE f1 % 7 = 0;
+
+query T multiline
+EXPLAIN SELECT * FROM v1 CROSS JOIN LATERAL (SELECT * FROM v2 WHERE counter < f1 ORDER BY counter DESC LIMIT 3);
+----
+Explained Query:
+  TopK group_by=[#0] order_by=[#1 desc nulls_first] limit=3 monotonic
+    Filter (#1 < #0)
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          Get materialize.public.v1
+        ArrangeBy keys=[[]]
+          Get materialize.public.v2
+
+EOF
+
+# Propagating monotonicity analysis thorugh recursive queries
+
+# Positive example: both c1 and c2 and consequently the body of the
+# WMR are monotonic.
+query T multiline
+EXPLAIN
+WITH MUTUALLY RECURSIVE
+  c0(x INT, y INT) AS (
+    SELECT * FROM (VALUES (1, 2), (3, 4), (5, 6))
+  ),
+  c1(x INT, y INT) AS (
+    SELECT * FROM c0
+    UNION ALL
+    SELECT DISTINCT y, y-1 FROM c2 WHERE x < 1
+  ),
+  c2(x INT, y INT) AS (
+    SELECT * FROM c0
+    UNION ALL
+    SELECT DISTINCT x, x+1 FROM c1 WHERE x >= 1
+  )
+SELECT x, MAX(y) FROM (SELECT * FROM c1 UNION SELECT * FROM c2) GROUP BY x
+----
+Explained Query:
+  Return
+    Reduce group_by=[#0] aggregates=[max(#1)] monotonic
+      Distinct group_by=[#0, #1] monotonic
+        Union
+          Get l0
+          Get l1
+  With Mutually Recursive
+    cte l1 =
+      Union
+        Distinct group_by=[#0, (#0 + 1)] monotonic
+          Project (#0)
+            Filter (#0 >= 1)
+              Get l0
+        Constant
+          - (1, 2)
+          - (3, 4)
+          - (5, 6)
+    cte l0 =
+      Union
+        Distinct group_by=[#0, (#0 - 1)] monotonic
+          Project (#1)
+            Filter (#0 < 1)
+              Get l1
+        Constant
+          - (1, 2)
+          - (3, 4)
+          - (5, 6)
+
+EOF
+
+# Negative example: c2 (and consequently c2 and the WMR block body) are not
+# monotonic because c2 has a LIMIT clause.
+query T multiline
+EXPLAIN
+WITH MUTUALLY RECURSIVE
+  c0(x INT, y INT) AS (
+    SELECT * FROM (VALUES (1, 2), (3, 4), (5, 6))
+  ),
+  c1(x INT, y INT) AS (
+    SELECT * FROM c0
+    UNION ALL
+    SELECT DISTINCT y, y-1 FROM c2 WHERE x < 1
+  ),
+  c2(x INT, y INT) AS (
+    SELECT * FROM c0
+    UNION ALL
+    SELECT DISTINCT x, x+1 FROM c1 WHERE x >= 1 LIMIT 2
+  )
+SELECT x, MAX(y) FROM (SELECT * FROM c1 UNION SELECT * FROM c2) GROUP BY x
+----
+Explained Query:
+  Return
+    Reduce group_by=[#0] aggregates=[max(#1)]
+      Distinct group_by=[#0, #1]
+        Union
+          Get l0
+          Get l1
+  With Mutually Recursive
+    cte l1 =
+      TopK limit=2
+        Union
+          Distinct group_by=[#0, (#0 + 1)]
+            Project (#0)
+              Filter (#0 >= 1)
+                Get l0
+          Constant
+            - (1, 2)
+            - (3, 4)
+            - (5, 6)
+    cte l0 =
+      Union
+        Distinct group_by=[#0, (#0 - 1)]
+          Project (#1)
+            Filter (#0 < 1)
+              Get l1
+        Constant
+          - (1, 2)
+          - (3, 4)
+          - (5, 6)
+
+EOF

--- a/test/sqllogictest/transform/non_null_requirements.slt
+++ b/test/sqllogictest/transform/non_null_requirements.slt
@@ -46,7 +46,7 @@ Explained Query:
   With Mutually Recursive
     cte l0 =
       Map (42) // { arity: 3 }
-        Distinct group_by=[#0, #1] // { arity: 2 }
+        Distinct group_by=[#0, #1] monotonic // { arity: 2 }
           Project (#0, #1) // { arity: 2 }
             Get l0 // { arity: 3 }
 

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -240,7 +240,7 @@ Explained Query:
           Get l1
     With Mutually Recursive
       cte l1 =
-        TopK group_by=[#0] order_by=[#1 asc nulls_last] limit=1 monotonic=false
+        TopK group_by=[#0] order_by=[#1 asc nulls_last] limit=1
           Union
             Map (0)
               Get l0
@@ -453,7 +453,7 @@ Explained Query:
           Get l1
     With Mutually Recursive [iteration_limit=23]
       cte l1 =
-        TopK group_by=[#0] order_by=[#1 asc nulls_last] limit=1 monotonic=false
+        TopK group_by=[#0] order_by=[#1 asc nulls_last] limit=1
           Union
             Map (0)
               Get l0

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -28,7 +28,7 @@ Explained Query:
     cte l0 =
       Project (#1)
         Map (1)
-          Distinct group_by=[#0]
+          Distinct group_by=[#0] monotonic
             Union
               Project (#1)
                 Map (7)
@@ -190,10 +190,10 @@ Explained Query:
       Get l1
   With Mutually Recursive
     cte l1 =
-      Distinct group_by=[#0]
+      Distinct group_by=[#0] monotonic
         Get l1
     cte l0 =
-      Distinct group_by=[#0]
+      Distinct group_by=[#0] monotonic
         Get l0
 
 EOF
@@ -287,7 +287,7 @@ Explained Query:
     Get l0
   With Mutually Recursive [iteration_limit=10]
     cte l0 =
-      Distinct group_by=[#0]
+      Distinct group_by=[#0] monotonic
         Union
           Project (#1)
             Map ((#0 + 1))
@@ -319,10 +319,10 @@ Explained Query:
       Get l1
   With Mutually Recursive
     cte [iteration_limit=7] l1 =
-      Distinct group_by=[(#0 - 2)]
+      Distinct group_by=[(#0 - 2)] monotonic
         Get l1
     cte [iteration_limit=5] l0 =
-      Distinct group_by=[#0]
+      Distinct group_by=[#0] monotonic
         Get l0
 
 EOF
@@ -350,10 +350,10 @@ Explained Query:
       Get l1
   With Mutually Recursive [iteration_limit=27]
     cte l1 =
-      Distinct group_by=[(#0 - 2)]
+      Distinct group_by=[(#0 - 2)] monotonic
         Get l1
     cte l0 =
-      Distinct group_by=[#0]
+      Distinct group_by=[#0] monotonic
         Get l0
 
 EOF

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -438,7 +438,7 @@ Explained Query:
         ArrangeBy keys=[[#0]]
           Get l0
         ArrangeBy keys=[[#0]]
-          TopK group_by=[#0] limit=5 monotonic=false
+          TopK group_by=[#0] limit=5
             Project (#0)
               Join on=(#0 = #1) type=differential
                 ArrangeBy keys=[[#0]]

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -1662,13 +1662,13 @@ Explained Query:
             - (9)
             - (10)
       cte l2 =
-        Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+        Reduce group_by=[#0] aggregates=[count(*)] monotonic // { arity: 2 }
           Project (#0) // { arity: 1 }
             Get l1 // { arity: 2 }
   With Mutually Recursive
     cte l1 =
       Union // { arity: 2 }
-        Distinct group_by=[#0, (#1 + #2)] // { arity: 2 }
+        Distinct group_by=[#0, (#1 + #2)] monotonic // { arity: 2 }
           Project (#0, #1, #3) // { arity: 3 }
             Join on=(#0 = #2) type=differential // { arity: 4 }
               implementation

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -185,7 +185,7 @@ Explained Query:
     Union // { non_negative: false }
       Get l0 // { non_negative: true }
       Negate // { non_negative: false }
-        TopK group_by=[#0] limit=1 monotonic=false // { non_negative: true }
+        TopK group_by=[#0] limit=1 // { non_negative: true }
           Get l0 // { non_negative: true }
   With
     cte l0 =
@@ -224,7 +224,7 @@ Explained Query:
     Union // { non_negative: false }
       Get l0 // { non_negative: true }
       Negate // { non_negative: false }
-        TopK group_by=[#0] limit=1 monotonic=false // { non_negative: true }
+        TopK group_by=[#0] limit=1 // { non_negative: true }
           Get l0 // { non_negative: true }
   With
     cte l0 =

--- a/test/sqllogictest/transform/topk.slt
+++ b/test/sqllogictest/transform/topk.slt
@@ -34,7 +34,7 @@ Explained Query:
   Project (#4, #0, #1) // { arity: 3 }
     Map ((bigint_to_double(#2) / bigint_to_double(case when (#3 = 0) then null else #3 end))) // { arity: 5 }
       Reduce group_by=[#1, #2] aggregates=[sum(#0), count(#0)] // { arity: 4 }
-        TopK order_by=[#0 asc nulls_first] limit=4 monotonic=false // { arity: 3 }
+        TopK order_by=[#0 asc nulls_first] limit=4 // { arity: 3 }
           Project (#3, #5, #6) // { arity: 3 }
             Map ((#0 + #1), (#4 + #2), (#4 + #3)) // { arity: 7 }
               Get materialize.public.test1 // { arity: 4 }
@@ -108,7 +108,7 @@ query T multiline
 explain with(arity, join_impls) view v1;
 ----
 materialize.public.v1:
-  TopK order_by=[#0 asc nulls_last] limit=3 offset=3 monotonic=false // { arity: 2 }
+  TopK order_by=[#0 asc nulls_last] limit=3 offset=3 // { arity: 2 }
     Get materialize.public.t1 // { arity: 2 }
 
 EOF

--- a/test/testdrive/char-varchar-orderby.td
+++ b/test/testdrive/char-varchar-orderby.td
@@ -73,7 +73,7 @@ $ set-regex match=u\d+ replacement=UID
 
 ? EXPLAIN SELECT * FROM (SELECT * FROM char_table ORDER BY f1 NULLS FIRST LIMIT 1 OFFSET 0)
 Explained Query:
-  TopK order_by=[#0 asc nulls_first] limit=1 monotonic=false
+  TopK order_by=[#0 asc nulls_first] limit=1
     Get materialize.public.char_table
 
 > SELECT * FROM (SELECT * FROM char_table ORDER BY f1 LIMIT 1 OFFSET 0)

--- a/test/testdrive/monotonic.td
+++ b/test/testdrive/monotonic.td
@@ -12,6 +12,9 @@
 # they do not test that the analysis doesn't have false positives on
 # non-monotonic sources.
 
+# TODO: Once we have support for more "LOAD GENERATOR"-based monotonic
+# sources these tests can be migrated to `monotonic.slt`.
+
 $ set non-dbz-schema={
     "type": "record",
     "name": "cpx",

--- a/test/testdrive/primary-key-optimizations.td
+++ b/test/testdrive/primary-key-optimizations.td
@@ -194,25 +194,25 @@ $ kafka-ingest format=avro topic=t1-pkne schema=${schema}
 # Optimization not possible - explicit distinct is present in plan
 
 > EXPLAIN SELECT DISTINCT key1 FROM t1_pkne;
-"Explained Query:  Distinct group_by=[#0]    Project (#0)      Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
+"Explained Query:  Distinct group_by=[#0] monotonic    Project (#0)      Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
 
 > EXPLAIN SELECT DISTINCT key2 FROM t1_pkne;
-"Explained Query:  Distinct group_by=[#0]    Project (#1)      Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
+"Explained Query:  Distinct group_by=[#0] monotonic    Project (#1)      Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
 
 > EXPLAIN SELECT DISTINCT key1, upper(key2) FROM t1_pkne;
-"Explained Query:  Distinct group_by=[#0, upper(#1)]    Project (#0, #1)      Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
+"Explained Query:  Distinct group_by=[#0, upper(#1)] monotonic    Project (#0, #1)      Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
 
 > EXPLAIN SELECT DISTINCT key1, key2 || 'a' FROM t1_pkne;
-"Explained Query:  Distinct group_by=[#0, (#1 || \"a\")]    Project (#0, #1)      Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
+"Explained Query:  Distinct group_by=[#0, (#1 || \"a\")] monotonic    Project (#0, #1)      Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
 
 > EXPLAIN SELECT key1 FROM t1_pkne GROUP BY key1;
-"Explained Query:  Distinct group_by=[#0]    Project (#0)      Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
+"Explained Query:  Distinct group_by=[#0] monotonic    Project (#0)      Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
 
 > EXPLAIN SELECT key2 FROM t1_pkne GROUP BY key2;
-"Explained Query:  Distinct group_by=[#0]    Project (#1)      Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
+"Explained Query:  Distinct group_by=[#0] monotonic    Project (#1)      Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
 
 > EXPLAIN SELECT COUNT(DISTINCT key1) FROM t1_pkne;
-"Explained Query:  Return    Union      Get l0      Map (0)        Union          Negate            Project ()              Get l0          Constant            - ()  With    cte l0 =      Reduce aggregates=[count(distinct #0)]        Project (#0)          Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
+"Explained Query:  Return    Union      Get l0      Map (0)        Union          Negate            Project ()              Get l0          Constant            - ()  With    cte l0 =      Reduce aggregates=[count(distinct #0)] monotonic        Project (#0)          Get t1_pkneUsed Indexes:  - t1_pkne_primary_idx"
 
 # Make sure that primary key information is inherited from the source
 

--- a/test/testdrive/source-linear-operators.td
+++ b/test/testdrive/source-linear-operators.td
@@ -209,7 +209,7 @@ materialize.public.v:
   Union
     Project (#1, #0)
       Map (1)
-        Reduce aggregates=[sum(#0)]
+        Reduce aggregates=[sum(#0)] monotonic
           Project (#1)
             Filter (#0 = 1)
               Get materialize.public.data


### PR DESCRIPTION
Migrates code from the _basic_ to the _advanced_ case in #18472.

### Motivation

  * This PR adds a known-desirable feature.

Closes #18472.

### Tips for reviewer

* The first commit unifies the `monotonic` flag handling in our `EXPLAIN AS TEXT` output (which causes most of the trivial changes to our existing plans in this PR).
* I copy-pasted and adapted code from `ColumnKnowledge`, so the code should be good review.
* I'm still looking for an optimal way to test this (`*.slt` tests didn't have monotonic inputs until now, but I think this might have changed recently). @philip-stoev can comment.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
