### PR TITLE
[persist/expr] Fallback and optimize for worst-case interpreter path

### DIFF
--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -746,7 +746,7 @@ impl<'a> ColumnSpecs<'a> {
     // - Adding a linear-time optimization for associative functions like AND, OR, COALESCE.
     // - Limiting the number of arguments we'll pass on to eval. If this limit is crossed, we'll
     //   return our default / safe overapproximation instead.
-    const MAX_EVAL_ARGS: usize = 8;
+    const MAX_EVAL_ARGS: usize = 6;
 
     /// Create a new, empty set of column specs. (Initially, the only assumption we make about the
     /// data in the column is that it matches the type.)

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -701,6 +701,12 @@ impl Interpreter for Trace {
     }
 
     fn variadic(&self, func: &VariadicFunc, exprs: Vec<Self::Summary>) -> Self::Summary {
+        if !func.is_associative() && exprs.len() >= ColumnSpecs::MAX_EVAL_ARGS {
+            // We can't efficiently evaluate functions with very large argument lists;
+            // see the comment on ColumnSpecs::MAX_EVAL_ARGS for details.
+            return RelationTrace::new();
+        }
+
         let is_monotonic = variadic_monotonic(func);
         exprs
             .into_iter()
@@ -734,6 +740,14 @@ pub struct ColumnSpecs<'a> {
 }
 
 impl<'a> ColumnSpecs<'a> {
+    // Interpreting a variadic function can lead to exponential blowup: there are up to 4 possibly-
+    // interesting values for each argument (error, null, range bounds...) and in the worst case
+    // we may need to test every combination. We mitigate that here in two ways:
+    // - Adding a linear-time optimization for associative functions like AND, OR, COALESCE.
+    // - Limiting the number of arguments we'll pass on to eval. If this limit is crossed, we'll
+    //   return our default / safe overapproximation instead.
+    const MAX_EVAL_ARGS: usize = 8;
+
     /// Create a new, empty set of column specs. (Initially, the only assumption we make about the
     /// data in the column is that it matches the type.)
     pub fn new(relation: &'a RelationType, arena: &'a RowArena) -> Self {
@@ -941,8 +955,6 @@ impl<'a> Interpreter for ColumnSpecs<'a> {
 
     fn variadic(&self, func: &VariadicFunc, args: Vec<Self::Summary>) -> Self::Summary {
         let mapped_spec = if func.is_associative() && !args.is_empty() {
-            // If the function is associative, like AND and OR, it's safe (and more efficient)
-            // to interpret it using a series of binary calls.
             let col_type = func.output_type(args.iter().map(|cs| cs.col_type.clone()).collect());
             let mut expr = MirScalarExpr::CallVariadic {
                 func: func.clone(),
@@ -964,30 +976,22 @@ impl<'a> Interpreter for ColumnSpecs<'a> {
                     })
                 })
                 .expect("reduce over non-empty argument list")
+        } else if args.len() >= Self::MAX_EVAL_ARGS {
+            ResultSpec::anything()
         } else {
-            // How many times are we willing to evaluate the underlying function before giving up?
-            // This is here to protect us from exponential blowup when the argument list is long and
-            // there are multiple cases to consider per argument.
-            const MAX_EVALUATIONS: usize = 1000;
             fn eval_loop<'a>(
                 is_monotonic: Monotonic,
                 expr: &mut MirScalarExpr,
                 args: &[ColumnSpec<'a>],
                 index: usize,
                 datum_map: &mut impl FnMut(&MirScalarExpr) -> ResultSpec<'a>,
-                evaluations: &mut usize,
             ) -> ResultSpec<'a> {
-                if *evaluations >= MAX_EVALUATIONS {
-                    return ResultSpec::anything();
-                }
-
                 if index >= args.len() {
-                    *evaluations += 1;
                     datum_map(expr)
                 } else {
                     args[index].range.flat_map(is_monotonic, |datum| {
                         ColumnSpecs::set_argument(expr, index, datum);
-                        eval_loop(is_monotonic, expr, args, index + 1, datum_map, evaluations)
+                        eval_loop(is_monotonic, expr, args, index + 1, datum_map)
                     })
                 }
             }
@@ -1005,7 +1009,6 @@ impl<'a> Interpreter for ColumnSpecs<'a> {
                 &args,
                 0,
                 &mut |expr| self.eval_result(expr.eval(&[], self.arena)),
-                &mut 0,
             )
         };
 

--- a/src/expr/tests/testdata/interpret
+++ b/src/expr/tests/testdata/interpret
@@ -97,27 +97,27 @@ interpret
 ----
 may contain: [true <err>]
 
-# Functions with many arguments can be expensive to interpret. 7 arguments is below the limit; note that
+# Functions with many arguments can be expensive to interpret. 5 arguments is below the limit; note that
 # the output spec contains the exact value.
 #
 # Expression: jsonb_array_length(jsonb_build_array(true, true))
 interpret
 []
 []
-(call_unary jsonb_array_length (call_variadic jsonb_build_array [true true true true true true true]))
-["string" (7 int32) (8 int32) true false null]
+(call_unary jsonb_array_length (call_variadic jsonb_build_array [true true true true true]))
+["string" (5 int32) (6 int32) true false null]
 ----
-may contain: [7]
+may contain: [5]
 
-# Here, the interpreter has given up on interpreting a function with 8+ arguments; any value is possible.
-# Expression: jsonb_array_length(jsonb_build_array(true, true, true, true, true, true, true, true))
+# Here, the interpreter has given up on interpreting a function with 6+ arguments; any value is possible.
+# Expression: jsonb_array_length(jsonb_build_array(true, true, true, true, true, true))
 interpret
 []
 []
-(call_unary jsonb_array_length (call_variadic jsonb_build_array [true true true true true true true true]))
-["string" (7 int32) (8 int32) true false null]
+(call_unary jsonb_array_length (call_variadic jsonb_build_array [true true true true true true]))
+["string" (5 int32) (6 int32) true false null]
 ----
-may contain: ["string" 7 8 true false null <err>]
+may contain: ["string" 5 6 true false null <err>]
 
 # And for associative functions like COALESCE, we can handle even long argument lists.
 # Expression: coalesce(true, true, true, true, true, true, true, true)

--- a/src/expr/tests/testdata/interpret
+++ b/src/expr/tests/testdata/interpret
@@ -96,3 +96,35 @@ interpret
 ["string" 300 true false null]
 ----
 may contain: [true <err>]
+
+# Functions with many arguments can be expensive to interpret. 7 arguments is below the limit; note that
+# the output spec contains the exact value.
+#
+# Expression: jsonb_array_length(jsonb_build_array(true, true))
+interpret
+[]
+[]
+(call_unary jsonb_array_length (call_variadic jsonb_build_array [true true true true true true true]))
+["string" (7 int32) (8 int32) true false null]
+----
+may contain: [7]
+
+# Here, the interpreter has given up on interpreting a function with 8+ arguments; any value is possible.
+# Expression: jsonb_array_length(jsonb_build_array(true, true, true, true, true, true, true, true))
+interpret
+[]
+[]
+(call_unary jsonb_array_length (call_variadic jsonb_build_array [true true true true true true true true]))
+["string" (7 int32) (8 int32) true false null]
+----
+may contain: ["string" 7 8 true false null <err>]
+
+# And for associative functions like COALESCE, we can handle even long argument lists.
+# Expression: coalesce(true, true, true, true, true, true, true, true)
+interpret
+[]
+[]
+(call_variadic coalesce [true true true true true true true true])
+["string" (7 int32) (8 int32) true false null]
+----
+may contain: [true]

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -926,8 +926,7 @@ class WhereExpression(Generator):
 
 class WhereConditionAnd(Generator):
     # Stack overflow, see https://github.com/MaterializeInc/materialize/issues/19327
-    # Also runs into https://github.com/MaterializeInc/materialize/issues/19399
-    COUNT = min(Generator.COUNT, 75)
+    COUNT = min(Generator.COUNT, 500)
 
     @classmethod
     def body(cls) -> None:
@@ -944,8 +943,7 @@ class WhereConditionAnd(Generator):
 
 class WhereConditionAndSameColumn(Generator):
     # Stack overflow, see https://github.com/MaterializeInc/materialize/issues/19327
-    # Also runs into https://github.com/MaterializeInc/materialize/issues/19399
-    COUNT = min(Generator.COUNT, 75)
+    COUNT = min(Generator.COUNT, 500)
 
     @classmethod
     def body(cls) -> None:
@@ -960,8 +958,7 @@ class WhereConditionAndSameColumn(Generator):
 
 class WhereConditionOr(Generator):
     # Stack overflow, see https://github.com/MaterializeInc/materialize/issues/19327
-    # Also runs into https://github.com/MaterializeInc/materialize/issues/19399
-    COUNT = min(Generator.COUNT, 75)
+    COUNT = min(Generator.COUNT, 500)
 
     @classmethod
     def body(cls) -> None:
@@ -978,8 +975,7 @@ class WhereConditionOr(Generator):
 
 class WhereConditionOrSameColumn(Generator):
     # Stack overflow, see https://github.com/MaterializeInc/materialize/issues/19327
-    # Also runs into https://github.com/MaterializeInc/materialize/issues/19399
-    COUNT = min(Generator.COUNT, 75)
+    COUNT = min(Generator.COUNT, 500)
 
     @classmethod
     def body(cls) -> None:

--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -140,3 +140,32 @@ Source materialize.public.events
   pushdown=(#1, #2)
 
 EOF
+
+# Verify explain behaviour for functions with many arguments. In theory, we can't push down
+# non-associative functions with long argument lists... but in practice all the functions we
+# can push down are also associative, so this is moot. Let's at least check that an associative
+# function _does_ report pushdown even when the argument list is long.
+
+query T multiline
+EXPLAIN WITH(mfp_pushdown)
+SELECT content, insert_ms, delete_ms
+FROM events
+WHERE mz_now() < delete_ms + 10000
+  AND mz_now() < delete_ms + 20000
+  AND mz_now() < delete_ms + 30000
+  AND mz_now() < delete_ms + 40000
+  AND mz_now() < delete_ms + 50000
+  AND mz_now() < delete_ms + 60000
+  AND mz_now() < delete_ms + 70000
+  AND mz_now() < delete_ms + 80000
+  AND mz_now() < delete_ms + 90000;
+----
+Explained Query:
+  Filter (mz_now() < numeric_to_mz_timestamp((#2 + 10000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 20000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 30000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 40000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 50000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 70000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 80000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 90000)))
+    Get materialize.public.events
+
+Source materialize.public.events
+  filter=((mz_now() < numeric_to_mz_timestamp((#2 + 10000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 20000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 30000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 40000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 50000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 70000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 80000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 90000))))
+  pushdown=(#2)
+
+EOF


### PR DESCRIPTION
The `ColumnSpecs` abstract interpreter has a exponential-time worst-case for function evaluation. In brief: each argument has perhaps four "special" values -- null, errors, range bounds -- and the interpreter needs to evaluate the function with every combination of those values for each argument, which makes the overall runtime exponential in the length of the argument list. Normally this is fine: for binary functions, for example, the exponent is 2, and this is still plenty fast. But this can get expensive for variadic functions with medium-to-long argument lists.

This PR addresses the issue in two ways:
- Adding a new linear-time implementation for associative functions. (If a function is associative, we effectively re-associate it to be evaluated as a linear number of binary function calls, each of which is sufficiently fast.) Conveniently, functions already have an `is_associative` method, and all the functions we care about are included. 
- Limiting the number of arguments for the non-optimized case. This prevents both deep stacks (as seen in https://github.com/MaterializeInc/materialize/issues/19399) and lots of calls to the function itself.

So the common case is now fast, and the uncommon case makes the approximation worse but does not blow up.

### Motivation

Fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/19400

(I believe it will also fix https://github.com/MaterializeInc/materialize/issues/19399 and https://github.com/MaterializeInc/materialize/issues/19402, but I need to confirm it.)

### Tips for reviewer

Hiding whitespace on this diff makes it a bit more clear!

I was split on whether to log when the newly-introduced limit is hit. It seems like it would be pretty noisy, and `explain with (mfp_pushdown)` will hopefully make it clear that pushdown is not kicking in for their large function calls if they ever expect it, which seems unlikely. But I am open to persuasion here!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
