### PR TITLE
Revert "cargo-test: don't run with more CPU cores"

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -134,7 +134,6 @@ steps:
 
   - id: cargo-test
     label: Cargo test
-    depends_on: build-x86_64
     timeout_in_minutes: 30
     artifact_paths: [junit_*.xml, target/nextest/ci/junit_cargo-test.xml]
     inputs:

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -29,7 +29,6 @@ import traceback
 from contextlib import contextmanager
 from dataclasses import dataclass
 from inspect import getmembers, isfunction
-from pathlib import Path
 from ssl import SSLContext
 from tempfile import TemporaryFile
 from typing import (
@@ -735,14 +734,6 @@ class Composition:
             self.exec(service, *args, stdin=input)
         else:
             self.run(service, *args, stdin=input)
-
-    def cp(
-        self,
-        source: Union[str, Path],
-        destination: Union[str, Path],
-    ) -> None:
-        """Copy a file to or from a container."""
-        self.invoke("cp", str(source), str(destination))
 
 
 class ServiceHealthcheck(TypedDict, total=False):


### PR DESCRIPTION
This reverts commit 7449de7f7412098cff15fce4365aa7f5fb391ded.

Running with more CPU cores wasn't the problem. The problem was that the `clusterd` binary was not being copied to the right place.

Just revert that part of 8cd0b1b rather than fixing the path. I'm almost certain that building `clusterd` is substantially faster than trying to copy it out of the `Clusterd` image. We have to build the test binaries in this job no matter what, so building `clusterd` too is relatively immaterial, and not having to wait for the `build_x86-64` job makes cargo-test results available much sooner for the first build.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
