### PR TITLE
storage: dont send invalid retractions from marketing loadgen

### DIFF
--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -168,6 +168,14 @@ create the following subsources:
     `created_at`        | [`timestamp with time zone`] | The time at which the prediction was made.
     `score`             | [`numeric`]                  | The predicted likelihood the lead will convert.
 
+  * `conversions` describes actual purchases made by customers.
+
+    Field          | Type                         | Description
+    ---------------|------------------------------|------------
+    `id`           | [`bigint`]                   | The identifier of the conversion.
+    `converted_at` | [`timestamp with time zone`] | The time at which the lead was converted.
+    `amount`       | [`bigint`]                   | The amount the lead converted for in pennies.
+
 ### TPCH
 
 The TPCH load generator implements the [TPC-H benchmark specification](https://www.tpc.org/tpch/default5.asp).

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -2200,8 +2200,6 @@ impl LoadGenerator {
                             .with_column("id", ScalarType::Int64.nullable(false))
                             .with_column("customer_id", ScalarType::Int64.nullable(false))
                             .with_column("created_at", ScalarType::TimestampTz.nullable(false))
-                            .with_column("converted_at", ScalarType::TimestampTz.nullable(true))
-                            .with_column("conversion_amount", ScalarType::Int64.nullable(true))
                             .with_key(vec![0]),
                     ),
                     (
@@ -2221,6 +2219,15 @@ impl LoadGenerator {
                             .with_column("predicted_at", ScalarType::TimestampTz.nullable(false))
                             .with_column("score", ScalarType::Float64.nullable(false))
                             .without_keys(),
+                    ),
+                    (
+                        "conversions",
+                        RelationDesc::empty()
+                            .with_column("id", ScalarType::Int64.nullable(false))
+                            .with_column("customer_id", ScalarType::Int64.nullable(false))
+                            .with_column("converted_at", ScalarType::TimestampTz.nullable(true))
+                            .with_column("amount", ScalarType::Int64.nullable(true))
+                            .with_key(vec![0]),
                     ),
                 ]
             }
@@ -2345,7 +2352,7 @@ impl LoadGenerator {
                 max_cardinality: None,
             } => true,
             LoadGenerator::Counter { .. } => false,
-            LoadGenerator::Marketing => false,
+            LoadGenerator::Marketing => true,
             LoadGenerator::Datums => true,
             LoadGenerator::Tpch { .. } => false,
         }

--- a/src/storage/src/source/generator/marketing.rs
+++ b/src/storage/src/source/generator/marketing.rs
@@ -23,6 +23,7 @@ const CLICK_OUTPUT: usize = 3;
 const LEADS_OUTPUT: usize = 4;
 const COUPONS_OUTPUT: usize = 5;
 const CONVERSIONS_PREDICTIONS_OUTPUT: usize = 6;
+const CONVERSIONS_OUTPUT: usize = 7;
 
 const CONTROL: &str = "control";
 const EXPERIMENT: &str = "experiment";
@@ -114,12 +115,10 @@ impl Generator for Marketing {
                     let id = counter;
                     counter += 1;
 
-                    let mut lead = Lead {
+                    let lead = Lead {
                         id,
                         customer_id: rng.gen_range(0..CUSTOMERS.len()).try_into().unwrap(),
                         created_at: now(),
-                        converted_at: None,
-                        conversion_amount: None,
                     };
 
                     pending.push((LEADS_OUTPUT, lead.to_row(), 1));
@@ -176,14 +175,23 @@ impl Generator for Marketing {
                     }
 
                     if converted {
-                        let converted_at = now() + rng.gen_range(1..30);
+                        let converted_at = now() + rng.gen_range(5..30);
 
-                        future_updates.insert(converted_at, (LEADS_OUTPUT, lead.to_row(), -1));
+                        let mut conversion = Row::with_capacity(3);
+                        let mut packer = conversion.packer();
 
-                        lead.converted_at = Some(converted_at);
-                        lead.conversion_amount = Some(rng.gen_range(1000..25000));
+                        let id = counter;
+                        counter += 1;
+                        packer.push(Datum::Int64(id));
+                        packer.push(Datum::Int64(lead.customer_id));
+                        packer.push(Datum::TimestampTz(
+                            to_datetime(converted_at)
+                                .try_into()
+                                .expect("timestamp must fit"),
+                        ));
+                        packer.push(Datum::Int64(rng.gen_range(1000..25000)));
 
-                        future_updates.insert(converted_at, (LEADS_OUTPUT, lead.to_row(), 1));
+                        future_updates.insert(converted_at, (CONVERSIONS_OUTPUT, conversion, 1));
                     }
                 }
             }
@@ -204,8 +212,6 @@ struct Lead {
     id: i64,
     customer_id: i64,
     created_at: u64,
-    converted_at: Option<u64>,
-    conversion_amount: Option<i64>,
 }
 
 impl Lead {
@@ -219,22 +225,6 @@ impl Lead {
                 .try_into()
                 .expect("timestamp must fit"),
         ));
-        packer.push(
-            self.converted_at
-                .map(|converted_at| {
-                    Datum::TimestampTz(
-                        to_datetime(converted_at)
-                            .try_into()
-                            .expect("timestamp must fit"),
-                    )
-                })
-                .unwrap_or(Datum::Null),
-        );
-        packer.push(
-            self.conversion_amount
-                .map(Datum::Int64)
-                .unwrap_or(Datum::Null),
-        );
 
         row
     }

--- a/src/storage/src/source/generator/marketing.rs
+++ b/src/storage/src/source/generator/marketing.rs
@@ -30,7 +30,7 @@ const EXPERIMENT: &str = "experiment";
 
 pub struct Marketing {}
 
-// Note that this generator issues retractions; if you change this,
+// Note that this generator does not issues retractions; if you change this,
 // `mz_storage_client::types::sources::LoadGenerator::is_monotonic`
 // must be updated.
 impl Generator for Marketing {
@@ -177,7 +177,7 @@ impl Generator for Marketing {
                     if converted {
                         let converted_at = now() + rng.gen_range(5..30);
 
-                        let mut conversion = Row::with_capacity(3);
+                        let mut conversion = Row::with_capacity(4);
                         let mut packer = conversion.packer();
 
                         let id = counter;


### PR DESCRIPTION
The marketing loadgen source would previously send invalid retractions whenever the source would restart. Instead of attempting to make the source perfectly deterministic, we skip updates and instead write to a new table - conversions - that can be joined against in user code.

