### PR TITLE
sql: disallow mutiple subsources referring to the same table

### DIFF
--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -165,6 +165,10 @@ pub enum PlanError {
         name: UnresolvedItemName,
         upstream_references: Vec<UnresolvedItemName>,
     },
+    SubsourceDuplicateReference {
+        name: UnresolvedItemName,
+        target_names: Vec<UnresolvedItemName>,
+    },
     PostgresDatabaseMissingFilteredSchemas {
         schemas: Vec<String>,
     },
@@ -436,6 +440,9 @@ impl fmt::Display for PlanError {
             Self::EmptyPublication(publication) => write!(f, "PostgreSQL PUBLICATION {publication} is empty"),
             Self::SubsourceNameConflict { name, upstream_references } => {
                 write!(f, "multiple tables with name {}: {}", name.to_ast_string_stable(), itertools::join(upstream_references.iter().map(|n| n.to_ast_string_stable()), ", "))
+            },
+            Self::SubsourceDuplicateReference { name, target_names } => {
+                write!(f, "table {} referred to by multiple subsources: {}", name.to_ast_string_stable(), itertools::join(target_names.iter().map(|n| n.to_ast_string_stable()), ", "))
             },
             Self::PostgresDatabaseMissingFilteredSchemas { schemas} => {
                 write!(f, "FOR SCHEMAS (..) included {}, but PostgreSQL database has no schema with that name", itertools::join(schemas.iter(), ", "))

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -161,7 +161,7 @@ pub enum PlanError {
         linked_object_name: String,
     },
     EmptyPublication(String),
-    DuplicateSubsourceReference {
+    SubsourceNameConflict {
         name: UnresolvedItemName,
         upstream_references: Vec<UnresolvedItemName>,
     },
@@ -252,7 +252,7 @@ impl PlanError {
                 let supported_azs_str = supported_azs.iter().join("\n  ");
                 Some(format!("Did you supply an availability zone name instead of an ID? Known availability zone IDs:\n  {}", supported_azs_str))
             }
-            Self::DuplicateSubsourceReference { .. } => {
+            Self::SubsourceNameConflict { .. } => {
                 Some("Specify target table names using FOR TABLES (foo AS bar), or limit the upstream tables using FOR SCHEMAS (foo)".into())
             }
             Self::InvalidKeysInSubscribeEnvelopeUpsert => {
@@ -434,7 +434,7 @@ impl fmt::Display for PlanError {
             Self::ItemAlreadyExists { name, item_type } => write!(f, "{item_type} {} already exists", name.quoted()),
             Self::ModifyLinkedCluster {cluster_name, ..} => write!(f, "cannot modify linked cluster {}", cluster_name.quoted()),
             Self::EmptyPublication(publication) => write!(f, "PostgreSQL PUBLICATION {publication} is empty"),
-            Self::DuplicateSubsourceReference { name, upstream_references } => {
+            Self::SubsourceNameConflict { name, upstream_references } => {
                 write!(f, "multiple tables with name {}: {}", name.to_ast_string_stable(), itertools::join(upstream_references.iter().map(|n| n.to_ast_string_stable()), ", "))
             },
             Self::PostgresDatabaseMissingFilteredSchemas { schemas} => {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -398,7 +398,7 @@ pub async fn purify_create_source(
 
                 upstream_references.sort();
 
-                return Err(PlanError::DuplicateSubsourceReference {
+                return Err(PlanError::SubsourceNameConflict {
                     name,
                     upstream_references,
                 });

--- a/test/pg-cdc/subsource-resolution-duplicates.td
+++ b/test/pg-cdc/subsource-resolution-duplicates.td
@@ -42,6 +42,11 @@ ALTER TABLE other.t REPLICA IDENTITY FULL;
   FOR ALL TABLES;
 contains:multiple tables with name "t": "postgres"."other"."t", "postgres"."public"."t"
 
+! CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES (public.t AS x, public.t as Y);
+contains:table "postgres"."public"."t" referred to by multiple subsources: "x", "y"
+
 > CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR SCHEMAS (other);

--- a/test/upgrade/create-in-v0.32.4-pg-cdc.td
+++ b/test/upgrade/create-in-v0.32.4-pg-cdc.td
@@ -77,3 +77,36 @@ var0
 3
 4
 5
+
+$ skip-if
+SELECT mz_version_num() >= 5600;
+
+# check that we support creating a source that supports referencing the same upstream table from
+# multiple subsources; the test is simply that this doesn't fail to upgrade to later # versions of
+# Materialize where this behavior is prohibited.
+
+> CREATE SOURCE upgrade_pg_cdc_duplicate_references
+  FROM POSTGRES
+  CONNECTION pgconn
+  (
+    PUBLICATION 'upgrade_pg_cdc_publication'
+  )
+  FOR TABLES
+  (
+    cdc_int_table AS cdc_int_table_zero,
+    cdc_int_table AS cdc_int_table_one
+  );
+
+> SELECT * FROM cdc_int_table_zero;
+1
+2
+3
+4
+5
+
+> SELECT * FROM cdc_int_table_one;
+1
+2
+3
+4
+5


### PR DESCRIPTION
### Motivation

This PR refactors existing code.

We allowed multiple PG subsources to refer to the same upstream table. This worked without issue, but is almost certainly not what a user intends, so make this error.

I put this check in purification and didn't enforce it anywhere in planning in case this would bite an active user; things are re-planned on boot, but not re-purified, so anyone who's using this behavior remains unaffected.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Prevent users from creating a PostgreSQL source with multiple references to the same upstream table.
