### PR TITLE
adapter: add `mz_canceled_peeks_total` metric

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -492,6 +492,11 @@ impl crate::coord::Coordinator {
         // The peek is present on some specific compute instance.
         // Allow dataflow to cancel any pending peeks.
         if let Some(uuids) = self.client_pending_peeks.remove(&conn_id) {
+            self.metrics
+                .canceled_peeks
+                .with_label_values(&[])
+                .inc_by(u64::cast_from(uuids.len()));
+
             let mut inverse: BTreeMap<ComputeInstanceId, BTreeSet<Uuid>> = Default::default();
             for (uuid, compute_instance) in &uuids {
                 inverse.entry(*compute_instance).or_default().insert(*uuid);

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -24,6 +24,7 @@ pub struct Metrics {
     pub commands: IntCounterVec,
     pub storage_usage_collection_time_seconds: HistogramVec,
     pub subscribe_outputs: IntCounterVec,
+    pub canceled_peeks: IntCounterVec,
 }
 
 impl Metrics {
@@ -68,6 +69,10 @@ impl Metrics {
                 name: "mz_subscribe_outputs",
                 help: "The total number of different subscribe outputs used",
                 var_labels: ["session_type", "subscribe_output"],
+            )),
+            canceled_peeks: registry.register(metric!(
+                name: "mz_canceled_peeks_total",
+                help: "The total number of canceled peeks since process start.",
             )),
         }
     }


### PR DESCRIPTION
This metric counts the number of canceled peeks since the start of environmentd.

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/materialize/issues/19458.

### Tips for reviewer

This is the simplest useful metric to track how often users cancel `SELECT`s, and therefore how effective improvements to dataflow cancellation will be.

It would be nice to have a more general metric that is more broadly useful. I was initially planning to add an `mz_canceled_queries_total` metric that tracks all query cancellations and includes `session_type` and `stmt_type` labels to differentiate them, akin to `mz_query_total`. Unfortunately, I couldn't figure out how to implement this. I assume such a metric would need to be updated in `handle_cancel` but that method doesn't have access to the type of the session or the canceled statement. We could add this information to `ConnMeta`, but I'm not sure if it is meant for things like this?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
