### PR TITLE
sql: implement array_fill + partial support for array lower bounds

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -604,6 +604,8 @@
   functions:
   - signature: 'array_cat(a1: arrayany, a2: arrayany) -> arrayany'
     description: 'Concatenates `a1` and `a2`.'
+  - signature: 'array_fill(anyelement, int[], [, int[]]) -> anyarray'
+    description: 'Returns an array initialized with supplied value and dimensions, optionally with lower bounds other than 1. (From [PG](https://www.postgresql.org/docs/current/functions-array.html))'
   - signature: 'array_position(haystack: anycompatiblearray, needle: anycompatible) -> int'
     description: 'Returns the subscript of `needle` in `haystack`. Returns `null` if not found.'
   - signature: 'array_position(haystack: anycompatiblearray, needle: anycompatible, skip: int) -> int'

--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -10,6 +10,7 @@
 
 from materialize.checks.aggregation import *  # noqa: F401 F403
 from materialize.checks.alter_index import *  # noqa: F401 F403
+from materialize.checks.array_type import *  # noqa: F401 F403
 from materialize.checks.boolean_type import *  # noqa: F401 F403
 from materialize.checks.cast import *  # noqa: F401 F403
 from materialize.checks.cluster import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/array_type.py
+++ b/misc/python/materialize/checks/array_type.py
@@ -1,0 +1,72 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+from typing import List
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.util import MzVersion
+
+
+class ArrayType(Check):
+    def _can_run(self) -> bool:
+        return self.base_version >= MzVersion.parse("0.57.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+            > CREATE TABLE array_type_table(int_col int[], text_col text[], array_col int[][]);
+
+            > INSERT INTO array_type_table VALUES (array_fill(2, ARRAY[2], ARRAY[2]), array_fill('foo'::text, ARRAY[2]), ARRAY[ARRAY[1,2], ARRAY[NULL, 4]]);
+        """
+            )
+        )
+
+    def manipulate(self) -> List[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > CREATE MATERIALIZED VIEW array_type_view1 AS SELECT
+                  int_col, array_fill(2, ARRAY[2], ARRAY[2]),
+                  text_col, array_fill('foo'::text, ARRAY[2]) AS array_fill2,
+                  array_col, ARRAY[ARRAY[1,2], ARRAY[NULL, 4]]
+                  FROM array_type_table;
+
+                > INSERT INTO array_type_table SELECT * FROM array_type_table LIMIT 1;
+                """,
+                """
+                > CREATE MATERIALIZED VIEW array_type_view2 AS SELECT
+                  int_col, array_fill(2, ARRAY[2], ARRAY[2]),
+                  text_col, array_fill('foo'::text, ARRAY[2]) AS array_fill2,
+                  array_col, ARRAY[ARRAY[1,2], ARRAY[NULL, 4]]
+                  FROM array_type_table;
+
+                > INSERT INTO array_type_table SELECT * FROM array_type_table LIMIT 1;
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT int_col::text, array_fill::text, text_col::text, array_fill2::text, array_col::text, "array"::text FROM array_type_view1;
+                [2:3]={2,2} [2:3]={2,2} {foo,foo} {foo,foo} {{1,2},{NULL,4}} {{1,2},{NULL,4}}
+                [2:3]={2,2} [2:3]={2,2} {foo,foo} {foo,foo} {{1,2},{NULL,4}} {{1,2},{NULL,4}}
+                [2:3]={2,2} [2:3]={2,2} {foo,foo} {foo,foo} {{1,2},{NULL,4}} {{1,2},{NULL,4}}
+
+                > SELECT int_col::text, array_fill::text, text_col::text, array_fill2::text, array_col::text, "array"::text FROM array_type_view2;
+                [2:3]={2,2} [2:3]={2,2} {foo,foo} {foo,foo} {{1,2},{NULL,4}} {{1,2},{NULL,4}}
+                [2:3]={2,2} [2:3]={2,2} {foo,foo} {foo,foo} {{1,2},{NULL,4}} {{1,2},{NULL,4}}
+                [2:3]={2,2} [2:3]={2,2} {foo,foo} {foo,foo} {{1,2},{NULL,4}} {{1,2},{NULL,4}}
+            """
+            )
+        )

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -633,7 +633,7 @@ message ProtoVariadicFunc {
         google.protobuf.Empty jsonb_build_object = 10;
         mz_repr.relation_and_scalar.ProtoScalarType array_create = 11;
         mz_repr.relation_and_scalar.ProtoScalarType array_to_string = 12;
-        uint64 array_index = 13;
+        int64 array_index = 13;
         mz_repr.relation_and_scalar.ProtoScalarType list_create = 14;
         ProtoRecordCreate record_create = 15;
         google.protobuf.Empty list_index = 6;

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -651,6 +651,7 @@ message ProtoVariadicFunc {
         google.protobuf.Empty make_mz_acl_item = 28;
         google.protobuf.Empty translate = 29;
         google.protobuf.Empty array_position = 30;
+        mz_repr.relation_and_scalar.ProtoScalarType array_fill = 31;
     }
 }
 
@@ -776,5 +777,7 @@ message ProtoEvalError {
         google.protobuf.Empty multi_dimensional_array_search = 66;
         string must_not_be_null = 67;
         ProtoInvalidIdentifier invalid_identifier = 68;
+        google.protobuf.Empty array_fill_wrong_array_subscripts = 69;
+        uint64 max_array_size_exceeded = 70;
     }
 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -6266,7 +6266,7 @@ where
     }
 }
 
