### PR TITLE
sql: remove TableFunc

### DIFF
--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -23,7 +23,9 @@ use std::hash::Hash;
 use std::mem;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
-use crate::ast::{AstInfo, Expr, FunctionArgs, Ident, ShowStatement, WithOptionValue};
+use crate::ast::{AstInfo, Expr, Ident, ShowStatement, WithOptionValue};
+
+use super::Function;
 
 /// The most complete variant of a `SELECT` query expression, optionally
 /// including `WITH`, `UNION` / other set operations, and `ORDER BY`.
@@ -531,12 +533,12 @@ pub enum TableFactor<T: AstInfo> {
         alias: Option<TableAlias>,
     },
     Function {
-        function: TableFunction<T>,
+        function: Function<T>,
         alias: Option<TableAlias>,
         with_ordinality: bool,
     },
     RowsFrom {
-        functions: Vec<TableFunction<T>>,
+        functions: Vec<Function<T>>,
         alias: Option<TableAlias>,
         with_ordinality: bool,
     },
@@ -624,21 +626,6 @@ impl<T: AstInfo> AstDisplay for TableFactor<T> {
     }
 }
 impl_display_t!(TableFactor);
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct TableFunction<T: AstInfo> {
-    pub name: T::ItemName,
-    pub args: FunctionArgs<T>,
-}
-impl<T: AstInfo> AstDisplay for TableFunction<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        f.write_str("(");
-        f.write_node(&self.args);
-        f.write_str(")");
-    }
-}
-impl_display_t!(TableFunction);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TableAlias {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -397,8 +397,8 @@ impl<'a> Parser<'a> {
         let expr = match tok {
             Token::LBracket => {
                 self.prev_token();
-                let name = self.parse_raw_name()?;
-                self.parse_function(name)
+                let function = self.parse_named_function()?;
+                Ok(Expr::Function(function))
             }
             Token::Keyword(TRUE) | Token::Keyword(FALSE) | Token::Keyword(NULL) => {
                 self.prev_token();
@@ -605,7 +605,7 @@ impl<'a> Parser<'a> {
         Ok(parse(self)?.into_expr())
     }
 
-    fn parse_function(&mut self, name: RawItemName) -> Result<Expr<Raw>, ParserError> {
+    fn parse_function(&mut self, name: RawItemName) -> Result<Function<Raw>, ParserError> {
         self.expect_token(&Token::LParen)?;
         let distinct = matches!(
             self.parse_at_most_one_keyword(&[ALL, DISTINCT], &format!("function: {}", name))?,
@@ -660,13 +660,13 @@ impl<'a> Parser<'a> {
             None
         };
 
-        Ok(Expr::Function(Function {
+        Ok(Function {
             name,
             args,
             filter,
             over,
             distinct,
-        }))
+        })
     }
 
     fn parse_window_frame(&mut self) -> Result<WindowFrame, ParserError> {
@@ -4567,9 +4567,10 @@ impl<'a> Parser<'a> {
                 }
                 if ends_with_wildcard {
                     Ok(Expr::QualifiedWildcard(id_parts))
-                } else if self.consume_token(&Token::LParen) {
-                    self.prev_token();
-                    self.parse_function(RawItemName::Name(UnresolvedItemName(id_parts)))
+                } else if self.peek_token() == Some(Token::LParen) {
+                    let function =
+                        self.parse_function(RawItemName::Name(UnresolvedItemName(id_parts)))?;
+                    Ok(Expr::Function(function))
                 } else {
                     Ok(Expr::Identifier(id_parts))
                 }
@@ -5363,7 +5364,13 @@ impl<'a> Parser<'a> {
                 let alias = self.parse_optional_table_alias()?;
                 let with_ordinality = self.parse_keywords(&[WITH, ORDINALITY]);
                 return Ok(TableFactor::Function {
-                    function: TableFunction { name, args },
+                    function: Function {
+                        name,
+                        args,
+                        filter: None,
+                        over: None,
+                        distinct: false,
+                    },
                     alias,
                     with_ordinality,
                 });
@@ -5429,7 +5436,13 @@ impl<'a> Parser<'a> {
                 let alias = self.parse_optional_table_alias()?;
                 let with_ordinality = self.parse_keywords(&[WITH, ORDINALITY]);
                 Ok(TableFactor::Function {
-                    function: TableFunction { name, args },
+                    function: Function {
+                        name,
+                        args,
+                        filter: None,
+                        over: None,
+                        distinct: false,
+                    },
                     alias,
                     with_ordinality,
                 })
@@ -5444,7 +5457,7 @@ impl<'a> Parser<'a> {
 
     fn parse_rows_from(&mut self) -> Result<TableFactor<Raw>, ParserError> {
         self.expect_token(&Token::LParen)?;
-        let functions = self.parse_comma_separated(Parser::parse_table_function)?;
+        let functions = self.parse_comma_separated(Parser::parse_named_function)?;
         self.expect_token(&Token::RParen)?;
         let alias = self.parse_optional_table_alias()?;
         let with_ordinality = self.parse_keywords(&[WITH, ORDINALITY]);
@@ -5455,13 +5468,9 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_table_function(&mut self) -> Result<TableFunction<Raw>, ParserError> {
+    fn parse_named_function(&mut self) -> Result<Function<Raw>, ParserError> {
         let name = self.parse_raw_name()?;
-        self.expect_token(&Token::LParen)?;
-        Ok(TableFunction {
-            name,
-            args: self.parse_optional_args(false)?,
-        })
+        self.parse_function(name)
     }
 
     fn parse_derived_table_factor(

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -894,7 +894,7 @@ SELECT foo FROM LATERAL bar(1)
 ----
 SELECT foo FROM bar(1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { function: TableFunction { name: Name(UnresolvedItemName([Ident("bar")])), args: Args { args: [Value(Number("1"))], order_by: [] } }, alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("bar")])), args: Args { args: [Value(Number("1"))], order_by: [] }, filter: None, over: None, distinct: false }, alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM LATERAL bar
@@ -1095,28 +1095,28 @@ SELECT * FROM customer LEFT JOIN LATERAL generate_series(1, customer.id) ON true
 ----
 SELECT * FROM customer LEFT JOIN generate_series(1, customer.id) ON true
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { function: TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] } }, alias: None, with_ordinality: false }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] }, filter: None, over: None, distinct: false }, alias: None, with_ordinality: false }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS alias
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS alias
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM generate_series(1, 2) WITH ORDINALITY
 ----
 SELECT * FROM generate_series(1, 2) WITH ORDINALITY
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Function { function: TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM ROWS FROM (generate_series(1, 2) WITH ORDINALITY)
@@ -1130,14 +1130,14 @@ SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDI
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 # Ensure parsing AS OF is case-insensitive
 parse-statement
@@ -1369,3 +1369,27 @@ WITH MUTUALLY RECURSIVE (RECURSION LIMIT 17)
 SELECT * FROM foo
 ----
 WITH MUTUALLY RECURSIVE (RECURSION LIMIT = 17) foo (a int8) AS ((WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT = 11) bar (b int8) AS (SELECT * FROM foo) SELECT * FROM (SELECT * FROM bar)) UNION ALL (WITH MUTUALLY RECURSIVE (ERROR AT RECURSION LIMIT = 15) bar (b int8) AS (SELECT * FROM foo) SELECT * FROM (SELECT * FROM bar))) SELECT * FROM foo
+
+# Ensure table function parsing does not pick up where clause.
+parse-statement
+SELECT * FROM table_function(x) WHERE x IS NULL
+----
+SELECT * FROM table_function(x) WHERE x IS NULL
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("table_function")])), args: Args { args: [Identifier([Ident("x")])], order_by: [] }, filter: None, over: None, distinct: false }, alias: None, with_ordinality: false }, joins: [] }], selection: Some(IsExpr { expr: Identifier([Ident("x")]), construct: Null, negated: false }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+# Table functions do not support OVER clauses
+parse-statement
+SELECT generate_series FROM generate_series(1, 3) OVER (ORDER BY generate_series);
+----
+error: Expected right parenthesis, found BY
+SELECT generate_series FROM generate_series(1, 3) OVER (ORDER BY generate_series);
+                                                              ^
+
+# Table functions do not support DISTINCT clauses
+parse-statement
+SELECT generate_series FROM generate_series(DISTINCT 1, 3);
+----
+error: Expected right parenthesis, found number "1"
+SELECT generate_series FROM generate_series(DISTINCT 1, 3);
+                                                     ^

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -20,7 +20,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::str::StrExt;
 use mz_repr::role_id::RoleId;
 use mz_repr::GlobalId;
-use mz_sql_parser::ast::{MutRecBlock, UnresolvedObjectName};
+use mz_sql_parser::ast::{MutRecBlock, TableFactor, UnresolvedObjectName};
 use mz_stash::objects::{proto, RustType, TryFromProtoError};
 use once_cell::sync::Lazy;
 use proptest_derive::Arbitrary;
@@ -1580,210 +1580,84 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
         }
     }
 
