### PR TITLE
bin/bump-version: die if any uncommitted content

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -21,6 +21,10 @@ if [[ $# -ne 1 ]]; then
     die "usage: $0 VERSION"
 fi
 
+if ! run git diff HEAD --compact-summary --exit-code; then
+    die "cannot begin bump with uncommitted content"
+fi
+
 version=${1#v}
 
 sed -i.bak \


### PR DESCRIPTION
`bin/bump-version` committed whatever diff you had lying around without warning––add a guardrail here to help ensure that doesn't happen.

### Motivation

This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
