### PR TITLE
Test generator for output consistency checks (V2): better type information

### DIFF
--- a/misc/python/materialize/output_consistency/data_value/data_column.py
+++ b/misc/python/materialize/output_consistency/data_value/data_column.py
@@ -27,8 +27,9 @@ class DataColumn(LeafExpression):
 
     def __init__(self, data_type: DataType, row_values_of_column: List[DataValue]):
         column_name = f"{data_type.identifier.lower()}_val"
-        super().__init__(column_name, set(), ValueStorageLayout.VERTICAL, False, False)
-        self.data_type = data_type
+        super().__init__(
+            column_name, data_type, set(), ValueStorageLayout.VERTICAL, False, False
+        )
         self.values = row_values_of_column
 
     def resolve_return_type_category(self) -> DataTypeCategory:

--- a/misc/python/materialize/output_consistency/data_value/data_value.py
+++ b/misc/python/materialize/output_consistency/data_value/data_value.py
@@ -32,10 +32,14 @@ class DataValue(LeafExpression):
     ):
         column_name = f"{data_type.identifier.lower()}_{value_identifier.lower()}"
         super().__init__(
-            column_name, characteristics, ValueStorageLayout.HORIZONTAL, False, False
+            column_name,
+            data_type,
+            characteristics,
+            ValueStorageLayout.HORIZONTAL,
+            False,
+            False,
         )
         self.value = value
-        self.data_type = data_type
 
     def resolve_return_type_category(self) -> DataTypeCategory:
         return self.data_type.category

--- a/misc/python/materialize/output_consistency/expression/expression.py
+++ b/misc/python/materialize/output_consistency/expression/expression.py
@@ -8,8 +8,9 @@
 # by the Apache License, Version 2.0.
 from __future__ import annotations
 
-from typing import List, Set
+from typing import List, Optional, Set
 
