### PR TITLE
adapter: Fix panic when creating a Mat View

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -173,7 +173,7 @@ impl Coordinator {
             }
             Plan::CreateMaterializedView(plan) => {
                 tx.send(
-                    self.sequence_create_materialized_view(&mut session, plan, depends_on)
+                    self.sequence_create_materialized_view(&mut session, plan)
                         .await,
                     session,
                 );

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -257,7 +257,7 @@ pub fn show_databases<'a>(
     filter: Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
     let query = "SELECT name FROM mz_catalog.mz_databases".to_string();
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter, None, Some(&["name"]))
 }
 
 pub fn show_schemas<'a>(
@@ -280,7 +280,7 @@ pub fn show_schemas<'a>(
         FROM mz_catalog.mz_schemas
         WHERE database_id IS NULL OR database_id = '{database_id}'",
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter, None, Some(&["name"]))
 }
 
 pub fn show_objects<'a>(
@@ -338,7 +338,7 @@ fn show_connections<'a>(
         FROM mz_catalog.mz_connections
         WHERE schema_id = '{schema_spec}'",
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter, None, Some(&["name", "type"]))
 }
 
 fn show_tables<'a>(
@@ -352,7 +352,7 @@ fn show_tables<'a>(
         FROM mz_catalog.mz_tables
         WHERE schema_id = '{schema_spec}'",
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter, None, Some(&["name"]))
 }
 
 fn show_sources<'a>(
@@ -366,7 +366,7 @@ fn show_sources<'a>(
         FROM mz_catalog.mz_sources
         WHERE schema_id = '{schema_spec}'"
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter, None, Some(&["name", "type", "size"]))
 }
 
 fn show_views<'a>(
@@ -380,7 +380,7 @@ fn show_views<'a>(
         FROM mz_catalog.mz_views
         WHERE schema_id = '{schema_spec}'"
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter, None, Some(&["name"]))
 }
 
 fn show_materialized_views<'a>(
@@ -403,7 +403,7 @@ fn show_materialized_views<'a>(
          WHERE {where_clause}"
     );
 
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter, None, Some(&["name", "cluster"]))
 }
 
 fn show_sinks<'a>(
@@ -421,7 +421,7 @@ fn show_sinks<'a>(
          FROM mz_catalog.mz_sinks AS sinks
          WHERE schema_id = '{schema_spec}'",
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter, None, Some(&["name", "type", "size"]))
 }
 
 fn show_types<'a>(
@@ -435,7 +435,7 @@ fn show_types<'a>(
         FROM mz_catalog.mz_types
         WHERE schema_id = '{schema_spec}'",
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter, None, Some(&["name"]))
 }
 
 fn show_all_objects<'a>(
@@ -449,7 +449,7 @@ fn show_all_objects<'a>(
         FROM mz_catalog.mz_objects
         WHERE schema_id = '{schema_spec}'",
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter, None, Some(&["name", "type"]))
 }
 
 pub fn show_indexes<'a>(
@@ -499,7 +499,13 @@ pub fn show_indexes<'a>(
         itertools::join(query_filter.iter(), " AND ")
     );
 
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(
+        scx,
+        query,
+        filter,
+        None,
+        Some(&["name", "on", "cluster", "key"]),
+    )
 }
 
 pub fn show_columns<'a>(
@@ -549,7 +555,7 @@ pub fn show_clusters<'a>(
 ) -> Result<ShowSelect<'a>, PlanError> {
     let query = "SELECT mz_clusters.name FROM mz_catalog.mz_clusters".to_string();
 
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter, None, Some(&["name"]))
 }
 
 pub fn show_cluster_replicas<'a>(
@@ -559,7 +565,13 @@ pub fn show_cluster_replicas<'a>(
     let query = "SELECT cluster, replica, size, ready FROM mz_internal.mz_show_cluster_replicas"
         .to_string();
 
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(
+        scx,
+        query,
+        filter,
+        None,
+        Some(&["cluster", "replica", "size", "ready"]),
+    )
 }
 
 pub fn show_secrets<'a>(
@@ -575,7 +587,7 @@ pub fn show_secrets<'a>(
         WHERE schema_id = '{schema_spec}'",
     );
 
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter, None, Some(&["name"]))
 }
 
 /// An intermediate result when planning a `SHOW` query.

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -561,12 +561,6 @@ size_1  1  1  18446744073709000000  18446744073709551615  1  1
 size_2_2  2-2  2  18446744073709000000  18446744073709551615  2  2
 size_32  32  1  18446744073709000000  18446744073709551615  32  1
 
