### PR TITLE
[persist] Stats trimming on Proto directly

### DIFF
--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1046,16 +1046,15 @@ pub struct LazyPartStats {
     key: LazyProto<ProtoStructStats>,
 }
 
-impl From<&PartStats> for LazyPartStats {
-    fn from(x: &PartStats) -> Self {
+impl LazyPartStats {
+    pub fn encode(x: &PartStats, map_proto: impl FnOnce(&mut ProtoStructStats)) -> Self {
         let PartStats { key } = x;
+        let mut proto_stats = ProtoStructStats::from_rust(key);
+        map_proto(&mut proto_stats);
         LazyPartStats {
-            key: LazyProto::from(&ProtoStructStats::from_rust(key)),
+            key: LazyProto::from(&proto_stats),
         }
     }
-}
-
-impl LazyPartStats {
     /// Decodes and returns PartStats from the encoded representation.
     ///
     /// This does not cache the returned value, it decodes each time it's
@@ -1089,7 +1088,7 @@ impl Arbitrary for LazyPartStats {
 
     fn arbitrary_with(_: ()) -> Self::Strategy {
         Strategy::prop_map((proptest::prelude::any::<PartStats>()), |(x)| {
-            LazyPartStats::from(&x)
+            LazyPartStats::encode(&x, |_| {})
         })
     }
 }

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 arrow2 = { version = "0.16.0", features = ["compute_aggregate", "io_ipc", "io_parquet"] }
 bytes = "1.3.0"
-mz-ore = { path = "../ore", features = [] }
+mz-ore = { path = "../ore", features = ["test"] }
 mz-proto = { path = "../proto" }
 parquet2 = { version = "0.17.1", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -208,7 +208,9 @@ mod tests {
     use mz_persist_types::codec_impls::UnitSchema;
     use mz_persist_types::columnar::{Data, PartEncoder};
     use mz_persist_types::part::PartBuilder;
-    use mz_persist_types::stats::{ColumnStats, DynStats, StructStats};
+    use mz_persist_types::stats::{
+        ColumnStats, DynStats, ProtoStructStats, StructStats, TrimStats,
+    };
     use mz_proto::RustType;
     use proptest::prelude::*;
 
@@ -230,13 +232,14 @@ mod tests {
         }
         let part = part.finish().unwrap();
         let expected = part.key_stats().unwrap();
-        let mut actual = StructStats::from_proto(RustType::into_proto(&expected)).unwrap();
+        let mut actual: ProtoStructStats = RustType::into_proto(&expected);
         // It's not particularly easy to give StructStats a PartialEq impl, but
         // verifying that there weren't any panics gets us pretty far.
 
         // Sanity check that trimming the stats doesn't cause them to be invalid
         // (regression for a bug we had that caused panic at stats usage time).
-        actual.trim_to_budget(0, |_| true);
+        actual.trim();
+        let actual: StructStats = RustType::from_proto(actual).unwrap();
         for (name, typ) in schema.iter() {
             struct ColMinMaxNulls<'a>(&'a dyn DynStats);
             impl<'a> DatumToPersistFn<()> for ColMinMaxNulls<'a> {


### PR DESCRIPTION
We couldn't think of a better way to quantify cost than the encoded size of the relevant protos, so it ends up being cleaner to think of trimming as operating on protos directly instead of re-encoding or estimating.

### Motivation

MFP burndown: #19292.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
