### PR TITLE
Add `rank()` window function

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -658,7 +658,9 @@
   description: Window functions compute values across sets of rows related to the current query.
   functions:
   - signature: 'dense_rank() -> int'
-    description: Returns the rank of the current row within its partition without gaps, counting from 1.
+    description: >-
+      Returns the rank of the current row within its partition without gaps, counting from 1.
+      Rows that compare equal will have the same rank.
   - signature: 'first_value(value anycompatible) -> anyelement'
     description: >-
       Returns `value` evaluated at the first row of the window frame. The default window frame is
@@ -681,8 +683,15 @@
       If `offset` is `NULL`, `NULL` is returned instead.
       Both `offset` and `default` are evaluated with respect to the current row.
       If omitted, `offset` defaults to 1 and `default` to `NULL`.
+  - signature: 'rank() -> int'
+    description: >-
+      Returns the rank of the current row within its partition with gaps (counting from 1):
+      rows that compare equal will have the same rank, and then the rank is incremented by the number of rows that
+      compared equal.
   - signature: 'row_number() -> int'
-    description: Returns the number of the current row within its partition, counting from 1.
+    description: >-
+      Returns the number of the current row within its partition, counting from 1.
+      Rows that compare equal will be ordered in an unspecified way.
 
 - type: System information
   description: Functions that return information about the system.

--- a/src/compute-client/src/plan/reduce.rs
+++ b/src/compute-client/src/plan/reduce.rs
@@ -920,6 +920,7 @@ fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::ListConcat { .. }
         | AggregateFunc::StringAgg { .. }
         | AggregateFunc::RowNumber { .. }