-fn array_index<'a>(datums: &[Datum<'a>], offset: usize) -> Datum<'a> {
+fn array_index<'a>(datums: &[Datum<'a>], offset: i64) -> Datum<'a> {
     mz_ore::soft_assert!(offset == 0 || offset == 1, "offset must be either 0 or 1");
 
     let array = datums[0].unwrap_array();
@@ -6280,10 +6280,13 @@ fn array_index<'a>(datums: &[Datum<'a>], offset: usize) -> Datum<'a> {
 
     for (d, idx) in dims.into_iter().zip_eq(datums[1..].iter()) {
         // Lower bound is written in terms of 1-based indexing, which offset accounts for.
-        let idx = usize::cast_from(u64::reinterpret_cast(idx.unwrap_int64())) + offset;
+        let idx = isize::cast_from(idx.unwrap_int64() + offset);
 
-        // This index missed all of the data at this layer.
-        if !(d.lower_bound..d.lower_bound + d.length).contains(&idx) {
+        let (lower, upper) = d.dimension_bounds();
+
+        // This index missed all of the data at this layer. The dimension bounds are inclusive,
+        // while range checks are exclusive, so adjust.
+        if !(lower..upper + 1).contains(&idx) {
             return Datum::Null;
         }
 
@@ -6291,8 +6294,10 @@ fn array_index<'a>(datums: &[Datum<'a>], offset: usize) -> Datum<'a> {
         final_idx *= d.length;
 
         // Because both index and lower bound are handled in 1-based indexing, taking their
-        // difference moves us back into 0-based indexing.
-        final_idx += idx - d.lower_bound;
+        // difference moves us back into 0-based indexing. Similarly, if the lower bound is
+        // negative, subtracting a negative value >= to itself ensures its non-negativity.
+        final_idx += usize::try_from(idx - d.lower_bound)
+            .expect("previous bounds check ensures phsical index is at least 0");
     }
 
     array
@@ -6972,12 +6977,12 @@ fn array_fill<'a>(
                 .iter()
                 .map(|l| match l {
                     Datum::Null => Err(EvalError::MustNotBeNull(NULL_ELEM_ERR.to_string())),
-                    l => Ok(usize::cast_from(u32::reinterpret_cast(l.unwrap_int32()))),
+                    l => Ok(isize::cast_from(l.unwrap_int32())),
                 })
                 .collect::<Result<Vec<_>, _>>()?
         }
         None => {
-            vec![1usize; dimensions.len()]
+            vec![1isize; dimensions.len()]
         }
     };
 
@@ -7046,9 +7051,9 @@ pub enum VariadicFunc {
         elem_type: ScalarType,
     },
     ArrayIndex {
-        // Subtract `offset` from users' input to use 0-indexed arrays, i.e. is
-        // `1` in the case of `ScalarType::Array`.
-        offset: usize,
+        // Adjusts the index by offset depending on whether being called on an array or an
+        // Int2Vector.
+        offset: i64,
     },
     ListCreate {
         // We need to know the element type to type empty lists.
@@ -7510,7 +7515,7 @@ impl Arbitrary for VariadicFunc {
             ScalarType::arbitrary()
                 .prop_map(|elem_type| VariadicFunc::ArrayToString { elem_type })
                 .boxed(),
-            usize::arbitrary()
+            i64::arbitrary()
                 .prop_map(|offset| VariadicFunc::ArrayIndex { offset })
                 .boxed(),
             ScalarType::arbitrary()

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -23,11 +23,12 @@ use itertools::Itertools;
 use md5::{Digest, Md5};
 use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
+use mz_ore::cast::{self, ReinterpretCast};
 use mz_ore::fmt::FormatBuffer;
 use mz_ore::lex::LexBuf;
 use mz_ore::option::OptionExt;
 use mz_ore::result::ResultExt;
-use mz_ore::{cast, soft_assert};
+use mz_ore::soft_assert;
 use mz_pgrepr::Type;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::array::ArrayDimension;
@@ -6266,9 +6267,9 @@ where
     }
 }
 
-// TODO(benesch): remove potentially dangerous usage of `as`.
-#[allow(clippy::as_conversions)]
 fn array_index<'a>(datums: &[Datum<'a>], offset: usize) -> Datum<'a> {
+    mz_ore::soft_assert!(offset == 0 || offset == 1, "offset must be either 0 or 1");
+
     let array = datums[0].unwrap_array();
     let dims = array.dims();
     if dims.len() != datums.len() - 1 {
@@ -6278,22 +6279,21 @@ fn array_index<'a>(datums: &[Datum<'a>], offset: usize) -> Datum<'a> {
 
     let mut final_idx = 0;
 
-    for (
-        ArrayDimension {
-            lower_bound,
-            length,
-        },
-        idx,
-    ) in dims.into_iter().zip_eq(datums[1..].iter())
-    {
-        let idx = idx.unwrap_int64();
-        if idx < lower_bound as i64 {
-            // TODO: How does/should this affect the offset? If this isn't 1,
-            // what is the physical representation of the array?
+    for (d, idx) in dims.into_iter().zip_eq(datums[1..].iter()) {
+        // Lower bound is written in terms of 1-based indexing, which offset accounts for.
+        let idx = usize::cast_from(u64::reinterpret_cast(idx.unwrap_int64())) + offset;
+
+        // This index missed all of the data at this layer.
+        if !(d.lower_bound..d.lower_bound + d.length).contains(&idx) {
             return Datum::Null;
         }
 
-        final_idx = final_idx * length + (idx as usize - offset);
+        // We discover how many indices our last index represents physically.
+        final_idx *= d.length;
+
+        // Because both index and lower bound are handled in 1-based indexing, taking their
+        // difference moves us back into 0-based indexing.
+        final_idx += idx - d.lower_bound;
     }
 
     array

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1566,7 +1566,11 @@ fn map_get_value<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     }
 }
 
