### PR TITLE
test: Remove RBAC test preamble and postamble

### DIFF
--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -11,18 +11,6 @@ mode cockroach
 
 reset-server
 
-# Enable rbac checks.
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
 simple conn=mz_system,user=mz_system
 CREATE ROLE joe CREATEDB CREATECLUSTER;
 ----
@@ -2633,17 +2621,5 @@ COMPLETE 0
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM joe;
-----
-COMPLETE 0
-
-# Disable rbac checks.
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_rbac_checks TO false;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
 ----
 COMPLETE 0

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -11,17 +11,6 @@ mode cockroach
 
 reset-server
 
-# Enable rbac checks.
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
 # Test mz_aclitem type and functions
 
 statement ok
@@ -1834,15 +1823,3 @@ query B
 SELECT has_table_privilege((SELECT oid FROM mz_tables WHERE name = 't'), 'SELECT')
 ----
 true
-
-# Disable rbac checks.
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_rbac_checks TO false;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
-----
-COMPLETE 0

--- a/test/sqllogictest/privileges_pg.slt
+++ b/test/sqllogictest/privileges_pg.slt
@@ -14,16 +14,6 @@ mode cockroach
 reset-server
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 CREATE ROLE regress_priv_user1;
 ----
 COMPLETE 0

--- a/test/sqllogictest/role_attributes.slt
+++ b/test/sqllogictest/role_attributes.slt
@@ -11,17 +11,6 @@ mode cockroach
 
 reset-server
 
-# Enable rbac checks.
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
 simple conn=mz_system,user=mz_system
 CREATE ROLE joe
 ----

--- a/test/sqllogictest/role_create.slt
+++ b/test/sqllogictest/role_create.slt
@@ -14,16 +14,6 @@ mode cockroach
 reset-server
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 CREATE ROLE regress_role_admin CREATEDB CREATECLUSTER CREATEROLE;
 ----
 COMPLETE 0

--- a/test/sqllogictest/role_membership.slt
+++ b/test/sqllogictest/role_membership.slt
@@ -11,12 +11,6 @@ mode cockroach
 
 reset-server
 
-# Give materialize the CREATEROLE attribute.
-simple conn=mz_system,user=mz_system
-ALTER ROLE materialize CREATEROLE;
-----
-COMPLETE 0
-
 statement ok
 CREATE VIEW role_members AS
   SELECT
@@ -330,15 +324,3 @@ group1  joe     mz_system  false
 group3  joe     mz_system  false
 group3  group1  mz_system  false
 group3  group2  mz_system  false
-
-# Disable RBAC checks
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_rbac_checks TO false;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
-----
-COMPLETE 0


### PR DESCRIPTION
Previous commits have done the following to all tests:

  - Enable RBAC at the start of all tests.
  - Reset system parameters at the end of all tests.
  - Give the materialize role extra privileges.

Therefore, there's no longer a need to enable RBAC at the start of each test, grant privileges to the materialize role at the start of each test, and disable RBAC at the end of each test. So this commit removes that preamble and postamble from all RBAC tests.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
