### PR TITLE
persist: fix up reconnection backoff / flaky test

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -246,6 +246,8 @@ impl PersistConfig {
         clamp: Duration::from_secs(16),
     };
 
+    pub(crate) const DEFAULT_PUBSUB_CLIENT_RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
+
     pub(crate) const DEFAULT_FALLBACK_ROLLUP_THRESHOLD_MULTIPLIER: usize = 3;
 
     /// Default value for [`DynamicConfig::blob_cache_mem_limit_bytes`].

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -118,6 +118,8 @@ pub struct PersistConfig {
     pub pubsub_server_connection_channel_size: usize,
     /// Size of channel used by the state cache to broadcast shard state references.
     pub pubsub_state_cache_shard_ref_channel_size: usize,
+    /// Backoff after an established connection to Persist PubSub service fails.
+    pub pubsub_reconnect_backoff: Duration,
 }
 
 impl PersistConfig {
@@ -175,6 +177,7 @@ impl PersistConfig {
             pubsub_client_receiver_channel_size: 25,
             pubsub_server_connection_channel_size: 25,
             pubsub_state_cache_shard_ref_channel_size: 25,
+            pubsub_reconnect_backoff: Duration::from_secs(5),
             // TODO: This doesn't work with the process orchestrator. Instead,
             // separate --log-prefix into --service-name and --enable-log-prefix
             // options, where the first is always provided and the second is
@@ -245,8 +248,6 @@ impl PersistConfig {
         multiplier: 2,
         clamp: Duration::from_secs(16),
     };
-
-    pub(crate) const DEFAULT_PUBSUB_CLIENT_RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
 
     pub(crate) const DEFAULT_FALLBACK_ROLLUP_THRESHOLD_MULTIPLIER: usize = 3;
 

--- a/src/persist-client/src/rpc.rs
+++ b/src/persist-client/src/rpc.rs
@@ -1319,7 +1319,7 @@ mod grpc {
     };
 
     const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
-    const SUBSCRIPTIONS_TIMEOUT: Duration = Duration::from_secs(5);
+    const SUBSCRIPTIONS_TIMEOUT: Duration = Duration::from_secs(3);
     const SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
     // NB: we use separate runtimes for client and server throughout these tests to cleanly drop

--- a/src/persist-client/src/rpc.rs
+++ b/src/persist-client/src/rpc.rs
@@ -1312,6 +1312,10 @@ mod grpc {
         data: Bytes::from_static(&[4, 5, 6, 7]),
     };
 
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+    const SUBSCRIPTIONS_TIMEOUT: Duration = Duration::from_secs(5);
+    const SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
     // NB: we use separate runtimes for client and server throughout these tests to cleanly drop
     // ALL tasks (including spawned child tasks) associated with one end of a connection, to most
     // closely model an actual disconnect.
@@ -1348,26 +1352,26 @@ mod grpc {
 
         // wait until the client is connected and subscribed
         server_runtime.block_on(async {
-            poll_until_true(Duration::from_secs(10), || {
+            poll_until_true(CONNECT_TIMEOUT, || {
                 server_state.active_connections().len() == 1
             })
             .await;
-            poll_until_true(Duration::from_secs(2), || {
+            poll_until_true(SUBSCRIPTIONS_TIMEOUT, || {
                 server_state.shard_subscription_counts() == HashMap::from([(SHARD_ID_0, 1)])
             })
             .await
         });
 
         // drop the client
-        client_runtime.shutdown_timeout(Duration::from_secs(2));
+        client_runtime.shutdown_timeout(SERVER_SHUTDOWN_TIMEOUT);
 
         // server should notice the client dropping and clean up its state
         server_runtime.block_on(async {
-            poll_until_true(Duration::from_secs(10), || {
+            poll_until_true(CONNECT_TIMEOUT, || {
                 server_state.active_connections().is_empty()
             })
             .await;
-            poll_until_true(Duration::from_secs(2), || {
+            poll_until_true(SUBSCRIPTIONS_TIMEOUT, || {
                 server_state.shard_subscription_counts() == HashMap::from([(SHARD_ID_0, 0)])
             })
             .await
@@ -1407,21 +1411,21 @@ mod grpc {
 
         server_runtime.block_on(async {
             // client connects automatically once the server is up
-            poll_until_true(Duration::from_secs(10), || {
+            poll_until_true(CONNECT_TIMEOUT, || {
                 server_state.active_connections().len() == 1
             })
             .await;
 
             // client rehydrated its subscriptions. notably, only includes the shard that
             // still has an active token
-            poll_until_true(Duration::from_secs(2), || {
+            poll_until_true(SUBSCRIPTIONS_TIMEOUT, || {
                 server_state.shard_subscription_counts() == HashMap::from([(SHARD_ID_0, 1)])
             })
             .await;
         });
 
         // kill the server
-        server_runtime.shutdown_timeout(Duration::from_secs(2));
+        server_runtime.shutdown_timeout(SERVER_SHUTDOWN_TIMEOUT);
 
         // client can still send requests without error
         let _token_2 = Arc::clone(&client.sender).subscribe(&SHARD_ID_1);
@@ -1439,14 +1443,14 @@ mod grpc {
 
         server_runtime.block_on(async {
             // client automatically reconnects to new server
-            poll_until_true(Duration::from_secs(5), || {
+            poll_until_true(CONNECT_TIMEOUT, || {
                 server_state.active_connections().len() == 1
             })
             .await;
 
             // and rehydrates its subscriptions, including the new one that was sent
             // while the server was unavailable.
-            poll_until_true(Duration::from_secs(3), || {
+            poll_until_true(SUBSCRIPTIONS_TIMEOUT, || {
                 server_state.shard_subscription_counts()
                     == HashMap::from([(SHARD_ID_0, 1), (SHARD_ID_1, 1)])
             })
@@ -1474,28 +1478,28 @@ mod grpc {
         );
 
         // our client connects
-        poll_until_true(Duration::from_secs(5), || {
+        poll_until_true(CONNECT_TIMEOUT, || {
             server_state.active_connections().len() == 1
         })
         .await;
 
         // we can subscribe to a shard, receiving back a token
         let token = Arc::clone(&client.sender).subscribe(&SHARD_ID_0);
-        poll_until_true(Duration::from_secs(3), || {
+        poll_until_true(SUBSCRIPTIONS_TIMEOUT, || {
             server_state.shard_subscription_counts() == HashMap::from([(SHARD_ID_0, 1)])
         })
         .await;
 
         // dropping the token will unsubscribe our client
         drop(token);
-        poll_until_true(Duration::from_secs(3), || {
+        poll_until_true(SUBSCRIPTIONS_TIMEOUT, || {
             server_state.shard_subscription_counts() == HashMap::from([(SHARD_ID_0, 0)])
         })
         .await;
 
         // we can resubscribe to a shard
         let token = Arc::clone(&client.sender).subscribe(&SHARD_ID_0);
-        poll_until_true(Duration::from_secs(3), || {
+        poll_until_true(SUBSCRIPTIONS_TIMEOUT, || {
             server_state.shard_subscription_counts() == HashMap::from([(SHARD_ID_0, 1)])
         })
         .await;
@@ -1504,7 +1508,7 @@ mod grpc {
         let token2 = Arc::clone(&client.sender).subscribe(&SHARD_ID_0);
         let token3 = Arc::clone(&client.sender).subscribe(&SHARD_ID_0);
         assert_eq!(Arc::strong_count(&token), 3);
-        poll_until_true(Duration::from_secs(3), || {
+        poll_until_true(SUBSCRIPTIONS_TIMEOUT, || {
             server_state.shard_subscription_counts() == HashMap::from([(SHARD_ID_0, 1)])
         })
         .await;
@@ -1513,7 +1517,7 @@ mod grpc {
         drop(token);
         drop(token2);
         drop(token3);
-        poll_until_true(Duration::from_secs(3), || {
+        poll_until_true(SUBSCRIPTIONS_TIMEOUT, || {
             server_state.shard_subscription_counts() == HashMap::from([(SHARD_ID_0, 0)])
         })
         .await;
@@ -1521,7 +1525,7 @@ mod grpc {
         // we can subscribe to many shards
         let _token0 = Arc::clone(&client.sender).subscribe(&SHARD_ID_0);
         let _token1 = Arc::clone(&client.sender).subscribe(&SHARD_ID_1);
-        poll_until_true(Duration::from_secs(3), || {
+        poll_until_true(SUBSCRIPTIONS_TIMEOUT, || {
             server_state.shard_subscription_counts()
                 == HashMap::from([(SHARD_ID_0, 1), (SHARD_ID_1, 1)])
         })
@@ -1571,7 +1575,7 @@ mod grpc {
         let server_state = server_runtime.block_on(spawn_server(tcp_listener_stream));
 
         // wait until both clients are connected
-        server_runtime.block_on(poll_until_true(Duration::from_secs(10), || {
+        server_runtime.block_on(poll_until_true(CONNECT_TIMEOUT, || {
             server_state.active_connections().len() == 2
         }));
 
@@ -1582,7 +1586,7 @@ mod grpc {
         // subscribe and send a diff
         let _token_client_1 = Arc::clone(&client_1.sender).subscribe(&SHARD_ID_0);
         let _token_client_2 = Arc::clone(&client_2.sender).subscribe(&SHARD_ID_0);
-        server_runtime.block_on(poll_until_true(Duration::from_secs(2), || {
+        server_runtime.block_on(poll_until_true(SUBSCRIPTIONS_TIMEOUT, || {
             server_state.shard_subscription_counts() == HashMap::from([(SHARD_ID_0, 2)])
         }));
 
@@ -1598,7 +1602,7 @@ mod grpc {
         });
 
         // kill the server
-        server_runtime.shutdown_timeout(Duration::from_secs(2));
+        server_runtime.shutdown_timeout(SERVER_SHUTDOWN_TIMEOUT);
 
         // receivers can still be polled without error
         assert!(client_1.receiver.next().now_or_never().is_none());
@@ -1617,11 +1621,11 @@ mod grpc {
 
         // client automatically reconnects to new server and rehydrates subscriptions
         server_runtime.block_on(async {
-            poll_until_true(Duration::from_secs(10), || {
+            poll_until_true(CONNECT_TIMEOUT, || {
                 server_state.active_connections().len() == 2
             })
             .await;
-            poll_until_true(Duration::from_secs(2), || {
+            poll_until_true(SUBSCRIPTIONS_TIMEOUT, || {
                 server_state.shard_subscription_counts() == HashMap::from([(SHARD_ID_0, 2)])
             })
             .await;

--- a/src/persist-client/src/rpc.rs
+++ b/src/persist-client/src/rpc.rs
@@ -205,7 +205,7 @@ impl GrpcPubSubClient {
             if is_first_connection_attempt {
                 is_first_connection_attempt = false;
             } else {
-                tokio::time::sleep(PersistConfig::DEFAULT_PUBSUB_CLIENT_RECONNECT_BACKOFF).await;
+                tokio::time::sleep(config.persist_cfg.pubsub_reconnect_backoff).await;
             }
 
             info!("Connecting to Persist PubSub: {}", config.url);
@@ -1691,7 +1691,8 @@ mod grpc {
     }
 
     fn test_persist_config() -> PersistConfig {
-        let cfg = PersistConfig::new_for_tests();
+        let mut cfg = PersistConfig::new_for_tests();
+        cfg.pubsub_reconnect_backoff = Duration::ZERO;
         let mut params = PersistParameters::default();
         params.pubsub_client_enabled = Some(true);
         params.apply(&cfg);


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

https://github.com/MaterializeInc/materialize/issues/19666 highlighted a case where pubsub connections could be established but immediately dropped, causing us to reconnect in a hot loop. This PR adds in a few seconds of backoff to pubsub client reconnection. 

This backoff affects our test setup a bit, so I tied in https://github.com/MaterializeInc/materialize/issues/19652 as well. The test timeouts are cleaned up with consts, and fixed a bug where the server state wasn't cleaning up its shard to connection mapping when all connections to a shard dropped.

### Motivation

Fixes #19666
Fixes #19652

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
