### PR TITLE
persist: dynamic knobs for enabling/disabling compaction and GC

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6899,9 +6899,11 @@ impl Catalog {
         PersistParameters {
             blob_target_size: Some(config.persist_blob_target_size()),
             blob_cache_mem_limit_bytes: Some(config.persist_blob_cache_mem_limit_bytes()),
+            compaction_enabled: Some(config.persist_compaction_enabled()),
             compaction_minimum_timeout: Some(config.persist_compaction_minimum_timeout()),
             consensus_connect_timeout: Some(config.crdb_connect_timeout()),
             consensus_tcp_user_timeout: Some(config.crdb_tcp_user_timeout()),
+            gc_enabled: Some(config.persist_gc_enabled()),
             sink_minimum_batch_updates: Some(config.persist_sink_minimum_batch_updates()),
             storage_sink_minimum_batch_updates: Some(
                 config.storage_persist_sink_minimum_batch_updates(),

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -28,6 +28,8 @@ message ProtoPersistParameters {
     mz_proto.ProtoDuration consensus_tcp_user_timeout = 12;
     optional uint64 rollup_threshold = 13;
     optional uint64 blob_cache_mem_limit_bytes = 14;
+    optional bool compaction_enabled = 15;
+    optional bool gc_enabled = 16;
 }
 
 message ProtoRetryParameters {

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -11,7 +11,6 @@ use std::cmp::Reverse;
 use std::collections::{BinaryHeap, VecDeque};
 use std::fmt::Debug;
 use std::marker::PhantomData;
-use std::ops::Not;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -11,6 +11,7 @@ use std::cmp::Reverse;
 use std::collections::{BinaryHeap, VecDeque};
 use std::fmt::Debug;
 use std::marker::PhantomData;
+use std::ops::Not;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -225,6 +226,10 @@ where
         req: CompactReq<T>,
         machine: &Machine<K, V, T, D>,
     ) -> Option<oneshot::Receiver<Result<ApplyMergeResult, anyhow::Error>>> {
+        if !self.cfg.dynamic.compaction_enabled() {
+            return None;
+        }
+
         // Run some initial heuristics to ignore some requests for compaction.
         // We don't gain much from e.g. compacting two very small batches that
         // were just written, but it does result in non-trivial blob traffic

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -13,7 +13,6 @@ use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::mem;
-use std::ops::Not;
 use std::sync::Arc;
 use std::time::Instant;
 

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1798,7 +1798,7 @@ pub mod tests {
                 .expect("invalid usage")
                 .expect("unexpected upper");
             writer_maintenance
-                .perform(&write.machine, &write.gc, write.compact.as_ref())
+                .perform(&write.machine, &write.gc, &write.compact)
                 .await;
         }
         let live_diffs = write

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -708,7 +708,6 @@ mod tests {
     use tokio::task::JoinHandle;
 
     use crate::cache::PersistClientCache;
-    use crate::cfg::DynamicConfig;
     use crate::error::{CodecConcreteType, CodecMismatch, UpperMismatch};
     use crate::internal::paths::BlobKey;
     use crate::read::ListenEvent;
@@ -780,7 +779,7 @@ mod tests {
     pub fn new_test_client_cache() -> PersistClientCache {
         // Configure an aggressively small blob_target_size so we get some
         // amount of coverage of that in tests. Similarly, for max_outstanding.
-        let mut cache = PersistClientCache::new_no_metrics();
+        let cache = PersistClientCache::new_no_metrics();
         cache.cfg.dynamic.set_blob_target_size(10);
         cache.cfg.dynamic.set_batch_builder_max_outstanding_parts(1);
         // Enable compaction in tests to ensure we get coverage.

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -902,7 +902,7 @@ mod tests {
         ];
 
         let shard_id = ShardId::new();
-        let mut client = new_test_client().await;
+        let client = new_test_client().await;
         let mut params = PersistParameters::default();
         // make things interesting and create multiple parts per batch
         params.blob_target_size = Some(0);

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -903,11 +903,11 @@ mod tests {
 
         let shard_id = ShardId::new();
         let mut client = new_test_client().await;
-        // make our bookkeeping simple by skipping compaction blobs writes
-        client.cfg.compaction_enabled = false;
-        // make things interesting and create multiple parts per batch
         let mut params = PersistParameters::default();
+        // make things interesting and create multiple parts per batch
         params.blob_target_size = Some(0);
+        // make our bookkeeping simple by skipping compaction blobs writes
+        params.compaction_enabled = Some(false);
         params.apply(&client.cfg);
 
         let (mut write, _read) = client

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -132,7 +132,7 @@ where
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) machine: Machine<K, V, T, D>,
     pub(crate) gc: GarbageCollector<K, V, T, D>,
-    pub(crate) compact: Option<Compactor<K, V, T, D>>,
+    pub(crate) compact: Compactor<K, V, T, D>,
     pub(crate) blob: Arc<dyn Blob + Send + Sync>,
     pub(crate) cpu_heavy_runtime: Arc<CpuHeavyRuntime>,
     pub(crate) writer_id: WriterId,
@@ -157,7 +157,7 @@ where
         metrics: Arc<Metrics>,
         machine: Machine<K, V, T, D>,
         gc: GarbageCollector<K, V, T, D>,
-        compact: Option<Compactor<K, V, T, D>>,
+        compact: Compactor<K, V, T, D>,
         blob: Arc<dyn Blob + Send + Sync>,
         cpu_heavy_runtime: Arc<CpuHeavyRuntime>,
         writer_id: WriterId,
@@ -492,7 +492,7 @@ where
             }
         };
 
-        maintenance.start_performing(&self.machine, &self.gc, self.compact.as_ref());
+        maintenance.start_performing(&self.machine, &self.gc, &self.compact);
 
         Ok(Ok(()))
     }

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -23,7 +23,10 @@ from materialize.mzcompose.services import (
     Zookeeper,
 )
 
-materialized_environment_extra = ["MZ_PERSIST_COMPACTION_DISABLED=false"]
+materialized_additional_system_parameter_defaults = {
+    "upsert_source_disk_default": "true",
+    "enable_unmanaged_cluster_replicas": "true",
+}
 
 SERVICES = [
     Zookeeper(),
@@ -33,11 +36,7 @@ SERVICES = [
         options=[
             "--orchestrator-process-scratch-directory=/mzdata/source_data",
         ],
-        additional_system_parameter_defaults={
-            "upsert_source_disk_default": "true",
-            "enable_unmanaged_cluster_replicas": "true",
-        },
-        environment_extra=materialized_environment_extra,
+        additional_system_parameter_defaults=materialized_additional_system_parameter_defaults,
     ),
     Testdrive(),
     Clusterd(
@@ -53,12 +52,14 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument(
         "--compaction-disabled",
         action="store_true",
-        help="Run with MZ_PERSIST_COMPACTION_DISABLED",
+        help="Run with `persist_compaction_enabled: false`",
     )
     args = parser.parse_args()
 
     if args.compaction_disabled:
-        materialized_environment_extra[0] = "MZ_PERSIST_COMPACTION_DISABLED=true"
+        materialized_additional_system_parameter_defaults[
+            "persist_compaction_enabled"
+        ] = "false"
 
     for name in [
         "rehydration",


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

I've wanted these knobs for a while both for testing and as an insurance policy against rolling out very bad compaction / GC bugs (right now I'm pondering how to write an interesting test for incremental GC, and I think we want to disable GC for a while to let it build up work first)

cc @MaterializeInc/qa once this merged, we'll be able to dynamically enable/disable persist compaction and GC to test more interesting scenarios:

```
ALTER SYSTEM SET persist_compaction_enabled = 'off';
ALTER SYSTEM SET persist_gc_enabled = 'off';
```

### Motivation

Related to https://github.com/MaterializeInc/materialize/issues/19102

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
