### PR TITLE
build: Remove unused const_format dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,26 +1249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_format"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3400,7 +3380,6 @@ dependencies = [
  "bytes",
  "bytesize",
  "chrono",
- "const_format",
  "criterion",
  "datadriven",
  "dec",
@@ -4756,7 +4735,6 @@ dependencies = [
  "aws-sdk-sts",
  "bitflags",
  "chrono",
- "const_format",
  "datadriven",
  "enum-kinds",
  "fail",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = "1.0.66"
 bytes = "1.3.0"
 bytesize = "1.1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
-const_format = "0.2.30"
 dec = "0.4.8"
 derivative = "2.2.0"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = "1.0.66"
 aws-sdk-sts = { version = "0.26", default-features = false, features = ["native-tls", "rt-tokio"] }
 bitflags = "1.3.2"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
-const_format = "0.2.30"
 enum-kinds = "0.5.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 globset = "0.4.9"


### PR DESCRIPTION
via https://buildkite.com/materialize/nightlies/builds/2464#01885020-4753-403e-8afe-ef31117acdab

unused dependencies:
```
`mz-adapter v0.0.0 (/var/lib/buildkite-agent/builds/buildkite-15f2293-i-09f7d8cc62da9331b-1/materialize/nightlies/src/adapter)` └─── dependencies
     └─── "const_format"
`mz-sql v0.0.0 (/var/lib/buildkite-agent/builds/buildkite-15f2293-i-09f7d8cc62da9331b-1/materialize/nightlies/src/sql)` └─── dependencies
     └─── "const_format"
```

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
