### PR TITLE
sqlsmith: Ignore type errors in new array_position function

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -61,10 +61,11 @@ known_errors = [
     "list_agg on char not yet supported",
     "does not allow subqueries",
     "range constructor flags argument must not be null",  # expected after https://github.com/MaterializeInc/materialize/issues/18036 has been fixed
-    "function array_remove(",
-    "function array_cat(",
-    "function list_append(",
-    "function list_prepend(",
+    "function array_remove(",  # insufficient type system, parameter types have to match
+    "function array_cat(",  # insufficient type system, parameter types have to match
+    "function array_position(",  # insufficient type system, parameter types have to match
+    "function list_append(",  # insufficient type system, parameter types have to match
+    "function list_prepend(",  # insufficient type system, parameter types have to match
     "does not support implicitly casting from",
     "aggregate functions that refer exclusively to outer columns not yet supported",  # https://github.com/MaterializeInc/materialize/issues/3720
     "range lower bound must be less than or equal to range upper bound",


### PR DESCRIPTION
Seen in nightly: https://buildkite.com/materialize/nightlies/builds/2507

Of course refining SQLsmith would be better than ignoring another error, but after taking a quick look it's a bit of a more involved change, so I'll postpone it for now.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
