### PR TITLE
sql: Add pg_is_in_recovery and pg_tablespace_location Functions

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -779,8 +779,12 @@
     description: Returns the underlying SELECT command for the given view.
   - signature: 'pg_get_viewdef(view_oid: oid[, wrap_column: integer]) -> text'
     description: Returns the underlying SELECT command for the given view.
+  - signature: 'pg_is_in_recovery() -> bool'
+    description: Returns if the a recovery is still in progress.
   - signature: 'pg_table_is_visible(relation: oid) -> boolean'
     description: Reports whether the relation with the specified OID is visible in the search path.
+  - signature: 'pg_tablespace_location(tablespace: oid) -> text'
+    description: Returns the path in the file system that the provided tablespace is on.
   - signature: 'pg_type_is_visible(relation: oid) -> boolean'
     description: Reports whether the type with the specified OID is visible in the search path.
   - signature: 'pg_function_is_visible(relation: oid) -> boolean'

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2242,6 +2242,13 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                 END"
             ) => String, 1642;
         },
+        // pg_is_in_recovery indicates whether a recovery is still in progress. Materialize does
+        // not have a concept of recovery, so we default to always returning false.
+        "pg_is_in_recovery" => Scalar {
+            params!() => Operation::nullary(|_ecx| {
+                Ok(HirScalarExpr::literal_false())
+            }) => Bool, 3810;
+        },
         "pg_postmaster_start_time" => Scalar {
             params!() => UnmaterializableFunc::PgPostmasterStartTime => TimestampTz, 2560;
         },
@@ -2265,6 +2272,14 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                      FROM mz_catalog.mz_functions f JOIN mz_catalog.mz_schemas s ON f.schema_id = s.id
                      WHERE f.oid = $1)"
             ) => Bool, 2081;
+        },
+        // pg_tablespace_location indicates what path in the filesystem that a given tablespace is
+        // located in. This concept does not make sense though in Materialize which is a cloud
+        // native database, so we just return the null value.
+        "pg_tablespace_location" => Scalar {
+            params!(Oid) => Operation::unary(|_ecx, _e| {
+                Ok(HirScalarExpr::literal_null(ScalarType::String))
+            }) => String, 3778;
         },
         "pg_typeof" => Scalar {
             params!(Any) => Operation::new(|ecx, exprs, params, _order_by| {

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1572,3 +1572,13 @@ query B
 SELECT pg_backend_pid() > 0
 ----
 true
+
+query B
+SELECT pg_is_in_recovery()
+----
+false
+
+query B
+SELECT pg_tablespace_location(0) IS NULL
+----
+true


### PR DESCRIPTION
### Motivation

Makes progress towards #9720 

This PR adds two Postgres functions, `pg_is_in_recovery()` and `pg_tablespace_location(oid)`. 

* `pg_is_in_recovery`, returns whether or not the database is currently in the middle of recovering. Materialize does not have this concept so we always return `false`.
* `pg_tablespace_location`, returns the path on the filesystem that contains the provided tablespace. Materialize is a cloud native database, so there is no filesystem path to return, so we default to `NULL`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This PR adds support for `pg_catalog.pg_is_in_recovery()` and `pg_catalog.pg_tablespace_location(oid)`. Neither concepts exist in Materialize so both return default values, but tools that expect these functions to exist will now work.
