### PR TITLE
Output consistency tests V2: error messages from non-aggregate functions on multiple rows may differ

### DIFF
--- a/misc/python/materialize/output_consistency/expression/expression.py
+++ b/misc/python/materialize/output_consistency/expression/expression.py
@@ -69,3 +69,13 @@ class Expression:
         """True if this expression itself exhibits any of the characteristics. Child expressions are not considered."""
         overlap = self.own_characteristics & characteristics
         return len(overlap) > 0
+
+    def is_leaf(self) -> bool:
+        raise RuntimeError("Not implemented")
+
+    def contains_leaf_not_directly_consumed_by_aggregation(self) -> bool:
+        """
+        True if any leaf is not directly consumed by an aggregation,
+        hence false if all leaves of this expression are directly consumed by an aggregation.
+        This is relevant because when using non-aggregate functions on multiple rows, different evaluation strategies may yield different error messages due to a different row processing order."""
+        raise RuntimeError("Not implemented")

--- a/misc/python/materialize/output_consistency/expression/expression.py
+++ b/misc/python/materialize/output_consistency/expression/expression.py
@@ -71,11 +71,11 @@ class Expression:
         return len(overlap) > 0
 
     def is_leaf(self) -> bool:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def contains_leaf_not_directly_consumed_by_aggregation(self) -> bool:
         """
         True if any leaf is not directly consumed by an aggregation,
         hence false if all leaves of this expression are directly consumed by an aggregation.
         This is relevant because when using non-aggregate functions on multiple rows, different evaluation strategies may yield different error messages due to a different row processing order."""
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError

--- a/misc/python/materialize/output_consistency/expression/expression_with_args.py
+++ b/misc/python/materialize/output_consistency/expression/expression_with_args.py
@@ -102,6 +102,21 @@ class ExpressionWithArgs(Expression):
 
         return leaves
 
+    def is_leaf(self) -> bool:
+        return False
+
+    def contains_leaf_not_directly_consumed_by_aggregation(self) -> bool:
+        for arg in self.args:
+            if arg.is_leaf() and not self.is_aggregate:
+                return True
+            elif (
+                not arg.is_leaf()
+                and arg.contains_leaf_not_directly_consumed_by_aggregation()
+            ):
+                return True
+
+        return False
+
 
 def _determine_storage_layout(args: List[Expression]) -> ValueStorageLayout:
     storage_layout: Optional[ValueStorageLayout] = None

--- a/misc/python/materialize/output_consistency/expression/leaf_expression.py
+++ b/misc/python/materialize/output_consistency/expression/leaf_expression.py
@@ -37,3 +37,10 @@ class LeafExpression(Expression):
 
     def collect_leaves(self) -> List[Expression]:
         return [self]
+
+    def is_leaf(self) -> bool:
+        return True
+
+    def contains_leaf_not_directly_consumed_by_aggregation(self) -> bool:
+        # This is not decided at leaf level.
+        return False

--- a/misc/python/materialize/output_consistency/generators/expression_generator.py
+++ b/misc/python/materialize/output_consistency/generators/expression_generator.py
@@ -124,10 +124,14 @@ class ExpressionGenerator:
         self, operation: DbOperationOrFunction
     ) -> ValueStorageLayout:
         if not operation.is_aggregation:
-            # Non-aggregate expressions can unfortunately only use horizontal layout because the processing order does
-            # not seem to be consistent between data-flow rendering and constant folding such that error messages will
-            # differ
-            return ValueStorageLayout.HORIZONTAL
+            # Prefer the horizontal row format for non-aggregate expressions. (It makes it less likely that a query
+            # results in (an unexpected) error. Furthermore, in case of an error, error messages of non-aggregate
+            # expressions can only be compared in HORIZONTAL layout (because the row processing order of an
+            # evaluation strategy is not defined).)
+            if self.randomized_picker.random_boolean(0.9):
+                return ValueStorageLayout.HORIZONTAL
+            else:
+                return ValueStorageLayout.VERTICAL
 
         # strongly prefer vertical storage for aggregations but allow some variance
 

--- a/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
@@ -30,7 +30,7 @@ class InconsistencyIgnoreFilter:
     def shall_ignore(
         self, expression: Expression, row_selection: DataRowSelection
     ) -> bool:
-        if isinstance(expression, LeafExpression):
+        if expression.is_leaf():
             return False
         elif isinstance(expression, ExpressionWithArgs):
             return self._shall_ignore_expression_with_args(expression, row_selection)

--- a/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
@@ -16,7 +16,6 @@ from materialize.output_consistency.expression.expression_characteristics import
 from materialize.output_consistency.expression.expression_with_args import (
     ExpressionWithArgs,
 )
-from materialize.output_consistency.expression.leaf_expression import LeafExpression
 from materialize.output_consistency.operation.operation import (
     DbFunction,
     DbOperationOrFunction,
@@ -92,7 +91,7 @@ class InconsistencyIgnoreFilter:
         if operation.is_aggregation:
             for arg in expression.args:
                 if (
-                    not isinstance(arg, LeafExpression)
+                    not arg.is_leaf()
                     and arg.resolve_return_type_category() == DataTypeCategory.NUMERIC
                 ):
                     # tracked with https://github.com/MaterializeInc/materialize/issues/19592

--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -108,7 +108,10 @@ class ResultComparator:
             # this needs will no longer be sensible when more than two evaluation strategies are used
             self.remark_on_success_with_single_column(outcome1, validation_outcome)
 
-        if both_failed:
+        if (
+            both_failed
+            and not query_execution.query_template.disable_error_message_validation
+        ):
             failure1 = cast(QueryFailure, outcome1)
             self.validate_error_messages(
                 query_execution,

--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -225,11 +225,15 @@ class ResultComparator:
         query_execution: QueryExecution,
         validation_outcome: ValidationOutcome,
     ) -> None:
-        # each outcome is known to contain at least one row
+        # each outcome is known to have the same number of rows
         # each row is supposed to have the same number of columns
 
         outcomes = query_execution.outcomes
         result1 = cast(QueryResult, outcomes[0])
+
+        if len(result1.result_rows) == 0:
+            # this is a valid case; all outcomes have the same number of rows
+            return
 
         for index in range(1, len(outcomes)):
             other_result = cast(QueryResult, outcomes[index])


### PR DESCRIPTION
Do not compare error messages when non-aggregate functions operate on multiple data rows.

This will also fix the failures in https://buildkite.com/materialize/nightlies/builds/2504.