-fn map_get_values<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
+fn map_get_values<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
     let map = a.unwrap_map();
     let values: Vec<Datum> = b
         .unwrap_array()
@@ -1580,17 +1584,15 @@ fn map_get_values<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) ->
         )
         .collect();
 
-    temp_storage.make_datum(|packer| {
-        packer
-            .push_array(
-                &[ArrayDimension {
-                    lower_bound: 1,
-                    length: values.len(),
-                }],
-                values,
-            )
-            .unwrap()
-    })
+    Ok(temp_storage.try_make_datum(|packer| {
+        packer.push_array(
+            &[ArrayDimension {
+                lower_bound: 1,
+                length: values.len(),
+            }],
+            values,
+        )
+    })?)
 }
 
 // TODO(jamii) nested loops are possibly not the fastest way to do this
@@ -1943,17 +1945,15 @@ fn parse_ident<'a>(
         }
     }
 
-    Ok(temp_storage.make_datum(|packer| {
-        packer
-            .push_array(
-                &[ArrayDimension {
-                    lower_bound: 1,
-                    length: elems.len(),
-                }],
-                elems,
-            )
-            .unwrap()
-    }))
+    Ok(temp_storage.try_make_datum(|packer| {
+        packer.push_array(
+            &[ArrayDimension {
+                lower_bound: 1,
+                length: elems.len(),
+            }],
+            elems,
+        )
+    })?)
 }
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
@@ -2345,7 +2345,7 @@ impl BinaryFunc {
             BinaryFunc::JsonbDeleteString => Ok(jsonb_delete_string(a, b, temp_storage)),
             BinaryFunc::MapContainsKey => Ok(map_contains_key(a, b)),
             BinaryFunc::MapGetValue => Ok(map_get_value(a, b)),
-            BinaryFunc::MapGetValues => Ok(map_get_values(a, b, temp_storage)),
+            BinaryFunc::MapGetValues => map_get_values(a, b, temp_storage),
             BinaryFunc::MapContainsAllKeys => Ok(map_contains_all_keys(a, b)),
             BinaryFunc::MapContainsAnyKeys => Ok(map_contains_any_keys(a, b)),
             BinaryFunc::MapContainsMap => Ok(map_contains_map(a, b)),
@@ -7024,11 +7024,8 @@ fn array_fill<'a>(
             .collect()
     };
 
-    Ok(temp_storage.make_datum(|packer| {
-        packer
-            .push_array(&array_dimensions, vec![fill; fill_count])
-            .unwrap()
-    }))
+    Ok(temp_storage
+        .try_make_datum(|packer| packer.push_array(&array_dimensions, vec![fill; fill_count]))?)
 }
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -6755,7 +6755,7 @@ fn array_array_concat<'a>(
                 return Err(EvalError::IncompatibleArrayDimensions { dims: None });
             }
             dims = vec![ArrayDimension {
-                lower_bound: 1,
+                lower_bound: a_dims[0].lower_bound,
                 length: a_dims[0].length + b_dims[0].length,
             }];
             dims.extend(&a_dims[1..]);
