### PR TITLE
ore, adapter: refactor connection ID handling

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -119,7 +119,7 @@ pub use crate::catalog::builtin_table_updates::BuiltinTableUpdate;
 pub use crate::catalog::config::{AwsPrincipalContext, ClusterReplicaSizeMap, Config};
 pub use crate::catalog::error::{AmbiguousRename, Error, ErrorKind};
 
-pub static SYSTEM_CONN_ID: ConnectionId = ConnectionId::new_static(0);
+pub static SYSTEM_CONN_ID: ConnectionId = ConnectionId::Static(0);
 
 const CREATE_SQL_TODO: &str = "TODO";
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1200,7 +1200,7 @@ impl CatalogState {
         let mut row = Row::default();
         let mut packer = row.packer();
         packer.push(Datum::String(&id.to_string()));
-        packer.push(Datum::UInt32(*subscribe.conn_id));
+        packer.push(Datum::UInt32(subscribe.conn_id.unhandled()));
         packer.push(Datum::String(&subscribe.cluster_id.to_string()));
 
         let start_dt = mz_ore::now::to_datetime(subscribe.start_time);
@@ -1225,7 +1225,7 @@ impl CatalogState {
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_SESSIONS),
             row: Row::pack_slice(&[
-                Datum::UInt32(**session.conn_id()),
+                Datum::UInt32(session.conn_id().unhandled()),
                 Datum::String(&session.role_id().to_string()),
                 Datum::TimestampTz(connect_dt.try_into().expect("must fit")),
             ]),

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -77,8 +77,6 @@ pub enum Command {
     },
 
     CancelRequest {
-        /// Note: This is a [`ConnectionIdType`] and not a `ConnetionId` to support external
-        /// clients.
         conn_id: ConnectionIdType,
         secret_key: u32,
     },

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -186,7 +186,7 @@ pub struct Response<T> {
 
 pub type RowsFuture = Pin<Box<dyn Future<Output = PeekResponseUnary> + Send>>;
 
-/// The response to [`ConnClient::startup`](crate::ConnClient::startup).
+/// The response to [`Client::startup`](crate::Client::startup).
 #[derive(Debug)]
 pub struct StartupResponse {
     /// Notifications associated with session startup.

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -25,9 +25,9 @@ pub struct SystemParameterBackend {
 
 impl SystemParameterBackend {
     pub async fn new(client: Client) -> Result<Self, AdapterError> {
-        let conn_client = client.new_conn()?;
-        let session = conn_client.new_session(SYSTEM_USER.clone());
-        let (session_client, _) = conn_client.startup(session).await?;
+        let conn_id = client.new_conn_id()?;
+        let session = client.new_session(conn_id, SYSTEM_USER.clone());
+        let (session_client, _) = client.startup(session).await?;
         Ok(Self { session_client })
     }
 

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -797,9 +797,9 @@ fn eval_unmaterializable_func(
         UnmaterializableFunc::MzVersionNum => {
             pack(Datum::Int32(state.config().build_info.version_num()))
         }
-        UnmaterializableFunc::PgBackendPid => {
-            pack(Datum::Int32(i32::reinterpret_cast(**session.conn_id())))
-        }
+        UnmaterializableFunc::PgBackendPid => pack(Datum::Int32(i32::reinterpret_cast(
+            session.conn_id().unhandled(),
+        ))),
         UnmaterializableFunc::PgPostmasterStartTime => {
             let t: Datum = state.config().start_time.try_into()?;
             pack(t)

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -72,7 +72,7 @@ impl Coordinator {
             // in any situation where you use it, you must also have a code
             // path that responds to the client (e.g. reporting an error).
             Message::RemovePendingPeeks { conn_id } => {
-                self.cancel_pending_peeks(*conn_id);
+                self.cancel_pending_peeks(&conn_id);
             }
             Message::LinearizeReads(pending_read_txns) => {
                 self.message_linearize_reads(pending_read_txns).await;

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -35,7 +35,7 @@ use timely::progress::Timestamp;
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
-use crate::client::{ConnectionId, ConnectionIdType};
+use crate::client::ConnectionId;
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::timestamp_selection::TimestampContext;
 use crate::util::{send_immediate_rows, ResultExt};
@@ -484,14 +484,11 @@ impl crate::coord::Coordinator {
     }
 
     /// Cancel and remove all pending peeks that were initiated by the client with `conn_id`.
-    ///
-    /// Note: Here we take a [`ConnectionIdType`] as opposed to an owned `ConnectionId` because
-    /// this method gets called by external clients when they request to cancel a request.
     #[tracing::instrument(level = "debug", skip(self))]
-    pub(crate) fn cancel_pending_peeks(&mut self, conn_id: ConnectionIdType) -> Vec<PendingPeek> {
+    pub(crate) fn cancel_pending_peeks(&mut self, conn_id: &ConnectionId) -> Vec<PendingPeek> {
         // The peek is present on some specific compute instance.
         // Allow dataflow to cancel any pending peeks.
-        if let Some(uuids) = self.client_pending_peeks.remove(&conn_id) {
+        if let Some(uuids) = self.client_pending_peeks.remove(conn_id) {
             self.metrics
                 .canceled_peeks
                 .with_label_values(&[])

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -119,7 +119,7 @@ pub mod metrics;
 pub mod session;
 pub mod telemetry;
 
-pub use crate::client::{Client, ConnClient, Handle, SessionClient};
+pub use crate::client::{Client, Handle, SessionClient};
 pub use crate::command::{
     Canceled, ExecuteResponse, ExecuteResponseKind, RowsFuture, StartupMessage, StartupResponse,
 };

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -134,6 +134,7 @@ pub fn check_command(catalog: &Catalog, cmd: &Command) -> Result<(), Unauthorize
         | Command::Execute { .. }
         | Command::Commit { .. }
         | Command::CancelRequest { .. }
+        | Command::PrivilegedCancelRequest { .. }
         | Command::CopyRows { .. }
         | Command::GetSystemVars { .. }
         | Command::SetSystemVars { .. }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -42,7 +42,7 @@ use crate::coord::timestamp_selection::TimestampContext;
 use crate::error::AdapterError;
 use crate::AdapterNotice;
 
-const DUMMY_CONNECTION_ID: ConnectionId = ConnectionId::new_static(0);
+const DUMMY_CONNECTION_ID: ConnectionId = ConnectionId::Static(0);
 const DUMMY_CONNECT_TIME: EpochMillis = 0;
 
 /// A session holds per-connection state.

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -294,8 +294,8 @@ impl AuthedClient {
     ) -> Result<Self, AdapterError> {
         let AuthedUser(user) = user;
         let drop_connection = DropConnection::new_connection(&user, active_connection_count)?;
-        let adapter_client = adapter_client.new_conn()?;
-        let session = adapter_client.new_session(user);
+        let conn_id = adapter_client.new_conn_id()?;
+        let session = adapter_client.new_session(conn_id, user);
         let (adapter_client, _) = adapter_client.startup(session).await?;
         Ok(AuthedClient {
             client: adapter_client,

--- a/src/pgwire/src/codec.rs
+++ b/src/pgwire/src/codec.rs
@@ -23,9 +23,9 @@ use byteorder::{ByteOrder, NetworkEndian};
 use bytes::{Buf, BufMut, BytesMut};
 use bytesize::ByteSize;
 use futures::{sink, SinkExt, TryStreamExt};
+use mz_adapter::client::ConnectionId;
 use mz_ore::cast::{u64_to_usize, CastFrom};
 use mz_ore::future::OreSinkExt;
-use mz_ore::id_gen::IdHandle;
 use mz_ore::netio::{self, AsyncReady};
 use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite, Interest, Ready};
 use tokio::time::{self, Duration};
@@ -61,7 +61,7 @@ impl fmt::Display for CodecError {
 
 /// A connection that manages the encoding and decoding of pgwire frames.
 pub struct FramedConn<A> {
-    conn_id: IdHandle<u32>,
+    conn_id: ConnectionId,
     inner: sink::Buffer<Framed<Conn<A>, Codec>, BackendMessage>,
 }
 
@@ -77,7 +77,7 @@ where
     ///
     /// The supplied `conn_id` is used to identify the connection in logging
     /// messages.
-    pub fn new(conn_id: IdHandle<u32>, inner: Conn<A>) -> FramedConn<A> {
+    pub fn new(conn_id: ConnectionId, inner: Conn<A>) -> FramedConn<A> {
         FramedConn {
             conn_id,
             inner: Framed::new(inner, Codec::new()).buffer(32),
@@ -186,6 +186,11 @@ where
                 Err(err) => return err,
             }
         }
+    }
+
+    /// Returns the ID associated with this connection.
+    pub fn conn_id(&self) -> &ConnectionId {
+        &self.conn_id
     }
 }
 

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -68,7 +68,7 @@ pub struct RunParams<'a, A> {
     /// The TLS mode of the pgwire server.
     pub tls_mode: Option<TlsMode>,
     /// A client for the adapter.
-    pub adapter_client: mz_adapter::ConnClient,
+    pub adapter_client: mz_adapter::Client,
     /// The connection to the client.
     pub conn: &'a mut FramedConn<A>,
     /// The protocol version that the client provided in the startup message.
@@ -159,10 +159,13 @@ where
     }
 
     // Construct session.
-    let mut session = adapter_client.new_session(User {
-        name: user.clone(),
-        external_metadata: None,
-    });
+    let mut session = adapter_client.new_session(
+        conn.conn_id().clone(),
+        User {
+            name: user.clone(),
+            external_metadata: None,
+        },
+    );
 
     let is_expired = if let Some(frontegg) = frontegg {
         conn.send(BackendMessage::AuthenticationCleartextPassword)

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -260,7 +260,7 @@ where
         buf.push(BackendMessage::ParameterStatus(var.name(), var.value()));
     }
     buf.push(BackendMessage::BackendKeyData {
-        conn_id: **session.conn_id(),
+        conn_id: session.conn_id().unhandled(),
         secret_key: session.secret_key(),
     });
     // Immediately respond with connection success without waiting on the

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -101,7 +101,7 @@ impl Server {
     where
         A: AsyncRead + AsyncWrite + AsyncReady + Send + Sync + Unpin + fmt::Debug + 'static,
     {
-        let adapter_client = self.adapter_client.new_conn();
+        let mut adapter_client = self.adapter_client.clone();
         let frontegg = self.frontegg.clone();
         let tls = self.tls.clone();
         let internal = self.internal;
@@ -110,8 +110,7 @@ impl Server {
         async move {
             let result = (|| {
                 async move {
-                    let mut adapter_client = adapter_client?;
-                    let conn_id = adapter_client.conn_id();
+                    let conn_id = adapter_client.new_conn_id()?;
                     let mut conn = Conn::Unencrypted(conn);
                     loop {
                         let message = codec::decode_startup(&mut conn).await?;


### PR DESCRIPTION
A few commits here:

  * The first commit makes it easier to reason about some connection ID handling in `SessionCancel::send_with_cancel`.
  * The second commit addresses @ParkMyCar's feedback on my last refactoring in this area: https://github.com/MaterializeInc/materialize/pull/19541#discussion_r1213151554.
  * The third commit completes a refactor we talked about in person: the removal of `ConnClient`.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Should be no behavior changes in this PR.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  -  n/a
