### PR TITLE
[persist] Use conservative f64 bounds on our numeric stats

### DIFF
--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -291,6 +291,7 @@ pub enum JsonStats {
     /// The min and max strings, or None if there were none.
     Strings(PrimitiveStats<String>),
     /// Lower and upper bounds on the numerics, or None if there were none.
+    // TODO: PrimitiveStats<Decimal> when we get a first-class decimal type.
     Numerics(PrimitiveStats<f64>),
     /// A sentinel that indicates all elements were `Datum::List`s.
     ///

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -290,9 +290,7 @@ pub enum JsonStats {
     Bools(PrimitiveStats<bool>),
     /// The min and max strings, or None if there were none.
     Strings(PrimitiveStats<String>),
-    /// The min and max numerics, or None if there were none.
-    ///
-    /// TODO(mfp): Storing this as an f64 is not correct.
+    /// Lower and upper bounds on the numerics, or None if there were none.
     Numerics(PrimitiveStats<f64>),
     /// A sentinel that indicates all elements were `Datum::List`s.
     ///

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -160,6 +160,7 @@ fn jsonb_stats_datum(stats: &mut JsonStats, datum: Datum<'_>) -> Result<(), Stri
             // We can't convert a decimal into a float with perfect precision,
             // so we at least ensure the true value is bounded on either side.
             // (And numbers without a fractional part can be converted exactly.)
+            // TODO: remove this when we get a first-class decimal type.
             let (lower, upper) = f64::try_from(val.0)
                 .map_or((f64::NEG_INFINITY, f64::INFINITY), |f| {
                     (f.floor(), f.ceil())

--- a/src/storage-client/src/source/persist_source.rs
+++ b/src/storage-client/src/source/persist_source.rs
@@ -405,6 +405,7 @@ impl PersistSourceDataStats<'_> {
                 strings.upper.as_str().into(),
             ),
             JsonStats::Numerics(floats) => {
+                // TODO: remove this when we get a first-class decimal type.
                 fn float_to_datum(float: f64) -> Datum<'static> {
                     let numeric: Numeric = float.into();
                     numeric.into()


### PR DESCRIPTION
We don't have a good representation of numerics at the statistics level, so we're tracking bounds as floating point for now.
However, since we can't convert between floats and decimals losslessly, we need to be conservative about our bounds. Taking the `floor` and `ceil` is a somewhat brutal approach to this, but should be correct unless the relevant numbers are very large.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