+from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
 from materialize.output_consistency.execution.value_storage_layout import (
     ValueStorageLayout,
@@ -40,6 +41,9 @@ class Expression:
         raise RuntimeError("Not implemented")
 
     def resolve_return_type_category(self) -> DataTypeCategory:
+        raise RuntimeError("Not implemented")
+
+    def try_resolve_exact_data_type(self) -> Optional[DataType]:
         raise RuntimeError("Not implemented")
 
     def recursively_collect_involved_characteristics(

--- a/misc/python/materialize/output_consistency/expression/expression.py
+++ b/misc/python/materialize/output_consistency/expression/expression.py
@@ -44,7 +44,7 @@ class Expression:
         raise RuntimeError("Not implemented")
 
     def try_resolve_exact_data_type(self) -> Optional[DataType]:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def recursively_collect_involved_characteristics(
         self, row_selection: DataRowSelection

--- a/misc/python/materialize/output_consistency/expression/expression_characteristics.py
+++ b/misc/python/materialize/output_consistency/expression/expression_characteristics.py
@@ -27,12 +27,3 @@ class ExpressionCharacteristics(Enum):
     NEGATIVE = 121
     DECIMAL = 122
     """value is not an integer"""
-
-    DECIMAL_OR_FLOAT_TYPED = 150
-    FLOAT_TYPED = 151
-    UNSIGNED_TYPED = 152
-
-    TYPE_LARGER_INT4_SIZED = 160
-    """INT8 or UINT4 or UINT8"""
-    TYPE_INT8_SIZED = 161
-    """INT8 or UINT8"""

--- a/misc/python/materialize/output_consistency/expression/expression_with_args.py
+++ b/misc/python/materialize/output_consistency/expression/expression_with_args.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 from typing import List, Optional, Set
 
+from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
 from materialize.output_consistency.execution.value_storage_layout import (
     ValueStorageLayout,
@@ -74,6 +75,9 @@ class ExpressionWithArgs(Expression):
                 return self.args[0].resolve_return_type_category()
 
         return self.return_type_category
+
+    def try_resolve_exact_data_type(self) -> Optional[DataType]:
+        return self.operation.try_resolve_exact_data_type(self.args)
 
     def __str__(self) -> str:
         args_desc = ", ".join(arg.__str__() for arg in self.args)

--- a/misc/python/materialize/output_consistency/expression/leaf_expression.py
+++ b/misc/python/materialize/output_consistency/expression/leaf_expression.py
@@ -8,6 +8,8 @@
 # by the Apache License, Version 2.0.
 from typing import List, Set
 
+from materialize.output_consistency.data_type.data_type import DataType
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
 from materialize.output_consistency.execution.value_storage_layout import (
     ValueStorageLayout,
 )
@@ -21,6 +23,7 @@ class LeafExpression(Expression):
     def __init__(
         self,
         column_name: str,
+        data_type: DataType,
         characteristics: Set[ExpressionCharacteristics],
         storage_layout: ValueStorageLayout,
         is_aggregate: bool,
@@ -28,6 +31,10 @@ class LeafExpression(Expression):
     ):
         super().__init__(characteristics, storage_layout, is_aggregate, is_expect_error)
         self.column_name = column_name
+        self.data_type = data_type
+
+    def resolve_data_type_category(self) -> DataTypeCategory:
+        return self.data_type.category
 
     def to_sql(self) -> str:
         return self.to_sql_as_column()

--- a/misc/python/materialize/output_consistency/expression/leaf_expression.py
+++ b/misc/python/materialize/output_consistency/expression/leaf_expression.py
@@ -6,7 +6,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-from typing import List, Set
+from typing import List, Optional, Set
 
 from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
@@ -35,6 +35,9 @@ class LeafExpression(Expression):
 
     def resolve_data_type_category(self) -> DataTypeCategory:
         return self.data_type.category
+
+    def try_resolve_exact_data_type(self) -> Optional[DataType]:
+        return self.data_type
 
     def to_sql(self) -> str:
         return self.to_sql_as_column()

--- a/misc/python/materialize/output_consistency/input_data/operations/number_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/number_operations_provider.py
@@ -82,12 +82,8 @@ NUMERIC_OPERATION_TYPES.append(
     DbOperation(
         "$ & $",
         [
-            NumericOperationParam(
-                incompatibilities={ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED}
-            ),
-            NumericOperationParam(
-                incompatibilities={ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED}
-            ),
+            NumericOperationParam(only_int_type=True),
+            NumericOperationParam(only_int_type=True),
         ],
         DataTypeCategory.NUMERIC,
         {Uint8MixedWithTypedArgsValidator()},
@@ -99,12 +95,8 @@ NUMERIC_OPERATION_TYPES.append(
     DbOperation(
         "$ | $",
         [
-            NumericOperationParam(
-                incompatibilities={ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED}
-            ),
-            NumericOperationParam(
-                incompatibilities={ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED}
-            ),
+            NumericOperationParam(only_int_type=True),
+            NumericOperationParam(only_int_type=True),
         ],
         DataTypeCategory.NUMERIC,
         {Uint8MixedWithTypedArgsValidator()},
@@ -116,12 +108,8 @@ NUMERIC_OPERATION_TYPES.append(
     DbOperation(
         "$ # $",
         [
-            NumericOperationParam(
-                incompatibilities={ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED}
-            ),
-            NumericOperationParam(
-                incompatibilities={ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED}
-            ),
+            NumericOperationParam(only_int_type=True),
+            NumericOperationParam(only_int_type=True),
         ],
         DataTypeCategory.NUMERIC,
         {Uint8MixedWithTypedArgsValidator()},
@@ -133,9 +121,7 @@ NUMERIC_OPERATION_TYPES.append(
     DbOperation(
         "~$",
         [
-            NumericOperationParam(
-                incompatibilities={ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED}
-            )
+            NumericOperationParam(only_int_type=True),
         ],
         DataTypeCategory.NUMERIC,
         relevance=OperationRelevance.LOW,
@@ -146,15 +132,8 @@ NUMERIC_OPERATION_TYPES.append(
     DbOperation(
         "$ << $",
         [
-            NumericOperationParam(
-                incompatibilities={ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED}
-            ),
-            NumericOperationParam(
-                incompatibilities={
-                    ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED,
-                    ExpressionCharacteristics.TYPE_LARGER_INT4_SIZED,
-                }
-            ),
+            NumericOperationParam(only_int_type=True),
+            NumericOperationParam(only_int_type=True, no_int_type_larger_int4=True),
         ],
         DataTypeCategory.NUMERIC,
         {Uint8MixedWithTypedArgsValidator()},
@@ -166,15 +145,8 @@ NUMERIC_OPERATION_TYPES.append(
     DbOperation(
         "$ >> $",
         [
-            NumericOperationParam(
-                incompatibilities={ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED}
-            ),
-            NumericOperationParam(
-                incompatibilities={
-                    ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED,
-                    ExpressionCharacteristics.TYPE_LARGER_INT4_SIZED,
-                }
-            ),
+            NumericOperationParam(only_int_type=True),
+            NumericOperationParam(only_int_type=True, no_int_type_larger_int4=True),
         ],
         DataTypeCategory.NUMERIC,
         {Uint8MixedWithTypedArgsValidator()},
@@ -257,20 +229,23 @@ NUMERIC_OPERATION_TYPES.append(
         [
             # first param is the base
             NumericOperationParam(
+                only_int_type=True,
+                # simplification: float would work if this was the only param
+                no_floating_point_type=True,
                 incompatibilities={
                     ExpressionCharacteristics.NEGATIVE,
                     ExpressionCharacteristics.ZERO,
                     ExpressionCharacteristics.ONE,
-                    ExpressionCharacteristics.FLOAT_TYPED,
-                }
+                },
             ),
             # not marked as optional because if not present the operation is equal to LOG10, which is separate
             NumericOperationParam(
+                only_int_type=True,
+                no_floating_point_type=True,
                 incompatibilities={
                     ExpressionCharacteristics.NEGATIVE,
                     ExpressionCharacteristics.ZERO,
-                    ExpressionCharacteristics.FLOAT_TYPED,
-                }
+                },
             ),
         ],
         DataTypeCategory.NUMERIC,
@@ -307,9 +282,9 @@ NUMERIC_OPERATION_TYPES.append(
             # negative values are allowed
             NumericOperationParam(
                 optional=True,
+                only_int_type=True,
+                no_int_type_larger_int4=True,
                 incompatibilities={
-                    ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED,
-                    ExpressionCharacteristics.TYPE_LARGER_INT4_SIZED,
                     ExpressionCharacteristics.LARGE_VALUE,
                 },
             ),

--- a/misc/python/materialize/output_consistency/input_data/params/any_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/any_operation_param.py
@@ -9,6 +9,7 @@
 
 from typing import List, Optional, Set
 
+from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
 from materialize.output_consistency.expression.expression_characteristics import (
     ExpressionCharacteristics,
@@ -31,3 +32,6 @@ class AnyOperationParam(OperationParam):
             incompatibilities,
             incompatibility_combinations,
         )
+
+    def supports_type(self, data_type: DataType) -> bool:
+        return True

--- a/misc/python/materialize/output_consistency/input_data/params/boolean_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/boolean_operation_param.py
@@ -9,9 +9,13 @@
 
 from typing import Optional, Set
 
+from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
 from materialize.output_consistency.expression.expression_characteristics import (
     ExpressionCharacteristics,
+)
+from materialize.output_consistency.input_data.types.boolean_type_provider import (
+    BOOLEAN_DATA_TYPE,
 )
 from materialize.output_consistency.operation.operation_param import OperationParam
 
@@ -28,3 +32,6 @@ class BooleanOperationParam(OperationParam):
             incompatibilities,
             incompatibility_combinations=None,
         )
+
+    def supports_type(self, data_type: DataType) -> bool:
+        return data_type == BOOLEAN_DATA_TYPE

--- a/misc/python/materialize/output_consistency/input_data/params/boolean_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/boolean_operation_param.py
@@ -15,7 +15,7 @@ from materialize.output_consistency.expression.expression_characteristics import
     ExpressionCharacteristics,
 )
 from materialize.output_consistency.input_data.types.boolean_type_provider import (
-    BOOLEAN_DATA_TYPE,
+    BOOLEAN_TYPE_IDENTIFIER,
 )
 from materialize.output_consistency.operation.operation_param import OperationParam
 
@@ -34,4 +34,4 @@ class BooleanOperationParam(OperationParam):
         )
 
     def supports_type(self, data_type: DataType) -> bool:
-        return data_type == BOOLEAN_DATA_TYPE
+        return data_type.identifier == BOOLEAN_TYPE_IDENTIFIER

--- a/misc/python/materialize/output_consistency/input_data/params/number_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/number_operation_param.py
@@ -15,6 +15,9 @@ from materialize.output_consistency.expression.expression_characteristics import
     ExpressionCharacteristics,
 )
 from materialize.output_consistency.input_data.types.number_types_provider import (
+    INT8_TYPE,
+    UINT4_TYPE,
+    UINT8_TYPE,
     NumberDataType,
 )
 from materialize.output_consistency.operation.operation_param import OperationParam
@@ -28,6 +31,10 @@ class NumericOperationParam(OperationParam):
         incompatibility_combinations: Optional[
             List[Set[ExpressionCharacteristics]]
         ] = None,
+        only_int_type: bool = False,
+        no_int_type_larger_int4: bool = False,
+        no_floating_point_type: bool = False,
+        no_unsigned_type: bool = False,
     ):
         if incompatibilities is None:
             incompatibilities = set()
@@ -41,11 +48,29 @@ class NumericOperationParam(OperationParam):
             incompatibilities,
             incompatibility_combinations,
         )
+        self.only_int_type = only_int_type
+        self.no_int_type_larger_int4 = no_int_type_larger_int4
+        self.no_floating_point_type = no_floating_point_type
+        self.no_unsigned_type = no_unsigned_type
 
     def supports_type(self, data_type: DataType) -> bool:
         if not isinstance(data_type, NumberDataType):
             return False
 
-        # TODO further filtering
+        if self.only_int_type and data_type.is_decimal:
+            return False
+
+        if self.no_int_type_larger_int4 and data_type in {
+            INT8_TYPE,
+            UINT4_TYPE,
+            UINT8_TYPE,
+        }:
+            return False
+
+        if self.no_floating_point_type and data_type.is_floating_point_type:
+            return False
+
+        if self.no_unsigned_type and not data_type.is_signed:
+            return False
 
         return True

--- a/misc/python/materialize/output_consistency/input_data/params/number_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/number_operation_param.py
@@ -9,9 +9,13 @@
 
 from typing import List, Optional, Set
 
+from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
 from materialize.output_consistency.expression.expression_characteristics import (
     ExpressionCharacteristics,
+)
+from materialize.output_consistency.input_data.types.number_types_provider import (
+    NumberDataType,
 )
 from materialize.output_consistency.operation.operation_param import OperationParam
 
@@ -37,3 +41,11 @@ class NumericOperationParam(OperationParam):
             incompatibilities,
             incompatibility_combinations,
         )
+
+    def supports_type(self, data_type: DataType) -> bool:
+        if not isinstance(data_type, NumberDataType):
+            return False
+
+        # TODO further filtering
+
+        return True

--- a/misc/python/materialize/output_consistency/input_data/params/number_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/number_operation_param.py
@@ -15,9 +15,9 @@ from materialize.output_consistency.expression.expression_characteristics import
     ExpressionCharacteristics,
 )
 from materialize.output_consistency.input_data.types.number_types_provider import (
-    INT8_TYPE,
-    UINT4_TYPE,
-    UINT8_TYPE,
+    INT8_TYPE_IDENTIFIER,
+    UINT4_TYPE_IDENTIFIER,
+    UINT8_TYPE_IDENTIFIER,
     NumberDataType,
 )
 from materialize.output_consistency.operation.operation_param import OperationParam
@@ -60,10 +60,10 @@ class NumericOperationParam(OperationParam):
         if self.only_int_type and data_type.is_decimal:
             return False
 
-        if self.no_int_type_larger_int4 and data_type in {
-            INT8_TYPE,
-            UINT4_TYPE,
-            UINT8_TYPE,
+        if self.no_int_type_larger_int4 and data_type.identifier in {
+            INT8_TYPE_IDENTIFIER,
+            UINT4_TYPE_IDENTIFIER,
+            UINT8_TYPE_IDENTIFIER,
         }:
             return False
 

--- a/misc/python/materialize/output_consistency/input_data/types/boolean_type_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/boolean_type_provider.py
@@ -10,4 +10,6 @@
 from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
 
-BOOLEAN_DATA_TYPE = DataType("BOOL", "BOOL", DataTypeCategory.BOOLEAN)
+BOOLEAN_TYPE_IDENTIFIER = "BOOL"
+
+BOOLEAN_DATA_TYPE = DataType(BOOLEAN_TYPE_IDENTIFIER, "BOOL", DataTypeCategory.BOOLEAN)

--- a/misc/python/materialize/output_consistency/input_data/types/number_types_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/number_types_provider.py
@@ -38,8 +38,19 @@ class NumberDataType(DataType):
         self.is_floating_point_type = is_floating_point_type
 
 
+INT2_TYPE_IDENTIFIER = "INT2"
+INT4_TYPE_IDENTIFIER = "INT4"
+INT8_TYPE_IDENTIFIER = "INT8"
+UINT2_TYPE_IDENTIFIER = "UINT2"
+UINT4_TYPE_IDENTIFIER = "UINT4"
+UINT8_TYPE_IDENTIFIER = "UINT8"
+DECIMAL_39_0_TYPE_IDENTIFIER = "DECIMAL_39_0"
+DECIMAL_39_8_TYPE_IDENTIFIER = "DECIMAL_39_8"
+REAL_TYPE_IDENTIFIER = "REAL"
+DOUBLE_TYPE_IDENTIFIER = "DOUBLE"
+
 INT2_TYPE = NumberDataType(
-    "INT2",
+    INT2_TYPE_IDENTIFIER,
     "INT2",
     is_signed=True,
     is_decimal=False,
@@ -48,7 +59,7 @@ INT2_TYPE = NumberDataType(
     max_negative_value="-32768",
 )
 INT4_TYPE = NumberDataType(
-    "INT4",
+    INT4_TYPE_IDENTIFIER,
     "INT4",
     is_signed=True,
     is_decimal=False,
@@ -57,7 +68,7 @@ INT4_TYPE = NumberDataType(
     max_negative_value="-2147483648",
 )
 INT8_TYPE = NumberDataType(
-    "INT8",
+    INT8_TYPE_IDENTIFIER,
     "INT8",
     is_signed=True,
     is_decimal=False,
@@ -67,7 +78,7 @@ INT8_TYPE = NumberDataType(
 )
 
 UINT2_TYPE = NumberDataType(
-    "UINT2",
+    UINT2_TYPE_IDENTIFIER,
     "UINT2",
     is_signed=False,
     is_decimal=False,
@@ -76,7 +87,7 @@ UINT2_TYPE = NumberDataType(
     max_negative_value=None,
 )
 UINT4_TYPE = NumberDataType(
-    "UINT4",
+    UINT4_TYPE_IDENTIFIER,
     "UINT4",
     is_signed=False,
     is_decimal=False,
@@ -85,7 +96,7 @@ UINT4_TYPE = NumberDataType(
     max_negative_value=None,
 )
 UINT8_TYPE = NumberDataType(
-    "UINT8",
+    UINT8_TYPE_IDENTIFIER,
     "UINT8",
     is_signed=False,
     is_decimal=False,
@@ -96,7 +107,7 @@ UINT8_TYPE = NumberDataType(
 
 # configurable decimal digits
 DECIMAL39_0_TYPE = NumberDataType(
-    "DECIMAL_39_0",
+    DECIMAL_39_0_TYPE_IDENTIFIER,
     "DECIMAL(39)",
     is_signed=True,
     is_decimal=True,
@@ -105,7 +116,7 @@ DECIMAL39_0_TYPE = NumberDataType(
     max_negative_value="-999999999999999999999999999999999999999",
 )
 DECIMAL39_8_TYPE = NumberDataType(
-    "DECIMAL_39_8",
+    DECIMAL_39_8_TYPE_IDENTIFIER,
     "DECIMAL(39,8)",
     is_signed=True,
     is_decimal=True,
@@ -116,7 +127,7 @@ DECIMAL39_8_TYPE = NumberDataType(
 )
 
 REAL_TYPE = NumberDataType(
-    "REAL",
+    REAL_TYPE_IDENTIFIER,
     "REAL",
     is_signed=True,
     is_decimal=True,
@@ -132,7 +143,7 @@ REAL_TYPE = NumberDataType(
     is_floating_point_type=True,
 )
 DOUBLE_TYPE = NumberDataType(
-    "DOUBLE",
+    DOUBLE_TYPE_IDENTIFIER,
     "DOUBLE",
     is_signed=True,
     is_decimal=True,

--- a/misc/python/materialize/output_consistency/input_data/types/number_types_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/number_types_provider.py
@@ -24,6 +24,7 @@ class NumberDataType(DataType):
         max_value: str,
         max_negative_value: Optional[str],
         further_tiny_dec_values: Optional[Set[str]] = None,
+        is_floating_point_type: bool = False,
     ):
         super().__init__(identifier, type_name, DataTypeCategory.NUMERIC)
         self.is_signed = is_signed
@@ -34,6 +35,7 @@ class NumberDataType(DataType):
         self.further_tiny_dec_values = (
             further_tiny_dec_values if further_tiny_dec_values is not None else set()
         )
+        self.is_floating_point_type = is_floating_point_type
 
 
 INT2_TYPE = NumberDataType(
@@ -127,6 +129,7 @@ REAL_TYPE = NumberDataType(
         "0.999999999999999999999999999999999999999",
         "1.000000000000000000000000000000000000001",
     },
+    is_floating_point_type=True,
 )
 DOUBLE_TYPE = NumberDataType(
     "DOUBLE",
@@ -142,6 +145,7 @@ DOUBLE_TYPE = NumberDataType(
         "0.999999999999999999999999999999999999999",
         "1.000000000000000000000000000000000000001",
     },
+    is_floating_point_type=True,
 )
 
 SIGNED_INT_TYPES: List[NumberDataType] = [

--- a/misc/python/materialize/output_consistency/input_data/validators/number_args_validator.py
+++ b/misc/python/materialize/output_consistency/input_data/validators/number_args_validator.py
@@ -34,7 +34,7 @@ class Uint8MixedWithTypedArgsValidator(OperationArgsValidator):
 
         index_of_signed = self.index_of(
             args,
-            lambda arg_characteristics, index: ExpressionCharacteristics.UNSIGNED_TYPED
+            lambda arg, arg_characteristics, index: ExpressionCharacteristics.UNSIGNED_TYPED
             not in arg_characteristics,
         )
 

--- a/misc/python/materialize/output_consistency/input_data/validators/number_args_validator.py
+++ b/misc/python/materialize/output_consistency/input_data/validators/number_args_validator.py
@@ -13,7 +13,7 @@ from materialize.output_consistency.expression.expression_characteristics import
     ExpressionCharacteristics,
 )
 from materialize.output_consistency.input_data.types.number_types_provider import (
-    UINT8_TYPE,
+    UINT8_TYPE_IDENTIFIER,
     NumberDataType,
 )
 from materialize.output_consistency.operation.operation_args_validator import (
@@ -49,7 +49,7 @@ class Uint8MixedWithTypedArgsValidator(NumericArgsValidator):
             return False
 
         index_of_uint8 = self.index_of_type_with_properties(
-            args, lambda number_type: number_type == UINT8_TYPE
+            args, lambda number_type: number_type.identifier == UINT8_TYPE_IDENTIFIER
         )
         index_of_signed = self.index_of_type_with_properties(
             args, lambda number_type: number_type.is_signed

--- a/misc/python/materialize/output_consistency/input_data/values/number_values_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/values/number_values_provider.py
@@ -15,13 +15,7 @@ from materialize.output_consistency.expression.expression_characteristics import
     ExpressionCharacteristics,
 )
 from materialize.output_consistency.input_data.types.number_types_provider import (
-    DOUBLE_TYPE,
-    INT8_TYPE,
     NUMERIC_DATA_TYPES,
-    REAL_TYPE,
-    UINT2_TYPE,
-    UINT4_TYPE,
-    UINT8_TYPE,
     NumberDataType,
 )
 
@@ -82,43 +76,6 @@ for num_data_type in NUMERIC_DATA_TYPES:
         )
 
 for type_definition, values_of_type in VALUES_PER_NUMERIC_DATA_TYPE.items():
-    if type_definition.is_decimal:
-        values_of_type.add_characteristic_to_all_values(
-            ExpressionCharacteristics.DECIMAL_OR_FLOAT_TYPED
-        )
-
     for value in values_of_type.raw_values:
         if ExpressionCharacteristics.MAX_VALUE in value.own_characteristics:
             value.own_characteristics.add(ExpressionCharacteristics.LARGE_VALUE)
-
-VALUES_PER_NUMERIC_DATA_TYPE[UINT4_TYPE].add_characteristic_to_all_values(
-    ExpressionCharacteristics.TYPE_LARGER_INT4_SIZED
-)
-VALUES_PER_NUMERIC_DATA_TYPE[INT8_TYPE].add_characteristic_to_all_values(
-    ExpressionCharacteristics.TYPE_LARGER_INT4_SIZED
-)
-VALUES_PER_NUMERIC_DATA_TYPE[INT8_TYPE].add_characteristic_to_all_values(
-    ExpressionCharacteristics.TYPE_INT8_SIZED
-)
-VALUES_PER_NUMERIC_DATA_TYPE[UINT8_TYPE].add_characteristic_to_all_values(
-    ExpressionCharacteristics.TYPE_LARGER_INT4_SIZED
-)
-VALUES_PER_NUMERIC_DATA_TYPE[UINT8_TYPE].add_characteristic_to_all_values(
-    ExpressionCharacteristics.TYPE_INT8_SIZED
-)
-VALUES_PER_NUMERIC_DATA_TYPE[REAL_TYPE].add_characteristic_to_all_values(
-    ExpressionCharacteristics.FLOAT_TYPED
-)
-VALUES_PER_NUMERIC_DATA_TYPE[DOUBLE_TYPE].add_characteristic_to_all_values(
-    ExpressionCharacteristics.FLOAT_TYPED
-)
-
-VALUES_PER_NUMERIC_DATA_TYPE[UINT2_TYPE].add_characteristic_to_all_values(
-    ExpressionCharacteristics.UNSIGNED_TYPED
-)
-VALUES_PER_NUMERIC_DATA_TYPE[UINT4_TYPE].add_characteristic_to_all_values(
-    ExpressionCharacteristics.UNSIGNED_TYPED
-)
-VALUES_PER_NUMERIC_DATA_TYPE[UINT8_TYPE].add_characteristic_to_all_values(
-    ExpressionCharacteristics.UNSIGNED_TYPED
-)

--- a/misc/python/materialize/output_consistency/operation/operation.py
+++ b/misc/python/materialize/output_consistency/operation/operation.py
@@ -10,6 +10,7 @@
 from enum import Enum
 from typing import List, Optional, Set
 
+from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
 from materialize.output_consistency.expression.expression import Expression
 from materialize.output_consistency.expression.expression_characteristics import (
@@ -74,6 +75,9 @@ class DbOperationOrFunction:
 
     def __str__(self) -> str:
         raise RuntimeError("Not implemented")
+
+    def try_resolve_exact_data_type(self, args: List[Expression]) -> Optional[DataType]:
+        return None
 
     def is_expected_to_cause_db_error(self, args: List[Expression]) -> bool:
         """checks incompatibilities (e.g., division by zero) and potential error scenarios (e.g., addition of two max

--- a/misc/python/materialize/output_consistency/operation/operation.py
+++ b/misc/python/materialize/output_consistency/operation/operation.py
@@ -89,7 +89,7 @@ class DbOperationOrFunction:
         for arg_index, arg in enumerate(args):
             param = self.params[arg_index]
 
-            if not param.supports_arg(arg):
+            if not param.supports_expression(arg):
                 return True
 
         return False

--- a/misc/python/materialize/output_consistency/operation/operation_args_validator.py
+++ b/misc/python/materialize/output_consistency/operation/operation_args_validator.py
@@ -24,7 +24,9 @@ class OperationArgsValidator:
     def index_of(
         self,
         args: List[Expression],
-        match_argument_fn: Callable[[Set[ExpressionCharacteristics], int], bool],
+        match_argument_fn: Callable[
+            [Expression, Set[ExpressionCharacteristics], int], bool
+        ],
         skip_argument_indices: Optional[Set[int]] = None,
     ) -> int:
         if skip_argument_indices is None:
@@ -34,7 +36,7 @@ class OperationArgsValidator:
             if index in skip_argument_indices:
                 continue
 
-            if match_argument_fn(arg.own_characteristics, index):
+            if match_argument_fn(arg, arg.own_characteristics, index):
                 return index
 
         return -1
@@ -46,7 +48,9 @@ class OperationArgsValidator:
         skip_argument_indices: Optional[Set[int]] = None,
     ) -> int:
         def match_fn(
-            arg_characteristics: Set[ExpressionCharacteristics], index: int
+            _arg: Expression,
+            arg_characteristics: Set[ExpressionCharacteristics],
+            _index: int,
         ) -> bool:
             return len(characteristic_combination & arg_characteristics) == len(
                 characteristic_combination

--- a/misc/python/materialize/output_consistency/operation/operation_param.py
+++ b/misc/python/materialize/output_consistency/operation/operation_param.py
@@ -48,7 +48,7 @@ class OperationParam:
                 self.incompatibility_combinations.append({incompatibility})
 
     def supports_type(self, data_type: DataType) -> bool:
-        raise RuntimeError("Not implemented")
+        raise NotImplementedError
 
     def supports_expression(self, arg: Expression) -> bool:
         for incompatibility_combination in self.incompatibility_combinations:

--- a/misc/python/materialize/output_consistency/operation/operation_param.py
+++ b/misc/python/materialize/output_consistency/operation/operation_param.py
@@ -46,7 +46,7 @@ class OperationParam:
             for incompatibility in incompatibilities:
                 self.incompatibility_combinations.append({incompatibility})
 
-    def supports_arg(self, arg: Expression) -> bool:
+    def supports_expression(self, arg: Expression) -> bool:
         for incompatibility_combination in self.incompatibility_combinations:
             if arg.has_all_characteristics(incompatibility_combination):
                 return False

--- a/misc/python/materialize/output_consistency/operation/operation_param.py
+++ b/misc/python/materialize/output_consistency/operation/operation_param.py
@@ -56,3 +56,6 @@ class OperationParam:
                 return False
 
         return True
+
+    def __str__(self) -> str:
+        return f"{type(self).__name__} (optional={self.optional})"

--- a/misc/python/materialize/output_consistency/operation/operation_param.py
+++ b/misc/python/materialize/output_consistency/operation/operation_param.py
@@ -9,6 +9,7 @@
 
 from typing import List, Optional, Set
 
+from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
 from materialize.output_consistency.expression.expression import Expression
 from materialize.output_consistency.expression.expression_characteristics import (
@@ -45,6 +46,9 @@ class OperationParam:
         if incompatibilities is not None:
             for incompatibility in incompatibilities:
                 self.incompatibility_combinations.append({incompatibility})
+
+    def supports_type(self, data_type: DataType) -> bool:
+        raise RuntimeError("Not implemented")
 
     def supports_expression(self, arg: Expression) -> bool:
         for incompatibility_combination in self.incompatibility_combinations:


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Improvements for https://github.com/MaterializeInc/materialize/issues/18858.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