-    fn fold_expr(&mut self, node: mz_sql_parser::ast::Expr<Raw>) -> mz_sql_parser::ast::Expr<Aug> {
-        use mz_sql_parser::ast::Expr::*;
-        match node {
-            mz_sql_parser::ast::Expr::Identifier(i) => {
-                Identifier(i.into_iter().map(|i| self.fold_ident(i)).collect())
-            }
-            mz_sql_parser::ast::Expr::QualifiedWildcard(i) => {
-                QualifiedWildcard(i.into_iter().map(|i| self.fold_ident(i)).collect())
-            }
-            mz_sql_parser::ast::Expr::FieldAccess { expr, field } => FieldAccess {
-                expr: Box::new(self.fold_expr(*expr)),
-                field: self.fold_ident(field),
+    fn fold_function(
+        &mut self,
+        node: mz_sql_parser::ast::Function<Raw>,
+    ) -> mz_sql_parser::ast::Function<Aug> {
+        mz_sql_parser::ast::Function {
+            name: match node.name {
+                name @ RawItemName::Name(..) => self.fold_raw_object_name_name_internal(name, true),
+                _ => self.fold_item_name(node.name),
             },
-            mz_sql_parser::ast::Expr::WildcardAccess(expr) => {
-                WildcardAccess(Box::new(self.fold_expr(*expr)))
-            }
-            mz_sql_parser::ast::Expr::Parameter(p) => Parameter(p),
-            mz_sql_parser::ast::Expr::Not { expr } => Not {
-                expr: Box::new(self.fold_expr(*expr)),
-            },
-            mz_sql_parser::ast::Expr::And { left, right } => And {
-                left: Box::new(self.fold_expr(*left)),
-                right: Box::new(self.fold_expr(*right)),
-            },
-            mz_sql_parser::ast::Expr::Or { left, right } => Or {
-                left: Box::new(self.fold_expr(*left)),
-                right: Box::new(self.fold_expr(*right)),
-            },
-            mz_sql_parser::ast::Expr::IsExpr {
-                expr,
-                construct,
-                negated,
-            } => IsExpr {
-                expr: Box::new(self.fold_expr(*expr)),
-                construct: self.fold_is_expr_construct(construct),
-                negated,
-            },
-            mz_sql_parser::ast::Expr::InList {
-                expr,
-                list,
-                negated,
-            } => InList {
-                expr: Box::new(self.fold_expr(*expr)),
-                list: list.into_iter().map(|l| self.fold_expr(l)).collect(),
-                negated,
-            },
-            mz_sql_parser::ast::Expr::InSubquery {
-                expr,
-                subquery,
-                negated,
-            } => InSubquery {
-                expr: Box::new(self.fold_expr(*expr)),
-                subquery: Box::new(self.fold_query(*subquery)),
-                negated,
-            },
-            mz_sql_parser::ast::Expr::Like {
-                expr,
-                pattern,
-                escape,
-                case_insensitive,
-                negated,
-            } => Like {
-                expr: Box::new(self.fold_expr(*expr)),
-                pattern: Box::new(self.fold_expr(*pattern)),
-                escape: escape.map(|expr| Box::new(self.fold_expr(*expr))),
-                case_insensitive,
-                negated,
-            },
-            mz_sql_parser::ast::Expr::Between {
-                expr,
-                negated,
-                low,
-                high,
-            } => Between {
-                expr: Box::new(self.fold_expr(*expr)),
-                negated,
-                low: Box::new(self.fold_expr(*low)),
-                high: Box::new(self.fold_expr(*high)),
-            },
-            mz_sql_parser::ast::Expr::Op { op, expr1, expr2 } => Op {
-                op: self.fold_op(op),
-                expr1: Box::new(self.fold_expr(*expr1)),
-                expr2: expr2.map(|expr2| Box::new(self.fold_expr(*expr2))),
-            },
-            mz_sql_parser::ast::Expr::Cast { expr, data_type } => Cast {
-                expr: Box::new(self.fold_expr(*expr)),
-                data_type: self.fold_data_type(data_type),
-            },
-            mz_sql_parser::ast::Expr::Collate { expr, collation } => Collate {
-                expr: Box::new(self.fold_expr(*expr)),
-                collation: self.fold_unresolved_item_name(collation),
-            },
-            mz_sql_parser::ast::Expr::HomogenizingFunction { function, exprs } => {
-                HomogenizingFunction {
-                    function: self.fold_homogenizing_function(function),
-                    exprs: exprs.into_iter().map(|expr| self.fold_expr(expr)).collect(),
-                }
-            }
-            mz_sql_parser::ast::Expr::NullIf { l_expr, r_expr } => NullIf {
-                l_expr: Box::new(self.fold_expr(*l_expr)),
-                r_expr: Box::new(self.fold_expr(*r_expr)),
-            },
-            mz_sql_parser::ast::Expr::Nested(expr) => Nested(Box::new(self.fold_expr(*expr))),
-            mz_sql_parser::ast::Expr::Row { exprs } => Row {
-                exprs: exprs.into_iter().map(|expr| self.fold_expr(expr)).collect(),
-            },
-            mz_sql_parser::ast::Expr::Value(value) => Value(self.fold_value(value)),
-            mz_sql_parser::ast::Expr::Function(mz_sql_parser::ast::Function {
-                name,
-                args,
-                filter,
-                over,
-                distinct,
-            }) => Function(mz_sql_parser::ast::Function {
-                name: match name {
-                    name @ RawItemName::Name(..) => {
-                        self.fold_raw_object_name_name_internal(name, true)
-                    }
-                    _ => self.fold_item_name(name),
-                },
-                args: self.fold_function_args(args),
-                filter: filter.map(|expr| Box::new(self.fold_expr(*expr))),
-                over: over.map(|over| self.fold_window_spec(over)),
-                distinct,
-            }),
-            mz_sql_parser::ast::Expr::Case {
-                operand,
-                conditions,
-                results,
-                else_result,
-            } => Case {
-                operand: operand.map(|expr| Box::new(self.fold_expr(*expr))),
-                conditions: conditions
-                    .into_iter()
-                    .map(|expr| self.fold_expr(expr))
-                    .collect(),
-                results: results
-                    .into_iter()
-                    .map(|expr| self.fold_expr(expr))
-                    .collect(),
-                else_result: else_result.map(|expr| Box::new(self.fold_expr(*expr))),
-            },
-            mz_sql_parser::ast::Expr::Exists(query) => Exists(Box::new(self.fold_query(*query))),
-            mz_sql_parser::ast::Expr::Subquery(subquery) => {
-                Subquery(Box::new(self.fold_query(*subquery)))
-            }
-            mz_sql_parser::ast::Expr::AnySubquery { left, op, right } => AnySubquery {
-                left: Box::new(self.fold_expr(*left)),
-                op: self.fold_op(op),
-                right: Box::new(self.fold_query(*right)),
-            },
-            mz_sql_parser::ast::Expr::AnyExpr { left, op, right } => AnyExpr {
-                left: Box::new(self.fold_expr(*left)),
-                op: self.fold_op(op),
-                right: Box::new(self.fold_expr(*right)),
-            },
-            mz_sql_parser::ast::Expr::AllSubquery { left, op, right } => AllSubquery {
-                left: Box::new(self.fold_expr(*left)),
-                op: self.fold_op(op),
-                right: Box::new(self.fold_query(*right)),
-            },
-            mz_sql_parser::ast::Expr::AllExpr { left, op, right } => AllExpr {
-                left: Box::new(self.fold_expr(*left)),
-                op: self.fold_op(op),
-                right: Box::new(self.fold_expr(*right)),
-            },
-            mz_sql_parser::ast::Expr::Array(exprs) => {
-                Array(exprs.into_iter().map(|expr| self.fold_expr(expr)).collect())
-            }
-            mz_sql_parser::ast::Expr::ArraySubquery(subquery) => {
-                ArraySubquery(Box::new(self.fold_query(*subquery)))
-            }
-            mz_sql_parser::ast::Expr::List(exprs) => {
-                List(exprs.into_iter().map(|expr| self.fold_expr(expr)).collect())
-            }
-            mz_sql_parser::ast::Expr::ListSubquery(subquery) => {
-                ListSubquery(Box::new(self.fold_query(*subquery)))
-            }
-            mz_sql_parser::ast::Expr::Subscript { expr, positions } => Subscript {
-                expr: Box::new(self.fold_expr(*expr)),
-                positions: positions
-                    .into_iter()
-                    .map(|p| self.fold_subscript_position(p))
-                    .collect(),
-            },
+            args: self.fold_function_args(node.args),
+            filter: node.filter.map(|expr| Box::new(self.fold_expr(*expr))),
+            over: node.over.map(|over| self.fold_window_spec(over)),
+            distinct: node.distinct,
         }
     }
 
-    fn fold_table_function(
+    fn fold_table_factor(
         &mut self,
-        node: mz_sql_parser::ast::TableFunction<Raw>,
-    ) -> mz_sql_parser::ast::TableFunction<Aug> {
-        mz_sql_parser::ast::TableFunction {
-            name: match &node.name {
-                RawItemName::Name(name) => {
-                    if *name == UnresolvedItemName::unqualified("values") && self.status.is_ok() {
-                        self.status = Err(PlanError::FromValueRequiresParen);
-                    }
-
-                    self.fold_raw_object_name_name_internal(node.name, true)
-                }
-                RawItemName::Id(..) => self.fold_item_name(node.name),
+        node: mz_sql_parser::ast::TableFactor<Raw>,
+    ) -> mz_sql_parser::ast::TableFactor<Aug> {
+        use mz_sql_parser::ast::TableFactor::*;
+        match node {
+            Table { name, alias } => Table {
+                name: self.fold_item_name(name),
+                alias: alias.map(|alias| self.fold_table_alias(alias)),
             },
-            args: self.fold_function_args(node.args),
+            Function {
+                function,
+                alias,
+                with_ordinality,
+            } => {
+                let function = mz_sql_parser::ast::TableFunction {
+                    name: match &function.name {
+                        RawItemName::Name(name) => {
+                            if *name == UnresolvedItemName::unqualified("values")
+                                && self.status.is_ok()
+                            {
+                                self.status = Err(PlanError::FromValueRequiresParen);
+                            }
+
+                            self.fold_raw_object_name_name_internal(function.name, true)
+                        }
+                        RawItemName::Id(..) => self.fold_item_name(function.name),
+                    },
+                    args: self.fold_function_args(function.args),
+                };
+
+                Function {
+                    function,
+                    alias: alias.map(|alias| self.fold_table_alias(alias)),
+                    with_ordinality,
+                }
+            }
+            RowsFrom {
+                functions,
+                alias,
+                with_ordinality,
+            } => RowsFrom {
+                functions: functions
+                    .into_iter()
+                    .map(|f| self.fold_table_function(f))
+                    .collect(),
+                alias: alias.map(|alias| self.fold_table_alias(alias)),
+                with_ordinality,
+            },
+            Derived {
+                lateral,
+                subquery,
+                alias,
+            } => Derived {
+                lateral,
+                subquery: Box::new(self.fold_query(*subquery)),
+                alias: alias.map(|alias| self.fold_table_alias(alias)),
+            },
+            NestedJoin { join, alias } => NestedJoin {
+                join: Box::new(self.fold_table_with_joins(*join)),
+                alias: alias.map(|alias| self.fold_table_alias(alias)),
+            },
         }
     }
 }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -20,7 +20,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::str::StrExt;
 use mz_repr::role_id::RoleId;
 use mz_repr::GlobalId;
-use mz_sql_parser::ast::{MutRecBlock, TableFactor, UnresolvedObjectName};
+use mz_sql_parser::ast::{MutRecBlock, UnresolvedObjectName};
 use mz_stash::objects::{proto, RustType, TryFromProtoError};
 use once_cell::sync::Lazy;
 use proptest_derive::Arbitrary;
@@ -1611,24 +1611,18 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 alias,
                 with_ordinality,
             } => {
-                let function = mz_sql_parser::ast::TableFunction {
-                    name: match &function.name {
-                        RawItemName::Name(name) => {
-                            if *name == UnresolvedItemName::unqualified("values")
-                                && self.status.is_ok()
-                            {
-                                self.status = Err(PlanError::FromValueRequiresParen);
-                            }
-
-                            self.fold_raw_object_name_name_internal(function.name, true)
+                match &function.name {
+                    RawItemName::Name(name) => {
+                        if *name == UnresolvedItemName::unqualified("values") && self.status.is_ok()
+                        {
+                            self.status = Err(PlanError::FromValueRequiresParen);
                         }
-                        RawItemName::Id(..) => self.fold_item_name(function.name),
-                    },
-                    args: self.fold_function_args(function.args),
-                };
+                    }
+                    _ => {}
+                }
 
                 Function {
-                    function,
+                    function: self.fold_function(function),
                     alias: alias.map(|alias| self.fold_table_alias(alias)),
                     with_ordinality,
                 }
@@ -1640,7 +1634,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
             } => RowsFrom {
                 functions: functions
                     .into_iter()
-                    .map(|f| self.fold_table_function(f))
+                    .map(|f| self.fold_function(f))
                     .collect(),
                 alias: alias.map(|alias| self.fold_table_alias(alias)),
                 with_ordinality,

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -25,7 +25,7 @@ use mz_sql_parser::ast::{
     CreateSecretStatement, CreateSinkStatement, CreateSourceStatement, CreateSubsourceStatement,
     CreateTableStatement, CreateTypeStatement, CreateViewStatement, CteBlock, Function,
     FunctionArgs, Ident, IfExistsBehavior, MutRecBlock, Op, Query, Statement, TableFactor,
-    TableFunction, UnresolvedItemName, UnresolvedSchemaName, Value, ViewDefinition,
+    UnresolvedItemName, UnresolvedSchemaName, Value, ViewDefinition,
 };
 
 use crate::names::{Aug, FullItemName, PartialItemName, PartialSchemaName, RawDatabaseSpecifier};
@@ -227,20 +227,6 @@ pub fn create_statement(
             }
             if let Some(over) = &mut func.over {
                 self.visit_window_spec_mut(over);
-            }
-        }
-
-        fn visit_table_function_mut(&mut self, func: &'ast mut TableFunction<Aug>) {
-            match &mut func.args {
-                FunctionArgs::Star => (),
-                FunctionArgs::Args { args, order_by } => {
-                    for arg in args {
-                        self.visit_expr_mut(arg);
-                    }
-                    for expr in order_by {
-                        self.visit_order_by_expr_mut(expr);
-                    }
-                }
             }
         }
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -59,7 +59,7 @@ use mz_sql_parser::ast::{
     HomogenizingFunction, Ident, InsertSource, IsExprConstruct, Join, JoinConstraint, JoinOperator,
     Limit, MutRecBlock, MutRecBlockOption, MutRecBlockOptionName, OrderByExpr, Query, Select,
     SelectItem, SelectOption, SelectOptionName, SetExpr, SetOperator, ShowStatement,
-    SubscriptPosition, TableAlias, TableFactor, TableFunction, TableWithJoins, UnresolvedItemName,
+    SubscriptPosition, TableAlias, TableFactor, TableWithJoins, UnresolvedItemName,
     UpdateStatement, Value, Values, WindowFrame, WindowFrameBound, WindowFrameUnits, WindowSpec,
 };
 use uuid::Uuid;
@@ -2100,7 +2100,7 @@ fn plan_view_select(
 
 fn plan_scalar_table_funcs(
     qcx: &QueryContext,
-    table_funcs: BTreeMap<TableFunction<Aug>, String>,
+    table_funcs: BTreeMap<Function<Aug>, String>,
     table_func_names: &mut BTreeMap<String, Ident>,
     relation_expr: &HirRelationExpr,
     from_scope: &Scope,
@@ -2412,7 +2412,7 @@ fn plan_table_factor(
 /// single coalesced ordinality column at the end of the entire expression.
 fn plan_rows_from(
     qcx: &QueryContext,
-    functions: &[TableFunction<Aug>],
+    functions: &[Function<Aug>],
     alias: Option<&TableAlias>,
     with_ordinality: bool,
 ) -> Result<(HirRelationExpr, Scope), PlanError> {
@@ -2484,7 +2484,7 @@ fn plan_rows_from(
 /// And a `Vec<usize>` of `[1, 2]`.
 fn plan_rows_from_internal<'a>(
     qcx: &QueryContext,
-    functions: impl IntoIterator<Item = &'a TableFunction<Aug>>,
+    functions: impl IntoIterator<Item = &'a Function<Aug>>,
     table_name: Option<FullItemName>,
 ) -> Result<(HirRelationExpr, Scope, Vec<usize>), PlanError> {
     let mut functions = functions.into_iter();
@@ -2546,7 +2546,7 @@ fn plan_rows_from_internal<'a>(
 /// apply.
 fn plan_solitary_table_function(
     qcx: &QueryContext,
-    function: &TableFunction<Aug>,
+    function: &Function<Aug>,
     alias: Option<&TableAlias>,
     with_ordinality: bool,
 ) -> Result<(HirRelationExpr, Scope), PlanError> {
@@ -2598,10 +2598,20 @@ fn plan_solitary_table_function(
 /// instead to get the appropriate aliasing behavior.
 fn plan_table_function_internal(
     qcx: &QueryContext,
-    TableFunction { name, args }: &TableFunction<Aug>,
+    Function {
+        name,
+        args,
+        filter,
+        over,
+        distinct,
+    }: &Function<Aug>,
     with_ordinality: bool,
     table_name: Option<FullItemName>,
 ) -> Result<(HirRelationExpr, Scope), PlanError> {
+    assert!(filter.is_none(), "cannot parse table function with FILTER");
+    assert!(over.is_none(), "cannot parse table function with OVER");
+    assert!(!*distinct, "cannot parse table function with DISTINCT");
+
     let ecx = &ExprContext {
         qcx,
         name: "table function arguments",
@@ -5072,7 +5082,7 @@ struct AggregateTableFuncVisitor<'a> {
     scx: &'a StatementContext<'a>,
     aggs: Vec<Function<Aug>>,
     within_aggregate: bool,
-    tables: BTreeMap<TableFunction<Aug>, String>,
+    tables: BTreeMap<Function<Aug>, String>,
     table_disallowed_context: Vec<&'static str>,
     in_select_item: bool,
     err: Option<PlanError>,
@@ -5093,7 +5103,7 @@ impl<'a> AggregateTableFuncVisitor<'a> {
 
     fn into_result(
         self,
-    ) -> Result<(Vec<Function<Aug>>, BTreeMap<TableFunction<Aug>, String>), PlanError> {
+    ) -> Result<(Vec<Function<Aug>>, BTreeMap<Function<Aug>, String>), PlanError> {
         match self.err {
             Some(err) => Err(err),
             None => {
@@ -5194,14 +5204,13 @@ impl<'a> VisitMut<'_, Aug> for AggregateTableFuncVisitor<'a> {
             visit_mut::visit_expr_mut(self, expr);
             // Don't attempt to replace table functions with unsupported syntax.
             if let Function {
-                name,
-                args,
+                name: _,
+                args: _,
                 filter: None,
                 over: None,
                 distinct: false,
-            } = func
+            } = &func
             {
-                let func = TableFunction { name, args };
                 // Identical table functions can be de-duplicated.
                 let id = self
                     .tables

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -18,7 +18,7 @@ use mz_repr::namespaces::{MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, PG_CATALOG_SCHE
 use mz_sql_parser::ast::visit_mut::{self, VisitMut, VisitMutNode};
 use mz_sql_parser::ast::{
     Expr, Function, FunctionArgs, Ident, Op, OrderByExpr, Query, Select, SelectItem, TableAlias,
-    TableFactor, TableFunction, TableWithJoins, Value,
+    TableFactor, TableWithJoins, Value,
 };
 use uuid::Uuid;
 
@@ -502,11 +502,14 @@ impl<'a> Desugarer<'a> {
                 Select::default()
                     .from(TableWithJoins {
                         relation: TableFactor::Function {
-                            function: TableFunction {
+                            function: Function {
                                 name: self
                                     .scx
                                     .dangerous_resolve_name(vec![MZ_CATALOG_SCHEMA, "unnest"]),
                                 args: FunctionArgs::args(vec![right.take()]),
+                                filter: None,
+                                over: None,
+                                distinct: false,
                             },
                             alias: Some(TableAlias {
                                 name: Ident::new("_"),

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1412,3 +1412,17 @@ Project (#5, #6)
             CallTable jsonb_object_keys(text_to_jsonb("{\"3\":4}"))
 
 EOF
+
+# Disallowed table function behaviour
+
+query I
+SELECT generate_series FROM generate_series(1, 3) WHERE (generate_series < 3);
+----
+1
+2
+
+query error Expected right parenthesis, found BY
+SELECT generate_series FROM generate_series(1, 3) OVER (ORDER BY generate_series);
+
+query error Expected right parenthesis, found number "1"
+SELECT generate_series FROM generate_series(DISTINCT 1, 3);


### PR DESCRIPTION
`TableFunc` was totally duplicative of `Function`, and some upcoming changes I'd like to make AST rewrites will be much simpler if I can use the same AST node.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
