### PR TITLE
limits test: Expand the size of the Mz instance tested

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -10,7 +10,7 @@
 import os
 import random
 import tempfile
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import toml
 
@@ -69,6 +69,7 @@ class Materialized(Service):
         system_parameter_defaults: Optional[Dict[str, str]] = None,
         additional_system_parameter_defaults: Optional[Dict[str, str]] = None,
         soft_assertions: bool = True,
+        ulimits: Optional[Dict[str, Any]] = None,
     ) -> None:
         depends_on: Dict[str, ServiceDependency] = {
             s: {"condition": "service_started"} for s in depends_on
@@ -227,6 +228,9 @@ class Materialized(Service):
                 }
             )
 
+        if ulimits:
+            config["ulimits"] = ulimits
+
         super().__init__(name=name, config=config)
 
 
@@ -238,6 +242,7 @@ class Clusterd(Service):
         environment_extra: List[str] = [],
         memory: Optional[str] = None,
         options: List[str] = [],
+        ulimits: Optional[Dict[str, Any]] = None,
     ) -> None:
         environment = [
             "CLUSTERD_LOG_FILTER",
@@ -271,6 +276,9 @@ class Clusterd(Service):
                 "volumes": DEFAULT_MZ_VOLUMES,
             }
         )
+
+        if ulimits:
+            config["ulimits"] = ulimits
 
         super().__init__(name=name, config=config)
 

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1268,7 +1268,9 @@ SERVICES = [
     SchemaRegistry(),
     # We create all sources, sinks and dataflows by default with SIZE '1'
     # The workflow_instance_size workflow is testing multi-process clusters
-    Materialized(memory="8G", default_size=1),
+    Materialized(
+        memory="8G", default_size=1, ulimits={"nproc": 513365, "nofile": 1048576}
+    ),
     Testdrive(default_timeout="120s"),
 ]
 
@@ -1294,10 +1296,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     c.up("materialized")
 
     nodes = [
-        Clusterd(name="clusterd_1_1"),
-        Clusterd(name="clusterd_1_2"),
-        Clusterd(name="clusterd_2_1"),
-        Clusterd(name="clusterd_2_2"),
+        Clusterd(name="clusterd_1_1", ulimits={"nproc": 513365, "nofile": 1048576}),
+        Clusterd(name="clusterd_1_2", ulimits={"nproc": 513365, "nofile": 1048576}),
+        Clusterd(name="clusterd_2_1", ulimits={"nproc": 513365, "nofile": 1048576}),
+        Clusterd(name="clusterd_2_2", ulimits={"nproc": 513365, "nofile": 1048576}),
     ]
     with c.override(*nodes):
         c.up(*[n.name for n in nodes])


### PR DESCRIPTION
@philip-stoev Maybe I'm missing something, but I think it works in CI like this. Proof: https://buildkite.com/materialize/nightlies/builds/2522#01887e74-c125-46a7-b61b-abd141879005 & https://buildkite.com/materialize/nightlies/builds/2524

Description taken from https://github.com/MaterializeInc/materialize/pull/19665:

With PubSub enabled, CRDB is no longer the limiting factor, so it is possible to expand the instance-size workflow in various dimensions.

At the same time, we are reducing the number of replicas to 3 per cluster. This will match reality closer in the sense that users are expected to have two replicas for failover as well as posssibly an occasional third replica during maintenance operations such as scale-up or scale-down of the compute instance type.

### Motivation

This is needed to test the operation of PubSub at scale.