### PR TITLE
make new postgres-util code properly use the crate features

### DIFF
--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -15,7 +15,7 @@ mz-repr = { path = "../repr", optional = true }
 mz-ssh-util = { path = "../ssh-util", optional = true }
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssh = { version = "0.9.8", default-features = false, features = ["native-mux"], optional = true }
-postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
+postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array", optional = true }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"], optional = true }
 prost = { version = "0.11.3", features = ["no-recursion-limit"], optional = true }
@@ -30,6 +30,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 default = ["workspace-hack", "schemas", "tunnel"]
 schemas = ["prost", "serde", "proptest", "mz-proto", "tunnel"]
 tunnel = ["mz-cloud-resources", "serde", "mz-ssh-util", "mz-repr", "openssh", "mz-ore"]
+privileges = ["postgres_array"]
 
 [build-dependencies]
 prost-build = "0.11.2"

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -91,7 +91,9 @@ macro_rules! bail_generic {
     };
 }
 
+#[cfg(feature = "privileges")]
 pub mod privileges;
+#[cfg(feature = "privileges")]
 pub use privileges::check_table_privileges;
 #[cfg(feature = "schemas")]
 pub mod desc;

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -30,7 +30,7 @@ mz-ore = { path = "../ore", features = ["chrono", "async"] }
 mz-persist-client = { path = "../persist-client" }
 mz-pgcopy = { path = "../pgcopy" }
 mz-pgrepr = { path = "../pgrepr" }
-mz-postgres-util = { path = "../postgres-util" }
+mz-postgres-util = { path = "../postgres-util", features = ["privileges"] }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr", features = ["tracing_"] }
 mz-rocksdb = { path = "../rocksdb" }


### PR DESCRIPTION
### Motivation

cloud is broken with this currently

### Tips for reviewer



### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - no user facing changes
