### PR TITLE
Update CTE docs on known limitations

### DIFF
--- a/doc/user/content/sql/select.md
+++ b/doc/user/content/sql/select.md
@@ -92,11 +92,8 @@ For an example, see [Using CTEs](#using-ctes).
 
 CTEs have the following limitations, which we are working to improve:
 
-- CTEs only support `SELECT` queries. {{% gh 4867 %}}
-- Materialize inlines the CTE where it's referenced, which could cause
-  unexpected performance characteristics for especially complex expressions. {{%
-  gh 4867 %}}
-- `WITH RECURSIVE` CTEs are not available yet. {{% gh 2516 %}}
+- `INSERT`/`UPDATE`/`DELETE` (with `RETURNING`) is not supported inside a CTE. {{% gh 19486 %}}
+- `WITH RECURSIVE` CTEs are not supported. Non-standard support for recursive CTEs is under active development (see {{% gh 17012 %}}).
 
 ### Query hints
 


### PR DESCRIPTION
[The CTE docs list some known limitations](https://materialize.com/docs/sql/select/#known-limitations), but these things have changed a lot. This PR updates this as follows:
- I rephrased the first point, [because it was not clear to me at all what is meant there](https://materializeinc.slack.com/archives/C02FWJ94HME/p1685023278642589).
- I deleted the second limitation. That was resolved by https://github.com/MaterializeInc/materialize/pull/9726 (and/or by introducing the `RelationCSE` MIR transform).
- The third point is about recursive queries, which will soon be supported. I rephrased it and updated the link to the stabilization issue, because the issue that was linked before is an "initial support" issue, which is closed already.

### Motivation

  * This PR updates documentation.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
