### PR TITLE
ci: Change Protobuf linting config from FILE to WIRE

### DIFF
--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -10,7 +10,7 @@
 version: v1
 breaking:
   use:
-    - FILE
+    - WIRE
   ignore:
     # does currently not require backward-compatibility
     - compute-client


### PR DESCRIPTION
### Motivation

According to @danhhz, `WIRE` instead of `FILE` compatibility should be sufficient for us. (https://materializeinc.slack.com/archives/C01LKF361MZ/p1684961884551029)

### See also
https://buf.build/docs/breaking/rules#categories