### PR TITLE
platform-checks: Move RenameCluster/Replica to own file

### DIFF
--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -45,7 +45,9 @@ from materialize.checks.peek_cancellation import *  # noqa: F401 F403
 from materialize.checks.pg_cdc import *  # noqa: F401 F403
 from materialize.checks.range import *  # noqa: F401 F403
 from materialize.checks.regex import *  # noqa: F401 F403
+from materialize.checks.rename_cluster import *  # noqa: F401 F403
 from materialize.checks.rename_index import *  # noqa: F401 F403
+from materialize.checks.rename_replica import *  # noqa: F401 F403
 from materialize.checks.rename_source import *  # noqa: F401 F403
 from materialize.checks.rename_table import *  # noqa: F401 F403
 from materialize.checks.rename_view import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/array_type.py
+++ b/misc/python/materialize/checks/array_type.py
@@ -16,7 +16,7 @@ from materialize.util import MzVersion
 
 class ArrayType(Check):
     def _can_run(self) -> bool:
-        return self.base_version >= MzVersion.parse("0.57.0-dev")
+        return self.base_version >= MzVersion.parse("0.58.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/cluster.py
+++ b/misc/python/materialize/checks/cluster.py
@@ -11,7 +11,6 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
-from materialize.util import MzVersion
 
 
 class CreateCluster(Check):
@@ -116,67 +115,6 @@ class DropCluster(Check):
 
                 ! SELECT * FROM drop_cluster2_view;
                 contains: unknown catalog item 'drop_cluster2_view'
-           """
-            )
-        )
-
-
-class RenameCluster(Check):
-    def _can_run(self) -> bool:
-        return self.base_version >= MzVersion.parse("0.57.0-dev")
-
-    def manipulate(self) -> List[Testdrive]:
-        return [
-            Testdrive(dedent(s))
-            for s in [
-                """
-                > CREATE TABLE rename_cluster1_table (f1 INTEGER);
-                > CREATE TABLE rename_cluster2_table (f1 INTEGER);
-
-                > INSERT INTO rename_cluster1_table VALUES (123);
-                > INSERT INTO rename_cluster2_table VALUES (234);
-
-                > CREATE CLUSTER rename_cluster1 REPLICAS (replica1 (SIZE '2-2'));
-                > CREATE CLUSTER rename_cluster2 REPLICAS (replica1 (SIZE '2-2'));
-
-                > SET cluster=rename_cluster1
-                > CREATE DEFAULT INDEX ON rename_cluster1_table;
-                > CREATE MATERIALIZED VIEW rename_cluster1_view AS SELECT SUM(f1) FROM rename_cluster1_table;
-
-                > SET cluster=rename_cluster2
-                > CREATE DEFAULT INDEX ON rename_cluster2_table;
-                > CREATE MATERIALIZED VIEW rename_cluster2_view AS SELECT SUM(f1) FROM rename_cluster2_table;
-
-                > ALTER CLUSTER rename_cluster1 RENAME TO rename_cluster_new1;
-                """,
-                """
-
-                > ALTER CLUSTER rename_cluster2 RENAME TO rename_cluster_new2;
-                """,
-            ]
-        ]
-
-    def validate(self) -> Testdrive:
-        return Testdrive(
-            dedent(
-                """
-                > SET cluster=rename_cluster_new1
-
-                > SET cluster=rename_cluster_new2
-
-                > SET cluster=default
-
-                > SELECT * FROM rename_cluster1_table;
-                123
-
-                > SELECT * FROM rename_cluster1_view;
-                123
-
-                > SELECT * FROM rename_cluster2_table;
-                234
-
-                > SELECT * FROM rename_cluster2_view;
-                234
            """
             )
         )

--- a/misc/python/materialize/checks/rename_cluster.py
+++ b/misc/python/materialize/checks/rename_cluster.py
@@ -1,0 +1,75 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+from typing import List
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.util import MzVersion
+
+
+class RenameCluster(Check):
+    def _can_run(self) -> bool:
+        return self.base_version >= MzVersion.parse("0.58.0-dev")
+
+    def manipulate(self) -> List[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > CREATE TABLE rename_cluster1_table (f1 INTEGER);
+                > CREATE TABLE rename_cluster2_table (f1 INTEGER);
+
+                > INSERT INTO rename_cluster1_table VALUES (123);
+                > INSERT INTO rename_cluster2_table VALUES (234);
+
+                > CREATE CLUSTER rename_cluster1 REPLICAS (replica1 (SIZE '2-2'));
+                > CREATE CLUSTER rename_cluster2 REPLICAS (replica1 (SIZE '2-2'));
+
+                > SET cluster=rename_cluster1
+                > CREATE DEFAULT INDEX ON rename_cluster1_table;
+                > CREATE MATERIALIZED VIEW rename_cluster1_view AS SELECT SUM(f1) FROM rename_cluster1_table;
+
+                > SET cluster=rename_cluster2
+                > CREATE DEFAULT INDEX ON rename_cluster2_table;
+                > CREATE MATERIALIZED VIEW rename_cluster2_view AS SELECT SUM(f1) FROM rename_cluster2_table;
+
+                > ALTER CLUSTER rename_cluster1 RENAME TO rename_cluster_new1;
+                """,
+                """
+
+                > ALTER CLUSTER rename_cluster2 RENAME TO rename_cluster_new2;
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SET cluster=rename_cluster_new1
+
+                > SET cluster=rename_cluster_new2
+
+                > SET cluster=default
+
+                > SELECT * FROM rename_cluster1_table;
+                123
+
+                > SELECT * FROM rename_cluster1_view;
+                123
+
+                > SELECT * FROM rename_cluster2_table;
+                234
+
+                > SELECT * FROM rename_cluster2_view;
+                234
+           """
+            )
+        )

