### PR TITLE
output-consistency-test: Use NotImplementedError

### DIFF
--- a/misc/python/materialize/output_consistency/execution/evaluation_strategy.py
+++ b/misc/python/materialize/output_consistency/execution/evaluation_strategy.py
@@ -68,7 +68,7 @@ class EvaluationStrategy:
         table_column_selection: TableColumnByNameSelection,
         override_db_object_name: Optional[str] = None,
     ) -> List[str]:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def get_db_object_name(
         self,

--- a/misc/python/materialize/output_consistency/execution/sql_executor.py
+++ b/misc/python/materialize/output_consistency/execution/sql_executor.py
@@ -32,19 +32,19 @@ class SqlExecutor:
         return self.__class__.__name__
 
     def ddl(self, sql: str) -> None:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def begin_tx(self, isolation_level: str) -> None:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def commit(self) -> None:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def rollback(self) -> None:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def query(self, sql: str) -> Sequence[Sequence[Any]]:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
 
 class PgWireDatabaseSqlExecutor(SqlExecutor):

--- a/misc/python/materialize/output_consistency/expression/expression.py
+++ b/misc/python/materialize/output_consistency/expression/expression.py
@@ -39,13 +39,13 @@ class Expression:
         self.is_expect_error = is_expect_error
 
     def to_sql(self) -> str:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def resolve_return_type_spec(self) -> ReturnTypeSpec:
         raise NotImplementedError
 
     def resolve_return_type_category(self) -> DataTypeCategory:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def try_resolve_exact_data_type(self) -> Optional[DataType]:
         raise NotImplementedError
@@ -54,13 +54,13 @@ class Expression:
         self, row_selection: DataRowSelection
     ) -> Set[ExpressionCharacteristics]:
         """Get all involved characteristics through recursion"""
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def collect_leaves(self) -> List[LeafExpression]:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def __str__(self) -> str:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def has_all_characteristics(
         self, characteristics: Set[ExpressionCharacteristics]

--- a/misc/python/materialize/output_consistency/operation/operation.py
+++ b/misc/python/materialize/output_consistency/operation/operation.py
@@ -55,7 +55,7 @@ class DbOperationOrFunction:
         self.relevance = relevance
 
     def to_pattern(self, args_count: int) -> str:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def validate_args_count_in_range(self, args_count: int) -> None:
         if args_count < self.min_param_count:
@@ -74,7 +74,7 @@ class DbOperationOrFunction:
         return set()
 
     def __str__(self) -> str:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def try_resolve_exact_data_type(self, args: List[Expression]) -> Optional[DataType]:
         return None

--- a/misc/python/materialize/output_consistency/operation/operation_args_validator.py
+++ b/misc/python/materialize/output_consistency/operation/operation_args_validator.py
@@ -19,7 +19,7 @@ class OperationArgsValidator:
     """Validator that performs heuristic checks to determine if a database error is to be expected"""
 
     def is_expected_to_cause_error(self, args: List[Expression]) -> bool:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def index_of(
         self,


### PR DESCRIPTION
I remembered there is a dedicated exception for this: https://docs.python.org/3/library/exceptions.html#NotImplementedError
```bash
sed -i 's/RuntimeError("Not implemented")/NotImplementedError/g' **/*.py
```

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
