### PR TITLE
Ignore `cluster-client` in `buf` lint

### DIFF
--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -13,6 +13,8 @@ breaking:
     - WIRE
   ignore:
     # does currently not require backward-compatibility
+    - cluster-client
+    # does currently not require backward-compatibility
     - compute-client
     # does currently not require backward-compatibility
     - storage-client


### PR DESCRIPTION
This PR adds the protobuf types under `cluster-client` to the set of types for which we presently do not require backward compatibility. These types are only used in the communication between `environmentd` and `clusterd` replicas, and not persisted anywhere.

### Motivation

  * This PR fixes a previously unreported bug.

    The set of ignored types for protobuf linting by `buf` did not include types under `cluster-client`, even though by our current backward compatibility policy, these types should be ignored. As an example of why this is a problem, some valid changes to these types can [fail the `buf` lint in CI](https://buildkite.com/materialize/tests/builds/56338#01885784-bf3d-4fb4-90ad-0d8790931239).

### Tips for reviewer

Slack ref: https://materializeinc.slack.com/archives/C02PPB50ZHS/p1685096502506669

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR is sufficiently small to not require a design.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
