### PR TITLE
platform-checks: Avoid setting the same settings after each upgrade

### DIFF
--- a/misc/python/materialize/checks/executors.py
+++ b/misc/python/materialize/checks/executors.py
@@ -9,7 +9,7 @@
 
 import random
 import threading
-from typing import Any, Optional
+from typing import Any, Optional, Set
 
 from materialize.cloudtest.application import MaterializeApplication
 from materialize.mzcompose import Composition
@@ -23,6 +23,10 @@ class Executor:
     # scenarios which are still in development and not available a few versions
     # back already.
     current_mz_version: MzVersion
+    # All the system settings we have already set in previous Mz versions. No
+    # need to set them again in a future version since they should be
+    # persisted.
+    system_settings: Set[str] = set()
 
     def testdrive(self, input: str) -> Any:
         assert False


### PR DESCRIPTION
Remember what we set already, should be faster, less spammy on stdout, and could find issues if settings are lost after an upgrade

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
