### PR TITLE
compute: better temp buffer format in join

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7492,7 +7492,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#d5614b78adac5b6b9d7d707396000acbac2478d5"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#382d24fea39189719e5cedf5a606a3ed6f02133b"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7510,12 +7510,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#d5614b78adac5b6b9d7d707396000acbac2478d5"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#382d24fea39189719e5cedf5a606a3ed6f02133b"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#d5614b78adac5b6b9d7d707396000acbac2478d5"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#382d24fea39189719e5cedf5a606a3ed6f02133b"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7531,7 +7531,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#d5614b78adac5b6b9d7d707396000acbac2478d5"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#382d24fea39189719e5cedf5a606a3ed6f02133b"
 dependencies = [
  "columnation",
  "serde",
@@ -7540,7 +7540,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#d5614b78adac5b6b9d7d707396000acbac2478d5"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#382d24fea39189719e5cedf5a606a3ed6f02133b"
 
 [[package]]
 name = "tiny-keccak"


### PR DESCRIPTION
This commit slightly changes the format of the temp buffer used in `mz_join_core` from `((D, T), R)` to `(D, T, R)`, making it more convenient to use with the Timely/DD APIs.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Credits to @petrosagg who pointed this out to me.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
