### PR TITLE
zippy: Add paused clusters and cluster replicas

### DIFF
--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -21,7 +21,7 @@ from materialize.zippy.debezium_capabilities import (
 from materialize.zippy.framework import Action, Capabilities, Capability
 from materialize.zippy.kafka_capabilities import KafkaRunning
 from materialize.zippy.mz_capabilities import MzIsRunning
-from materialize.zippy.storaged_capabilities import StoragedRunning
+from materialize.zippy.storage_capabilities import StorageRunning
 
 
 class DebeziumStart(Action):
@@ -53,7 +53,7 @@ class CreateDebeziumSource(Action):
 
     @classmethod
     def requires(self) -> Set[Type[Capability]]:
-        return {MzIsRunning, StoragedRunning, KafkaRunning, PostgresTableExists}
+        return {MzIsRunning, StorageRunning, KafkaRunning, PostgresTableExists}
 
     def __init__(self, capabilities: Capabilities) -> None:
         # To avoid conflicts, we make sure the postgres table and the debezium source have matching names
@@ -120,7 +120,7 @@ class CreateDebeziumSource(Action):
                     > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (URL '${{testdrive.schema-registry-url}}');
 
                     > CREATE SOURCE {self.debezium_source.name}
-                      IN CLUSTER storaged
+                      IN CLUSTER storage
                       FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.{self.postgres_table.name}')
                       FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                       ENVELOPE DEBEZIUM

--- a/misc/python/materialize/zippy/pg_cdc_actions.py
+++ b/misc/python/materialize/zippy/pg_cdc_actions.py
@@ -17,7 +17,7 @@ from materialize.zippy.framework import Action, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.pg_cdc_capabilities import PostgresCdcTableExists
 from materialize.zippy.postgres_capabilities import PostgresRunning, PostgresTableExists
-from materialize.zippy.storaged_capabilities import StoragedRunning
+from materialize.zippy.storage_capabilities import StorageRunning
 
 
 class CreatePostgresCdcTable(Action):
@@ -25,7 +25,7 @@ class CreatePostgresCdcTable(Action):
 
     @classmethod
     def requires(self) -> Set[Type[Capability]]:
-        return {MzIsRunning, StoragedRunning, PostgresRunning, PostgresTableExists}
+        return {MzIsRunning, StorageRunning, PostgresRunning, PostgresTableExists}
 
     def __init__(self, capabilities: Capabilities) -> None:
         postgres_table = random.choice(capabilities.get(PostgresTableExists))
@@ -74,7 +74,7 @@ class CreatePostgresCdcTable(Action):
                       );
 
                     > CREATE SOURCE {name}_source
