### PR TITLE
feature-benchmark: Allow for benchmarking of feature flags, in particular MFP Pushdown

### DIFF
--- a/doc/developer/feature-benchmark.md
+++ b/doc/developer/feature-benchmark.md
@@ -48,6 +48,15 @@ To use a specific SIZE for sources, sinks and dataflows:
 ./mzcompose run default --this-size 2 --other-size 4 ...
 ```
 
+To benchmark specific product features:
+
+```
+./mzcompose run default --this-params="enable_upsert_source_disk=false;upsert_source_disk_default=false" --other-params="..."
+```
+
+Make sure to describe the desired state of any relevant flags exhaustively in order to avoid the unwanted
+interference of any defaults that may be in effect and that can change over time from release to release.
+
 ## Running manually in Buildkite
 
 Go to the [Buildkite Nightly Job](https://buildkite.com/materialize/nightlies), click the down arrow button

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -68,13 +68,14 @@ class Materialized(Service):
         ports: Optional[List[str]] = None,
         system_parameter_defaults: Optional[Dict[str, str]] = None,
         additional_system_parameter_defaults: Optional[Dict[str, str]] = None,
+        soft_assertions: bool = True,
     ) -> None:
         depends_on: Dict[str, ServiceDependency] = {
             s: {"condition": "service_started"} for s in depends_on
         }
 
         environment = [
-            "MZ_SOFT_ASSERTIONS=1",
+            f"MZ_SOFT_ASSERTIONS={int(soft_assertions)}",
             # TODO(benesch): remove the following environment variables
             # after v0.38 ships, since these environment variables will be
             # baked into the Docker image.

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -128,6 +128,7 @@ def run_one_scenario(
             default_size=size,
             # Avoid clashes with the Kafka sink progress topic across restarts
             environment_id=f"local-az1-{uuid.uuid4()}-0",
+            soft_assertions=False,
             additional_system_parameter_defaults=additional_system_parameter_defaults,
         )
 

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -62,6 +62,34 @@ true
         )
 
 
+class MFPPushdown(Scenario):
+    """Test MFP pushdown -- WHERE clause with a suitable condition and no index defined."""
+
+    SCALE = 7
+
+    def init(self) -> List[Action]:
+        return [
+            self.table_ten(),
+            TdAction(
+                f"""
+> CREATE MATERIALIZED VIEW v1 (f1, f2) AS SELECT {self.unique_values()} AS f1, 1 AS f2 FROM {self.join()}
+
+> SELECT COUNT(*) = {self.n()} FROM v1;
+true
+"""
+            ),
+        ]
+
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            """
+> /* A */ SELECT 1;
+1
+> /* B */ SELECT * FROM v1 WHERE f2 < 0;
+"""
+        )
+
+
 class FastPathFilterIndex(FastPath):
     """Measure the time it takes for the fast path to filter our all rows from a materialized view using an index and return"""
 


### PR DESCRIPTION
See individual commits:

```
commit 08ee4ebc14f1a19df2d09433eae6c38ebbd7ad46 (HEAD -> feature-benchmark-feature-flags, origin/feature-benchmark-feature-flags)
Author: Philip Stoev <pstoev@materialize.com>
Date:   Tue May 30 13:28:58 2023 +0200

    feature-benchmark: Add information on feature flags to the documentation

commit 44a5eb30de60e08b7582f72a32ba5fc272bec74a
Author: Philip Stoev <pstoev@materialize.com>
Date:   Tue May 30 13:15:22 2023 +0200

    feature-benchmark: Add a scenario for MFP pushdown
    
    Pushdown is triggered when:
    - no index is available to answer the query via FastPath
    - the WHERE clause contains a suitable predicate

commit d2146b2d849c86b6852cd54b27123cd1d1d9cd88
Author: Philip Stoev <pstoev@materialize.com>
Date:   Tue May 30 13:14:40 2023 +0200

    feature-benchmark: Disable soft assertions
    
    Soft assertions are sometimes computationally-intensive so will
    skew the results.

commit 579dea557572f14f5f752708c158382c912db186
Author: Philip Stoev <pstoev@materialize.com>
Date:   Mon May 29 10:24:41 2023 +0200

    feature-benchmark: Allow specifying system parameters
```

### Motivation

It was not possible to run a comparison between a feature enabled and a feature disabled.