### PR TITLE
Remove support to maintain the threshold based on retractions

### DIFF
--- a/src/compute-client/src/explain/text.rs
+++ b/src/compute-client/src/explain/text.rs
@@ -334,11 +334,6 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                         write!(f, "{}Threshold::Basic", ctx.indent)?;
                         writeln!(f, " ensure_arrangement={}", ensure_arrangement)?;
                     }
-                    ThresholdPlan::Retractions(plan) => {
-                        let ensure_arrangement = Arrangement::from(&plan.ensure_arrangement);
-                        write!(f, "{}Threshold::Retractions", ctx.indent)?;
-                        writeln!(f, " ensure_arrangement={}", ensure_arrangement)?;
-                    }
                 };
                 ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1459,8 +1459,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 } else {
                     input
                 };
-                let (threshold_plan, required_arrangement) =
-                    ThresholdPlan::create_from(arity, false);
+                let (threshold_plan, required_arrangement) = ThresholdPlan::create_from(arity);
                 let input = if !keys
                     .arranged
                     .iter()

--- a/src/compute-client/src/plan/threshold.proto
+++ b/src/compute-client/src/plan/threshold.proto
@@ -16,10 +16,10 @@ import "expr/src/scalar.proto";
 package mz_compute_client.plan.threshold;
 
 message ProtoThresholdPlan {
-   oneof kind {
-       ProtoArrangement basic = 1;
-       ProtoArrangement retractions = 2;
-   }
+    reserved 2; // retractions
+    oneof kind {
+        ProtoArrangement basic = 1;
+    }
 }
 
 message ProtoArrangement {
@@ -31,5 +31,4 @@ message ProtoArrangement {
     repeated mz_expr.scalar.ProtoMirScalarExpr all_columns = 1;
     repeated ProtoArrangementPermutation  permutation = 2;
     repeated uint64 thinning = 3;
-
 };


### PR DESCRIPTION
This removes the `ThresholdPlan::Retractions` that was never exercised and known to be incorrect.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
