### PR TITLE
build: Remove unused mz-sql-parser dependency in mz-expr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3932,7 +3932,6 @@ dependencies = [
  "mz-pgrepr",
  "mz-proto",
  "mz-repr",
- "mz-sql-parser",
  "num",
  "num_enum",
  "once_cell",

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -32,7 +32,6 @@ mz-lowertest = { path = "../lowertest" }
 mz-ore = { path = "../ore", features = ["network"] }
 mz-pgrepr = { path = "../pgrepr" }
 mz-repr = { path = "../repr" }
-mz-sql-parser = { path = "../sql-parser" }
 mz-proto = { path = "../proto" }
 num = "0.4.0"
 num_enum = "0.5.7"


### PR DESCRIPTION
As seen in Nightly: https://buildkite.com/materialize/nightlies/builds/2515#01887be0-fd0a-438b-bc25-9fe5c593bbf6

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
