### PR TITLE
persist: resolve a batch of TODO(mfp)

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -203,8 +203,8 @@ impl From<&PersistConfig> for BatchBuilderConfig {
                 .dynamic
                 .batch_builder_max_outstanding_parts(),
             stats_collection_enabled: value.dynamic.stats_collection_enabled(),
-            // TODO(mfp): Make a dynamic config for this? This initial constant
-            // is the rough upper bound on what we see for the total serialized
+            // TODO: Make a dynamic config for this? This initial constant is
+            // the rough upper bound on what we see for the total serialized
             // batch size in prod, so it will at worst double it.
             stats_budget: 1024,
         }
@@ -671,8 +671,6 @@ pub(crate) struct BatchParts<T> {
 }
 
 fn force_keep_stats_col(name: &str) -> bool {
-    // TODO(mfp): Flesh out initial heuristics. At the very least, this should
-    // probably be case insensitive.
     name == "mz_internal_super_secret_source_data_errors"
         || name == "timestamp"
         || name == "ts"
@@ -743,10 +741,6 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
                     .spawn_named(|| "batch::encode_part", async move {
                         let stats = if stats_collection_enabled {
                             let stats_start = Instant::now();
-                            // TODO(mfp): For now, if stats collections fails,
-                            // log it with `error!` so it shows up in Sentry,
-                            // but don't crash the process. Turn this into a
-                            // hard error once we've shaken out any issues.
                             match PartStats::legacy_part_format(&schemas, &batch.updates) {
                                 Ok(mut x) => {
                                     x.key.trim_to_budget(stats_budget, force_keep_stats_col);

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -748,15 +748,6 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
                             // but don't crash the process. Turn this into a
                             // hard error once we've shaken out any issues.
                             match PartStats::legacy_part_format(&schemas, &batch.updates) {
-                                // TODO(mfp): HACK Only keep stats if it's not
-                                // empty. This makes it easier to exactly
-                                // roundtrip through the placeholder proto
-                                // serialization, which doesn't keep the
-                                // difference between empty and unset. We could
-                                // make it keep the distinction, but at the cost
-                                // of additional complexity which I don't think
-                                // is worth it.
-                                Ok(x) if x.is_empty() => None,
                                 Ok(mut x) => {
                                     x.key.trim_to_budget(stats_budget, force_keep_stats_col);
                                     Some((Arc::new(x), stats_start.elapsed()))

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -450,7 +450,7 @@ where
                             let bytes_emitted = {
                                 let mut bytes_emitted = 0;
                                 for mut part_desc in std::mem::take(&mut batch_parts) {
-                                    // TODO(mfp): Push the filter down into the Subscribe?
+                                    // TODO: Push the filter down into the Subscribe?
                                     if cfg.dynamic.stats_filter_enabled() {
                                         let should_fetch = part_desc.stats.as_ref().map_or(true, |stats| should_fetch_part(stats));
                                         let bytes = u64::cast_from(part_desc.encoded_size_bytes);

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -67,9 +67,4 @@ impl PartStats {
         let new_format = new_format.finish()?;
         Self::new(schemas, &new_format)
     }
-
-    pub(crate) fn is_empty(&self) -> bool {
-        let Self { key } = self;
-        key.len == 0
-    }
 }

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -49,7 +49,7 @@ impl PartStats {
         // on the old part format. We don't intend to make this fast, rather we
         // intend to compute stats on the new part format.
         let mut new_format = PartBuilder::new(schemas.key.as_ref(), schemas.val.as_ref());
-        let builder = new_format.get_mut();
+        let mut builder = new_format.get_mut();
         let mut key = schemas.key.encoder(builder.key)?;
         let mut val = schemas.val.encoder(builder.val)?;
         for x in part {

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -233,10 +233,10 @@ pub fn validate_roundtrip<T: Codec + Default + PartialEq + Debug>(
 ) -> Result<(), String> {
     let mut part = PartBuilder::new(schema, &UnitSchema);
     {
-        let part_mut = part.get_mut();
+        let mut part_mut = part.get_mut();
         schema.encoder(part_mut.key)?.encode(val);
-        part_mut.ts.push(1);
-        part_mut.diff.push(1);
+        part_mut.ts.push(1u64);
+        part_mut.diff.push(1i64);
     }
     let part = part.finish()?;
 

--- a/src/persist-types/src/parquet.rs
+++ b/src/persist-types/src/parquet.rs
@@ -102,10 +102,10 @@ pub fn validate_roundtrip<T: Default + PartialEq + Debug, S: Schema<T>>(
 ) -> Result<(), String> {
     let mut part = PartBuilder::new(schema, &UnitSchema);
     {
-        let part_mut = part.get_mut();
+        let mut part_mut = part.get_mut();
         schema.encoder(part_mut.key)?.encode(val);
-        part_mut.ts.push(1);
-        part_mut.diff.push(1);
+        part_mut.ts.push(1u64);
+        part_mut.diff.push(1i64);
     }
     let part = part.finish()?;
 

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -759,7 +759,9 @@ mod impls {
                 .expect("lower bound should always truncate");
             let upper = arrow2::compute::aggregate::max_binary(value).unwrap_or_default();
             let upper = truncate_bytes(upper, TRUNCATE_LEN, TruncateBound::Upper)
-                // TODO(mfp): Instead, truncate this column's stats entirely.
+                // NB: The cost+trim stuff will remove the column entirely if
+                // it's still too big (also this should be extremely rare in
+                // practice).
                 .unwrap_or_else(|| upper.to_owned());
             PrimitiveStats { lower, upper }
         }
@@ -772,7 +774,9 @@ mod impls {
                 .expect("lower bound should always truncate");
             let upper = arrow2::compute::aggregate::max_binary(value).unwrap_or_default();
             let upper = truncate_bytes(upper, TRUNCATE_LEN, TruncateBound::Upper)
-                // TODO(mfp): Instead, truncate this column's stats entirely.
+                // NB: The cost+trim stuff will remove the column entirely if
+                // it's still too big (also this should be extremely rare in
+                // practice).
                 .unwrap_or_else(|| upper.to_owned());
             let none = value.validity().map_or(0, |x| x.unset_bits());
             OptionStats {
@@ -806,7 +810,9 @@ mod impls {
                 .expect("lower bound should always truncate");
             let upper = arrow2::compute::aggregate::max_string(value).unwrap_or_default();
             let upper = truncate_string(upper, TRUNCATE_LEN, TruncateBound::Upper)
-                // TODO(mfp): Instead, truncate this column's stats entirely.
+                // NB: The cost+trim stuff will remove the column entirely if
+                // it's still too big (also this should be extremely rare in
+                // practice).
                 .unwrap_or_else(|| upper.to_owned());
             PrimitiveStats { lower, upper }
         }
@@ -819,7 +825,9 @@ mod impls {
                 .expect("lower bound should always truncate");
             let upper = arrow2::compute::aggregate::max_string(value).unwrap_or_default();
             let upper = truncate_string(upper, TRUNCATE_LEN, TruncateBound::Upper)
-                // TODO(mfp): Instead, truncate this column's stats entirely.
+                // NB: The cost+trim stuff will remove the column entirely if
+                // it's still too big (also this should be extremely rare in
+                // practice).
                 .unwrap_or_else(|| upper.to_owned());
             let none = value.validity().map_or(0, |x| x.unset_bits());
             OptionStats {

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -334,13 +334,15 @@ fn decode_legacy(part: &ColumnarRecords) -> Vec<Row> {
 
 fn encode_structured(schema: &RelationDesc, rows: &[Row]) -> Part {
     let mut part = PartBuilder::new(schema, &UnitSchema);
-    let mut encoder = schema.encoder(part.key_mut()).unwrap();
+    let mut part_mut = part.get_mut();
+    let mut encoder = schema.encoder(part_mut.key).unwrap();
     for row in rows.iter() {
         encoder.encode(row);
     }
     drop(encoder);
     for _ in rows.iter() {
-        part.push_ts_diff(1, 1);
+        part_mut.ts.push(1u64);
+        part_mut.diff.push(1i64);
     }
     part.finish().unwrap()
 }

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -212,12 +212,12 @@ mod tests {
     ) {
         let mut part = PartBuilder::new(schema, &UnitSchema);
         {
-            let part_mut = part.get_mut();
+            let mut part_mut = part.get_mut();
             let mut encoder = schema.encoder(part_mut.key).unwrap();
             for datum in datums {
                 encoder.encode(datum);
-                part_mut.ts.push(1);
-                part_mut.diff.push(1);
+                part_mut.ts.push(1u64);
+                part_mut.diff.push(1i64);
             }
         }
         let part = part.finish().unwrap();

--- a/src/storage-client/src/source/persist_source.rs
+++ b/src/storage-client/src/source/persist_source.rs
@@ -611,10 +611,10 @@ mod tests {
 
             let mut part = PartBuilder::new::<SourceData, _, _, _>(&schema, &UnitSchema);
             {
-                let part_mut = part.get_mut();
+                let mut part_mut = part.get_mut();
                 <RelationDesc as Schema<SourceData>>::encoder(&schema, part_mut.key)?.encode(&row);
-                part_mut.ts.push(1);
-                part_mut.diff.push(1);
+                part_mut.ts.push(1u64);
+                part_mut.diff.push(1i64);
             }
             let part = part.finish()?;
             let stats = part.key_stats::<SourceData, _>(&schema)?;


### PR DESCRIPTION
`TODO(mfp)` is our marker for things we should resolve in some way (potentially by talking ourselves into making them a normal TODO) before turning pushdown on in prod.

See individual commits for details.

Touches #12684 

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
