### PR TITLE
platform-checks: Wait for snapshot in older versions too

### DIFF
--- a/misc/python/materialize/checks/pg_cdc.py
+++ b/misc/python/materialize/checks/pg_cdc.py
@@ -73,7 +73,7 @@ class PgCdc(Check):
                 INSERT INTO postgres_source_table SELECT 'C', i, REPEAT('C', 1024 - i) FROM generate_series(1,100) AS i;
                 UPDATE postgres_source_table SET f2 = f2 + 100;
                 # Wait until Pg snapshot is complete in order to avoid #18940
-                >[version>=4601] SELECT COUNT(*) > 0 FROM postgres_source_tableA
+                > SELECT COUNT(*) > 0 FROM postgres_source_tableA
                 true
                 """,
                 """
@@ -119,9 +119,9 @@ class PgCdc(Check):
                 INSERT INTO postgres_source_table SELECT 'H', i, REPEAT('X', 1024 - i) FROM generate_series(1,100) AS i;
                 UPDATE postgres_source_table SET f2 = f2 + 100;
                 # Wait until Pg snapshot is complete in order to avoid #18940
-                >[version>=4601] SELECT COUNT(*) > 0 FROM postgres_source_tableB
+                > SELECT COUNT(*) > 0 FROM postgres_source_tableB
                 true
-                >[version>=4601] SELECT COUNT(*) > 0 FROM postgres_source_tableC
+                > SELECT COUNT(*) > 0 FROM postgres_source_tableC
                 true
                 """,
             ]


### PR DESCRIPTION
Fixes #19703

See more details in https://github.com/MaterializeInc/materialize/issues/18940

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
