### PR TITLE
[draft] Move monotonicity info to live directly on `UnaryFunc`

### DIFF
--- a/src/expr/src/explain/json.rs
+++ b/src/expr/src/explain/json.rs
@@ -53,17 +53,9 @@ where
                         "op": op,
                     });
 
-                    if let Some(PushdownInfo {
-                        pushdown,
-                        potential_pushdown,
-                    }) = pushdown_info
-                    {
+                    if let Some(PushdownInfo { pushdown }) = pushdown_info {
                         let object = json.as_object_mut().unwrap();
                         object.insert("pushdown".to_owned(), serde_json::json!(pushdown));
-                        object.insert(
-                            "potential_pushdown".to_owned(),
-                            serde_json::json!(potential_pushdown),
-                        );
                     }
 
                     json

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -965,6 +965,7 @@ mod tests {
         ScalarType::Bool,
         ScalarType::Jsonb,
         NUM_TYPE,
+        ScalarType::Date,
         ScalarType::Timestamp,
         ScalarType::MzTimestamp,
         ScalarType::String,
@@ -979,6 +980,7 @@ mod tests {
             UnaryFunc::CastJsonbToString(CastJsonbToString),
             UnaryFunc::DateTruncTimestamp(DateTruncTimestamp(DateTimeUnits::Epoch)),
             UnaryFunc::ExtractTimestamp(ExtractTimestamp(DateTimeUnits::Epoch)),
+            UnaryFunc::ExtractDate(ExtractDate(DateTimeUnits::Epoch)),
             UnaryFunc::Not(Not),
             UnaryFunc::IsNull(IsNull),
             UnaryFunc::IsFalse(IsFalse),
@@ -995,6 +997,7 @@ mod tests {
             ExtractTimestamp(_) | DateTruncTimestamp(_) => {
                 arg.scalar_type.base_eq(&ScalarType::Timestamp)
             }
+            ExtractDate(_) => arg.scalar_type.base_eq(&ScalarType::Date),
             Not(_) => arg.scalar_type.base_eq(&ScalarType::Bool),
             IsNull(_) => true,
             _ => false,

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4101,6 +4101,14 @@ trait LazyUnaryFunc {
     ///
     /// [inverse]: https://en.wikipedia.org/wiki/Inverse_function
     fn inverse(&self) -> Option<crate::UnaryFunc>;
+
+    /// Returns true if the function is monotone. (Non-strict; either increasing or decreasing.)
+    /// Monotone functions map ranges to ranges: ie. given a range of possible inputs, we can
+    /// determine the range of possible outputs just by mapping the endpoints.
+    ///
+    /// This property describes the behaviour of the function over ranges where the function is defined:
+    /// ie. the argument and the result are non-null (and non-error) datums.
+    fn is_monotone(&self) -> bool;
 }
 
 /// A description of an SQL unary function that operates on eagerly evaluated expressions
@@ -4132,6 +4140,10 @@ trait EagerUnaryFunc<'a> {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
+    }
+
+    fn is_monotone(&self) -> bool {
+        false
     }
 }
 
@@ -4172,6 +4184,10 @@ impl<T: for<'a> EagerUnaryFunc<'a>> LazyUnaryFunc for T {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         self.inverse()
+    }
+
+    fn is_monotone(&self) -> bool {
+        self.is_monotone()
     }
 }
 
@@ -7388,7 +7404,7 @@ impl VariadicFunc {
         }
     }
 
-    /// Returns true if the function is monotone. (Non-strict; eithern increasing or decreasing.)
+    /// Returns true if the function is monotone. (Non-strict; either increasing or decreasing.)
     /// Monotone functions map ranges to ranges: ie. given a range of possible inputs, we can
     /// determine the range of possible outputs just by mapping the endpoints.
     ///
