### PR TITLE
Handle float over/underflows in pow, exp

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1237,7 +1237,14 @@ fn power<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         // > a negative number raised to a non-integer power yields a complex result
         return Err(EvalError::ComplexOutOfRange("pow".to_owned()));
     }
-    Ok(Datum::from(a.powf(b)))
+    let res = a.powf(b);
+    if res.is_infinite() {
+        return Err(EvalError::FloatOverflow);
+    }
+    if res == 0.0 && a != 0.0 {
+        return Err(EvalError::FloatUnderflow);
+    }
+    Ok(Datum::from(res))
 }
 
 fn uuid_generate_v5<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {

--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -419,8 +419,15 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "expf64"]
-    fn exp(a: f64) -> f64 {
-        a.exp()
+    fn exp(a: f64) -> Result<f64, EvalError> {
+        let r = a.exp();
+        if r.is_infinite() {
+            return Err(EvalError::FloatOverflow);
+        }
+        if r == 0.0 {
+            return Err(EvalError::FloatUnderflow);
+        }
+        Ok(r)
     }
 );
 

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1456,6 +1456,12 @@ SELECT exp(ln(2::decimal(15, 5)))
 ----
 2
 
+query error value out of range: overflow
+SELECT exp(10000::float)
+
+query error value out of range: underflow
+SELECT exp(-10000::float)
+
 query R
 SELECT power(382, 5);
 ----
@@ -1491,6 +1497,17 @@ query T
 SELECT pow(9::decimal(15, 5), 0.5::decimal(15, 5));
 ----
 3
+
+query error value out of range: overflow
+SELECT pow(3::float, 10000)
+
+query T
+SELECT pow(0::float, 10000)
+----
+0.000
+
+query error value out of range: underflow
+SELECT pow(3::float, -10000)
 
 query T
 SELECT pg_column_size(NULL)


### PR DESCRIPTION
The SQL spec says about pow:

    [...] the result is the result of
    EXP(NVEE*LN(NVEB))

and about exp:

    If <exponential function> is specified, then let V be the value of
    the simply contained <numeric value expression>.  [...] the result
    is e (the base of natural logarithms) raised to the power V. If
    the result is not representable in the declared type of the
    result, then an exception condition is raised: data exception —
    numeric value out of range.

Arguably, the result is representable, since inf is part of the type, but the section on "characteristics of numbers" seems to indicate that loss of the most-significant digit is considered an overflow.

Notably, this change matches Postgres's behavior for these functions.

In this case (unlike some of the other functions), Rust's f64 implementations compile to the LLVM intrinsics rather than libm calls, and the former don't check any of these error cases for us.  (Then again, historically libm implementations have been buggy enough that lots of code duplicates those checks anyway...)

Fixes #19275.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug: #19275.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
