### PR TITLE
adapter: Add pg_locks Catalog table

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -3238,6 +3238,31 @@ AS SELECT
 WHERE false",
 };
 
+pub const PG_LOCKS: BuiltinView = BuiltinView {
+    name: "pg_locks",
+    schema: PG_CATALOG_SCHEMA,
+    sql: "CREATE VIEW pg_catalog.pg_locks
+AS SELECT
+-- While there exist locks in Materialize, we don't expose them, so all of these fields are NULL.
+    NULL::pg_catalog.text AS locktype,
+    NULL::pg_catalog.oid AS database,
+    NULL::pg_catalog.oid AS relation,
+    NULL::pg_catalog.int4 AS page,
+    NULL::pg_catalog.int2 AS tuple,
+    NULL::pg_catalog.text AS virtualxid,
+    NULL::pg_catalog.text AS transactionid,
+    NULL::pg_catalog.oid AS classid,
+    NULL::pg_catalog.oid AS objid,
+    NULL::pg_catalog.int2 AS objsubid,
+    NULL::pg_catalog.text AS virtualtransaction,
+    NULL::pg_catalog.int4 AS pid,
+    NULL::pg_catalog.text AS mode,
+    NULL::pg_catalog.bool AS granted,
+    NULL::pg_catalog.bool AS fastpath,
+    NULL::pg_catalog.timestamptz AS waitstart
+WHERE false",
+};
+
 pub const PG_AUTHID: BuiltinView = BuiltinView {
     name: "pg_authid",
     schema: PG_CATALOG_SCHEMA,
@@ -3907,6 +3932,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&PG_TABLES),
         Builtin::View(&PG_TABLESPACE),
         Builtin::View(&PG_ACCESS_METHODS),
+        Builtin::View(&PG_LOCKS),
         Builtin::View(&PG_AUTHID),
         Builtin::View(&PG_ROLES),
         Builtin::View(&PG_VIEWS),

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -585,6 +585,10 @@ pg_inherits
 VIEW
 materialize
 pg_catalog
+pg_locks
+VIEW
+materialize
+pg_catalog
 pg_matviews
 VIEW
 materialize

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -157,6 +157,26 @@ name                nullable    type
  grantor            false       oid
  admin_option       false       boolean
 
+> SHOW COLUMNS FROM pg_locks
+name                nullable    type
+------------------------------------------------------------
+ locktype           false       text
+ database           false       oid
+ relation           false       oid
+ page               false       integer
+ tuple              false       smallint
+ virtualxid         false       text
+ transactionid      false       text
+ classid            false       oid
+ objid              false       oid
+ objsubid           false       smallint
+ virtualtransaction false       text
+ pid                false       integer
+ mode               false       text
+ granted            false       boolean
+ fastpath           false       boolean
+ waitstart          false       "timestamp with time zone"
+
 > SHOW COLUMNS FROM pg_tablespace
 name                nullable    type
 ------------------------------------------------------------


### PR DESCRIPTION
### Motivation

Makes progress towards #9720 

This PR adds the [`pg_locks`](https://www.postgresql.org/docs/current/view-pg-locks.html) catalog table, which is required to support DataGrip. Internally Materialize does have some locks, e.g. when updating or deleting rows from a table, but I believe this is more of an implementation detail, and not something we want to generally expose. As such, `pg_locks` is an empty view.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This PR adds the `pg_catalog.pg_locks` table. Materialize uses locks, but we don't expose them at all, adding this table allows tools that require it to work though.
