### PR TITLE
sql: Fix NULL handling for contains privilege fn

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2522,7 +2522,7 @@ impl BinaryFunc {
                 input1_type.scalar_type.without_modifiers().nullable(true)
             }
 
-            MzAclItemContainsPrivilege => ScalarType::Bool.nullable(false)
+            MzAclItemContainsPrivilege => ScalarType::Bool.nullable(in_nullable)
         }
     }
 

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -161,6 +161,23 @@ SELECT mz_internal.make_mz_aclitem('sd98fas9df8', 's1', 'CREATE')
 query error unrecognized privilege type: "asdfa ljefioj"
 SELECT mz_internal.make_mz_aclitem('u1', 's1', 'asdfa ljefioj')
 
+# Test mz_acl_item_contains_privilege NULLs
+
+query B
+SELECT mz_internal.mz_acl_item_contains_privilege(NULL, 'SELECT')
+----
+NULL
+
+query B
+SELECT mz_internal.mz_acl_item_contains_privilege(mz_internal.make_mz_aclitem('u1', 'u2', 'CREATE'), NULL)
+----
+NULL
+
+query B
+SELECT mz_internal.mz_acl_item_contains_privilege(NULL, NULL)
+----
+NULL
+
 # Test default privileges
 
 ## Create some helper views


### PR DESCRIPTION
This commit fixes NULL handling for the mz_internal mz_acl_item_contains_privilege function.

Fixes #19568

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
