### PR TITLE
persist: fix build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,9 @@ name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -32,7 +32,7 @@ bench = false
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 async-stream = "0.3.3"
 async-trait = "0.1.68"
-bytes = "1.3.0"
+bytes = { version = "1.3.0", features = ["serde"] }
 clap = { version = "3.2.24", features = [ "derive" ] }
 differential-dataflow = "0.12.0"
 futures = "0.3.25"

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -24,7 +24,7 @@ axum = { version = "0.6.7", features = ["headers", "ws"] }
 base64 = { version = "0.13.1", features = ["alloc"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
-bytes = { version = "1.3.0" }
+bytes = { version = "1.3.0", features = ["serde"] }
 chrono = { version = "0.4.24", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
@@ -121,7 +121,7 @@ axum = { version = "0.6.7", features = ["headers", "ws"] }
 base64 = { version = "0.13.1", features = ["alloc"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
-bytes = { version = "1.3.0" }
+bytes = { version = "1.3.0", features = ["serde"] }
 cc = { version = "1.0.78", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.24", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }


### PR DESCRIPTION
Looks like a "ships passing" error with #19636, slash persist was accidentally relying on a feature of the "bytes" crate that it wasn't declaring.

### Motivation
  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
