### PR TITLE
adapter: connection validation on creation and on demand

### DIFF
--- a/misc/python/materialize/checks/pg_cdc.py
+++ b/misc/python/materialize/checks/pg_cdc.py
@@ -32,14 +32,6 @@ class PgCdcBase:
         return Testdrive(
             dedent(
                 f"""
-                > CREATE SECRET pgpass1 AS 'postgres';
-
-                > CREATE CONNECTION pg1 FOR POSTGRES
-                  HOST 'postgres',
-                  DATABASE postgres,
-                  USER postgres1,
-                  PASSWORD SECRET pgpass1
-
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
                 CREATE USER postgres1 WITH SUPERUSER PASSWORD 'postgres';
                 ALTER USER postgres1 WITH replication;
@@ -53,6 +45,14 @@ class PgCdcBase:
                 INSERT INTO postgres_source_table SELECT 'A', i, REPEAT('A', {self.repeats} - i) FROM generate_series(1,100) AS i;
 
                 CREATE PUBLICATION postgres_source FOR ALL TABLES;
+
+                > CREATE SECRET pgpass1 AS 'postgres';
+
+                > CREATE CONNECTION pg1 FOR POSTGRES
+                  HOST 'postgres',
+                  DATABASE postgres,
+                  USER postgres1,
+                  PASSWORD SECRET pgpass1
                 """
             )
         )
@@ -229,14 +229,6 @@ class PgCdcMzNow(Check):
         return Testdrive(
             dedent(
                 """
-                > CREATE SECRET postgres_mz_now_pass AS 'postgres';
-
-                > CREATE CONNECTION postgres_mz_now_conn FOR POSTGRES
-                  HOST 'postgres',
-                  DATABASE postgres,
-                  USER postgres2,
-                  PASSWORD SECRET postgres_mz_now_pass
-
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
                 CREATE USER postgres2 WITH SUPERUSER PASSWORD 'postgres';
                 ALTER USER postgres2 WITH replication;
@@ -254,6 +246,14 @@ class PgCdcMzNow(Check):
                 INSERT INTO postgres_mz_now_table VALUES (NOW(), 'E1');
 
                 CREATE PUBLICATION postgres_mz_now_publication FOR ALL TABLES;
+
+                > CREATE SECRET postgres_mz_now_pass AS 'postgres';
+
+                > CREATE CONNECTION postgres_mz_now_conn FOR POSTGRES
+                  HOST 'postgres',
+                  DATABASE postgres,
+                  USER postgres2,
+                  PASSWORD SECRET postgres_mz_now_pass
 
                 > CREATE SOURCE postgres_mz_now_source
                   FROM POSTGRES CONNECTION postgres_mz_now_conn

--- a/misc/python/materialize/checks/source_errors.py
+++ b/misc/python/materialize/checks/source_errors.py
@@ -19,14 +19,6 @@ class SourceErrors(Check):
         return Testdrive(
             dedent(
                 """
-                > CREATE SECRET source_errors_secret AS 'postgres';
-
-                > CREATE CONNECTION source_errors_connection FOR POSTGRES
-                  HOST 'postgres',
-                  DATABASE postgres,
-                  USER source_errors_user1,
-                  PASSWORD SECRET source_errors_secret
-
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
                 # In order to avoid conflicts, user must be unique
                 CREATE USER source_errors_user1 WITH SUPERUSER PASSWORD 'postgres';
@@ -43,6 +35,14 @@ class SourceErrors(Check):
 
                 CREATE PUBLICATION source_errors_publicationA FOR ALL TABLES;
                 CREATE PUBLICATION source_errors_publicationB FOR ALL TABLES;
+
+                > CREATE SECRET source_errors_secret AS 'postgres';
+
+                > CREATE CONNECTION source_errors_connection FOR POSTGRES
+                  HOST 'postgres',
+                  DATABASE postgres,
+                  USER source_errors_user1,
+                  PASSWORD SECRET source_errors_secret
 
                 > CREATE SOURCE source_errors_sourceA
                   FROM POSTGRES CONNECTION source_errors_connection

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -396,6 +396,8 @@ pub enum ExecuteResponse {
     },
     /// The specified number of rows were updated in the requested table.
     Updated(usize),
+    /// A connection was validated.
+    ValidatedConnection,
 }
 
 impl ExecuteResponse {
@@ -461,6 +463,7 @@ impl ExecuteResponse {
             TransactionCommitted { .. } => Some("COMMIT".into()),
             TransactionRolledBack { .. } => Some("ROLLBACK".into()),
             Updated(n) => Some(format!("UPDATE {}", n)),
+            ValidatedConnection => Some("VALIDATE CONNECTION".into()),
         }
     }
 
@@ -536,6 +539,7 @@ impl ExecuteResponse {
             PlanKind::Subscribe => vec![Subscribing, CopyTo],
             StartTransaction => vec![StartedTransaction],
             SideEffectingFunc => vec![SendingRows],
+            ValidateConnection => vec![ExecuteResponseKind::ValidatedConnection],
         }
     }
 }

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -106,6 +106,7 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
         | Plan::RevokePrivileges(_)
         | Plan::AlterDefaultPrivileges(_)
         | Plan::ReassignOwned(_)
+        | Plan::ValidateConnection(_)
         | Plan::SideEffectingFunc(_) => return TargetCluster::Active,
     };
 
