### PR TITLE
adapter: add subsources column to mz_sources

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -367,6 +367,7 @@ Field            | Type                 | Meaning
 `cluster_id`     | [`text`]             | The ID of the cluster maintaining the source. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters).
 `owner_id`       | [`text`]             | The role ID of the owner of the source. Corresponds to [`mz_roles.id`](/sql/system-catalog/mz_catalog/#mz_roles).
 `privileges`     | [`mz_aclitem array`] | The privileges belonging to the source.
+`subsources`     | [`text array`]       | This source's subsources, if any.
 
 ### `mz_storage_usage`
 

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1503,6 +1503,10 @@ pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column(
             "privileges",
             ScalarType::Array(Box::new(ScalarType::MzAclItem)).nullable(false),
+        )
+        .with_column(
+            "subsources",
+            ScalarType::Array(Box::new(ScalarType::String)).nullable(true),
         ),
     is_retained_metrics_object: true,
 });

--- a/test/pg-cdc/mz-sources.td
+++ b/test/pg-cdc/mz-sources.td
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# IMPORTANT: The Postgres server has a custom pg_hba.conf that only
+# accepts connections from specific users. You will have to update
+# pg_hba.conf if you modify the existing user names or add new ones.
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+CREATE TABLE table_a (a INTEGER);
+INSERT INTO table_a VALUES (1);
+ALTER TABLE table_a REPLICA IDENTITY FULL;
+
+CREATE TABLE table_b (a INTEGER);
+INSERT INTO table_b VALUES (1);
+ALTER TABLE table_b REPLICA IDENTITY FULL;
+
+> CREATE SOURCE "mz_source"
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES (
+    "table_a",
+    "table_b"
+  );
+
+> SHOW SOURCES
+mz_source             postgres  ${arg.default-storage-size}
+mz_source_progress    subsource <null>
+table_a               subsource <null>
+table_b               subsource <null>
+
+> SELECT envelope_type FROM mz_sources WHERE name = 'mz_source'
+none
+
+> SELECT subsources FROM mz_sources WHERE name = 'mz_source'
+{u3,u4}

--- a/test/testdrive/mz-sources.td
+++ b/test/testdrive/mz-sources.td
@@ -145,3 +145,6 @@ debezium
 
 > SELECT envelope_type FROM mz_sources WHERE name = 'upsert_source'
 upsert
+
+> SELECT subsources IS NULL FROM mz_sources WHERE name = 'upsert_source'
+true


### PR DESCRIPTION
Now that PG sources have become a more integral part of MZ, we need a better introspection tool to understand the relationship between sources and subsources; this will help us out in docs (#19453) and upcoming changes to account limits (#19460) as well as internal observability.

### Motivation

This PR adds a known-desirable feature. #19534

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add a `subsources` column to `mz_catalog.mz_sources` to simplify correlation between subsources and the source to which they're associated.
