### PR TITLE
persist: remove soft-assertions-based audit

### DIFF
--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -15,7 +15,6 @@ use std::convert::Infallible;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -24,7 +23,6 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::Hashable;
 use futures::StreamExt;
 use futures_util::future::Either;
-use mz_ore::assert::SOFT_ASSERTIONS;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::vec::VecExt;
@@ -462,7 +460,7 @@ where
                                         } else {
                                             metrics.pushdown.parts_filtered_count.inc();
                                             metrics.pushdown.parts_filtered_bytes.inc_by(bytes);
-                                            let should_audit = SOFT_ASSERTIONS.load(Ordering::Relaxed) || {
+                                            let should_audit = {
                                                 let mut h = DefaultHasher::new();
                                                 part_desc.key.hash(&mut h);
                                                 usize::cast_from(h.finish()) % 100 < cfg.dynamic.stats_audit_percent()


### PR DESCRIPTION
When we hooked this up, the `system_parameter_defaults` stuff wasn't totally wired up in CI yet. We wanted to be very sure that we were getting auditing in all CI jobs. Now that QA is trying to write tests to verify the performance benefit of pushdown, pull out the soft-assertions-based audit trigger and rely entirely on system_parameter_defaults to set auditing in CI.

Closes #19571

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
