### PR TITLE
deps: prohibit non-MaterializeInc Git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "columnation"
 version = "0.1.0"
-source = "git+https://github.com/frankmcsherry/columnation#eb8e20c10e748dcbfe6266be8e24e14422d3de0f"
+source = "git+https://github.com/MaterializeInc/columnation.git#16e53d69878847979457f3d5ae867ebf4922f1ee"
 dependencies = [
  "paste",
 ]
@@ -1664,7 +1664,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#438804d98d1888416ef20288570b804bdba8bea9"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#7c79e0c1827eec2639aa628ab54722087c00ac86"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1741,7 +1741,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#438804d98d1888416ef20288570b804bdba8bea9"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#7c79e0c1827eec2639aa628ab54722087c00ac86"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#432ef57fae761f1e4773833b0474b41f1efe7e7c"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#d5614b78adac5b6b9d7d707396000acbac2478d5"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7507,12 +7507,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#432ef57fae761f1e4773833b0474b41f1efe7e7c"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#d5614b78adac5b6b9d7d707396000acbac2478d5"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#432ef57fae761f1e4773833b0474b41f1efe7e7c"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#d5614b78adac5b6b9d7d707396000acbac2478d5"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7528,7 +7528,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#432ef57fae761f1e4773833b0474b41f1efe7e7c"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#d5614b78adac5b6b9d7d707396000acbac2478d5"
 dependencies = [
  "columnation",
  "serde",
@@ -7537,7 +7537,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#432ef57fae761f1e4773833b0474b41f1efe7e7c"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#d5614b78adac5b6b9d7d707396000acbac2478d5"
 
 [[package]]
 name = "tiny-keccak"
@@ -8128,7 +8128,7 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 [[package]]
 name = "utf8parse"
 version = "0.2.0"
-source = "git+https://github.com/alacritty/vte#45670c47cebd7af050def2f80a307bdeec7caba3"
+source = "git+https://github.com/MaterializeInc/vte?rev=45670c47cebd7af050def2f80a307bdeec7caba3#45670c47cebd7af050def2f80a307bdeec7caba3"
 
 [[package]]
 name = "uuid"
@@ -8168,7 +8168,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "vte"
 version = "0.10.1"
-source = "git+https://github.com/alacritty/vte#45670c47cebd7af050def2f80a307bdeec7caba3"
+source = "git+https://github.com/MaterializeInc/vte?rev=45670c47cebd7af050def2f80a307bdeec7caba3#45670c47cebd7af050def2f80a307bdeec7caba3"
 dependencies = [
  "arrayvec",
  "utf8parse",
@@ -8178,7 +8178,7 @@ dependencies = [
 [[package]]
 name = "vte_generate_state_changes"
 version = "0.1.1"
-source = "git+https://github.com/alacritty/vte#45670c47cebd7af050def2f80a307bdeec7caba3"
+source = "git+https://github.com/MaterializeInc/vte?rev=45670c47cebd7af050def2f80a307bdeec7caba3#45670c47cebd7af050def2f80a307bdeec7caba3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,9 +1009,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chrono"
 version = "0.4.24"
-source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#ada0629bb45cf08e9ff72f0ac18fe5eb43d628cb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
+ "num-integer",
  "num-traits",
  "serde",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,26 +105,74 @@ rustc-demangle = { opt-level = 3 }
 # production installations, but we still want useful crash reports.
 debug = 1
 
-# Use this section only to change the source of dependencies that appear as
-# transitive dependencies of other external dependencies in the dependency
-# graph. For everything else (e.g. rust-postgres, rdkafka,
-# differential-dataflow, proptest, timely), use a `git` source directly in each
-# Cargo.toml.
-#
-# The reasons for each of these overrides are listed in deny.toml.
+# IMPORTANT: when patching a dependency, you should only depend on "main",
+# "master", or an upstream release branch (e.g., "v7.x"). Do *not* depend on a
+# feature/patch branch (e.g., "fix-thing" or "pr-1234"). Feature/patch branches
+# tend to get rewritten or disappear (e.g., because a PR is force pushed or gets
+# merged), after which point it becomes impossible to build that historical
+# version of Materialize.
 [patch.crates-io]
-# IMPORTANT: you should only depend on "main", "master", or an upstream release
-# branch (e.g., "v7.x"). Do *not* depend on a feature/patch branch (e.g.,
-# "fix-thing" or "pr-1234"). Feature/patch branches tend to get rewritten or
-# disappear (e.g., because a PR is force pushed or gets merged), after which
-# point it becomes impossible to build that historical version of Materialize.
+# Projects that do not reliably release to crates.io.
+columnation = { git = "https://github.com/MaterializeInc/columnation.git" }
+timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
+timely_bytes = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
+timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
+timely_container = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
+timely_logging = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
+differential-dataflow = { git = "https://github.com/MaterializeInc/differential-dataflow.git" }
+dogsdogsdogs = { git = "https://github.com/MaterializeInc/differential-dataflow.git" }
+
+# Waiting for hashlink, indexmap, and lru to upgrade to hashbrown v0.13,
+# which depends on ahash v0.8 instead of v0.7. In the meantime we've
+# backported the ahash v0.8 bump into hashbrown v0.12.
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git" }
-postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
+
+# Waiting on https://github.com/sfackler/rust-postgres/pull/752.
+postgres  = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
+
+# Waiting on https://github.com/MaterializeInc/serde-value/pull/35.
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
-vte = { git = "https://github.com/alacritty/vte" }
+
+# Waiting for a new release of strip-ansi-escapes that avoids the indirect
+# dependency on arrayvec v0.5.2 via a dependency on vte v0.10.1.
+vte = { git = "https://github.com/MaterializeInc/vte", rev = "45670c47cebd7af050def2f80a307bdeec7caba3" }
+
+# Waiting on https://github.com/tokio-rs/prost/pull/833 to make it into a
+# release.
 prost = { git = "https://github.com/MaterializeInc/prost" }
 prost-build = { git = "https://github.com/MaterializeInc/prost" }
 prost-derive = { git = "https://github.com/MaterializeInc/prost" }
 prost-types = { git = "https://github.com/MaterializeInc/prost" }
+
+# Waiting on https://github.com/hyperium/tonic/pull/1398.
 tonic-build = { git = "https://github.com/MaterializeInc/tonic" }
+
+# Waiting on v0.18.
+# See: https://github.com/open-telemetry/opentelemetry-rust/pull/779
+opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git" }
+opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git" }
+
+# Waiting on tracing-opentelemetry to upgrade to the as-yet unreleased
+# v0.18 of opentelemetry.
+tracing-opentelemetry = { git = "https://github.com/MaterializeInc/tracing.git", branch = "v0.1.x" }
+
+# Waiting on https://github.com/tokio-rs/console/pull/388.
+console-api = { git = "https://github.com/MaterializeInc/tokio-console.git" }
+console-subscriber = { git = "https://github.com/MaterializeInc/tokio-console.git" }
+
+# Waiting on https://github.com/launchdarkly/rust-server-sdk/pull/20 to make
+# it into a release.
+launchdarkly-server-sdk = { git = "https://github.com/MaterializeInc/rust-server-sdk" }
+
+# Waiting on https://github.com/AltSysrq/proptest/pull/264.
+proptest = { git = "https://github.com/MaterializeInc/proptest.git" }
+proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git" }
+
+# Waiting on https://github.com/edenhill/librdkafka/pull/4051.
+rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git" }
+rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,6 @@ debug = 1
 # "fix-thing" or "pr-1234"). Feature/patch branches tend to get rewritten or
 # disappear (e.g., because a PR is force pushed or gets merged), after which
 # point it becomes impossible to build that historical version of Materialize.
-chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x" }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/deny.toml
+++ b/deny.toml
@@ -182,10 +182,6 @@ allow-git = [
     # dependency on arrayvec v0.5.2 via a dependency on vte v0.10.1.
     "https://github.com/alacritty/vte",
 
-    # Waiting for https://github.com/chronotope/chrono/pull/906
-    # to be released in the v0.4.x series.
-    "https://github.com/chronotope/chrono.git",
-
     # Waiting on v0.18.
     # See: https://github.com/open-telemetry/opentelemetry-rust/pull/779
     "https://github.com/MaterializeInc/opentelemetry-rust.git",

--- a/deny.toml
+++ b/deny.toml
@@ -177,64 +177,10 @@ license-files = [
 [sources]
 unknown-git = "deny"
 unknown-registry = "deny"
-allow-git = [
-    # Waiting for a new release of strip-ansi-escapes that avoids the indirect
-    # dependency on arrayvec v0.5.2 via a dependency on vte v0.10.1.
-    "https://github.com/alacritty/vte",
-
-    # Waiting on v0.18.
-    # See: https://github.com/open-telemetry/opentelemetry-rust/pull/779
-    "https://github.com/MaterializeInc/opentelemetry-rust.git",
-
-    # Waiting on tracing-opentelemetry to upgrade to the as-yet unreleased
-    # v0.18 of opentelemetry.
-    "https://github.com/MaterializeInc/tracing.git",
-
-    # Waiting on https://github.com/AltSysrq/proptest/pull/264.
-    "https://github.com/MaterializeInc/proptest.git",
-
-    # Waiting on https://github.com/sfackler/rust-postgres/pull/752.
-    "https://github.com/MaterializeInc/rust-postgres.git",
-    "https://github.com/MaterializeInc/rust-postgres-array.git",
-
-    # Waiting on https://github.com/MaterializeInc/serde-value/pull/35.
-    "https://github.com/MaterializeInc/serde-value.git",
-
-    # Waiting on https://github.com/edenhill/librdkafka/pull/4051.
-    "https://github.com/MaterializeInc/rust-rdkafka.git",
-
-    # Waiting for hashlink, indexmap, and lru to upgrade to hashbrown v0.13,
-    # which depends on ahash v0.8 instead of v0.7. In the meantime we've
-    # backported the ahash v0.8 bump into hashbrown v0.12.
-    "https://github.com/MaterializeInc/hashbrown.git",
-
-    # Dependencies that we control upstream whose official releases we don't
-    # care about.
-    "https://github.com/frankmcsherry/columnation",
-    "https://github.com/TimelyDataflow/timely-dataflow",
-    "https://github.com/TimelyDataflow/differential-dataflow.git",
-
-    # Waiting on https://github.com/launchdarkly/rust-eventsource-client/pull/43
-    # to make it into a release.
-    "https://github.com/MaterializeInc/rust-eventsource-client.git",
-
-    # Waiting on https://github.com/launchdarkly/rust-server-sdk/pull/20 to make
-    # it into a release.
-    "https://github.com/MaterializeInc/rust-server-sdk",
-
-    # Waiting on https://github.com/tokio-rs/prost/pull/833 to make it into a
-    # release.
-    "https://github.com/MaterializeInc/prost",
-
-    # Waiting on https://github.com/hyperium/tonic/pull/1398.
-    "https://github.com/MaterializeInc/tonic",
-
-    # Do not add personal GitHub forks here! Forks must be owned by the
-    # MaterializeInc organization so that maintainership is shared amongst
-    # Materialize employees. If you don't have permissions to create a fork in
-    # the MaterializeInc organization, ask in #eng-infra.
-    #
-    # Personal GitHub repositories are okay for projects where the true upstream
-    # is a personal GitHub account (e.g., frankmcsherry/columnation) rather than
-    # a fork.
-]
+# Do not allow non-MaterializeInc Git repositories here! Git repositories must
+# be owned by the MaterializeInc organization so that maintainership is shared
+# amongst Materialize employees and so that historical versions of Materialize
+# remain buildable even if upstream Git repositories disappear. If you don't
+# have permissions to create a fork in the MaterializeInc organization, ask in
+# #eng-infra on Slack.
+allow-org = { github = ["MaterializeInc"] }

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -13,14 +13,14 @@ bytesize = "1.1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 dec = "0.4.8"
 derivative = "2.2.0"
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 enum-kinds = "0.5.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 hex = "0.4.3"
 itertools = "0.10.5"
 once_cell = "1.16.0"
-launchdarkly-server-sdk = { git = "https://github.com/MaterializeInc/rust-server-sdk", default_features = false, features = ["hypertls"] }
+launchdarkly-server-sdk = { version = "1.0.0", default_features = false, features = ["hypertls"] }
 maplit = "1.0.2"
 mz-audit-log = { path = "../audit-log" }
 mz-build-info = { path = "../build-info" }
@@ -48,23 +48,23 @@ mz-stash = { path = "../stash" }
 mz-storage-client = { path = "../storage-client" }
 mz-transform = { path = "../transform" }
 mz-cloud-resources = { path = "../cloud-resources" }
-opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.17.0", features = ["rt-tokio", "trace"] }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
-rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = "1.7.0"
 reqwest = "0.11.13"
 semver = "1.0.16"
 serde = "1.0.152"
 serde_json = "1.0.89"
 smallvec = { version = "1.10.0", features = ["union"] }
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["rt", "time"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { version = "0.7.8" }
 tokio-stream = "0.1.11"
 tracing = "0.1.37"
-tracing-opentelemetry = { git = "https://github.com/MaterializeInc/tracing.git", branch = "v0.1.x" }
+tracing-opentelemetry = { version = "0.17.4" }
 tracing-subscriber = "0.3.16"
 thiserror = "1.0.37"
 uncased = "0.9.7"
@@ -74,7 +74,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }
 datadriven = "0.6.0"
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 
 [[bench]]
 name = "catalog"

--- a/src/cluster-client/Cargo.toml
+++ b/src/cluster-client/Cargo.toml
@@ -17,8 +17,8 @@ mz-ore = { path = "../ore", features = ["tracing_"] }
 mz-proto = { path = "../proto" }
 once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
-proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -13,7 +13,7 @@ bytesize = "1.1.0"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 futures = "0.3.25"
 mz-build-info = { path = "../build-info" }
 mz-cluster-client = { path = "../cluster-client" }
@@ -34,7 +34,7 @@ rocksdb = { version = "0.21.0", default-features = false, features = ["snappy"] 
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -29,7 +29,7 @@ mz-storage = { path = "../storage" }
 mz-storage-client = { path = "../storage-client" }
 mz-timely-util = { path = "../timely-util" }
 once_cell = { version = "1.16.0" }
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util"] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -11,9 +11,9 @@ anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.68"
 bytesize = "1.1.0"
-columnation = { git = "https://github.com/frankmcsherry/columnation" }
+columnation = "0.1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 futures = "0.3.25"
 http = "0.2.8"
 itertools = "0.10.5"
@@ -32,14 +32,14 @@ mz-storage-client = { path = "../storage-client" }
 mz-timely-util = { path = "../timely-util" }
 once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
-proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = "1.24.2"
 tokio-stream = "0.1.11"
 tonic = "0.8.2"

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -13,8 +13,8 @@ bytesize = "1.1.0"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
-dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
+dogsdogsdogs = "0.1.0"
 futures = "0.3.25"
 itertools = "0.10.5"
 mz-build-info = { path = "../build-info" }
@@ -35,7 +35,7 @@ prometheus = { version = "0.13.3", default-features = false }
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 futures = "0.3.25"
 mz-build-info = { path = "../build-info" }
 mz-cluster-client = { path = "../cluster-client" }
@@ -26,7 +26,7 @@ once_cell = "1.16.0"
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = "1.24.2"
 tokio-stream = "0.1.11"
 tracing = "0.1.37"

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -60,9 +60,9 @@ nix = "0.26.1"
 num_cpus = "1.14.0"
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
-opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.17.0", features = ["rt-tokio", "trace"] }
 prometheus = { version = "0.13.3", default-features = false }
-rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+rdkafka-sys = { version = "4.3.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
 rlimit = "0.8.3"
@@ -77,12 +77,12 @@ tempfile = "3.2.0"
 thiserror = "1.0.37"
 tokio = { version = "1.24.2", features = ["sync"] }
 tokio-openssl = "0.6.3"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { version = "0.7.8" }
 tokio-stream = { version = "0.1.11", features = ["net"] }
 tower-http = { version = "0.3.5", features = ["cors"] }
 tracing = "0.1.37"
 tracing-core = "0.1.30"
-tracing-opentelemetry = { git = "https://github.com/MaterializeInc/tracing.git", branch = "v0.1.x" }
+tracing-opentelemetry = { version = "0.17.4" }
 tracing-subscriber = "0.3.16"
 tungstenite = { version = "0.18.0", features = ["native-tls"] }
 url = "2.3.1"
@@ -100,17 +100,17 @@ mz-pgrepr = { path = "../pgrepr" }
 mz-pgtest = { path = "../pgtest" }
 mz-repr = { path = "../repr" }
 mz-sql-parser = { path = "../sql-parser" }
-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4"] }
-postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
-postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
-postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
+postgres = { version = "0.19.5", features = ["with-chrono-0_4"] }
+postgres-openssl = { version = "0.5.0" }
+postgres-protocol = { version = "0.6.5" }
+postgres_array = { version = "0.11.0" }
 predicates = "2.1.4"
 regex = "1.7.0"
 reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.89"
 serde_urlencoded = "0.7.1"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4"] }
 
 [build-dependencies]
 anyhow = "1.0.66"

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -47,8 +47,8 @@ sha2 = "0.10.6"
 tracing = "0.1.37"
 uncased = "0.9.7"
 uuid = {version = "1.2.2", features = ["v5"]}
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
-proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0.66"
 byteorder = "1.4.3"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive"] }
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 maplit = "1.0.2"
@@ -29,7 +29,7 @@ ordered-float = { version = "3.4.0", features = ["serde"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 prost-reflect = "0.9.2"
 serde_json = "1.0.89"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde"] }

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -17,7 +17,7 @@ mz-ore = { path = "../ore", features = ["cli", "network", "async"] }
 num_cpus = "1.14.0"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
-rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 tokio = { version = "1.24.2", features = ["macros", "sync"] }

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -21,7 +21,7 @@ mz-service = { path = "../service" }
 sentry-tracing = { version = "0.29.1" }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.16", default-features = false }
-opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.17.0", features = ["rt-tokio", "trace"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [features]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -48,22 +48,22 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 atty = { version = "0.2.14", optional = true }
 http = { version = "0.2.8", optional = true }
 tracing = { version = "0.1.37", optional = true }
-tracing-opentelemetry = { git = "https://github.com/MaterializeInc/tracing.git", branch = "v0.1.x", optional = true }
+tracing-opentelemetry = { version = "0.17.4", optional = true }
 tonic = { version = "0.8.2", features = ["transport"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 native-tls = { version = "0.2.11", features = ["alpn"], optional = true }
 hyper = { version = "0.14.23", features = ["http1", "server"], optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
-opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", features = ["rt-tokio", "trace"], optional = true }
-opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", optional = true }
-console-subscriber = { git = "https://github.com/MaterializeInc/tokio-console.git", optional = true }
+opentelemetry = { version = "0.17.0", features = ["rt-tokio", "trace"], optional = true }
+opentelemetry-otlp = { version = "0.10.0", optional = true }
+console-subscriber = { version = "0.1.8", optional = true }
 sentry-tracing = { version = "0.29.1", optional = true }
 yansi = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
 anyhow = { version = "1.0.66" }
 scopeguard = "1.1.0"
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 serde_json = "1.0.89"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 tokio-test = "0.4.2"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -34,7 +34,7 @@ async-stream = "0.3.3"
 async-trait = "0.1.68"
 bytes = "1.3.0"
 clap = { version = "3.2.24", features = [ "derive" ] }
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 futures = "0.3.25"
 futures-util = "0.3"
 h2 = "0.3.13"
@@ -45,14 +45,14 @@ mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
 mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
-proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 sentry-tracing = "0.29.1"
 semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.89"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 thiserror = "1.0.37"
 tokio = { version = "1.24.2", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tokio-stream = "0.1.11"

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -14,14 +14,14 @@ arrow2 = { version = "0.16.0", features = ["compute_aggregate", "io_ipc", "io_pa
 bytes = "1.3.0"
 mz-proto = { path = "../proto" }
 parquet2 = { version = "0.17.1", default-features = false }
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 
 [build-dependencies]
 prost-build = "0.11.2"

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -29,7 +29,7 @@ aws-types = "0.55"
 base64 = "0.13.1"
 bytes = "1.3.0"
 deadpool-postgres = "0.10.3"
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures-util = "0.3.25"
 once_cell = "1.16.0"
@@ -40,16 +40,16 @@ mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
-postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-openssl = { version = "0.5.0" }
 prometheus = { version = "0.13.3", default-features = false }
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
-proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 url = "2.3.1"
 uuid = { version = "1.2.2", features = ["v4"] }

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -15,7 +15,7 @@ once_cell = "1.16.0"
 mz-ore = { path = "../ore" }
 mz-pgrepr-consts = { path = "../pgrepr-consts" }
 mz-repr = { path = "../repr" }
-postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-uuid-1"] }
+postgres-types = { version = "0.2.5", features = ["with-chrono-0_4", "with-uuid-1"] }
 uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/pgtest/Cargo.toml
+++ b/src/pgtest/Cargo.toml
@@ -13,7 +13,7 @@ clap = { version = "3.2.24", features = ["derive"] }
 datadriven = "0.6.0"
 fallible-iterator = "0.2.0"
 mz-ore = { path = "../ore", features = ["cli"] }
-postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-protocol = { version = "0.6.5" }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -23,7 +23,7 @@ mz-pgrepr = { path = "../pgrepr" }
 mz-repr = { path = "../repr" }
 mz-sql = { path = "../sql" }
 openssl = { version = "0.10.48", features = ["vendored"] }
-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres = { version = "0.19.5" }
 tokio = "1.24.2"
 tokio-openssl = "0.6.3"
 tokio-util = { version = "0.7.4", features = ["codec"] }

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -15,14 +15,14 @@ mz-repr = { path = "../repr", optional = true }
 mz-ssh-util = { path = "../ssh-util", optional = true }
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssh = { version = "0.9.8", default-features = false, features = ["native-mux"], optional = true }
-postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array", optional = true }
-postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"], optional = true }
+postgres_array = { version = "0.11.0", optional = true }
+postgres-openssl = { version = "0.5.0" }
+proptest = { version = "1.0.0", default-features = false, features = ["std"], optional = true }
 prost = { version = "0.11.3", features = ["no-recursion-limit"], optional = true }
 serde = { version = "1.0.152", features = ["derive"], optional = true }
 thiserror = "1.0.37"
 tokio = { version = "1.24.2", features = ["fs", "rt", "sync"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 

--- a/src/proto/Cargo.toml
+++ b/src/proto/Cargo.toml
@@ -12,11 +12,11 @@ anyhow = "1.0.66"
 globset = "0.4.9"
 http = "0.2.8"
 mz-ore = { path = "../ore", default-features = false }
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 regex = "1.7.0"
 serde_json = { version = "1.0.89", features = ["arbitrary_precision"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", optional = true }
+tokio-postgres = { version = "0.7.8", optional = true }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -18,11 +18,11 @@ harness = false
 anyhow = "1.0.66"
 bitflags = "1.3.2"
 bytes = "1.3.0"
-columnation = { git = "https://github.com/frankmcsherry/columnation" }
+columnation = "0.1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
 dec = "0.4.8"
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 enum_dispatch = "0.3.11"
 enum-kinds = "0.5.1"
 fast-float = "0.2.0"
@@ -36,7 +36,7 @@ mz-proto = { path = "../proto" }
 num-traits = "0.2.15"
 num_enum = "0.5.7"
 ordered-float = { version = "3.4.0", features = ["serde"] }
-postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-protocol = { version = "0.6.5" }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 regex = "1.7.0"
 ryu = "1.0.12"
@@ -44,12 +44,12 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision"] }
 serde_regex = "1.1.0"
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+tokio-postgres = { version = "0.7.8" }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde"] }
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
-proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 thiserror = "1.0.37"
 
 # for the tracing_ feature

--- a/src/rocksdb/Cargo.toml
+++ b/src/rocksdb/Cargo.toml
@@ -15,8 +15,8 @@ mz-ore = { path = "../ore", features = ["async", "metrics", "test"] }
 mz-proto = { path = "../proto" }
 num_cpus = "1.14.0"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
-proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 tokio = { version = "1.24.2", features = ["macros", "sync", "rt"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -26,7 +26,7 @@ os_info = "3.5.1"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 semver = "1.0.16"
 sysinfo = "0.27.2"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = "1.24.2"
 tokio-stream = "0.1.11"
 tonic = "0.8.2"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -39,17 +39,17 @@ mz-sql-parser = { path = "../sql-parser" }
 mz-storage-client = { path = "../storage-client" }
 paste = "1.0"
 protobuf-native = "0.2.1"
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
-proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
-rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = "1.7.0"
 reqwest = "0.11.13"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 tokio = { version = "1.24.2", features = ["fs"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde"] }
+tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tracing = "0.1.37"
 uncased = "0.9.7"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -32,14 +32,14 @@ mz-sql-parser = { path = "../sql-parser" }
 mz-stash = { path = "../stash" }
 mz-storage-client = { path = "../storage-client" }
 mz-cloud-resources = { path = "../cloud-resources" }
-postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-protocol = { version = "0.6.5" }
 regex = "1.7.0"
 serde_json = "1.0.89"
 tempfile = "3.2.0"
 time = "0.3.17"
 tracing = "0.1.37"
 tokio = "1.24.2"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }
+tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }
 tower-http = { version = "0.3.5", features = ["cors"] }
 uuid = "1.2.2"
 walkdir = "2.3.2"

--- a/src/stash-debug/Cargo.toml
+++ b/src/stash-debug/Cargo.toml
@@ -20,7 +20,7 @@ mz-storage-client = { path = "../storage-client" }
 once_cell = "1.16.0"
 serde_json = "1.0.89"
 tokio = "1.24.2"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = [ "with-serde_json-1" ] }
+tokio-postgres = { version = "0.7.8", features = [ "with-serde_json-1" ] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -14,23 +14,23 @@ harness = false
 anyhow = "1.0.66"
 bitflags = "1.3.2"
 bytes = "1.3.0"
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 itertools = "0.10.5"
 mz-ore = { path = "../ore", features = ["metrics", "network", "async", "test"] }
 mz-postgres-util = { path = "../postgres-util" }
-postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-openssl = { version = "0.5.0" }
 prometheus = { version = "0.13.3", default-features = false }
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
-proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.9", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 serde = "1.0.152"
 serde_json = "1.0.89"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
+timely = { version = "0.12.0", default-features = false }
 tokio = "1.24.2"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = [ "with-serde_json-1" ] }
+tokio-postgres = { version = "0.7.8", features = [ "with-serde_json-1" ] }
 tracing = "0.1.37"
 uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "1.3.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 dec = "0.4.8"
 derivative = "2.2.0"
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 futures = "0.3.25"
 http = "0.2.8"
 itertools = { version = "0.10.5" }
@@ -43,19 +43,19 @@ mz-ssh-util = { path = "../ssh-util" }
 mz-stash = { path = "../stash" }
 mz-timely-util = { path = "../timely-util" }
 openssh = { version = "0.9.8", default-features = false, features = ["native-mux"] }
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 prometheus = { version = "0.13.3", default-features = false }
-proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
-rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = { version = "1.7.0" }
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 thiserror = "1.0.37"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde"] }
+tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"
 tonic = "0.8.2"
 tracing = "0.1.37"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
 csv-core = { version = "0.1.10" }
 dec = "0.4.8"
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 either = { version = "1.8.0", features = ["serde"] }
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
@@ -54,20 +54,20 @@ mz-sql-parser = { path = "../sql-parser" }
 mz-storage-client = { path = "../storage-client" }
 mz-timely-util = { path = "../timely-util" }
 once_cell = { version = "1.16.0" }
-postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-protocol = { version = "0.6.5" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
-rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = { version = "1.7.0" }
 rocksdb = { version = "0.21.0", default-features = false, features = ["snappy"] }
 seahash = "4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 sha2 = "0.10.6"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde"] }
+tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["io"] }
 tracing = "0.1.37"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -45,12 +45,12 @@ mz-repr = { path = "../repr" }
 mz-sql = { path = "../sql" }
 mz-sql-parser = { path = "../sql-parser" }
 mz-stash = { path = "../stash" }
-postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
+postgres_array = { version = "0.11.0" }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 prost-reflect = { version = "0.9.2", features = ["serde"] }
 protobuf-src = "1.1.0"
 rand = "0.8.5"
-rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = "1.7.0"
 reqwest = { version = "0.11.13", features = ["native-tls-vendored"] }
 serde = "1.0.152"
@@ -63,7 +63,7 @@ time = "0.3.17"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 tokio = { version = "1.24.2", features = ["process"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["compat"] }
 url = "2.3.1"

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -7,10 +7,10 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 futures-util = "0.3.25"
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+proptest = { version = "1.0.0", default-features = false, features = ["std"]}
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 serde = { version = "1.0.152", features = ["derive"] }
 mz-ore = { path = "../ore", features = ["tracing_"] }
 polonius-the-crab = "0.3.1"

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+differential-dataflow = "0.12.0"
 itertools = "0.10.5"
 mz-compute-client = { path = "../compute-client" }
 mz-expr = { path = "../expr" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -25,7 +25,7 @@ base64 = { version = "0.13.1", features = ["alloc"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
 bytes = { version = "1.3.0" }
-chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x", default-features = false, features = ["alloc", "clock", "serde"] }
+chrono = { version = "0.4.24", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 crossbeam-channel = { version = "0.5.8" }
@@ -122,7 +122,7 @@ bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
 bytes = { version = "1.3.0" }
 cc = { version = "1.0.78", default-features = false, features = ["parallel"] }
-chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x", default-features = false, features = ["alloc", "clock", "serde"] }
+chrono = { version = "0.4.24", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 crossbeam-channel = { version = "0.5.8" }

--- a/test/metabase/smoketest/Cargo.toml
+++ b/test/metabase/smoketest/Cargo.toml
@@ -12,7 +12,7 @@ itertools = "0.10.5"
 mz-metabase = { path = "../../../src/metabase" }
 mz-ore = { path = "../../../src/ore", features = ["network", "async", "test"] }
 tokio = { version = "1.24.2", features = ["macros"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../../../src/workspace-hack" }
 

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -12,9 +12,9 @@ chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 mz-kafka-util = { path = "../../src/kafka-util" }
 mz-ore = { path = "../../src/ore", features = ["async"] }
 rand = "0.8.5"
-rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 tokio = "1.24.2"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../../src/workspace-hack" }
 


### PR DESCRIPTION
Git dependencies on repositories that are not under Materialize's
control pose a risk to historical builds. If those repositories or their
contents ever go missing (e.g., due to a force push, or because their
owner deletes them), any version of Materialize that referenced those
repositories becomes unbuildable. Most notably, this breaks `git
bisect`.

So, prohibit dependencies on non-MaterializeInc Git repositories.
There's still a small risk here that *we* delete these repositories, but
at least we control our own destiny.

To facilitate this policy, this commit uses the `allow-org`
configuration knob in deny.toml to blanket allow all `MaterializeInc`
repositories. This required some fiddling with Cargo.toml to ensure
there remained a place to document, for each Git dependency, why we
couldn't use the official crates.io release.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