-# We should be able to create a Materialized View on top of SHOW CLUSTERS.
-#
-# Note: previously this panicked.
-statement ok
-CREATE MATERIALIZED VIEW should_not_panic AS SELECT * FROM (SHOW CLUSTER REPLICAS);
-
 statement ok
 DROP CLUSTER foo CASCADE
 

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -561,6 +561,12 @@ size_1  1  1  18446744073709000000  18446744073709551615  1  1
 size_2_2  2-2  2  18446744073709000000  18446744073709551615  2  2
 size_32  32  1  18446744073709000000  18446744073709551615  32  1
 
+# We should be able to create a Materialized View on top of SHOW CLUSTERS.
+#
+# Note: previously this panicked.
+statement ok
+CREATE MATERIALIZED VIEW should_not_panic AS SELECT * FROM (SHOW CLUSTER REPLICAS);
+
 statement ok
 DROP CLUSTER foo CASCADE
 

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -370,6 +370,53 @@ ALTER VIEW mv RENAME TO mv2
 statement error materialize\.public\.mv is not a view\nHINT: Use EXPLAIN \[\.\.\.\] MATERIALIZED VIEW to explain a materialized view\.
 EXPLAIN WITH(arity, join_impls) VIEW mv
 
+# We should be able to create materialized views on top of 'SHOW' commands.
+
+statement ok
+CREATE MATERIALIZED VIEW mat_clusters AS SELECT name FROM (SHOW CLUSTERS);
+
+# Depends on an mz_internal table.
+statement error cannot create materialized view with unstable dependencies
+CREATE MATERIALIZED VIEW mat_cluster_replicas AS SELECT cluster, replica, size, ready FROM (SHOW CLUSTER REPLICAS);
+
+# Note: the only reason we use mat_clusters here, is because we know it should exist.
+statement ok
+CREATE MATERIALIZED VIEW mat_columns AS SELECT name, nullable, type FROM (SHOW COLUMNS FROM mat_clusters);
+
+statement ok
+CREATE MATERIALIZED VIEW mat_connections AS SELECT name, type FROM (SHOW CONNECTIONS);
+
+statement ok
+CREATE MATERIALIZED VIEW mat_databases AS SELECT name FROM (SHOW DATABASES);
+
+# Depends on an mz_internal table.
+statement error cannot create materialized view with unstable dependencies
+CREATE MATERIALIZED VIEW mat_indexes AS SELECT name, on, cluster, key FROM (SHOW INDEXES);
+
+# Depends on an mz_internal table.
+statement error cannot create materialized view with unstable dependencies
+CREATE MATERIALIZED VIEW mat_mat_views AS SELECT name, cluster FROM (SHOW MATERIALIZED VIEWS);
+
+statement ok
+CREATE MATERIALIZED VIEW mat_objects AS SELECT name FROM (SHOW OBJECTS);
+
+statement ok
+CREATE MATERIALIZED VIEW mat_schemas AS SELECT name FROM (SHOW SCHEMAS);
+
+statement ok
+CREATE MATERIALIZED VIEW mat_secrets AS SELECT name FROM (SHOW SECRETS);
+
+statement ok
+CREATE MATERIALIZED VIEW mat_sinks AS SELECT name, type, size FROM (SHOW SINKS);
+
+statement ok
+CREATE MATERIALIZED VIEW mat_sources AS SELECT name, type, size FROM (SHOW SOURCES);
+
+statement ok
+CREATE MATERIALIZED VIEW mat_tables AS SELECT name FROM (SHOW TABLES);
+
+statement ok
+CREATE MATERIALIZED VIEW mat_views AS SELECT name FROM (SHOW VIEWS);
 
 # Cleanup
 


### PR DESCRIPTION
### Motivation

Fixes #18908

This PR changes the `depends_on` set that is provided when sequencing a "create materialized view". Previously when picking an `as_of` timestamp when sequencing, we were using the `depends_on` set from planning, which only does name resolution. When creating a materialized view with a `SHOW` command, we wouldn't yet have determined that our materialized view depends on a system table, in fact our dependencies list was empty. This resulted in us picking an `Antichain { elements: [0] }`, which later on resulted in a panic.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
