### PR TITLE
test: fix cloud canary access to unmanaged cluster replicas

### DIFF
--- a/test/cloud-canary/canary-clusters.td
+++ b/test/cloud-canary/canary-clusters.td
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
-
 > DROP CLUSTER IF EXISTS cluster1 CASCADE;
 
 > CREATE CLUSTER cluster1 REPLICAS (replica1 (SIZE '3xsmall'), replica2 (SIZE '3xsmall'));


### PR DESCRIPTION
An attempt to fix #19434

I tried running this myself on [`nightly`](https://buildkite.com/materialize/nightlies/builds/2477#018858d5-51c1-400a-a04f-e5d78900dd3c) but got [an error I do not understand](https://buildkite.com/materialize/nightlies/builds/2477#018858d5-51c1-400a-a04f-e5d78900dd3c). Running statements through `mz` is not, afaict, dependent on any feature flags so should not have any real interaction with the changes I've made. I've verified that I can run `mz` locally without issue, so I am a little stumped as to what the error is.

In the linked-to issue, Phillip points out that we don't have access to the `mz_system` user in testdrive (I don't know if that's only true for this test, as the negative diff in this PR is a pattern used elsewhere without issue). To work around this limitation, we can instead just default the flag to "on" and that should work for any tests running against that invocation of `Materialized`. We have at least one other test that ensures that this pattern works (`sql-feature-flags`), so if we can get this to a place where the environments start, I am confident that we should be able to pass testdrive.

@philip-stoev Do you have any suggestions here? Is it possible that there's some unmarked dependence between some greater set of nightlies

### Motivation

This PR fixes a recognized bug. #19434

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
