### PR TITLE
Deduplicate keys in `keys_with_input_keys`

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -514,7 +514,7 @@ impl MirRelationExpr {
     {
         use MirRelationExpr::*;
 
-        match self {
+        let mut keys = match self {
             Constant {
                 rows: Ok(rows),
                 typ,
@@ -852,7 +852,10 @@ impl MirRelationExpr {
                 // Important: do not inherit keys of either input, as not unique.
                 result
             }
-        }
+        };
+        keys.sort();
+        keys.dedup();
+        keys
     }
 
     /// The number of columns in the relation.

--- a/src/transform/tests/testdata/lifting
+++ b/src/transform/tests/testdata/lifting
@@ -306,9 +306,9 @@ With
 build format=types apply=LiteralLifting
 (constant [[1 2 3] [1 4 3]] ([int64 int64 int64] [[1 2]]))
 ----
-Map (3) // { types: "(Int64, Int64, Int64)", keys: "([1], [1])" }
-  Project (#1, #0) // { types: "(Int64, Int64)", keys: "([1], [1])" }
-    Map (1) // { types: "(Int64, Int64)", keys: "([0], [0])" }
-      Constant // { types: "(Int64)", keys: "([0], [0])" }
+Map (3) // { types: "(Int64, Int64, Int64)", keys: "([1])" }
+  Project (#1, #0) // { types: "(Int64, Int64)", keys: "([1])" }
+    Map (1) // { types: "(Int64, Int64)", keys: "([0])" }
+      Constant // { types: "(Int64)", keys: "([0])" }
         - (2)
         - (4)


### PR DESCRIPTION
For example, the `Constant` case can create duplicates when a key is both in the `typ` of the node, and can be detected by looking at the actual constant rows.

Having duplicate keys might hinder CSE in some cases when two expressions differ only in whether a duplicate of a certain key is present. There was a suspicion that this might be happening [here](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1684230764826599?thread_ts=1684178495.123909&cid=C02PPB50ZHS), but the slt rewrite didn't yield a change.

(It would be also great to normalize a key set to an antichain, but that might slow things down too much. We can consider that when working on https://github.com/MaterializeInc/materialize/issues/18553)

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