@@ -251,7 +252,8 @@ pub fn user_privilege_hack(
         | Plan::Prepare(_)
         | Plan::Execute(_)
         | Plan::Deallocate(_)
-        | Plan::SideEffectingFunc(_) => {}
+        | Plan::SideEffectingFunc(_)
+        | Plan::ValidateConnection(_) => {}
 
         Plan::CreateConnection(_)
         | Plan::CreateDatabase(_)

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -148,6 +148,7 @@ where
         StatementKind::RevokePrivileges => "revoke_privileges",
         StatementKind::AlterDefaultPrivileges => "alter_default_privileges",
         StatementKind::ReassignOwned => "reassign_owned",
+        StatementKind::ValidateConnection => "validate_connection",
     }
 }
 

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -403,6 +403,7 @@ fn generate_required_ownership(plan: &Plan) -> Vec<ObjectId> {
         | Plan::DropOwned(_)
         | Plan::ReassignOwned(_)
         | Plan::AlterDefaultPrivileges(_)
+        | Plan::ValidateConnection(_)
         | Plan::SideEffectingFunc(_) => Vec::new(),
         Plan::CreateIndex(plan) => vec![ObjectId::Item(plan.index.on)],
         Plan::CreateView(CreateViewPlan { replace, .. })
@@ -424,7 +425,6 @@ fn generate_required_ownership(plan: &Plan) -> Vec<ObjectId> {
         Plan::AlterSource(plan) => vec![ObjectId::Item(plan.id)],
         Plan::AlterItemRename(plan) => vec![ObjectId::Item(plan.id)],
         Plan::AlterSecret(plan) => vec![ObjectId::Item(plan.id)],
-        Plan::ValidateConnection(plan) => vec![ObjectId::Item(plan.id)],
         Plan::RotateKeys(plan) => vec![ObjectId::Item(plan.id)],
         Plan::AlterOwner(plan) => vec![plan.id.clone()],
         Plan::GrantPrivileges(plan) => plan
@@ -539,8 +539,8 @@ fn generate_required_privileges(
         Plan::ValidateConnection(ValidateConnectionPlan { id, connection: _ }) => {
             let schema_id: ObjectId = catalog.get_item(id).name().qualifiers.clone().into();
             vec![
-                (schema_id, AclMode::USAGE, role_id),
-                (id.into(), AclMode::USAGE, role_id),
+                (SystemObjectId::Object(schema_id), AclMode::USAGE, role_id),
+                (SystemObjectId::Object(id.into()), AclMode::USAGE, role_id),
             ]
         }
         Plan::CreateSchema(CreateSchemaPlan {

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -959,6 +959,7 @@ async fn execute_stmt<S: ResultSender>(
         | ExecuteResponse::AlteredRole
         | ExecuteResponse::AlteredSystemConfiguration
         | ExecuteResponse::Deallocate { .. }
+        | ExecuteResponse::ValidatedConnection
         | ExecuteResponse::Prepare => SqlResult::ok(client, tag.expect("ok only called on tag-generating results"), Vec::default()).into(),
         ExecuteResponse::TransactionCommitted { params } | ExecuteResponse::TransactionRolledBack { params }=> {
             let notify_set: mz_ore::collections::HashSet<String> = client

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1470,7 +1470,8 @@ where
             | ExecuteResponse::RevokedPrivilege
             | ExecuteResponse::RevokedRole
             | ExecuteResponse::StartedTransaction { .. }
-            | ExecuteResponse::Updated(..) => {
+            | ExecuteResponse::Updated(..)
+            | ExecuteResponse::ValidatedConnection => {
                 command_complete!()
             }
         };

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -841,62 +841,94 @@ impl_display_t!(SshConnectionOption);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CreateConnection<T: AstInfo> {
     Aws {
-        with_options: Vec<AwsConnectionOption<T>>,
+        options: Vec<AwsConnectionOption<T>>,
     },
     AwsPrivatelink {
-        with_options: Vec<AwsPrivatelinkConnectionOption<T>>,
+        options: Vec<AwsPrivatelinkConnectionOption<T>>,
     },
     Kafka {
-        with_options: Vec<KafkaConnectionOption<T>>,
+        options: Vec<KafkaConnectionOption<T>>,
     },
     Csr {
-        with_options: Vec<CsrConnectionOption<T>>,
+        options: Vec<CsrConnectionOption<T>>,
     },
     Postgres {
-        with_options: Vec<PostgresConnectionOption<T>>,
+        options: Vec<PostgresConnectionOption<T>>,
     },
     Ssh {
-        with_options: Vec<SshConnectionOption<T>>,
+        options: Vec<SshConnectionOption<T>>,
     },
 }
 
 impl<T: AstInfo> AstDisplay for CreateConnection<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            Self::Kafka { with_options } => {
+            Self::Kafka { options } => {
                 f.write_str("KAFKA (");
-                f.write_node(&display::comma_separated(with_options));
+                f.write_node(&display::comma_separated(options));
                 f.write_str(")");
             }
-            Self::Csr { with_options } => {
+            Self::Csr { options } => {
                 f.write_str("CONFLUENT SCHEMA REGISTRY (");
-                f.write_node(&display::comma_separated(with_options));
+                f.write_node(&display::comma_separated(options));
                 f.write_str(")");
             }
-            Self::Postgres { with_options } => {
+            Self::Postgres { options } => {
                 f.write_str("POSTGRES (");
-                f.write_node(&display::comma_separated(with_options));
+                f.write_node(&display::comma_separated(options));
                 f.write_str(")");
             }
-            Self::Aws { with_options } => {
+            Self::Aws { options } => {
                 f.write_str("AWS (");
-                f.write_node(&display::comma_separated(with_options));
+                f.write_node(&display::comma_separated(options));
                 f.write_str(")");
             }
-            Self::AwsPrivatelink { with_options } => {
+            Self::AwsPrivatelink { options } => {
                 f.write_str("AWS PRIVATELINK (");
-                f.write_node(&display::comma_separated(with_options));
+                f.write_node(&display::comma_separated(options));
                 f.write_str(")");
             }
-            Self::Ssh { with_options } => {
+            Self::Ssh { options } => {
                 f.write_str("SSH TUNNEL (");
-                f.write_node(&display::comma_separated(with_options));
+                f.write_node(&display::comma_separated(options));
                 f.write_str(")");
             }
         }
     }
 }
 impl_display_t!(CreateConnection);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CreateConnectionOptionName {
+    Validate,
+}
+
+impl AstDisplay for CreateConnectionOptionName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str(match self {
+            CreateConnectionOptionName::Validate => "VALIDATE",
+        })
+    }
+}
+impl_display!(CreateConnectionOptionName);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// An option in a `CREATE CONNECTION...` statement.
+pub struct CreateConnectionOption<T: AstInfo> {
+    pub name: CreateConnectionOptionName,
+    pub value: Option<WithOptionValue<T>>,
+}
+
+impl<T: AstInfo> AstDisplay for CreateConnectionOption<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        if let Some(v) = &self.value {
+            f.write_str(" = ");
+            f.write_node(v);
+        }
+    }
+}
+impl_display_t!(CreateConnectionOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum KafkaConfigOptionName {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -28,11 +28,11 @@ use enum_kinds::EnumKind;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{
-    AstInfo, ColumnDef, CreateConnection, CreateSinkConnection, CreateSourceConnection,
-    CreateSourceFormat, CreateSourceOption, CreateSourceOptionName, DeferredItemName, Envelope,
-    Expr, Format, Ident, KeyConstraint, Query, SelectItem, SourceIncludeMetadata, SubscribeOutput,
-    TableAlias, TableConstraint, TableWithJoins, UnresolvedDatabaseName, UnresolvedItemName,
-    UnresolvedObjectName, UnresolvedSchemaName, Value,
+    AstInfo, ColumnDef, CreateConnection, CreateConnectionOption, CreateSinkConnection,
+    CreateSourceConnection, CreateSourceFormat, CreateSourceOption, CreateSourceOptionName,
+    DeferredItemName, Envelope, Expr, Format, Ident, KeyConstraint, Query, SelectItem,
+    SourceIncludeMetadata, SubscribeOutput, TableAlias, TableConstraint, TableWithJoins,
+    UnresolvedDatabaseName, UnresolvedItemName, UnresolvedObjectName, UnresolvedSchemaName, Value,
 };
 
 /// A top-level statement (SELECT, INSERT, CREATE, etc.)
@@ -97,6 +97,7 @@ pub enum Statement<T: AstInfo> {
     RevokePrivileges(RevokePrivilegesStatement<T>),
     AlterDefaultPrivileges(AlterDefaultPrivilegesStatement<T>),
     ReassignOwned(ReassignOwnedStatement<T>),
+    ValidateConnection(ValidateConnectionStatement<T>),
 }
 
 impl<T: AstInfo> AstDisplay for Statement<T> {
@@ -159,6 +160,7 @@ impl<T: AstInfo> AstDisplay for Statement<T> {
             Statement::RevokePrivileges(stmt) => f.write_node(stmt),
             Statement::AlterDefaultPrivileges(stmt) => f.write_node(stmt),
             Statement::ReassignOwned(stmt) => f.write_node(stmt),
+            Statement::ValidateConnection(stmt) => f.write_node(stmt),
         }
     }
 }
@@ -546,6 +548,7 @@ pub struct CreateConnectionStatement<T: AstInfo> {
     pub name: UnresolvedItemName,
     pub connection: CreateConnection<T>,
     pub if_not_exists: bool,
+    pub with_options: Vec<CreateConnectionOption<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for CreateConnectionStatement<T> {
@@ -556,10 +559,30 @@ impl<T: AstInfo> AstDisplay for CreateConnectionStatement<T> {
         }
         f.write_node(&self.name);
         f.write_str(" TO ");
-        self.connection.fmt(f)
+        self.connection.fmt(f);
+        if !self.with_options.is_empty() {
+            f.write_str(" WITH (");
+            f.write_node(&display::comma_separated(&self.with_options));
+            f.write_str(")");
+        }
     }
 }
 impl_display_t!(CreateConnectionStatement);
+
+/// `VALIDATE CONNECTION`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ValidateConnectionStatement<T: AstInfo> {
+    /// The connection to validate
+    pub name: T::ItemName,
+}
+
+impl<T: AstInfo> AstDisplay for ValidateConnectionStatement<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("VALIDATE CONNECTION ");
+        f.write_node(&self.name);
+    }
+}
+impl_display_t!(ValidateConnectionStatement);
 
 /// `CREATE SOURCE`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -389,6 +389,7 @@ User
 Username
 Users
 Using
+Validate
 Value
 Values
 Varchar

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -386,35 +386,49 @@ CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME 'com.amazonaw
 ----
 CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME = 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES = ('use1-az1', 'use1-az4'))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("privatelinkconn")]), connection: AwsPrivatelink { with_options: [AwsPrivatelinkConnectionOption { name: ServiceName, value: Some(Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc"))) }, AwsPrivatelinkConnectionOption { name: AvailabilityZones, value: Some(Sequence([Value(String("use1-az1")), Value(String("use1-az4"))])) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("privatelinkconn")]), connection: AwsPrivatelink { options: [AwsPrivatelinkConnectionOption { name: ServiceName, value: Some(Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc"))) }, AwsPrivatelinkConnectionOption { name: AvailabilityZones, value: Some(Sequence([Value(String("use1-az1")), Value(String("use1-az4"))])) }] }, if_not_exists: false, with_options: [] })
+
+parse-statement
+CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES ('use1-az1', 'use1-az4')) WITH (VALIDATE = FALSE)
+----
+CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME = 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES = ('use1-az1', 'use1-az4')) WITH (VALIDATE = false)
+=>
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("privatelinkconn")]), connection: AwsPrivatelink { options: [AwsPrivatelinkConnectionOption { name: ServiceName, value: Some(Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc"))) }, AwsPrivatelinkConnectionOption { name: AvailabilityZones, value: Some(Sequence([Value(String("use1-az1")), Value(String("use1-az4"))])) }] }, if_not_exists: false, with_options: [CreateConnectionOption { name: Validate, value: Some(Value(Boolean(false))) }] })
 
 parse-statement
 CREATE CONNECTION privatelinkconn FOR AWS PRIVATELINK SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES ('use1-az1', 'use1-az4')
 ----
 CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME = 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES = ('use1-az1', 'use1-az4'))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("privatelinkconn")]), connection: AwsPrivatelink { with_options: [AwsPrivatelinkConnectionOption { name: ServiceName, value: Some(Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc"))) }, AwsPrivatelinkConnectionOption { name: AvailabilityZones, value: Some(Sequence([Value(String("use1-az1")), Value(String("use1-az4"))])) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("privatelinkconn")]), connection: AwsPrivatelink { options: [AwsPrivatelinkConnectionOption { name: ServiceName, value: Some(Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc"))) }, AwsPrivatelinkConnectionOption { name: AvailabilityZones, value: Some(Sequence([Value(String("use1-az1")), Value(String("use1-az4"))])) }] }, if_not_exists: false, with_options: [] })
