### PR TITLE
sql: Prevent panic in mz_error_if_null

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -5619,7 +5619,14 @@ fn error_if_null<'a>(
         .map(|e| e.eval(datums, temp_storage))
         .collect::<Result<Vec<_>, _>>()?;
     match datums[0] {
-        Datum::Null => Err(EvalError::Internal(datums[1].unwrap_str().to_string())),
+        Datum::Null => {
+            let err_msg = if datums[1].is_null() {
+                "unexpected NULL"
+            } else {
+                datums[1].unwrap_str()
+            };
+            Err(EvalError::Internal(err_msg.to_string()))
+        }
         _ => Ok(datums[0]),
     }
 }

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1565,6 +1565,9 @@ SELECT mz_internal.mz_error_if_null(1, '')
 ----
 1
 
+query error unexpected NULL
+SELECT mz_internal.mz_error_if_null(NULL, NULL)
+
 query B
 SELECT pg_backend_pid() > 0
 ----


### PR DESCRIPTION
This commit prevents a panic when the second parameter of mz_internal.mz_error_if_null is NULL.

Works towards resolving #19570

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
