### PR TITLE
compute-client: define `Interpreter` and `Transform` APIs

### DIFF
--- a/src/compute-client/src/plan/interpret/api.rs
+++ b/src/compute-client/src/plan/interpret/api.rs
@@ -1,0 +1,650 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Utilities for abstract interpretation of [crate::plan::Plan] structures.
+//!
+//! Those can be used to define analysis passes over [crate::plan::Plan]s in a
+//! consistent and unified manner. The primary abstraction here is the
+//! [Interpreter] trait.
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+use differential_dataflow::lattice::Lattice;
+use itertools::zip_eq;
+use mz_expr::{EvalError, Id, LetRecLimit, LocalId, MapFilterProject, MirScalarExpr, TableFunc};
+use mz_ore::cast::CastFrom;
+use mz_ore::soft_panic_or_log;
+use mz_repr::{Diff, Row};
+
+use crate::plan::join::JoinPlan;
+use crate::plan::reduce::{KeyValPlan, ReducePlan};
+use crate::plan::threshold::ThresholdPlan;
+use crate::plan::top_k::TopKPlan;
+use crate::plan::{AvailableCollections, GetPlan, Plan};
+
+/// An [abstract interpreter] for [Plan] expressions.
+///
+/// This is an [object algebra] / [tagless final encoding] of the language
+/// defined by [crate::plan::Plan], with the exception of the `Get` and `Let*`
+/// variants. The latter are modeled as part of the various recursion methods,
+/// as they are constructs to introduce and reference context.
+///
+/// [abstract interpreter]:
+///     <https://en.wikipedia.org/wiki/Abstract_interpretation>
+/// [object algebra]:
+///     <https://www.cs.utexas.edu/~wcook/Drafts/2012/ecoop2012.pdf>
+/// [tagless final encoding]: <https://okmij.org/ftp/tagless-final/>
+pub trait Interpreter<T = mz_repr::Timestamp> {
+    type Domain: Debug + Sized;
+
+    fn constant(
+        &self,
+        ctx: &Context<Self::Domain>,
+        rows: &Result<Vec<(Row, T, Diff)>, EvalError>,
+    ) -> Self::Domain;
+
+    fn get(
+        &self,
+        ctx: &Context<Self::Domain>,
+        id: &Id,
+        keys: &AvailableCollections,
+        plan: &GetPlan,
+    ) -> Self::Domain;
+
+    fn mfp(
+        &self,
+        ctx: &Context<Self::Domain>,
+        input: Self::Domain,
+        mfp: &MapFilterProject,
+        input_key_val: &Option<(Vec<MirScalarExpr>, Option<Row>)>,
+    ) -> Self::Domain;
+
+    fn flat_map(
+        &self,
+        ctx: &Context<Self::Domain>,
+        input: Self::Domain,
+        func: &TableFunc,
+        exprs: &Vec<MirScalarExpr>,
+        mfp: &MapFilterProject,
+        input_key: &Option<Vec<MirScalarExpr>>,
+    ) -> Self::Domain;
+
+    fn join(
+        &self,
+        ctx: &Context<Self::Domain>,
+        inputs: Vec<Self::Domain>,
+        plan: &JoinPlan,
+    ) -> Self::Domain;
+
+    fn reduce(
+        &self,
+        ctx: &Context<Self::Domain>,
+        input: Self::Domain,
+        key_val_plan: &KeyValPlan,
+        plan: &ReducePlan,
+        input_key: &Option<Vec<MirScalarExpr>>,
+    ) -> Self::Domain;
+
+    fn top_k(
+        &self,
+        ctx: &Context<Self::Domain>,
+        input: Self::Domain,
+        top_k_plan: &TopKPlan,
+    ) -> Self::Domain;
+
+    fn negate(&self, ctx: &Context<Self::Domain>, input: Self::Domain) -> Self::Domain;
+
+    fn threshold(
+        &self,
+        ctx: &Context<Self::Domain>,
+        input: Self::Domain,
+        threshold_plan: &ThresholdPlan,
+    ) -> Self::Domain;
+
+    fn union(&self, ctx: &Context<Self::Domain>, inputs: Vec<Self::Domain>) -> Self::Domain;
+
+    fn arrange_by(
+        &self,
+        ctx: &Context<Self::Domain>,
+        input: Self::Domain,
+        forms: &AvailableCollections,
+        input_key: &Option<Vec<MirScalarExpr>>,
+        input_mfp: &MapFilterProject,
+    ) -> Self::Domain;
+}
+
+/// An [Interpreter] context.
+pub type Context<Domain> = BTreeMap<LocalId, ContextEntry<Domain>>;
+
+/// An entry in an [Interpreter] context.
+///
+/// Each entry corresponds to a binding identified by a [LocalId] that is
+/// visible in the current context.
+#[derive(Debug)]
+pub struct ContextEntry<Domain> {
+    /// Is this entry correspond to a recursive binding or not.
+    pub is_rec: bool,
+    /// The domain value associated with this binding.
+    pub value: Domain,
+}
+
+impl<Domain> ContextEntry<Domain> {
+    fn of_let(value: Domain) -> Self {
+        Self {
+            is_rec: false,
+            value,
+        }
+    }
+
+    fn of_let_rec(value: Domain) -> Self {
+        Self {
+            is_rec: true,
+            value,
+        }
+    }
+}
+
+/// A lattice with existing `top` and `bottom` elements.
+pub trait BoundedLattice: Lattice {
+    /// The top element of this lattice (represents the most general
+    /// approximation).
+    fn top() -> Self;
+
+    /// The bottom element of this lattice (represents the most constrained
+    /// approximation).
+    fn bottom() -> Self;
+}
+
+/// The maximum of iterations of running lattice-based dataflow inference for
+/// the LetRec nodes before falling back to a conservative estimate of all
+/// bottom() elements for all recursive bindings.
+const MAX_LET_REC_ITERATIONS: u64 = 100;
+
+/// A wrapper for a recursive fold invocation over a [Plan] that cannot
+/// mutate its input.
+#[allow(missing_debug_implementations)]
+pub struct Fold<I, T>
+where
+    I: Interpreter<T>,
+{
+    interpret: I,
+    ctx: Context<I::Domain>,
+}
+
+impl<I, T> Fold<I, T>
+where
+    I: Interpreter<T>,
+    I::Domain: BoundedLattice + Clone,
+{
+    pub fn new(interpreter: I) -> Self {
+        Self {
+            interpret: interpreter,
+            ctx: Context::default(),
+        }
+    }
+
+    /// An immutable fold (structural recursion) over a [Plan] instance.
+    ///
+    /// Runs an abstract interpreter over the given `expr` in a bottom-up
+    /// manner, keeping the `ctx` field of the enclosing field up to date, and
+    /// returns the final result for the entire `expr`.
+    pub fn apply(&mut self, expr: &Plan<T>) -> I::Domain {
+        use Plan::*;
+        match expr {
+            Constant { rows } => {
+                // Interpret the current node.
+                self.interpret.constant(&self.ctx, rows)
+            }
+            Get { id, keys, plan } => {
+                // Interpret the current node.
+                self.interpret.get(&self.ctx, id, keys, plan)
+            }
+            Let { id, value, body } => {
+                // Extend context with the `value` result.
+                let res_value = self.apply(value);
+                let old_entry = self.ctx.insert(*id, ContextEntry::of_let(res_value));
+                assert!(old_entry.is_none(), "No shadowing");
+
+                // Descend into `body` with the extended context.
+                let res_body = self.apply(body);
+
+                // Revert the context.
+                self.ctx.remove(id);
+
+                // Return result from `body`.
+                res_body
+            }
+            LetRec {
+                ids,
+                values,
+                limits,
+                body,
+            } => {
+                // Extend the context with `bottom` for each recursive binding.
+                // This corresponds to starting with the most optimistic value.
+                for id in ids.iter() {
+                    let new_entry = ContextEntry::of_let_rec(I::Domain::bottom());
+                    let old_entry = self.ctx.insert(*id, new_entry);
+                    assert!(old_entry.is_none());
+                }
+
+                let min_max_iter = LetRecLimit::min_max_iter(limits);
+                let mut curr_iteration = 0;
+                loop {
+                    // Check for conditions (2) and (3).
+                    if curr_iteration >= MAX_LET_REC_ITERATIONS
+                        || min_max_iter
+                            .map(|min_max_iter| curr_iteration >= min_max_iter)
+                            .unwrap_or(false)
+                    {
+                        if curr_iteration > u64::cast_from(ids.len()) {
+                            soft_panic_or_log!(
+                                "LetRec loop in Plan fold has not converged in |{}|",
+                                ids.len()
+                            );
+                        }
+
+                        // Reset all ids to `top` (a conservative value).
+                        for id in ids.iter() {
+                            let new_entry = ContextEntry::of_let_rec(I::Domain::top());
+                            self.ctx.insert(*id, new_entry);
+                        }
+
+                        break;
+                    }
+
+                    // Check for condition (1).
+                    let mut change = false;
+                    for (id, value) in zip_eq(ids.iter(), values.iter()) {
+                        // Compute and join new with the current estimate.
+                        let mut res_value_new = self.apply(value);
+                        res_value_new.join_assign(&self.ctx.get(id).unwrap().value);
+                        // If the estimate has changed
+                        if res_value_new != self.ctx.get(id).unwrap().value {
+                            // Set the change flag.
+                            change = true;
+                            // Update the the context entry.
+                            let new_entry = ContextEntry::of_let_rec(res_value_new);
+                            self.ctx.insert(*id, new_entry);
+                        }
+                    }
+                    if !change {
+                        break;
+                    }
+
+                    curr_iteration += 1;
+                }
+
+                // Descend into `body` with the extended context.
+                let res_body = self.apply(body);
+
+                // Revert the context.
+                for id in ids.iter() {
+                    self.ctx.remove(id);
+                }
+
+                // Return result from `body`.
+                res_body
+            }
+            Mfp {
+                input,
+                mfp,
+                input_key_val,
+            } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                self.interpret.mfp(&self.ctx, input, mfp, input_key_val)
+            }
+            FlatMap {
+                input,
+                func,
+                exprs,
+                mfp,
+                input_key,
+            } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                self.interpret
+                    .flat_map(&self.ctx, input, func, exprs, mfp, input_key)
+            }
+            Join { inputs, plan } => {
+                // Descend recursively into all children.
+                let inputs = inputs.iter().map(|input| self.apply(input)).collect();
+                // Interpret the current node.
+                self.interpret.join(&self.ctx, inputs, plan)
+            }
+            Reduce {
+                input,
+                key_val_plan,
+                plan,
+                input_key,
+            } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                self.interpret
+                    .reduce(&self.ctx, input, key_val_plan, plan, input_key)
+            }
+            TopK { input, top_k_plan } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                self.interpret.top_k(&self.ctx, input, top_k_plan)
+            }
+            Negate { input } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                self.interpret.negate(&self.ctx, input)
+            }
+            Threshold {
+                input,
+                threshold_plan,
+            } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                self.interpret.threshold(&self.ctx, input, threshold_plan)
+            }
+            Union { inputs } => {
+                // Descend recursively into all children.
+                let inputs = inputs.iter().map(|input| self.apply(input)).collect();
+                // Interpret the current node.
+                self.interpret.union(&self.ctx, inputs)
+            }
+            ArrangeBy {
+                input,
+                forms,
+                input_key,
+                input_mfp,
+            } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                self.interpret
+                    .arrange_by(&self.ctx, input, forms, input_key, input_mfp)
+            }
+        }
+    }
+}
+
+/// A wrapper for a recursive fold invocation over a [Plan] that can
+/// mutate its input.
+#[allow(missing_debug_implementations)]
+pub struct FoldMut<I, T, Action>
+where
+    I: Interpreter<T>,
+{
+    interpret: I,
+    action: Action,
+    ctx: Context<I::Domain>,
+}
+
+impl<I, T, A> FoldMut<I, T, A>
+where
+    I: Interpreter<T>,
+    I::Domain: BoundedLattice + Clone,
+    A: FnMut(&mut Plan<T>, &I::Domain, &[I::Domain]),
+{
+    pub fn new(interpreter: I, action: A) -> Self {
+        Self {
+            interpret: interpreter,
+            action,
+            ctx: Context::default(),
+        }
+    }
+
+    /// An immutable fold (structural recursion) over a [Plan] instance.
+    ///
+    /// Runs an abstract interpreter over the given `expr` in a bottom-up
+    /// manner, keeping the `ctx` field of the enclosing field up to date, and
+    /// returns the final result for the entire `expr`.
+    ///
+    /// At each step, the current `expr` is passed along with the interpretation
+    /// result of itself and its children to an `action` callback that can
+    /// optionally mutate it.
+    pub fn apply(&mut self, expr: &mut Plan<T>) -> I::Domain {
+        use Plan::*;
+        match expr {
+            Constant { rows } => {
+                // Interpret the current node.
+                let result = self.interpret.constant(&self.ctx, rows);
+                // Mutate the current node using the given `action`.
+                (self.action)(expr, &result, &[]);
+                // Pass the interpretation result up.
+                result
+            }
+            Get { id, keys, plan } => {
+                // Interpret the current node.
+                let result = self.interpret.get(&self.ctx, id, keys, plan);
+                // Mutate the current node using the given `action`.
+                (self.action)(expr, &result, &[]);
+                // Pass the interpretation result up.
+                result
+            }
+            Let { id, value, body } => {
+                // Extend context with the `value` result.
+                let res_value = self.apply(value);
+                let old_entry = self.ctx.insert(*id, ContextEntry::of_let(res_value));
+                assert!(old_entry.is_none(), "No shadowing");
+
+                // Descend into `body` with the extended context.
+                let res_body = self.apply(body);
+
+                // Revert the context.
+                self.ctx.remove(id);
+
+                // Return result from `body`.
+                res_body
+            }
+            LetRec {
+                ids,
+                values,
+                limits,
+                body,
+            } => {
+                // Extend the context with `bottom` for each recursive binding.
+                // This corresponds to starting with the most optimistic value.
+                for id in ids.iter() {
+                    let new_entry = ContextEntry::of_let_rec(I::Domain::bottom());
+                    let old_entry = self.ctx.insert(*id, new_entry);
+                    assert!(old_entry.is_none());
+                }
+
+                let min_max_iter = LetRecLimit::min_max_iter(limits);
+                let mut curr_iteration = 0;
+                loop {
+                    // Check for conditions (2) and (3).
+                    if curr_iteration >= MAX_LET_REC_ITERATIONS
+                        || min_max_iter
+                            .map(|min_max_iter| curr_iteration >= min_max_iter)
+                            .unwrap_or(false)
+                    {
+                        if curr_iteration > u64::cast_from(ids.len()) {
+                            soft_panic_or_log!(
+                                "LetRec loop in Plan fold has not converged in |{}|",
+                                ids.len()
+                            );
+                        }
+
+                        // Reset all ids to `top` (a conservative value).
+                        for id in ids.iter() {
+                            let new_entry = ContextEntry::of_let_rec(I::Domain::top());
+                            self.ctx.insert(*id, new_entry);
+                        }
+
+                        break;
+                    }
+
+                    // Check for condition (1).
+                    let mut change = false;
+                    for (id, value) in zip_eq(ids.iter(), values.iter_mut()) {
+                        // Compute and join new with the current estimate.
+                        let mut res_value_new = self.apply(value);
+                        res_value_new.join_assign(&self.ctx.get(id).unwrap().value);
+                        // If the estimate has changed
+                        if res_value_new != self.ctx.get(id).unwrap().value {
+                            // Set the change flag.
+                            change = true;
+                            // Update the the context entry.
+                            let new_entry = ContextEntry::of_let_rec(res_value_new);
+                            self.ctx.insert(*id, new_entry);
+                        }
+                    }
+                    if !change {
+                        break;
+                    }
+
+                    curr_iteration += 1;
+                }
+
+                // Descend into `body` with the extended context.
+                let res_body = self.apply(body);
+
+                // Revert the context.
+                for id in ids.iter() {
+                    self.ctx.remove(id);
+                }
+
+                // Return result from `body`.
+                res_body
+            }
+            Mfp {
+                input,
+                mfp,
+                input_key_val,
+            } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                let result = self
+                    .interpret
+                    .mfp(&self.ctx, input.clone(), mfp, input_key_val);
+                // Mutate the current node using the given `action`.
+                (self.action)(expr, &result, &[input]);
+                // Pass the interpretation result up.
+                result
+            }
+            FlatMap {
+                input,
+                func,
+                exprs,
+                mfp,
+                input_key,
+            } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                let result =
+                    self.interpret
+                        .flat_map(&self.ctx, input.clone(), func, exprs, mfp, input_key);
+                // Mutate the current node using the given `action`.
+                (self.action)(expr, &result, &[input]);
+                // Pass the interpretation result up.
+                result
+            }
+            Join { inputs, plan } => {
+                // Descend recursively into all children.
+                let inputs: Vec<_> = inputs.iter_mut().map(|input| self.apply(input)).collect();
+                // Interpret the current node.
+                let result = self.interpret.join(&self.ctx, inputs.clone(), plan);
+                // Mutate the current node using the given `action`.
+                (self.action)(expr, &result, &inputs);
+                // Pass the interpretation result up.
+                result
+            }
+            Reduce {
+                input,
+                key_val_plan,
+                plan,
+                input_key,
+            } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                let result =
+                    self.interpret
+                        .reduce(&self.ctx, input.clone(), key_val_plan, plan, input_key);
+                // Mutate the current node using the given `action`.
+                (self.action)(expr, &result, &[input]);
+                // Pass the interpretation result up.
+                result
+            }
+            TopK { input, top_k_plan } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                let result = self.interpret.top_k(&self.ctx, input.clone(), top_k_plan);
+                // Mutate the current node using the given `action`.
+                (self.action)(expr, &result, &[input]);
+                // Pass the interpretation result up.
+                result
+            }
+            Negate { input } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                let result = self.interpret.negate(&self.ctx, input.clone());
+                // Mutate the current node using the given `action`.
+                (self.action)(expr, &result, &[input]);
+                // Pass the interpretation result up.
+                result
+            }
+            Threshold {
+                input,
+                threshold_plan,
+            } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                let result = self
+                    .interpret
+                    .threshold(&self.ctx, input.clone(), threshold_plan);
+                // Mutate the current node using the given `action`.
+                (self.action)(expr, &result, &[input]);
+                // Pass the interpretation result up.
+                result
+            }
+            Union { inputs } => {
+                // Descend recursively into all children.
+                let inputs: Vec<_> = inputs.iter_mut().map(|input| self.apply(input)).collect();
+                // Interpret the current node.
+                let result = self.interpret.union(&self.ctx, inputs.clone());
+                // Mutate the current node using the given `action`.
+                (self.action)(expr, &result, &inputs);
+                // Pass the interpretation result up.
+                result
+            }
+            ArrangeBy {
+                input,
+                forms,
+                input_key,
+                input_mfp,
+            } => {
+                // Descend recursively into all children.
+                let input = self.apply(input);
+                // Interpret the current node.
+                let result = self.interpret.arrange_by(
+                    &self.ctx,
+                    input.clone(),
+                    forms,
+                    input_key,
+                    input_mfp,
+                );
+                // Mutate the current node using the given `action`.
+                (self.action)(expr, &result, &[input]);
+                // Pass the interpretation result up.
+                result
+            }
+        }
+    }
+}

