### PR TITLE
storage usage: calculate referenced data from persist state directly

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -95,7 +95,7 @@ use mz_ore::task::spawn;
 use mz_ore::thread::JoinHandleExt;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{stack, task};
-use mz_persist_client::usage::{ShardsUsage, StorageUsageClient};
+use mz_persist_client::usage::{ShardsUsageReferenced, StorageUsageClient};
 use mz_repr::explain::ExplainFormat;
 use mz_repr::{Datum, GlobalId, RelationType, Row, Timestamp};
 use mz_secrets::SecretsController;
@@ -203,7 +203,7 @@ pub enum Message<T = mz_repr::Timestamp> {
     },
     LinearizeReads(Vec<PendingReadTxn>),
     StorageUsageFetch,
-    StorageUsageUpdate(ShardsUsage),
+    StorageUsageUpdate(ShardsUsageReferenced),
     RealTimeRecencyTimestamp {
         conn_id: ConnectionId,
         real_time_recency_ts: Timestamp,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -18,7 +18,7 @@ use mz_controller::clusters::ClusterEvent;
 use mz_controller::ControllerResponse;
 use mz_ore::now::EpochMillis;
 use mz_ore::task;
-use mz_persist_client::usage::ShardsUsage;
+use mz_persist_client::usage::ShardsUsageReferenced;
 use mz_sql::ast::Statement;
 use mz_sql::plan::{CreateSourcePlans, Plan};
 use mz_storage_client::controller::CollectionMetadata;
@@ -136,16 +136,7 @@ impl Coordinator {
         // requires a slow scan of the underlying storage engine.
         task::spawn(|| "storage_usage_fetch", async move {
             let collection_metric_timer = collection_metric.start_timer();
-            let mut shard_sizes = client.shards_usage().await;
-
-            // Don't record usage for shards that are no longer live.
-            // Technically the storage is in use, but we never free it, and
-            // we don't want to bill the customer for it.
-            //
-            // See: https://github.com/MaterializeInc/materialize/issues/8185
-            shard_sizes
-                .by_shard
-                .retain(|shard_id, _| live_shards.contains(shard_id));
+            let shard_sizes = client.shards_usage_referenced(live_shards).await;
             collection_metric_timer.observe_duration();
 
             // It is not an error for shard sizes to become ready after
@@ -157,7 +148,7 @@ impl Coordinator {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn storage_usage_update(&mut self, shards_usage: ShardsUsage) {
+    async fn storage_usage_update(&mut self, shards_usage: ShardsUsageReferenced) {
         // Similar to audit events, use the oracle ts so this is guaranteed to
         // increase. This is intentionally the timestamp of when collection
         // finished, not when it started, so that we don't write data with a
@@ -168,14 +159,7 @@ impl Coordinator {
         for (shard_id, shard_usage) in shards_usage.by_shard {
             ops.push(catalog::Op::UpdateStorageUsage {
                 shard_id: Some(shard_id.to_string()),
-                size_bytes: shard_usage.referenced_bytes(),
-                collection_timestamp,
-            });
-        }
-        if shards_usage.unattributable_bytes > 0 {
-            ops.push(catalog::Op::UpdateStorageUsage {
-                shard_id: None,
-                size_bytes: shards_usage.unattributable_bytes,
+                size_bytes: shard_usage.size_bytes(),
                 collection_timestamp,
             });
         }

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -622,10 +622,10 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
     )?);
 
     if let Some(shard_id) = shard_id {
-        let usage = usage.shard_usage(shard_id).await;
+        let usage = usage.shard_usage_audit(shard_id).await;
         println!("{}\n{}", shard_id, usage);
     } else {
-        let usage = usage.shards_usage().await;
+        let usage = usage.shards_usage_audit().await;
         let mut by_shard = usage.by_shard.iter().collect::<Vec<_>>();
         by_shard.sort_by_key(|(_, x)| x.total_bytes());
         by_shard.reverse();

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -279,9 +279,9 @@ impl StorageUsageClient {
 
     /// Computes [ShardUsageAudit] for a single shard.
     ///
-    /// Performs a full scan of [Blob] and [Consensus] to compute a full audit of blob usage,
-    /// categorizing both referenced and unreferenced blobs (see [ShardUsageAudit] for full
-    /// details). While [ShardUsageAudit::referenced_bytes] is suitable for billing, prefer
+    /// Performs a full scan of [Blob] and [mz_persist::location::Consensus] to compute a full audit
+    /// of blob usage, categorizing both referenced and unreferenced blobs (see [ShardUsageAudit]
+    /// for full details). While [ShardUsageAudit::referenced_bytes] is suitable for billing, prefer
     /// [Self::shard_usage_referenced] to avoid the (costly!) scan of [Blob] if the additional
     /// categorizations are not needed.
     pub async fn shard_usage_audit(&self, shard_id: ShardId) -> ShardUsageAudit {

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -279,10 +279,11 @@ impl StorageUsageClient {
 
     /// Computes [ShardUsageAudit] for a single shard.
     ///
-    /// Performs a full scan of [Blob] and [Consensus] to compute a full audit of blob
-    /// usage for the shard. While [ShardUsageAudit::referenced_bytes] is suitable for
-    /// billing, prefer [Self::shard_usage_referenced] instead to avoid the costly scan
-    /// of [Blob].
+    /// Performs a full scan of [Blob] and [Consensus] to compute a full audit of blob usage,
+    /// categorizing both referenced and unreferenced blobs (see [ShardUsageAudit] for full
+    /// details). While [ShardUsageAudit::referenced_bytes] is suitable for billing, prefer
+    /// [Self::shard_usage_referenced] to avoid the (costly!) scan of [Blob] if the additional
+    /// categorizations are not needed.
     pub async fn shard_usage_audit(&self, shard_id: ShardId) -> ShardUsageAudit {
         let mut blob_usage = self.blob_raw_usage(BlobKeyPrefix::Shard(&shard_id)).await;
         let blob_usage = blob_usage.by_shard.remove(&shard_id).unwrap_or_default();
@@ -292,7 +293,7 @@ impl StorageUsageClient {
 
     /// Computes [ShardUsageAudit] for every shard in an env.
     ///
-    /// See [Self::shard_usage_audit] for more details on when to use this function.
+    /// See [Self::shard_usage_audit] for more details on when to use a full audit.
     pub async fn shards_usage_audit(&self) -> ShardsUsageAudit {
         let blob_usage = self.blob_raw_usage(BlobKeyPrefix::All).await;
         self.metrics


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Currently the hourly storage usage collection does a big scan of every blob in S3 + every live state in Consensus. We then do a ton of tricky calculations to categorize each byte found [into a detailed funnel](https://github.com/MaterializeInc/materialize/issues/17293). Then, we throw away all of the data except for bytes referenced by any live state!

This PR updates the storage usage collection to simply grab the referenced bytes from Consensus directly. This will complete much, _much_ faster for large customers, will scale O(shards) rather than O(blobs), won't be affected by S3 versioning's impact on latency, and won't incur any S3 LIST operations cost.

I've chosen to keep all of the full storage audit code around because I think it's quite useful, as I imagine we'll want to run it on-demand or hook it up to some unreferenced blob deletion job down the line.

cc @necaris @arusahni @benesch 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
