### PR TITLE
adapter: describe progress subsources' type as 'progress'

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -360,7 +360,7 @@ Field            | Type                 | Meaning
 `oid`            | [`oid`]              | A [PostgreSQL-compatible OID][oid] for the source.
 `schema_id`      | [`uint8`]            | The ID of the schema to which the source belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).
 `name`           | [`text`]             | The name of the source.
-`type`           | [`text`]             | The type of the source: `kafka`, `postgres`, `load-generator`, or `subsource`.
+`type`           | [`text`]             | The type of the source: `kafka`, `postgres`, `load-generator`, `progress`, or `subsource`.
 `connection_id`  | [`text`]             | The ID of the connection associated with the source, if any. Corresponds to [`mz_connections.id`](/sql/system-catalog/mz_catalog/#mz_connections).
 `size`           | [`text`]             | The [size](/sql/create-source/#sizing-a-source) of the source.
 `envelope_type`  | [`text`]             | The [envelope](/sql/create-source/#envelopes) of the source: `none`, `upsert`, or `debezium`.

--- a/misc/python/materialize/checks/source_errors.py
+++ b/misc/python/materialize/checks/source_errors.py
@@ -91,7 +91,8 @@ class SourceErrors(Check):
                 > SELECT status, error ~* 'publication .+ does not exist'
                   FROM mz_internal.mz_source_statuses
                   WHERE name LIKE 'source_errors_source%'
-                  AND type != 'subsource';
+                  AND type != 'subsource'
+                  AND type != 'progress';
                 stalled true
                 stalled true
                 """

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1930,7 +1930,8 @@ impl Source {
     pub fn source_type(&self) -> &str {
         match &self.data_source {
             DataSourceDesc::Ingestion(ingestion) => ingestion.desc.connection.name(),
-            DataSourceDesc::Progress | DataSourceDesc::Source => "subsource",
+            DataSourceDesc::Progress => "progress",
+            DataSourceDesc::Source => "subsource",
             DataSourceDesc::Introspection(_) => "source",
         }
     }

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -267,7 +267,7 @@ escaped_text_table    subsource <null>
 large_text            subsource <null>
 multipart_pk          subsource <null>
 mz_source             postgres  ${arg.default-storage-size}
-mz_source_progress    subsource <null>
+mz_source_progress    progress  <null>
 no_replica_identity   subsource <null>
 nonpk_table           subsource <null>
 nulls_table           subsource <null>
@@ -643,7 +643,7 @@ contains: invalid TEXT COLUMNS option value: table utf8_table not found in sourc
 > SELECT * FROM (SHOW SOURCES) WHERE name LIKE '%enum%';
 another_enum_table      subsource <null>
 enum_source             postgres  ${arg.default-storage-size}
-enum_source_progress    subsource <null>
+enum_source_progress    progress  <null>
 enum_table              subsource <null>
 
 > SELECT * FROM enum_table
@@ -685,7 +685,7 @@ regex:Source error: .*: db error: ERROR: publication "mz_source" does not exist
 
 > SHOW SOURCES
 another_source          postgres  ${arg.default-storage-size}
-another_source_progress subsource <null>
+another_source_progress progress  <null>
 another_table           subsource <null>
 
 > DROP SOURCE another_source

--- a/test/pg-cdc/subsource-resolution-duplicates.td
+++ b/test/pg-cdc/subsource-resolution-duplicates.td
@@ -48,7 +48,7 @@ contains:multiple tables with name "t": "postgres"."other"."t", "postgres"."publ
 
 > SHOW sources
  mz_source          postgres  ${arg.default-storage-size}
- mz_source_progress subsource <null>
+ mz_source_progress progress  <null>
  t                  subsource <null>
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -110,7 +110,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 25  create  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
 26  drop  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
 27  drop  view  {"database":"materialize","id":"u2","item":"renamed","schema":"public"}  materialize
-28  create  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public","size":null,"type":"subsource"}  materialize
+28  create  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public","size":null,"type":"progress"}  materialize
 29  create  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
 30  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","logical_size":"1","replica_id":"5","replica_name":"linked"}  materialize
 31  create  source  {"database":"materialize","id":"u8","item":"s","schema":"public","size":"1","type":"load-generator"}  materialize
@@ -126,7 +126,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 41  create  source  {"database":"materialize","id":"u11","item":"bids","schema":"public","size":null,"type":"subsource"}  materialize
 42  create  source  {"database":"materialize","id":"u12","item":"organizations","schema":"public","size":null,"type":"subsource"}  materialize
 43  create  source  {"database":"materialize","id":"u13","item":"users","schema":"public","size":null,"type":"subsource"}  materialize
-44  create  source  {"database":"materialize","id":"u14","item":"multiplex_progress","schema":"public","size":null,"type":"subsource"}  materialize
+44  create  source  {"database":"materialize","id":"u14","item":"multiplex_progress","schema":"public","size":null,"type":"progress"}  materialize
 45  create  cluster  {"id":"u4","name":"materialize_public_multiplex"}  materialize
 46  create  cluster-replica  {"cluster_id":"u4","cluster_name":"materialize_public_multiplex","logical_size":"1","replica_id":"7","replica_name":"linked"}  materialize
 47  create  source  {"database":"materialize","id":"u15","item":"multiplex","schema":"public","size":"1","type":"load-generator"}  materialize

--- a/test/sqllogictest/source_sizing.slt
+++ b/test/sqllogictest/source_sizing.slt
@@ -23,13 +23,13 @@ SELECT id, schema_id, name, type, connection_id, size FROM mz_sources WHERE id L
 ----
 u2  u3  s1  load-generator  NULL  1
 u4  u3  s2  load-generator  NULL  1
-u1  u3  s1_progress  subsource  NULL  NULL
-u3  u3  s2_progress  subsource  NULL  NULL
+u1  u3  s1_progress  progress   NULL  NULL
+u3  u3  s2_progress  progress   NULL  NULL
 
 query TTT
 SHOW SOURCES
 ----
-s1  load-generator  1
-s1_progress  subsource  NULL
-s2  load-generator  1
-s2_progress  subsource  NULL
+s1          load-generator  1
+s1_progress progress        NULL
+s2          load-generator  1
+s2_progress progress        NULL

--- a/test/sqllogictest/source_with_schema.slt
+++ b/test/sqllogictest/source_with_schema.slt
@@ -24,7 +24,7 @@ SHOW SOURCES FROM foo;
 ----
 accounts         subsource      NULL
 auction          load-generator 1
-auction_progress subsource      NULL
+auction_progress progress       NULL
 auctions         subsource      NULL
 bids             subsource      NULL
 organizations    subsource      NULL
@@ -41,7 +41,7 @@ query TTT
 SHOW SOURCES FROM bar;
 ----
 auction          load-generator 1
-auction_progress subsource      NULL
+auction_progress progress       NULL
 bids             subsource      NULL
 
 statement ok
@@ -59,7 +59,7 @@ query TTT
 SHOW SOURCES FROM baz;
 ----
 auction          load-generator 1
-auction_progress subsource      NULL
+auction_progress progress       NULL
 baz_bids         subsource      NULL
 
 query TTT

--- a/test/testdrive/get-started.td
+++ b/test/testdrive/get-started.td
@@ -15,7 +15,7 @@
 name          type           size
 ----------------------------------
 demo          load-generator ${arg.default-storage-size}
-demo_progress subsource      <null>
+demo_progress progress       <null>
 accounts      subsource      <null>
 auctions      subsource      <null>
 bids          subsource      <null>

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -15,7 +15,7 @@ ALTER SYSTEM SET enable_format_json = true
 > SHOW SOURCES
 accounts                subsource      <null>
 auction_house           load-generator ${arg.default-storage-size}
-auction_house_progress  subsource <null>
+auction_house_progress  progress       <null>
 auctions                subsource      <null>
 bids                    subsource      <null>
 organizations           subsource      <null>
@@ -27,7 +27,7 @@ users                   subsource      <null>
 
 > SHOW SOURCES FROM a;
 auction_bids            load-generator ${arg.default-storage-size}
-auction_bids_progress   subsource      <null>
+auction_bids_progress   progress       <null>
 bids                    subsource      <null>
 
 # For Tables with mentioned schema should work
@@ -37,7 +37,7 @@ bids                    subsource      <null>
 > SHOW SOURCES FROM another;
 accounts                subsource      <null>
 auction_house           load-generator ${arg.default-storage-size}
-auction_house_progress  subsource <null>
+auction_house_progress  progress       <null>
 auctions                subsource      <null>
 bids                    subsource      <null>
 organizations           subsource      <null>
@@ -52,7 +52,7 @@ users                   subsource      <null>
 
 > SHOW SOURCES FROM foo;
 auction_subset            load-generator ${arg.default-storage-size}
-auction_subset_progress   subsource      <null>
+auction_subset_progress   progress       <null>
 foo_bids                  subsource      <null>
 
 > SHOW SOURCES FROM bar;

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -338,9 +338,9 @@ a  b
 name     type    size
 ---------------------
 data              kafka     ${arg.default-storage-size}
-data_progress     subsource <null>
+data_progress     progress  <null>
 mat_data          kafka     ${arg.default-storage-size}
-mat_data_progress subsource <null>
+mat_data_progress progress  <null>
 
 # If there exists another index, dropping the primary index will not #
 # unmaterialize the source. This also tests creating a default index when the

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -190,8 +190,8 @@ renamed_sink
 > SHOW SOURCES;
 name               type   size
 ------------------------------
-renamed_mz_data    kafka  ${arg.default-storage-size}
-mz_data_progress   subsource <null>
+renamed_mz_data    kafka     ${arg.default-storage-size}
+mz_data_progress   progress  <null>
 
 # Sink was successfully renamed
 > SHOW SINKS

--- a/test/testdrive/tpch.td
+++ b/test/testdrive/tpch.td
@@ -30,7 +30,7 @@ name         type       size
 --------------------------------
  customer  subsource       <null>
  gen       load-generator  ${source-size}
- gen_progress  subsource       <null>
+ gen_progress  progress        <null>
  lineitem  subsource       <null>
  nation    subsource       <null>
  orders    subsource       <null>


### PR DESCRIPTION
We previously described progress collections' type as "subsource," however, that leave us with no means by which to differentiate progress subsources from user-data-bearing subsources. Instead, we can describe progress subsources' type as 'progress'.

cc @RobinClowers @SangJunBak just a heads up in case this need to coordinate with any changes to front end code that reads from `mz_sources`.

### Motivation

This PR adds a known-desirable feature. Implements #19542

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Describe progress collections' type as `progress` rather than `subsource` in `mz_sources`. This could be a breaking change for any introspection users have built themselves.