--- a/src/compute-client/src/plan/interpret/api.rs
+++ b/src/compute-client/src/plan/interpret/api.rs
@@ -18,9 +18,13 @@ use std::fmt::Debug;
 
 use differential_dataflow::lattice::Lattice;
 use itertools::zip_eq;
-use mz_expr::{EvalError, Id, LetRecLimit, LocalId, MapFilterProject, MirScalarExpr, TableFunc};
+use mz_expr::{
+    EvalError, Id, LetRecLimit, LocalId, MapFilterProject, MirScalarExpr, TableFunc,
+    RECURSION_LIMIT,
+};
 use mz_ore::cast::CastFrom;
 use mz_ore::soft_panic_or_log;
+use mz_ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
 use mz_repr::{Diff, Row};
 
 use crate::plan::join::JoinPlan;
@@ -32,7 +36,7 @@ use crate::plan::{AvailableCollections, GetPlan, Plan};
 /// An [abstract interpreter] for [Plan] expressions.
 ///
 /// This is an [object algebra] / [tagless final encoding] of the language
-/// defined by [crate::plan::Plan], with the exception of the `Get` and `Let*`
+/// defined by [crate::plan::Plan], with the exception of the `Let*`
 /// variants. The latter are modeled as part of the various recursion methods,
 /// as they are constructs to introduce and reference context.
 ///
