### PR TITLE
tests: Fix session.td for cloudtest

### DIFF
--- a/test/cloudtest/test_full_testdrive.py
+++ b/test/cloudtest/test_full_testdrive.py
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from textwrap import dedent
-
 import pytest
 
 from materialize.cloudtest.application import MaterializeApplication
@@ -16,14 +14,5 @@ from materialize.cloudtest.application import MaterializeApplication
 
 @pytest.mark.long
 def test_full_testdrive(mz: MaterializeApplication) -> None:
-    mz.testdrive.run(
-        input=dedent(
-            """
-            $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-            ALTER SYSTEM SET enable_rbac_checks = true;
-            """
-        ),
-        no_reset=True,
-    )
     mz.testdrive.copy("test/testdrive", "/workdir")
     mz.testdrive.run("testdrive/*.td")

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -7,6 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Cloudtest is still running with RBAC off, while the mzcompose-based tests
+# have it enabled, so enable it explicitly for this test so that we have
+# consistent output in "SHOW ALL".
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_rbac_checks = true;
+
 $ set-regex match="cluster1|default|v\d+\.\d+\.\d+(-[a-z0-9]+)? \([a-f0-9]{9}\)" replacement=<VARIES>
 
 > SHOW ALL


### PR DESCRIPTION
Seen in nightly: https://buildkite.com/materialize/nightlies/builds/2458#01884af5-362d-468c-847d-dccd8e92ea36

The previous approach didn't work since testdrive is resetting the state before each td file

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