@@ -7397,9 +7413,6 @@ impl VariadicFunc {
     /// any specific argument as the others are held constant. (For example, `COALESCE(a, b)` is
     /// monotone in `a` because for any particular non-null value of `b`, increasing `a` will never
     /// cause the result to decrease.)
-    ///
-    /// For monotone functions, this will return true whether the function is *non-decreasing*
-    /// or *non-increasing*.
     ///
     /// This property describes the behaviour of the function over ranges where the function is defined:
     /// ie. the arguments and the result are non-null (and non-error) datums.

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -77,6 +77,10 @@ impl LazyUnaryFunc for CastArrayToListOneDim {
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
     }
+
+    fn is_monotone(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for CastArrayToListOneDim {
@@ -128,6 +132,10 @@ impl LazyUnaryFunc for CastArrayToString {
         // TODO? If we moved typeconv into `expr` we could determine the right
         // inverse of this.
         None
+    }
+
+    fn is_monotone(&self) -> bool {
+        false
     }
 }
 
@@ -190,6 +198,10 @@ impl LazyUnaryFunc for CastArrayToArray {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
+    }
+
+    fn is_monotone(&self) -> bool {
+        false
     }
 }
 

--- a/src/expr/src/scalar/func/impls/boolean.rs
+++ b/src/expr/src/scalar/func/impls/boolean.rs
@@ -34,6 +34,7 @@ sqlfunc!(
     #[sqlname = "boolean_to_nonstandard_text"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastStringToBool)]
+    #[is_monotone = true]
     fn cast_bool_to_string_nonstandard<'a>(a: bool) -> &'a str {
         // N.B. this function differs from `cast_bool_to_string` because
         // the SQL specification requires `true` and `false` to be spelled out in

--- a/src/expr/src/scalar/func/impls/boolean.rs
+++ b/src/expr/src/scalar/func/impls/boolean.rs
@@ -13,6 +13,7 @@ sqlfunc!(
     #[sqlname = "NOT"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(Not)]
+    #[is_monotone = true]
     fn not(a: bool) -> bool {
         !a
     }
@@ -22,6 +23,7 @@ sqlfunc!(
     #[sqlname = "boolean_to_text"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastStringToBool)]
+    #[is_monotone = true]
     fn cast_bool_to_string<'a>(a: bool) -> &'a str {
         match a {
             true => "true",
@@ -48,6 +50,7 @@ sqlfunc!(
     #[sqlname = "boolean_to_integer"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt32ToBool)]
+    #[is_monotone = true]
     fn cast_bool_to_int32(a: bool) -> i32 {
         match a {
             true => 1,
@@ -60,6 +63,7 @@ sqlfunc!(
     #[sqlname = "boolean_to_bigint"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt64ToBool)]
+    #[is_monotone = true]
     fn cast_bool_to_int64(a: bool) -> i64 {
         match a {
             true => 1,

--- a/src/expr/src/scalar/func/impls/date.rs
+++ b/src/expr/src/scalar/func/impls/date.rs
@@ -37,6 +37,7 @@ sqlfunc!(
     #[sqlname = "date_to_timestamp"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastTimestampToDate)]
+    #[is_monotone = true]
     fn cast_date_to_timestamp(a: Date) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
         Ok(CheckedTimestamp::from_timestamplike(
             NaiveDate::from(a).and_hms_opt(0, 0, 0).unwrap(),
@@ -48,6 +49,7 @@ sqlfunc!(
     #[sqlname = "date_to_timestamp_with_timezone"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastTimestampTzToDate)]
+    #[is_monotone = true]
     fn cast_date_to_timestamp_tz(a: Date) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
         Ok(CheckedTimestamp::from_timestamplike(
             DateTime::<Utc>::from_utc(NaiveDate::from(a).and_hms_opt(0, 0, 0).unwrap(), Utc),

--- a/src/expr/src/scalar/func/impls/date.rs
+++ b/src/expr/src/scalar/func/impls/date.rs
@@ -19,6 +19,7 @@ use mz_repr::{strconv, ColumnType, ScalarType};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
+use crate::func::most_significant_unit;
 use crate::scalar::func::EagerUnaryFunc;
 use crate::EvalError;
 
@@ -104,6 +105,10 @@ impl<'a> EagerUnaryFunc<'a> for ExtractDate {
 
     fn output_type(&self, input: ColumnType) -> ColumnType {
         ScalarType::Numeric { max_scale: None }.nullable(input.nullable)
+    }
+
+    fn is_monotone(&self) -> bool {
+        most_significant_unit(self.0)
     }
 }
 

--- a/src/expr/src/scalar/func/impls/datum.rs
+++ b/src/expr/src/scalar/func/impls/datum.rs
@@ -13,6 +13,7 @@ use crate::EvalError;
 
 sqlfunc!(
     #[sqlname = "isnull"]
+    #[is_monotone = true]
     fn is_null<'a>(a: Datum<'a>) -> bool {
         a.is_null()
     }

--- a/src/expr/src/scalar/func/impls/float32.rs
+++ b/src/expr/src/scalar/func/impls/float32.rs
@@ -21,6 +21,7 @@ sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(NegFloat32)]
+    #[is_monotone = true]
     fn neg_float32(a: f32) -> f32 {
         -a
     }

--- a/src/expr/src/scalar/func/impls/float32.rs
+++ b/src/expr/src/scalar/func/impls/float32.rs
@@ -71,6 +71,7 @@ sqlfunc!(
     #[sqlname = "real_to_smallint"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastInt16ToFloat32)]
+    #[is_monotone = true]
     fn cast_float32_to_int16(a: f32) -> Result<i16, EvalError> {
         let f = round_float32(a);
         // TODO(benesch): remove potentially dangerous usage of `as`.
@@ -87,6 +88,7 @@ sqlfunc!(
     #[sqlname = "real_to_integer"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastInt32ToFloat32)]
+    #[is_monotone = true]
     fn cast_float32_to_int32(a: f32) -> Result<i32, EvalError> {
         let f = round_float32(a);
         // This condition is delicate because i32::MIN can be represented exactly by
@@ -107,6 +109,7 @@ sqlfunc!(
     #[sqlname = "real_to_bigint"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastInt64ToFloat32)]
+    #[is_monotone = true]
     fn cast_float32_to_int64(a: f32) -> Result<i64, EvalError> {
         let f = round_float32(a);
         // This condition is delicate because i64::MIN can be represented exactly by
@@ -127,6 +130,7 @@ sqlfunc!(
     #[sqlname = "real_to_double"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastFloat64ToFloat32)]
+    #[is_monotone = true]
     fn cast_float32_to_float64(a: f32) -> f64 {
         a.into()
     }
@@ -147,6 +151,7 @@ sqlfunc!(
     #[sqlname = "real_to_uint2"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastUint16ToFloat32)]
+    #[is_monotone = true]
     fn cast_float32_to_uint16(a: f32) -> Result<u16, EvalError> {
         let f = round_float32(a);
         // TODO(benesch): remove potentially dangerous usage of `as`.
@@ -163,6 +168,7 @@ sqlfunc!(
     #[sqlname = "real_to_uint4"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastUint32ToFloat32)]
+    #[is_monotone = true]
     fn cast_float32_to_uint32(a: f32) -> Result<u32, EvalError> {
         let f = round_float32(a);
         // TODO(benesch): remove potentially dangerous usage of `as`.
@@ -179,6 +185,7 @@ sqlfunc!(
     #[sqlname = "real_to_uint8"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastUint64ToFloat32)]
+    #[is_monotone = true]
     fn cast_float32_to_uint64(a: f32) -> Result<u64, EvalError> {
         let f = round_float32(a);
         // TODO(benesch): remove potentially dangerous usage of `as`.
@@ -220,6 +227,10 @@ impl<'a> EagerUnaryFunc<'a> for CastFloat32ToNumeric {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToFloat32)
+    }
+
+    fn is_monotone(&self) -> bool {
+        true
     }
 }
 

--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -75,6 +75,7 @@ sqlfunc!(
     #[sqlname = "double_to_smallint"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastInt16ToFloat64)]
+    #[is_monotone = true]
     fn cast_float64_to_int16(a: f64) -> Result<i16, EvalError> {
         let f = round_float64(a);
         // TODO(benesch): remove potentially dangerous usage of `as`.
@@ -91,6 +92,7 @@ sqlfunc!(
     #[sqlname = "double_to_integer"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastInt32ToFloat64)]
+    #[is_monotone = true]
     fn cast_float64_to_int32(a: f64) -> Result<i32, EvalError> {
         let f = round_float64(a);
         // This condition is delicate because i32::MIN can be represented exactly by
@@ -111,6 +113,7 @@ sqlfunc!(
     #[sqlname = "f64toi64"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastInt64ToFloat64)]
+    #[is_monotone = true]
     fn cast_float64_to_int64(a: f64) -> Result<i64, EvalError> {
         let f = round_float64(a);
         // This condition is delicate because i64::MIN can be represented exactly by
@@ -131,6 +134,7 @@ sqlfunc!(
     #[sqlname = "double_to_real"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastFloat32ToFloat64)]
+    #[is_monotone = true]
     fn cast_float64_to_float32(a: f64) -> Result<f32, EvalError> {
         // TODO(benesch): remove potentially dangerous usage of `as`.
         #[allow(clippy::as_conversions)]
@@ -160,6 +164,7 @@ sqlfunc!(
     #[sqlname = "double_to_uint2"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastUint16ToFloat64)]
+    #[is_monotone = true]
     fn cast_float64_to_uint16(a: f64) -> Result<u16, EvalError> {
         let f = round_float64(a);
         // TODO(benesch): remove potentially dangerous usage of `as`.
@@ -176,6 +181,7 @@ sqlfunc!(
     #[sqlname = "double_to_uint4"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastUint32ToFloat64)]
+    #[is_monotone = true]
     fn cast_float64_to_uint32(a: f64) -> Result<u32, EvalError> {
         let f = round_float64(a);
         // TODO(benesch): remove potentially dangerous usage of `as`.
@@ -192,6 +198,7 @@ sqlfunc!(
     #[sqlname = "double_to_uint8"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastUint64ToFloat64)]
+    #[is_monotone = true]
     fn cast_float64_to_uint64(a: f64) -> Result<u64, EvalError> {
         let f = round_float64(a);
         // TODO(benesch): remove potentially dangerous usage of `as`.
@@ -235,6 +242,10 @@ impl<'a> EagerUnaryFunc<'a> for CastFloat64ToNumeric {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToFloat64)
+    }
+
+    fn is_monotone(&self) -> bool {
+        true
     }
 }
 

--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -25,6 +25,7 @@ sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(NegFloat64)]
+    #[is_monotone = true]
     fn neg_float64(a: f64) -> f64 {
         -a
     }

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -21,6 +21,7 @@ sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(NegInt16)]
+    #[is_monotone = true]
     fn neg_int16(a: i16) -> Result<i16, EvalError> {
         a.checked_neg().ok_or(EvalError::Int16OutOfRange)
     }

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -46,6 +46,7 @@ sqlfunc!(
     #[sqlname = "smallint_to_real"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastFloat32ToInt16)]
+    #[is_monotone = true]
     fn cast_int16_to_float32(a: i16) -> f32 {
         f32::from(a)
     }
@@ -55,6 +56,7 @@ sqlfunc!(
     #[sqlname = "smallint_to_double"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastFloat64ToInt16)]
+    #[is_monotone = true]
     fn cast_int16_to_float64(a: i16) -> f64 {
         f64::from(a)
     }
@@ -64,6 +66,7 @@ sqlfunc!(
     #[sqlname = "smallint_to_integer"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt32ToInt16)]
+    #[is_monotone = true]
     fn cast_int16_to_int32(a: i16) -> i32 {
         i32::from(a)
     }
@@ -73,6 +76,7 @@ sqlfunc!(
     #[sqlname = "smallint_to_bigint"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt64ToInt16)]
+    #[is_monotone = true]
     fn cast_int16_to_int64(a: i16) -> i64 {
         i64::from(a)
     }
@@ -93,6 +97,7 @@ sqlfunc!(
     #[sqlname = "smallint_to_uint2"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint16ToInt16)]
+    #[is_monotone = true]
     fn cast_int16_to_uint16(a: i16) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -102,6 +107,7 @@ sqlfunc!(
     #[sqlname = "smallint_to_uint4"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint32ToInt16)]
+    #[is_monotone = true]
     fn cast_int16_to_uint32(a: i16) -> Result<u32, EvalError> {
         u32::try_from(a).or(Err(EvalError::UInt32OutOfRange))
     }
@@ -111,6 +117,7 @@ sqlfunc!(
     #[sqlname = "smallint_to_uint8"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint64ToInt16)]
+    #[is_monotone = true]
     fn cast_int16_to_uint64(a: i16) -> Result<u64, EvalError> {
         u64::try_from(a).or(Err(EvalError::UInt64OutOfRange))
     }
@@ -139,6 +146,10 @@ impl<'a> EagerUnaryFunc<'a> for CastInt16ToNumeric {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToInt16)
+    }
+
+    fn is_monotone(&self) -> bool {
+        true
     }
 }
 

--- a/src/expr/src/scalar/func/impls/int2vector.rs
+++ b/src/expr/src/scalar/func/impls/int2vector.rs
@@ -57,6 +57,10 @@ impl LazyUnaryFunc for CastInt2VectorToArray {
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
     }
+
+    fn is_monotone(&self) -> bool {
+        true // A noop is trivially monotone.
+    }
 }
 
 impl fmt::Display for CastInt2VectorToArray {
@@ -104,6 +108,10 @@ impl LazyUnaryFunc for CastInt2VectorToString {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastStringToInt2Vector)
+    }
+
+    fn is_monotone(&self) -> bool {
+        false
     }
 }
 

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -57,6 +57,7 @@ sqlfunc!(
     #[sqlname = "integer_to_real"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastFloat32ToInt32)]
+    #[is_monotone = true]
     fn cast_int32_to_float32(a: i32) -> f32 {
         // TODO(benesch): remove potentially dangerous usage of `as`.
         #[allow(clippy::as_conversions)]
@@ -70,6 +71,7 @@ sqlfunc!(
     #[sqlname = "integer_to_double"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastFloat64ToInt32)]
+    #[is_monotone = true]
     fn cast_int32_to_float64(a: i32) -> f64 {
         f64::from(a)
     }
@@ -79,6 +81,7 @@ sqlfunc!(
     #[sqlname = "integer_to_smallint"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt16ToInt32)]
+    #[is_monotone = true]
     fn cast_int32_to_int16(a: i32) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }
@@ -88,6 +91,7 @@ sqlfunc!(
     #[sqlname = "integer_to_bigint"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt64ToInt32)]
+    #[is_monotone = true]
     fn cast_int32_to_int64(a: i32) -> i64 {
         i64::from(a)
     }
@@ -108,6 +112,7 @@ sqlfunc!(
     #[sqlname = "integer_to_uint2"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint16ToInt32)]
+    #[is_monotone = true]
     fn cast_int32_to_uint16(a: i32) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -117,6 +122,7 @@ sqlfunc!(
     #[sqlname = "integer_to_uint4"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint32ToInt32)]
+    #[is_monotone = true]
     fn cast_int32_to_uint32(a: i32) -> Result<u32, EvalError> {
         u32::try_from(a).or(Err(EvalError::UInt32OutOfRange))
     }
@@ -126,6 +132,7 @@ sqlfunc!(
     #[sqlname = "integer_to_uint8"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint64ToInt32)]
+    #[is_monotone = true]
     fn cast_int32_to_uint64(a: i32) -> Result<u64, EvalError> {
         u64::try_from(a).or(Err(EvalError::UInt64OutOfRange))
     }
@@ -155,6 +162,10 @@ impl<'a> EagerUnaryFunc<'a> for CastInt32ToNumeric {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToInt32)
+    }
+
+    fn is_monotone(&self) -> bool {
+        true
     }
 }
 

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -23,6 +23,7 @@ sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(NegInt32)]
+    #[is_monotone = true]
     fn neg_int32(a: i32) -> Result<i32, EvalError> {
         a.checked_neg().ok_or(EvalError::Int32OutOfRange)
     }

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -56,6 +56,7 @@ sqlfunc!(
     #[sqlname = "bigint_to_smallint"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt16ToInt64)]
+    #[is_monotone = true]
     fn cast_int64_to_int16(a: i64) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }
@@ -65,6 +66,7 @@ sqlfunc!(
     #[sqlname = "bigint_to_integer"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt32ToInt64)]
+    #[is_monotone = true]
     fn cast_int64_to_int32(a: i64) -> Result<i32, EvalError> {
         i32::try_from(a).or(Err(EvalError::Int32OutOfRange))
     }
@@ -85,6 +87,7 @@ sqlfunc!(
     #[sqlname = "bigint_to_uint2"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint16ToInt64)]
+    #[is_monotone = true]
     fn cast_int64_to_uint16(a: i64) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -94,6 +97,7 @@ sqlfunc!(
     #[sqlname = "bigint_to_uint4"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint32ToInt64)]
+    #[is_monotone = true]
     fn cast_int64_to_uint32(a: i64) -> Result<u32, EvalError> {
         u32::try_from(a).or(Err(EvalError::UInt32OutOfRange))
     }
@@ -103,6 +107,7 @@ sqlfunc!(
     #[sqlname = "bigint_to_uint8"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint64ToInt64)]
+    #[is_monotone = true]
     fn cast_int64_to_uint64(a: i64) -> Result<u64, EvalError> {
         u64::try_from(a).or(Err(EvalError::UInt64OutOfRange))
     }
@@ -133,6 +138,10 @@ impl<'a> EagerUnaryFunc<'a> for CastInt64ToNumeric {
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToInt64)
     }
+
+    fn is_monotone(&self) -> bool {
+        true
+    }
 }
 
 impl fmt::Display for CastInt64ToNumeric {
@@ -145,6 +154,7 @@ sqlfunc!(
     #[sqlname = "bigint_to_real"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastFloat32ToInt64)]
+    #[is_monotone = true]
     fn cast_int64_to_float32(a: i64) -> f32 {
         // TODO(benesch): remove potentially dangerous usage of `as`.
         #[allow(clippy::as_conversions)]
@@ -158,6 +168,7 @@ sqlfunc!(
     #[sqlname = "bigint_to_double"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastFloat64ToInt64)]
+    #[is_monotone = true]
     fn cast_int64_to_float64(a: i64) -> f64 {
         // TODO(benesch): remove potentially dangerous usage of `as`.
         #[allow(clippy::as_conversions)]

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -22,6 +22,7 @@ sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(NegInt64)]
+    #[is_monotone = true]
     fn neg_int64(a: i64) -> Result<i64, EvalError> {
         a.checked_neg().ok_or(EvalError::Int64OutOfRange)
     }

--- a/src/expr/src/scalar/func/impls/jsonb.rs
+++ b/src/expr/src/scalar/func/impls/jsonb.rs
@@ -33,6 +33,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "jsonb_to_smallint"]
+    #[is_monotone = true]
     fn cast_jsonb_to_int16<'a>(a: JsonbRef<'a>) -> Result<i16, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_int16(a.into_inner()),
@@ -46,6 +47,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "jsonb_to_integer"]
+    #[is_monotone = true]
     fn cast_jsonb_to_int32<'a>(a: JsonbRef<'a>) -> Result<i32, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_int32(a.into_inner()),
@@ -59,6 +61,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "jsonb_to_bigint"]
+    #[is_monotone = true]
     fn cast_jsonb_to_int64<'a>(a: JsonbRef<'a>) -> Result<i64, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_int64(a.into_inner()),
@@ -72,6 +75,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "jsonb_to_real"]
+    #[is_monotone = true]
     fn cast_jsonb_to_float32<'a>(a: JsonbRef<'a>) -> Result<f32, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_float32(a.into_inner()),
@@ -85,6 +89,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "jsonb_to_double"]
+    #[is_monotone = true]
     fn cast_jsonb_to_float64<'a>(a: JsonbRef<'a>) -> Result<f64, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_float64(a.into_inner()),
@@ -126,6 +131,10 @@ impl<'a> EagerUnaryFunc<'a> for CastJsonbToNumeric {
     fn output_type(&self, input: ColumnType) -> ColumnType {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
+
+    fn is_monotone(&self) -> bool {
+        true
+    }
 }
 
 impl fmt::Display for CastJsonbToNumeric {
@@ -136,6 +145,7 @@ impl fmt::Display for CastJsonbToNumeric {
 
 sqlfunc!(
     #[sqlname = "jsonb_to_boolean"]
+    #[is_monotone = true]
     fn cast_jsonb_to_bool<'a>(a: JsonbRef<'a>) -> Result<bool, EvalError> {
         match a.into_datum() {
             Datum::True => Ok(true),

--- a/src/expr/src/scalar/func/impls/list.rs
+++ b/src/expr/src/scalar/func/impls/list.rs
@@ -60,6 +60,10 @@ impl LazyUnaryFunc for CastListToString {
         // TODO? if typeconv was in expr, we could determine this
         None
     }
+
+    fn is_monotone(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for CastListToString {
@@ -122,6 +126,10 @@ impl LazyUnaryFunc for CastList1ToList2 {
         // TODO: this could be figured out--might be easier after enum dispatch?
         None
     }
+
+    fn is_monotone(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for CastList1ToList2 {
@@ -170,6 +178,10 @@ impl LazyUnaryFunc for ListLength {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
+    }
+
+    fn is_monotone(&self) -> bool {
+        false
     }
 }
 

--- a/src/expr/src/scalar/func/impls/map.rs
+++ b/src/expr/src/scalar/func/impls/map.rs
@@ -60,6 +60,10 @@ impl LazyUnaryFunc for CastMapToString {
         // TODO? If we moved typeconv into expr, we could evaluate this
         None
     }
+
+    fn is_monotone(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for CastMapToString {
@@ -108,6 +112,10 @@ impl LazyUnaryFunc for MapLength {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
+    }
+
+    fn is_monotone(&self) -> bool {
+        false
     }
 }
 

--- a/src/expr/src/scalar/func/impls/mz_timestamp.rs
+++ b/src/expr/src/scalar/func/impls/mz_timestamp.rs
@@ -114,6 +114,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "step_mz_timestamp"]
     #[preserves_uniqueness = true]
+    #[is_monotone = true]
     fn step_mz_timestamp(a: Timestamp) -> Result<Timestamp, EvalError> {
         a.checked_add(1).ok_or(EvalError::MzTimestampStepOverflow)
     }

--- a/src/expr/src/scalar/func/impls/mz_timestamp.rs
+++ b/src/expr/src/scalar/func/impls/mz_timestamp.rs
@@ -42,6 +42,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "numeric_to_mz_timestamp"]
     #[preserves_uniqueness = true]
+    #[is_monotone = true]
     fn cast_numeric_to_mz_timestamp(a: Numeric) -> Result<Timestamp, EvalError> {
         // The try_into will error if the conversion is lossy (out of range or fractional).
         a.try_into().map_err(|_| EvalError::MzTimestampOutOfRange)
@@ -51,6 +52,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint8_to_mz_timestamp"]
     #[preserves_uniqueness = true]
+    #[is_monotone = true]
     fn cast_uint64_to_mz_timestamp(a: u64) -> Timestamp {
         a.into()
     }
@@ -59,6 +61,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint4_to_mz_timestamp"]
     #[preserves_uniqueness = true]
+    #[is_monotone = true]
     fn cast_uint32_to_mz_timestamp(a: u32) -> Timestamp {
         u64::from(a).into()
     }
@@ -67,6 +70,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_mz_timestamp"]
     #[preserves_uniqueness = true]
+    #[is_monotone = true]
     fn cast_int64_to_mz_timestamp(a: i64) -> Result<Timestamp, EvalError> {
         a.try_into().map_err(|_| EvalError::MzTimestampOutOfRange)
     }
@@ -75,6 +79,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_mz_timestamp"]
     #[preserves_uniqueness = true]
+    #[is_monotone = true]
     fn cast_int32_to_mz_timestamp(a: i32) -> Result<Timestamp, EvalError> {
         i64::from(a)
             .try_into()
@@ -84,6 +89,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "timestamp_tz_to_mz_timestamp"]
+    #[is_monotone = true]
     fn cast_timestamp_tz_to_mz_timestamp(
         a: CheckedTimestamp<DateTime<Utc>>,
     ) -> Result<Timestamp, EvalError> {
@@ -95,6 +101,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "timestamp_to_mz_timestamp"]
+    #[is_monotone = true]
     fn cast_timestamp_to_mz_timestamp(
         a: CheckedTimestamp<NaiveDateTime>,
     ) -> Result<Timestamp, EvalError> {

--- a/src/expr/src/scalar/func/impls/numeric.rs
+++ b/src/expr/src/scalar/func/impls/numeric.rs
@@ -23,6 +23,7 @@ sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(NegNumeric)]
+    #[is_monotone = true]
     fn neg_numeric(mut a: Numeric) -> Numeric {
         numeric::cx_datum().neg(&mut a);
         numeric::munge_numeric(&mut a).unwrap();
@@ -40,6 +41,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "ceilnumeric"]
+    #[is_monotone = true]
     fn ceil_numeric(mut a: Numeric) -> Numeric {
         // ceil will be nop if has no fractional digits.
         if a.exponent() >= 0 {
@@ -72,6 +74,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "floornumeric"]
+    #[is_monotone = true]
     fn floor_numeric(mut a: Numeric) -> Numeric {
         // floor will be nop if has no fractional digits.
         if a.exponent() >= 0 {
@@ -127,6 +130,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "roundnumeric"]
+    #[is_monotone = true]
     fn round_numeric(mut a: Numeric) -> Numeric {
         // round will be nop if has no fractional digits.
         if a.exponent() >= 0 {
@@ -139,6 +143,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "truncnumeric"]
+    #[is_monotone = true]
     fn trunc_numeric(mut a: Numeric) -> Numeric {
         // trunc will be nop if has no fractional digits.
         if a.exponent() >= 0 {

--- a/src/expr/src/scalar/func/impls/numeric.rs
+++ b/src/expr/src/scalar/func/impls/numeric.rs
@@ -169,6 +169,7 @@ sqlfunc!(
     #[sqlname = "numeric_to_smallint"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastInt16ToNumeric(None))]
+    #[is_monotone = true]
     fn cast_numeric_to_int16(mut a: Numeric) -> Result<i16, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -182,6 +183,7 @@ sqlfunc!(
     #[sqlname = "numeric_to_integer"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastInt32ToNumeric(None))]
+    #[is_monotone = true]
     fn cast_numeric_to_int32(mut a: Numeric) -> Result<i32, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -194,6 +196,7 @@ sqlfunc!(
     #[sqlname = "numeric_to_bigint"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastInt64ToNumeric(None))]
+    #[is_monotone = true]
     fn cast_numeric_to_int64(mut a: Numeric) -> Result<i64, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -206,6 +209,7 @@ sqlfunc!(
     #[sqlname = "numeric_to_real"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastFloat32ToNumeric(None))]
+    #[is_monotone = true]
     fn cast_numeric_to_float32(a: Numeric) -> Result<f32, EvalError> {
         let i = a.to_string().parse::<f32>().unwrap();
         if i.is_infinite() {
@@ -220,6 +224,7 @@ sqlfunc!(
     #[sqlname = "numeric_to_double"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastFloat64ToNumeric(None))]
+    #[is_monotone = true]
     fn cast_numeric_to_float64(a: Numeric) -> Result<f64, EvalError> {
         let i = a.to_string().parse::<f64>().unwrap();
         if i.is_infinite() {
@@ -245,6 +250,7 @@ sqlfunc!(
     #[sqlname = "numeric_to_uint2"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastUint16ToNumeric(None))]
+    #[is_monotone = true]
     fn cast_numeric_to_uint16(mut a: Numeric) -> Result<u16, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -258,6 +264,7 @@ sqlfunc!(
     #[sqlname = "numeric_to_uint4"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastUint32ToNumeric(None))]
+    #[is_monotone = true]
     fn cast_numeric_to_uint32(mut a: Numeric) -> Result<u32, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -270,6 +277,7 @@ sqlfunc!(
     #[sqlname = "numeric_to_uint8"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastUint64ToNumeric(None))]
+    #[is_monotone = true]
     fn cast_numeric_to_uint64(mut a: Numeric) -> Result<u64, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);

--- a/src/expr/src/scalar/func/impls/range.rs
+++ b/src/expr/src/scalar/func/impls/range.rs
@@ -61,6 +61,10 @@ impl LazyUnaryFunc for CastRangeToString {
         // TODO? if typeconv was in expr, we could determine this
         None
     }
+
+    fn is_monotone(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for CastRangeToString {
@@ -114,6 +118,10 @@ impl LazyUnaryFunc for RangeLower {
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
     }
+
+    fn is_monotone(&self) -> bool {
+        true // Ranges are sorted by lower first.
+    }
 }
 
 impl fmt::Display for RangeLower {
@@ -166,6 +174,10 @@ impl LazyUnaryFunc for RangeUpper {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
+    }
+
+    fn is_monotone(&self) -> bool {
+        false
     }
 }
 

--- a/src/expr/src/scalar/func/impls/record.rs
+++ b/src/expr/src/scalar/func/impls/record.rs
@@ -61,6 +61,10 @@ impl LazyUnaryFunc for CastRecordToString {
         // TODO? if we moved typeconv into expr, we could evaluate this
         None
     }
+
+    fn is_monotone(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for CastRecordToString {
@@ -117,6 +121,13 @@ impl LazyUnaryFunc for CastRecord1ToRecord2 {
         // TODO: we could determine Record1's type from `cast_exprs`
         None
     }
+
+    fn is_monotone(&self) -> bool {
+        // In theory this could be marked as monotone if we knew that all the expressions were
+        // monotone in the same direction. (ie. all increasing or all decreasing.) We don't yet
+        // track enough information to make that call, though!
+        false
+    }
 }
 
 impl fmt::Display for CastRecord1ToRecord2 {
@@ -170,6 +181,10 @@ impl LazyUnaryFunc for RecordGet {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
+    }
+
+    fn is_monotone(&self) -> bool {
+        false
     }
 }
 

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -294,6 +294,10 @@ impl LazyUnaryFunc for CastStringToArray {
             ty: self.return_ty.clone(),
         })
     }
+
+    fn is_monotone(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for CastStringToArray {
@@ -366,6 +370,10 @@ impl LazyUnaryFunc for CastStringToList {
         to_unary!(super::CastListToString {
             ty: self.return_ty.clone(),
         })
+    }
+
+    fn is_monotone(&self) -> bool {
+        false
     }
 }
 
@@ -447,6 +455,10 @@ impl LazyUnaryFunc for CastStringToMap {
         to_unary!(super::CastMapToString {
             ty: self.return_ty.clone(),
         })
+    }
+
+    fn is_monotone(&self) -> bool {
+        false
     }
 }
 
@@ -561,6 +573,10 @@ impl LazyUnaryFunc for CastStringToRange {
             ty: self.return_ty.clone(),
         })
     }
+
+    fn is_monotone(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for CastStringToRange {
@@ -672,6 +688,10 @@ impl LazyUnaryFunc for CastStringToInt2Vector {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastInt2VectorToString)
+    }
+
+    fn is_monotone(&self) -> bool {
+        false
     }
 }
 
@@ -878,6 +898,10 @@ impl LazyUnaryFunc for RegexpMatch {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
+    }
+
+    fn is_monotone(&self) -> bool {
+        false
     }
 }
 

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -50,6 +50,7 @@ sqlfunc!(
     #[sqlname = "timestamp_to_date"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastDateToTimestamp)]
+    #[is_monotone = true]
     fn cast_timestamp_to_date(a: CheckedTimestamp<NaiveDateTime>) -> Result<Date, EvalError> {
         Ok(a.date().try_into()?)
     }
@@ -59,6 +60,7 @@ sqlfunc!(
     #[sqlname = "timestamp_with_time_zone_to_date"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastDateToTimestampTz)]
+    #[is_monotone = true]
     fn cast_timestamp_tz_to_date(a: CheckedTimestamp<DateTime<Utc>>) -> Result<Date, EvalError> {
         Ok(a.naive_utc().date().try_into()?)
     }
@@ -68,6 +70,7 @@ sqlfunc!(
     #[sqlname = "timestamp_to_timestamp_with_time_zone"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastTimestampTzToTimestamp)]
+    #[is_monotone = true]
     fn cast_timestamp_to_timestamp_tz(
         a: CheckedTimestamp<NaiveDateTime>,
     ) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
@@ -81,6 +84,7 @@ sqlfunc!(
     #[sqlname = "timestamp_with_time_zone_to_timestamp"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastTimestampToTimestampTz)]
+    #[is_monotone = true]
     fn cast_timestamp_tz_to_timestamp(
         a: CheckedTimestamp<DateTime<Utc>>,
     ) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {

--- a/src/expr/src/scalar/func/impls/uint16.rs
+++ b/src/expr/src/scalar/func/impls/uint16.rs
@@ -30,6 +30,7 @@ sqlfunc!(
     #[sqlname = "uint2_to_real"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastFloat32ToUint16)]
+    #[is_monotone = true]
     fn cast_uint16_to_float32(a: u16) -> f32 {
         f32::from(a)
     }
@@ -39,6 +40,7 @@ sqlfunc!(
     #[sqlname = "uint2_to_double"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastFloat64ToUint16)]
+    #[is_monotone = true]
     fn cast_uint16_to_float64(a: u16) -> f64 {
         f64::from(a)
     }
@@ -48,6 +50,7 @@ sqlfunc!(
     #[sqlname = "uint2_to_uint4"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint32ToUint16)]
+    #[is_monotone = true]
     fn cast_uint16_to_uint32(a: u16) -> u32 {
         u32::from(a)
     }
@@ -57,6 +60,7 @@ sqlfunc!(
     #[sqlname = "uint2_to_uint8"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint64ToUint16)]
+    #[is_monotone = true]
     fn cast_uint16_to_uint64(a: u16) -> u64 {
         u64::from(a)
     }
@@ -66,6 +70,7 @@ sqlfunc!(
     #[sqlname = "uint2_to_smallint"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt16ToUint16)]
+    #[is_monotone = true]
     fn cast_uint16_to_int16(a: u16) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }
@@ -75,6 +80,7 @@ sqlfunc!(
     #[sqlname = "uint2_to_integer"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt32ToUint16)]
+    #[is_monotone = true]
     fn cast_uint16_to_int32(a: u16) -> i32 {
         i32::from(a)
     }
@@ -83,6 +89,7 @@ sqlfunc!(
     #[sqlname = "uint2_to_bigint"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt64ToUint16)]
+    #[is_monotone = true]
     fn cast_uint16_to_int64(a: u16) -> i64 {
         i64::from(a)
     }
@@ -122,6 +129,10 @@ impl<'a> EagerUnaryFunc<'a> for CastUint16ToNumeric {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToUint16)
+    }
+
+    fn is_monotone(&self) -> bool {
+        true
     }
 }
 

--- a/src/expr/src/scalar/func/impls/uint32.rs
+++ b/src/expr/src/scalar/func/impls/uint32.rs
@@ -30,6 +30,7 @@ sqlfunc!(
     #[sqlname = "uint4_to_real"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastFloat32ToUint32)]
+    #[is_monotone = true]
     fn cast_uint32_to_float32(a: u32) -> f32 {
         // TODO(benesch): remove potentially dangerous usage of `as`.
         #[allow(clippy::as_conversions)]
@@ -43,6 +44,7 @@ sqlfunc!(
     #[sqlname = "uint4_to_double"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastFloat64ToUint32)]
+    #[is_monotone = true]
     fn cast_uint32_to_float64(a: u32) -> f64 {
         f64::from(a)
     }
@@ -52,6 +54,7 @@ sqlfunc!(
     #[sqlname = "uint4_to_uint2"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint16ToUint32)]
+    #[is_monotone = true]
     fn cast_uint32_to_uint16(a: u32) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -61,6 +64,7 @@ sqlfunc!(
     #[sqlname = "uint4_to_uint8"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint64ToUint32)]
+    #[is_monotone = true]
     fn cast_uint32_to_uint64(a: u32) -> u64 {
         u64::from(a)
     }
@@ -70,6 +74,7 @@ sqlfunc!(
     #[sqlname = "uint4_to_smallint"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt16ToUint32)]
+    #[is_monotone = true]
     fn cast_uint32_to_int16(a: u32) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }
@@ -79,6 +84,7 @@ sqlfunc!(
     #[sqlname = "uint4_to_integer"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt32ToUint32)]
+    #[is_monotone = true]
     fn cast_uint32_to_int32(a: u32) -> Result<i32, EvalError> {
         i32::try_from(a).or(Err(EvalError::Int32OutOfRange))
     }
@@ -88,6 +94,7 @@ sqlfunc!(
     #[sqlname = "uint4_to_bigint"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt64ToUint32)]
+    #[is_monotone = true]
     fn cast_uint32_to_int64(a: u32) -> i64 {
         i64::from(a)
     }
@@ -128,6 +135,10 @@ impl<'a> EagerUnaryFunc<'a> for CastUint32ToNumeric {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToUint32)
+    }
+
+    fn is_monotone(&self) -> bool {
+        true
     }
 }
 

--- a/src/expr/src/scalar/func/impls/uint64.rs
+++ b/src/expr/src/scalar/func/impls/uint64.rs
@@ -30,6 +30,7 @@ sqlfunc!(
     #[sqlname = "uint8_to_real"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastFloat32ToUint64)]
+    #[is_monotone = true]
     fn cast_uint64_to_float32(a: u64) -> f32 {
         // TODO(benesch): remove potentially dangerous usage of `as`.
         #[allow(clippy::as_conversions)]
@@ -43,6 +44,7 @@ sqlfunc!(
     #[sqlname = "uint8_to_double"]
     #[preserves_uniqueness = false]
     #[inverse = to_unary!(super::CastFloat64ToUint64)]
+    #[is_monotone = true]
     fn cast_uint64_to_float64(a: u64) -> f64 {
         // TODO(benesch): remove potentially dangerous usage of `as`.
         #[allow(clippy::as_conversions)]
@@ -56,6 +58,7 @@ sqlfunc!(
     #[sqlname = "uint8_to_uint2"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint16ToUint64)]
+    #[is_monotone = true]
     fn cast_uint64_to_uint16(a: u64) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -65,6 +68,7 @@ sqlfunc!(
     #[sqlname = "uint8_to_uint4"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastUint32ToUint64)]
+    #[is_monotone = true]
     fn cast_uint64_to_uint32(a: u64) -> Result<u32, EvalError> {
         u32::try_from(a).or(Err(EvalError::UInt32OutOfRange))
     }
@@ -74,6 +78,7 @@ sqlfunc!(
     #[sqlname = "uint8_to_smallint"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt16ToUint64)]
+    #[is_monotone = true]
     fn cast_uint64_to_int16(a: u64) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }
@@ -83,6 +88,7 @@ sqlfunc!(
     #[sqlname = "uint8_to_integer"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt32ToUint64)]
+    #[is_monotone = true]
     fn cast_uint64_to_int32(a: u64) -> Result<i32, EvalError> {
         i32::try_from(a).or(Err(EvalError::Int32OutOfRange))
     }
@@ -92,6 +98,7 @@ sqlfunc!(
     #[sqlname = "uint8_to_bigint"]
     #[preserves_uniqueness = true]
     #[inverse = to_unary!(super::CastInt64ToUint64)]
+    #[is_monotone = true]
     fn cast_uint64_to_int64(a: u64) -> Result<i64, EvalError> {
         i64::try_from(a).or(Err(EvalError::Int64OutOfRange))
     }
@@ -132,6 +139,10 @@ impl<'a> EagerUnaryFunc<'a> for CastUint64ToNumeric {
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToUint64)
+    }
+
+    fn is_monotone(&self) -> bool {
+        true
     }
 }
 

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -317,6 +317,11 @@ macro_rules! derive_unary {
                     $(Self::$name(f) => LazyUnaryFunc::inverse(f),)*
                 }
             }
+            pub fn is_monotone(&self) -> bool {
+                match self {
+                    $(Self::$name(f) => LazyUnaryFunc::is_monotone(f),)*
+                }
+            }
         }
 
         impl fmt::Display for UnaryFunc {

--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -155,6 +155,22 @@ query T multiline
 EXPLAIN WITH(mfp_pushdown)
 SELECT content, insert_ms, delete_ms
 FROM events
+WHERE COALESCE(delete_ms, insert_ms) < mz_now();
+----
+Explained Query:
+  Filter (numeric_to_mz_timestamp(coalesce(#2, #1)) < mz_now())
+    Get materialize.public.events
+
+Source materialize.public.events
+  filter=((numeric_to_mz_timestamp(coalesce(#2, #1)) < mz_now()))
+  pushdown=((numeric_to_mz_timestamp(coalesce(#2, #1)) < mz_now()))
+
+EOF
+
+query T multiline
+EXPLAIN WITH(mfp_pushdown)
+SELECT content, insert_ms, delete_ms
+FROM events
 WHERE mz_now() < delete_ms + 10000
   AND mz_now() < delete_ms + 20000
   AND mz_now() < delete_ms + 30000


### PR DESCRIPTION
Followup to #19298, handling unary funcs.

There are a lot of monotone funcs! I suspect there are some remaining funcs that are monotone that I haven't annotated, but this should include:
- all the funcs that were previously annotated;
- easy-to-classify funcs like casts;
- some other functions that I feel like might be surprising if they don't work, like rounding.

At this point, since `is_monotone` returns `bool`, we can get rid of `Monotonic::Maybe` and similar.

### Motivation

See #19298 for context.

### Tips for reviewer

For correctness, it's especially important that func never returns true when the function is not monotonic. Let me know if there's any func you're not totally sure of!

It's less crucial that all monotonic functions are annotated, but still nice. Feel free to ask me to look at more functions or suggest new annotations as well, if something feels especially important for temporal filters.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