@@ -195,185 +199,204 @@ where
     /// Runs an abstract interpreter over the given `expr` in a bottom-up
     /// manner, keeping the `ctx` field of the enclosing field up to date, and
     /// returns the final result for the entire `expr`.
-    pub fn apply(&mut self, expr: &Plan<T>) -> I::Domain {
+    pub fn apply(&mut self, expr: &Plan<T>) -> Result<I::Domain, RecursionLimitError> {
+        self.apply_rec(expr, RecursionGuard::with_limit(RECURSION_LIMIT))
+    }
+
+    fn apply_rec(
+        &mut self,
+        expr: &Plan<T>,
+        rg: RecursionGuard,
+    ) -> Result<I::Domain, RecursionLimitError> {
         use Plan::*;
-        match expr {
-            Constant { rows } => {
-                // Interpret the current node.
-                self.interpret.constant(&self.ctx, rows)
-            }
-            Get { id, keys, plan } => {
-                // Interpret the current node.
-                self.interpret.get(&self.ctx, id, keys, plan)
-            }
-            Let { id, value, body } => {
-                // Extend context with the `value` result.
-                let res_value = self.apply(value);
-                let old_entry = self.ctx.insert(*id, ContextEntry::of_let(res_value));
-                assert!(old_entry.is_none(), "No shadowing");
-
-                // Descend into `body` with the extended context.
-                let res_body = self.apply(body);
-
-                // Revert the context.
-                self.ctx.remove(id);
-
-                // Return result from `body`.
-                res_body
-            }
-            LetRec {
-                ids,
-                values,
-                limits,
-                body,
-            } => {
-                // Extend the context with `bottom` for each recursive binding.
-                // This corresponds to starting with the most optimistic value.
-                for id in ids.iter() {
-                    let new_entry = ContextEntry::of_let_rec(I::Domain::bottom());
-                    let old_entry = self.ctx.insert(*id, new_entry);
-                    assert!(old_entry.is_none());
+        rg.checked_recur(|_| {
+            match expr {
+                Constant { rows } => {
+                    // Interpret the current node.
+                    Ok(self.interpret.constant(&self.ctx, rows))
                 }
-
-                let min_max_iter = LetRecLimit::min_max_iter(limits);
-                let mut curr_iteration = 0;
-                loop {
-                    // Check for conditions (2) and (3).
-                    if curr_iteration >= MAX_LET_REC_ITERATIONS
-                        || min_max_iter
-                            .map(|min_max_iter| curr_iteration >= min_max_iter)
-                            .unwrap_or(false)
-                    {
-                        if curr_iteration > u64::cast_from(ids.len()) {
-                            soft_panic_or_log!(
-                                "LetRec loop in Plan fold has not converged in |{}|",
-                                ids.len()
-                            );
-                        }
-
-                        // Reset all ids to `top` (a conservative value).
-                        for id in ids.iter() {
-                            let new_entry = ContextEntry::of_let_rec(I::Domain::top());
-                            self.ctx.insert(*id, new_entry);
-                        }
-
-                        break;
-                    }
-
-                    // Check for condition (1).
-                    let mut change = false;
-                    for (id, value) in zip_eq(ids.iter(), values.iter()) {
-                        // Compute and join new with the current estimate.
-                        let mut res_value_new = self.apply(value);
-                        res_value_new.join_assign(&self.ctx.get(id).unwrap().value);
-                        // If the estimate has changed
-                        if res_value_new != self.ctx.get(id).unwrap().value {
-                            // Set the change flag.
-                            change = true;
-                            // Update the the context entry.
-                            let new_entry = ContextEntry::of_let_rec(res_value_new);
-                            self.ctx.insert(*id, new_entry);
-                        }
-                    }
-                    if !change {
-                        break;
-                    }
-
-                    curr_iteration += 1;
+                Get { id, keys, plan } => {
+                    // Interpret the current node.
+                    Ok(self.interpret.get(&self.ctx, id, keys, plan))
                 }
+                Let { id, value, body } => {
+                    // Extend context with the `value` result.
+                    let res_value = self.apply(value)?;
+                    let old_entry = self.ctx.insert(*id, ContextEntry::of_let(res_value));
+                    assert!(old_entry.is_none(), "No shadowing");
 
-                // Descend into `body` with the extended context.
-                let res_body = self.apply(body);
+                    // Descend into `body` with the extended context.
+                    let res_body = self.apply(body);
 
-                // Revert the context.
-                for id in ids.iter() {
+                    // Revert the context.
                     self.ctx.remove(id);
-                }
 
-                // Return result from `body`.
-                res_body
+                    // Return result from `body`.
+                    res_body
+                }
+                LetRec {
+                    ids,
+                    values,
+                    limits,
+                    body,
+                } => {
+                    // Extend the context with `bottom` for each recursive binding.
+                    // This corresponds to starting with the most optimistic value.
+                    for id in ids.iter() {
+                        let new_entry = ContextEntry::of_let_rec(I::Domain::bottom());
+                        let old_entry = self.ctx.insert(*id, new_entry);
+                        assert!(old_entry.is_none());
+                    }
+
+                    let min_max_iter = LetRecLimit::min_max_iter(limits);
+                    let mut curr_iteration = 0;
+                    loop {
+                        // Check for conditions (2) and (3).
+                        if curr_iteration >= MAX_LET_REC_ITERATIONS
+                            || min_max_iter
+                                .map(|min_max_iter| curr_iteration >= min_max_iter)
+                                .unwrap_or(false)
+                        {
+                            if curr_iteration > u64::cast_from(ids.len()) {
+                                soft_panic_or_log!(
+                                    "LetRec loop in Plan fold has not converged in |{}|",
+                                    ids.len()
+                                );
+                            }
+
+                            // Reset all ids to `top` (a conservative value).
+                            for id in ids.iter() {
+                                let new_entry = ContextEntry::of_let_rec(I::Domain::top());
+                                self.ctx.insert(*id, new_entry);
+                            }
+
+                            break;
+                        }
+
+                        // Check for condition (1).
+                        let mut change = false;
+                        for (id, value) in zip_eq(ids.iter(), values.iter()) {
+                            // Compute and join new with the current estimate.
+                            let mut res_value_new = self.apply(value)?;
+                            res_value_new.join_assign(&self.ctx.get(id).unwrap().value);
+                            // If the estimate has changed
+                            if res_value_new != self.ctx.get(id).unwrap().value {
+                                // Set the change flag.
+                                change = true;
+                                // Update the the context entry.
+                                let new_entry = ContextEntry::of_let_rec(res_value_new);
+                                self.ctx.insert(*id, new_entry);
+                            }
+                        }
+                        if !change {
+                            break;
+                        }
+
+                        curr_iteration += 1;
+                    }
+
+                    // Descend into `body` with the extended context.
+                    let res_body = self.apply(body);
+
+                    // Revert the context.
+                    for id in ids.iter() {
+                        self.ctx.remove(id);
+                    }
+
+                    // Return result from `body`.
+                    res_body
+                }
+                Mfp {
+                    input,
+                    mfp,
+                    input_key_val,
+                } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    Ok(self.interpret.mfp(&self.ctx, input, mfp, input_key_val))
+                }
+                FlatMap {
+                    input,
+                    func,
+                    exprs,
+                    mfp,
+                    input_key,
+                } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    Ok(self
+                        .interpret
+                        .flat_map(&self.ctx, input, func, exprs, mfp, input_key))
+                }
+                Join { inputs, plan } => {
+                    // Descend recursively into all children.
+                    let inputs = inputs
+                        .iter()
+                        .map(|input| self.apply(input))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    // Interpret the current node.
+                    Ok(self.interpret.join(&self.ctx, inputs, plan))
+                }
+                Reduce {
+                    input,
+                    key_val_plan,
+                    plan,
+                    input_key,
+                } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    Ok(self
+                        .interpret
+                        .reduce(&self.ctx, input, key_val_plan, plan, input_key))
+                }
+                TopK { input, top_k_plan } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    Ok(self.interpret.top_k(&self.ctx, input, top_k_plan))
+                }
+                Negate { input } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    Ok(self.interpret.negate(&self.ctx, input))
+                }
+                Threshold {
+                    input,
+                    threshold_plan,
+                } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    Ok(self.interpret.threshold(&self.ctx, input, threshold_plan))
+                }
+                Union { inputs } => {
+                    // Descend recursively into all children.
+                    let inputs = inputs
+                        .iter()
+                        .map(|input| self.apply(input))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    // Interpret the current node.
+                    Ok(self.interpret.union(&self.ctx, inputs))
+                }
+                ArrangeBy {
+                    input,
+                    forms,
+                    input_key,
+                    input_mfp,
+                } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    Ok(self
+                        .interpret
+                        .arrange_by(&self.ctx, input, forms, input_key, input_mfp))
+                }
             }
-            Mfp {
-                input,
-                mfp,
-                input_key_val,
-            } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                self.interpret.mfp(&self.ctx, input, mfp, input_key_val)
-            }
-            FlatMap {
-                input,
-                func,
-                exprs,
-                mfp,
-                input_key,
-            } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                self.interpret
-                    .flat_map(&self.ctx, input, func, exprs, mfp, input_key)
-            }
-            Join { inputs, plan } => {
-                // Descend recursively into all children.
-                let inputs = inputs.iter().map(|input| self.apply(input)).collect();
-                // Interpret the current node.
-                self.interpret.join(&self.ctx, inputs, plan)
-            }
-            Reduce {
-                input,
-                key_val_plan,
-                plan,
-                input_key,
-            } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                self.interpret
-                    .reduce(&self.ctx, input, key_val_plan, plan, input_key)
-            }
-            TopK { input, top_k_plan } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                self.interpret.top_k(&self.ctx, input, top_k_plan)
-            }
-            Negate { input } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                self.interpret.negate(&self.ctx, input)
-            }
-            Threshold {
-                input,
-                threshold_plan,
-            } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                self.interpret.threshold(&self.ctx, input, threshold_plan)
-            }
-            Union { inputs } => {
-                // Descend recursively into all children.
-                let inputs = inputs.iter().map(|input| self.apply(input)).collect();
-                // Interpret the current node.
-                self.interpret.union(&self.ctx, inputs)
-            }
-            ArrangeBy {
-                input,
-                forms,
-                input_key,
-                input_mfp,
-            } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                self.interpret
-                    .arrange_by(&self.ctx, input, forms, input_key, input_mfp)
-            }
-        }
+        })
     }
 }
 
