### PR TITLE
sql: rename PeekPlan to SelectPlan

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -516,7 +516,7 @@ impl ExecuteResponse {
             DropObjects => vec![DroppedObject],
             DropOwned => vec![DroppedOwned],
             PlanKind::EmptyQuery => vec![ExecuteResponseKind::EmptyQuery],
-            Explain | Peek | ShowAllVariables | ShowCreate | ShowVariable | InspectShard => {
+            Explain | Select | ShowAllVariables | ShowCreate | ShowVariable | InspectShard => {
                 vec![CopyTo, SendingRows]
             }
             Execute | ReadThenWrite => vec![Deleted, Inserted, SendingRows, Updated],

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -311,7 +311,7 @@ impl PeekStage {
 
 #[derive(Debug)]
 pub struct PeekStageValidate {
-    pub plan: mz_sql::plan::PeekPlan,
+    pub plan: mz_sql::plan::SelectPlan,
     target_cluster: TargetCluster,
 }
 

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -39,7 +39,7 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
     plan: &'p Plan,
 ) -> TargetCluster {
     let depends_on = match plan {
-        Plan::Peek(plan) => plan.source.depends_on(),
+        Plan::Select(plan) => plan.source.depends_on(),
         Plan::Subscribe(plan) => plan.from.depends_on(),
         Plan::CreateConnection(_)
         | Plan::CreateDatabase(_)
@@ -174,7 +174,7 @@ pub fn check_cluster_restrictions(
             SubscribeFrom::Id(id) => Box::new(std::iter::once(id)),
             SubscribeFrom::Query { ref expr, .. } => Box::new(expr.depends_on().into_iter()),
         },
-        Plan::Peek(plan) => Box::new(plan.source.depends_on().into_iter()),
+        Plan::Select(plan) => Box::new(plan.source.depends_on().into_iter()),
         _ => return Ok(()),
     };
 
@@ -232,7 +232,7 @@ pub fn user_privilege_hack(
         }
 
         Plan::Subscribe(_)
-        | Plan::Peek(_)
+        | Plan::Select(_)
         | Plan::CopyFrom(_)
         | Plan::Explain(_)
         | Plan::ShowAllVariables

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -253,7 +253,7 @@ impl Coordinator {
                 }
                 self.sequence_end_transaction(ctx, action);
             }
-            Plan::Peek(plan) => {
+            Plan::Select(plan) => {
                 self.sequence_peek(ctx, plan, target_cluster).await;
             }
             Plan::Subscribe(plan) => {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -50,9 +50,9 @@ use mz_sql::plan::{
     CreateMaterializedViewPlan, CreateRolePlan, CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan,
     CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan, DropObjectsPlan,
     DropOwnedPlan, ExecutePlan, ExplainPlan, GrantPrivilegesPlan, GrantRolePlan, IndexOption,
-    InsertPlan, InspectShardPlan, MaterializedView, MutationKind, OptimizerConfig, PeekPlan, Plan,
-    QueryWhen, ReadThenWritePlan, ReassignOwnedPlan, ResetVariablePlan, RevokePrivilegesPlan,
-    RevokeRolePlan, SendDiffsPlan, SetTransactionPlan, SetVariablePlan, ShowVariablePlan,
+    InsertPlan, InspectShardPlan, MaterializedView, MutationKind, OptimizerConfig, Plan, QueryWhen,
+    ReadThenWritePlan, ReassignOwnedPlan, ResetVariablePlan, RevokePrivilegesPlan, RevokeRolePlan,
+    SelectPlan, SendDiffsPlan, SetTransactionPlan, SetVariablePlan, ShowVariablePlan,
     SideEffectingFunc, SourceSinkClusterConfig, SubscribeFrom, SubscribePlan, UpdatePrivilege,
     VariableValue, View,
 };
@@ -1747,7 +1747,7 @@ impl Coordinator {
     pub(super) async fn sequence_peek(
         &mut self,
         ctx: ExecuteContext,
-        plan: PeekPlan,
+        plan: SelectPlan,
         target_cluster: TargetCluster,
     ) {
         event!(Level::TRACE, plan = format!("{:?}", plan));
@@ -1814,7 +1814,7 @@ impl Coordinator {
             target_cluster,
         }: PeekStageValidate,
     ) -> Result<PeekStageOptimize, AdapterError> {
-        let PeekPlan {
+        let SelectPlan {
             source,
             when,
             finishing,
@@ -3221,7 +3221,7 @@ impl Coordinator {
         );
         self.sequence_peek(
             peek_ctx,
-            PeekPlan {
+            SelectPlan {
                 source: selection,
                 when: QueryWhen::Freshest,
                 finishing,

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -31,11 +31,11 @@ use mz_sql::plan::{
     CreateSecretPlan, CreateSinkPlan, CreateSourcePlan, CreateSourcePlans, CreateTablePlan,
     CreateTypePlan, CreateViewPlan, DeallocatePlan, DeclarePlan, DropObjectsPlan, DropOwnedPlan,
     ExecutePlan, ExplainPlan, FetchPlan, GrantPrivilegesPlan, GrantRolePlan, InsertPlan,
-    InspectShardPlan, MutationKind, PeekPlan, Plan, PlannedRoleAttributes, PreparePlan, RaisePlan,
+    InspectShardPlan, MutationKind, Plan, PlannedRoleAttributes, PreparePlan, RaisePlan,
     ReadThenWritePlan, ReassignOwnedPlan, ResetVariablePlan, RevokePrivilegesPlan, RevokeRolePlan,
-    RotateKeysPlan, SetTransactionPlan, SetVariablePlan, ShowCreatePlan, ShowVariablePlan,
-    SideEffectingFunc, SourceSinkClusterConfig, StartTransactionPlan, SubscribePlan,
-    UpdatePrivilege,
+    RotateKeysPlan, SelectPlan, SetTransactionPlan, SetVariablePlan, ShowCreatePlan,
+    ShowVariablePlan, SideEffectingFunc, SourceSinkClusterConfig, StartTransactionPlan,
+    SubscribePlan, UpdatePrivilege,
 };
 use mz_sql::session::user::{INTROSPECTION_USER, SYSTEM_USER};
 use mz_sql::session::vars::SystemVars;
@@ -335,7 +335,7 @@ pub fn generate_required_role_membership(
         | Plan::StartTransaction(_)
         | Plan::CommitTransaction(_)
         | Plan::AbortTransaction(_)
-        | Plan::Peek(_)
+        | Plan::Select(_)
         | Plan::Subscribe(_)
         | Plan::CopyFrom(_)
         | Plan::CopyRows(_)
@@ -439,7 +439,7 @@ fn generate_required_plan_attribute(plan: &Plan) -> Vec<Attribute> {
         | Plan::StartTransaction(_)
         | Plan::CommitTransaction(_)
         | Plan::AbortTransaction(_)
-        | Plan::Peek(_)
+        | Plan::Select(_)
         | Plan::Subscribe(_)
         | Plan::CopyRows(_)
         | Plan::CopyFrom(_)
@@ -599,7 +599,7 @@ fn generate_required_ownership(plan: &Plan) -> Vec<ObjectId> {
         | Plan::StartTransaction(_)
         | Plan::CommitTransaction(_)
         | Plan::AbortTransaction(_)
-        | Plan::Peek(_)
+        | Plan::Select(_)
         | Plan::Subscribe(_)
         | Plan::ShowCreate(_)
         | Plan::CopyFrom(_)
@@ -918,7 +918,7 @@ fn generate_required_privileges(
             )]
         }
 
-        Plan::Peek(PeekPlan {
+        Plan::Select(SelectPlan {
             source,
             when: _,
             finishing: _,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -120,7 +120,7 @@ pub enum Plan {
     StartTransaction(StartTransactionPlan),
     CommitTransaction(CommitTransactionPlan),
     AbortTransaction(AbortTransactionPlan),
-    Peek(PeekPlan),
+    Select(SelectPlan),
     Subscribe(SubscribePlan),
     CopyFrom(CopyFromPlan),
     CopyRows(CopyRowsPlan),
@@ -196,7 +196,7 @@ impl Plan {
             StatementKind::AlterOwner => vec![PlanKind::AlterNoop, PlanKind::AlterOwner],
             StatementKind::Close => vec![PlanKind::Close],
             StatementKind::Commit => vec![PlanKind::CommitTransaction],
-            StatementKind::Copy => vec![PlanKind::CopyFrom, PlanKind::Peek, PlanKind::Subscribe],
+            StatementKind::Copy => vec![PlanKind::CopyFrom, PlanKind::Select, PlanKind::Subscribe],
             StatementKind::CreateCluster => vec![PlanKind::CreateCluster],
             StatementKind::CreateClusterReplica => vec![PlanKind::CreateClusterReplica],
             StatementKind::CreateConnection => vec![PlanKind::CreateConnection],
@@ -232,11 +232,11 @@ impl Plan {
             StatementKind::RevokePrivileges => vec![PlanKind::RevokePrivileges],
             StatementKind::RevokeRole => vec![PlanKind::RevokeRole],
             StatementKind::Rollback => vec![PlanKind::AbortTransaction],
-            StatementKind::Select => vec![PlanKind::Peek, PlanKind::SideEffectingFunc],
+            StatementKind::Select => vec![PlanKind::Select, PlanKind::SideEffectingFunc],
             StatementKind::SetTransaction => vec![PlanKind::SetTransaction],
             StatementKind::SetVariable => vec![PlanKind::SetVariable],
             StatementKind::Show => vec![
-                PlanKind::Peek,
+                PlanKind::Select,
                 PlanKind::ShowVariable,
                 PlanKind::ShowCreate,
                 PlanKind::ShowAllVariables,
@@ -297,7 +297,7 @@ impl Plan {
             Plan::StartTransaction(_) => "start transaction",
             Plan::CommitTransaction(_) => "commit",
             Plan::AbortTransaction(_) => "abort",
-            Plan::Peek(_) => "select",
+            Plan::Select(_) => "select",
             Plan::Subscribe(_) => "subscribe",
             Plan::CopyRows(_) => "copy rows",
             Plan::CopyFrom(_) => "copy from",
@@ -682,7 +682,7 @@ pub struct SetTransactionPlan {
 }
 
 #[derive(Clone, Debug)]
-pub struct PeekPlan {
+pub struct SelectPlan {
     pub source: MirRelationExpr,
     pub when: QueryWhen,
     pub finishing: RowSetFinishing,

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -41,8 +41,8 @@ use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::with_options::TryFromValue;
 use crate::plan::{self, side_effecting_func};
 use crate::plan::{
-    query, CopyFormat, CopyFromPlan, ExplainPlan, InsertPlan, MutationKind, Params, PeekPlan, Plan,
-    PlanError, QueryContext, ReadThenWritePlan, SubscribeFrom, SubscribePlan,
+    query, CopyFormat, CopyFromPlan, ExplainPlan, InsertPlan, MutationKind, Params, Plan,
+    PlanError, QueryContext, ReadThenWritePlan, SelectPlan, SubscribeFrom, SubscribePlan,
 };
 use crate::session::vars;
 
@@ -193,7 +193,7 @@ pub fn plan_select(
         QueryLifetime::OneShot(scx.pcx()?),
     )?;
     let when = query::plan_as_of(scx, select.as_of)?;
-    Ok(Plan::Peek(PeekPlan {
+    Ok(Plan::Select(SelectPlan {
         source: expr,
         when,
         finishing,

--- a/src/timely-util/src/reduce.rs
+++ b/src/timely-util/src/reduce.rs
@@ -1,0 +1,83 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use differential_dataflow::difference::{Abelian, Semigroup};
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
+use differential_dataflow::operators::reduce::ReduceCore;
+use differential_dataflow::trace::{Batch, Trace, TraceReader};
+use differential_dataflow::Data;
+use timely::dataflow::Scope;
+
+/// Extension trait for `ReduceCore`, currently providing a reduction based
+/// on an operator-pair approach.
+pub trait ReduceExt<G: Scope, K: Data, V: Data, R: Semigroup>
+where
+    G::Timestamp: Lattice + Ord,
+{
+    /// This method produces a reduction pair based on the same input arrangement. Each reduction
+    /// in the pair operates with its own logic and the two output arrangements from the reductions
+    /// are produced as a result. The method is useful for reductions that need to present different
+    /// output views on the same input data. An example is producing an error-free reduction output
+    /// along with a separate error output indicating when the error-free output is valid.
+    fn reduce_pair<L1, T1, L2, T2>(
+        &self,
+        name1: &str,
+        name2: &str,
+        logic1: L1,
+        logic2: L2,
+    ) -> (Arranged<G, TraceAgent<T1>>, Arranged<G, TraceAgent<T2>>)
+    where
+        T1: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
+        T1::Val: Data,
+        T1::R: Abelian,
+        T1::Batch: Batch,
+        L1: FnMut(&K, &[(&V, R)], &mut Vec<(T1::Val, T1::R)>) + 'static,
+        T2: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
+        T2::Val: Data,
+        T2::R: Abelian,
+        T2::Batch: Batch,
+        L2: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val, T2::R)>) + 'static;
+}
+
+impl<G: Scope, K: Data, V: Data, Tr, R: Semigroup> ReduceExt<G, K, V, R> for Arranged<G, Tr>
+where
+    G::Timestamp: Lattice + Ord,
+    Tr: TraceReader<Key = K, Val = V, Time = G::Timestamp, R = R> + Clone + 'static,
+{
+    fn reduce_pair<L1, T1, L2, T2>(
+        &self,
+        name1: &str,
+        name2: &str,
+        logic1: L1,
+        logic2: L2,
+    ) -> (Arranged<G, TraceAgent<T1>>, Arranged<G, TraceAgent<T2>>)
+    where
+        T1: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
+        T1::Val: Data,
+        T1::R: Abelian,
+        T1::Batch: Batch,
+        L1: FnMut(&K, &[(&V, R)], &mut Vec<(T1::Val, T1::R)>) + 'static,
+        T2: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
+        T2::Val: Data,
+        T2::R: Abelian,
+        T2::Batch: Batch,
+        L2: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val, T2::R)>) + 'static,
+    {
+        let arranged1 = self.reduce_abelian::<L1, T1>(name1, logic1);
+        let arranged2 = self.reduce_abelian::<L2, T2>(name2, logic2);
+        (arranged1, arranged2)
+    }
+}


### PR DESCRIPTION
The name "PeekPlan" is historical, from the days when we had a PEEK SQL command. Nowadays we're intended to use "peek" to refer to the compute concept and "select" to refer to the SQL concept, to distinguish that these two concepts are related but not the same.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.


### Tips for reviewer

Should be no behavior changes here.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
