### PR TITLE
Revert revert multi worker pg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,9 @@ name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -4931,6 +4934,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bincode",
+ "bytes",
  "bytesize",
  "chrono",
  "clap",

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -14,6 +14,7 @@ bench = false
 anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.68"
+bytes = { version = "1.3.0", features = ["serde"] }
 bytesize = "1.1.0"
 bincode = "1"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -249,7 +249,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 &debug_name,
                 primary_source_id,
                 description.clone(),
-                resume_upper,
+                resume_upper.clone(),
                 source_resume_upper,
                 storage_state,
             );
@@ -292,6 +292,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
             let health_token = crate::source::health_operator(
                 into_time_scope,
                 storage_state,
+                resume_upper,
                 primary_source_id,
                 &health_stream,
                 health_configs,

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -40,7 +40,6 @@ pub mod testscript;
 pub mod types;
 
 pub use kafka::KafkaSourceReader;
-pub use postgres::PostgresSourceReader;
 pub(crate) use source_reader_pipeline::health_operator;
 pub use source_reader_pipeline::{
     create_raw_source, RawSourceCreationConfig, SourceCreationParams, SourceStatistics,

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -7,1661 +7,365 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! Code to render the ingestion dataflow of a [`PostgresSourceConnection`]. The dataflow consists
+//! of multiple operators in order to take advantage of all the available workers.
+//!
+//! # Snapshot
+//!
+//! One part of the dataflow deals with snapshotting the tables involved in the ingestion. Each
+//! table that needs a snapshot is assigned to a specific worker which performs a `COPY` query
+//! and distributes the raw COPY bytes to all workers to decode the text encoded rows.
+//!
+//! For all tables that ended up being snapshotted the snapshot reader also emits a rewind request
+//! to the replication reader which will ensure that the requested portion of the replication
+//! stream is subtracted from the snapshot.
+//!
+//! See the [snapshot] module for more information on the snapshot strategy.
+//!
+//! # Replication
+//!
+//! The other part of the dataflow deals with reading the logical replication slot, which must
+//! happen from a single worker. The minimum amount of processing is performed from that worker
+//! and the data is then distributed among all workers for decoding.
+//!
+//! See the [replication] module for more information on the replication strategy.
+//!
+//! # Error handling
+//!
+//! There are two kinds of errors that can happen during ingestion that are represented as two
+//! separate error types:
+//!
+//! [`DefiniteError`]s are errors that happen during processing of a specific
+//! collection record at a specific LSN. These are the only errors that can ever end up in the
+//! error collection of a subsource.
+//!
+//! Transient errors are any errors that can happen for reasons that are unrelated to the data
+//! itself. This could be authentication failures, connection failures, etc. The only operators
+//! that can emit such errors are the `TableReader` and the `ReplicationReader` operators, which
+//! are the ones that talk to the external world. Both of these operators are built with the
+//! `AsyncOperatorBuilder::build_fallible` method which allows transient errors to be propagated
+//! upwards with the standard `?` operator without risking downgrading the capability and producing
+//! bogus frontiers.
+//!
+//! The error streams from both of those operators are published to the source status and also
+//! trigger a restart of the dataflow.
+//!
+//! ```text
+//!    ┏━━━━━━━━━━━━━━┓
+//!    ┃    table     ┃
+//!    ┃    reader    ┃
+//!    ┗━┯━━━━━━━━━━┯━┛
+//!      │          │rewind
+//!      │          │requests
+//!      │          ╰────╮
+//!      │             ┏━v━━━━━━━━━━━┓
+//!      │             ┃ replication ┃
+//!      │             ┃   reader    ┃
+//!      │             ┗━┯━━━━━━━━━┯━┛
+//!  COPY│           slot│         │
+//!  data│           data│         │
+//! ┏━━━━v━━━━━┓ ┏━━━━━━━v━━━━━┓   │
+//! ┃  COPY    ┃ ┃ replication ┃   │
+//! ┃ decoder  ┃ ┃   decoder   ┃   │
+//! ┗━━━━┯━━━━━┛ ┗━━━━━┯━━━━━━━┛   │
+//!      │snapshot     │replication│
+//!      │updates      │updates    │
+//!      ╰────╮    ╭───╯           │
+//!          ╭┴────┴╮              │
+//!          │concat│              │
+//!          ╰──┬───╯              │
+//!             │ data             │progress
+//!             │ output           │output
+//!             v                  v
+//! ```
+
 use std::any::Any;
 use std::collections::BTreeMap;
 use std::convert::Infallible;
-use std::error::Error;
-use std::future;
 use std::rc::Rc;
-use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
-use anyhow::{anyhow, bail};
-use differential_dataflow::{AsCollection, Collection};
-use futures::{StreamExt, TryStreamExt};
-use mz_expr::MirScalarExpr;
+use differential_dataflow::Collection;
+use mz_expr::{EvalError, MirScalarExpr};
 use mz_ore::error::ErrorExt;
-use mz_ore::future::TimeoutError;
-use mz_ore::task;
 use mz_postgres_util::desc::PostgresTableDesc;
-use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
-use mz_sql_parser::ast::display::AstDisplay;
-use mz_sql_parser::ast::Ident;
+use mz_postgres_util::PostgresError;
+use mz_repr::{Datum, Diff, Row};
+use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::errors::SourceErrorDetails;
 use mz_storage_client::types::sources::{MzOffset, PostgresSourceConnection, SourceTimestamp};
-use mz_timely_util::antichain::AntichainExt;
-use mz_timely_util::builder_async::OperatorBuilder as AsyncOperatorBuilder;
-use once_cell::sync::Lazy;
-use postgres_protocol::message::backend::{
-    LogicalReplicationMessage, ReplicationMessage, TupleData,
-};
-use timely::dataflow::operators::to_stream::Event;
-use timely::dataflow::operators::Capability;
+use serde::{Deserialize, Serialize};
+use timely::dataflow::operators::{Concat, Map};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
-use tokio::sync::mpsc::{Receiver, Sender};
-use tokio_postgres::error::DbError;
-use tokio_postgres::replication::LogicalReplicationStream;
+use tokio_postgres::error::SqlState;
 use tokio_postgres::types::PgLsn;
-use tokio_postgres::{Client, SimpleQueryMessage};
-use tracing::{info, warn};
+use tokio_postgres::{Client, SimpleQueryMessage, SimpleQueryRow};
 
-use crate::source::postgres::metrics::PgSourceMetrics;
-use crate::source::types::{HealthStatus, HealthStatusUpdate, SourceReaderMetrics, SourceRender};
+use crate::source::types::{HealthStatus, HealthStatusUpdate, SourceRender};
 use crate::source::{RawSourceCreationConfig, SourceMessage, SourceReaderError};
 
 mod metrics;
-
-/// Postgres epoch is 2000-01-01T00:00:00Z
-static PG_EPOCH: Lazy<SystemTime> = Lazy::new(|| UNIX_EPOCH + Duration::from_secs(946_684_800));
-
-/// How often a status update message should be sent to the server
-static FEEDBACK_INTERVAL: Duration = Duration::from_secs(30);
-
-/// The amount of time we should wait after the last received message before worrying about WAL lag
-static WAL_LAG_GRACE_PERIOD: Duration = Duration::from_secs(30);
-
-trait PgErrorExt {
-    fn is_definite(&self) -> bool;
-}
-
-impl PgErrorExt for tokio::time::error::Elapsed {
-    fn is_definite(&self) -> bool {
-        false
-    }
-}
-
-impl PgErrorExt for DbError {
-    fn is_definite(&self) -> bool {
-        let class = match self.code().code().get(0..2) {
-            None => return false,
-            Some(class) => class,
-        };
-        // See https://www.postgresql.org/docs/current/errcodes-appendix.html for the class
-        // definitions.
-        match class {
-            // unknown catalog or schema names
-            "3D" | "3F" => true,
-            // syntax error or access rule violation
-            "42" => true,
-            _ => false,
-        }
-    }
-}
-
-impl PgErrorExt for tokio_postgres::Error {
-    fn is_definite(&self) -> bool {
-        match self.source() {
-            Some(err) => match err.downcast_ref::<DbError>() {
-                Some(db_err) => db_err.is_definite(),
-                None => false,
-            },
-            // We have no information about what happened, it might be a fatal error or
-            // it might not. Unexpected errors can happen if the upstream crashes for
-            // example in which case we should retry.
-            //
-            // Therefore, we adopt a "indefinite unless proven otherwise" policy and
-            // keep retrying in the event of unexpected errors.
-            None => false,
-        }
-    }
-}
-
-impl PgErrorExt for std::io::Error {
-    fn is_definite(&self) -> bool {
-        match self.source() {
-            Some(err) => match err.downcast_ref::<tokio_postgres::Error>() {
-                Some(tokio_err) => tokio_err.is_definite(),
-                None => match err.downcast_ref::<DbError>() {
-                    Some(db_err) => db_err.is_definite(),
-                    None => false,
-                },
-            },
-            // We have no information about what happened, it might be a fatal error or
-            // it might not. Unexpected errors can happen if the upstream crashes for
-            // example in which case we should retry.
-            //
-            // Therefore, we adopt a "indefinite unless proven otherwise" policy and
-            // keep retrying in the event of unexpected errors.
-            None => false,
-        }
-    }
-}
-
-#[derive(Debug)]
-enum ReplicationError {
-    /// This error is definite: this source is permanently wedged.
-    /// Returning a definite error will cause the collection to become un-queryable.
-    Definite(anyhow::Error),
-    /// This error may or may not resolve itself in the future, and
-    /// should be retried instead of being added to the output.
-    Indefinite(anyhow::Error),
-    /// When this error happens we must halt
-    Irrecoverable(anyhow::Error),
-}
-
-impl<E: PgErrorExt + Into<anyhow::Error>> From<E> for ReplicationError {
-    fn from(err: E) -> Self {
-        if err.is_definite() {
-            Self::Definite(err.into())
-        } else {
-            Self::Indefinite(err.into())
-        }
-    }
-}
-
-trait ResultExt<T, E> {
-    fn err_definite(self) -> Result<T, ReplicationError>;
-    fn err_indefinite(self) -> Result<T, ReplicationError>;
-    fn err_irrecoverable(self) -> Result<T, ReplicationError>;
-}
-
-impl<T, E: Into<anyhow::Error>> ResultExt<T, E> for Result<T, E> {
-    fn err_definite(self) -> Result<T, ReplicationError> {
-        match self {
-            Ok(val) => Ok(val),
-            Err(err) => Err(ReplicationError::Definite(err.into())),
-        }
-    }
-    fn err_indefinite(self) -> Result<T, ReplicationError> {
-        match self {
-            Ok(val) => Ok(val),
-            Err(err) => Err(ReplicationError::Indefinite(err.into())),
-        }
-    }
-    fn err_irrecoverable(self) -> Result<T, ReplicationError> {
-        match self {
-            Ok(val) => Ok(val),
-            Err(err) => Err(ReplicationError::Irrecoverable(err.into())),
-        }
-    }
-}
-
-/// Message used to communicate between `get_next_message` and the tokio task
-#[derive(Debug)]
-enum InternalMessage {
-    /// A definite error for the source, i.e. not a subsource error.
-    Err(SourceReaderError),
-    Status(HealthStatusUpdate),
-    /// A value meant for a subsource.
-    Value {
-        lsn: PgLsn,
-        /// Errors sent here are meant to express a subsource error that occurred in the process of
-        /// decoding values, i.e. it is in lieu of a value. This contrasts with
-        /// `InternalEssage::Err`, which signals an error in the source itself, e.g. a programming
-        /// error.
-        value: Result<(Row, Diff), anyhow::Error>,
-        end: bool,
-    },
-}
-
-/// Information required to sync data from Postgres
-pub struct PostgresSourceReader {
-    receiver_stream: Receiver<(usize, InternalMessage)>,
-
-    /// The lsn we last emitted data at. Used to fabricate timestamps for errors. This should
-    /// ideally go away and only emit errors that we can associate with source timestamps
-    last_lsn: PgLsn,
-
-    /// Capabilities used to produce messages
-    data_capability: Capability<MzOffset>,
-    upper_capability: Capability<MzOffset>,
-}
-
-/// An OffsetCommitter for postgres, that sends
-/// the offsets (lsns) to the replication stream
-/// through a channel
-pub struct PgOffsetCommitter {
-    resume_lsn: Arc<AtomicU64>,
-}
-
-/// Information about an ingested upstream table
-#[derive(Debug)]
-struct SourceTable {
-    /// The source output index of this table
-    output_index: usize,
-    /// The relational description of this table
-    desc: PostgresTableDesc,
-    /// The scalar expressions required to cast the text encoded columns received from postgres
-    /// into the target relational types
-    casts: Vec<MirScalarExpr>,
-}
-
-/// An internal struct held by the spawned tokio task
-struct PostgresTaskInfo {
-    source_id: GlobalId,
-    connection_config: mz_postgres_util::Config,
-    publication: String,
-    slot: String,
-    /// Our cursor into the WAL
-    replication_lsn: PgLsn,
-    metrics: PgSourceMetrics,
-    /// A map of the table oid to its information.
-    ///
-    /// Note that we populate this information with state from the catalog, but only remove it if we
-    /// encounter errors during execution. This means it is possible for items to be removed during
-    /// one execution cycle, only to have them re-appear on restart. For instance, if we remove a
-    /// table because of an issue with its schema, and the operator then "fixes" the issue with the
-    /// schema, we will not remove the table during the next execution cycle. This isn't a large
-    /// concern because the fact that we never retract errors from subsources means that the source
-    /// never return readable values, though it will start sending data along its Ok stream again.
-    ///
-    /// At the time of writing, the plan is to resolve the above issue when we track each source
-    /// table's frontier independently; in that world, we can close the source table's frontier so
-    /// we have a durable signal that it should never produce any data.
-    source_tables: BTreeMap<u32, SourceTable>,
-    row_sender: RowSender,
-    sender: Sender<(usize, InternalMessage)>,
-    resume_lsn: Arc<AtomicU64>,
-}
+mod replication;
+mod snapshot;
 
 impl SourceRender for PostgresSourceConnection {
     type Key = ();
     type Value = Row;
     type Time = MzOffset;
 
+    /// Render the ingestion dataflow. This function only connects things together and contains no
+    /// actual processing logic.
     fn render<G: Scope<Timestamp = MzOffset>>(
         self,
         scope: &mut G,
         config: RawSourceCreationConfig,
-        connection_context: ConnectionContext,
+        context: ConnectionContext,
         resume_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
     ) -> (
-        Collection<
-            G,
-            (
-                usize,
-                Result<SourceMessage<Self::Key, Self::Value>, SourceReaderError>,
-            ),
-            Diff,
-        >,
+        Collection<G, (usize, Result<SourceMessage<(), Row>, SourceReaderError>), Diff>,
         Option<Stream<G, Infallible>>,
         Stream<G, (usize, HealthStatusUpdate)>,
         Rc<dyn Any>,
     ) {
-        let mut builder = AsyncOperatorBuilder::new(config.name.clone(), scope.clone());
+        let resume_upper =
+            Antichain::from_iter(config.source_resume_upper.iter().map(MzOffset::decode_row));
 
-        let (mut data_output, stream) = builder.new_output();
-        let (mut _upper_output, progress) = builder.new_output();
-        let (mut health_output, health_stream) = builder.new_output();
-
-        let button = builder.build(move |mut capabilities| async move {
-            let health_capability = capabilities.pop().unwrap();
-            let mut upper_capability = capabilities.pop().unwrap();
-            let mut data_capability = capabilities.pop().unwrap();
-            assert!(capabilities.is_empty());
-
-            if !config.responsible_for(()) {
-                return;
-            }
-
-            // TODO: figure out the best default here; currently this is optimized
-            // for the speed to pass pg-cdc-resumption tests on a local machine.
-            let (dataflow_tx, dataflow_rx) = tokio::sync::mpsc::channel(50_000);
-
-            let resume_upper =
-                Antichain::from_iter(config.source_resume_upper.iter().map(MzOffset::decode_row));
-            let Some(start_offset) = resume_upper.into_option() else {
-                return;
-            };
-            data_capability.downgrade(&start_offset);
-            upper_capability.downgrade(&start_offset);
-
-            let resume_lsn = Arc::new(AtomicU64::new(start_offset.offset));
-
-            let connection_config = match self
-                .connection
-                .config(&*connection_context.secrets_reader)
-                .await
-            {
-                Ok(config) => config,
-                Err(e) => {
-                    let update = HealthStatusUpdate {
-                        update: HealthStatus::StalledWithError {
-                            error: format!(
-                                "failed creating postgres config: {}",
-                                e.display_with_causes()
-                            ),
-                            hint: None,
-                        },
-                        should_halt: true,
-                    };
-                    let primary_output_index = 0;
-                    health_output.give(&health_capability, (primary_output_index, update)).await;
-                    // IMPORTANT: wedge forever until the `SuspendAndRestart` is processed.
-                    // Returning would incorrectly present to the remap operator as progress to the
-                    // empty frontier which would be incorrectly recorded to the remap shard.
-                    std::future::pending::<()>().await;
-                    unreachable!("pending future never returns");
-                }
-            };
-
-            let connection_config =
-                connection_config.replication_timeouts(config.params.pg_replication_timeouts);
-
-            let mut source_tables = BTreeMap::new();
-            let tables_iter = self.publication_details.tables.iter();
-
-            for (i, desc) in tables_iter.enumerate() {
-                let output_index = i + 1;
-                // We maintain descriptions for all tables in the publication,
-                // but only casts for those we aim to use (and have validated
-                // that their types are ingestable). This also prevents us from
-                // creating snapshots for tables in the publication that are
-                // not referenced in the source.
-                match self.table_casts.get(&output_index) {
-                    Some(casts) => {
-                        let source_table = SourceTable {
-                            output_index,
-                            desc: desc.clone(),
-                            casts: casts.to_vec(),
-                        };
-                        source_tables.insert(desc.oid, source_table);
-                    }
-                    None => continue,
-                }
-            }
-
-            let task_info = PostgresTaskInfo {
-                source_id: config.id,
-                connection_config,
-                publication: self.publication,
-                slot: self.publication_details.slot,
-                replication_lsn: start_offset.offset.into(),
-                metrics: PgSourceMetrics::new(&config.base_metrics, config.id),
-                source_tables,
-                row_sender: RowSender::new(dataflow_tx.clone()),
-                sender: dataflow_tx,
-                resume_lsn: Arc::clone(&resume_lsn),
-            };
-
-            task::spawn(|| format!("postgres_source:{}", config.id), {
-                postgres_replication_loop(task_info)
-            });
-
-            let source_metrics = SourceReaderMetrics::new(&config.base_metrics, config.id);
-            let offset_commit_metrics = source_metrics.offset_commit_metrics();
-
-            let mut reader = PostgresSourceReader {
-                receiver_stream: dataflow_rx,
-                last_lsn: start_offset.offset.into(),
-                data_capability,
-                upper_capability,
-            };
-
-            let offset_committer = PgOffsetCommitter { resume_lsn };
-            let offset_commit_loop = async move {
-                tokio::pin!(resume_uppers);
-                while let Some(frontier) = resume_uppers.next().await {
-                    tracing::trace!(
-                        "timely-{} source({}) committing offsets: resume_upper={}",
-                        config.id,
-                        config.worker_id,
-                        frontier.pretty()
-                    );
-                    if let Err(e) = offset_committer.commit_offsets(frontier.clone()) {
-                        offset_commit_metrics.offset_commit_failures.inc();
-                        tracing::warn!(
-                            %e,
-                            "timely-{} source({}) failed to commit offsets: resume_upper={}",
-                            config.id,
-                            config.worker_id,
-                            frontier.pretty()
-                        );
-                    }
-                }
-                // During dataflow shutdown this loop can end due to the general chaos caused by
-                // dropping tokens as a means to shutdown. This call ensures this future never ends
-                // and we instead rely on this operator being dropped altogether when *its* token
-                // is dropped.
-                std::future::pending::<()>().await;
-            };
-            tokio::pin!(offset_commit_loop);
-
-            loop {
-                tokio::select! {
-                    message = reader.receiver_stream.recv() => match message {
-                        Some((output_index, InternalMessage::Value {
-                            lsn,
-                            value,
-                            end,
-                        })) => {
-                            mz_ore::soft_assert!(
-                                output_index != 0,
-                                "InternalMessage::Value is meant only for subsources"
-                            );
-
-                            reader.last_lsn = lsn;
-                            let (msg, diff) = match value {
-                                Ok((row, diff)) => (
-                                    Ok(SourceMessage {
-                                        upstream_time_millis: None,
-                                        key: (),
-                                        value: row,
-                                        headers: None,
-                                    }),
-                                    diff,
-                                ),
-                                Err(err) => (Err(SourceReaderError::other_definite(err)), 1),
-                            };
-
-                            let ts = lsn.into();
-                            let cap = reader.data_capability.delayed(&ts);
-                            let next_ts = ts + 1;
-                            reader.upper_capability.downgrade(&next_ts);
-                            if end {
-                                reader.data_capability.downgrade(&next_ts);
-                            }
-                            data_output.give(&cap, ((output_index, msg), *cap.time(), diff)).await;
-                        }
-                        Some((output_index, InternalMessage::Status(update))) => {
-                            health_output.give(&health_capability, (output_index, update)).await;
-                        }
-                        Some((output_index, InternalMessage::Err(err))) => {
-                            mz_ore::soft_assert!(
-                                output_index == 0,
-                                "InternalMessage::Err is meant only for the primary source"
-                            );
-
-                            // XXX(petrosagg): we are fabricating a timestamp here!!
-                            let non_definite_ts = MzOffset::from(reader.last_lsn) + 1;
-
-                            let cap = reader.data_capability.delayed(&non_definite_ts);
-                            let next_ts = non_definite_ts + 1;
-                            reader.data_capability.downgrade(&next_ts);
-                            reader.upper_capability.downgrade(&next_ts);
-                            data_output.give(&cap, ((output_index, Err(err)), *cap.time(), 1)).await;
-                        }
-                        None => return,
-                    },
-                    // This future is not cancel safe but we are only passing a reference to it in
-                    // the select! loop so the future stays on the stack and never gets cancelled
-                    // until the end of the function.
-                    _ = offset_commit_loop.as_mut() => {},
-                }
-            }
-        });
-
-        (
-            stream.as_collection(),
-            Some(progress),
-            health_stream,
-            Rc::new(button.press_on_drop()),
-        )
-    }
-}
-
-impl PgOffsetCommitter {
-    fn commit_offsets(&self, frontier: Antichain<MzOffset>) -> Result<(), anyhow::Error> {
-        if let Some(offset) = frontier.as_option() {
-            // TODO(petrosagg): this minus one is very suspicious. It is replicating the previous
-            // behaviour where the commit offset was calculated by calling
-            // OffsetAntichain::as_data_offsets, which subtracted one. Investigate if it's truly
-            // needed
-            self.resume_lsn
-                .store(offset.offset.saturating_sub(1), Ordering::SeqCst);
-        }
-
-        Ok(())
-    }
-}
-
-/// Defers to `postgres_replication_loop_inner` and sends errors through the channel if they occur
-#[allow(clippy::or_fun_call)]
-async fn postgres_replication_loop(mut task_info: PostgresTaskInfo) {
-    loop {
-        // Signal that the source + its subsources are running. Note that this does not directly
-        // correlate with the ability to query a subsource; if a subsource errors due to a schema
-        // change, the schema gets "fixed" to make it compatible, and the source restarts, we will
-        // begin ingesting its values again (it will be "running"), but you will not be able to
-        // query the subsource.
-        for output_index in
-            std::iter::once(0).chain(task_info.source_tables.values().map(|t| t.output_index))
-        {
-            let _ = task_info
-                .sender
-                .send((
-                    output_index,
-                    InternalMessage::Status(HealthStatusUpdate {
-                        update: HealthStatus::Running,
-                        should_halt: false,
-                    }),
-                ))
-                .await;
-        }
-
-        match postgres_replication_loop_inner(&mut task_info).await {
-            Ok(()) => {}
-            Err(ReplicationError::Indefinite(e)) => {
-                warn!(
-                    "replication for source {} interrupted, retrying: {e}",
-                    task_info.source_id
-                );
-                // Indefinite errors affect all subsources.
-                for output_index in std::iter::once(0)
-                    .chain(task_info.source_tables.values().map(|t| t.output_index))
-                {
-                    // If the channel is shutting down, so is the source.
-                    let _ = task_info
-                        .sender
-                        .send((
-                            output_index,
-                            InternalMessage::Status(HealthStatusUpdate {
-                                update: HealthStatus::StalledWithError {
-                                    error: e.to_string_with_causes(),
-                                    hint: None,
-                                },
-                                should_halt: false,
-                            }),
-                        ))
-                        .await;
-                }
-            }
-            Err(ReplicationError::Irrecoverable(e)) => {
-                warn!(
-                    "irrecoverable error for source {}: {}, cause: {}",
-                    &task_info.source_id,
-                    e,
-                    e.source().unwrap_or(anyhow::anyhow!("unknown").as_ref())
-                );
-                // Irrecoverable errors affect all subsources.
-                for output_index in std::iter::once(0)
-                    .chain(task_info.source_tables.values().map(|t| t.output_index))
-                {
-                    // If the channel is shutting down, so is the source.
-                    let _ = task_info
-                        .sender
-                        .send((
-                            output_index,
-                            InternalMessage::Status(HealthStatusUpdate {
-                                update: HealthStatus::StalledWithError {
-                                    error: e.to_string_with_causes(),
-                                    hint: None,
-                                },
-                                // TODO: In the future we probably want to handle this more
-                                // gracefully, but for now halting is the easiest way to dump the
-                                // data in the pipe. The restarted clusterd instance will restart
-                                // the snapshot fresh, which will avoid any inconsistencies. Note
-                                // that if the same lsn is chosen in the next snapshotting, the
-                                // remapped timestamp chosen will be the same for both instances of
-                                // clusterd.
-                                //
-                                // Note that only the primary source halts, though all of them
-                                // error.
-                                should_halt: output_index == 0,
-                            }),
-                        ))
-                        .await;
-                }
-
-                future::pending().await
-            }
-            Err(ReplicationError::Definite(e)) => {
-                warn!(
-                    "definite error for source {}: {}, cause: {}",
-                    &task_info.source_id,
-                    e,
-                    e.source().unwrap_or(anyhow::anyhow!("unknown").as_ref())
-                );
-
-                // Close the replication LSN to ensure its buffer is clear.
-                task_info
-                    .row_sender
-                    .close_lsn(task_info.replication_lsn)
-                    .await;
-
-                // Invent an LSN to send these new definite errors at.
-                let non_definite_lsn = PgLsn::from(u64::from(task_info.replication_lsn) + 1);
-
-                // Definite errors affect all subsources in a way that they should be errored out.
-                for output_index in task_info.source_tables.values().map(|t| t.output_index) {
-                    // If the channel is shutting down, so is the source.
-                    let _ = task_info
-                        .row_sender
-                        .send_row(non_definite_lsn, output_index, Err(anyhow!(e.to_string())))
-                        .await;
-                }
-
-                // Close the LSN to "commit" the messages we just sent.
-                task_info.row_sender.close_lsn(non_definite_lsn).await;
-
-                // Drop the send error, as we have no way of communicating back to the
-                // source operator if the channel is gone.
-                let _ = task_info
-                    .row_sender
-                    .sender
-                    .send((
-                        0,
-                        InternalMessage::Err(SourceReaderError {
-                            inner: SourceErrorDetails::Initialization(e.to_string()),
-                        }),
-                    ))
-                    .await;
-                return;
+        // Collect the tables that we will be ingesting.
+        let mut table_info = BTreeMap::new();
+        let mut subsource_outputs = vec![];
+        for (i, desc) in self.publication_details.tables.iter().enumerate() {
+            // Index zero maps to the main source
+            let output_index = i + 1;
+            // The publication might contain more tables than the user has selected to ingest (via
+            // a restricted FOR TABLES <..>). The tables that are to be ingested will be present in
+            // the table_casts map and so we can filter the publication tables based on whether or
+            // not we have casts for it.
+            if let Some(casts) = self.table_casts.get(&output_index) {
+                table_info.insert(desc.oid, (output_index, desc.clone(), casts.clone()));
+                subsource_outputs.push(output_index);
             }
         }
-        // TODO(petrosagg): implement exponential back-off
-        tokio::time::sleep(Duration::from_secs(3)).await;
-    }
-}
 
-/// The logic to snapshot the PG collections.
-///
-/// Importantly this is broken out so we can ensure nothing returns an indefinite error, which can
-/// happen inadvertently.
-async fn postgres_replication_loop_inner_snapshot(
-    task_info: &mut PostgresTaskInfo,
-) -> Result<(), ReplicationError> {
-    // Verify relevant tables for this publication; we do this on every loop to cleanup source
-    // tables and very lazily detect dropped tables.
-    let publication_tables = mz_postgres_util::publication_info(
-        &task_info.connection_config,
-        &task_info.publication,
-        None,
-    )
-    .await
-    .err_indefinite()?;
-
-    // Validate publication tables against the state snapshot
-    let incompatible_tables =
-        determine_table_compatibility(task_info.source_tables.iter(), publication_tables);
-    for (id, output, err) in incompatible_tables {
-        task_info.source_tables.remove(&id);
-        task_info
-            .row_sender
-            .send_row(task_info.replication_lsn, output, Err(err))
-            .await;
-    }
-
-    let client = task_info
-        .connection_config
-        .clone()
-        .connect_replication()
-        .await
-        .err_indefinite()?;
-
-    // Technically there is TOCTOU problem here but it makes the code easier and if we end
-    // up attempting to create a slot and it already exists we will simply retry
-    // Also, we must check if the slot exists before we start a transaction because creating a
-    // slot must be the first statement in a transaction
-    let res = client
-        .simple_query(&format!(
-            r#"SELECT confirmed_flush_lsn FROM pg_replication_slots WHERE slot_name = '{}'"#,
-            task_info.slot
-        ))
-        .await?;
-    let slot_lsn = parse_single_row(&res, "confirmed_flush_lsn");
-    client
-        .simple_query("BEGIN READ ONLY ISOLATION LEVEL REPEATABLE READ;")
-        .await?;
-
-    let (slot_lsn, snapshot_lsn, temp_slot) = match slot_lsn {
-        Ok(slot_lsn) => {
-            // The main slot already exists which means we can't use it for the snapshot. So
-            // we'll create a temporary replication slot in order to both set the transaction's
-            // snapshot to be a consistent point and also to find out the LSN that the snapshot
-            // is going to run at.
-            //
-            // When this happens we'll most likely be snapshotting at a later LSN than the slot
-            // which we will take care below by rewinding.
-            let temp_slot = uuid::Uuid::new_v4().to_string().replace('-', "");
-            let res = client
-                .simple_query(&format!(
-                    r#"CREATE_REPLICATION_SLOT {:?} TEMPORARY LOGICAL "pgoutput" USE_SNAPSHOT"#,
-                    temp_slot
-                ))
-                .await?;
-            let snapshot_lsn = parse_single_row(&res, "consistent_point")?;
-            (slot_lsn, snapshot_lsn, Some(temp_slot))
-        }
-        Err(_) => {
-            let res = client
-                .simple_query(&format!(
-                    r#"CREATE_REPLICATION_SLOT {:?} LOGICAL "pgoutput" USE_SNAPSHOT"#,
-                    task_info.slot
-                ))
-                .await?;
-            let slot_lsn = parse_single_row(&res, "consistent_point")?;
-            (slot_lsn, slot_lsn, None)
-        }
-    };
-
-    // If we sent any messages earlier, we need to close that LSN to send the next messages from
-    // the slot.
-    if task_info.replication_lsn < slot_lsn {
-        task_info
-            .row_sender
-            .close_lsn(task_info.replication_lsn)
-            .await;
-    }
-
-    let mut stream = Box::pin(produce_snapshot(
-        &client,
-        &task_info.metrics,
-        &mut task_info.source_tables,
-        task_info.source_id,
-    ));
-
-    while let Some(event) = stream.as_mut().next().await {
-        let (output_index, value) = match event {
-            Ok(event) => event,
-            Err(err @ ReplicationError::Definite(_)) => return Err(err),
-            Err(ReplicationError::Indefinite(err) | ReplicationError::Irrecoverable(err)) => {
-                return Err(ReplicationError::Irrecoverable(err))
-            }
-        };
-        task_info
-            .row_sender
-            .send_row(slot_lsn, output_index, value)
-            .await
-    }
-
-    // Failure scenario after we have produced at least one row, but before a
-    // successful `COMMIT`
-    fail::fail_point!("pg_snapshot_failure", |_| {
-        Err(ReplicationError::Indefinite(anyhow::anyhow!(
-            "recoverable errors should crash the process during snapshots"
-        )))
-    });
-
-    if let Some(temp_slot) = temp_slot {
-        let _ = client
-            .simple_query(&format!("DROP_REPLICATION_SLOT {temp_slot:?}"))
-            .await;
-    }
-    client.simple_query("COMMIT;").await?;
-
-    // Drop the stream and the client, to ensure that the future `produce_replication` don't
-    // conflict with the above processing.
-    //
-    // Its possible we can avoid dropping the `client` value here, but we do it out of an
-    // abundance of caution, as rust-postgres has had curious bugs around this.
-    drop(stream);
-    drop(client);
-
-    assert!(slot_lsn <= snapshot_lsn);
-
-    // We only need to rewind values from the WAL if there are any values between the `slot_lsn`
-    // and `snapshot_lsn`. If there is nothing in the WAL for us to see between those times, we
-    // would just sit there dumbly waiting for a timeout.
-    if slot_lsn < snapshot_lsn
-        && peek_wal_lsns(
-            task_info.connection_config.clone(),
-            &task_info.slot,
-            &task_info.publication,
-            Some(snapshot_lsn),
-        )
-        .await
-        .err_irrecoverable()?
-        .count()
-            > 0
-    {
-        tracing::info!(
-            "postgres snapshot was at {snapshot_lsn:?} but we need it at {slot_lsn:?}. Rewinding"
+        let (snapshot_updates, rewinds, snapshot_err, snapshot_token) = snapshot::render(
+            scope.clone(),
+            config.clone(),
+            self.clone(),
+            context.clone(),
+            resume_upper.clone(),
+            table_info.clone(),
         );
-        // Our snapshot was too far ahead so we must rewind it by reading the replication
-        // stream until the snapshot lsn and emitting any rows that we find with negated diffs
-        let replication_stream = produce_replication(
-            task_info.connection_config.clone(),
-            &task_info.slot,
-            &task_info.publication,
-            slot_lsn,
-            Arc::clone(&task_info.resume_lsn),
-            &task_info.metrics,
-            &mut task_info.source_tables,
-            task_info.source_id,
-        )
-        .await;
-        tokio::pin!(replication_stream);
 
-        while let Some(event) = replication_stream.next().await {
-            match event {
-                Ok(Event::Message(lsn, (output_index, row))) => {
-                    // Here we ignore the lsn that this row actually happened at and we
-                    // forcefully emit it at the slot_lsn with a negated diff.
-                    if lsn <= snapshot_lsn {
-                        task_info
-                            .row_sender
-                            .send_row(slot_lsn, output_index, row.map(|(row, diff)| (row, -diff)))
-                            .await;
-                    }
-                }
-                Ok(Event::Progress([lsn])) => {
-                    if lsn > snapshot_lsn {
-                        // We successfully rewinded the snapshot from snapshot_lsn to slot_lsn
-                        task_info.row_sender.close_lsn(slot_lsn).await;
-                        break;
-                    }
-                }
-                Err(err @ ReplicationError::Definite(_)) => return Err(err),
-                Err(ReplicationError::Indefinite(err) | ReplicationError::Irrecoverable(err)) => {
-                    return Err(ReplicationError::Irrecoverable(err))
-                }
-            }
-        }
-    }
-    task_info.metrics.lsn.set(slot_lsn.into());
-    task_info.row_sender.close_lsn(slot_lsn).await;
+        let (repl_updates, uppers, repl_err, repl_token) = replication::render(
+            scope.clone(),
+            config,
+            self,
+            context,
+            resume_upper,
+            table_info,
+            &rewinds,
+            resume_uppers,
+        );
 
-    info!(
-        "replication snapshot for source {} succeeded",
-        &task_info.source_id
-    );
-    task_info.replication_lsn = slot_lsn;
-
-    Ok(())
-}
-
-/// Core logic
-async fn postgres_replication_loop_inner(
-    task_info: &mut PostgresTaskInfo,
-) -> Result<(), ReplicationError> {
-    if task_info.replication_lsn == PgLsn::from(0) {
-        match postgres_replication_loop_inner_snapshot(task_info).await {
-            // Snapshotting cannot, under any circmstance, return indefinite errors; everything must
-            // be restarted.
-            Err(ReplicationError::Indefinite(err)) => {
-                return Err(ReplicationError::Irrecoverable(err))
-            }
-            o => o?,
-        }
-    }
-
-    let replication_stream = produce_replication(
-        task_info.connection_config.clone(),
-        &task_info.slot,
-        &task_info.publication,
-        task_info.replication_lsn,
-        Arc::clone(&task_info.resume_lsn),
-        &task_info.metrics,
-        &mut task_info.source_tables,
-        task_info.source_id,
-    )
-    .await;
-    tokio::pin!(replication_stream);
-
-    // TODO(petrosagg): The API does not guarantee that we won't see an error after we have already
-    // partially emitted a transaction, but we know it is the case due to the implementation. Find
-    // a way to encode this in the type signature
-    while let Some(event) = replication_stream.next().await.transpose()? {
-        match event {
-            Event::Message(lsn, (output_index, row)) => {
-                task_info.row_sender.send_row(lsn, output_index, row).await;
-            }
-            Event::Progress([lsn]) => {
-                // The lsn passed to `START_REPLICATION_SLOT` produces all transactions that
-                // committed at LSNs *strictly after*, but upper frontiers have "greater than
-                // or equal" semantics, so we must subtract one from the upper to make it
-                // compatible with what `START_REPLICATION_SLOT` expects.
-                task_info.replication_lsn = PgLsn::from(u64::from(lsn) - 1);
-                task_info.row_sender.close_lsn(lsn).await;
-            }
-        }
-    }
-
-    Ok(())
-}
-
-struct RowMessage {
-    lsn: PgLsn,
-    output_index: usize,
-    value: Result<(Row, Diff), anyhow::Error>,
-}
-
-/// A type that makes it easy to correctly send inserts and deletes.
-///
-/// Note: `RowSender::delete/insert` should be called with the same
-/// lsn until `close_lsn` is called, which should be called and awaited
-/// before dropping the `RowSender` or moving onto a new lsn.
-/// Internally, this type uses asserts to uphold the first requirement.
-struct RowSender {
-    sender: Sender<(usize, InternalMessage)>,
-    buffered_message: Option<RowMessage>,
-}
-
-impl RowSender {
-    /// Create a new `RowSender`.
-    pub fn new(sender: Sender<(usize, InternalMessage)>) -> Self {
-        Self {
-            sender,
-            buffered_message: None,
-        }
-    }
-
-    /// Send a triplet for the specific output
-    pub async fn send_row(
-        &mut self,
-        lsn: PgLsn,
-        output_index: usize,
-        value: Result<(Row, Diff), anyhow::Error>,
-    ) {
-        if let Some(buffered) = self.buffered_message.take() {
-            assert_eq!(buffered.lsn, lsn);
-            self.send_row_inner(buffered.lsn, buffered.output_index, buffered.value, false)
-                .await;
-        }
-
-        self.buffered_message = Some(RowMessage {
-            lsn,
-            output_index,
-            value,
+        let updates = snapshot_updates.concat(&repl_updates).map(|(output, res)| {
+            let res = res.map(|row| SourceMessage {
+                upstream_time_millis: None,
+                key: (),
+                value: row,
+                headers: None,
+            });
+            (output, res)
         });
-    }
 
-    /// Finalize an lsn, making sure all messages that my be buffered are flushed, and that the
-    /// last message sent is marked as closing the `lsn` (which is the messages `offset` in the
-    /// rest of the source pipeline.
-    pub async fn close_lsn(&mut self, lsn: PgLsn) {
-        match self.buffered_message.take() {
-            Some(buffered) => {
-                assert!(buffered.lsn <= lsn);
-                self.send_row_inner(buffered.lsn, buffered.output_index, buffered.value, true)
-                    .await;
-            }
-            // We should still announce that we're running even if nothing else.
-            None => {
-                // If the channel is shutting down, so is the source.
-                let _ = self
-                    .sender
-                    .send((
-                        0,
-                        InternalMessage::Status(HealthStatusUpdate {
-                            update: HealthStatus::Running,
-                            should_halt: false,
-                        }),
-                    ))
-                    .await;
-            }
-        }
-    }
+        let health = snapshot_err.concat(&repl_err).flat_map(move |err| {
+            let update = HealthStatus::StalledWithError {
+                error: err.display_with_causes().to_string(),
+                hint: None,
+            };
+            // This update will cause the dataflow to restart
+            let halt_status = HealthStatusUpdate {
+                update: update.clone(),
+                should_halt: true,
+            };
+            let mut statuses = vec![(0, halt_status)];
 
-    async fn send_row_inner(
-        &self,
-        lsn: PgLsn,
-        output: usize,
-        value: Result<(Row, Diff), anyhow::Error>,
-        end: bool,
-    ) {
-        let message = InternalMessage::Value { lsn, value, end };
-        // a closed receiver means the source has been shutdown (dropped or the process is dying),
-        // so just continue on without activation
-        let _ = self.sender.send((output, message)).await;
+            // But we still want to report the transient error for all subsources
+            statuses.extend(subsource_outputs.iter().map(|index| {
+                let status = HealthStatusUpdate {
+                    update: update.clone(),
+                    should_halt: false,
+                };
+                (*index, status)
+            }));
+            statuses
+        });
+
+        let token = Rc::new((snapshot_token, repl_token));
+        (updates, Some(uppers), health, token)
     }
 }
 
-/// Determines if a set of [`SourceTable`]s and a set of [`PostgresTableDesc`] are compatible with
-/// one another in a way that Materialize can handle.
-///
-/// The returned tuples are `(a,b)`:
-/// - `a`: the ID of the incompatible table
-/// - `b`: the subsource error to propagate reflecting that the subsource is in an errored state
-fn determine_table_compatibility<'a, I>(
-    source_tables: I,
-    tables: Vec<PostgresTableDesc>,
-) -> Vec<(u32, usize, anyhow::Error)>
-where
-    I: Iterator<Item = (&'a u32, &'a SourceTable)>,
-{
-    let pub_tables: BTreeMap<u32, PostgresTableDesc> =
-        tables.into_iter().map(|t| (t.oid, t)).collect();
-    let mut errors = vec![];
-    for (id, info) in source_tables {
-        match pub_tables.get(id) {
-            Some(desc) => {
-                // Keep this method in sync with the Relation check in the replication stream.
-                if let Err(err) = info.desc.determine_compatibility(desc) {
-                    warn!(
-                        "Error validating table in publication. Expected: {:?} Actual: {:?}",
-                        &info.desc, desc
-                    );
-                    errors.push((*id, info.output_index, err));
-                }
-            }
-            None => {
-                warn!(
-                    "alter table error, table removed from upstream source: name {}, oid {}, old_schema {:?}",
-                    info.desc.name,
-                    info.desc.oid,
-                    info.desc.columns,
-                );
-                errors.push((
-                    *id,
-                    info.output_index,
-                    anyhow!(
-                        "source table {} with oid {} has been dropped",
-                        info.desc.name,
-                        info.desc.oid
-                    ),
-                ));
-            }
-        }
-    }
-    errors
+/// A transient error that never ends up in the collection of a specific table.
+#[derive(Debug, thiserror::Error)]
+pub enum TransientError {
+    #[error("replication slot mysteriously missing")]
+    MissingReplicationSlot,
+    #[error("slot overcompacted. Requested LSN {requested_lsn} but only LSNs >= {available_lsn} are available")]
+    OvercompactedReplicationSlot {
+        requested_lsn: MzOffset,
+        available_lsn: MzOffset,
+    },
+    #[error("stream ended prematurely")]
+    ReplicationEOF,
+    #[error("unexpected replication message")]
+    UnknownReplicationMessage,
+    #[error("unexpected logical replication message")]
+    UnknownLogicalReplicationMessage,
+    #[error("malformed logical replication message")]
+    MalformedReplicationMessage(#[source] std::io::Error),
+    #[error("transaction begun without BEGIN")]
+    UnmatchedTransaction,
+    #[error("received replication event outside of transaction")]
+    BareTransactionEvent,
+    #[error("lsn mismatch between BEGIN and COMMIT")]
+    InvalidTransaction,
+    #[error("BEGIN within existing BEGIN stream")]
+    NestedTransaction,
+    #[error("query returned more rows than expected")]
+    UnexpectedRow,
+    #[error("recoverable errors should crash the process during snapshots")]
+    SyntheticError,
+    #[error("sql client error")]
+    SQLClient(#[from] tokio_postgres::Error),
+    #[error(transparent)]
+    PostgresError(#[from] PostgresError),
+    #[error(transparent)]
+    Generic(#[from] anyhow::Error),
 }
 
-/// Parses SQL results that are expected to be a single row into a Rust type
-fn parse_single_row<T: FromStr>(
-    result: &[SimpleQueryMessage],
-    column: &str,
-) -> Result<T, ReplicationError> {
+/// A definite error that always ends up in the collection of a specific table.
+#[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error)]
+pub enum DefiniteError {
+    #[error("table was truncated")]
+    TableTruncated,
+    #[error("table was dropped")]
+    TableDropped,
+    #[error("publication {0:?} does not exist")]
+    PublicationDropped(String),
+    #[error("unexpected number of columns while parsing COPY output")]
+    MissingColumn,
+    #[error("failed to parse COPY protocol")]
+    InvalidCopyInput,
+    #[error("TOASTed value missing from old row. Did you forget to set REPLICA IDENTITY to FULL for your table?")]
+    MissingToast,
+    #[error("old row missing from replication stream. Did you forget to set REPLICA IDENTITY to FULL for your table?")]
+    DefaultReplicaIdentity,
+    #[error("incompatible schema change: {0}")]
+    // TODO: proper error variants for all the expected schema violations
+    IncompatibleSchema(String),
+    #[error("invalid UTF8 string: {0:?}")]
+    InvalidUTF8(Vec<u8>),
+    #[error("failed to cast raw column: {0}")]
+    CastError(#[source] EvalError),
+}
+
+impl From<DefiniteError> for SourceReaderError {
+    fn from(err: DefiniteError) -> Self {
+        SourceReaderError {
+            inner: SourceErrorDetails::Other(err.to_string()),
+        }
+    }
+}
+
+/// Ensures the replication slot of this connection is created.
+async fn ensure_replication_slot(client: &Client, slot: &str) -> Result<(), TransientError> {
+    let slot = Ident::from(slot).to_ast_string();
+    let query = format!("CREATE_REPLICATION_SLOT {slot} LOGICAL \"pgoutput\" NOEXPORT_SNAPSHOT");
+    match simple_query_opt(client, &query).await {
+        Ok(_) => Ok(()),
+        // If the slot already exists that's still ok
+        Err(TransientError::SQLClient(err)) if err.code() == Some(&SqlState::DUPLICATE_OBJECT) => {
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Fetches the minimum LSN at which this slot can safely resume.
+async fn fetch_slot_resume_lsn(client: &Client, slot: &str) -> Result<MzOffset, TransientError> {
+    loop {
+        let query = format!(
+            "SELECT confirmed_flush_lsn FROM pg_replication_slots WHERE slot_name = '{slot}'"
+        );
+        let Some(row) = simple_query_opt(client, &query).await? else {
+            return Err(TransientError::MissingReplicationSlot);
+        };
+
+        match row.get("confirmed_flush_lsn") {
+            // For postgres, `confirmed_flush_lsn` means that the slot is able to produce
+            // all transactions that happen at tx_lsn > confirmed_flush_lsn. Therefore the
+            // upper is confirmed_flush_lsn + 1
+            Some(flush_lsn) => return Ok(MzOffset::from(flush_lsn.parse::<PgLsn>().unwrap()) + 1),
+            // It can happen that confirmed_flush_lsn is NULL as the slot initializes
+            None => tokio::time::sleep(Duration::from_millis(500)).await,
+        };
+    }
+}
+
+// Ensures that the table with oid `oid` and expected schema `expected_schema` is still compatible
+// with the current upstream schema `upstream_info`.
+fn verify_schema(
+    oid: u32,
+    expected_desc: &PostgresTableDesc,
+    upstream_info: &BTreeMap<u32, PostgresTableDesc>,
+) -> Result<(), DefiniteError> {
+    let current_desc = upstream_info.get(&oid).ok_or(DefiniteError::TableDropped)?;
+
+    match expected_desc.determine_compatibility(current_desc) {
+        Ok(()) => Ok(()),
+        Err(err) => Err(DefiniteError::IncompatibleSchema(err.to_string())),
+    }
+}
+
+/// Runs the given query using the client and expects at most a single row to be returned.
+async fn simple_query_opt(
+    client: &Client,
+    query: &str,
+) -> Result<Option<SimpleQueryRow>, TransientError> {
+    let result = client.simple_query(query).await?;
     let mut rows = result.into_iter().filter_map(|msg| match msg {
         SimpleQueryMessage::Row(row) => Some(row),
         _ => None,
     });
     match (rows.next(), rows.next()) {
-        (Some(row), None) => row
-            .get(column)
-            .ok_or_else(|| anyhow!("missing expected column: {column}"))
-            .and_then(|col| col.parse().or_else(|_| Err(anyhow!("invalid data"))))
-            .err_indefinite(),
-        (None, None) => Err(anyhow!("empty result")).err_indefinite(),
-        _ => Err(anyhow!("ambiguous result, more than one row")).err_indefinite(),
+        (Some(row), None) => Ok(Some(row)),
+        (None, None) => Ok(None),
+        _ => Err(TransientError::UnexpectedRow),
     }
 }
 
-/// Produces the initial snapshot of the data by performing a `COPY` query for each of the provided
-/// `source_tables`.
-///
-/// The return stream of data returned is not annotated with LSN numbers. It is up to the caller to
-/// provide a client that is in a known LSN context in which the snapshot will be taken. For
-/// example by calling this method while being in a transaction for which the LSN is known.
-fn produce_snapshot<'a>(
-    client: &'a Client,
-    metrics: &'a PgSourceMetrics,
-    source_tables: &'a mut BTreeMap<u32, SourceTable>,
-    source_id: GlobalId,
-) -> impl futures::Stream<Item = Result<(usize, Result<(Row, Diff), anyhow::Error>), ReplicationError>>
-       + 'a {
-    async_stream::try_stream! {
-        // Scratch space to use while evaluating casts
-        let mut datum_vec = DatumVec::new();
-        let mut subsources_to_remove = vec![];
-
-        'tables: for (id, info) in source_tables.iter() {
-            // To handle quoted/keyword names, we can use `Ident`'s AST printing, which emulate's
-            // PG's rules for name formatting.
-            let copy_cmd = format!(
-                "COPY {}.{} TO STDOUT (FORMAT TEXT, DELIMITER '\t')",
-                Ident::from(info.desc.namespace.clone()).to_ast_string(),
-                Ident::from(info.desc.name.clone()).to_ast_string()
-            );
-
-            let reader = client
-                .copy_out_simple(
-                    copy_cmd
-                    .as_str(),
-                )
-                .await?;
-
-            tokio::pin!(reader);
-            let mut text_row = Row::default();
-            // TODO: once tokio-stream is released with https://github.com/tokio-rs/tokio/pull/4502
-            //    we can convert this into a single `timeout(...)` call on the reader CopyOutStream
-            while let Some(b) = tokio::time::timeout(Duration::from_secs(30), reader.next())
-                .await?
-                .transpose()?
-            {
-                // Try catch
-                let mut pack_row = || -> Result<(Row, Diff), anyhow::Error> {
-                    let mut packer = text_row.packer();
-                    // Convert raw rows from COPY into repr:Row. Each Row is a relation_id
-                    // and list of string-encoded values, e.g. Row{ 16391 , ["1", "2"] }
-                    let parser = mz_pgcopy::CopyTextFormatParser::new(b.as_ref(), "\t", "\\N");
-
-                    let mut raw_values = parser.iter_raw_truncating(info.desc.columns.len());
-                    while let Some(raw_value) = raw_values.next() {
-                        match raw_value.map_err(|e| if e.to_string() == "missing data for column" {
-                            anyhow!(
-                                "source table {} with oid {} has been altered",
-                                info.desc.name,
-                                id
-                            )
-                        } else {
-                             e.into()
-                        })? {
-                            Some(value) => {
-                                packer.push(Datum::String(std::str::from_utf8(value)?))
-                            }
-                            None => packer.push(Datum::Null),
-                        }
-                    }
-
-                    let mut datums = datum_vec.borrow();
-                    datums.extend(text_row.iter());
-
-                    Ok((cast_row(&info.casts, &datums)?, 1))
-                };
-
-                let row = pack_row();
-                let is_err = if let Err(e) = &row {
-                    warn!(
-                        "definite error for subsource of {} with oid {}: {}, cause: {}",
-                        source_id,
-                        id,
-                        e,
-                        e.source().unwrap_or(anyhow::anyhow!("unknown").as_ref())
-                    );
-                    true
-                } else {
-                    false
-                };
-                yield (info.output_index, row);
-                if is_err {
-                    subsources_to_remove.push(*id);
-                    continue 'tables;
-                }
-            }
-
-            metrics.tables.inc();
-        }
-
-        for id in subsources_to_remove {
-            source_tables.remove(&id);
-        }
-    }
-}
-
-/// Packs a Tuple received in the replication stream into a Row packer.
-fn datums_from_tuple<'a, T>(
-    rel_id: u32,
-    len: usize,
-    tuple_data: T,
-    datums: &mut Vec<Datum<'a>>,
-) -> Result<(), anyhow::Error>
-where
-    T: IntoIterator<Item = &'a TupleData>,
-{
-    for val in tuple_data.into_iter().take(len) {
-        let datum = match val {
-            TupleData::Null => Datum::Null,
-            TupleData::UnchangedToast => bail!(
-                "Missing TOASTed value from table with OID = {}. \
-                Did you forget to set REPLICA IDENTITY to FULL for your table?",
-                rel_id
-            ),
-            TupleData::Text(b) => std::str::from_utf8(b)?.into(),
-        };
-        datums.push(datum);
+/// Casts a text row into the target types
+fn cast_row(
+    casts: &[MirScalarExpr],
+    datums: &[Datum<'_>],
+    row: &mut Row,
+) -> Result<(), DefiniteError> {
+    let arena = mz_repr::RowArena::new();
+    let mut packer = row.packer();
+    for column_cast in casts {
+        let datum = column_cast
+            .eval(datums, &arena)
+            .map_err(DefiniteError::CastError)?;
+        packer.push(datum);
     }
     Ok(())
 }
 
-/// Casts a text row into the target types
-fn cast_row(table_cast: &[MirScalarExpr], datums: &[Datum<'_>]) -> Result<Row, anyhow::Error> {
-    let arena = mz_repr::RowArena::new();
-    let mut row = Row::default();
-    let mut packer = row.packer();
-    for column_cast in table_cast {
-        let datum = column_cast.eval(datums, &arena)?;
-        packer.push(datum);
+/// Converts raw bytes that are expected to be UTF8 encoded into a `Datum::String`
+fn decode_utf8_text(bytes: &[u8]) -> Result<Datum<'_>, DefiniteError> {
+    match std::str::from_utf8(bytes) {
+        Ok(text) => Ok(Datum::String(text)),
+        Err(_) => Err(DefiniteError::InvalidUTF8(bytes.to_vec())),
     }
-    Ok(row)
-}
-
-// TODO(guswynn|petrosagg): fix the underlying bug that prevents client re-use
-// when exiting the CopyBoth mode, so we don't need to re-create clients in every loop
-// in this function.
-async fn produce_replication<'a>(
-    client_config: mz_postgres_util::Config,
-    slot: &'a str,
-    publication: &'a str,
-    as_of: PgLsn,
-    committed_lsn: Arc<AtomicU64>,
-    metrics: &'a PgSourceMetrics,
-    source_tables: &'a mut BTreeMap<u32, SourceTable>,
-    source_id: GlobalId,
-) -> impl futures::Stream<
-    Item = Result<Event<[PgLsn; 1], (usize, Result<(Row, Diff), anyhow::Error>)>, ReplicationError>,
-> + 'a {
-    use ReplicationError::*;
-    use ReplicationMessage::*;
-    async_stream::try_stream!({
-        //let mut last_data_message = Instant::now();
-        let mut inserts = vec![];
-        let mut deletes = vec![];
-        let mut errors = vec![];
-
-        let mut last_feedback = Instant::now();
-
-        // Scratch space to use while evaluating casts
-        let mut datum_vec = DatumVec::new();
-
-        let mut last_commit_lsn = as_of;
-        let mut observed_wal_end = as_of;
-        // The outer loop alternates the client between streaming the replication slot and using
-        // normal SQL queries with pg admin functions to fast-foward our cursor in the event of WAL
-        // lag.
-        //
-        // TODO(petrosagg): we need to do the above because a replication slot can be active only
-        // one place which is why we need to do this dance of entering and exiting replication mode
-        // in order to be able to use the administrative functions below. Perhaps it's worth
-        // creating two independent slots so that we can use the secondary to check without
-        // interrupting the stream on the first one
-        loop {
-            // If either inserts or deletes have values, we have mishandled ingesting data and risk
-            // double-counting values.
-            if !inserts.is_empty() || !deletes.is_empty() || !errors.is_empty() {
-                return Err(Definite(anyhow!(
-                    "tried to reconnect to PG replication stream with uncommitted data",
-                )))?;
-            }
-
-            let client = client_config
-                .clone()
-                .connect_replication()
-                .await
-                .err_indefinite()?;
-            tracing::trace!("starting replication slot");
-            let query = format!(
-                r#"START_REPLICATION SLOT "{name}" LOGICAL {lsn}
-                      ("proto_version" '1', "publication_names" '{publication}')"#,
-                name = &slot,
-                lsn = last_commit_lsn,
-                publication = publication
-            );
-            let copy_stream = client.copy_both_simple(&query).await.err_indefinite()?;
-            let mut stream = Box::pin(LogicalReplicationStream::new(copy_stream));
-
-            let mut last_data_message = Instant::now();
-
-            // The inner loop
-            loop {
-                use LogicalReplicationMessage::*;
-                metrics.total.inc();
-
-                // Ensure no more than `FEEDBACK_INTERVAL` passes; if we exceed the deadline, we
-                // should let the upstream PG source know we're still here. This also gives us an
-                // opportunity to check that it's still alive.
-                let res = mz_ore::future::timeout(
-                    FEEDBACK_INTERVAL.saturating_sub(last_feedback.elapsed()),
-                    stream.as_mut().try_next(),
-                )
-                .await;
-
-                // The upstream will periodically request status updates by setting the keepalive's
-                // reply field to 1. However, we cannot rely on these messages arriving on time. For
-                // example, when the upstream is sending a big transaction its keepalive messages are
-                // queued and can be delayed arbitrarily. Therefore, we also make sure to
-                // send a proactive status update every 30 seconds There is an implicit requirement
-                // that a new resumption frontier is converted into an lsn relatively soon after
-                // startup.
-                //
-                // See: https://www.postgresql.org/message-id/CAMsr+YE2dSfHVr7iEv1GSPZihitWX-PMkD9QALEGcTYa+sdsgg@mail.gmail.com
-                let mut needs_status_update = last_feedback.elapsed() > FEEDBACK_INTERVAL;
-
-                // A gentle suggestion for how to properly handle subsource errors. This is
-                // annoyingly long because we can't capture anything.
-                macro_rules! handle_subsource_err {
-                    ($errors:expr, $source_tables:expr, $output_index:expr, $err:expr, $rel_id:expr) => {{
-                        warn!(
-                            "definite error for subsource of {} with oid {}: {}, cause: {}",
-                            source_id,
-                            $rel_id,
-                            $err,
-                            $err.source().unwrap_or(anyhow::anyhow!("unknown").as_ref())
-                        );
-                        $errors.push(($output_index, $err));
-                        $source_tables.remove(&$rel_id);
-                    }};
-                }
-
-                match res {
-                    Ok(Some(XLogData(xlog_data))) => match xlog_data.data() {
-                        Begin(_) => {
-                            last_data_message = Instant::now();
-                            if !inserts.is_empty() || !deletes.is_empty() {
-                                return Err(Definite(anyhow!(
-                                    "got BEGIN statement after uncommitted data"
-                                )))?;
-                            }
-                        }
-                        Insert(insert) if source_tables.contains_key(&insert.rel_id()) => {
-                            let rel_id = insert.rel_id();
-                            let info = source_tables.get(&rel_id).unwrap();
-                            last_data_message = Instant::now();
-                            metrics.inserts.inc();
-                            let new_tuple = insert.tuple().tuple_data();
-                            let mut datums = datum_vec.borrow();
-
-                            let mut gen_row = || -> Result<Row, anyhow::Error> {
-                                datums_from_tuple(
-                                    rel_id,
-                                    info.desc.columns.len(),
-                                    new_tuple,
-                                    &mut *datums,
-                                )?;
-                                cast_row(&info.casts, &datums)
-                            };
-
-                            match gen_row() {
-                                Ok(row) => inserts.push((info.output_index, row)),
-                                Err(err) => handle_subsource_err!(
-                                    errors,
-                                    source_tables,
-                                    info.output_index,
-                                    err,
-                                    rel_id
-                                ),
-                            }
-                        }
-                        Update(update) if source_tables.contains_key(&update.rel_id()) => {
-                            last_data_message = Instant::now();
-                            metrics.updates.inc();
-                            let rel_id = update.rel_id();
-                            let info = source_tables.get(&rel_id).unwrap();
-
-                            let mut gen_row = || -> Result<(Row, Row), anyhow::Error> {
-                                let err = || {
-                                    anyhow!(
-                                            "Old row missing from replication stream for table with OID = {}.
-                                             Did you forget to set REPLICA IDENTITY to FULL for your table?",
-                                            rel_id
-                                        )
-                                };
-                                let old_tuple = update.old_tuple().ok_or_else(err)?.tuple_data();
-
-                                let mut old_datums = datum_vec.borrow();
-                                datums_from_tuple(
-                                    rel_id,
-                                    info.desc.columns.len(),
-                                    old_tuple,
-                                    &mut *old_datums,
-                                )?;
-                                let old_row = cast_row(&info.casts, &old_datums)?;
-
-                                drop(old_datums);
-
-                                // If the new tuple contains unchanged toast values, reuse the ones
-                                // from the old tuple
-                                let new_tuple = update
-                                    .new_tuple()
-                                    .tuple_data()
-                                    .iter()
-                                    .zip(old_tuple.iter())
-                                    .map(|(new, old)| match new {
-                                        TupleData::UnchangedToast => old,
-                                        _ => new,
-                                    });
-                                let mut new_datums = datum_vec.borrow();
-                                datums_from_tuple(
-                                    rel_id,
-                                    info.desc.columns.len(),
-                                    new_tuple,
-                                    &mut *new_datums,
-                                )?;
-                                Ok((old_row, cast_row(&info.casts, &new_datums)?))
-                            };
-
-                            match gen_row() {
-                                Ok((old_row, new_row)) => {
-                                    deletes.push((info.output_index, old_row));
-                                    inserts.push((info.output_index, new_row));
-                                }
-                                Err(err) => handle_subsource_err!(
-                                    errors,
-                                    source_tables,
-                                    info.output_index,
-                                    err,
-                                    rel_id
-                                ),
-                            }
-                        }
-                        Delete(delete) if source_tables.contains_key(&delete.rel_id()) => {
-                            last_data_message = Instant::now();
-                            metrics.deletes.inc();
-                            let rel_id = delete.rel_id();
-                            let info = source_tables.get(&rel_id).unwrap();
-                            let mut gen_row = || -> Result<Row, anyhow::Error> {
-                                let err = || {
-                                    anyhow!(
-                                            "Old row missing from replication stream for table with OID = {}.
-                                             Did you forget to set REPLICA IDENTITY to FULL for your table?",
-                                            rel_id
-                                        )
-                                };
-                                let old_tuple = delete.old_tuple().ok_or_else(err)?.tuple_data();
-                                let mut datums = datum_vec.borrow();
-                                datums_from_tuple(
-                                    rel_id,
-                                    info.desc.columns.len(),
-                                    old_tuple,
-                                    &mut *datums,
-                                )?;
-                                cast_row(&info.casts, &datums)
-                            };
-
-                            match gen_row() {
-                                Ok(row) => deletes.push((info.output_index, row)),
-                                Err(err) => handle_subsource_err!(
-                                    errors,
-                                    source_tables,
-                                    info.output_index,
-                                    err,
-                                    rel_id
-                                ),
-                            };
-                        }
-                        Commit(commit) => {
-                            last_data_message = Instant::now();
-                            metrics.transactions.inc();
-                            last_commit_lsn = PgLsn::from(commit.end_lsn());
-
-                            for (output, row) in deletes.drain(..) {
-                                yield Event::Message(last_commit_lsn, (output, Ok((row, -1))));
-                            }
-                            for (output, row) in inserts.drain(..) {
-                                yield Event::Message(last_commit_lsn, (output, Ok((row, 1))));
-                            }
-                            for (output, err) in errors.drain(..) {
-                                yield Event::Message(last_commit_lsn, (output, Err(err)));
-                            }
-                            yield Event::Progress([PgLsn::from(u64::from(last_commit_lsn) + 1)]);
-                            metrics.lsn.set(last_commit_lsn.into());
-                        }
-                        Relation(relation) => {
-                            last_data_message = Instant::now();
-                            let rel_id = relation.rel_id();
-                            if let Some(info) = source_tables.get(&rel_id) {
-                                // Because the replication stream doesn't include columns'
-                                // attnums, we need to check the current local schema against
-                                // the current remote schema to ensure e.g. we haven't received
-                                // a schema update with the same terminal column name which is
-                                // actually a different column.
-                                let current_publication_info = mz_postgres_util::publication_info(
-                                    &client_config,
-                                    publication,
-                                    Some(rel_id),
-                                )
-                                .await
-                                .err_indefinite()?;
-
-                                // Validate publication tables against the state snapshot
-                                let incompatible_tables = determine_table_compatibility(
-                                    std::iter::once((&rel_id, info)),
-                                    current_publication_info,
-                                );
-                                for (rel_id, output_index, err) in incompatible_tables {
-                                    handle_subsource_err!(
-                                        errors,
-                                        source_tables,
-                                        output_index,
-                                        err,
-                                        rel_id
-                                    );
-                                }
-                            }
-                        }
-                        Insert(_) | Update(_) | Delete(_) | Origin(_) | Type(_) => {
-                            last_data_message = Instant::now();
-                            metrics.ignored.inc();
-                        }
-                        Truncate(truncate) => {
-                            let truncated_tables = truncate
-                                .rel_ids()
-                                .iter()
-                                // Filter here makes option handling in map "safe"
-                                .filter_map(|id| source_tables.get(id).map(|info| (id, info)))
-                                .map(|(id, info)| {
-                                    (
-                                        id,
-                                        info.output_index,
-                                        anyhow!(
-                                            "source table truncated: name: {} id: {}",
-                                            info.desc.name,
-                                            info.desc.oid
-                                        ),
-                                    )
-                                })
-                                .collect::<Vec<_>>();
-
-                            for (rel_id, output_index, err) in truncated_tables {
-                                handle_subsource_err!(
-                                    errors,
-                                    source_tables,
-                                    output_index,
-                                    err,
-                                    rel_id
-                                );
-                            }
-                        }
-                        // The enum is marked as non_exhaustive. Better to be conservative here in
-                        // case a new message is relevant to the semantics of our source
-                        _ => {
-                            return Err(Definite(anyhow!(
-                                "unexpected logical replication message"
-                            )))?;
-                        }
-                    },
-                    Ok(Some(PrimaryKeepAlive(keepalive))) => {
-                        needs_status_update = needs_status_update || keepalive.reply() == 1;
-                        // Irrespective of the WAL lag, we do not want to reconnect if we have
-                        // pending writes, nor do we want to consider fast-forwarding the WAL. If
-                        // the WAL lag is intense enough, we'll receive a TCP error.
-                        if inserts.is_empty() && deletes.is_empty() && errors.is_empty() {
-                            observed_wal_end = PgLsn::from(keepalive.wal_end());
-
-                            if last_data_message.elapsed() > WAL_LAG_GRACE_PERIOD {
-                                break;
-                            }
-                        }
-                    }
-                    // The enum is marked non_exhaustive, better be conservative
-                    Ok(Some(_)) => {
-                        return Err(Definite(anyhow!("Unexpected replication message")))?
-                    }
-                    Ok(None) => break,
-                    Err(TimeoutError::Inner(err)) => return Err(ReplicationError::from(err))?,
-                    Err(TimeoutError::DeadlineElapsed) => {
-                        // if we did timeout, skip message handling to let us continue polling, but do
-                        // ensure we perform a status update to heartbeat the upstream PG source.
-                        mz_ore::soft_assert!(
-                            needs_status_update,
-                            "if our request timed out, it must have been at least long enough to require \
-                             a status update"
-                        );
-                    }
-                }
-                if needs_status_update {
-                    let ts: i64 = PG_EPOCH
-                        .elapsed()
-                        .expect("system clock set earlier than year 2000!")
-                        .as_micros()
-                        .try_into()
-                        .expect("software more than 200k years old, consider updating");
-
-                    let committed_lsn = PgLsn::from(committed_lsn.load(Ordering::SeqCst));
-                    let standby_res = stream
-                        .as_mut()
-                        .standby_status_update(committed_lsn, committed_lsn, committed_lsn, ts, 0)
-                        .await;
-                    if let Err(err) = standby_res {
-                        return Err(Indefinite(err.into()))?;
-                    }
-                    last_feedback = Instant::now();
-                }
-            }
-            // This may not be required, but as mentioned above in
-            // `postgres_replication_loop_inner`, we drop clients aggressively out of caution.
-            drop(stream);
-
-            // We reach this place if the consume loop above detected large WAL lag. This
-            // section determines whether or not we can skip over that part of the WAL by
-            // peeking into the replication slot using a normal SQL query and the
-            // `pg_logical_slot_peek_binary_changes` administrative function.
-            //
-            // By doing so we can get a positive statement about existence or absence of
-            // relevant data from the current LSN to the observed WAL end. If there are no
-            // messages then it is safe to fast forward last_commit_lsn to the WAL end LSN and restart
-            // the replication stream from there.
-            let peek_binary_start_time = Instant::now();
-
-            let changes = peek_wal_lsns(client_config.clone(), slot, publication, None)
-                .await
-                .err_indefinite()?
-                .filter(|change_lsn| change_lsn > &last_commit_lsn)
-                .count();
-
-            // If there are no changes until the end of the WAL it's safe to fast forward
-            if changes == 0 {
-                last_commit_lsn = observed_wal_end;
-                // `Progress` events are _frontiers_, so we add 1, just like when we
-                // handle data in `Commit` above.
-                yield Event::Progress([PgLsn::from(u64::from(last_commit_lsn) + 1)]);
-            }
-
-            tracing::info!(
-                slot = ?slot,
-                query_time = ?peek_binary_start_time.elapsed(),
-                current_lsn = ?last_commit_lsn,
-                "Found {} changes in the wal.",
-                changes
-            );
-        }
-    })
-}
-
-/// Return a peek of all LSNs in the WAL beyond the current position.
-///
-/// If `up_to` is `None`, this will be all LSNs until the end of the log, otherwise will be up to
-/// the specified LSN.
-///
-/// For more details, see <https://pgpedia.info/p/pg_logical_slot_peek_binary_changes.html>.
-async fn peek_wal_lsns(
-    config: mz_postgres_util::Config,
-    slot: &str,
-    publication: &str,
-    up_to: Option<PgLsn>,
-) -> Result<impl Iterator<Item = PgLsn>, mz_postgres_util::PostgresError> {
-    let client = config.connect_replication().await?;
-    let query = format!(
-        "SELECT lsn FROM pg_logical_slot_peek_binary_changes(
-            '{}', {}, NULL,
-            'proto_version', '1',
-            'publication_names', '{}'
-        )",
-        slot,
-        match up_to {
-            Some(lsn) => format!("'{lsn}'"),
-            None => "NULL".to_string(),
-        },
-        publication,
-    );
-
-    let rows = client.simple_query(&query).await?;
-
-    Ok(rows.into_iter().filter_map(|row| match row {
-        SimpleQueryMessage::Row(row) => {
-            let lsn: PgLsn = row
-                .get("lsn")
-                .expect("missing expected column: `lsn`")
-                .parse()
-                .expect("invalid lsn");
-            Some(lsn)
-        }
-        SimpleQueryMessage::CommandComplete(_) => None,
-        _ => panic!("unexpected enum variant"),
-    }))
 }

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -1,0 +1,560 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Renders the logical replication side of the [`PostgresSourceConnection`] ingestion dataflow.
+//!
+//! ```text
+//!              o
+//!              │rewind
+//!              │requests
+//!          ╭───┴────╮
+//!          │exchange│ (collect all requests to one worker)
+//!          ╰───┬────╯
+//!           ┏━━v━━━━━━━━━━┓
+//!           ┃ replication ┃ (single worker)
+//!           ┃   reader    ┃
+//!           ┗━┯━━━━━━━━┯━━┛
+//!             │raw     │
+//!             │data    │
+//!        ╭────┴─────╮  │
+//!        │distribute│  │ (distribute to all workers)
+//!        ╰────┬─────╯  │
+//! ┏━━━━━━━━━━━┷━┓      │
+//! ┃ replication ┃      │ (parallel decode)
+//! ┃   decoder   ┃      │
+//! ┗━━━━━┯━━━━━━━┛      │
+//!       │ replication  │ progress
+//!       │ updates      │ output
+//!       v              v
+//! ```
+
+use std::any::Any;
+use std::collections::BTreeMap;
+use std::convert::Infallible;
+use std::pin::pin;
+use std::rc::Rc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use bytes::Bytes;
+use differential_dataflow::{AsCollection, Collection};
+use futures::{future, future::select, FutureExt, Stream as AsyncStream, StreamExt, TryStreamExt};
+use once_cell::sync::Lazy;
+use postgres_protocol::message::backend::{
+    LogicalReplicationMessage, ReplicationMessage, TupleData,
+};
+use serde::{Deserialize, Serialize};
+use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::operators::Capability;
+use timely::dataflow::{Scope, Stream};
+use timely::progress::Antichain;
+use tokio_postgres::replication::LogicalReplicationStream;
+use tokio_postgres::types::PgLsn;
+use tokio_postgres::Client;
+use tracing::{error, trace};
+
+use mz_expr::MirScalarExpr;
+use mz_ore::cast::CastFrom;
+use mz_ore::collections::HashSet;
+use mz_ore::result::ResultExt;
+use mz_postgres_util::desc::PostgresTableDesc;
+use mz_repr::{Datum, DatumVec, Diff, Row};
+use mz_sql_parser::ast::{display::AstDisplay, Ident};
+use mz_storage_client::types::connections::ConnectionContext;
+use mz_storage_client::types::sources::{MzOffset, PostgresSourceConnection};
+use mz_timely_util::builder_async::{Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder};
+use mz_timely_util::operator::StreamExt as TimelyStreamExt;
+
+use crate::source::postgres::verify_schema;
+use crate::source::postgres::{metrics::PgSourceMetrics, DefiniteError, TransientError};
+use crate::source::types::SourceReaderError;
+use crate::source::RawSourceCreationConfig;
+
+/// Postgres epoch is 2000-01-01T00:00:00Z
+static PG_EPOCH: Lazy<SystemTime> = Lazy::new(|| UNIX_EPOCH + Duration::from_secs(946_684_800));
+
+/// How often a proactive standby status update message should be sent to the server.
+///
+/// The upstream will periodically request status updates by setting the keepalive's reply field to
+/// 1. However, we cannot rely on these messages arriving on time. For example, when the upstream
+/// is sending a big transaction its keepalive messages are queued and can be delayed arbitrarily.
+///
+/// See: <https://www.postgresql.org/message-id/CAMsr+YE2dSfHVr7iEv1GSPZihitWX-PMkD9QALEGcTYa+sdsgg@mail.gmail.com>
+const FEEDBACK_INTERVAL: Duration = Duration::from_secs(30);
+
+/// The maximum amount of waiting for a transaction to appear in the replication stream before
+/// checking for replication lag.
+const TX_TIMEOUT: Duration = Duration::from_secs(30);
+
+// A request to rewind a snapshot taken at `snapshot_lsn` to the initial LSN of the replication
+// slot. This is accomplished by emitting `(data, 0, -diff)` for all updates `(data, lsn, diff)`
+// whose `lsn <= snapshot_lsn`. By convention the snapshot is always emitted at LSN 0.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct RewindRequest {
+    /// The table OID that should be rewound.
+    pub(crate) oid: u32,
+    /// The LSN that the snapshot was taken at.
+    pub(crate) snapshot_lsn: MzOffset,
+}
+
+/// Renders the replication dataflow. See the module documentation for more information.
+pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
+    scope: G,
+    config: RawSourceCreationConfig,
+    connection: PostgresSourceConnection,
+    context: ConnectionContext,
+    resume_upper: Antichain<MzOffset>,
+    table_info: BTreeMap<u32, (usize, PostgresTableDesc, Vec<MirScalarExpr>)>,
+    rewind_stream: &Stream<G, RewindRequest>,
+    committed_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
+) -> (
+    Collection<G, (usize, Result<Row, SourceReaderError>), Diff>,
+    Stream<G, Infallible>,
+    Stream<G, Rc<TransientError>>,
+    Rc<dyn Any>,
+) {
+    let op_name = format!("ReplicationReader({})", config.id);
+    let mut builder = AsyncOperatorBuilder::new(op_name, scope);
+
+    let slot_reader = u64::cast_from(config.responsible_worker("slot"));
+    let mut rewind_input = builder.new_input(rewind_stream, Exchange::new(move |_| slot_reader));
+    let (mut data_output, data_stream) = builder.new_output();
+    let (_upper_output, upper_stream) = builder.new_output();
+
+    let metrics = PgSourceMetrics::new(&config.base_metrics, config.id);
+    metrics.tables.set(u64::cast_from(table_info.len()));
+
+    let reader_table_info = table_info.clone();
+    let (button, errors) = builder.build_fallible(move |caps| {
+        let table_info = reader_table_info;
+        Box::pin(async move {
+            let (id, worker_id) = (config.id, config.worker_id);
+            let [data_cap, upper_cap]: &mut [_; 2] = caps.try_into().unwrap();
+            let (data_cap, upper_cap) = (data_cap.as_mut().unwrap(), upper_cap.as_mut().unwrap());
+
+            if !config.responsible_for("slot") {
+                return Ok(());
+            }
+
+            let Some(resume_lsn) = resume_upper.into_option() else {
+                return Ok(());
+            };
+            data_cap.downgrade(&resume_lsn);
+            upper_cap.downgrade(&resume_lsn);
+
+            let connection_config = connection
+                .connection
+                .config(&*context.secrets_reader)
+                .await?
+                .replication_timeouts(config.params.pg_replication_timeouts.clone());
+
+            let mut rewinds = BTreeMap::new();
+            while let Some(event) = rewind_input.next_mut().await {
+                if let AsyncEvent::Data(cap, data) = event {
+                    let cap = cap.retain_for_output(0);
+                    for req in data.drain(..) {
+                        assert!(
+                            resume_lsn <= req.snapshot_lsn,
+                            "slot compacted past snapshot point. snapshot_lsn={} resume_lsn={resume_lsn}", req.snapshot_lsn
+                        );
+                        rewinds.insert(req.oid, (cap.clone(), req));
+                    }
+                }
+            }
+
+            let mut committed_uppers = pin!(committed_uppers);
+
+            // This loop alternates  between streaming the replication slot and using normal SQL
+            // queries with pg admin functions to fast-foward our cursor in the event of WAL lag.
+            let client = connection_config.connect("replication metadata").await?;
+            loop {
+                if let Err(err) = ensure_publication_exists(&client, &connection.publication).await? {
+                    // If the publication gets deleted there is nothing else to do. These errors
+                    // are not retractable.
+                    for &oid in table_info.keys() {
+                        let update = ((oid, Err(err.clone())), *data_cap.time(), 1);
+                        data_output.give(data_cap, update).await;
+                    }
+                    return Ok(());
+                }
+
+                // We will peek the slot first to eagerly advance the frontier in case the stream
+                // is currently empty. This avoids needlesly holding back the capability and allows
+                // the rest of the ingestion pipeline to proceed immediately.
+                let slot = &connection.publication_details.slot;
+                advance_upper(&client, slot, &connection.publication, data_cap).await?;
+                upper_cap.downgrade(data_cap.time());
+                rewinds.retain(|_, (_, req)| data_cap.time() <= &req.snapshot_lsn);
+                trace!(%id, "timely-{worker_id} downgraded capability to {}", data_cap.time());
+                trace!(%id, "timely-{worker_id} pending rewinds {rewinds:?}");
+
+                let mut stream = pin!(raw_stream(
+                    &config,
+                    &connection_config,
+                    &client,
+                    slot,
+                    &connection.publication,
+                    *data_cap.time(),
+                    committed_uppers.as_mut()
+                )
+                .peekable());
+
+                let mut errored = HashSet::new();
+                let mut container = Vec::new();
+                let max_capacity = timely::container::buffer::default_capacity::<((u32, Result<Vec<Option<Bytes>>, DefiniteError>), MzOffset, Diff)>();
+
+                while let Ok(_) = tokio::time::timeout(TX_TIMEOUT, stream.as_mut().peek()).await {
+                    let mut new_upper = *data_cap.time();
+                    while let Some(event) = stream.as_mut().peek().now_or_never() {
+                        match event {
+                            Some(Ok(LogicalReplicationMessage::Begin(begin))) => {
+                                let tx_lsn = MzOffset::from(begin.final_lsn());
+                                let mut tx = pin!(extract_transaction(
+                                    stream.by_ref(),
+                                    &table_info,
+                                    &connection_config,
+                                    &metrics,
+                                    &connection.publication,
+                                    &mut errored
+                                ));
+
+                                trace!(%id, "timely-{worker_id} extracting transaction at {tx_lsn}");
+                                while let Some((oid, event, diff)) = tx.try_next().await? {
+                                    if !table_info.contains_key(&oid) {
+                                        continue;
+                                    }
+                                    let data = (oid, event);
+                                    if let Some((rewind_cap, req)) = rewinds.get(&oid) {
+                                        if tx_lsn <= req.snapshot_lsn {
+                                            let update = (data.clone(), MzOffset::from(0), -diff);
+                                            data_output.give(rewind_cap, update).await;
+                                        }
+                                    }
+                                    container.push((data, tx_lsn, diff));
+                                }
+                                new_upper = tx_lsn + 1;
+                                if container.len() > max_capacity {
+                                    data_output.give_container(data_cap, &mut container).await;
+                                    upper_cap.downgrade(&new_upper);
+                                    data_cap.downgrade(&new_upper);
+                                }
+                            }
+                            Some(Ok(_)) => return Err(TransientError::BareTransactionEvent),
+                            Some(Err(_)) => {
+                                return Err(stream.as_mut().next().await.unwrap().unwrap_err())
+                            }
+                            None => break,
+                        }
+                    }
+                    data_output.give_container(data_cap, &mut container).await;
+                    upper_cap.downgrade(&new_upper);
+                    data_cap.downgrade(&new_upper);
+                    rewinds.retain(|_, (_, req)| data_cap.time() <= &req.snapshot_lsn);
+                }
+            }
+        })
+    });
+
+    // Distribute the raw slot data to all workers and turn it into a collection
+    let raw_collection = data_stream.distribute().as_collection();
+
+    // We now process the slot updates and apply the cast expressions
+    let mut final_row = Row::default();
+    let mut datum_vec = DatumVec::new();
+    let replication_updates = raw_collection.map(move |(oid, event)| {
+        let (output_index, _, casts) = &table_info[&oid];
+        let event = event.and_then(|row| {
+            let mut datums = datum_vec.borrow();
+            for col in row.iter() {
+                let datum = col.as_deref().map(super::decode_utf8_text).transpose()?;
+                datums.push(datum.unwrap_or(Datum::Null));
+            }
+            super::cast_row(casts, &datums, &mut final_row)?;
+            Ok(final_row.clone())
+        });
+
+        (*output_index, event.err_into())
+    });
+
+    (
+        replication_updates,
+        upper_stream,
+        errors,
+        Rc::new(button.press_on_drop()),
+    )
+}
+
+/// Produces the logical replication stream while taking care of regularly sending standby
+/// keepalive messages with the provided `uppers` stream.
+///
+/// The returned stream will contain all transactions that whose commit LSN is beyond `resume_lsn`.
+fn raw_stream<'a>(
+    config: &'a RawSourceCreationConfig,
+    connection_config: &'a mz_postgres_util::Config,
+    metadata_client: &'a Client,
+    slot: &'a str,
+    publication: &'a str,
+    resume_lsn: MzOffset,
+    uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'a,
+) -> impl AsyncStream<Item = Result<LogicalReplicationMessage, TransientError>> + 'a {
+    async_stream::try_stream!({
+        let mut uppers = pin!(uppers);
+        let mut last_committed_upper = resume_lsn;
+
+        let replication_client = connection_config.connect_replication().await?;
+        super::ensure_replication_slot(&replication_client, slot).await?;
+
+        // Postgres will return all transactions that commit *strictly* after the provided LSN but
+        // we want to produce all transactions that commit *at or after* the provided LSN. We
+        // therefore subtract one.
+        let lsn = PgLsn::from(resume_lsn.offset.saturating_sub(1));
+        let query = format!(
+            r#"START_REPLICATION SLOT "{}" LOGICAL {} ("proto_version" '1', "publication_names" '{}')"#,
+            Ident::from(slot.clone()).to_ast_string(),
+            lsn,
+            publication,
+        );
+        let copy_stream = replication_client.copy_both_simple(&query).await?;
+        let mut stream = pin!(LogicalReplicationStream::new(copy_stream));
+
+        // According to the documentation [1] we must check that the slot LSN matches our
+        // expectations otherwise we risk getting silently fast-forwarded to a future LSN. In order
+        // to avoid a TOCTOU issue we must do this check after starting the replication stream. We
+        // cannot use the replication client to do that because it's already in CopyBoth mode.
+        // [1] https://www.postgresql.org/docs/15/protocol-replication.html#PROTOCOL-REPLICATION-START-REPLICATION-SLOT-LOGICAL
+        let min_resume_lsn = super::fetch_slot_resume_lsn(metadata_client, slot).await?;
+        if !(resume_lsn == MzOffset::from(0) || min_resume_lsn <= resume_lsn) {
+            let err = TransientError::OvercompactedReplicationSlot {
+                available_lsn: min_resume_lsn,
+                requested_lsn: resume_lsn,
+            };
+            error!("timely-{} ({}) {err}", config.worker_id, config.id);
+            Err(err)?;
+        }
+
+        let mut last_feedback = Instant::now();
+        loop {
+            let send_feedback = match select(stream.as_mut().next(), uppers.as_mut().next()).await {
+                future::Either::Left((next_message, _)) => match next_message.transpose()? {
+                    Some(ReplicationMessage::XLogData(data)) => {
+                        yield data.into_data();
+                        last_feedback.elapsed() > FEEDBACK_INTERVAL
+                    }
+                    Some(ReplicationMessage::PrimaryKeepAlive(keepalive)) => keepalive.reply() == 1,
+                    Some(_) => Err(TransientError::UnknownReplicationMessage)?,
+                    None => return,
+                },
+                future::Either::Right((upper, _)) => match upper.and_then(|u| u.into_option()) {
+                    Some(lsn) => {
+                        last_committed_upper = std::cmp::max(last_committed_upper, lsn);
+                        true
+                    }
+                    None => false,
+                },
+            };
+            if send_feedback {
+                let ts: i64 = PG_EPOCH.elapsed().unwrap().as_micros().try_into().unwrap();
+                // For the same reason as above, we must subtract one here too.
+                let lsn = PgLsn::from(last_committed_upper.offset.saturating_sub(1));
+                stream
+                    .as_mut()
+                    .standby_status_update(lsn, lsn, lsn, ts, 0)
+                    .await?;
+                last_feedback = Instant::now();
+            }
+        }
+    })
+}
+
+/// Extracts a single transaction from the replication stream delimited by a BEGIN and COMMIT message.
+fn extract_transaction<'a>(
+    stream: impl AsyncStream<Item = Result<LogicalReplicationMessage, TransientError>> + 'a,
+    table_info: &'a BTreeMap<u32, (usize, PostgresTableDesc, Vec<MirScalarExpr>)>,
+    connection_config: &'a mz_postgres_util::Config,
+    metrics: &'a PgSourceMetrics,
+    publication: &'a str,
+    errored_tables: &'a mut HashSet<u32>,
+) -> impl AsyncStream<
+    Item = Result<(u32, Result<Vec<Option<Bytes>>, DefiniteError>, Diff), TransientError>,
+> + 'a {
+    use LogicalReplicationMessage::*;
+    async_stream::try_stream!({
+        let mut stream = pin!(stream);
+        let commit_lsn = match stream.try_next().await? {
+            Some(Begin(body)) => body.final_lsn(),
+            Some(_) => Err(TransientError::UnmatchedTransaction)?,
+            None => Err(TransientError::ReplicationEOF)?,
+        };
+        metrics.transactions.inc();
+        metrics.lsn.set(commit_lsn.into());
+        while let Some(event) = stream.try_next().await? {
+            metrics.total.inc();
+            match event {
+                Insert(body) if errored_tables.contains(&body.rel_id()) => continue,
+                Update(body) if errored_tables.contains(&body.rel_id()) => continue,
+                Delete(body) if errored_tables.contains(&body.rel_id()) => continue,
+                Relation(body) if errored_tables.contains(&body.rel_id()) => continue,
+                Insert(body) => {
+                    metrics.inserts.inc();
+                    let row = unpack_tuple(body.tuple().tuple_data());
+                    yield (body.rel_id(), row, 1);
+                }
+                Update(body) => match body.old_tuple() {
+                    Some(old_tuple) => {
+                        metrics.updates.inc();
+                        // If the new tuple contains unchanged toast values we reference the old ones
+                        let new_tuple =
+                            std::iter::zip(body.new_tuple().tuple_data(), old_tuple.tuple_data())
+                                .map(|(new, old)| match new {
+                                    TupleData::UnchangedToast => old,
+                                    _ => new,
+                                });
+                        let old_row = unpack_tuple(old_tuple.tuple_data());
+                        yield (body.rel_id(), old_row, -1);
+                        let new_row = unpack_tuple(new_tuple);
+                        yield (body.rel_id(), new_row, 1);
+                    }
+                    None => {
+                        yield (body.rel_id(), Err(DefiniteError::DefaultReplicaIdentity), 1);
+                    }
+                },
+                Delete(body) => match body.old_tuple() {
+                    Some(old_tuple) => {
+                        metrics.deletes.inc();
+                        let row = unpack_tuple(old_tuple.tuple_data());
+                        yield (body.rel_id(), row, -1);
+                    }
+                    None => {
+                        yield (body.rel_id(), Err(DefiniteError::DefaultReplicaIdentity), 1);
+                    }
+                },
+                Relation(body) => {
+                    let rel_id = body.rel_id();
+                    if let Some((_, expected_desc, _)) = table_info.get(&rel_id) {
+                        // Because the replication stream doesn't include columns' attnums, we need
+                        // to check the current local schema against the current remote schema to
+                        // ensure e.g. we haven't received a schema update with the same terminal
+                        // column name which is actually a different column.
+                        let upstream_info = mz_postgres_util::publication_info(
+                            connection_config,
+                            publication,
+                            Some(rel_id),
+                        )
+                        .await?;
+                        let upstream_info = upstream_info.into_iter().map(|t| (t.oid, t)).collect();
+
+                        if let Err(err) = verify_schema(rel_id, expected_desc, &upstream_info) {
+                            errored_tables.insert(rel_id);
+                            yield (rel_id, Err(err), 1);
+                        }
+                    }
+                }
+                Truncate(body) => {
+                    for &rel_id in body.rel_ids() {
+                        if errored_tables.insert(rel_id) {
+                            yield (rel_id, Err(DefiniteError::TableTruncated), 1);
+                        }
+                    }
+                }
+                Commit(body) => {
+                    if commit_lsn != body.commit_lsn() {
+                        Err(TransientError::InvalidTransaction)?
+                    }
+                    return;
+                }
+                // TODO: We should handle origin messages and emit an error as they indicate that
+                // the upstream performed a point in time restore so all bets are off about the
+                // continuity of the stream.
+                Origin(_) | Type(_) => metrics.ignored.inc(),
+                Begin(_) => Err(TransientError::NestedTransaction)?,
+                // The enum is marked as non_exhaustive. Better to be conservative
+                _ => Err(TransientError::UnknownLogicalReplicationMessage)?,
+            }
+        }
+        Err(TransientError::ReplicationEOF)?;
+    })
+}
+
+/// Discovers LSN of the next replication stream update that happens beyond `start_lsn`. If there
+/// is no such update the current upper LSN is returned.
+async fn advance_upper(
+    client: &Client,
+    slot: &str,
+    publication: &str,
+    cap: &mut Capability<MzOffset>,
+) -> Result<(), TransientError> {
+    // Figure out the last written LSN and then add one to convert it into an upper.
+    let row = client.query_one("SELECT pg_current_wal_lsn()", &[]).await?;
+    let last_write: PgLsn = row.get("pg_current_wal_lsn");
+    let pg_upper = PgLsn::from(u64::from(last_write) + 1);
+
+    // `pg_logical_slot_peek_binary_changes` will include only those transactions which commit
+    // *prior* to the specified LSN. i.e (commit_lsn < pg_upper).
+    let query = format!(
+        "SELECT data FROM pg_logical_slot_peek_binary_changes(
+        '{slot}', '{pg_upper}', NULL, 'proto_version', '1', 'publication_names', '{publication}')"
+    );
+    let rows = client.query(&query, &[]).await?;
+
+    for row in rows {
+        let data = Bytes::from(row.get::<_, Vec<u8>>("data"));
+        let message = LogicalReplicationMessage::parse(&data)
+            .map_err(TransientError::MalformedReplicationMessage)?;
+        if let LogicalReplicationMessage::Begin(body) = message {
+            let ts = MzOffset::from(body.final_lsn());
+            if cap.time() <= &ts {
+                cap.downgrade(&ts);
+                return Ok(());
+            }
+        }
+    }
+    // If there is no transaction with commit_lsn < pg_upper, the upper is pg_upper.
+    cap.downgrade(&MzOffset::from(pg_upper));
+    Ok(())
+}
+
+/// Unpacks an iterator of TupleData into a list of nullable bytes or an error if this can't be
+/// done.
+fn unpack_tuple<'a, I>(tuple_data: I) -> Result<Vec<Option<Bytes>>, DefiniteError>
+where
+    I: IntoIterator<Item = &'a TupleData>,
+    I::IntoIter: ExactSizeIterator,
+{
+    let iter = tuple_data.into_iter();
+    let mut row = Vec::with_capacity(iter.len());
+    for data in iter {
+        let datum = match data {
+            TupleData::Text(bytes) => Some(bytes.clone()),
+            TupleData::Null => None,
+            TupleData::UnchangedToast => return Err(DefiniteError::MissingToast),
+        };
+        row.push(datum);
+    }
+    Ok(row)
+}
+
+/// Ensures the publication exists on the server. It returns an outer transient error in case of
+/// connection issues and an inner definite error if the publication is dropped.
+async fn ensure_publication_exists(
+    client: &Client,
+    publication: &str,
+) -> Result<Result<(), DefiniteError>, TransientError> {
+    // Figure out the last written LSN and then add one to convert it into an upper.
+    let result = client
+        .query_opt(
+            "SELECT 1 FROM pg_publication WHERE pubname = $1;",
+            &[&publication],
+        )
+        .await?;
+    match result {
+        Some(_) => Ok(Ok(())),
+        None => Ok(Err(DefiniteError::PublicationDropped(
+            publication.to_owned(),
+        ))),
+    }
+}

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -1,0 +1,385 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Renders the table snapshot side of the [`PostgresSourceConnection`] ingestion dataflow.
+//!
+//! # Snapshot reading
+//!
+//! Depending on the resumption LSNs the table reader decides which tables need to be snapshotted
+//! and performs a simple `COPY` query on them in order to get a snapshot. There are a few subtle
+//! points about this operation, described in the following sections.
+//!
+//! ## Consistent LSN point for snapshot transactions
+//!
+//! Given that all our ingestion is based on correctly timestamping updates with the LSN they
+//! happened at it is important that we run the `COPY` query at a specific LSN point that is
+//! relatable with the LSN numbers we receive from the replication stream. Such point does not
+//! necessarily exist for a normal SQL transaction. To achieve this we must force postgres to
+//! produce a consistent point and let us know of the LSN number of that by creating a replication
+//! slot as the first statement in a transaction.
+//!
+//! This is a temporary dummy slot that is only used to put our snapshot transaction on a
+//! consistent LSN point. Unfortunately no lighterweight method exists for doing this. See this
+//! [postgres thread] for more details.
+//!
+//! One might wonder why we don't use the actual real slot to provide us with the snapshot point
+//! which would automatically be at the correct LSN. The answer is that it's possible that we crash
+//! and restart after having already created the slot but before having finished the snapshot. In
+//! that case the restarting process will have lost its opportunity to run queries at the slot's
+//! consistent point as that opportunity only exists in the ephemeral transaction that created the
+//! slot and that is long gone. Additionally there are good reasons of why we'd like to move the
+//! slot creation much earlier, e.g during purification, in which case the slot will always be
+//! pre-created.
+//!
+//! [postgres thread]: https://www.postgresql.org/message-id/flat/CAMN0T-vzzNy6TV1Jvh4xzNQdAvCLBQK_kh6_U7kAXgGU3ZFg-Q%40mail.gmail.com
+//!
+//! ## Reusing the consistent point among all workers
+//!
+//! Creating replication slots is potentially expensive so the code makes is such that all workers
+//! cooperate and reuse one consistent snapshot among them. In order to do so we make use the
+//! "export transaction" feature of postgres. This feature allows one SQL session to create an
+//! identifier for the transaction (a string identifier) it is currently in, which can be used by
+//! other sessions to enter the same "snapshot".
+//!
+//! We accomplish this by picking one worker at random to function as the transaction leader. The
+//! transaction leader is responsible for starting a SQL session, creating a temporary replication
+//! slot in a transaction, exporting the transaction id, and broadcasting the transaction
+//! information to all other workers via a broadcasted feedback edge.
+//!
+//! During this phase the follower workers are simply waiting to hear on the feedback edge,
+//! effectively synchronizing with the leader. Once all workers have received the snapshot
+//! information they can all start to perform their assigned COPY queries.
+//!
+//! The leader and follower steps described above are accomplished by the [`export_snapshot`] and
+//! [`use_snapshot`] functions respectively.
+//!
+//! ## Coordinated transaction COMMIT
+//!
+//! When follower workers are done with snapshotting they commit their transaction, close their
+//! session, and then drop their snapshot feedback capability. When the leader worker is done with
+//! snapshotting it drops its snapshot feedback capability and waits until it observes the
+//! snapshot input advancing to the empty frontier. This allows the leader to COMMIT its
+//! transaction last, which is the transaction that exported the snapshot.
+//!
+//! It's unclear if this is strictly necessary, but having the frontiers made it easy enough that I
+//! added the synchronization.
+//!
+//! ## Snapshot rewinding
+//!
+//! Ingestion dataflows must produce definite data, including the snapshot. What this means
+//! practically is that whenever we deem it necessary to snapshot a table we must do so at the same
+//! LSN. However, the method for running a transaction described above doesn't let us choose the
+//! LSN, it could be an LSN in the future chosen by PostgresSQL while it creates the temporary
+//! replication slot.
+//!
+//! The definition of differential collections states that a collection at some time `t_snapshot`
+//! is defined to be the accumulation of all updates that happen at `t <= t_snapshot`, where `<=`
+//! is the partial order. In this case we are faced with the problem of knowing the state of a
+//! table at `t_snapshot` but actually wanting to know the snapshot at `t_slot <= t_snapshot`.
+//!
+//! From the definition we can see that the snapshot at `t_slot` is related to the snapshot at
+//! `t_snapshot` with the following equations:
+//!
+//!```text
+//! sum(update: t <= t_snapshot) = sum(update: t <= t_slot) + sum(update: t_slot <= t <= t_snapshot)
+//!                                         |
+//!                                         V
+//! sum(update: t <= t_slot) = sum(update: t <= snapshot) - sum(update: t_slot <= t <= t_snapshot)
+//! ```
+//!
+//! Therefore, if we manage to recover the `sum(update: t_slot <= t <= t_snapshot)` term we will be
+//! able to "rewind" the snapshot we obtained at `t_snapshot` to `t_slot` by emitting all updates
+//! that happen between these two points with their diffs negated.
+//!
+//! It turns out that this term is exactly what the main replication slot provides us with and we
+//! can rewind snapshot at arbitrary points! In order to do this the snapshot dataflow emits rewind
+//! requests to the replication reader which informs it that a certain range of updates must be
+//! emitted at LSN 0 (by convention) with their diffs negated. These negated diffs are consolidated
+//! with the diffs taken at `t_snapshot` that were also emitted at LSN 0 (by convention) and we end
+//! up with a TVC that at LSN 0 contains the snapshot at `t_slot`.
+//!
+//! # Snapshot decoding
+//!
+//! The expectation is that tables will most likely be skewed on the number of rows they contain so
+//! while a `COPY` query for any given table runs on a single worker the decoding of the COPY
+//! stream is distributed to all workers.
+//!
+//!
+//! ```text
+//!                 ╭──────────────────╮
+//!    ┏━━━━━━━━━━━━v━┓                │ exported
+//!    ┃    table     ┃   ╭─────────╮  │ snapshot id
+//!    ┃    reader    ┠─>─┤broadcast├──╯
+//!    ┗━┯━━━━━━━━━━┯━┛   ╰─────────╯
+//!   raw│          │
+//!  COPY│          │
+//!  data│          │
+//! ╭────┴─────╮    │
+//! │distribute│    │
+//! ╰────┬─────╯    │
+//! ┏━━━━┷━━━━┓     │
+//! ┃  COPY   ┃     │
+//! ┃ decoder ┃     │
+//! ┗━━━━┯━━━━┛     │
+//!      │ snapshot │rewind
+//!      │ updates  │requests
+//!      v          v
+//! ```
+
+use std::any::Any;
+use std::collections::BTreeMap;
+use std::pin::pin;
+use std::rc::Rc;
+
+use differential_dataflow::{AsCollection, Collection};
+use futures::TryStreamExt;
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::{Broadcast, ConnectLoop, Feedback};
+use timely::dataflow::{Scope, Stream};
+use timely::progress::{Antichain, Timestamp};
+use tokio_postgres::types::PgLsn;
+use tokio_postgres::Client;
+use tracing::trace;
+
+use mz_expr::MirScalarExpr;
+use mz_ore::result::ResultExt;
+use mz_postgres_util::desc::PostgresTableDesc;
+use mz_repr::{Datum, DatumVec, Diff, Row};
+use mz_sql_parser::ast::{display::AstDisplay, Ident};
+use mz_storage_client::types::connections::ConnectionContext;
+use mz_storage_client::types::sources::{MzOffset, PostgresSourceConnection};
+use mz_timely_util::antichain::AntichainExt;
+use mz_timely_util::builder_async::{Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder};
+use mz_timely_util::operator::StreamExt as TimelyStreamExt;
+
+use crate::source::postgres::replication::RewindRequest;
+use crate::source::postgres::{simple_query_opt, verify_schema, DefiniteError, TransientError};
+use crate::source::types::SourceReaderError;
+use crate::source::RawSourceCreationConfig;
+
+/// Renders the snapshot dataflow. See the module documentation for more information.
+pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
+    mut scope: G,
+    config: RawSourceCreationConfig,
+    connection: PostgresSourceConnection,
+    context: ConnectionContext,
+    resume_upper: Antichain<MzOffset>,
+    table_info: BTreeMap<u32, (usize, PostgresTableDesc, Vec<MirScalarExpr>)>,
+) -> (
+    Collection<G, (usize, Result<Row, SourceReaderError>), Diff>,
+    Stream<G, RewindRequest>,
+    Stream<G, Rc<TransientError>>,
+    Rc<dyn Any>,
+) {
+    let op_name = format!("TableReader({})", config.id);
+    let mut builder = AsyncOperatorBuilder::new(op_name, scope.clone());
+
+    let (feedback_handle, feedback_data) = scope.feedback(Default::default());
+
+    let (mut raw_handle, raw_data) = builder.new_output();
+    let (mut rewinds_handle, rewinds) = builder.new_output();
+    let (mut snapshot_handle, snapshot) = builder.new_output();
+
+    // This operator needs to broadcast data to itself in order to synchronize the transaction
+    // snapshot. However, none of the feedback capabilities result in output messages and for the
+    // feedback edge specifically having a default conncetion would result in a loop.
+    let disconnected = vec![Antichain::new(); 3];
+    let mut snapshot_input = builder.new_input_connection(&feedback_data, Pipeline, disconnected);
+
+    // The export id must be sent to all workes, so we broadcast the feedback connection
+    snapshot.broadcast().connect_loop(feedback_handle);
+
+    let is_snapshot_leader = config.responsible_for("snapshot_leader");
+
+    // A filtered table info containing only the tables that this worker should read
+    let mut reader_table_info = table_info.clone();
+    reader_table_info.retain(|oid, _| config.responsible_for(oid));
+    let (button, errors) = builder.build_fallible(move |caps| {
+        Box::pin(async move {
+            let id = config.id;
+            let worker_id = config.worker_id;
+
+            let [data_cap, rewind_cap, snapshot_cap]: &mut [_; 3] = caps.try_into().unwrap();
+            let data_cap = data_cap.as_mut().unwrap();
+            trace!(%id, "timely-{worker_id} initializing table reader {}", resume_upper.pretty());
+
+            // We have already snapshotted, so the replication dataflow will take over
+            if resume_upper.into_option() != Some(MzOffset::from(0)) {
+                return Ok(());
+            }
+
+            let connection_config = connection
+                .connection
+                .config(&*context.secrets_reader)
+                .await?
+                .replication_timeouts(config.params.pg_replication_timeouts.clone());
+
+            let client = connection_config.connect_replication().await?;
+            if is_snapshot_leader {
+                // The main slot must be created *before* we start snapshotting so that we can be
+                // certain that the temporarly slot created for the snapshot start at an LSN that
+                // is greater than or equal to that of the main slot.
+                super::ensure_replication_slot(&client, &connection.publication_details.slot).await?;
+
+                let snapshot_info = export_snapshot(&client).await?;
+                trace!(%id, "timely-{worker_id} exporting snapshot info {snapshot_info:?}");
+                let cap = snapshot_cap.as_ref().unwrap();
+                snapshot_handle.give(cap, snapshot_info).await;
+            }
+
+            let (snapshot, snapshot_lsn) = loop {
+                match snapshot_input.next_mut().await {
+                    Some(AsyncEvent::Data(_, data)) => break data.pop().expect("snapshot sent above"),
+                    Some(AsyncEvent::Progress(_)) => continue,
+                    None => panic!("feedback closed before sending snapshot info"),
+                }
+            };
+            // Snapshot leader is already in identified transaction but all other workers need to enter it.
+            if !is_snapshot_leader {
+                trace!(%id, "timely-{worker_id} using snapshot id {snapshot:?}");
+                use_snapshot(&client, &snapshot).await?;
+            }
+
+            // We have established a snapshot LSN so we can broadcast the rewind requests
+            for &oid in reader_table_info.keys() {
+                trace!(%id, "timely-{worker_id} producing rewind request for {oid}");
+                let req = RewindRequest { oid, snapshot_lsn };
+                rewinds_handle.give(rewind_cap.as_ref().unwrap(), req).await;
+            }
+            *rewind_cap = None;
+
+            let upstream_info = mz_postgres_util::publication_info(
+                &connection_config,
+                &connection.publication,
+                None,
+            )
+            .await?;
+            let upstream_info = upstream_info.into_iter().map(|t| (t.oid, t)).collect();
+
+            for (&oid, (_, expected_desc, _)) in reader_table_info.iter() {
+                let desc = match verify_schema(oid, expected_desc, &upstream_info) {
+                    Ok(()) => expected_desc,
+                    Err(err) => {
+                        raw_handle.give(data_cap, ((oid, Err(err)), MzOffset::minimum(), 1)).await;
+                        continue;
+                    }
+                };
+
+                trace!(%id, "timely-{worker_id} snapshotting table {:?}({oid}) @ {snapshot_lsn}", desc.name);
+                // To handle quoted/keyword names, we can use `Ident`'s AST printing, which
+                // emulate's PG's rules for name formatting.
+                let query = format!(
+                    "COPY {}.{} TO STDOUT (FORMAT TEXT, DELIMITER '\t')",
+                    Ident::from(desc.namespace.clone()).to_ast_string(),
+                    Ident::from(desc.name.clone()).to_ast_string(),
+                );
+                let mut stream = pin!(client.copy_out_simple(&query).await?);
+
+                while let Some(bytes) = stream.try_next().await? {
+                    raw_handle.give(data_cap, ((oid, Ok(bytes)), MzOffset::minimum(), 1)).await;
+                }
+            }
+            // Failure scenario after we have produced the snapshot, but before a successful COMMIT
+            fail::fail_point!("pg_snapshot_failure", |_| Err(TransientError::SyntheticError));
+
+            // The exporting worker should wait for all the other workers to commit before dropping
+            // its client since this is what holds the exported transaction alive.
+            if is_snapshot_leader {
+                trace!(%id, "timely-{worker_id} waiting for all workers to finish");
+                *snapshot_cap = None;
+                while snapshot_input.next().await.is_some() {}
+                trace!(%id, "timely-{worker_id} (leader) comitting COPY transaction");
+                client.simple_query("COMMIT").await?;
+            } else {
+                trace!(%id, "timely-{worker_id} comitting COPY transaction");
+                client.simple_query("COMMIT").await?;
+                *snapshot_cap = None;
+            }
+            drop(client);
+            Ok(())
+        })
+    });
+
+    // Distribute the raw COPY data to all workers and turn it into a collection
+    let raw_collection = raw_data.distribute().as_collection();
+
+    // We now decode the COPY protocol and apply the cast expressions
+    let mut text_row = Row::default();
+    let mut final_row = Row::default();
+    let mut datum_vec = DatumVec::new();
+    let snapshot_updates = raw_collection.map(move |(oid, event)| {
+        let (output_index, _, casts) = &table_info[&oid];
+
+        let event = event.and_then(|bytes| {
+            decode_copy_row(&bytes, casts.len(), &mut text_row)?;
+            let datums = datum_vec.borrow_with(&text_row);
+            super::cast_row(casts, &datums, &mut final_row)?;
+            Ok(final_row.clone())
+        });
+
+        (*output_index, event.err_into())
+    });
+
+    (
+        snapshot_updates,
+        rewinds,
+        errors,
+        Rc::new(button.press_on_drop()),
+    )
+}
+
+/// Starts a read-only transaction on the SQL session of `client` at a consistent LSN point by
+/// creating a temporary replication slot. Returns a snapshot identifier that can be imported in
+/// other SQL session and the LSN of the consistent point.
+async fn export_snapshot(client: &Client) -> Result<(String, MzOffset), TransientError> {
+    client
+        .simple_query("BEGIN READ ONLY ISOLATION LEVEL REPEATABLE READ;")
+        .await?;
+    // A temporary replication slot is the only way to get the tx in a consistent LSN point
+    let slot = format!("mzsnapshot_{}", uuid::Uuid::new_v4()).replace('-', "");
+    let query =
+        format!("CREATE_REPLICATION_SLOT {slot:?} TEMPORARY LOGICAL \"pgoutput\" USE_SNAPSHOT");
+    let row = simple_query_opt(client, &query).await?.unwrap();
+    let consistent_point: PgLsn = row.get("consistent_point").unwrap().parse().unwrap();
+
+    let row = simple_query_opt(client, "SELECT pg_export_snapshot();")
+        .await?
+        .unwrap();
+    let snapshot = row.get("pg_export_snapshot").unwrap().to_owned();
+
+    Ok((snapshot, MzOffset::from(consistent_point)))
+}
+
+/// Starts a read-only transaction on the SQL session of `client` at a the consistent LSN point of
+/// `snapshot`.
+async fn use_snapshot(client: &Client, snapshot: &str) -> Result<(), TransientError> {
+    client
+        .simple_query("BEGIN READ ONLY ISOLATION LEVEL REPEATABLE READ;")
+        .await?;
+    let query = format!("SET TRANSACTION SNAPSHOT '{snapshot}';");
+    client.simple_query(&query).await?;
+    Ok(())
+}
+
+/// Decodes a row of `col_len` columns obtained from a text encoded COPY query into `row`.
+fn decode_copy_row(data: &[u8], col_len: usize, row: &mut Row) -> Result<(), DefiniteError> {
+    let mut packer = row.packer();
+    let row_parser = mz_pgcopy::CopyTextFormatParser::new(data, "\t", "\\N");
+    let mut column_iter = row_parser.iter_raw_truncating(col_len);
+    for _ in 0..col_len {
+        let value = match column_iter.next() {
+            Some(Ok(value)) => value,
+            Some(Err(_)) => return Err(DefiniteError::InvalidCopyInput),
+            None => return Err(DefiniteError::MissingColumn),
+        };
+        let datum = value.map(super::decode_utf8_text).transpose()?;
+        packer.push(datum.unwrap_or(Datum::Null));
+    }
+    Ok(())
+}

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -139,11 +139,15 @@ pub struct RawSourceCreationConfig {
 }
 
 impl RawSourceCreationConfig {
+    /// Returns the worker id responsible for handling the given partition.
+    pub fn responsible_worker<P: Hash>(&self, partition: P) -> usize {
+        let key = usize::cast_from((self.id, partition).hashed());
+        key % self.worker_count
+    }
+
     /// Returns true if this worker is responsible for handling the given partition.
     pub fn responsible_for<P: Hash>(&self, partition: P) -> bool {
-        let key = usize::cast_from((self.id, partition).hashed());
-        // Distribute partitions equally amongst workers.
-        (key % self.worker_count) == self.worker_id
+        self.responsible_worker(partition) == self.worker_id
     }
 }
 
@@ -308,9 +312,11 @@ where
 
                 let statuses: &mut Vec<_> = statuses_by_idx.entry(*output_index).or_default();
 
-                let status_wrapper = Some((*output_index, status));
-                if statuses.last() != status_wrapper.as_ref() {
-                    statuses.push(status_wrapper.expect("definitely Some"));
+                let status = (*output_index, status);
+                if statuses.last() != Some(&status) {
+                    statuses.push(status.clone());
+                    // The global status contains the most recent update of the subsources
+                    statuses.push((0, status.1));
                 }
 
                 match message {
@@ -391,6 +397,7 @@ impl<'a> HealthState<'a> {
 pub(crate) fn health_operator<'g, G: Scope<Timestamp = ()>>(
     scope: &mut Child<'g, G, mz_repr::Timestamp>,
     storage_state: &crate::storage_state::StorageState,
+    resume_upper: Antichain<mz_repr::Timestamp>,
     primary_source_id: GlobalId,
     health_stream: &Stream<G, (WorkerId, OutputIndex, HealthStatusUpdate)>,
     configs: BTreeMap<OutputIndex, (GlobalId, CollectionMetadata)>,
@@ -462,7 +469,7 @@ pub(crate) fn health_operator<'g, G: Scope<Timestamp = ()>>(
             .collect();
 
         // Write the initial starting state to the status shard for all managed sources
-        if is_active_worker {
+        if is_active_worker && !resume_upper.is_empty() {
             for state in health_states.values() {
                 if let Some((status_shard, persist_client)) = state.persist_details {
                     let status = HealthStatus::Starting;

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -217,7 +217,7 @@ pub struct DecodeResult {
 }
 
 /// A structured error for `SourceReader::get_next_message` implementors.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SourceReaderError {
     pub inner: SourceErrorDetails,
 }

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -544,6 +544,68 @@ impl<G: Scope> OperatorBuilder<G> {
         self.shutdown_button
     }
 
+    /// Creates a fallible operator implementation from supplied logic constructor. If the `Future`
+    /// resolves to an error it will be emitted in the returned error stream and then the operator
+    /// will wait indefinitely until the shutdown button is pressed.
+    ///
+    /// # Capability handling
+    ///
+    /// Unlike [`OperatorBuilder::build`], this method does not give owned capabilities to the
+    /// constructor. All initial capabilities are wrapped in an `Option` and a mutable reference to
+    /// them is given instead. This is done to avoid storing owned capabilities in the state of the
+    /// logic future which would make using the `?` operator unsafe, since the frontiers would
+    /// incorrectly advance, potentially causing incorrect actions downstream.
+    ///
+    /// ```ignore
+    /// builder.build_fallible(|caps| Box::pin(async move {
+    ///     // Assert that we have the number of capabilities we expect
+    ///     // `cap` will be a `&mut Option<Capability<T>>`:
+    ///     let [cap]: &mut [_; 1] = caps.try_into().unwrap();
+    ///
+    ///     // Using cap to send data:
+    ///     output.give(cap.as_ref().unwrap(), 42);
+    ///
+    ///     // Using cap to downgrade it:
+    ///     cap.as_mut().unwrap().downgrade();
+    ///
+    ///     // Explicitly dropping the capability:
+    ///     // Simply running `drop(cap)` will only drop the reference and not the capability itself!
+    ///     *cap = None;
+    ///
+    ///     // !! BIG WARNING !!:
+    ///     // It is tempting to `take` the capability out of the option for convenience. This will
+    ///     // move the capability into the future state, tying its lifetime to it, which will get
+    ///     // dropped when an error is hit, causing incorrect progress statements.
+    ///     let cap = cap.take().unwrap(); // DO NOT DO THIS
+    /// }));
+    /// ```
+    pub fn build_fallible<E: 'static, F>(
+        mut self,
+        constructor: F,
+    ) -> (Button, StreamCore<G, Vec<Rc<E>>>)
+    where
+        F: for<'a> FnOnce(
+                &'a mut [Option<Capability<G::Timestamp>>],
+            ) -> Pin<Box<dyn Future<Output = Result<(), E>> + 'a>>
+            + 'static,
+    {
+        // Create a new completely disconnected output
+        let disconnected = vec![Antichain::new(); self.builder.shape().inputs()];
+        let (mut error_output, error_stream) = self.new_output_connection(disconnected);
+        let button = self.build(|mut caps| async move {
+            let error_cap = caps.pop().unwrap();
+            let mut caps = caps.into_iter().map(Some).collect::<Vec<_>>();
+            if let Err(err) = constructor(&mut *caps).await {
+                error_output.give(&error_cap, Rc::new(err)).await;
+                drop(error_cap);
+                // IMPORTANT: wedge this operator until the button is pressed. Returning would drop
+                // the capabilities and could produce incorrect progress statements.
+                std::future::pending().await
+            }
+        });
+        (button, error_stream)
+    }
+
     /// Creates operator info for the operator.
     pub fn operator_info(&self) -> OperatorInfo {
         self.builder.operator_info()

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -89,6 +89,7 @@ pub mod capture;
 pub mod event;
 pub mod operator;
 pub mod order;
+pub mod pact;
 pub mod panic;
 pub mod probe;
 pub mod progress;

--- a/src/timely-util/src/pact.rs
+++ b/src/timely-util/src/pact.rs
@@ -1,0 +1,71 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Parallelization contracts, describing requirements for data movement along dataflow edges.
+
+use timely::communication::{Data, Pull, Push};
+use timely::dataflow::channels::pact::{LogPuller, LogPusher, ParallelizationContractCore};
+use timely::dataflow::channels::{BundleCore, Message};
+use timely::logging::TimelyLogger;
+use timely::progress::Timestamp;
+use timely::worker::AsWorker;
+use timely::Container;
+
+/// A connection that distributes containers to all workers in a round-robin fashion
+#[derive(Debug)]
+pub struct Distribute;
+
+impl<T: Timestamp, C: Container + Data> ParallelizationContractCore<T, C> for Distribute {
+    type Pusher = DistributePusher<LogPusher<T, C, Box<dyn Push<BundleCore<T, C>>>>>;
+    type Puller = LogPuller<T, C, Box<dyn Pull<BundleCore<T, C>>>>;
+
+    fn connect<A: AsWorker>(
+        self,
+        allocator: &mut A,
+        identifier: usize,
+        address: &[usize],
+        logging: Option<TimelyLogger>,
+    ) -> (Self::Pusher, Self::Puller) {
+        let (senders, receiver) = allocator.allocate::<Message<T, C>>(identifier, address);
+        let senders = senders
+            .into_iter()
+            .enumerate()
+            .map(|(i, x)| LogPusher::new(x, allocator.index(), i, identifier, logging.clone()))
+            .collect::<Vec<_>>();
+        (
+            DistributePusher::new(senders),
+            LogPuller::new(receiver, allocator.index(), identifier, logging.clone()),
+        )
+    }
+}
+
+/// Distributes records among target pushees.
+///
+/// It is more efficient than `Exchange` when the target worker doesn't matter
+pub struct DistributePusher<P> {
+    pushers: Vec<P>,
+    next: usize,
+}
+
+impl<P> DistributePusher<P> {
+    /// Allocates a new `DistributePusher` from a supplied set of pushers
+    pub fn new(pushers: Vec<P>) -> DistributePusher<P> {
+        Self { pushers, next: 0 }
+    }
+}
+
+impl<T: Eq + Data, C: Container, P: Push<BundleCore<T, C>>> Push<BundleCore<T, C>>
+    for DistributePusher<P>
+{
+    fn push(&mut self, message: &mut Option<BundleCore<T, C>>) {
+        let worker_idx = self.next;
+        self.next = (self.next + 1) % self.pushers.len();
+        self.pushers[worker_idx].push(message);
+    }
+}

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -24,7 +24,7 @@ axum = { version = "0.6.7", features = ["headers", "ws"] }
 base64 = { version = "0.13.1", features = ["alloc"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
-bytes = { version = "1.3.0" }
+bytes = { version = "1.3.0", features = ["serde"] }
 chrono = { version = "0.4.24", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
@@ -120,7 +120,7 @@ axum = { version = "0.6.7", features = ["headers", "ws"] }
 base64 = { version = "0.13.1", features = ["alloc"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
-bytes = { version = "1.3.0" }
+bytes = { version = "1.3.0", features = ["serde"] }
 cc = { version = "1.0.78", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.24", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -667,7 +667,7 @@ INSERT INTO pk_table VALUES (99999);
 # todo: we're purifying Postgres view names incorrectly, fix that and this error!
 # should be "materialize.public.pk_table"
 ! SELECT COUNT(*) = 0 FROM pk_table;
-regex:Source error: .*: db error: ERROR: publication "mz_source" does not exist
+regex:publication "mz_source" does not exist
 
 > DROP SOURCE enum_source CASCADE;
 > DROP SOURCE "mz_source" CASCADE;


### PR DESCRIPTION
### Motivation

This was originally reverted because it was triggering the correctness problem outlined in https://github.com/MaterializeInc/materialize/issues/18837 . Now that the correctness issue is fixed we can revert the revert!
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->


<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
