### PR TITLE
storage: test that we don't resolve remote hosts when using ssh tunnels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,9 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]
@@ -1712,13 +1712,14 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5457,8 +5458,7 @@ dependencies = [
 [[package]]
 name = "openssh"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca6c277973fb549b36dd8980941b5ea3ecebea026f5b1f0060acde74d893c22"
+source = "git+https://github.com/MaterializeInc/openssh.git#34404a274c5e1a7addd48940656fa12b7531e793"
 dependencies = [
  "dirs",
  "libc",
@@ -5620,6 +5620,12 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,3 +172,7 @@ proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git" }
 # Waiting on https://github.com/edenhill/librdkafka/pull/4051.
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git" }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git" }
+
+# Waiting on https://github.com/openssh-rust/openssh/pull/120 to make it into
+# a release.
+openssh = { git = "https://github.com/MaterializeInc/openssh.git" }

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 anyhow = "1.0.66"
 axum = { version = "0.6.7" }
 clap = { version = "3.2.24", features = [ "derive" ] }
-dirs = "4.0.0"
+dirs = "5.0.0"
 indicatif = "0.17.2"
 mz-build-info = { path = "../build-info" }
 mz-ore = { path = "../ore", features = ["async", "cli"] }

--- a/src/ssh-util/src/tunnel.rs
+++ b/src/ssh-util/src/tunnel.rs
@@ -199,8 +199,8 @@ async fn connect(
         // Force use of IPv4 loopback. Do not use the hostname `localhost`,
         // as that can resolve to IPv6, and the SSH tunnel is only listening
         // for IPv4 connections.
-        let local = openssh::Socket::new(&(Ipv4Addr::LOCALHOST, local_port))?;
-        let remote = openssh::Socket::new(&(host, port))?;
+        let local = openssh::Socket::from((Ipv4Addr::LOCALHOST, local_port));
+        let remote = openssh::Socket::new(host, port);
 
         match session
             .request_port_forward(ForwardType::Local, local, remote)

--- a/test/ssh-connection/hidden-hosts.td
+++ b/test/ssh-connection/hidden-hosts.td
@@ -1,0 +1,54 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test creating a source that uses Kafka/CSR via an SSH tunnel where the Kafka
+# broker and CSR server have hostnames that can only be resolved from the
+# SSH bastion host.
+#
+# The `openssh` crate previously had a bug where it would attempt to resolve
+# the target host on the client.
+# See: https://github.com/openssh-rust/openssh/pull/120
+
+$ kafka-create-topic topic=thetopic
+
+$ kafka-ingest topic=thetopic format=bytes
+one
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER 'hidden-kafka:9092' USING SSH TUNNEL thancred);
+
+
+> CREATE CONNECTION csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL 'http://hidden-schema-registry:8081',
+    SSH TUNNEL thancred
+  );
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-create-topic topic=avroavro
+
+$ kafka-ingest format=avro topic=avroavro schema=${schema}
+{"f1": "fish", "f2": 1000}
+
+> CREATE SOURCE csr_source
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-avroavro-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+
+> SELECT * FROM csr_source
+f1    f2
+----------
+fish  1000


### PR DESCRIPTION
The `openssh` crate has a bug in which it attempts to resolve the target host, which my only be resolvable on the SSH bastion host, on the client.

Upgrade to a patched version of `openssh` that does not have this bug, and add a test for this scenario (that would fail without the patched version of `openssh`).

### Motivation

  * This PR fixes a bug reported by a customer on Slack.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
