### PR TITLE
adapter: session ID in mz_subscriptions

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -164,7 +164,7 @@ operations in the system.
 | Field                    | Type                           | Meaning                                                                                                                    |
 | ------------------------ | ------------------------------ | --------                                                                                                                   |
 | `id`                     | [`text`]                       | The ID of the subscription.                                                                                                |
-| `user`                   | [`text`]                       | The user who started the subscription.                                                                                     |
+| `session_id`             | [`uint4`]                      | The ID of the session that runs the subscription. Corresponds to [`mz_sessions.id`](#mz_sessions).                         |
 | `cluster_id`             | [`text`]                       | The ID of the cluster on which the subscription is running. Corresponds to [`mz_clusters.id`](../mz_catalog/#mz_clusters). |
 | `created_at`             | [`timestamp with time zone`]   | The time at which the subscription was created.                                                                            |
 | `referenced_object_ids`  | [`text list`]                  | The IDs of objects referenced by the subscription. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects)             |

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1889,7 +1889,7 @@ pub static MZ_SUBSCRIPTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
-        .with_column("user", ScalarType::String.nullable(false))
+        .with_column("session_id", ScalarType::UInt32.nullable(false))
         .with_column("cluster_id", ScalarType::String.nullable(false))
         .with_column("created_at", ScalarType::TimestampTz.nullable(false))
         .with_column(

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1198,7 +1198,7 @@ impl CatalogState {
         let mut row = Row::default();
         let mut packer = row.packer();
         packer.push(Datum::String(&id.to_string()));
-        packer.push(Datum::String(&subscribe.user.name));
+        packer.push(Datum::UInt32(subscribe.conn_id.val()));
         packer.push(Datum::String(&subscribe.cluster_id.to_string()));
 
         let start_dt = mz_ore::now::to_datetime(subscribe.start_time);

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1518,8 +1518,10 @@ def workflow_test_mz_subscriptions(c: Composition) -> None:
         """
         output = c.sql_query(
             """
-            SELECT s.user, c.name, t.name
+            SELECT r.name, c.name, t.name
             FROM mz_internal.mz_subscriptions s
+              JOIN mz_internal.mz_sessions e ON (e.id = s.session_id)
+              JOIN mz_roles r ON (r.id = e.role_id)
               JOIN mz_clusters c ON (c.id = s.cluster_id)
               JOIN mz_tables t ON (t.id = s.referenced_object_ids[1])
             ORDER BY s.created_at


### PR DESCRIPTION
This PR replaces the direct user name in `mz_subscriptions` with a foreign key into the `mz_sessions` table.

### Motivation

Follow up to https://github.com/MaterializeInc/materialize/issues/18289 and @benesch's comment [in Notion](https://www.notion.so/Weekly-Product-Updates-46515707eba84deab6d6d3cd4bb2768a?d=c1a2cddbfb6f43c1b0f6efbfa2173e96#16b4bc387f684391b5442609b03dada8).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Replace the `mz_internal.mz_subscriptions.user` column with a `session_id` column that contains a foreign key into `mz_internal.mz_sessions`.
