### PR TITLE
adapter: rename Command::{Describe => Prepare}

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -306,17 +306,17 @@ impl SessionClient {
             .expect("must exist"))
     }
 
-    /// Saves the specified statement as a prepared statement.
+    /// Saves the parsed statement as a prepared statement.
     ///
     /// The prepared statement is saved in the connection's [`crate::session::Session`]
     /// under the specified name.
-    pub async fn describe(
+    pub async fn prepare(
         &mut self,
         name: String,
         stmt: Option<Statement<Raw>>,
         param_types: Vec<Option<ScalarType>>,
     ) -> Result<(), AdapterError> {
-        self.send(|tx, session| Command::Describe {
+        self.send(|tx, session| Command::Prepare {
             name,
             stmt,
             param_types,
@@ -516,7 +516,7 @@ impl SessionClient {
                 Command::Declare { .. } => typ = Some("declare"),
                 Command::Execute { .. } => typ = Some("execute"),
                 Command::Startup { .. }
-                | Command::Describe { .. }
+                | Command::Prepare { .. }
                 | Command::VerifyPreparedStatement { .. }
                 | Command::Commit { .. }
                 | Command::CancelRequest { .. }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -49,7 +49,7 @@ pub enum Command {
         tx: oneshot::Sender<Response<ExecuteResponse>>,
     },
 
-    Describe {
+    Prepare {
         name: String,
         stmt: Option<Statement<Raw>>,
         param_types: Vec<Option<ScalarType>>,
@@ -116,7 +116,7 @@ impl Command {
         match self {
             Command::Startup { session, .. }
             | Command::Declare { session, .. }
-            | Command::Describe { session, .. }
+            | Command::Prepare { session, .. }
             | Command::VerifyPreparedStatement { session, .. }
             | Command::Execute { session, .. }
             | Command::Commit { session, .. }
@@ -133,7 +133,7 @@ impl Command {
         match self {
             Command::Startup { session, .. }
             | Command::Declare { session, .. }
-            | Command::Describe { session, .. }
+            | Command::Prepare { session, .. }
             | Command::VerifyPreparedStatement { session, .. }
             | Command::Execute { session, .. }
             | Command::Commit { session, .. }
@@ -156,7 +156,7 @@ impl Command {
         match self {
             Command::Startup { tx, session, .. } => send(tx, session, e),
             Command::Declare { tx, session, .. } => send(tx, session, e),
-            Command::Describe { tx, session, .. } => send(tx, session, e),
+            Command::Prepare { tx, session, .. } => send(tx, session, e),
             Command::VerifyPreparedStatement { tx, session, .. } => send(tx, session, e),
             Command::Execute { tx, session, .. } => send(tx, session, e),
             Command::Commit { tx, session, .. } => send(tx, session, e),

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -89,7 +89,7 @@ impl Coordinator {
                 self.declare(tx, session, name, stmt, param_types);
             }
 
-            Command::Describe {
+            Command::Prepare {
                 name,
                 stmt,
                 param_types,
@@ -97,7 +97,7 @@ impl Coordinator {
                 tx,
             } => {
                 let tx = ClientTransmitter::new(tx, self.internal_cmd_tx.clone());
-                self.handle_describe(tx, session, name, stmt, param_types);
+                self.handle_prepare(tx, session, name, stmt, param_types);
             }
 
             Command::CancelRequest {
@@ -551,7 +551,7 @@ impl Coordinator {
         }
     }
 
-    fn handle_describe(
+    fn handle_prepare(
         &self,
         tx: ClientTransmitter<()>,
         mut session: Session,
@@ -560,7 +560,7 @@ impl Coordinator {
         param_types: Vec<Option<ScalarType>>,
     ) {
         let catalog = self.owned_catalog();
-        mz_ore::task::spawn(|| "coord::handle_describe", async move {
+        mz_ore::task::spawn(|| "coord::handle_prepare", async move {
             let res = match Self::describe(&catalog, &session, stmt.clone(), param_types) {
                 Ok(desc) => {
                     session.set_prepared_statement(

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -129,7 +129,7 @@ pub fn check_command(catalog: &Catalog, cmd: &Command) -> Result<(), Unauthorize
         }
         Command::Startup { .. }
         | Command::Declare { .. }
-        | Command::Describe { .. }
+        | Command::Prepare { .. }
         | Command::VerifyPreparedStatement { .. }
         | Command::Execute { .. }
         | Command::Commit { .. }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -736,7 +736,7 @@ async fn execute_stmt<S: ResultSender>(
 ) -> Result<StatementResult, anyhow::Error> {
     const EMPTY_PORTAL: &str = "";
     if let Err(e) = client
-        .describe(EMPTY_PORTAL.into(), Some(stmt.clone()), vec![])
+        .prepare(EMPTY_PORTAL.into(), Some(stmt.clone()), vec![])
         .await
     {
         return Ok(SqlResult::err(client, e).into());

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -747,7 +747,7 @@ where
         }
         match self
             .adapter_client
-            .describe(name, maybe_stmt, param_types)
+            .prepare(name, maybe_stmt, param_types)
             .await
         {
             Ok(()) => {


### PR DESCRIPTION
@umanwizard pointed out that `Command::Describe` corresponds to `Parse` in the pgwire protocol, not `Describe`. Rename the coordinator command to avoid confusion. The new name, "prepare", does not directly map to any pgwire commands, and seems to clearly map to what the command does: turning a parsed SQL statement into a named prepared statement.

Note that "describe" remains in use in the coordinator/SQL planner for the functions that convert parsed SQL statements into "statement descriptions". This seems appropriate, as those descriptions are what the `Describe` pgwire command later references.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
