### PR TITLE
sql: support UPDATE t AS x

### DIFF
--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -20,6 +20,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 
 [dev-dependencies]
 datadriven = "0.6.0"
+mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 unicode-width = "0.1.10"
 
 [build-dependencies]

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -345,6 +345,7 @@ impl_display_t!(CopyStatement);
 pub struct UpdateStatement<T: AstInfo> {
     /// `FROM`
     pub table_name: T::ItemName,
+    pub alias: Option<TableAlias>,
     /// Column assignments
     pub assignments: Vec<Assignment<T>>,
     /// WHERE
@@ -355,6 +356,10 @@ impl<T: AstInfo> AstDisplay for UpdateStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("UPDATE ");
         f.write_node(&self.table_name);
+        if let Some(alias) = &self.alias {
+            f.write_str(" AS ");
+            f.write_node(alias);
+        }
         if !self.assignments.is_empty() {
             f.write_str(" SET ");
             f.write_node(&display::comma_separated(&self.assignments));

--- a/src/sql-parser/src/keywords.rs
+++ b/src/sql-parser/src/keywords.rs
@@ -91,6 +91,8 @@ impl Keyword {
             // These keywords are ambiguous when used as a table alias, as they
             // conflict with the syntax for joins.
             ON | JOIN | INNER | CROSS | FULL | LEFT | RIGHT | NATURAL | USING |
+            // Needed for UPDATE.
+            SET |
             // `OUTER` is not strictly ambiguous, but it prevents `a OUTER JOIN
             // b` from parsing as `a AS outer JOIN b`, instead producing a nice
             // syntax error.

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5533,6 +5533,13 @@ impl<'a> Parser<'a> {
 
     fn parse_update(&mut self) -> Result<Statement<Raw>, ParserError> {
         let table_name = RawItemName::Name(self.parse_item_name()?);
+        // The alias here doesn't support columns, so don't use parse_optional_table_alias.
+        let alias = self.parse_optional_alias(Keyword::is_reserved_in_table_alias)?;
+        let alias = alias.map(|name| TableAlias {
+            name,
+            columns: Vec::new(),
+            strict: false,
+        });
 
         self.expect_keyword(SET)?;
         let assignments = self.parse_comma_separated(Parser::parse_assignment)?;
@@ -5544,6 +5551,7 @@ impl<'a> Parser<'a> {
 
         Ok(Statement::Update(UpdateStatement {
             table_name,
+            alias,
             assignments,
             selection,
         }))

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -132,10 +132,10 @@ fn datadriven() {
                 let stmt = s.into_element();
                 let parsed = match parser::parse_statements(&stmt.to_string()) {
                     Ok(parsed) => parsed.into_element(),
-                    Err(err) => return format!("reparse failed: {}\n", err),
+                    Err(err) => panic!("reparse failed: {}\n", err),
                 };
                 if parsed != stmt {
-                    return format!("reparse comparison failed:\n{:?}\n!=\n{:?}\n", stmt, parsed);
+                    panic!("reparse comparison failed:\n{:?}\n!=\n{:?}\n", stmt, parsed);
                 }
                 if tc.args.get("roundtrip").is_some() {
                     format!("{}\n", stmt)

--- a/src/sql-parser/tests/testdata/update
+++ b/src/sql-parser/tests/testdata/update
@@ -28,4 +28,18 @@ UPDATE t SET a = 1, b = 2, c = 3 WHERE d
 ----
 UPDATE t SET a = 1, b = 2, c = 3 WHERE d
 =>
-Update(UpdateStatement { table_name: Name(UnresolvedItemName([Ident("t")])), assignments: [Assignment { id: Ident("a"), value: Value(Number("1")) }, Assignment { id: Ident("b"), value: Value(Number("2")) }, Assignment { id: Ident("c"), value: Value(Number("3")) }], selection: Some(Identifier([Ident("d")])) })
+Update(UpdateStatement { table_name: Name(UnresolvedItemName([Ident("t")])), alias: None, assignments: [Assignment { id: Ident("a"), value: Value(Number("1")) }, Assignment { id: Ident("b"), value: Value(Number("2")) }, Assignment { id: Ident("c"), value: Value(Number("3")) }], selection: Some(Identifier([Ident("d")])) })
+
+parse-statement
+UPDATE t AS o SET a = 1, b = 2, c = 3 WHERE d
+----
+UPDATE t AS o SET a = 1, b = 2, c = 3 WHERE d
+=>
+Update(UpdateStatement { table_name: Name(UnresolvedItemName([Ident("t")])), alias: Some(TableAlias { name: Ident("o"), columns: [], strict: false }), assignments: [Assignment { id: Ident("a"), value: Value(Number("1")) }, Assignment { id: Ident("b"), value: Value(Number("2")) }, Assignment { id: Ident("c"), value: Value(Number("3")) }], selection: Some(Identifier([Ident("d")])) })
+
+parse-statement
+UPDATE t AS o (x) SET a = 1, b = 2, c = 3 WHERE d
+----
+error: Expected SET, found left parenthesis
+UPDATE t AS o (x) SET a = 1, b = 2, c = 3 WHERE d
+              ^

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -552,7 +552,7 @@ pub fn plan_update_query(
     plan_mutation_query_inner(
         qcx,
         update_stmt.table_name,
-        None,
+        update_stmt.alias,
         vec![],
         update_stmt.assignments,
         update_stmt.selection,

--- a/test/sqllogictest/updates.slt
+++ b/test/sqllogictest/updates.slt
@@ -83,3 +83,24 @@ query I
 SELECT * FROM t1
 ----
 4
+
+# Test UPDATE AS
+
+statement ok
+UPDATE t1 AS m SET x = 5 WHERE m.x < 10
+
+query I
+SELECT * FROM t1
+----
+5
+
+statement ok
+UPDATE t1 AS m SET x = 6 WHERE x < 10
+
+query I
+SELECT * FROM t1
+----
+6
+
+statement error db error: ERROR: column "t1\.x" does not exist
+UPDATE t1 AS m SET x = 5 WHERE t1.x < 10


### PR DESCRIPTION
The plumbing already existed from `DELETE USING`, so only needed a small bit of parsing.

Funnily, this is already in the bnf and docs even though it was not actually supported.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add support for `UPDATE` table aliases: `UPDATE t AS x`.