### PR TITLE
sql: fix normalization of cluster names in CREATE CLUSTER REPLICA

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2900,7 +2900,9 @@ pub fn plan_create_cluster_replica(
         of_cluster,
     }: CreateClusterReplicaStatement<Aug>,
 ) -> Result<Plan, PlanError> {
-    let cluster = scx.catalog.resolve_cluster(Some(&of_cluster.to_string()))?;
+    let cluster = scx
+        .catalog
+        .resolve_cluster(Some(&normalize::ident(of_cluster)))?;
     if is_storage_cluster(scx, cluster)
         && cluster.bound_objects().len() > 0
         && cluster.replica_ids().len() > 0

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -453,6 +453,18 @@ statement ok
 DROP CLUSTER REPLICA default."foo-bar"
 
 statement ok
+CREATE CLUSTER "foo-bar" REPLICAS ()
+
+statement ok
+CREATE CLUSTER REPLICA "foo-bar"."foo-bar" SIZE '1'
+
+statement ok
+DROP CLUSTER REPLICA "foo-bar"."foo-bar"
+
+statement ok
+DROP CLUSTER "foo-bar"
+
+statement ok
 CREATE CLUSTER REPLICA default."好-好" SIZE '1'
 
 statement ok


### PR DESCRIPTION
We were failing to normalize cluster names in `CREATE CLUSTER REPLICA` statements, which made it impossible to create a replica of a cluster whose name contained characters that could not be represented as a bare ident (e.g., "foo-bar").

### Motivation

  * This PR fixes a recognized bug.

    Fixes https://github.com/MaterializeInc/terraform-provider-materialize/issues/173.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - `CREATE CLUSTER REPLICA` now correctly handles creating replicas of clusters whose names require escaping.