@@ -412,239 +435,264 @@ where
     /// At each step, the current `expr` is passed along with the interpretation
     /// result of itself and its children to an `action` callback that can
     /// optionally mutate it.
-    pub fn apply(&mut self, expr: &mut Plan<T>) -> I::Domain {
+    pub fn apply(&mut self, expr: &mut Plan<T>) -> Result<I::Domain, RecursionLimitError> {
+        self.apply_rec(expr, RecursionGuard::with_limit(RECURSION_LIMIT))
+    }
+
+    fn apply_rec(
+        &mut self,
+        expr: &mut Plan<T>,
+        rg: RecursionGuard,
+    ) -> Result<I::Domain, RecursionLimitError> {
         use Plan::*;
-        match expr {
-            Constant { rows } => {
-                // Interpret the current node.
-                let result = self.interpret.constant(&self.ctx, rows);
-                // Mutate the current node using the given `action`.
-                (self.action)(expr, &result, &[]);
-                // Pass the interpretation result up.
-                result
-            }
-            Get { id, keys, plan } => {
-                // Interpret the current node.
-                let result = self.interpret.get(&self.ctx, id, keys, plan);
-                // Mutate the current node using the given `action`.
-                (self.action)(expr, &result, &[]);
-                // Pass the interpretation result up.
-                result
-            }
-            Let { id, value, body } => {
-                // Extend context with the `value` result.
-                let res_value = self.apply(value);
-                let old_entry = self.ctx.insert(*id, ContextEntry::of_let(res_value));
-                assert!(old_entry.is_none(), "No shadowing");
-
-                // Descend into `body` with the extended context.
-                let res_body = self.apply(body);
-
-                // Revert the context.
-                self.ctx.remove(id);
-
-                // Return result from `body`.
-                res_body
-            }
-            LetRec {
-                ids,
-                values,
-                limits,
-                body,
-            } => {
-                // Extend the context with `bottom` for each recursive binding.
-                // This corresponds to starting with the most optimistic value.
-                for id in ids.iter() {
-                    let new_entry = ContextEntry::of_let_rec(I::Domain::bottom());
-                    let old_entry = self.ctx.insert(*id, new_entry);
-                    assert!(old_entry.is_none());
+        rg.checked_recur(|_| {
+            match expr {
+                Constant { rows } => {
+                    // Interpret the current node.
+                    let result = self.interpret.constant(&self.ctx, rows);
+                    // Mutate the current node using the given `action`.
+                    (self.action)(expr, &result, &[]);
+                    // Pass the interpretation result up.
+                    Ok(result)
                 }
-
-                let min_max_iter = LetRecLimit::min_max_iter(limits);
-                let mut curr_iteration = 0;
-                loop {
-                    // Check for conditions (2) and (3).
-                    if curr_iteration >= MAX_LET_REC_ITERATIONS
-                        || min_max_iter
-                            .map(|min_max_iter| curr_iteration >= min_max_iter)
-                            .unwrap_or(false)
-                    {
-                        if curr_iteration > u64::cast_from(ids.len()) {
-                            soft_panic_or_log!(
-                                "LetRec loop in Plan fold has not converged in |{}|",
-                                ids.len()
-                            );
-                        }
-
-                        // Reset all ids to `top` (a conservative value).
-                        for id in ids.iter() {
-                            let new_entry = ContextEntry::of_let_rec(I::Domain::top());
-                            self.ctx.insert(*id, new_entry);
-                        }
-
-                        break;
-                    }
-
-                    // Check for condition (1).
-                    let mut change = false;
-                    for (id, value) in zip_eq(ids.iter(), values.iter_mut()) {
-                        // Compute and join new with the current estimate.
-                        let mut res_value_new = self.apply(value);
-                        res_value_new.join_assign(&self.ctx.get(id).unwrap().value);
-                        // If the estimate has changed
-                        if res_value_new != self.ctx.get(id).unwrap().value {
-                            // Set the change flag.
-                            change = true;
-                            // Update the the context entry.
-                            let new_entry = ContextEntry::of_let_rec(res_value_new);
-                            self.ctx.insert(*id, new_entry);
-                        }
-                    }
-                    if !change {
-                        break;
-                    }
-
-                    curr_iteration += 1;
+                Get { id, keys, plan } => {
+                    // Interpret the current node.
+                    let result = self.interpret.get(&self.ctx, id, keys, plan);
+                    // Mutate the current node using the given `action`.
+                    (self.action)(expr, &result, &[]);
+                    // Pass the interpretation result up.
+                    Ok(result)
                 }
+                Let { id, value, body } => {
+                    // Extend context with the `value` result.
+                    let res_value = self.apply(value)?;
+                    let old_entry = self.ctx.insert(*id, ContextEntry::of_let(res_value));
+                    assert!(old_entry.is_none(), "No shadowing");
 
-                // Descend into `body` with the extended context.
-                let res_body = self.apply(body);
+                    // Descend into `body` with the extended context.
+                    let res_body = self.apply(body);
 
-                // Revert the context.
-                for id in ids.iter() {
+                    // Revert the context.
                     self.ctx.remove(id);
-                }
 
-                // Return result from `body`.
-                res_body
-            }
-            Mfp {
-                input,
-                mfp,
-                input_key_val,
-            } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                let result = self
-                    .interpret
-                    .mfp(&self.ctx, input.clone(), mfp, input_key_val);
-                // Mutate the current node using the given `action`.
-                (self.action)(expr, &result, &[input]);
-                // Pass the interpretation result up.
-                result
-            }
-            FlatMap {
-                input,
-                func,
-                exprs,
-                mfp,
-                input_key,
-            } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                let result =
-                    self.interpret
-                        .flat_map(&self.ctx, input.clone(), func, exprs, mfp, input_key);
-                // Mutate the current node using the given `action`.
-                (self.action)(expr, &result, &[input]);
-                // Pass the interpretation result up.
-                result
-            }
-            Join { inputs, plan } => {
-                // Descend recursively into all children.
-                let inputs: Vec<_> = inputs.iter_mut().map(|input| self.apply(input)).collect();
-                // Interpret the current node.
-                let result = self.interpret.join(&self.ctx, inputs.clone(), plan);
-                // Mutate the current node using the given `action`.
-                (self.action)(expr, &result, &inputs);
-                // Pass the interpretation result up.
-                result
-            }
-            Reduce {
-                input,
-                key_val_plan,
-                plan,
-                input_key,
-            } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                let result =
-                    self.interpret
-                        .reduce(&self.ctx, input.clone(), key_val_plan, plan, input_key);
-                // Mutate the current node using the given `action`.
-                (self.action)(expr, &result, &[input]);
-                // Pass the interpretation result up.
-                result
-            }
-            TopK { input, top_k_plan } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                let result = self.interpret.top_k(&self.ctx, input.clone(), top_k_plan);
-                // Mutate the current node using the given `action`.
-                (self.action)(expr, &result, &[input]);
-                // Pass the interpretation result up.
-                result
-            }
-            Negate { input } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                let result = self.interpret.negate(&self.ctx, input.clone());
-                // Mutate the current node using the given `action`.
-                (self.action)(expr, &result, &[input]);
-                // Pass the interpretation result up.
-                result
-            }
-            Threshold {
-                input,
-                threshold_plan,
-            } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                let result = self
-                    .interpret
-                    .threshold(&self.ctx, input.clone(), threshold_plan);
-                // Mutate the current node using the given `action`.
-                (self.action)(expr, &result, &[input]);
-                // Pass the interpretation result up.
-                result
-            }
-            Union { inputs } => {
-                // Descend recursively into all children.
-                let inputs: Vec<_> = inputs.iter_mut().map(|input| self.apply(input)).collect();
-                // Interpret the current node.
-                let result = self.interpret.union(&self.ctx, inputs.clone());
-                // Mutate the current node using the given `action`.
-                (self.action)(expr, &result, &inputs);
-                // Pass the interpretation result up.
-                result
-            }
-            ArrangeBy {
-                input,
-                forms,
-                input_key,
-                input_mfp,
-            } => {
-                // Descend recursively into all children.
-                let input = self.apply(input);
-                // Interpret the current node.
-                let result = self.interpret.arrange_by(
-                    &self.ctx,
-                    input.clone(),
+                    // Return result from `body`.
+                    res_body
+                }
+                LetRec {
+                    ids,
+                    values,
+                    limits,
+                    body,
+                } => {
+                    // Extend the context with `bottom` for each recursive binding.
+                    // This corresponds to starting with the most optimistic value.
+                    for id in ids.iter() {
+                        let new_entry = ContextEntry::of_let_rec(I::Domain::bottom());
+                        let old_entry = self.ctx.insert(*id, new_entry);
+                        assert!(old_entry.is_none());
+                    }
+
+                    let min_max_iter = LetRecLimit::min_max_iter(limits);
+                    let mut curr_iteration = 0;
+                    loop {
+                        // Check for conditions (2) and (3).
+                        if curr_iteration >= MAX_LET_REC_ITERATIONS
+                            || min_max_iter
+                                .map(|min_max_iter| curr_iteration >= min_max_iter)
+                                .unwrap_or(false)
+                        {
+                            if curr_iteration > u64::cast_from(ids.len()) {
+                                soft_panic_or_log!(
+                                    "LetRec loop in Plan fold has not converged in |{}|",
+                                    ids.len()
+                                );
+                            }
+
+                            // Reset all ids to `top` (a conservative value).
+                            for id in ids.iter() {
+                                let new_entry = ContextEntry::of_let_rec(I::Domain::top());
+                                self.ctx.insert(*id, new_entry);
+                            }
+
+                            break;
+                        }
+
+                        // Check for condition (1).
+                        let mut change = false;
+                        for (id, value) in zip_eq(ids.iter(), values.iter_mut()) {
+                            // Compute and join new with the current estimate.
+                            let mut res_value_new = self.apply(value)?;
+                            res_value_new.join_assign(&self.ctx.get(id).unwrap().value);
+                            // If the estimate has changed
+                            if res_value_new != self.ctx.get(id).unwrap().value {
+                                // Set the change flag.
+                                change = true;
+                                // Update the the context entry.
+                                let new_entry = ContextEntry::of_let_rec(res_value_new);
+                                self.ctx.insert(*id, new_entry);
+                            }
+                        }
+                        if !change {
+                            break;
+                        }
+
+                        curr_iteration += 1;
+                    }
+
+                    // Descend into `body` with the extended context.
+                    let res_body = self.apply(body);
+
+                    // Revert the context.
+                    for id in ids.iter() {
+                        self.ctx.remove(id);
+                    }
+
+                    // Return result from `body`.
+                    res_body
+                }
+                Mfp {
+                    input,
+                    mfp,
+                    input_key_val,
+                } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    let result = self
+                        .interpret
+                        .mfp(&self.ctx, input.clone(), mfp, input_key_val);
+                    // Mutate the current node using the given `action`.
+                    (self.action)(expr, &result, &[input]);
+                    // Pass the interpretation result up.
+                    Ok(result)
+                }
+                FlatMap {
+                    input,
+                    func,
+                    exprs,
+                    mfp,
+                    input_key,
+                } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    let result = self.interpret.flat_map(
+                        &self.ctx,
+                        input.clone(),
+                        func,
+                        exprs,
+                        mfp,
+                        input_key,
+                    );
+                    // Mutate the current node using the given `action`.
+                    (self.action)(expr, &result, &[input]);
+                    // Pass the interpretation result up.
+                    Ok(result)
+                }
+                Join { inputs, plan } => {
+                    // Descend recursively into all children.
+                    let inputs: Vec<_> = inputs
+                        .iter_mut()
+                        .map(|input| self.apply(input))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    // Interpret the current node.
+                    let result = self.interpret.join(&self.ctx, inputs.clone(), plan);
+                    // Mutate the current node using the given `action`.
+                    (self.action)(expr, &result, &inputs);
+                    // Pass the interpretation result up.
+                    Ok(result)
+                }
+                Reduce {
+                    input,
+                    key_val_plan,
+                    plan,
+                    input_key,
+                } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    let result = self.interpret.reduce(
+                        &self.ctx,
+                        input.clone(),
+                        key_val_plan,
+                        plan,
+                        input_key,
+                    );
+                    // Mutate the current node using the given `action`.
+                    (self.action)(expr, &result, &[input]);
+                    // Pass the interpretation result up.
+                    Ok(result)
+                }
+                TopK { input, top_k_plan } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    let result = self.interpret.top_k(&self.ctx, input.clone(), top_k_plan);
+                    // Mutate the current node using the given `action`.
+                    (self.action)(expr, &result, &[input]);
+                    // Pass the interpretation result up.
+                    Ok(result)
+                }
+                Negate { input } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    let result = self.interpret.negate(&self.ctx, input.clone());
+                    // Mutate the current node using the given `action`.
+                    (self.action)(expr, &result, &[input]);
+                    // Pass the interpretation result up.
+                    Ok(result)
+                }
+                Threshold {
+                    input,
+                    threshold_plan,
+                } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    let result = self
+                        .interpret
+                        .threshold(&self.ctx, input.clone(), threshold_plan);
+                    // Mutate the current node using the given `action`.
+                    (self.action)(expr, &result, &[input]);
+                    // Pass the interpretation result up.
+                    Ok(result)
+                }
+                Union { inputs } => {
+                    // Descend recursively into all children.
+                    let inputs: Vec<_> = inputs
+                        .iter_mut()
+                        .map(|input| self.apply(input))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    // Interpret the current node.
+                    let result = self.interpret.union(&self.ctx, inputs.clone());
+                    // Mutate the current node using the given `action`.
+                    (self.action)(expr, &result, &inputs);
+                    // Pass the interpretation result up.
+                    Ok(result)
+                }
+                ArrangeBy {
+                    input,
                     forms,
                     input_key,
                     input_mfp,
-                );
-                // Mutate the current node using the given `action`.
-                (self.action)(expr, &result, &[input]);
-                // Pass the interpretation result up.
-                result
+                } => {
+                    // Descend recursively into all children.
+                    let input = self.apply(input)?;
+                    // Interpret the current node.
+                    let result = self.interpret.arrange_by(
+                        &self.ctx,
+                        input.clone(),
+                        forms,
+                        input_key,
+                        input_mfp,
+                    );
+                    // Mutate the current node using the given `action`.
+                    (self.action)(expr, &result, &[input]);
+                    // Pass the interpretation result up.
+                    Ok(result)
+                }
             }
