### PR TITLE
storage: fix checksum assertion in ensure_decoded

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -24,10 +24,11 @@ steps:
           - { value: limits }
           - { value: limits-instance-size }
           - { value: testdrive-partitions-5 }
-          - { value: testdrive-replicas-4}
-          - { value: testdrive-size-1}
-          - { value: testdrive-size-8}
-          - { value: testdrive-in-cloudtest}
+          - { value: testdrive-replicas-4 }
+          - { value: testdrive-size-1 }
+          - { value: testdrive-size-8 }
+          - { value: testdrive-in-cloudtest }
+          - { value: upsert-compaction-disabled }
           - { value: feature-benchmark }
           - { value: zippy-kafka-sources }
           - { value: zippy-kafka-parallel-insert }
@@ -238,6 +239,17 @@ steps:
           composition: testdrive
           args: [--aws-region=us-east-1, --persistent-user-tables]
     skip: Persistence tests disabled
+
+  - id: upsert-compaction-disabled
+    label: Upsert (compaction disabled)
+    timeout_in_minutes: 30
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: upsert
+          args: [--compaction-disabled]
+    agents:
+      queue: linux-x86_64
 
   - id: zippy-kafka-sources
     label: "Zippy Kafka Sources"

--- a/test/upsert/incident-49/01-setup.td
+++ b/test/upsert/incident-49/01-setup.td
@@ -1,0 +1,52 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-create-topic topic=upsert
+
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"} {"f1": "MUCHMUCHMUCHLONGERVALUE", "f2": 1}
+
+> CREATE CONNECTION conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+
+> CREATE CONNECTION c_conn
+  FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}'
+
+> CREATE SOURCE upsert
+  FROM KAFKA CONNECTION conn (TOPIC
+  'testdrive-upsert-${testdrive.seed}'
+  )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION c_conn
+  ENVELOPE UPSERT WITH (SIZE = '1')
+
+> SELECT f2 from upsert
+1
+
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"} {"f1": "s", "f2": 2}
+
+> SELECT f2 from upsert
+2

--- a/test/upsert/incident-49/02-after-rehydration.td
+++ b/test/upsert/incident-49/02-after-rehydration.td
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"} {"f1": "random", "f2": 3}
+
+> SELECT f2 from upsert
+3

--- a/test/upsert/incident-49/03-reset.td
+++ b/test/upsert/incident-49/03-reset.td
@@ -1,0 +1,8 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.


### PR DESCRIPTION
Replaces: https://github.com/MaterializeInc/materialize/pull/19629, for incident 49, closes #19628

Looking into the logs, I saw that the actual assert that was failing was this one: https://github.com/MaterializeInc/materialize/blob/main/src/storage/src/render/upsert/types.rs#L242

Turns out, we were hashing the full buffer, not the value itself, when checking the checksum. @def- figure this out before me https://github.com/MaterializeInc/materialize/issues/19628#issuecomment-1571760006 !

We DO test rehydrating upsert state in CI, but I believe this requires uncompacted data. Because of this, I wrote a unit-test to test.

### Motivation

  * This PR fixes a recognized bug.



### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
