### PR TITLE
sqlsmith: Verify that any queries were actually run

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -36,6 +36,8 @@ SERVICES = [
         restart="on-failure",
         memory=f"{TOTAL_MEMORY / len(MZ_SERVERS)}GB",
         use_default_volumes=False,
+        # TODO(def-): Remove this when #19496 is fixed
+        additional_system_parameter_defaults={"persist_stats_filter_enabled": "false"},
     )
     for mz_server in MZ_SERVERS
 ] + [
@@ -227,6 +229,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             if frozen_key not in new_errors:
                 new_errors[frozen_key] = []
             new_errors[frozen_key].append({x: error[x] for x in ["timestamp", "query"]})
+
+    assert aggregate["queries"] > 0, "No queries were executed"
 
     print(
         f"SQLsmith: {aggregate['version']} seed: {seed} queries: {aggregate['queries']}"


### PR DESCRIPTION
I noticed that in https://github.com/MaterializeInc/materialize/issues/19496 we are actually not executing any queries, this should have been noticed much earlier, got stuck in a query which never returned.


### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
