### PR TITLE
sql: implement array_position

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -596,6 +596,10 @@
   functions:
   - signature: 'array_cat(a1: arrayany, a2: arrayany) -> arrayany'
     description: 'Concatenates `a1` and `a2`.'
+  - signature: 'array_position(haystack: anycompatiblearray, needle: anycompatible) -> int'
+    description: 'Returns the subscript of `needle` in `haystack`. Returns `null` if not found.'
+  - signature: 'array_position(haystack: anycompatiblearray, needle: anycompatible, skip: int) -> int'
+    description: 'Returns the subscript of `needle` in `haystack`, skipping the first `skip` elements. Returns `null` if not found.'
   - signature: 'array_to_string(a: anyarray, sep: text [, ifnull: text]) -> text'
     description: >-
       Concatenates the elements of `array` together separated by `sep`.

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -647,6 +647,7 @@ message ProtoVariadicFunc {
         mz_repr.relation_and_scalar.ProtoScalarType range_create = 27;
         google.protobuf.Empty make_mz_acl_item = 28;
         google.protobuf.Empty translate = 29;
+        google.protobuf.Empty array_position = 30;
     }
 }
 
@@ -765,5 +766,7 @@ message ProtoEvalError {
         string invalid_role_id = 63;
         string invalid_privileges = 64;
         string wmr_recursion_limit_exceeded = 65;
+        google.protobuf.Empty multi_dimensional_array_search = 66;
+        string must_not_be_null = 67;
     }
 }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -2223,6 +2223,8 @@ pub enum EvalError {
     InvalidRoleId(String),
     InvalidPrivileges(String),
     LetRecLimitExceeded(String),
+    MultiDimensionalArraySearch,
+    MustNotBeNull(String),
 }
 
 impl fmt::Display for EvalError {
@@ -2380,6 +2382,11 @@ impl fmt::Display for EvalError {
                 write!(f, "Recursive query exceeded the recursion limit {}. (Use RETURN AT RECURSION LIMIT to not error, but return the current state as the final result when reaching the limit.)",
                        max_iters)
             }
+            EvalError::MultiDimensionalArraySearch => write!(
+                f,
+                "searching for elements in multidimensional arrays is not supported"
+            ),
+            EvalError::MustNotBeNull(v) => write!(f, "{v} must not be null"),
         }
     }
 }
@@ -2584,6 +2591,8 @@ impl RustType<ProtoEvalError> for EvalError {
             EvalError::InvalidRoleId(v) => InvalidRoleId(v.clone()),
             EvalError::InvalidPrivileges(v) => InvalidPrivileges(v.clone()),
             EvalError::LetRecLimitExceeded(v) => WmrRecursionLimitExceeded(v.clone()),
+            EvalError::MultiDimensionalArraySearch => MultiDimensionalArraySearch(()),
+            EvalError::MustNotBeNull(v) => MustNotBeNull(v.clone()),
         };
         ProtoEvalError { kind: Some(kind) }
     }
@@ -2683,6 +2692,8 @@ impl RustType<ProtoEvalError> for EvalError {
                 InvalidRoleId(v) => Ok(EvalError::InvalidRoleId(v)),
                 InvalidPrivileges(v) => Ok(EvalError::InvalidPrivileges(v)),
                 WmrRecursionLimitExceeded(v) => Ok(EvalError::LetRecLimitExceeded(v)),
+                MultiDimensionalArraySearch(()) => Ok(EvalError::MultiDimensionalArraySearch),
+                MustNotBeNull(v) => Ok(EvalError::MustNotBeNull(v)),
             },
             None => Err(TryFromProtoError::missing_field("ProtoEvalError::kind")),
         }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1690,6 +1690,10 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         "array_lower" => Scalar {
             params!(ArrayAny, Int64) => BinaryFunc::ArrayLower => Int32, 2091;
         },
+        "array_position" => Scalar {
+            params!(ArrayAnyCompatible, AnyCompatible) => VariadicFunc::ArrayPosition => Int32, 3277;
+            params!(ArrayAnyCompatible, AnyCompatible, Int32) => VariadicFunc::ArrayPosition => Int32, 3278;
+        },
         "array_remove" => Scalar {
             params!(ArrayAnyCompatible, AnyCompatible) => BinaryFunc::ArrayRemove => ArrayAnyCompatible, 3167;
         },

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -935,3 +935,98 @@ SELECT privileges::text[] FROM mz_views;
 
 query error CAST does not support casting from regproc list to text list
 SELECT (LIST[1299::regproc]::regproc list)::text list
+
+# Array position
+
+query I
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','sun'], 'sun')
+----
+1
+
+query I
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','sun'], 'sun', 1)
+----
+1
+
+query I
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','sun'], 'sun', 2)
+----
+8
+
+query I
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','sun'], 'sun', 3)
+----
+8
+
+query I
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','sun'], 'mon')
+----
+2
+
+query I
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','sun'], 'mon', 1)
+----
+2
+
+query I
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','sun'], 'mon', 2)
+----
+2
+
+query I
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','sun'], 'mon', 3)
+----
+NULL
+
+query I
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','mon'], 'mon', -3)
+----
+2
+
+query I
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','mon'], 'x')
+----
+NULL
+
+query I
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','mon'], 'x', 1)
+----
+NULL
+
+query I
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','mon'], null)
+----
+NULL
+
+query I
+SELECT array_position(null::text[], 'abc')
+----
+NULL
+
+query I
+SELECT array_position(null::text[], 'abc', null)
+----
+NULL
+
+query I
+SELECT array_position(ARRAY['sun'], null, null)
+----
+NULL
+
+query error initial position must not be null
+SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat','mon'], 'mon', null)
+
+query error searching for elements in multidimensional arrays is not supported
+SELECT array_position(ARRAY[['mon']]::text[], 'mon')
+
+query error searching for elements in multidimensional arrays is not supported
+SELECT array_position(ARRAY[[null]]::text[], 'mon')
+
+query error searching for elements in multidimensional arrays is not supported
+SELECT array_position(ARRAY[['mon']]::text[], 'mon', 1)
+
+query error searching for elements in multidimensional arrays is not supported
+SELECT array_position(ARRAY[['mon']]::text[], null, 1)
+
+query error searching for elements in multidimensional arrays is not supported
+SELECT array_position(ARRAY[['mon']]::text[], 'mon', null)


### PR DESCRIPTION
@jkosh44 We can use this to provide the right ordering resolution in `mz_name_to_global_id`.

### Motivation

This PR adds a known-desirable feature. This provides a handle to order by the "ordinality" of an array, which we otherwise lose because `unnest` doesn't retain the array's original order.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support the `array_position` function to linearly search an array for a given value.
