### PR TITLE
docs: Various pg_catalog

### DIFF
--- a/doc/user/content/sql/system-catalog/pg_catalog.md
+++ b/doc/user/content/sql/system-catalog/pg_catalog.md
@@ -10,6 +10,7 @@ menu:
 Materialize has compatibility shims for the following relations from [PostgreSQL's
 system catalog](https://www.postgresql.org/docs/current/catalogs.html):
 
+  * [`pg_aggregate`](https://www.postgresql.org/docs/current/catalog-pg-aggregate.html)
   * [`pg_am`](https://www.postgresql.org/docs/current/catalog-pg-am.html)
   * [`pg_attribute`](https://www.postgresql.org/docs/current/catalog-pg-attribute.html)
   * [`pg_auth_members`](https://www.postgresql.org/docs/current/catalog-pg-auth-members.html)
@@ -22,6 +23,7 @@ system catalog](https://www.postgresql.org/docs/current/catalogs.html):
   * [`pg_extension`](https://www.postgresql.org/docs/current/catalog-pg-extension.html)
   * [`pg_index`](https://www.postgresql.org/docs/current/catalog-pg-index.html)
   * [`pg_inherits`](https://www.postgresql.org/docs/current/catalog-pg-inherits.html)
+  * [`pg_locks`](https://www.postgresql.org/docs/current/view-pg-locks.html)
   * [`pg_matviews`](https://www.postgresql.org/docs/current/view-pg-matviews.html)
   * [`pg_namespace`](https://www.postgresql.org/docs/current/catalog-pg-namespace.html)
   * [`pg_policy`](https://www.postgresql.org/docs/current/catalog-pg-policy.html)
@@ -32,6 +34,7 @@ system catalog](https://www.postgresql.org/docs/current/catalogs.html):
   * [`pg_settings`](https://www.postgresql.org/docs/current/view-pg-settings.html)
   * [`pg_tables`](https://www.postgresql.org/docs/current/view-pg-tables.html)
   * [`pg_tablespace`](https://www.postgresql.org/docs/current/catalog-pg-tablespace.html)
+  * [`pg_trigger`](https://www.postgresql.org/docs/current/catalog-pg-trigger.html)
   * [`pg_type`](https://www.postgresql.org/docs/current/catalog-pg-type.html)
   * [`pg_views`](https://www.postgresql.org/docs/current/view-pg-views.html)
   * [`pg_authid`](https://www.postgresql.org/docs/current/catalog-pg-authid.html)

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -445,6 +445,9 @@
   description: Time functions take or produce a time-like type, e.g. [`date`](../types/date),
     [`timestamp`](../types/timestamp), [`timestamp with time zone`](../types/timestamptz).
   functions:
+  - signature: 'age(timestamp, timestamp) -> interval'
+    description: 'Subtracts one timestamp from another, producing a "symbolic" result that uses years and months, rather than just days.'
+
   - signature: current_timestamp() -> timestamptz
     description: 'The `timestamp with time zone` representing when the query was executed.'
     unmaterializable: true


### PR DESCRIPTION
### Motivation

This PR updates the docs for recently added Postgres tables and functions. The original changes were in #19686, #19684, #19424, and #19423

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