@@ -6768,7 +6768,7 @@ fn array_array_concat<'a>(
                 return Err(EvalError::IncompatibleArrayDimensions { dims: None });
             }
             dims = vec![ArrayDimension {
-                lower_bound: 1,
+                lower_bound: b_dims[0].lower_bound,
                 // Since `a` is treated as an element of `b`, the length of
                 // the first dimension of `b` is incremented by one, as `a` is
                 // non-empty.
@@ -6784,7 +6784,7 @@ fn array_array_concat<'a>(
                 return Err(EvalError::IncompatibleArrayDimensions { dims: None });
             }
             dims = vec![ArrayDimension {
-                lower_bound: 1,
+                lower_bound: a_dims[0].lower_bound,
                 // Since `b` is treated as an element of `a`, the length of
                 // the first dimension of `a` is incremented by one, as `b`
                 // is non-empty.

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -169,11 +169,7 @@ impl LazyUnaryFunc for CastArrayToArray {
             .map(|datum| self.cast_expr.eval(&[datum], temp_storage))
             .collect::<Result<Vec<Datum<'a>>, EvalError>>()?;
 
-        Ok(temp_storage.make_datum(|packer| {
-            packer
-                .push_array(&dims, casted_datums)
-                .expect("failed to construct array");
-        }))
+        Ok(temp_storage.try_make_datum(|packer| packer.push_array(&dims, casted_datums))?)
     }
 
     fn output_type(&self, _input_type: ColumnType) -> ColumnType {

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -399,7 +399,12 @@ impl Value {
                 buf.put_u32(elem_type.oid());
                 for dim in dims {
                     buf.put_i32(pg_len("array dimension length", dim.length)?);
-                    buf.put_i32(pg_len("array dimension lower bound", dim.lower_bound)?);
+                    buf.put_i32(dim.lower_bound.try_into().map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::Other,
+                            "array dimension lower bound does not fit into an i32",
+                        )
+                    })?);
                 }
                 for elem in elements {
                     encode_element(buf, elem.as_ref(), elem_type)?;

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -731,7 +731,7 @@ mod tests {
 
         assert_eq!(
             decoded_int_array.map_err(|e| e.to_string()).unwrap_err(),
-            "invalid input syntax for type array: invalid input syntax for type integer: invalid digit found in string: \"t\": \"{t}\"".to_string()
+            "invalid input syntax for type array: specifying array lower bounds is not supported: \"[0:0]={t}\"".to_string()
         );
     }
 }

--- a/src/repr/src/row.proto
+++ b/src/repr/src/row.proto
@@ -102,7 +102,7 @@ message ProtoArray {
 }
 
 message ProtoArrayDimension {
-    uint64 lower_bound = 1;
+    int64 lower_bound = 1;
     uint64 length = 2;
 }
 

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -1308,7 +1308,7 @@ impl RowPacker<'_> {
         for dim in dims {
             self.row
                 .data
-                .extend_from_slice(&u64::cast_from(dim.lower_bound).to_le_bytes());
+                .extend_from_slice(&i64::cast_from(dim.lower_bound).to_le_bytes());
             self.row
                 .data
                 .extend_from_slice(&u64::cast_from(dim.length).to_le_bytes());

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -588,7 +588,7 @@ impl<'a> From<Datum<'a>> for ProtoDatum {
                     .dims()
                     .into_iter()
                     .map(|x| ProtoArrayDimension {
-                        lower_bound: u64::cast_from(x.lower_bound),
+                        lower_bound: i64::cast_from(x.lower_bound),
                         length: u64::cast_from(x.length),
                     })
                     .collect(),
@@ -727,7 +727,7 @@ impl RowPacker<'_> {
                     .dims
                     .iter()
                     .map(|x| ArrayDimension {
-                        lower_bound: usize::cast_from(x.lower_bound),
+                        lower_bound: isize::cast_from(x.lower_bound),
                         length: usize::cast_from(x.length),
                     })
                     .collect::<Vec<_>>();

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1137,7 +1137,8 @@ impl fmt::Display for Datum<'_> {
             Datum::Array(array) => {
                 if array.dims().into_iter().any(|dim| dim.lower_bound != 1) {
                     write_delimited(f, "", array.dims().into_iter(), |f, e| {
-                        write!(f, "[{}:{}]", e.lower_bound, e.lower_bound + e.length - 1)
+                        let (lower, upper) = e.dimension_bounds();
+                        write!(f, "[{}:{}]", lower, upper)
                     })?;
                     f.write_str("=")?;
                 }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -2762,6 +2762,53 @@ impl<'a> ScalarType {
             */
         ]
     }
+
+    /// Returns the appropriate element type for making a [`ScalarType::Array`] whose elements are
+    /// of `self`.
+    ///
+    /// If the type is not compatible with making an array, returns in the error position.
+    pub fn array_of_self_elem_type(self) -> Result<ScalarType, ScalarType> {
+        match self {
+            t @ (ScalarType::Bool
+            | ScalarType::Int16
+            | ScalarType::Int32
+            | ScalarType::Int64
+            | ScalarType::UInt16
+            | ScalarType::UInt32
+            | ScalarType::UInt64
+            | ScalarType::Float32
+            | ScalarType::Float64
+            | ScalarType::Numeric { .. }
+            | ScalarType::Date
+            | ScalarType::Time
+            | ScalarType::Timestamp
+            | ScalarType::TimestampTz
+            | ScalarType::Interval
+            | ScalarType::PgLegacyChar
+            | ScalarType::Bytes
+            | ScalarType::String
+            | ScalarType::VarChar { .. }
+            | ScalarType::Jsonb
+            | ScalarType::Uuid
+            | ScalarType::Record { .. }
+            | ScalarType::Oid
+            | ScalarType::RegProc
+            | ScalarType::RegType
+            | ScalarType::RegClass
+            | ScalarType::Int2Vector
+            | ScalarType::MzTimestamp
+            | ScalarType::Range { .. }
+            | ScalarType::MzAclItem { .. }) => Ok(t),
+
+            ScalarType::Array(elem) => Ok(elem.array_of_self_elem_type()?),
+
+            // https://github.com/MaterializeInc/materialize/issues/7613
+            t @ (ScalarType::Char { .. }
+            // not sensible to put in arrays
+            | ScalarType::Map { .. }
+            | ScalarType::List { .. }) => Err(t),
+        }
+    }
 }
 
 // See the chapter "Generating Recurisve Data" from the proptest book:

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1135,6 +1135,12 @@ impl fmt::Display for Datum<'_> {
             }
             Datum::Uuid(u) => write!(f, "{}", u),
             Datum::Array(array) => {
+                if array.dims().into_iter().any(|dim| dim.lower_bound != 1) {
+                    write_delimited(f, "", array.dims().into_iter(), |f, e| {
+                        write!(f, "[{}:{}]", e.lower_bound, e.lower_bound + e.length - 1)
+                    })?;
+                    f.write_str("=")?;
+                }
                 f.write_str("{")?;
                 write_delimited(f, ", ", &array.elements, |f, e| write!(f, "{}", e))?;
                 f.write_str("}")

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -1357,12 +1357,9 @@ where
     F: FormatBuffer,
 {
     if dims.iter().any(|dim| dim.lower_bound != 1) {
-        for ArrayDimension {
-            lower_bound,
-            length,
-        } in dims.iter()
-        {
-            write!(buf, "[{}:{}]", lower_bound, *lower_bound + *length - 1);
+        for d in dims.iter() {
+            let (lower, upper) = d.dimension_bounds();
+            write!(buf, "[{}:{}]", lower, upper);
         }
         buf.write_char('=');
     }

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -765,6 +765,10 @@ where
     let mut elems = vec![];
     let buf = &mut LexBuf::new(s);
 
+    if buf.consume('[') {
+        bail!("specifying array lower bounds is not supported");
+    }
+
     if !buf.consume('{') {
         bail!("malformed array literal: missing opening left brace");
     }
@@ -1352,6 +1356,17 @@ pub fn format_array<F, T, E>(
 where
     F: FormatBuffer,
 {
+    if dims.iter().any(|dim| dim.lower_bound != 1) {
+        for ArrayDimension {
+            lower_bound,
+            length,
+        } in dims.iter()
+        {
+            write!(buf, "[{}:{}]", lower_bound, *lower_bound + *length - 1);
+        }
+        buf.write_char('=');
+    }
+
     format_array_inner(buf, dims, &mut elems.into_iter(), &mut format_elem)?;
     Ok(Nestable::Yes)
 }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1671,6 +1671,36 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                 Ok(lhs.call_binary(rhs, BinaryFunc::ArrayArrayConcat))
             }) => ArrayAnyCompatible, 383;
         },
+        "array_fill" => Scalar {
+            params!(AnyElement, ScalarType::Array(Box::new(ScalarType::Int32))) => Operation::binary(|ecx, elem, dims| {
+                let elem_type = ecx.scalar_type(&elem);
+
+                let elem_type = match elem_type.array_of_self_elem_type() {
+                    Ok(elem_type) => elem_type,
+                    Err(elem_type) => bail_unsupported!(
+                        format!("array_fill on {}", ecx.humanize_scalar_type(&elem_type))
+                    ),
+                };
+
+                Ok(HirScalarExpr::CallVariadic { func: VariadicFunc::ArrayFill { elem_type }, exprs: vec![elem, dims] })
+            }) => ArrayAnyCompatible, 1193;
+            params!(
+                AnyElement,
+                ScalarType::Array(Box::new(ScalarType::Int32)),
+                ScalarType::Array(Box::new(ScalarType::Int32))
+            ) => Operation::variadic(|ecx, exprs| {
+                let elem_type = ecx.scalar_type(&exprs[0]);
+
+                let elem_type = match elem_type.array_of_self_elem_type() {
+                    Ok(elem_type) => elem_type,
+                    Err(elem_type) => bail_unsupported!(
+                        format!("array_fill on {}", ecx.humanize_scalar_type(&elem_type))
+                    ),
+                };
+
+                Ok(HirScalarExpr::CallVariadic { func: VariadicFunc::ArrayFill { elem_type }, exprs })
+            }) => ArrayAny, 1286;
+        },
         "array_in" => Scalar {
             params!(String, Oid, Int32) =>
                 Operation::variadic(|_ecx, _exprs| bail_unsupported!("array_in")) => ArrayAnyCompatible, 750;
@@ -2532,13 +2562,18 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         "array_agg" => Aggregate {
             params!(NonVecAny) => Operation::unary_ordered(|ecx, e, order_by| {
                 let elem_type = ecx.scalar_type(&e);
-                if let ScalarType::Char {.. } | ScalarType::Map { .. } = elem_type {
-                    bail_unsupported!(format!("array_agg on {}", ecx.humanize_scalar_type(&elem_type)));
+
+                let elem_type = match elem_type.array_of_self_elem_type() {
+                    Ok(elem_type) => elem_type,
+                    Err(elem_type) => bail_unsupported!(
+                        format!("array_agg on {}", ecx.humanize_scalar_type(&elem_type))
+                    ),
                 };
+
                 // ArrayConcat excepts all inputs to be arrays, so wrap all input datums into
                 // arrays.
                 let e_arr = HirScalarExpr::CallVariadic{
-                    func: VariadicFunc::ArrayCreate { elem_type: ecx.scalar_type(&e) },
+                    func: VariadicFunc::ArrayCreate { elem_type },
                     exprs: vec![e],
                 };
                 Ok((e_arr, AggregateFunc::ArrayConcat { order_by }))

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -179,6 +179,7 @@ pub enum PlanError {
     InvalidOrderByInSubscribeWithinTimestampOrderBy,
     FromValueRequiresParen,
     VarError(VarError),
+    UnsolvablePolymorphicFunctionInput,
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -462,6 +463,9 @@ impl fmt::Display for PlanError {
                 "VALUES expression in FROM clause must be surrounded by parentheses"
             ),
             Self::VarError(e) => e.fmt(f),
+            Self::UnsolvablePolymorphicFunctionInput => f.write_str(
+                "could not determine polymorphic type because input has type unknown"
+            ),
         }
     }
 }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3561,7 +3561,7 @@ fn plan_subscript_array(
     ecx: &ExprContext,
     expr: HirScalarExpr,
     positions: &[SubscriptPosition<Aug>],
-    offset: usize,
+    offset: i64,
 ) -> Result<CoercibleScalarExpr, PlanError> {
     let mut exprs = Vec::with_capacity(positions.len() + 1);
     exprs.push(expr);

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3521,11 +3521,10 @@ fn plan_subscript(
             ecx,
             expr,
             positions,
-            if matches!(ty, ScalarType::Array(..)) {
-                1
-            } else {
-                0
-            },
+            // Int2Vector uses 0-based indexing, while arrays use 1-based indexing, so we need to
+            // adjust all Int2Vector subscript operations by 1 (both w/r/t input and the values we
+            // track in its backing data).
+            if ty == ScalarType::Int2Vector { 1 } else { 0 },
         ),
         ScalarType::Jsonb => plan_subscript_jsonb(ecx, expr, positions),
         ScalarType::List { element_type, .. } => {

--- a/test/sqllogictest/array_fill.slt
+++ b/test/sqllogictest/array_fill.slt
@@ -314,6 +314,12 @@ SELECT array_fill(1, ARRAY[4, -199, 3]);
 query error db error: ERROR: array size exceeds the maximum allowed \(134217728 bytes\)
 SELECT array_fill(8, ARRAY[-1, -1, -1, -1]);
 
+query error db error: ERROR: number of array dimensions \(10\) exceeds the maximum allowed \(6\)
+SELECT array_fill(1, ARRAY[1,1,1,1,1,1,1,1,1,1]);
+
+query error db error: ERROR: number of array dimensions \(10\) exceeds the maximum allowed \(6\)
+SELECT array_fill(1, ARRAY[1,1,1,1,1,1,1,1,1,1], ARRAY[1,1,1,1,1,1,1,1,1,1]);
+
 # But large arrays are still ok
 
 query II

--- a/test/sqllogictest/array_fill.slt
+++ b/test/sqllogictest/array_fill.slt
@@ -46,6 +46,16 @@ SELECT (array_fill(5, array[3]))[1]
 
 # Lower bound adjustment works
 query T
+SELECT array_fill(5, array[3], array[2])
+----
+[2:4]={5,5,5}
+
+query T
+SELECT array_fill(5, array[3, 1], array[2, 4])
+----
+[2:4][4:4]={{5},{5},{5}}
+
+query T
 SELECT (array_fill(5, array[3], array[2]))[1]
 ----
 NULL
@@ -100,7 +110,7 @@ ORDER BY 1;
 query T
 SELECT array_fill(5, array[3, 2], array[2, 3])
 ----
-{{5,5},{5,5},{5,5}}
+[2:4][3:4]={{5,5},{5,5},{5,5}}
 
 # Reveal structure of 2D array
 query T
@@ -321,3 +331,27 @@ SELECT array_length(a, 1), array_length(a, 2) FROM (
 ----
 99
 101
+
+# Concatenating arrays
+
+query error db error: ERROR: cannot concatenate incompatible arrays
+SELECT array_fill(1, ARRAY[2], ARRAY[1] || array_fill(1, ARRAY[3, 2], ARRAY[4, 1]));
+
+# RHS is element of LHS
+
+query T
+SELECT array_fill(6, ARRAY[3, 2], ARRAY[4, 3]) || array_fill(7, ARRAY[2], ARRAY[3]);
+----
+[4:7][3:4]={{6,6},{6,6},{6,6},{7,7}}
+
+# LHS is element of RHS
+query T
+SELECT array_fill(6, ARRAY[2], ARRAY[3]) || array_fill(7, ARRAY[3, 2], ARRAY[4, 3]);
+----
+[4:7][3:4]={{6,6},{7,7},{7,7},{7,7}}
+
+# Array || Array
+query T
+SELECT array_fill(6, ARRAY[3, 2], ARRAY[4, 3]) || array_fill(7, ARRAY[3, 2], ARRAY[4, 3]);
+----
+[4:9][3:4]={{6,6},{6,6},{6,6},{7,7},{7,7},{7,7}}

--- a/test/sqllogictest/array_fill.slt
+++ b/test/sqllogictest/array_fill.slt
@@ -1,0 +1,323 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Misc. types
+
+query T
+SELECT array_fill(5, array[3])
+----
+{5,5,5}
+
+query T
+SELECT array_fill(5.1::double, array[3])
+----
+{5.1,5.1,5.1}
+
+query T
+SELECT array_fill(5.1, array[3])
+----
+{5.1,5.1,5.1}
+
+query T
+SELECT array_fill('z'::text, array[3])
+----
+{z,z,z}
+
+query T
+SELECT array_fill(INTERVAL '1d', array[3])
+----
+{"1 day","1 day","1 day"}
+
+query T
+SELECT array_fill('[1,)'::int4range, array[3])
+----
+{[1,),[1,),[1,)}
+
+query T
+SELECT (array_fill(5, array[3]))[1]
+----
+5
+
+# Lower bound adjustment works
+query T
+SELECT (array_fill(5, array[3], array[2]))[1]
+----
+NULL
+
+query T
+SELECT (array_fill(5, array[3], array[2]))[2]
+----
+5
+
+query error wrong number of array subscripts
+SELECT array_fill(5, array[3], array[2, 1])
+
+query error wrong number of array subscripts
+SELECT array_fill(5, array[3, 1], array[2])
+
+query error wrong number of array subscripts
+SELECT array_fill(5, array[]::int[], array[2, 1])
+
+query error wrong number of array subscripts
+SELECT array_fill(5, array[3, 1], array[]::int[])
+
+# Reveal structure of array
+query T
+SELECT
+    concat(
+        o,
+        ' ',
+        i,
+        ' ',
+        COALESCE(((array_fill(5, ARRAY[3, 2]))[o][i])::text, 'null')
+    )
+FROM generate_series(1, 4) AS o, generate_series(1, 4) AS i
+ORDER BY 1;
+----
+1 1 5
+1 2 5
+1 3 null
+1 4 null
+2 1 5
+2 2 5
+2 3 null
+2 4 null
+3 1 5
+3 2 5
+3 3 null
+3 4 null
+4 1 null
+4 2 null
+4 3 null
+4 4 null
+
+query T
+SELECT array_fill(5, array[3, 2], array[2, 3])
+----
+{{5,5},{5,5},{5,5}}
+
+# Reveal structure of 2D array
+query T
+SELECT
+    concat(
+        o,
+        ' ',
+        i,
+        ' ',
+        COALESCE(((array_fill(5, ARRAY[3, 2], ARRAY[2, 3]))[o][i])::text, 'null')
+    )
+FROM generate_series(1, 4) AS o, generate_series(1, 4) AS i
+ORDER BY 1;
+----
+1 1 null
+1 2 null
+1 3 null
+1 4 null
+2 1 null
+2 2 null
+2 3 5
+2 4 5
+3 1 null
+3 2 null
+3 3 5
+3 4 5
+4 1 null
+4 2 null
+4 3 5
+4 4 5
+
+# Reveal structure of 3D array
+query T
+SELECT
+    concat(
+        a,
+        ' ',
+        b,
+        ' ',
+        c,
+        ' ',
+        COALESCE(((array_fill(5, ARRAY[3, 2, 1], ARRAY[1, 2, 3]))[a][b][c])::text, 'null')
+    )
+FROM
+    generate_series(1, 3) AS a,
+    generate_series(1, 3) AS b,
+    generate_series(1, 3) AS c
+ORDER BY 1;
+----
+1 1 1 null
+1 1 2 null
+1 1 3 null
+1 2 1 null
+1 2 2 null
+1 2 3 5
+1 3 1 null
+1 3 2 null
+1 3 3 5
+2 1 1 null
+2 1 2 null
+2 1 3 null
+2 2 1 null
+2 2 2 null
+2 2 3 5
+2 3 1 null
+2 3 2 null
+2 3 3 5
+3 1 1 null
+3 1 2 null
+3 1 3 null
+3 2 1 null
+3 2 2 null
+3 2 3 5
+3 3 1 null
+3 3 2 null
+3 3 3 5
+
+# Polymorphic solution
+
+query error db error: ERROR: could not determine polymorphic type because input has type unknown
+SELECT array_fill(null, array[3])
+
+query error db error: ERROR: could not determine polymorphic type because input has type unknown
+SELECT array_fill(null, null)
+
+query T
+SELECT array_fill(null::int, array[3])
+----
+{NULL,NULL,NULL}
+
+# Prohibited types
+
+query error db error: ERROR: array_fill with arrays not yet supported
+SELECT array_fill(ARRAY[1], array[3, 2])
+
+query error db error: ERROR: array_fill with arrays not yet supported
+SELECT array_fill(ARRAY[1], array[3, 2], array[2, 3])
+
+query error db error: ERROR: array_fill on integer list not yet supported
+SELECT array_fill(LIST[1], array[3, 2])
+
+query error db error: ERROR: array_fill on integer list not yet supported
+SELECT array_fill(LIST[1], array[3, 2], array[2, 3])
+
+query error db error: ERROR: array_fill on character not yet supported
+SELECT array_fill('c'::char, array[3, 2])
+
+query error db error: ERROR: array_fill on character not yet supported
+SELECT array_fill('c'::char, array[3, 2], array[2, 3])
+
+query error db error: ERROR: array_fill on map\[text=>integer\] not yet supported
+SELECT array_fill('{}'::map[text=>int], array[3, 2])
+
+query error db error: ERROR: array_fill on map\[text=>integer\] not yet supported
+SELECT array_fill('{}'::map[text=>int], array[3, 2], array[2, 3])
+
+# Null errors
+
+query error db error: ERROR: dimension array or low bound array must not be null
+SELECT array_fill(1, null);
+
+query error db error: ERROR: dimension array or low bound array must not be null
+SELECT array_fill(null::int, null);
+
+query error db error: ERROR: dimension array or low bound array must not be null
+SELECT array_fill(1, ARRAY[8], null);
+
+query error db error: ERROR: dimension array or low bound array must not be null
+SELECT array_fill(1, null, ARRAY[8]);
+
+query error db error: ERROR: dimension values must not be null
+SELECT array_fill(1, ARRAY[null::int]);
+
+query error db error: ERROR: dimension values must not be null
+SELECT array_fill(null::int, ARRAY[null::int], ARRAY[8]);
+
+query error db error: ERROR: dimension values must not be null
+SELECT array_fill(1, ARRAY[8], ARRAY[null::int]);
+
+query error db error: ERROR: dimension values must not be null
+SELECT array_fill(1, ARRAY[null::int], ARRAY[null::int]);
+
+query error db error: ERROR: dimension values must not be null
+SELECT array_fill(1, ARRAY[6, null::int]);
+
+query error db error: ERROR: dimension values must not be null
+SELECT array_fill(null::int, ARRAY[6, null::int], ARRAY[8]);
+
+query error db error: ERROR: dimension values must not be null
+SELECT array_fill(1, ARRAY[8], ARRAY[6, null::int]);
+
+query error db error: ERROR: dimension values must not be null
+SELECT array_fill(1, ARRAY[6, null::int], ARRAY[6, null::int]);
+
+# Multi-dimensional w/ 0
+query T
+SELECT array_fill(1, ARRAY[0]);
+----
+{}
+
+query T
+SELECT array_fill(1, ARRAY[4, 0]);
+----
+{}
+
+query T
+SELECT array_fill(1, ARRAY[0, 4]);
+----
+{}
+
+query T
+SELECT array_fill(1, ARRAY[4, 3, 0]);
+----
+{}
+
+query T
+SELECT array_fill(1, ARRAY[4, 0, 3]);
+----
+{}
+
+# Too large of array
+
+query error db error: ERROR: array size exceeds the maximum allowed \(134217728 bytes\)
+SELECT array_fill(2, ARRAY[-1]);
+
+query error db error: ERROR: array size exceeds the maximum allowed \(134217728 bytes\)
+SELECT array_fill(2, ARRAY[-1]);
+
+query error db error: ERROR: array size exceeds the maximum allowed \(134217728 bytes\)
+SELECT array_fill(1, ARRAY[4, -199]);
+
+query error db error: ERROR: array size exceeds the maximum allowed \(134217728 bytes\)
+SELECT array_fill(1, ARRAY[-199, 4]);
+
+query error db error: ERROR: array size exceeds the maximum allowed \(134217728 bytes\)
+SELECT array_fill(1, ARRAY[4, 3, -199]);
+
+query error db error: ERROR: array size exceeds the maximum allowed \(134217728 bytes\)
+SELECT array_fill(1, ARRAY[4, -199, 3]);
+
+query error db error: ERROR: array size exceeds the maximum allowed \(134217728 bytes\)
+SELECT array_fill(8, ARRAY[-1, -1, -1, -1]);
+
+# But large arrays are still ok
+
+query II
+SELECT array_length(a, 1), array_length(a, 2) FROM (
+    SELECT array_fill(1, ARRAY[99, 101]) AS a
+);
+----
+99
+101
+
+query II
+SELECT array_length(a, 1), array_length(a, 2) FROM (
+    SELECT array_fill(1, ARRAY[99, 101], ARRAY[2, 3]) AS a
+);
+----
+99
+101

--- a/test/sqllogictest/array_fill.slt
+++ b/test/sqllogictest/array_fill.slt
@@ -355,3 +355,40 @@ query T
 SELECT array_fill(6, ARRAY[3, 2], ARRAY[4, 3]) || array_fill(7, ARRAY[3, 2], ARRAY[4, 3]);
 ----
 [4:9][3:4]={{6,6},{6,6},{6,6},{7,7},{7,7},{7,7}}
+
+# Negative lower bounds
+
+query T
+SELECT array_fill(3, ARRAY[2], ARRAY[-3]);
+----
+[-3:-2]={3,3}
+
+query I
+SELECT (array_fill(3, ARRAY[2], ARRAY[-3]))[-3];
+----
+3
+
+query T
+SELECT
+    concat(
+        o,
+        E'\t',
+        i,
+        E'\t',
+        COALESCE(((array_fill(5, ARRAY[2, 2], ARRAY[-2, -1]))[o][i])::text, 'null')
+    )
+FROM generate_series(-3, 0) AS o, generate_series(-2, 0) AS i
+ORDER BY o, i;
+----
+-3	-2	null
+-3	-1	null
+-3	0	null
+-2	-2	null
+-2	-1	5
+-2	0	5
+-1	-2	null
+-1	-1	5
+-1	0	5
+0	-2	null
+0	-1	null
+0	0	null

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -36,6 +36,9 @@ SELECT '{1, 2, 3} 4'::int[]
 query error parsing multi-dimensional arrays is not supported
 SELECT '{{1}, {2}}'::int[]
 
+query error specifying array lower bounds is not supported
+SELECT '[1:2]={1,2}'::int[]
+
 # Test coercion behavior of multidimensional arrays.
 
 query error ARRAY could not convert type text\[\] to integer\[\]

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -60,7 +60,6 @@ known_errors = [
     "value too long for type",
     "list_agg on char not yet supported",
     "does not allow subqueries",
-    "range constructor flags argument must not be null",  # expected after https://github.com/MaterializeInc/materialize/issues/18036 has been fixed
     "function array_remove(",  # insufficient type system, parameter types have to match
     "function array_cat(",  # insufficient type system, parameter types have to match
     "function array_position(",  # insufficient type system, parameter types have to match
@@ -107,6 +106,8 @@ known_errors = [
     "null character not permitted",
     "is defined for numbers between",
     "field position must be greater than zero",
+    "array_fill on ",  # Not yet supported
+    "must not be null",  # Expected with array_fill, array_position
     "' not recognized",  # Expected, see https://github.com/MaterializeInc/materialize/issues/17981
     "must appear in the GROUP BY clause or be used in an aggregate function",
     "Expected joined table, found",  # Should fix for multi table join
@@ -122,7 +123,6 @@ known_errors = [
     "OneShot plan has temporal constraints",  # Expected, see https://github.com/MaterializeInc/materialize/issues/18048
     "internal error: cannot evaluate unmaterializable function",  # Currently expected, see https://github.com/MaterializeInc/materialize/issues/14290
     "string is not a valid identifier:",  # Expected in parse_ident
-    "initial position must not be null",  # "expected in array_position
 ]
 
 

--- a/test/testdrive/array.td
+++ b/test/testdrive/array.td
@@ -36,3 +36,6 @@ contains:map[text=>integer][] not yet supported
 > CREATE TYPE bigint_map AS MAP (KEY TYPE = text, VALUE TYPE = bigint);
 ! CREATE TABLE bigint_map_map_array_table (f1 bigint_map[]);
 contains:type "bigint_map[]" does not exist
+
+> SELECT array_fill(1, ARRAY[2], ARRAY[3]);
+[3:4]={1,1}


### PR DESCRIPTION
As part of improving introspection, I wanted this function to help normalize parsed identifiers.

This function also supports generating non-1 lower bounds on arrays, so I included partial support for that, as well (we can output them, but cannot yet parse them).

@MaterializeInc/qa PTAL

@benesch Pinging you because it also impacts in-row representation (8a29fa91730b0b8bf62b12b217a4bbec83c8b178), which I don't believe anyone else has really taken over ownership of.

### Motivation

This PR adds a feature that has not yet been specified.

### Tips for reviewer

I recommend proceeding through this commit-by-commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add the `array_fill` function.