-        }
+        })
     }
 }

--- a/src/compute-client/src/plan/interpret/mod.rs
+++ b/src/compute-client/src/plan/interpret/mod.rs
@@ -1,0 +1,24 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Utilities and implementations for abstract interpretation of
+//! [crate::plan::Plan] structures.
+
+// Keep nested modules private (those are primary used for introducing better
+// physical separation between the API and its various implementations) and
+// explicitly export public members that need to be visible outside of this
+// crate.
+mod api;
+mod physically_monotonic;
+
+// Re-export public interpreter API.
+pub use api::*;
+
+// Re-export Interpreter implementations.
+pub use physically_monotonic::*;

--- a/src/compute-client/src/plan/interpret/physically_monotonic.rs
+++ b/src/compute-client/src/plan/interpret/physically_monotonic.rs
@@ -1,0 +1,11 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Placeholder module for an [crate::plan::interpret::Interpreter] that infers
+//! physical monotonicity.

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -38,6 +38,7 @@ use crate::plan::threshold::ThresholdPlan;
 use crate::plan::top_k::TopKPlan;
 use crate::types::dataflows::{BuildDesc, DataflowDescription};
 
+pub mod interpret;
 pub mod join;
 pub mod reduce;
 pub mod threshold;

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -43,6 +43,7 @@ pub mod join;
 pub mod reduce;
 pub mod threshold;
 pub mod top_k;
