### PR TITLE
docs: Update to v0.56.2, tests: skip v0.56.0

### DIFF
--- a/doc/user/content/releases/v0.56.md
+++ b/doc/user/content/releases/v0.56.md
@@ -2,7 +2,7 @@
 title: "Materialize v0.56"
 date: 2023-05-31
 released: true
-patch: 1
+patch: 2
 ---
 
 ## v0.56.0

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -19,6 +19,10 @@ from materialize.util import MzVersion
 
 ROOT = Path(os.environ["MZ_ROOT"])
 
+INVALID_VERSIONS = [
+    MzVersion.parse_mz("v0.56.0"),  # not released on Docker
+]
+
 
 class VersionList:
     def __init__(self) -> None:
@@ -103,7 +107,9 @@ class VersionsFromDocs(VersionList):
             current_patch = metadata.get("patch", 0)
 
             for patch in range(current_patch + 1):
-                self.versions.append(MzVersion.parse_mz(f"{base}.{patch}"))
+                version = MzVersion.parse_mz(f"{base}.{patch}")
+                if version not in INVALID_VERSIONS:
+                    self.versions.append(version)
 
         assert len(self.versions) > 0
         self.versions.sort()


### PR DESCRIPTION
Noticed in Nightly CI run that v0.56.0 doesn't exist on Docker as it was never released:

```
Upgrading going through v0.54.0 -> v0.55.0 -> v0.56.0 -> v0.56.1
Error response from daemon: manifest for materialize/materialized:v0.56.0 not found: manifest unknown: manifest unknown
```

v0.56.1 had a regression, so v0.56.2 it is. We use the versions from documentation for our upgrade testing.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
