### PR TITLE
sql: Prevent changing isolation levels mid-txn

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -78,6 +78,8 @@ pub enum AdapterError {
         size: String,
         expected: Vec<String>,
     },
+    /// SET TRANSACTION ISOLATION LEVEL was called in the middle of a transaction.
+    InvalidSetIsolationLevel,
     /// No such storage instance size has been configured.
     InvalidStorageClusterSize {
         size: String,
@@ -387,6 +389,10 @@ impl fmt::Display for AdapterError {
             AdapterError::InvalidClusterReplicaSize { size, expected: _ } => {
                 write!(f, "unknown cluster replica size {size}",)
             }
+            AdapterError::InvalidSetIsolationLevel => write!(
+                f,
+                "SET TRANSACTION ISOLATION LEVEL must be called before any query"
+            ),
             AdapterError::InvalidStorageClusterSize { size, .. } => {
                 write!(f, "unknown source size {size}")
             }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -888,6 +888,14 @@ impl<T> TransactionStatus<T> {
             | TransactionStatus::Failed(txn) => txn.timeline(),
         }
     }
+
+    /// Reports whether any operations have been executed as part of this transaction
+    pub fn contains_ops(&self) -> bool {
+        match self.inner() {
+            Some(txn) => txn.contains_ops(),
+            None => false,
+        }
+    }
 }
 
 /// An abstraction allowing us to identify different transactions.
@@ -934,6 +942,11 @@ impl<T> Transaction<T> {
             | TransactionOps::Subscribe
             | TransactionOps::Writes(_) => None,
         }
+    }
+
+    /// Reports whether any operations have been executed as part of this transaction
+    fn contains_ops(&self) -> bool {
+        !matches!(self.ops, TransactionOps::None)
     }
 }
 

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -333,6 +333,7 @@ impl ErrorResponse {
             AdapterError::InvalidLogDependency { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::InvalidClusterReplicaAz { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::InvalidClusterReplicaSize { .. } => SqlState::FEATURE_NOT_SUPPORTED,
+            AdapterError::InvalidSetIsolationLevel => SqlState::ACTIVE_SQL_TRANSACTION,
             AdapterError::InvalidStorageClusterSize { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::SourceOrSinkSizeRequired { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::InvalidTableMutationSelection => SqlState::INVALID_TRANSACTION_STATE,

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -688,7 +688,6 @@ SET TRANSACTION_ISOLATION TO serializable
 statement ok
 SELECT * FROM t
 
-# PostgreSQL does not return an error here (though it might be a bug).
 statement error SET TRANSACTION ISOLATION LEVEL must be called before any query
 RESET TRANSACTION_ISOLATION
 

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -654,3 +654,15 @@ SELECT * FROM t AS OF AT LEAST 1683131452106;
 
 statement ok
 COMMIT
+
+statement ok
+BEGIN
+
+statement ok
+SELECT * FROM t
+
+statement error SET TRANSACTION ISOLATION LEVEL must be called before any query
+SET TRANSACTION_ISOLATION TO serializable
+
+statement ok
+ROLLBACK

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -666,3 +666,31 @@ SET TRANSACTION_ISOLATION TO serializable
 
 statement ok
 ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+SELECT * FROM t
+
+statement error SET TRANSACTION ISOLATION LEVEL must be called before any query
+SET TRANSACTION ISOLATION LEVEL serializable
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+SET TRANSACTION_ISOLATION TO serializable
+
+statement ok
+SELECT * FROM t
+
+# PostgreSQL does not return an error here (though it might be a bug).
+statement error SET TRANSACTION ISOLATION LEVEL must be called before any query
+RESET TRANSACTION_ISOLATION
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
This commit will prevent users from changing isolation levels in the middle of a transaction

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Prevent changing isolation levels in the middle of a transaction.