+pub mod transform;
 
 include!(concat!(env!("OUT_DIR"), "/mz_compute_client.plan.rs"));
 

--- a/src/compute-client/src/plan/transform/api.rs
+++ b/src/compute-client/src/plan/transform/api.rs
@@ -1,0 +1,71 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Utilities for transformation of [crate::plan::Plan] structures.
+
+use crate::plan::interpret::{BoundedLattice, FoldMut, Interpreter};
+use crate::plan::Plan;
+
+/// The type of configuration options passed to all [Transform::transform] calls
+/// as an immutable reference.
+pub type TransformConfig = ();
+
+/// A transform for [crate::plan::Plan] nodes.
+pub trait Transform<T = mz_repr::Timestamp> {
+    fn name(&self) -> &'static str;
+
+    /// Transform a [Plan] using the given [TransformConfig].
+    ///
+    /// The default implementation of method just handles plan tracing and
+    /// delegates to the [Transform::do_transform] method. Clients should
+    /// override this method if they don't want the [Transform::transform] call
+    /// to record a trace of its output.
+    fn transform(&self, config: &TransformConfig, plan: &mut Plan<T>) {
+        use tracing::{span, Level};
+        let _span = span!(Level::TRACE, "transform", path.segment = self.name()).entered();
+        self.do_transform(config, plan);
+    }
+
+    /// A method that performs the actual transform.
+    fn do_transform(&self, config: &TransformConfig, plan: &mut Plan<T>);
+}
+
+pub trait BottomUpTransform<T = mz_repr::Timestamp> {
+    /// A type representing analysis information to be associated with each
+    /// sub-term and exposed to the transformation action callback.
+    type Info: BoundedLattice + Clone;
+
+    /// A type responsible for synthesizing the [Self::Info] associated with
+    /// each sub-term.
+    type Interpreter: Interpreter<T, Domain = Self::Info>;
+
+    /// The name for this transform.
+    fn name(&self) -> &'static str;
+
+    /// Derive a [Self::Interpreter] instance from the [TransformConfig].
+    fn interpreter(config: &TransformConfig) -> Self::Interpreter;
+
+    /// A callback for manipulating the root of the given [Plan] using the
+    /// [Self::Info] derived for itself and its children.
+    fn action(plan: &mut Plan<T>, plan_info: &Self::Info, input_infos: &[Self::Info]);
+}
+
+impl<A, T> Transform<T> for A
+where
+    A: BottomUpTransform<T>,
+{
+    fn name(&self) -> &'static str {
+        self.name()
+    }
+
+    fn do_transform(&self, config: &TransformConfig, plan: &mut Plan<T>) {
+        let mut fold = FoldMut::new(Self::interpreter(config), Self::action);
+        fold.apply(plan);
+    }
+}

