### PR TITLE
doc/user: adjust progress subsource type in SHOW SOURCES

### DIFF
--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -163,7 +163,7 @@ For this guide, you'll use a [built-in load generator](/sql/create-source/load-g
     ------------------------+----------------+------
      accounts               | subsource      |
      auction_house          | load-generator |
-     auction_house_progress | subsource      |
+     auction_house_progress | progress       |
      auctions               | subsource      |
      bids                   | subsource      |
      organizations          | subsource      |

--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -244,14 +244,15 @@ To display the created subsources:
 SHOW SOURCES;
 ```
 ```nofmt
-     name      |      type      |  size
----------------+----------------+---------
- accounts      | subsource      |
- auction_house | load-generator | 3xsmall
- auctions      | subsource      |
- bids          | subsource      |
- organizations | subsource      |
- users         | subsource      |
+          name          |      type      |  size
+------------------------+----------------+---------
+ accounts               | subsource      |
+ auction_house          | load-generator | 3xsmall
+ auction_house_progress | progress       |
+ auctions               | subsource      |
+ bids                   | subsource      |
+ organizations          | subsource      |
+ users                  | subsource      |
 ```
 
 To examine the simulated bids:
@@ -294,7 +295,7 @@ SHOW SOURCES;
  impressions            | subsource      |
  leads                  | subsource      |
  marketing              | load-generator | 3xsmall
- marketing_progress     | subsource      |
+ marketing_progress     | progress       |
 ```
 
 To find all impressions and clicks associated with a campaign over the last 30 days:
@@ -361,17 +362,18 @@ To display the created subsources:
 SHOW SOURCES;
 ```
 ```nofmt
-   name   |      type      |  size
-----------+----------------+---------
- tpch     | load-generator | 3xsmall
- supplier | subsource      |
- region   | subsource      |
- partsupp | subsource      |
- part     | subsource      |
- orders   | subsource      |
- nation   | subsource      |
- lineitem | subsource      |
- customer | subsource      |
+      name     |      type      |  size
+---------------+----------------+---------
+ tpch          | load-generator | 3xsmall
+ tpch_progress | progress       |
+ supplier      | subsource      |
+ region        | subsource      |
+ partsupp      | subsource      |
+ part          | subsource      |
+ orders        | subsource      |
+ nation        | subsource      |
+ lineitem      | subsource      |
+ customer      | subsource      |
 ```
 
 To run the Pricing Summary Report Query (Q1), which reports the amount of

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -93,9 +93,10 @@ When you define a source, Materialize will automatically:
     ```nofmt
              name         |   type    |  size
     ----------------------+-----------+---------
+     mz_source            | postgres  | 3xsmall
+     mz_source_progress   | progress  |
      table_1              | subsource |
      table_2              | subsource |
-     mz_source            | postgres  | 3xsmall
     ```
 
     And perform an initial, snapshot-based sync of the tables in the publication before it starts ingesting change events.

--- a/doc/user/content/sql/show-sources.md
+++ b/doc/user/content/sql/show-sources.md
@@ -31,7 +31,7 @@ _schema&lowbar;name_ | The schema to show sources from. Defaults to first resolv
 Field | Meaning
 ------|--------
 **name** | The name of the source.
-**type** | The type of the source: `kafka`, `postgres`, `load-generator`, or `subsource`.
+**type** | The type of the source: `kafka`, `postgres`, `load-generator`, `progress`, or `subsource`.
 **size** | The [size](/sql/create-source/#sizing-a-source) of the source. Null if the source is created using the `IN CLUSTER` clause.
 
 ## Examples


### PR DESCRIPTION
@jseldess This is the first set of these; I'm working on some SQL functions that will let us refactor some of the documentation around progress subsources, so didn't change those docs yet (they're not wrong, so don't think it's quite as urgent).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
