### PR TITLE
ci: Give a larger instance to the pubsub-disruption test

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -696,7 +696,7 @@ steps:
     label: "PubSub disruption"
     artifact_paths: junit_*.xml
     agents:
-      queue: linux-x86_64
+      queue: builder-linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: pubsub-disruption


### PR DESCRIPTION
Apparently, 16Gb are not enough to process 192Mb worth of integers.

Fixes #19718

### Motivation

Nightly CI was failing.

The OOM is happening because the test is using multiple materialized views with multiple aggregations per materialized view. Since the sources are all upsert, that is, not monotonic, each aggregation needs to keep the *entire set of inputs* in memory in case there are retractions. For example, if `MAX(f1)` has output 10 because the max f1 was10, if that 10 gets retracted, the MAX needs to also retract the 10 from its output and replace it with the new maximum, and in order to know what that maximum is, it needs to keep **all previously seen inputs** in memory. And same for the other aggregations.

At the same time, the test uses multiple min+max in order to detect situations where parts of the inputs are not ingested or doubly-ingested because PubSub misbehaved in some way. Quite possibly a better dataset could be devised that allows for such checks to be made without relying on all those aggregations, but that would take some thinking on my part, which is currently in shorter supply as compared to EC2 instances.

As previously discussed with Nikhil, the "builder" instances, which are usually used for compilation, are a valid instance type to use for CI jobs that need that particular size.