--- a/src/compute-client/src/plan/transform/mod.rs
+++ b/src/compute-client/src/plan/transform/mod.rs
@@ -1,0 +1,33 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Utilities and implementations for transformation of [crate::plan::Plan]
+//! structures.
+//!
+//! As a general rule, semantic transformations should be done at the
+//! [mz_expr::MirRelationExpr] level. However, in certain situations where we
+//! want to do a pass over a [crate::plan::Plan] lowered from an
+//! [mz_expr::MirRelationExpr] in order to fix sub-optimal aspects of that plan.
+//!
+//! To do that, create a struct that implements [Transform] and call the
+//! [Transform::transform] method towards the end of
+//! [crate::plan::Plan::finalize_dataflow], but before the
+//! [mz_repr::explain::trace_plan] call.
+
+// Keep nested modules private (those are primary used for introducing better
+// physical separation between the API and its various implementations) and
+// explicitly export public members that need to be visible outside of this crate.
+mod api;
+mod relax_must_consolidate;
+
+// Re-export public transform API.
+pub use api::*;
+
+// Re-export Transform implementations.
+pub use relax_must_consolidate::*;

--- a/src/compute-client/src/plan/transform/relax_must_consolidate.rs
+++ b/src/compute-client/src/plan/transform/relax_must_consolidate.rs
@@ -1,0 +1,11 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Placeholder module for an [crate::plan::transform::Transform] that infers
+//! physical monotonicity.


