### PR TITLE
adapter: Fix temporary object handling in alters

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5985,11 +5985,13 @@ impl Catalog {
                             builtin_table_updates.extend(state.pack_item_update(id, -1));
                             let entry = state.get_entry_mut(&id);
                             update_privilege_fn(&mut entry.privileges, privilege);
-                            tx.update_item(
-                                id,
-                                &entry.name().item,
-                                &Self::serialize_item(entry.item()),
-                            )?;
+                            if !entry.item().is_temporary() {
+                                tx.update_item(
+                                    id,
+                                    &entry.name().item,
+                                    &Self::serialize_item(entry.item()),
+                                )?;
+                            }
                             builtin_table_updates.extend(state.pack_item_update(id, 1));
                         }
                         ObjectId::Role(_) | ObjectId::ClusterReplica(_) => {}
@@ -6226,11 +6228,13 @@ impl Catalog {
                             new_owner,
                         );
                         entry.owner_id = new_owner;
-                        tx.update_item(
-                            id,
-                            &entry.name().item,
-                            &Self::serialize_item(entry.item()),
-                        )?;
+                        if !entry.item().is_temporary() {
+                            tx.update_item(
+                                id,
+                                &entry.name().item,
+                                &Self::serialize_item(entry.item()),
+                            )?;
+                        }
                         builtin_table_updates.extend(state.pack_item_update(id, 1));
                     }
                     ObjectId::Role(_) => unreachable!("roles have no owner"),

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -2360,6 +2360,14 @@ query T
 SELECT name FROM mz_cluster_replicas WHERE name = 'replica1'
 ----
 
+## Test dropping temporary objects
+
+statement ok
+CREATE TEMP VIEW v AS SELECT 1
+
+statement ok
+DROP OWNED BY materialize
+
 ## Test dropping system objects
 
 simple conn=mz_system,user=mz_system
@@ -2494,6 +2502,19 @@ SELECT mz_roles.name
   WHERE mz_cluster_replicas.name = 'replica1'
 ----
 group1
+
+## Test reassigning temporary objects. It's weird that this is allowed, but it is.
+
+simple conn=mz_system,user=mz_system
+GRANT joe TO materialize
+----
+COMPLETE 0
+
+statement ok
+CREATE TEMPORARY VIEW v AS SELECT 1
+
+statement ok
+REASSIGN OWNED BY materialize TO joe
 
 ## Test reassigning system objects
 


### PR DESCRIPTION
This commit fixes how `DROP OWNED BY` and `REASSIGN OWNED BY` handle temporary objects. Previously, they were trying to update the stash state for temporary objects, but the stash doesn't store temporary objects. Now, those commands don't try and update the stash state for temporary objects.

Fixes #19730

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