+
+parse-statement
+CREATE CONNECTION privatelinkconn FOR AWS PRIVATELINK SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES ('use1-az1', 'use1-az4') WITH (VALIDATE = TRUE)
+----
+CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME = 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES = ('use1-az1', 'use1-az4')) WITH (VALIDATE = true)
+=>
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("privatelinkconn")]), connection: AwsPrivatelink { options: [AwsPrivatelinkConnectionOption { name: ServiceName, value: Some(Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc"))) }, AwsPrivatelinkConnectionOption { name: AvailabilityZones, value: Some(Sequence([Value(String("use1-az1")), Value(String("use1-az4"))])) }] }, if_not_exists: false, with_options: [CreateConnectionOption { name: Validate, value: Some(Value(Boolean(true))) }] })
 
 parse-statement
 CREATE CONNECTION pgconn FOR postgres HOST foo, PORT 1234, SSL CERTIFICATE AUTHORITY 'foo', SSH TUNNEL tun
 ----
 CREATE CONNECTION pgconn TO POSTGRES (HOST = foo, PORT = 1234, SSL CERTIFICATE AUTHORITY = 'foo', SSH TUNNEL = tun)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, PostgresConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, PostgresConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("tun")])))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection: Postgres { options: [PostgresConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, PostgresConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, PostgresConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("tun")])))) }] }, if_not_exists: false, with_options: [] })
 
 parse-statement
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK db.schema.item, PORT 1234)
 ----
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK = db.schema.item, PORT = 1234)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection: Postgres { options: [PostgresConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }] }, if_not_exists: false, with_options: [] })
 
 parse-statement
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK db.schema.item, PORT 1234, HOST foo)
 ----
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK = db.schema.item, PORT = 1234, HOST = foo)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, PostgresConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection: Postgres { options: [PostgresConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, PostgresConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }] }, if_not_exists: false, with_options: [] })
 
 
 parse-statement
@@ -1568,7 +1582,7 @@ CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234', SSL KEY = 'foo', SSL CERT
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKER = 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: Direct })) }, KafkaConnectionOption { name: SslKey, value: Some(Value(String("foo"))) }, KafkaConnectionOption { name: SslCertificate, value: Some(Value(String("qux"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: Direct })) }, KafkaConnectionOption { name: SslKey, value: Some(Value(String("foo"))) }, KafkaConnectionOption { name: SslCertificate, value: Some(Value(String("qux"))) }] }, if_not_exists: false, with_options: [] })
 
 parse-statement roundtrip
 CREATE CONNECTION conn1 TO KAFKA (BROKER 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux');
@@ -1580,21 +1594,21 @@ CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234', PROGRESS TOPIC 'my-materi
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKER = 'kafka:1234', PROGRESS TOPIC = 'my-materialize-progress-topic')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: Direct })) }, KafkaConnectionOption { name: ProgressTopic, value: Some(Value(String("my-materialize-progress-topic"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: Direct })) }, KafkaConnectionOption { name: ProgressTopic, value: Some(Value(String("my-materialize-progress-topic"))) }] }, if_not_exists: false, with_options: [] })
 
 parse-statement
 CREATE CONNECTION conn1 TO KAFKA (BROKER 'kafka:1234' USING AWS PRIVATELINK aws.privatelink.c1);
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKER = 'kafka:1234' USING AWS PRIVATELINK aws.privatelink.c1)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })) }] }, if_not_exists: false, with_options: [] })
 
 parse-statement
 CREATE CONNECTION conn1 TO KAFKA (BROKER 'kafka:1234' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9093));
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKER = 'kafka:1234' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9093))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) })) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { options: [KafkaConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) })) }] }, if_not_exists: false, with_options: [] })
 
 parse-statement
 CREATE CONNECTION conn1 TO KAFKA (
@@ -1607,7 +1621,7 @@ CREATE CONNECTION conn1 TO KAFKA (
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKERS = ('kafka:9092' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9092), 'kafka:9093' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9093), 'kafka:9094' USING AWS PRIVATELINK aws.privatelink.c1))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9092"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9094", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })])) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { options: [KafkaConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9092"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9094", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })])) }] }, if_not_exists: false, with_options: [] })
 
 parse-statement
 CREATE CONNECTION conn1 TO KAFKA (
@@ -1620,7 +1634,7 @@ CREATE CONNECTION conn1 TO KAFKA (
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKERS = ('kafka:9092' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9092), 'kafka:9093' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9093), 'kafka:9094' USING AWS PRIVATELINK aws.privatelink.c1))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9092"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9094", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })])) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { options: [KafkaConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9092"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9094", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })])) }] }, if_not_exists: false, with_options: [] })
 
 parse-statement
 CREATE CONNECTION conn1 TO KAFKA (
@@ -1643,7 +1657,7 @@ CREATE CONNECTION conn1 TO KAFKA (
 ----
 CREATE CONNECTION conn1 TO KAFKA (BROKERS = ('kafka:9092'USING SSH TUNNEL tunn, 'kafka:9093'USING SSH TUNNEL tunn))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: SshTunnel(Name(UnresolvedItemName([Ident("tunn")]))) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: SshTunnel(Name(UnresolvedItemName([Ident("tunn")]))) })])) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Kafka { options: [KafkaConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: SshTunnel(Name(UnresolvedItemName([Ident("tunn")]))) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: SshTunnel(Name(UnresolvedItemName([Ident("tunn")]))) })])) }] }, if_not_exists: false, with_options: [] })
 
 parse-statement
 DROP CONNECTION conn1
@@ -1664,7 +1678,7 @@ CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY URL 'http://localhost:8081
 ----
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (URL = 'http://localhost:8081', USERNAME = 'user', PASSWORD = 'word')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }, CsrConnectionOption { name: Username, value: Some(Value(String("user"))) }, CsrConnectionOption { name: Password, value: Some(Value(String("word"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Csr { options: [CsrConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }, CsrConnectionOption { name: Username, value: Some(Value(String("user"))) }, CsrConnectionOption { name: Password, value: Some(Value(String("word"))) }] }, if_not_exists: false, with_options: [] })
 
 parse-statement roundtrip
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (URL = 'http://localhost:8081', USERNAME = 'user', PASSWORD = 'word')
@@ -1677,14 +1691,14 @@ CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (AWS PRIVATELINK db.schema.
 ----
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (AWS PRIVATELINK = db.schema.item, PORT = 8080)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, CsrConnectionOption { name: Port, value: Some(Value(Number("8080"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Csr { options: [CsrConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, CsrConnectionOption { name: Port, value: Some(Value(Number("8080"))) }] }, if_not_exists: false, with_options: [] })
 
 parse-statement
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (SSH TUNNEL ssh)
 ----
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (SSH TUNNEL = ssh)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("ssh")])))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Csr { options: [CsrConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("ssh")])))) }] }, if_not_exists: false, with_options: [] })
 
 
 parse-statement
@@ -1692,7 +1706,7 @@ CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (AWS PRIVATELINK db.schema.
 ----
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (AWS PRIVATELINK = db.schema.item, PORT = 8080, URL = 'http://localhost:8081')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, CsrConnectionOption { name: Port, value: Some(Value(Number("8080"))) }, CsrConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection: Csr { options: [CsrConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, CsrConnectionOption { name: Port, value: Some(Value(Number("8080"))) }, CsrConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }] }, if_not_exists: false, with_options: [] })
 
 
 parse-statement
@@ -1752,7 +1766,7 @@ CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST 'ssh-bastion', PORT 1234, US
 ----
 CREATE CONNECTION my_ssh_tunnel TO SSH TUNNEL (HOST = 'ssh-bastion', PORT = 1234, USER = 'blah')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("my_ssh_tunnel")]), connection: Ssh { with_options: [SshConnectionOption { name: Host, value: Some(Value(String("ssh-bastion"))) }, SshConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, SshConnectionOption { name: User, value: Some(Value(String("blah"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("my_ssh_tunnel")]), connection: Ssh { options: [SshConnectionOption { name: Host, value: Some(Value(String("ssh-bastion"))) }, SshConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, SshConnectionOption { name: User, value: Some(Value(String("blah"))) }] }, if_not_exists: false, with_options: [] })
 
 parse-statement roundtrip
 CREATE CONNECTION my_ssh_tunnel TO SSH TUNNEL (HOST 'ssh-bastion', PORT 1234, USER 'blah')

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -13,16 +13,12 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use anyhow::bail;
-use mz_kafka_util::client::{
-    BrokerRewritingClientContext, MzClientContext, DEFAULT_FETCH_METADATA_TIMEOUT,
-};
-use mz_ore::error::ErrorExt;
+use mz_kafka_util::client::DEFAULT_FETCH_METADATA_TIMEOUT;
 use mz_ore::task;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{AstInfo, KafkaConfigOption, KafkaConfigOptionName};
-use mz_storage_client::types::connections::{ConnectionContext, KafkaConnection, StringOrSecret};
+use mz_storage_client::types::connections::StringOrSecret;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
-use rdkafka::error::KafkaError;
 use rdkafka::{Offset, TopicPartitionList};
 use tokio::time::Duration;
 
@@ -194,54 +190,6 @@ impl TryFrom<&KafkaConfigOptionExtracted> for Option<KafkaStartOffsetType> {
             _ => None,
         })
     }
