### PR TITLE
*: migrate all infra from us-east-2 to us-east-1

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -258,7 +258,7 @@ Launched instances:
 ```
 
 <small>* You may need to update the instance type and AMI above as we upgrade our Buildkite agents. The latest Buildkite AMI is available [here][elastic-yml] under
-the `AWSRegion2AMI` heading. Use the AMI for `us-east-2` and `linuxamd64`.</small>
+the `AWSRegion2AMI` heading. Use the AMI for `us-east-1` and `linuxamd64`.</small>
 
 This will create an EC2 instance that looks like a CI agent and push your local
 copy of the repository to it. You can SSH in to the agent using the instance ID

--- a/ci/cleanup/pipeline.yml
+++ b/ci/cleanup/pipeline.yml
@@ -18,7 +18,6 @@ steps:
       AWS_DEFAULT_REGION: "{{matrix}}"
     matrix:
       - us-east-1
-      - us-east-2
     plugins:
        - ./ci/plugins/scratch-aws-access
 

--- a/ci/load/pipeline.yml
+++ b/ci/load/pipeline.yml
@@ -15,6 +15,6 @@ steps:
     agents:
       queue: linux-x86_64
     env:
-      AWS_DEFAULT_REGION: us-east-2
+      AWS_DEFAULT_REGION: us-east-1
     plugins:
        - ./ci/plugins/scratch-aws-access

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -129,7 +129,7 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          args: [--redpanda, --aws-region=us-east-2]
+          args: [--redpanda, --aws-region=us-east-1]
 
 # Disabled due to taking too long for the value provided
 #  - id: redpanda-testdrive-aarch64
@@ -142,7 +142,7 @@ steps:
 #      - ./ci/plugins/scratch-aws-access: ~
 #      - ./ci/plugins/mzcompose:
 #          composition: testdrive
-#          args: [--redpanda, --aws-region=us-east-2]
+#          args: [--redpanda, --aws-region=us-east-1]
 
   - id: limits
     label: "Product limits"
@@ -177,7 +177,7 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          args: [--aws-region=us-east-2, --kafka-default-partitions=5]
+          args: [--aws-region=us-east-1, --kafka-default-partitions=5]
 
   - id: testdrive-replicas-4
     label: ":racing_car: testdrive 4 replicas"
@@ -189,7 +189,7 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          args: [--aws-region=us-east-2, --replicas=4]
+          args: [--aws-region=us-east-1, --replicas=4]
 
   - id: testdrive-size-1
     label: ":racing_car: testdrive with SIZE 1"
@@ -201,7 +201,7 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          args: [--aws-region=us-east-2, --default-size=1]
+          args: [--aws-region=us-east-1, --default-size=1]
 
   - id: testdrive-size-8
     label: ":racing_car: testdrive with SIZE 8"
@@ -213,7 +213,7 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          args: [--aws-region=us-east-2, --default-size=8]
+          args: [--aws-region=us-east-1, --default-size=8]
 
   - id: testdrive-in-cloudtest
     label: Full Testdrive in Cloudtest (K8s)
@@ -224,7 +224,7 @@ steps:
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
-          args: [-m=long, --aws-region=us-east-2, test/cloudtest/test_full_testdrive.py]
+          args: [-m=long, --aws-region=us-east-1, test/cloudtest/test_full_testdrive.py]
 
   - id: persistence-testdrive
     label: ":racing_car: testdrive with --persistent-user-tables"
@@ -236,7 +236,7 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          args: [--aws-region=us-east-2, --persistent-user-tables]
+          args: [--aws-region=us-east-1, --persistent-user-tables]
     skip: Persistence tests disabled
 
   - id: zippy-kafka-sources
@@ -504,7 +504,7 @@ steps:
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
-          args: [-m=long,  --aws-region=us-east-2, test/cloudtest/test_upgrade.py]
+          args: [-m=long,  --aws-region=us-east-1, test/cloudtest/test_upgrade.py]
 
   - id: persist-maelstrom-single-node
     label: Long single-node Maelstrom coverage of persist

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -174,7 +174,7 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          args: [--aws-region=us-east-2]
+          args: [--aws-region=us-east-1]
     agents:
       queue: linux-x86_64
 
@@ -555,7 +555,7 @@ steps:
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
-          args: [--exitfirst, -m, "not long", --aws-region=us-east-2, test/cloudtest/]
+          args: [--exitfirst, -m, "not long", --aws-region=us-east-1, test/cloudtest/]
 
   - id: source-sink-errors
     label: "Source/Sink Error Reporting"

--- a/src/s3-datagen/src/main.rs
+++ b/src/s3-datagen/src/main.rs
@@ -113,7 +113,7 @@ struct Args {
     bucket: String,
 
     /// Which region to operate in
-    #[clap(short = 'r', long, default_value = "us-east-2")]
+    #[clap(short = 'r', long, default_value = "us-east-1")]
     region: String,
 
     /// Number of copy operations to run concurrently


### PR DESCRIPTION
Since a week ago we use AWS Organization SCPs to deny creating any resources in us-east-2:

https://github.com/MaterializeInc/i2/blob/main/i2/ocpdeny.py

This has broken the few bits of CI infrastructure that still run in us-east-2. This commit puts the finishing touches on the transition and moves all remaining CI infrastructure to us-east-1.
