### PR TITLE
ore: minor refactorings to `IdAlloc`

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1200,7 +1200,7 @@ impl CatalogState {
         let mut row = Row::default();
         let mut packer = row.packer();
         packer.push(Datum::String(&id.to_string()));
-        packer.push(Datum::UInt32(subscribe.conn_id.val()));
+        packer.push(Datum::UInt32(*subscribe.conn_id));
         packer.push(Datum::String(&subscribe.cluster_id.to_string()));
 
         let start_dt = mz_ore::now::to_datetime(subscribe.start_time);
@@ -1225,7 +1225,7 @@ impl CatalogState {
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_SESSIONS),
             row: Row::pack_slice(&[
-                Datum::UInt32(session.conn_id().val()),
+                Datum::UInt32(**session.conn_id()),
                 Datum::String(&session.role_id().to_string()),
                 Datum::TimestampTz(connect_dt.try_into().expect("must fit")),
             ]),

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -393,7 +393,7 @@ impl SessionClient {
 
     /// Cancels the query currently running on another connection.
     pub fn cancel_request(&mut self, conn_id: ConnectionId, secret_key: u32) {
-        self.inner_mut().cancel_request(conn_id.val(), secret_key)
+        self.inner_mut().cancel_request(*conn_id, secret_key)
     }
 
     /// Ends a transaction.
@@ -557,7 +557,7 @@ impl SessionClient {
                 },
                 _err = &mut cancel_future, if !cancelled => {
                     cancelled = true;
-                    self.inner_mut().cancel_request(conn_id.val(), secret_key);
+                    self.inner_mut().cancel_request(*conn_id, secret_key);
                 }
             };
         }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -112,7 +112,7 @@ impl Client {
             build_info: self.build_info,
             conn_id: self
                 .id_alloc
-                .alloc_owned()
+                .alloc()
                 .ok_or(AdapterError::IdExhaustionError)?,
             inner: self.clone(),
         })

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -607,7 +607,7 @@ impl Coordinator {
                 matches!(pending_write_txn, PendingWriteTxn::User {
                     pending_txn: PendingTxn { session, .. },
                     ..
-                } if session.conn_id().val() == conn_id)
+                } if **session.conn_id() == conn_id)
             }) {
                 if let PendingWriteTxn::User {
                     pending_txn:
@@ -627,7 +627,7 @@ impl Coordinator {
             if let Some(idx) = self
                 .write_lock_wait_group
                 .iter()
-                .position(|ready| matches!(ready, Deferred::Plan(ready) if ready.session.conn_id().val() == conn_id))
+                .position(|ready| matches!(ready, Deferred::Plan(ready) if **ready.session.conn_id() == conn_id))
             {
                 let ready = self.write_lock_wait_group.remove(idx).expect("known to exist from call to `position` above");
                 if let Deferred::Plan(ready) = ready {
@@ -685,7 +685,7 @@ impl Coordinator {
             .with_label_values(&[session_type])
             .dec();
         self.active_conns.remove(session.conn_id());
-        self.cancel_pending_peeks(session.conn_id().val());
+        self.cancel_pending_peeks(**session.conn_id());
         let update = self.catalog().state().pack_session_update(session, -1);
         self.send_builtin_table_updates(vec![update]).await;
     }

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -798,7 +798,7 @@ fn eval_unmaterializable_func(
             pack(Datum::Int32(state.config().build_info.version_num()))
         }
         UnmaterializableFunc::PgBackendPid => {
-            pack(Datum::Int32(i32::reinterpret_cast(session.conn_id().val())))
+            pack(Datum::Int32(i32::reinterpret_cast(**session.conn_id())))
         }
         UnmaterializableFunc::PgPostmasterStartTime => {
             let t: Datum = state.config().start_time.try_into()?;

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -72,7 +72,7 @@ impl Coordinator {
             // in any situation where you use it, you must also have a code
             // path that responds to the client (e.g. reporting an error).
             Message::RemovePendingPeeks { conn_id } => {
-                self.cancel_pending_peeks(conn_id.val());
+                self.cancel_pending_peeks(*conn_id);
             }
             Message::LinearizeReads(pending_read_txns) => {
                 self.message_linearize_reads(pending_read_txns).await;

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -260,7 +260,7 @@ where
         buf.push(BackendMessage::ParameterStatus(var.name(), var.value()));
     }
     buf.push(BackendMessage::BackendKeyData {
-        conn_id: session.conn_id().val(),
+        conn_id: **session.conn_id(),
         secret_key: session.secret_key(),
     });
     // Immediately respond with connection success without waiting on the


### PR DESCRIPTION
Minor refactorings to #19493 based on a post-merge review!

### Motivation

  * This PR fixes a previously unreported bug and refactors some code. See commit messages for details.

### Tips for reviewer

The first commit is removing dead code; the third commit is fixing a bug; I expect both to be uncontroversial.

The second commit is more a matter of taste, and happy to omit it.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