-}
-
-/// Create a new `rdkafka::ClientConfig` with the provided
-/// [`options`](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md),
-/// and test its ability to create an `rdkafka::consumer::BaseConsumer`.
-///
-/// Expected to test the output of `extract_security_config`.
-///
-/// # Panics
-///
-/// - `options` does not contain `bootstrap.servers` as a key
-///
-/// # Errors
-///
-/// - `librdkafka` cannot create a BaseConsumer using the provided `options`.
-pub async fn create_consumer(
-    connection_context: &ConnectionContext,
-    kafka_connection: &KafkaConnection,
-) -> Result<BaseConsumer<BrokerRewritingClientContext<MzClientContext>>, PlanError> {
-    let consumer: BaseConsumer<_> = kafka_connection
-        .create_with_context(connection_context, MzClientContext, &BTreeMap::new())
-        .await
-        .map_err(|e| sql_err!("{}", e.display_with_causes()))?;
-
-    // librdkafka doesn't expose an API for determining whether a connection to
-    // the Kafka cluster has been successfully established. So we make a
-    // metadata request, though we don't care about the results, so that we can
-    // report any errors making that request. If the request succeeds, we know
-    // we were able to contact at least one broker, and that's a good proxy for
-    // being able to contact all the brokers in the cluster.
-    //
-    // The downside of this approach is it produces a generic error message like
-    // "metadata fetch error" with no additional details. The real networking
-    // error is buried in the librdkafka logs, which are not visible to users.
-    //
-    // TODO(benesch): pull out more error details from the librdkafka logs and
-    // include them in the error message.
-    let consumer = task::spawn_blocking(
-        || "kafka_get_metadata",
-        move || {
-            consumer.fetch_metadata(None, DEFAULT_FETCH_METADATA_TIMEOUT)?;
-            Ok::<_, KafkaError>(consumer)
-        },
-    )
-    .await
-    .map_err(|e| sql_err!("{}", e))?
-    .map_err(|e| sql_err!("librdkafka: {}", e.display_with_causes()))?;
-    Ok(consumer)
 }
 
 /// Returns start offsets for the partitions of `topic` and the provided

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -409,6 +409,7 @@ pub fn create_statement(
         Statement::CreateConnection(CreateConnectionStatement {
             name,
             connection: _,
+            with_options: _,
             if_not_exists,
         }) => {
             *name = allocate_name(name)?;

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -568,6 +568,7 @@ pub struct CreateConnectionPlan {
 
 #[derive(Debug)]
 pub struct ValidateConnectionPlan {
+    pub id: GlobalId,
     /// The connection to validate.
     pub connection: mz_storage_client::types::connections::Connection,
 }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -160,6 +160,7 @@ pub enum Plan {
     AlterDefaultPrivileges(AlterDefaultPrivilegesPlan),
     ReassignOwned(ReassignOwnedPlan),
     SideEffectingFunc(SideEffectingFunc),
+    ValidateConnection(ValidateConnectionPlan),
 }
 
 impl Plan {
@@ -248,6 +249,7 @@ impl Plan {
             StatementKind::StartTransaction => vec![PlanKind::StartTransaction],
             StatementKind::Subscribe => vec![PlanKind::Subscribe],
             StatementKind::Update => vec![PlanKind::ReadThenWrite],
+            StatementKind::ValidateConnection => vec![PlanKind::ValidateConnection],
         }
     }
 
@@ -373,6 +375,7 @@ impl Plan {
             Plan::AlterDefaultPrivileges(_) => "alter default privileges",
             Plan::ReassignOwned(_) => "reassign owned",
             Plan::SideEffectingFunc(_) => "side effecting func",
+            Plan::ValidateConnection(_) => "validate connection",
         }
     }
 }
@@ -560,6 +563,13 @@ pub struct CreateConnectionPlan {
     pub name: QualifiedItemName,
     pub if_not_exists: bool,
     pub connection: Connection,
+    pub validate: bool,
+}
+
+#[derive(Debug)]
+pub struct ValidateConnectionPlan {
+    /// The connection to validate.
+    pub connection: mz_storage_client::types::connections::Connection,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -43,6 +43,7 @@ mod raise;
 mod scl;
 pub(crate) mod show;
 mod tcl;
+mod validate;
 
 pub(crate) use ddl::PgConfigOptionExtracted;
 use mz_repr::role_id::RoleId;
@@ -218,6 +219,7 @@ pub fn describe(
         Statement::Show(ShowStatement::InspectShard(stmt)) => {
             scl::describe_inspect_shard(&scx, stmt)?
         }
+        Statement::ValidateConnection(stmt) => validate::describe_validate_connection(&scx, stmt)?,
     };
 
     let desc = desc.with_params(scx.finalize_param_types()?);
@@ -354,6 +356,7 @@ pub fn plan(
         // Other statements.
         Statement::Raise(stmt) => raise::plan_raise(scx, stmt),
         Statement::Show(ShowStatement::InspectShard(stmt)) => scl::plan_inspect_shard(scx, stmt),
+        Statement::ValidateConnection(stmt) => validate::plan_validate_connection(scx, stmt),
     };
 
     if let Ok(plan) = &plan {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -32,10 +32,10 @@ use mz_sql_parser::ast::display::comma_separated;
 use mz_sql_parser::ast::{
     AlterClusterAction, AlterClusterStatement, AlterRoleStatement, AlterSinkAction,
     AlterSinkStatement, AlterSourceAction, AlterSourceStatement, AlterSystemResetAllStatement,
-    AlterSystemResetStatement, AlterSystemSetStatement, CreateTypeListOption,
-    CreateTypeListOptionName, CreateTypeMapOption, CreateTypeMapOptionName, DeferredItemName,
-    DropOwnedStatement, SshConnectionOption, UnresolvedItemName, UnresolvedObjectName,
-    UnresolvedSchemaName, Value,
+    AlterSystemResetStatement, AlterSystemSetStatement, CreateConnectionOptionName,
+    CreateTypeListOption, CreateTypeListOptionName, CreateTypeMapOption, CreateTypeMapOptionName,
+    DeferredItemName, DropOwnedStatement, SshConnectionOption, UnresolvedItemName,
+    UnresolvedObjectName, UnresolvedSchemaName, Value, WithOptionValue,
 };
 use mz_storage_client::types::connections::aws::{AwsAssumeRole, AwsConfig, AwsCredentials};
 use mz_storage_client::types::connections::{
@@ -3491,27 +3491,28 @@ pub fn plan_create_connection(
         name,
         connection,
         if_not_exists,
+        with_options,
     } = stmt;
     let connection = match connection {
-        CreateConnection::Kafka { with_options } => {
-            let c = KafkaConnectionOptionExtracted::try_from(with_options)?;
+        CreateConnection::Kafka { options } => {
+            let c = KafkaConnectionOptionExtracted::try_from(options)?;
             Connection::Kafka(c.to_connection(scx)?)
         }
-        CreateConnection::Csr { with_options } => {
-            let c = CsrConnectionOptionExtracted::try_from(with_options)?;
+        CreateConnection::Csr { options } => {
+            let c = CsrConnectionOptionExtracted::try_from(options)?;
             Connection::Csr(c.to_connection(scx)?)
         }
-        CreateConnection::Postgres { with_options } => {
-            let c = PostgresConnectionOptionExtracted::try_from(with_options)?;
+        CreateConnection::Postgres { options } => {
+            let c = PostgresConnectionOptionExtracted::try_from(options)?;
             Connection::Postgres(c.to_connection(scx)?)
         }
-        CreateConnection::Aws { with_options } => {
-            let c = AwsConnectionOptionExtracted::try_from(with_options)?;
+        CreateConnection::Aws { options } => {
+            let c = AwsConnectionOptionExtracted::try_from(options)?;
             let connection = AwsConfig::try_from(c)?;
             Connection::Aws(connection)
         }
-        CreateConnection::AwsPrivatelink { with_options } => {
-            let c = AwsPrivatelinkConnectionOptionExtracted::try_from(with_options)?;
+        CreateConnection::AwsPrivatelink { options } => {
+            let c = AwsPrivatelinkConnectionOptionExtracted::try_from(options)?;
             let connection = AwsPrivatelinkConnection::try_from(c)?;
             if let Some(supported_azs) = scx.catalog.aws_privatelink_availability_zones() {
                 for connection_az in &connection.availability_zones {
@@ -3525,13 +3526,27 @@ pub fn plan_create_connection(
             }
             Connection::AwsPrivatelink(connection)
         }
-        CreateConnection::Ssh { with_options } => {
-            let c = SshConnectionOptionExtracted::try_from(with_options)?;
+        CreateConnection::Ssh { options } => {
+            let c = SshConnectionOptionExtracted::try_from(options)?;
             let connection = mz_storage_client::types::connections::SshConnection::try_from(c)?;
             Connection::Ssh(connection)
         }
     };
     let name = scx.allocate_qualified_name(normalize::unresolved_item_name(name)?)?;
+
+    let mut user_validate = None;
+    for option in with_options {
+        match option.name {
+            CreateConnectionOptionName::Validate => match option.value {
+                Some(WithOptionValue::Value(Value::Boolean(new_val))) => match user_validate {
+                    Some(_) => sql_bail!("Option VALIDATE must be set at most once"),
+                    None => user_validate = Some(new_val),
+                },
+                _ => sql_bail!("Option VALIDATE must be set to either TRUE or FALSE"),
+            },
+        }
+    }
+    let validate = user_validate.unwrap_or_else(|| connection.validate_by_default());
 
     // Check for an object in the catalog with this same name
     let full_name = scx.catalog.resolve_full_name(&name);
@@ -3550,6 +3565,7 @@ pub fn plan_create_connection(
             create_sql,
             connection,
         },
+        validate,
     };
     Ok(Plan::CreateConnection(plan))
 }

--- a/src/sql/src/plan/statement/validate.rs
+++ b/src/sql/src/plan/statement/validate.rs
@@ -1,0 +1,43 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Queries that validate CONNECTION objects.
+
+use crate::ast::ValidateConnectionStatement;
+use crate::names::Aug;
+use crate::plan::statement::{StatementContext, StatementDesc};
+use crate::plan::{Plan, PlanError, ValidateConnectionPlan};
+
+pub fn describe_validate_connection(
+    _: &StatementContext,
+    _: ValidateConnectionStatement<Aug>,
+) -> Result<StatementDesc, PlanError> {
+    Ok(StatementDesc::new(None))
+}
+
+pub fn plan_validate_connection(
+    scx: &StatementContext,
+    stmt: ValidateConnectionStatement<Aug>,
+) -> Result<Plan, PlanError> {
+    let item = scx.get_item_by_resolved_name(&stmt.name)?;
+
+    // Validate the target of the validate statement.
+    match item.connection().cloned() {
+        Ok(connection) => Ok(Plan::ValidateConnection(ValidateConnectionPlan {
+            connection,
+        })),
+        Err(_) => {
+            sql_bail!(
+                "cannot validate {} '{}'",
+                item.item_type(),
+                stmt.name.full_name_str()
+            );
+        }
+    }
+}

--- a/src/sql/src/plan/statement/validate.rs
+++ b/src/sql/src/plan/statement/validate.rs
@@ -32,6 +32,7 @@ pub fn plan_validate_connection(
     // Validate the target of the validate statement.
     match item.connection().cloned() {
         Ok(connection) => Ok(Plan::ValidateConnection(ValidateConnectionPlan {
+            id: item.id(),
             connection,
         })),
         Err(_) => {

--- a/src/sql/src/plan/statement/validate.rs
+++ b/src/sql/src/plan/statement/validate.rs
@@ -13,6 +13,7 @@ use crate::ast::ValidateConnectionStatement;
 use crate::names::Aug;
 use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::{Plan, PlanError, ValidateConnectionPlan};
+use crate::session::vars;
 
 pub fn describe_validate_connection(
     _: &StatementContext,
@@ -25,6 +26,7 @@ pub fn plan_validate_connection(
     scx: &StatementContext,
     stmt: ValidateConnectionStatement<Aug>,
 ) -> Result<Plan, PlanError> {
+    scx.require_feature_flag(&vars::ENABLE_CONNECTION_VALIDATION_SYNTAX)?;
     let item = scx.get_item_by_resolved_name(&stmt.name)?;
 
     // Validate the target of the validate statement.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -945,6 +945,14 @@ const ENABLE_MZ_JOIN_CORE: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
+pub const ENABLE_DEFAULT_CONNECTION_VALIDATION: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_default_connection_validation"),
+    value: &true,
+    description:
+        "LD facing global boolean flag that allows turning default connection validation off for everyone (Materialize).",
+    internal: true,
+};
+
 pub const AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("auto_route_introspection_queries"),
     value: &true,
@@ -1122,6 +1130,10 @@ feature_flags!(
         "`WITHIN TIMESTAMP ORDER BY ..`"
     ),
     (enable_managed_clusters, "managed clusters"),
+    (
+        enable_connection_validation_syntax,
+        "CREATE CONNECTION .. WITH (VALIDATE) and VALIDATE CONNECTION syntax"
+    )
 );
 
 /// Represents the input to a variable.
@@ -1748,7 +1760,8 @@ impl SystemVars {
             .with_var(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
             .with_var(&KEEP_N_SINK_STATUS_HISTORY_ENTRIES)
             .with_var(&ENABLE_MZ_JOIN_CORE)
-            .with_var(&ENABLE_STORAGE_SHARD_FINALIZATION);
+            .with_var(&ENABLE_STORAGE_SHARD_FINALIZATION)
+            .with_var(&ENABLE_DEFAULT_CONNECTION_VALIDATION);
         vars.refresh_internal_state();
         vars
     }
@@ -2242,6 +2255,11 @@ impl SystemVars {
     /// Returns the `enable_storage_shard_finalization` configuration parameter.
     pub fn enable_storage_shard_finalization(&self) -> bool {
         *self.expect_value(&ENABLE_STORAGE_SHARD_FINALIZATION)
+    }
+
+    /// Returns the `enable_default_connection_validation` configuration parameter.
+    pub fn enable_default_connection_validation(&self) -> bool {
+        *self.expect_value(&ENABLE_DEFAULT_CONNECTION_VALIDATION)
     }
 }
 

--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -17,7 +17,9 @@ use anyhow::{anyhow, Context};
 use itertools::Itertools;
 use mz_ccsr::tls::{Certificate, Identity};
 use mz_cloud_resources::AwsExternalIdPrefix;
-use mz_kafka_util::client::{BrokerRewrite, BrokerRewritingClientContext};
+use mz_kafka_util::client::{
+    BrokerRewrite, BrokerRewritingClientContext, MzClientContext, DEFAULT_FETCH_METADATA_TIMEOUT,
+};
 use mz_proto::tokio_postgres::any_ssl_mode;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::url::any_url;
@@ -29,6 +31,7 @@ use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use rdkafka::client::BrokerAddr;
 use rdkafka::config::FromClientConfigAndContext;
+use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::ClientContext;
 use serde::{Deserialize, Serialize};
 use tokio::net;
@@ -163,6 +166,35 @@ pub enum Connection {
     Ssh(SshConnection),
     Aws(AwsConfig),
     AwsPrivatelink(AwsPrivatelinkConnection),
+}
+
+impl Connection {
+    /// Whether this connection should be validated by default on creation.
+    pub fn validate_by_default(&self) -> bool {
+        match self {
+            Connection::Kafka(conn) => conn.validate_by_default(),
+            Connection::Csr(conn) => conn.validate_by_default(),
+            Connection::Postgres(conn) => conn.validate_by_default(),
+            Connection::Ssh(conn) => conn.validate_by_default(),
+            Connection::Aws(conn) => conn.validate_by_default(),
+            Connection::AwsPrivatelink(conn) => conn.validate_by_default(),
+        }
+    }
+
+    /// Validates this connection by attempting to connect to the upstream system.
+    pub async fn validate(
+        &self,
+        connection_context: &ConnectionContext,
+    ) -> Result<(), anyhow::Error> {
+        match self {
+            Connection::Kafka(conn) => conn.validate(connection_context).await,
+            Connection::Csr(conn) => conn.validate(connection_context).await,
+            Connection::Postgres(conn) => conn.validate(connection_context).await,
+            Connection::Ssh(conn) => conn.validate(connection_context).await,
+            Connection::Aws(conn) => conn.validate(connection_context).await,
+            Connection::AwsPrivatelink(conn) => conn.validate(connection_context).await,
+        }
+    }
 }
 
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -371,6 +403,36 @@ impl KafkaConnection {
         }
 
         Ok(config.create_with_context(context)?)
+    }
+
+    async fn validate(&self, connection_context: &ConnectionContext) -> Result<(), anyhow::Error> {
+        let consumer: BaseConsumer<_> = self
+            .create_with_context(connection_context, MzClientContext, &BTreeMap::new())
+            .await?;
+
+        // librdkafka doesn't expose an API for determining whether a connection to
+        // the Kafka cluster has been successfully established. So we make a
+        // metadata request, though we don't care about the results, so that we can
+        // report any errors making that request. If the request succeeds, we know
+        // we were able to contact at least one broker, and that's a good proxy for
+        // being able to contact all the brokers in the cluster.
+        //
+        // The downside of this approach is it produces a generic error message like
+        // "metadata fetch error" with no additional details. The real networking
+        // error is buried in the librdkafka logs, which are not visible to users.
+        //
+        // TODO(benesch): pull out more error details from the librdkafka logs and
+        // include them in the error message.
+        mz_ore::task::spawn_blocking(
+            || "kafka_get_metadata",
+            move || consumer.fetch_metadata(None, DEFAULT_FETCH_METADATA_TIMEOUT),
+        )
+        .await??;
+        Ok(())
+    }
+
+    fn validate_by_default(&self) -> bool {
+        true
     }
 }
 
@@ -614,6 +676,15 @@ impl CsrConnection {
 
         client_config.build()
     }
+
+    async fn validate(&self, connection_context: &ConnectionContext) -> Result<(), anyhow::Error> {
+        self.connect(connection_context).await?;
+        Ok(())
+    }
+
+    fn validate_by_default(&self) -> bool {
+        true
+    }
 }
 
 impl RustType<ProtoCsrConnection> for CsrConnection {
@@ -793,6 +864,16 @@ impl PostgresConnection {
         };
 
         Ok(mz_postgres_util::Config::new(config, tunnel)?)
+    }
+
+    async fn validate(&self, connection_context: &ConnectionContext) -> Result<(), anyhow::Error> {
+        let config = self.config(&*connection_context.secrets_reader).await?;
+        config.connect("connection validation").await?;
+        Ok(())
+    }
+
+    fn validate_by_default(&self) -> bool {
+        true
     }
 }
 
@@ -1034,5 +1115,26 @@ impl SshTunnel {
                 remote_port,
             )
             .await
+    }
+}
+impl SshConnection {
+    #[allow(clippy::unused_async)]
+    async fn validate(&self, _connection_context: &ConnectionContext) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+
+    fn validate_by_default(&self) -> bool {
+        false
+    }
+}
+
+impl AwsPrivatelinkConnection {
+    #[allow(clippy::unused_async)]
+    async fn validate(&self, _connection_context: &ConnectionContext) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+
+    fn validate_by_default(&self) -> bool {
+        false
     }
 }

--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -1120,7 +1120,7 @@ impl SshTunnel {
 impl SshConnection {
     #[allow(clippy::unused_async)]
     async fn validate(&self, _connection_context: &ConnectionContext) -> Result<(), anyhow::Error> {
-        Ok(())
+        Err(anyhow!("Validating SSH connections is not supported yet"))
     }
 
     fn validate_by_default(&self) -> bool {
@@ -1131,7 +1131,9 @@ impl SshConnection {
 impl AwsPrivatelinkConnection {
     #[allow(clippy::unused_async)]
     async fn validate(&self, _connection_context: &ConnectionContext) -> Result<(), anyhow::Error> {
-        Ok(())
+        Err(anyhow!(
+            "Validating AWS Privatelink connections is not supported yet"
+        ))
     }
 
     fn validate_by_default(&self) -> bool {

--- a/src/storage-client/src/types/connections/aws.rs
+++ b/src/storage-client/src/types/connections/aws.rs
@@ -9,6 +9,7 @@
 
 //! AWS configuration for sources and sinks.
 
+use anyhow::anyhow;
 use mz_cloud_resources::AwsExternalIdPrefix;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::GlobalId;
@@ -185,7 +186,7 @@ impl AwsConfig {
         &self,
         _connection_context: &ConnectionContext,
     ) -> Result<(), anyhow::Error> {
-        Ok(())
+        Err(anyhow!("Validating SSH connections is not supported yet"))
     }
 
     pub(crate) fn validate_by_default(&self) -> bool {

--- a/src/storage-client/src/types/connections/aws.rs
+++ b/src/storage-client/src/types/connections/aws.rs
@@ -16,7 +16,7 @@ use mz_secrets::SecretsReader;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
-use crate::types::connections::StringOrSecret;
+use crate::types::connections::{ConnectionContext, StringOrSecret};
 
 include!(concat!(
     env!("OUT_DIR"),
@@ -178,5 +178,17 @@ impl AwsConfig {
             loader = loader.endpoint_url(endpoint);
         }
         loader.load().await
+    }
+
+    #[allow(clippy::unused_async)]
+    pub(crate) async fn validate(
+        &self,
+        _connection_context: &ConnectionContext,
+    ) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+
+    pub(crate) fn validate_by_default(&self) -> bool {
+        false
     }
 }

--- a/test/cloudtest/test_privatelink_connection.py
+++ b/test/cloudtest/test_privatelink_connection.py
@@ -62,6 +62,11 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
     # its existence.
 
     mz.environmentd.sql(
+        "ALTER SYSTEM SET enable_connection_validation_syntax = true",
+        port="internal",
+        user="mz_system",
+    )
+    mz.environmentd.sql(
         dedent(
             """\
             CREATE CONNECTION kafkaconn TO KAFKA (

--- a/test/cloudtest/test_privatelink_connection.py
+++ b/test/cloudtest/test_privatelink_connection.py
@@ -71,7 +71,7 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
                     'customer-hostname-3:9092' USING AWS PRIVATELINK privatelinkconn (AVAILABILITY ZONE 'use1-az1', PORT 9093),
                     'customer-hostname-4:9094'
                 )
-            );
+            ) WITH (VALIDATE = false);
             """
         )
     )
@@ -110,7 +110,7 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
                 USER postgres,
                 AWS PRIVATELINK privatelinkconn,
                 SSH TUNNEL sshconn
-            )
+            ) WITH (VALIDATE = false);
             """
             )
         )
@@ -141,7 +141,7 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
                     BROKERS (
                         'customer-hostname-3:9092' USING AWS PRIVATELINK privatelinkconn (AVAILABILITY ZONE 'use1-az3', PORT 9093)
                     )
-                );
+                ) WITH (VALIDATE = false);
                 """
             )
         )

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -25,17 +25,14 @@ def test_secrets(mz: MaterializeApplication) -> None:
             > CREATE SECRET username AS '123';
             > CREATE SECRET password AS '234';
 
-            > CREATE CONNECTION secrets_conn TO KAFKA (
+            # Our Redpanda instance is not configured for SASL, so we can not
+            # really establish a successful connection.
+            ! CREATE CONNECTION secrets_conn TO KAFKA (
                 BROKER '${testdrive.kafka-addr}',
                 SASL MECHANISMS 'PLAIN',
                 SASL USERNAME = SECRET username,
                 SASL PASSWORD = SECRET password
               );
-
-            # Our Redpanda instance is not configured for SASL, so we can not
-            # really establish a successful connection.
-            ! CREATE SOURCE secrets_source
-              FROM KAFKA CONNECTION secrets_conn (TOPIC 'foo_bar');
             contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
             """
         )
@@ -112,7 +109,7 @@ def test_missing_secret(mz: MaterializeApplication) -> None:
                 SASL MECHANISMS 'PLAIN',
                 SASL USERNAME = SECRET to_be_deleted,
                 SASL PASSWORD = SECRET to_be_deleted
-              );
+              ) WITH (VALIDATE = false);
 
           > CREATE CONNECTION pg_conn_with_deleted_secret TO POSTGRES (
             HOST 'postgres',

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -100,6 +100,9 @@ def test_missing_secret(mz: MaterializeApplication) -> None:
     mz.testdrive.run(
         input=dedent(
             """
+          $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+          ALTER SYSTEM SET enable_connection_validation_syntax = true
+
           > CREATE CLUSTER to_be_killed REPLICAS (to_be_killed (SIZE '1'));
 
           > CREATE SECRET to_be_deleted AS 'postgres'

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -67,16 +67,12 @@ $ kafka-verify-data format=avro sink=materialize.public.data_snk sort-messages=t
 {"before": null, "after": {"row": {"a": 2}}}
 
 # Ensure that connectors do not require the certificate authority
-> CREATE CONNECTION kafka_sasl_no_ca TO KAFKA (
+# This ensures that the error is not that the CA was required, but simply that
+# not providing it prohibits connecting.
+! CREATE CONNECTION kafka_sasl_no_ca TO KAFKA (
     BROKER 'kafka:9092',
     SASL MECHANISMS = 'PLAIN',
     SASL USERNAME = 'materialize',
     SASL PASSWORD = SECRET sasl_password
   );
-
-# This ensures that the error is not that the CA was required, but simply that
-# not providing it prohibits connecting.
-! CREATE SOURCE connector_source
-  FROM KAFKA CONNECTION kafka_sasl_no_ca (TOPIC 'testdrive-data-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_sasl
 contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -130,24 +130,11 @@ a
 
 # Ensure that connectors do not require the certificate authority
 
-> CREATE CONNECTION kafka_sasl_no_ca TO KAFKA (
+# This ensures that the error is not that the CA was required, but simply that
+# not providing it prohibits connecting.
+! CREATE CONNECTION kafka_sasl_no_ca TO KAFKA (
     BROKER 'kafka:9092',
     SSL KEY = SECRET ssl_key_kafka,
     SSL CERTIFICATE = '${arg.materialized-kafka-crt}'
   );
-
-> CREATE CONNECTION csr_ssl_no_ca TO CONFLUENT SCHEMA REGISTRY (
-    URL '${testdrive.schema-registry-url}',
-    SSL KEY = SECRET ssl_key_csr,
-    SSL CERTIFICATE = '${arg.materialized-schema-registry-crt}',
-    USERNAME = 'materialize',
-    PASSWORD = SECRET password_csr
-  );
-
-# This ensures that the error is not that the CA was required, but simply that
-# not providing it prohibits connecting.
-! CREATE SOURCE kafka_ssl_no_ca
-  FROM KAFKA CONNECTION kafka_sasl_no_ca (TOPIC 'testdrive-data-${testdrive.seed}')
-    FORMAT AVRO
-  USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl_no_ca
 contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -156,62 +156,47 @@ $ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=mat
 # Error checking
 #
 
-> CREATE CONNECTION no_such_host TO POSTGRES (
+! CREATE CONNECTION no_such_host TO POSTGRES (
     HOST 'no_such_postgres.mtrlz.com',
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass
   )
-! CREATE SOURCE "no_such_host"
-  FROM POSTGRES CONNECTION no_such_host (PUBLICATION 'mz_source');
-# TODO: assert on `detail` here.
-exact:failed to connect to PostgreSQL database
+contains:error connecting to server: failed to lookup address information: Name or service not known: failed to lookup address
 
-> CREATE CONNECTION no_such_port TO POSTGRES (
+! CREATE CONNECTION no_such_port TO POSTGRES (
     HOST postgres,
     PORT 65534,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass
   )
-! CREATE SOURCE "no_such_port"
-  FROM POSTGRES CONNECTION no_such_port (PUBLICATION 'mz_source');
-# TODO: assert on `detail` here.
-exact:failed to connect to PostgreSQL database
+contains:error connecting to server: Connection refused
 
-> CREATE CONNECTION no_such_user TO POSTGRES (
+! CREATE CONNECTION no_such_user TO POSTGRES (
     HOST postgres,
     DATABASE postgres,
     USER no_such_user,
     PASSWORD SECRET pgpass
   )
-! CREATE SOURCE "no_such_user"
-  FROM POSTGRES CONNECTION no_such_user (PUBLICATION 'mz_source');
-# TODO: assert on `detail` here.
-exact:failed to connect to PostgreSQL database
+contains:password authentication failed for user "no_such_user"
 
 > CREATE SECRET badpass AS 'badpass'
-> CREATE CONNECTION no_such_password TO POSTGRES (
+! CREATE CONNECTION no_such_password TO POSTGRES (
     HOST postgres,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET badpass
   )
-! CREATE SOURCE "no_such_password"
-  FROM POSTGRES CONNECTION no_such_password (PUBLICATION 'mz_source');
-# TODO: assert on `detail` here.
-exact:failed to connect to PostgreSQL database
+contains:password authentication failed for user "postgres"
 
-> CREATE CONNECTION no_such_dbname TO POSTGRES (
+! CREATE CONNECTION no_such_dbname TO POSTGRES (
     HOST postgres,
     DATABASE no_such_dbname,
     USER postgres,
     PASSWORD SECRET pgpass
   )
-! CREATE SOURCE "no_such_dbname"
-  FROM POSTGRES CONNECTION no_such_dbname (PUBLICATION 'mz_source');
-# TODO: assert on `detail` here.
-exact:failed to connect to PostgreSQL database
+contains:database "no_such_dbname" does not exist
 
 ! CREATE SOURCE "no_such_publication"
   FROM POSTGRES CONNECTION pg (PUBLICATION 'no_such_publication');

--- a/test/pg-cdc/privileges.td
+++ b/test/pg-cdc/privileges.td
@@ -29,22 +29,18 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 REVOKE CONNECT ON DATABASE postgres FROM public;
 
+#
+# CONNECT error
+#
+
 > CREATE SECRET pgpass AS 'priv'
-> CREATE CONNECTION pg TO POSTGRES (
+! CREATE CONNECTION pg TO POSTGRES (
     HOST postgres,
     DATABASE postgres,
     USER priv,
     PASSWORD SECRET pgpass
   )
-
-#
-# CONNECT error
-#
-
-! CREATE SOURCE mz_source
-  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
-  FOR SCHEMAS(public, other);
-contains:failed to connect to PostgreSQL database
+contains:permission denied for database "postgres"
 
 #
 # USAGE error
@@ -53,6 +49,13 @@ contains:failed to connect to PostgreSQL database
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 GRANT CONNECT ON DATABASE postgres TO public;
 REVOKE USAGE ON SCHEMA other FROM priv;
+
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER priv,
+    PASSWORD SECRET pgpass
+  )
 
 ! CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -9,6 +9,11 @@
 
 mode cockroach
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_connection_validation_syntax TO true;
+----
+COMPLETE 0
+
 query error system schema 'mz_catalog' cannot be modified
 ALTER TABLE mz_tables RENAME TO foo;
 

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -19,7 +19,7 @@ query error cannot ALTER this type of source
 ALTER SOURCE mz_internal.mz_storage_shards RESET (size);
 
 statement ok
-CREATE CONNECTION c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query TT
 SHOW CONNECTIONS

--- a/test/sqllogictest/default_privileges.slt
+++ b/test/sqllogictest/default_privileges.slt
@@ -3353,7 +3353,7 @@ materialize  d1    s1    CONNECTION  r5      U
 materialize  d2    s2    CONNECTION  r5      U
 
 statement ok
-CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query TT
 SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
@@ -3368,7 +3368,7 @@ statement ok
 DROP CONNECTION c
 
 statement ok
-CREATE CONNECTION d1.s11.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d1.s11.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query TT
 SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
@@ -3384,7 +3384,7 @@ statement ok
 DROP CONNECTION d1.s11.c
 
 statement ok
-CREATE CONNECTION d2.s22.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d2.s22.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query TT
 SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
@@ -3400,7 +3400,7 @@ statement ok
 DROP CONNECTION d2.s22.c
 
 statement ok
-CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query TT
 SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
@@ -3417,7 +3417,7 @@ statement ok
 DROP CONNECTION d1.s1.c
 
 statement ok
-CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query TT
 SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
@@ -3434,7 +3434,7 @@ statement ok
 DROP CONNECTION d2.s2.c
 
 simple conn=r6,user=r6
-CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3450,7 +3450,7 @@ DROP CONNECTION materialize.public.c;
 COMPLETE 0
 
 simple conn=r7,user=r7
-CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3466,7 +3466,7 @@ DROP CONNECTION materialize.public.c;
 COMPLETE 0
 
 simple conn=r9,user=r9
-CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3482,7 +3482,7 @@ DROP CONNECTION d1.s1.c;
 COMPLETE 0
 
 simple conn=r9,user=r9
-CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3498,7 +3498,7 @@ DROP CONNECTION d2.s2.c;
 COMPLETE 0
 
 simple conn=r11,user=r11
-CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3514,7 +3514,7 @@ DROP CONNECTION d1.s1.c;
 COMPLETE 0
 
 simple conn=r11,user=r11
-CREATE CONNECTION d1.s11.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d1.s11.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3529,7 +3529,7 @@ DROP CONNECTION d1.s11.c;
 COMPLETE 0
 
 simple conn=r11,user=r11
-CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3545,7 +3545,7 @@ DROP CONNECTION d2.s2.c;
 COMPLETE 0
 
 simple conn=r11,user=r11
-CREATE CONNECTION d2.s22.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d2.s22.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3674,7 +3674,7 @@ SELECT * FROM default_privileges
 PUBLIC       NULL  NULL  TYPE        PUBLIC  U
 
 statement ok
-CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query TT
 SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
@@ -3685,7 +3685,7 @@ statement ok
 DROP CONNECTION c
 
 statement ok
-CREATE CONNECTION d1.s11.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d1.s11.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query TT
 SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
@@ -3696,7 +3696,7 @@ statement ok
 DROP CONNECTION d1.s11.c
 
 statement ok
-CREATE CONNECTION d2.s22.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d2.s22.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query TT
 SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
@@ -3707,7 +3707,7 @@ statement ok
 DROP CONNECTION d2.s22.c
 
 statement ok
-CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query TT
 SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
@@ -3718,7 +3718,7 @@ statement ok
 DROP CONNECTION d1.s1.c
 
 statement ok
-CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query TT
 SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
@@ -3729,7 +3729,7 @@ statement ok
 DROP CONNECTION d2.s2.c
 
 simple conn=r6,user=r6
-CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3744,7 +3744,7 @@ DROP CONNECTION materialize.public.c;
 COMPLETE 0
 
 simple conn=r7,user=r7
-CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3759,7 +3759,7 @@ DROP CONNECTION materialize.public.c;
 COMPLETE 0
 
 simple conn=r9,user=r9
-CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3774,7 +3774,7 @@ DROP CONNECTION d1.s1.c;
 COMPLETE 0
 
 simple conn=r9,user=r9
-CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3789,7 +3789,7 @@ DROP CONNECTION d2.s2.c;
 COMPLETE 0
 
 simple conn=r11,user=r11
-CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3804,7 +3804,7 @@ DROP CONNECTION d1.s1.c;
 COMPLETE 0
 
 simple conn=r11,user=r11
-CREATE CONNECTION d1.s11.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d1.s11.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3819,7 +3819,7 @@ DROP CONNECTION d1.s11.c;
 COMPLETE 0
 
 simple conn=r11,user=r11
-CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -3834,7 +3834,7 @@ DROP CONNECTION d2.s2.c;
 COMPLETE 0
 
 simple conn=r11,user=r11
-CREATE CONNECTION d2.s22.c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d2.s22.c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 

--- a/test/sqllogictest/default_privileges.slt
+++ b/test/sqllogictest/default_privileges.slt
@@ -22,6 +22,11 @@ ALTER SYSTEM SET enable_ld_rbac_checks TO true;
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_connection_validation_syntax TO true;
+----
+COMPLETE 0
+
 # Test pre-populated default privileges
 
 query TTTTTT

--- a/test/sqllogictest/name_resolution.slt
+++ b/test/sqllogictest/name_resolution.slt
@@ -9,6 +9,11 @@
 
 mode cockroach
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_connection_validation_syntax TO true;
+----
+COMPLETE 0
+
 # over qualified objects should return an error
 query error qualified name did not have between 1 and 3 components
 SELECT * FROM universe.db.schema.foo

--- a/test/sqllogictest/name_resolution.slt
+++ b/test/sqllogictest/name_resolution.slt
@@ -22,19 +22,19 @@ statement ok
 CREATE TABLE not_a_secret (a int);
 
 statement ok
-CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'broker');
+CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'broker') WITH (VALIDATE = false);
 
 statement error connection "materialize.public.kafka_conn" already exists
-CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'broker');
+CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'broker') WITH (VALIDATE = false);
 
 statement ok
-CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER 'broker');
+CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER 'broker') WITH (VALIDATE = false);
 
 statement error materialize.public.not_a_secret is not a secret
-CREATE CONNECTION kafka_conn2 TO KAFKA (BROKER 'broker', SASL PASSWORD = SECRET not_a_secret);
+CREATE CONNECTION kafka_conn2 TO KAFKA (BROKER 'broker', SASL PASSWORD = SECRET not_a_secret) WITH (VALIDATE = false);
 
 statement error unknown catalog item 'not_an_object_at_all'
-CREATE CONNECTION kafka_conn2 TO KAFKA (BROKER 'broker', SASL PASSWORD = SECRET not_an_object_at_all);
+CREATE CONNECTION kafka_conn2 TO KAFKA (BROKER 'broker', SASL PASSWORD = SECRET not_an_object_at_all) WITH (VALIDATE = false);
 
 statement ok
 CREATE SECRET pgpass AS 'postgres'
@@ -47,7 +47,7 @@ CREATE CONNECTION pg TO POSTGRES (
   PASSWORD SECRET pgpass,
   SSL MODE require,
   SSH TUNNEL not_an_object_at_all
-)
+ ) WITH (VALIDATE = false)
 
 statement ok
 CREATE TABLE object_reference (a int);
@@ -58,4 +58,4 @@ CREATE CONNECTION pg TO POSTGRES (
   HOST object_reference,
   DATABASE postgres,
   USER postgres
-)
+) WITH (VALIDATE = false)

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -12,6 +12,11 @@ mode cockroach
 reset-server
 
 simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_connection_validation_syntax TO true;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks = true
 ----
 COMPLETE 0

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -528,7 +528,7 @@ ALTER MATERIALIZED VIEW jmv OWNER TO group_materialize
 ## Connections
 
 statement ok
-CREATE CONNECTION mc TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION mc TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query T
 SELECT mz_roles.name
@@ -559,13 +559,13 @@ statement ok
 DROP CONNECTION ICs
 
 statement ok
-CREATE CONNECTION mssh TO SSH TUNNEL (HOST 'ssh-bastion-host', USER 'mz', PORT 22);
+CREATE CONNECTION mssh TO SSH TUNNEL (HOST 'ssh-bastion-host', USER 'mz', PORT 22) WITH (VALIDATE = false);
 
 statement ok
 ALTER CONNECTION mssh ROTATE KEYS
 
 simple conn=joe,user=joe
-CREATE CONNECTION jc TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION jc TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -587,7 +587,7 @@ statement error must be owner of CONNECTION materialize.public.jc
 ALTER CONNECTION jc OWNER TO group_materialize
 
 simple conn=joe,user=joe
-CREATE CONNECTION jssh TO SSH TUNNEL (HOST 'ssh-bastion-host', USER 'mz', PORT 22);
+CREATE CONNECTION jssh TO SSH TUNNEL (HOST 'ssh-bastion-host', USER 'mz', PORT 22) WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -1455,7 +1455,7 @@ GRANT CREATE ON CLUSTER default TO owner;
 COMPLETE 0
 
 simple conn=owner6,user=owner
-CREATE CONNECTION c TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION c TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -66,12 +66,12 @@ COMPLETE 0
 # CREATE CONNECTION
 
 simple conn=joe,user=joe
-CREATE CONNECTION conn TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION conn TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
-CREATE CONNECTION conn TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION conn TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 db error: ERROR: permission denied for SCHEMA "materialize.public"
 
@@ -81,12 +81,12 @@ GRANT CREATE ON SCHEMA materialize.public TO joe;
 COMPLETE 0
 
 simple conn=joe,user=joe
-CREATE CONNECTION conn TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION conn TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
 simple conn=child,user=child
-CREATE CONNECTION conn1 TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION conn1 TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -24,6 +24,11 @@ ALTER SYSTEM SET enable_ld_rbac_checks TO true;
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_connection_validation_syntax TO true;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
 CREATE ROLE joe;
 ----
 COMPLETE 0

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -22,6 +22,11 @@ ALTER SYSTEM SET enable_ld_rbac_checks TO true;
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_connection_validation_syntax TO true;
+----
+COMPLETE 0
+
 # Test mz_aclitem type and functions
 
 statement ok

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -318,7 +318,7 @@ SELECT name, privilege FROM item_privileges WHERE name = 'se'
 se  materialize=U/materialize
 
 statement ok
-CREATE CONNECTION conn TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION conn TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 
 query TT
 SELECT name, privilege FROM item_privileges WHERE name = 'conn'
@@ -3143,22 +3143,22 @@ CREATE SECRET d2.s2.se4 AS decode('c2VjcmV0Cg==', 'base64');
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-CREATE CONNECTION d1.s1.conn1 TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d1.s1.conn1 TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-CREATE CONNECTION d1.s1.conn2 TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d1.s1.conn2 TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-CREATE CONNECTION d2.s2.conn3 TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d2.s2.conn3 TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-CREATE CONNECTION d2.s2.conn4 TO KAFKA (BROKER 'localhost:9092');
+CREATE CONNECTION d2.s2.conn4 TO KAFKA (BROKER 'localhost:9092') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 

--- a/test/ssh-connection/ssh-connections.td
+++ b/test/ssh-connection/ssh-connections.td
@@ -9,6 +9,9 @@
 #
 # Test SSH key generation and management for SSH connections
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_connection_validation_syntax = true
+
 > SELECT * FROM mz_ssh_tunnel_connections;
 id public_key_1 public_key_2
 ----------------------------

--- a/test/ssh-connection/ssh-connections.td
+++ b/test/ssh-connection/ssh-connections.td
@@ -82,7 +82,7 @@ name     pkey1 pkey2
     DATABASE 'source',
     USER 'yshtola',
     SSH TUNNEL phoenix
-  );
+  ) WITH (VALIDATE = false);
 
 ! CREATE CONNECTION papalymo TO POSTGRES (
     HOST 'gridania.example.com',

--- a/test/testdrive/connection-validation.td
+++ b/test/testdrive/connection-validation.td
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_connection_validation_syntax = true
+
+> CREATE CONNECTION kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}')
+
+> VALIDATE CONNECTION kafka_conn
+
+> DROP CONNECTION kafka_conn
+
+# Explicitly enable validation
+
+> CREATE CONNECTION kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}') WITH (VALIDATE = true)
+
+> VALIDATE CONNECTION kafka_conn
+
+> DROP CONNECTION kafka_conn
+
+# WITH (VALIDATE) variant
+
+> CREATE CONNECTION kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}') WITH (VALIDATE)
+
+> VALIDATE CONNECTION kafka_conn
+
+> DROP CONNECTION kafka_conn
+
+> CREATE CONNECTION invalid_tunnel TO SSH TUNNEL (HOST 'invalid', USER 'invalid', PORT 22)
+
+! CREATE CONNECTION invalid_kafka_conn TO KAFKA (BROKERS ('${testdrive.kafka-addr}' USING SSH TUNNEL invalid_tunnel))
+contains:failed to connect to the remote host
+
+# Create the connection without validation and validate later
+> CREATE CONNECTION invalid_kafka_conn TO KAFKA (BROKERS ('${testdrive.kafka-addr}' USING SSH TUNNEL invalid_tunnel)) WITH (VALIDATE = false)
+
+! VALIDATE CONNECTION invalid_kafka_conn
+contains:failed to connect to the remote host

--- a/test/testdrive/kafka-source-errors.td
+++ b/test/testdrive/kafka-source-errors.td
@@ -15,24 +15,18 @@
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
 contains:Source format must be specified
 
-> CREATE CONNECTION no_topic TO KAFKA (BROKER '');
-
-! CREATE SOURCE s
-  FROM KAFKA CONNECTION no_topic
-contains:KAFKA CONNECTION without TOPIC
+! CREATE CONNECTION no_topic TO KAFKA (BROKER '');
+contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
 
 # Verify that incorrect/unreachable brokers throw up an error on source creation.
 
-> CREATE CONNECTION fawlty_kafka_conn
+! CREATE CONNECTION fawlty_kafka_conn
   TO KAFKA (BROKER 'non-existent-broker:9092');
+contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
   );
-
-! CREATE SOURCE fawlty_broker_source
-  FROM KAFKA CONNECTION fawlty_kafka_conn (TOPIC 'testdrive-fawlty-broker-source-${testdrive.seed}')
-contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
 
 > CREATE CONNECTION IF NOT EXISTS fawlty_csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL 'http://non-existent-csr:8081'

--- a/test/testdrive/mz-depends.td
+++ b/test/testdrive/mz-depends.td
@@ -9,6 +9,9 @@
 
 # Test `mz_internal.mz_object_dependencies`.
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_connection_validation_syntax = true
+
 > CREATE SOURCE with_subsources FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
 
 > SELECT

--- a/test/testdrive/mz-depends.td
+++ b/test/testdrive/mz-depends.td
@@ -51,7 +51,7 @@ source          subsource
     DATABASE unused,
     USER unused,
     SSH TUNNEL ssh_conn
-  );
+  ) WITH (VALIDATE = false);
 
 > SELECT
   top_level_c.name as conn,

--- a/test/testdrive/privilege_checks.td
+++ b/test/testdrive/privilege_checks.td
@@ -9,6 +9,9 @@
 
 # Test privilege checks of creating sinks. All other tests are implemented in SQLogicTests
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_connection_validation_syntax = true
+
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 
 $ postgres-execute connection=mz_system

--- a/test/testdrive/structured-errors.td
+++ b/test/testdrive/structured-errors.td
@@ -10,20 +10,14 @@
 # Testing user-focused error messages
 
 > CREATE SECRET pgpass AS 'postgres'
-> CREATE CONNECTION pg TO POSTGRES (
+! CREATE CONNECTION pg TO POSTGRES (
     HOST 'localhost',
     PORT 5433,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass
   )
-
-# TODO(guswynn): make testdrive support `startswith`
-! CREATE SOURCE "test_error"
-  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
-  FOR ALL TABLES
-exact:failed to connect to PostgreSQL database
-detail:error connecting to server:
+contains:error connecting to server:
 
 > CREATE MATERIALIZED VIEW mv as SELECT 1;
 


### PR DESCRIPTION
### Motivation

This PR adds a new feature giving the ability to users to validate `CONNECTION` objects on creation and on demand. This accomplished by two modifications in the SQL we accept:

**Validation on creation:** All `CREATE CONNECTION` statements can now be modified with the familiar "WITH" options. For now the only option that can be specified is the `VALIDATE` option whose value must be either `true` or `false`. When the option is not specified a sensible default is picked depending on the type of connection. The default values can be seen in the following table:

| Type            | Validate by default |
|-----------------|---------------------|
| Postgres        | Yes                 |
| Kafka           | Yes                 |
| Schema Registry | Yes                 |
| AWS             | No                  |
| AWS Privatelink | No                  |
| SSH             | No                  |

**Validation on demand:** All `CONNECTION` objects can be validated on demand using a new `VALIDATE CONNECTION <name>` statement. This query will block until the validation completes and will either successfully finish, returning no rows, or it will return SQL error with details about what went wrong.

**NOTE:** This PR does *NOT* actually implement validation for `SSH`, `AWS`, and `AWS PRIVATELINK` connections. This will be done in a separate PR to leave this one focused on the validation infrastructure. `KAFKA`, `POSTGRES`, and `CSR` connections are validated as part of the PR since it has trivial to do. Of course if a `KAFKA`/`POSTGRES`/`CSR` connection *does* use ssh/privatelink then those are implicitly validated too.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
