### PR TITLE
persist: fix pushdown metrics

### DIFF
--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -186,7 +186,7 @@ where
     G::Timestamp: Timestamp + Lattice + Codec64 + TotalOrder,
 {
     let cfg = clients.cfg().clone();
-    let metrics = clients.metrics.shards.shard(&shard_id);
+    let metrics = Arc::clone(&clients.metrics);
     let worker_index = scope.index();
     let num_workers = scope.peers();
 
@@ -468,6 +468,8 @@ where
                                                 usize::cast_from(h.finish()) % 100 < cfg.dynamic.stats_audit_percent()
                                             };
                                             if should_audit {
+                                                metrics.pushdown.parts_audited_count.inc();
+                                                metrics.pushdown.parts_audited_bytes.inc_by(bytes);
                                                 part_desc.request_filter_pushdown_audit();
                                             } else {
                                                 debug!("skipping part because of stats filter {:?}", part_desc.stats);


### PR DESCRIPTION
These were on ShardMetrics in an attempt to make them per-shard, but for SELECTs, there's no good way to make sure that ShardMetrics live long enough for prometheus to scrape them. This is a footgun (as evidenced by me spending a bunch of time debugging it XD), so fix it by making them not per-shard for now.

While I'm in here, also add some metrics for audit, so we can keep an eye on how much work it's causing the system to do.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