### PR DESCRIPTION
This PR proposes a lightweight API for analyzing and transforming LIR plans.

The API should be used conservatively, as in general we want most transformations to happen on the `MIR ⇒ MIR` level. However, recently we have identified several use cases for analysis and transformation on top of LIR plans in #19250 and #19260.

### Motivation

  * This PR adds a feature that has not yet been specified.

In preparation for providing the implementations proposed in #19250 me and @vmarcos discussed providing a more structured API for `LIR` analysis and `LIR ⇒ LIR` transforms.

This might also be of help @mgree once he starts defining LIR-based cost models. We _should be_ able to express this in terms of `Interpreter` implementations, but we might need to tweak the API so we can compose a list of interpreters `I_1, ..., I_m` that need to be inferred in sequence, where `I_m` should get access to the context maps and input values for `I_l` for `l < m`.

### Tips for reviewer

* The first commit is for the abstract interpretation API and the second for the transformation API.
* The API itself is in an `api.rs` sub-module, but all public items are re-exported at the top level.
* The commits provision one file in each of the two modules for the concrete implementation that @vmarcos will work on next.
* Some open questions:
  * I'm not sure if the `transform` and `interpret` modules should live under `plan` or next to `plan`. For example `explain` is next to `plan`, but rendering is within `plan`.
  * At the moment the API is not recursion safe. We can make it recursion-safe in one of several ways:
      * By using stacker through the `mz_ore` extensions (requires changing the return type to `Result`). :heavy_check_mark:
      * By tracking the recursion depth manually (requires changing the return type to `Result`). :x: 
      * By reverting to an iterative algorithms in the `fold` implementations (this will complicate the code somewhat, see the code in `attribute.rs` for the state machines that need to be introduced). :x:

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