-                      IN CLUSTER storaged
+                      IN CLUSTER storage
                       FROM POSTGRES CONNECTION {name}_connection (PUBLICATION '{name}_publication')
                       FOR TABLES ({self.postgres_cdc_table.postgres_table.name} AS {name})
                     """

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -20,7 +20,14 @@ from materialize.zippy.kafka_actions import (
 )
 from materialize.zippy.kafka_capabilities import Envelope
 from materialize.zippy.minio_actions import MinioRestart, MinioStart
-from materialize.zippy.mz_actions import KillClusterd, MzRestart, MzStart, MzStop
+from materialize.zippy.mz_actions import (
+    ComputeStartDisabledCluster,
+    ComputeStartDisabledReplica,
+    KillClusterd,
+    MzRestart,
+    MzStart,
+    MzStop,
+)
 from materialize.zippy.peek_actions import PeekCancellation
 from materialize.zippy.pg_cdc_actions import CreatePostgresCdcTable
 from materialize.zippy.postgres_actions import (
@@ -36,11 +43,7 @@ from materialize.zippy.replica_actions import (
 )
 from materialize.zippy.sink_actions import CreateSinkParameterized
 from materialize.zippy.source_actions import CreateSourceParameterized
-from materialize.zippy.storaged_actions import (
-    StoragedKill,
-    StoragedRestart,
-    StoragedStart,
-)
+from materialize.zippy.storage_actions import StorageKill, StorageRestart, StorageStart
 from materialize.zippy.table_actions import DML, CreateTableParameterized, ValidateTable
 from materialize.zippy.view_actions import CreateViewParameterized, ValidateView
 
@@ -49,7 +52,11 @@ DEFAULT_BOOTSTRAP: List[ActionOrFactory] = [
     CockroachStart,
     MinioStart,
     MzStart,
-    StoragedStart,
+    StorageStart,
+    # Make sure that non-functional clusters and replicas
+    # do not cause an OOM elsewhere in the product.
+    ComputeStartDisabledReplica,
+    ComputeStartDisabledCluster,
 ]
 
 
@@ -64,8 +71,8 @@ class KafkaSources(Scenario):
             MzStart: 5,
             MzStop: 1,
             KillClusterd: 5,
-            StoragedKill: 5,
-            StoragedStart: 5,
+            StorageKill: 5,
+            StorageStart: 5,
             CreateTopicParameterized(): 5,
             CreateSourceParameterized(): 5,
             CreateViewParameterized(max_inputs=2): 5,
@@ -87,7 +94,7 @@ class UserTables(Scenario):
             MzStart: 1,
             MzStop: 15,
             KillClusterd: 10,
-            StoragedRestart: 5,
+            StorageRestart: 5,
             CreateTableParameterized(): 10,
             CreateViewParameterized(): 10,
             CreateSinkParameterized(): 10,
@@ -112,8 +119,8 @@ class DebeziumPostgres(Scenario):
             CreatePostgresTable: 10,
             CreateDebeziumSource: 10,
             KillClusterd: 5,
-            StoragedKill: 5,
-            StoragedStart: 5,
+            StorageKill: 5,
+            StorageStart: 5,
             CreateViewParameterized(): 10,
             ValidateView: 20,
             PostgresDML: 100,
@@ -131,8 +138,8 @@ class PostgresCdc(Scenario):
             CreatePostgresTable: 10,
             CreatePostgresCdcTable: 10,
             KillClusterd: 5,
-            StoragedKill: 5,
-            StoragedStart: 5,
+            StorageKill: 5,
+            StorageStart: 5,
             PostgresRestart: 10,
             CreateViewParameterized(): 10,
             ValidateView: 20,
@@ -154,7 +161,7 @@ class ClusterReplicas(Scenario):
     def config(self) -> Dict[ActionOrFactory, float]:
         return {
             KillClusterd: 5,
-            StoragedRestart: 5,
+            StorageRestart: 5,
             CreateReplica: 30,
             DropReplica: 10,
             CreateTopicParameterized(): 10,
@@ -178,8 +185,8 @@ class KafkaParallelInsert(Scenario):
     def config(self) -> Dict[ActionOrFactory, float]:
         return {
             KillClusterd: 5,
-            StoragedKill: 5,
-            StoragedStart: 5,
+            StorageKill: 5,
+            StorageStart: 5,
             CreateTopicParameterized(): 10,
             CreateSourceParameterized(): 10,
             CreateViewParameterized(expensive_aggregates=False, max_inputs=1): 5,
@@ -206,7 +213,7 @@ class CrdbMinioRestart(Scenario):
             ValidateView: 15,
             MzRestart: 5,
             KillClusterd: 5,
-            StoragedRestart: 10,
+            StorageRestart: 10,
             CockroachRestart: 15,
             MinioRestart: 15,
         }
@@ -230,7 +237,7 @@ class CrdbRestart(Scenario):
             ValidateView: 15,
             MzRestart: 5,
             KillClusterd: 5,
-            StoragedRestart: 10,
+            StorageRestart: 10,
             CockroachRestart: 15,
         }
 
@@ -305,8 +312,8 @@ class PostgresCdcLarge(Scenario):
             CreatePostgresTable: 10,
             CreatePostgresCdcTable: 10,
             KillClusterd: 5,
-            StoragedKill: 5,
-            StoragedStart: 5,
+            StorageKill: 5,
+            StorageStart: 5,
             CreateViewParameterized(): 10,
             ValidateView: 20,
             PostgresDML: 100,

--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -15,7 +15,7 @@ from materialize.mzcompose import Composition
 from materialize.zippy.framework import Action, ActionFactory, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.sink_capabilities import SinkExists
-from materialize.zippy.storaged_capabilities import StoragedRunning
+from materialize.zippy.storage_capabilities import StorageRunning
 from materialize.zippy.view_capabilities import ViewExists
 
 
@@ -24,7 +24,7 @@ class CreateSinkParameterized(ActionFactory):
 
     @classmethod
     def requires(self) -> List[Set[Type[Capability]]]:
-        return [{MzIsRunning, StoragedRunning, ViewExists}]
+        return [{MzIsRunning, StorageRunning, ViewExists}]
 
     def __init__(self, max_sinks: int = 10) -> None:
         self.max_sinks = max_sinks
@@ -106,7 +106,7 @@ class CreateSink(Action):
                 # Ingest the sink again in order to be able to validate its contents
 
                 > CREATE SOURCE {self.sink.name}_source
-                  IN CLUSTER storaged
+                  IN CLUSTER storage
                   FROM KAFKA CONNECTION {self.sink.name}_kafka_conn (TOPIC 'sink-{self.sink.name}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {self.sink.name}_csr_conn
                   ENVELOPE NONE

--- a/misc/python/materialize/zippy/source_actions.py
+++ b/misc/python/materialize/zippy/source_actions.py
@@ -16,7 +16,7 @@ from materialize.zippy.framework import Action, ActionFactory, Capabilities, Cap
 from materialize.zippy.kafka_capabilities import KafkaRunning, TopicExists
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.source_capabilities import SourceExists
-from materialize.zippy.storaged_capabilities import StoragedRunning
+from materialize.zippy.storage_capabilities import StorageRunning
 
 
 class CreateSourceParameterized(ActionFactory):
@@ -24,7 +24,7 @@ class CreateSourceParameterized(ActionFactory):
 
     @classmethod
     def requires(self) -> Set[Type[Capability]]:
-        return {MzIsRunning, StoragedRunning, KafkaRunning, TopicExists}
+        return {MzIsRunning, StorageRunning, KafkaRunning, TopicExists}
 
     def __init__(self, max_sources: int = 10) -> None:
         self.max_sources = max_sources
@@ -65,7 +65,7 @@ class CreateSource(Action):
                   TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
 
                 > CREATE SOURCE {self.source.name}
-                  IN CLUSTER storaged
+                  IN CLUSTER storage
                   FROM KAFKA CONNECTION {self.source.name}_kafka_conn
                   (TOPIC 'testdrive-{self.source.topic.name}-${{testdrive.seed}}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {self.source.name}_csr_conn

--- a/misc/python/materialize/zippy/storage_actions.py
+++ b/misc/python/materialize/zippy/storage_actions.py
@@ -14,42 +14,42 @@ from materialize.zippy.crdb_capabilities import CockroachIsRunning
 from materialize.zippy.framework import Action, Capability
 from materialize.zippy.minio_capabilities import MinioIsRunning
 from materialize.zippy.mz_capabilities import MzIsRunning
-from materialize.zippy.storaged_capabilities import StoragedRunning
+from materialize.zippy.storage_capabilities import StorageRunning
 
 
-class StoragedStart(Action):
-    """Starts a storaged clusterd instance."""
+class StorageStart(Action):
+    """Starts a storage clusterd instance."""
 
     @classmethod
     def requires(self) -> Set[Type[Capability]]:
         return {CockroachIsRunning, MinioIsRunning}
 
     def run(self, c: Composition) -> None:
-        c.up("storaged")
+        c.up("storage")
 
     def provides(self) -> List[Capability]:
-        return [StoragedRunning()]
+        return [StorageRunning()]
 
 
-class StoragedRestart(Action):
-    """Restarts the entire storaged clusterd instance."""
+class StorageRestart(Action):
+    """Restarts the entire storage clusterd instance."""
 
     @classmethod
     def requires(self) -> Set[Type[Capability]]:
-        return {MzIsRunning, StoragedRunning}
+        return {MzIsRunning, StorageRunning}
 
     def run(self, c: Composition) -> None:
-        c.kill("storaged")
-        c.up("storaged")
+        c.kill("storage")
+        c.up("storage")
 
 
-class StoragedKill(Action):
+class StorageKill(Action):
     @classmethod
     def requires(self) -> Set[Type[Capability]]:
-        return {MzIsRunning, StoragedRunning}
+        return {MzIsRunning, StorageRunning}
 
     def run(self, c: Composition) -> None:
-        c.kill("storaged")
+        c.kill("storage")
 
     def withholds(self) -> Set[Type[Capability]]:
-        return {StoragedRunning}
+        return {StorageRunning}

--- a/misc/python/materialize/zippy/storage_capabilities.py
+++ b/misc/python/materialize/zippy/storage_capabilities.py
@@ -10,5 +10,5 @@
 from materialize.zippy.framework import Capability
 
 
-class StoragedRunning(Capability):
+class StorageRunning(Capability):
     pass

--- a/misc/python/materialize/zippy/view_actions.py
+++ b/misc/python/materialize/zippy/view_actions.py
@@ -17,7 +17,7 @@ from materialize.zippy.framework import Action, ActionFactory, Capabilities, Cap
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.pg_cdc_capabilities import PostgresCdcTableExists
 from materialize.zippy.source_capabilities import SourceExists
-from materialize.zippy.storaged_capabilities import StoragedRunning
+from materialize.zippy.storage_capabilities import StorageRunning
 from materialize.zippy.table_capabilities import TableExists
 from materialize.zippy.view_capabilities import ViewExists, WatermarkedObjects
 
@@ -127,7 +127,7 @@ class ValidateView(Action):
 
     @classmethod
     def requires(self) -> Set[Type[Capability]]:
-        return {MzIsRunning, StoragedRunning, ViewExists}
+        return {MzIsRunning, StorageRunning, ViewExists}
 
     def __init__(self, capabilities: Capabilities) -> None:
         self.view = random.choice(capabilities.get(ViewExists))

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -40,7 +40,10 @@ SERVICES = [
     Minio(setup_materialize=True),
     # Those two are overriden below
     Materialized(),
-    Clusterd(name="storaged"),
+    Clusterd(name="storage"),
+    Clusterd(name="storage_replica_disabled"),
+    Clusterd(name="compute_replica_disabled"),
+    Clusterd(name="cluster_disabled"),
     Testdrive(),
     Grafana(),
     Prometheus(),
@@ -167,11 +170,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         c.sql(
             """
-            CREATE CLUSTER storaged REPLICAS (r2 (
-                STORAGECTL ADDRESSES ['storaged:2100'],
-                STORAGE ADDRESSES ['storaged:2103'],
-                COMPUTECTL ADDRESSES ['storaged:2101'],
-                COMPUTE ADDRESSES ['storaged:2102'],
+            CREATE CLUSTER storage REPLICAS (r2 (
+                STORAGECTL ADDRESSES ['storage:2100'],
+                STORAGE ADDRESSES ['storage:2103'],
+                COMPUTECTL ADDRESSES ['storage:2101'],
+                COMPUTE ADDRESSES ['storage:2102'],
                 WORKERS 4
             ))
         """


### PR DESCRIPTION
Add a paused cluster and a paused cluster replica that live for the duration of the test in order to detect any issues that may occur, such as OOMs.

Remove mentions of 'storaged' and 'computed' from the code, as those concepts no longer exist in the product.

Relates to: #19246

### Motivation

This is part of the testing for PubSub, but is generally a good thing to test. In order to not have a dedicated long-running test just for that, we will deputize all existing Zippy tests.