### PR TITLE
feature-benchmark: Print queries once

### DIFF
--- a/misc/python/materialize/feature_benchmark/action.py
+++ b/misc/python/materialize/feature_benchmark/action.py
@@ -57,9 +57,9 @@ class Kgen(Action):
         self,
         executor: Optional[Executor] = None,
     ) -> None:
-        getattr((executor or self._executor), "Kgen")(
-            topic=self._topic, args=self._args
-        )
+        executor = executor or self._executor
+        assert executor
+        executor.Kgen(topic=self._topic, args=self._args)
 
 
 class TdAction(Action):
@@ -73,7 +73,14 @@ class TdAction(Action):
         self,
         executor: Optional[Executor] = None,
     ) -> None:
-        getattr((executor or self._executor), "Td")(self._td_str)
+        executor = executor or self._executor
+        assert executor
+        td_output = executor.Td(self._td_str)
+
+        # Print each query once so that it is easier to reproduce regressions
+        # based on just the logs from CI
+        if executor.add_known_fragment(self._td_str):
+            print(td_output)
 
 
 class DummyAction(Action):

--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -104,7 +104,7 @@ class Benchmark:
             ), f"Second timestamp reported not greater than first: scenario: {scenario}, timestamps: {timestamps}"
 
             measurement = timestamps[1] - timestamps[0]
-            if self._filter and getattr(self._filter, "filter")(measurement):
+            if self._filter and self._filter.filter(measurement):
                 continue
 
             print(f"Measurement {i}: {measurement}")

--- a/misc/python/materialize/feature_benchmark/executor.py
+++ b/misc/python/materialize/feature_benchmark/executor.py
@@ -7,15 +7,32 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Set
 
 from materialize.mzcompose import Composition
 from materialize.mzcompose.services import Materialized
 
 
 class Executor:
+    _known_fragments: Set[str] = set()
+
     def Lambda(self, _lambda: Callable[["Executor"], float]) -> float:
         return _lambda(self)
+
+    def Td(self, input: str) -> Any:
+        raise NotImplementedError
+
+    def Kgen(self, topic: str, args: List[str]) -> Any:
+        raise NotImplementedError
+
+    def add_known_fragment(self, fragment: str) -> bool:
+        """
+        Record whether a TD fragment has been printed already. Returns true
+        if it wasn't added before.
+        """
+        result = fragment not in self._known_fragments
+        self._known_fragments.add(fragment)
+        return result
 
 
 class Docker(Executor):

--- a/misc/python/materialize/feature_benchmark/filter.py
+++ b/misc/python/materialize/feature_benchmark/filter.py
@@ -16,6 +16,9 @@ class Filter:
     def __init__(self) -> None:
         self._data: List[float] = []
 
+    def filter(self, measurement: float) -> bool:
+        raise NotImplementedError
+
 
 class RemoveOutliers(Filter):
     def filter(self, measurement: float) -> bool:

--- a/misc/python/materialize/feature_benchmark/measurement_source.py
+++ b/misc/python/materialize/feature_benchmark/measurement_source.py
@@ -49,10 +49,15 @@ class Td(MeasurementSource):
         self,
         executor: Optional[Executor] = None,
     ) -> List[Timestamp]:
-        assert not (executor is None and self._executor is None)
         assert not (executor is not None and self._executor is not None)
+        executor = executor or self._executor
+        assert executor
 
-        td_output = getattr((executor or self._executor), "Td")(self._td_str)
+        td_output = executor.Td(self._td_str)
+        # Print each query once so that it is easier to reproduce regressions
+        # based on just the logs from CI
+        if executor.add_known_fragment(self._td_str):
+            print(td_output)
 
         lines = td_output.splitlines()
         lines = [l for l in lines if l]


### PR DESCRIPTION
For a new scenario the executor will be fresh and thus the testdrive fragments be printed again

Also removed the useless getattr calls, which seem to have been to get around the mypy type hints

Sample output:
```
Sizing in effect for scenario GroupBy: scale = 6 , N = 1000000
Running the init() section for GroupBy ...
> CREATE VIEW ten (f1) AS (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9));
rows match; continuing at ts 1685536986.535084

> CREATE MATERIALIZED VIEW v1 AS SELECT (a1.f1 * 1) + (a2.f1 * 10) + (a3.f1 * 100) + (a4.f1 * 1000) + (a5.f1 * 10000) + (a6.f1 * 100000) AS f1, (a1.f1 * 1) + (a2.f1 * 10) + (a3.f1 * 100) + (a4.f1 * 1000) + (a5.f1 * 10000) + (a6.f1 * 100000) AS f2 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6
rows match; continuing at ts 1685536987.431823
> SELECT COUNT(*) = 1000000 FROM v1
rows match; continuing at ts 1685536988.881629

init() done
> SELECT 1 /* A */
rows match; continuing at ts 1685536989.1930754
> SELECT COUNT(*), MIN(f1_min), MAX(f1_max) FROM (SELECT f2, MIN(f1) AS f1_min, MAX(f1) AS f1_max FROM v1 GROUP BY f2) /* B */
rows match; continuing at ts 1685536990.628383

Discarding first measurement.
Measurement 1: 1.3472251892089844
Measurement 2: 1.4249870777130127
```
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
