### PR TITLE
[persist/expr] Enhanced explain filter

### DIFF
--- a/src/expr/src/explain/json.rs
+++ b/src/expr/src/explain/json.rs
@@ -12,7 +12,6 @@
 use mz_repr::explain::json::DisplayJson;
 
 use crate::explain::{ExplainMultiPlan, ExplainSinglePlan, ExplainSource, PushdownInfo};
-use crate::interpret::Pushdownable;
 
 impl<'a, T: 'a> DisplayJson for ExplainSinglePlan<'a, T>
 where
@@ -54,18 +53,17 @@ where
                         "op": op,
                     });
 
-                    if let Some(PushdownInfo { trace }) = pushdown_info {
-                        let pushdownable: Vec<_> = trace
-                            .0
-                            .iter()
-                            .enumerate()
-                            .filter(|(_, p)| **p == Pushdownable::Yes)
-                            .map(|(i, _)| i)
-                            .collect();
-
-                        json.as_object_mut()
-                            .unwrap()
-                            .insert("pushdown".to_owned(), serde_json::json!(pushdownable));
+                    if let Some(PushdownInfo {
+                        pushdown,
+                        potential_pushdown,
+                    }) = pushdown_info
+                    {
+                        let object = json.as_object_mut().unwrap();
+                        object.insert("pushdown".to_owned(), serde_json::json!(pushdown));
+                        object.insert(
+                            "potential_pushdown".to_owned(),
+                            serde_json::json!(potential_pushdown),
+                        );
                     }
 
                     json

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -336,10 +336,12 @@ pub fn plan_explain(
         .iter()
         .map(|ident| ident.to_string().to_lowercase())
         .collect::<BTreeSet<_>>();
-    let config = ExplainConfig::try_from(config_flags)?;
+    let mut config = ExplainConfig::try_from(config_flags)?;
 
     if config.mfp_pushdown {
         scx.require_feature_flag(&vars::ENABLE_MFP_PUSHDOWN_EXPLAIN)?;
+        // If filtering is disabled, explain plans should not include pushdown info.
+        config.mfp_pushdown = scx.catalog.system_vars().persist_stats_filter_enabled();
     }
 
     let format = match format {

--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -14,6 +14,11 @@ ALTER SYSTEM SET enable_mfp_pushdown_explain = true
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET persist_stats_filter_enabled = true
+----
+COMPLETE 0
+
 # Verify filter pushdown information for various temporal filters.
 # For straightforward temporal filters like these, every column mentioned in the filter
 # should be present in the pushdown list.
@@ -52,7 +57,7 @@ Explained Query:
 
 Source materialize.public.events
   filter=((mz_now() >= numeric_to_mz_timestamp(#1)) AND (mz_now() < numeric_to_mz_timestamp(#2)))
-  pushdown=(#1, #2)
+  pushdown=((mz_now() >= numeric_to_mz_timestamp(#1)) AND (mz_now() < numeric_to_mz_timestamp(#2)))
 
 EOF
 
@@ -75,7 +80,7 @@ Explained Query:
 Source materialize.public.events
   filter=((mz_now() < numeric_to_mz_timestamp((10000 * (1 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
   map=((#1 / 10000))
-  pushdown=(#1)
+  pushdown=((mz_now() < numeric_to_mz_timestamp((10000 * (1 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
 
 EOF
 
@@ -98,7 +103,7 @@ Explained Query:
 Source materialize.public.events
   filter=((mz_now() < numeric_to_mz_timestamp((6 * (10000 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
   map=((#1 / 10000))
-  pushdown=(#1)
+  pushdown=((mz_now() < numeric_to_mz_timestamp((6 * (10000 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
 
 EOF
 
@@ -120,7 +125,7 @@ Explained Query:
 
 Source materialize.public.events
   filter=((mz_now() < numeric_to_mz_timestamp((#1 + 30000))) AND (mz_now() >= numeric_to_mz_timestamp(#1)))
-  pushdown=(#1)
+  pushdown=((mz_now() < numeric_to_mz_timestamp((#1 + 30000))) AND (mz_now() >= numeric_to_mz_timestamp(#1)))
 
 EOF
 
@@ -137,6 +142,6 @@ Explained Query:
 
 Source materialize.public.events
   filter=((mz_now() >= numeric_to_mz_timestamp((#1 + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 60000))))
-  pushdown=(#1, #2)
+  pushdown=((mz_now() >= numeric_to_mz_timestamp((#1 + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 60000))))
 
 EOF


### PR DESCRIPTION
Two changes:
- Pushdown info is now only included when filtering is enabled.
- Instead of listing the columns that will see pushdown, we list the expressions where pushdown is expected. (Various folks reported that this was more helpful.)

### Motivation

Addresses: #19401
Design doc: #18007 

### Tips for reviewer

The new explain plan format is indicated by the test. Happy to take more suggestions here!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
