### PR TITLE
Rename `sql` field in `PreparedStatement` to `stmt`

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3973,10 +3973,10 @@ impl Coordinator {
         let ps = session
             .get_prepared_statement_unverified(&plan.name)
             .expect("known to exist");
-        let sql = ps.sql().cloned();
+        let stmt = ps.stmt().cloned();
         let desc = ps.desc().clone();
         let revision = ps.catalog_revision;
-        session.create_new_portal(sql, desc, plan.params, Vec::new(), revision)
+        session.create_new_portal(stmt, desc, plan.params, Vec::new(), revision)
     }
 
     pub(super) async fn sequence_grant_privilege(

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -104,7 +104,7 @@ impl Coordinator {
         if let Some(revision) = Self::verify_statement_revision(
             catalog,
             session,
-            ps.sql(),
+            ps.stmt(),
             ps.desc(),
             ps.catalog_revision,
         )? {

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -684,7 +684,7 @@ impl<T: TimestampManipulation> Session<T> {
 /// A prepared statement.
 #[derive(Debug, Clone)]
 pub struct PreparedStatement {
-    sql: Option<Statement<Raw>>,
+    stmt: Option<Statement<Raw>>,
     desc: StatementDesc,
     /// The most recent catalog revision that has verified this statement.
     pub catalog_revision: u64,
@@ -693,21 +693,21 @@ pub struct PreparedStatement {
 impl PreparedStatement {
     /// Constructs a new prepared statement.
     pub fn new(
-        sql: Option<Statement<Raw>>,
+        stmt: Option<Statement<Raw>>,
         desc: StatementDesc,
         catalog_revision: u64,
     ) -> PreparedStatement {
         PreparedStatement {
-            sql,
+            stmt,
             desc,
             catalog_revision,
         }
     }
 
-    /// Returns the raw SQL string associated with this prepared statement,
+    /// Returns the AST associated with this prepared statement,
     /// if the prepared statement was not the empty query.
-    pub fn sql(&self) -> Option<&Statement<Raw>> {
-        self.sql.as_ref()
+    pub fn stmt(&self) -> Option<&Statement<Raw>> {
+        self.stmt.as_ref()
     }
 
     /// Returns the description of the prepared statement.

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -796,7 +796,7 @@ async fn execute_stmt<S: ResultSender>(
 
     let desc = prep_stmt.desc().clone();
     let revision = prep_stmt.catalog_revision;
-    let stmt = prep_stmt.sql().cloned();
+    let stmt = prep_stmt.stmt().cloned();
     if let Err(err) = client.session().set_portal(
         EMPTY_PORTAL.into(),
         desc,

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -829,7 +829,7 @@ where
                     .await
             }
         };
-        if aborted_txn && !is_txn_exit_stmt(stmt.sql()) {
+        if aborted_txn && !is_txn_exit_stmt(stmt.stmt()) {
             return self.aborted_txn_error().await;
         }
         let buf = RowArena::new();
@@ -893,7 +893,7 @@ where
 
         let desc = stmt.desc().clone();
         let revision = stmt.catalog_revision;
-        let stmt = stmt.sql().cloned();
+        let stmt = stmt.stmt().cloned();
         if let Err(err) = self.adapter_client.session().set_portal(
             portal_name,
             desc,


### PR DESCRIPTION
This is not a raw SQL string anymore. Change its name to reflect that fact.