--- a/misc/python/materialize/checks/rename_replica.py
+++ b/misc/python/materialize/checks/rename_replica.py
@@ -1,0 +1,68 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+from typing import List
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.util import MzVersion
+
+
+class RenameReplica(Check):
+    def _can_run(self) -> bool:
+        return self.base_version >= MzVersion.parse("0.58.0-dev")
+
+    def manipulate(self) -> List[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > CREATE TABLE rename_replica_table (f1 INTEGER);
+                > INSERT INTO rename_replica_table VALUES (1);
+
+                > CREATE CLUSTER rename_replica REPLICAS ();
+
+                > SET cluster=rename_replica
+                > CREATE DEFAULT INDEX ON rename_replica_table;
+                > CREATE MATERIALIZED VIEW rename_replica_view AS SELECT COUNT(f1) FROM rename_replica_table;
+
+                > INSERT INTO rename_replica_table VALUES (2);
+                > CREATE CLUSTER REPLICA rename_replica.replica1 SIZE '2-2';
+                > INSERT INTO rename_replica_table VALUES (3);
+                > CREATE CLUSTER REPLICA rename_replica.replica2 SIZE '2-2';
+                > INSERT INTO rename_replica_table VALUES (4);
+                > ALTER CLUSTER REPLICA rename_replica.replica1 RENAME TO replica_new1
+                """,
+                """
+                > INSERT INTO rename_replica_table VALUES (5);
+                > ALTER CLUSTER REPLICA rename_replica.replica2 RENAME TO replica_new2;
+                > INSERT INTO rename_replica_table VALUES (6);
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SET cluster=rename_replica
+
+                > SELECT * FROM rename_replica_table;
+                1
+                2
+                3
+                4
+                5
+                6
+
+                > SELECT * FROM rename_replica_view;
+                6
+           """
+            )
+        )


### PR DESCRIPTION
to be consistent with the other rename_* checks

Also fix the minimum version requirement as v0.57.3 is out without this, seen failing in nightly: https://buildkite.com/materialize/nightlies/builds/2544#0188907b-27ac-42ba-8778-75b525d5c4fc

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