+        | AggregateFunc::Rank { .. }
         | AggregateFunc::DenseRank { .. }
         | AggregateFunc::LagLead { .. }
         | AggregateFunc::FirstValue { .. }

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -1833,6 +1833,7 @@ pub mod monoids {
             | AggregateFunc::ListConcat { .. }
             | AggregateFunc::StringAgg { .. }
             | AggregateFunc::RowNumber { .. }
+            | AggregateFunc::Rank { .. }
             | AggregateFunc::DenseRank { .. }
             | AggregateFunc::LagLead { .. }
             | AggregateFunc::FirstValue { .. }

--- a/src/expr/src/relation.proto
+++ b/src/expr/src/relation.proto
@@ -113,6 +113,7 @@ message ProtoAggregateFunc {
         ProtoColumnOrders list_concat  = 35;
         ProtoColumnOrders string_agg  = 36;
         ProtoColumnOrders row_number  = 37;
+        ProtoColumnOrders rank  = 54;
         ProtoColumnOrders dense_rank  = 38;
         ProtoLagLead lag_lead  = 39;
         google.protobuf.Empty dummy = 40;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2791,6 +2791,9 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         "row_number" => ScalarWindow {
             params!() => ScalarWindowFunc::RowNumber => Int64, 3100;
         },
+        "rank" => ScalarWindow {
+            params!() => ScalarWindowFunc::Rank => Int64, 3101;
+        },
         "dense_rank" => ScalarWindow {
             params!() => ScalarWindowFunc::DenseRank => Int64, 3102;
         },

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -438,6 +438,7 @@ impl ScalarWindowExpr {
     {
         match self.func {
             ScalarWindowFunc::RowNumber => {}
+            ScalarWindowFunc::Rank => {}
             ScalarWindowFunc::DenseRank => {}
         }
         Ok(())
@@ -450,6 +451,7 @@ impl ScalarWindowExpr {
     {
         match self.func {
             ScalarWindowFunc::RowNumber => {}
+            ScalarWindowFunc::Rank => {}
             ScalarWindowFunc::DenseRank => {}
         }
         Ok(())
@@ -469,6 +471,9 @@ impl ScalarWindowExpr {
             ScalarWindowFunc::RowNumber => mz_expr::AggregateFunc::RowNumber {
                 order_by: self.order_by,
             },
+            ScalarWindowFunc::Rank => mz_expr::AggregateFunc::Rank {
+                order_by: self.order_by,
+            },
             ScalarWindowFunc::DenseRank => mz_expr::AggregateFunc::DenseRank {
                 order_by: self.order_by,
             },
@@ -480,6 +485,7 @@ impl ScalarWindowExpr {
 /// Scalar Window functions
 pub enum ScalarWindowFunc {
     RowNumber,
+    Rank,
     DenseRank,
 }
 
@@ -487,6 +493,7 @@ impl ScalarWindowFunc {
     pub fn output_type(&self) -> ColumnType {
         match self {
             ScalarWindowFunc::RowNumber => ScalarType::Int64.nullable(false),
+            ScalarWindowFunc::Rank => ScalarType::Int64.nullable(false),
             ScalarWindowFunc::DenseRank => ScalarType::Int64.nullable(false),
         }
     }

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -370,165 +370,165 @@ a
 b
 c
 
-# dense_rank
+# rank and dense_rank
 
-query IT
+query IIT
 WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
-SELECT dense_rank() OVER (ORDER BY x), x FROM t
+SELECT rank() OVER (ORDER BY x), dense_rank() OVER (ORDER BY x), x FROM t
 ORDER BY dense_rank
 ----
-1  a
-2  b
-3  c
+1  1  a
+2  2  b
+3  3  c
 
-query IT
+query IIT
 WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
-SELECT dense_rank() OVER (ORDER BY x), x FROM t
+SELECT rank() OVER (ORDER BY x), dense_rank() OVER (ORDER BY x), x FROM t
 ORDER BY dense_rank
 ----
-1  a
-2  b
-2  b
-3  c
+1  1  a
+2  2  b
+2  2  b
+4  3  c
 
-query IT
+query IIT
 WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
-SELECT dense_rank() OVER (ORDER BY x), x FROM t
+SELECT rank() OVER (ORDER BY x), dense_rank() OVER (ORDER BY x), x FROM t
 ORDER BY dense_rank
 ----
-1  a
-2  b
-2  b
-3  c
-3  c
+1  1  a
+2  2  b
+2  2  b
+4  3  c
+4  3  c
 
-query IT
+query IIT
 WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
-SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+SELECT rank() OVER (ORDER BY x DESC), dense_rank() OVER (ORDER BY x DESC), x FROM t
 ORDER BY dense_rank
 ----
-1  c
-2  b
-3  a
+1  1  c
+2  2  b
+3  3  a
 
-query IT
+query IIT
 WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
-SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+SELECT rank() OVER (ORDER BY x DESC), dense_rank() OVER (ORDER BY x DESC), x FROM t
 ORDER BY dense_rank
 ----
-1  c
-2  b
-2  b
-3  a
+1  1  c
+2  2  b
+2  2  b
+4  3  a
 
-query IT
+query IIT
 WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
-SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+SELECT rank() OVER (ORDER BY x DESC), dense_rank() OVER (ORDER BY x DESC), x FROM t
 ORDER BY dense_rank
 ----
-1  c
-1  c
-2  b
-2  b
-3  a
+1  1  c
+1  1  c
+3  2  b
+3  2  b
+5  3  a
 
-query IT
+query IIT
 WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
-SELECT dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
+SELECT rank() OVER (PARTITION BY y ORDER BY x), dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
 ORDER BY dense_rank, x
 ----
-1  a
-1  b
-2  c
+1  1  a
+1  1  b
+2  2  c
 
-query IT
+query IIT
 WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98), ('a', 98), ('a', 99))
-SELECT dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
+SELECT rank() OVER (PARTITION BY y ORDER BY x), dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
 ORDER BY dense_rank, x
 ----
-1  a
-1  a
-1  a
-2  b
-2  c
+1  1  a
+1  1  a
+1  1  a
+2  2  b
+3  2  c
 
-query IT
+query IIT
 WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
-SELECT dense_rank() OVER (PARTITION BY y ORDER BY x DESC), x FROM t
+SELECT rank() OVER (PARTITION BY y ORDER BY x DESC), dense_rank() OVER (PARTITION BY y ORDER BY x DESC), x FROM t
 ORDER BY dense_rank, x
 ----
-1  b
-1  c
-2  a
+1  1  b
+1  1  c
+2  2  a
 
-query IT
+query IIT
 WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
-SELECT dense_rank() OVER (PARTITION BY x ORDER BY x), x FROM t
+SELECT rank() OVER (PARTITION BY x ORDER BY x), dense_rank() OVER (PARTITION BY x ORDER BY x), x FROM t
 ORDER BY dense_rank, x
 ----
-1  a
-1  b
-1  c
+1  1  a
+1  1  b
+1  1  c
 
-query IT
+query IIT
 WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
-SELECT dense_rank() OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+SELECT rank() OVER (PARTITION BY NULL ORDER BY 10000), dense_rank() OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
 FROM t AS a1, t AS a2
 ORDER BY q DESC, a1.x DESC
 ----
-1  c
-1  c
-1  c
-1  b
-1  b
-1  b
-1  a
-1  a
-1  a
+1  1  c
+1  1  c
+1  1  c
+1  1  b
+1  1  b
+1  1  b
+1  1  a
+1  1  a
+1  1  a
 
 # Make sure a non-column expression following the window function is correctly
 # handled.
-query ITT
+query IITT
 WITH t (x) AS (VALUES ('a'))
-SELECT dense_rank() OVER (PARTITION BY NULL) AS q, x, 'b'
+SELECT rank() OVER (PARTITION BY NULL), dense_rank() OVER (PARTITION BY NULL) AS q, x, 'b'
 FROM t
 ----
-1 a b
+1  1  a  b
 
 
-query IITT
+query IIITT
 WITH t (x, y, z) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0))
-SELECT dense_rank() OVER (PARTITION BY y ORDER BY x DESC, z), x, y, z
+SELECT rank() OVER (PARTITION BY y ORDER BY x DESC, z), dense_rank() OVER (PARTITION BY y ORDER BY x DESC, z), x, y, z
 FROM t
 ORDER BY y, x DESC, z
 ----
-1  3  a    1
-2  2  a    1
-2  2  a    1
-3  1  a    1
-1  4  b    0
-2  4  b    1
-1  3  c    1
-2  2  c  NaN
-3  1  c  NaN
+1  1  3  a  1
+2  2  2  a  1
+2  2  2  a  1
+4  3  1  a  1
+1  1  4  b  0
+2  2  4  b  1
+1  1  3  c  1
+2  2  2  c  NaN
+3  3  1  c  NaN
 
 
 # NaNs have the same rank
-query IITT
+query IIITT
 WITH t (x, y, z) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0))
-SELECT dense_rank() OVER (PARTITION BY y ORDER BY z DESC), x, y, z
+SELECT rank() OVER (PARTITION BY y ORDER BY z DESC), dense_rank() OVER (PARTITION BY y ORDER BY z DESC), x, y, z
 FROM t
 ORDER BY y, z DESC, x
 ----
-1  1  a    1
-1  2  a    1
-1  2  a    1
-1  3  a    1
-1  4  b    1
-2  4  b    0
-1  1  c  NaN
-1  2  c  NaN
-2  3  c    1
+1  1  1  a  1
+1  1  2  a  1
+1  1  2  a  1
+1  1  3  a  1
+1  1  4  b  1
+2  2  4  b  0
+1  1  1  c  NaN
+1  1  2  c  NaN
+3  2  3  c  1
 
 ## lag
 


### PR DESCRIPTION
This is my warm-up for getting into the implementation part of the window function line of work. It simply adds `rank` (with a naive, i.e. non-incremental implementation), which is very similar to the already-existing `dense_rank` (and `row_number`).

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/materialize/issues/19607

### Tips for reviewer


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - I extended the already-existing tests for `dense_rank`, and checked results against Postgres.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add the `rank()` window function.
