### PR TITLE
upgrade tests: Switch some tests to using versions from git tags

### DIFF
--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -22,8 +22,8 @@ from materialize.util import MzVersion
 from materialize.version_list import VersionsFromGit
 
 version_list = VersionsFromGit()
-released_versions = version_list.all_versions()
-previous_version, last_version = version_list.minor_versions()[-2:]
+minor_versions = version_list.minor_versions()
+previous_version, last_version = minor_versions[-2:]
 
 
 class UpgradeEntireMz(Scenario):
@@ -116,23 +116,23 @@ class UpgradeEntireMzFourVersions(Scenario):
     """Test upgrade X-4 -> X-3 -> X-2 -> X-1 -> X"""
 
     def base_version(self) -> MzVersion:
-        return released_versions[-4]
+        return minor_versions[-4]
 
     def actions(self) -> List[Action]:
         print(
-            f"Upgrading going through {released_versions[-4]} -> {released_versions[-3]} -> {released_versions[-2]} -> {released_versions[-1]}"
+            f"Upgrading going through {minor_versions[-4]} -> {minor_versions[-3]} -> {minor_versions[-2]} -> {minor_versions[-1]}"
         )
         return [
-            StartMz(tag=released_versions[-4]),
+            StartMz(tag=minor_versions[-4]),
             Initialize(self),
             KillMz(),
-            StartMz(tag=released_versions[-3]),
+            StartMz(tag=minor_versions[-3]),
             Manipulate(self, phase=1),
             KillMz(),
-            StartMz(tag=released_versions[-2]),
+            StartMz(tag=minor_versions[-2]),
             Manipulate(self, phase=2),
             KillMz(),
-            StartMz(tag=released_versions[-1]),
+            StartMz(tag=minor_versions[-1]),
             KillMz(),
             StartMz(tag=None),
             Validate(self),

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -19,9 +19,9 @@ from materialize.checks.mzcompose_actions import (
 )
 from materialize.checks.scenarios import Scenario
 from materialize.util import MzVersion
-from materialize.version_list import VersionsFromDocs
+from materialize.version_list import VersionsFromGit
 
-version_list = VersionsFromDocs()
+version_list = VersionsFromGit()
 released_versions = version_list.all_versions()
 previous_version, last_version = version_list.minor_versions()[-2:]
 

--- a/test/upgrade-matrix/mzcompose.py
+++ b/test/upgrade-matrix/mzcompose.py
@@ -47,7 +47,7 @@ from materialize.mzcompose.services import (
 )
 from materialize.mzcompose.services import Testdrive as TestdriveService
 from materialize.util import MzVersion
-from materialize.version_list import VersionsFromDocs
+from materialize.version_list import VersionsFromGit
 
 SERVICES = [
     Cockroach(setup_materialize=True),
@@ -137,7 +137,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     executor = MzcomposeExecutor(composition=c)
 
     versions = list(
-        [v for v in VersionsFromDocs().minor_versions() if v >= args.min_version]
+        [v for v in VersionsFromGit().minor_versions() if v >= args.min_version]
     )
     print(
         "--- Testing upgrade scenarios involving the following versions: "


### PR DESCRIPTION
Switch the Platform Checks-based tests to retrieve versions to operate with from git tags. This provides additional coverage in case the version list from doc/user/content/releases is lagging behind reality.

The legacy upgrade test as well as the cloudtest-based upgrade tests remain unaffected and will use version information from doc/user/content/releases.

### Motivation

Sometimes the metadata in doc/user/content/releases lags behind reality, which leaves some upgrade sequences untested.