### PR TITLE
environmentd: downgrade ws traces to debug

### DIFF
--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -177,7 +177,7 @@ async fn run_ws(state: &WsState, mut ws: WebSocket) {
         };
 
         if let Err(err) = ws_response().await {
-            debug!("failed to send respond over WebSocket, {err:?}");
+            debug!("failed to send response over WebSocket, {err:?}");
             return;
         }
     }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -36,7 +36,7 @@ use mz_sql::plan::Plan;
 use serde::{Deserialize, Serialize};
 use tokio::time;
 use tokio_postgres::error::SqlState;
-use tracing::warn;
+use tracing::debug;
 use tungstenite::protocol::frame::coding::CloseCode;
 
 use crate::http::{init_ws, AuthedClient, WsState, MAX_REQUEST_SIZE};
@@ -90,7 +90,7 @@ async fn run_ws(state: &WsState, mut ws: WebSocket) {
             // We omit most detail from the error message we send to the client, to
             // avoid giving attackers unnecessary information during auth. AdapterErrors
             // are safe to return because they're generated after authentication.
-            warn!("WS request failed init: {}", e);
+            debug!("WS request failed init: {}", e);
             let reason = match e.downcast_ref::<AdapterError>() {
                 Some(error) => Cow::Owned(error.to_string()),
                 None => "unauthorized".into(),
@@ -118,7 +118,7 @@ async fn run_ws(state: &WsState, mut ws: WebSocket) {
     // Send any notices that might have been generated on startup.
     let notices = client.client.session().drain_notices();
     if let Err(err) = forward_notices(&mut ws, notices).await {
-        tracing::error!("failed to forward notices to WebSocket, {err:?}");
+        debug!("failed to forward notices to WebSocket, {err:?}");
         return;
     }
 
@@ -177,7 +177,7 @@ async fn run_ws(state: &WsState, mut ws: WebSocket) {
         };
 
         if let Err(err) = ws_response().await {
-            tracing::error!("failed to send respond over WebSocket, {err:?}");
+            debug!("failed to send respond over WebSocket, {err:?}");
             return;
         }
     }


### PR DESCRIPTION
They were too noisy before and used during development.

See https://github.com/MaterializeInc/materialize/issues/18224#issuecomment-1579227164

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a