### PR TITLE
storage: implement granular backpressure in `persist_source_core`

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -29,7 +29,7 @@ steps:
           - { value: testdrive-size-1 }
           - { value: testdrive-size-8 }
           - { value: testdrive-in-cloudtest }
-          - { value: upsert-compaction-disabled }
+          - { value: upsert-compaction-enabled }
           - { value: feature-benchmark }
           - { value: zippy-kafka-sources }
           - { value: zippy-kafka-parallel-insert }
@@ -263,14 +263,13 @@ steps:
           args: [--aws-region=us-east-1, --persistent-user-tables]
     skip: Persistence tests disabled
 
-  - id: upsert-compaction-disabled
-    label: Upsert (compaction disabled)
+  - id: upsert-compaction-enabled
+    label: Upsert (compaction enabled)
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: upsert
-          args: [--compaction-disabled]
     agents:
       queue: linux-x86_64
 

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -185,8 +185,8 @@ steps:
     agents:
       queue: linux-x86_64
 
-  - id: upsert
-    label: Upsert
+  - id: upsert-compaction-disabled
+    label: Upsert (compaction disabled)
     depends_on: build-x86_64
     timeout_in_minutes: 30
     inputs: [test/upsert]
@@ -194,6 +194,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: upsert
+          args: [--compaction-disabled]
     agents:
       queue: linux-x86_64
 

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -68,6 +68,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             allow_spilling_to_disk: config.upsert_rocksdb_auto_spill_to_disk(),
             spill_to_disk_threshold_bytes: config.upsert_rocksdb_auto_spill_threshold_bytes(),
         },
+        storage_dataflow_max_inflight_bytes: config.storage_dataflow_max_inflight_bytes(),
     }
 }
 

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -217,6 +217,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                     let flow_control = FlowControl {
                         progress_stream: flow_control_input,
                         max_inflight_bytes: compute_state.dataflow_max_inflight_bytes,
+                        summary: mz_repr::Timestamp::minimum().step_forward(),
                     };
 
                     // Note: For correctness, we require that sources only emit times advanced by

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -94,7 +94,7 @@ where
     // current shard upper anyway.
     let source_as_of = None;
     let (ok_stream, err_stream, token) = mz_storage_client::source::persist_source::persist_source(
-        &desired_collection.scope(),
+        &mut desired_collection.scope(),
         sink_id,
         Arc::clone(&compute_state.persist_clients),
         target.clone(),

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -635,6 +635,13 @@ pub struct SerdeLeasedBatchPart {
     filter_pushdown_audit: bool,
 }
 
+impl SerdeLeasedBatchPart {
+    /// Returns the encoded size of the given part.
+    pub fn encoded_size_bytes(&self) -> usize {
+        self.encoded_size_bytes
+    }
+}
+
 impl<T: Timestamp + Codec64> LeasedBatchPart<T> {
     /// Takes a [`SerdeLeasedBatchPart`] into a [`LeasedBatchPart`].
     ///

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -25,14 +25,14 @@ use futures::StreamExt;
 use futures_util::future::Either;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
-use mz_ore::vec::VecExt;
 use mz_persist_types::{Codec, Codec64};
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
-use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use mz_timely_util::order::refine_antichain;
+use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::{CapabilitySet, ConnectLoop, Feedback};
 use timely::dataflow::{Scope, ScopeParent, Stream};
 use timely::order::TotalOrder;
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::{timestamp::Refines, Antichain, Timestamp};
 use timely::scheduling::Activator;
 use timely::PartialOrder;
 use tokio::sync::mpsc;
@@ -66,27 +66,33 @@ use crate::{PersistLocation, ShardId};
 /// using [`timely::dataflow::operators::generic::operator::empty`].
 ///
 /// [advanced by]: differential_dataflow::lattice::Lattice::advance_by
-pub fn shard_source<K, V, D, F, G>(
+pub fn shard_source<T, K, V, D, F, DT, G, R>(
     scope: &mut G,
     name: &str,
     clients: Arc<PersistClientCache>,
     location: PersistLocation,
     shard_id: ShardId,
-    as_of: Option<Antichain<G::Timestamp>>,
-    until: Antichain<G::Timestamp>,
-    flow_control: Option<FlowControl<G>>,
+    as_of: Option<Antichain<T>>,
+    until: Antichain<T>,
+    desc_transformer: Option<DT>,
     key_schema: Arc<K::Schema>,
     val_schema: Arc<V::Schema>,
     should_fetch_part: F,
-) -> (Stream<G, FetchedPart<K, V, G::Timestamp, D>>, Rc<dyn Any>)
+) -> (Stream<G, FetchedPart<K, V, T, D>>, Rc<dyn Any>)
 where
     K: Debug + Codec,
     V: Debug + Codec,
     D: Semigroup + Codec64 + Send + Sync,
     F: FnMut(&PartStats) -> bool + 'static,
-    G: Scope,
+    G: Scope<Timestamp = R>,
+    R: Refines<T>,
     // TODO: Figure out how to get rid of the TotalOrder bound :(.
-    G::Timestamp: Timestamp + Lattice + Codec64 + TotalOrder,
+    T: Timestamp + Lattice + Codec64 + TotalOrder,
+    DT: FnOnce(
+        G,
+        &Stream<G, (usize, SerdeLeasedBatchPart)>,
+        usize,
+    ) -> (Stream<G, (usize, SerdeLeasedBatchPart)>, Rc<dyn Any>),
 {
     // WARNING! If emulating any of this code, you should read the doc string on
     // [`LeasedBatchPart`] and [`Subscribe`] or will likely run into intentional
@@ -110,7 +116,7 @@ where
     let (completed_fetches_feedback_handle, completed_fetches_feedback_stream) =
         scope.feedback(<<G as ScopeParent>::Timestamp as Timestamp>::Summary::default());
 
-    let (descs, descs_token) = shard_source_descs::<K, V, D, _, G>(
+    let (descs, descs_token) = shard_source_descs::<T, K, V, D, _, G, R>(
         scope,
         name,
         Arc::clone(&clients),
@@ -118,22 +124,37 @@ where
         shard_id.clone(),
         as_of,
         until,
-        flow_control,
         completed_fetches_feedback_stream,
         chosen_worker,
         Arc::clone(&key_schema),
         Arc::clone(&val_schema),
         should_fetch_part,
     );
+    let (descs, backpressure_token) = match desc_transformer {
+        Some(desc_transformer) => desc_transformer(scope.clone(), &descs, chosen_worker),
+        None => {
+            let token: Rc<dyn Any> = Rc::new(());
+            // Just coercing to trait object
+            #[allow(clippy::as_conversions)]
+            {
+                (descs, token)
+            }
+        }
+    };
+
     let (parts, completed_fetches_stream, fetch_token) = shard_source_fetch(
         &descs, name, clients, location, shard_id, key_schema, val_schema,
     );
     completed_fetches_stream.connect_loop(completed_fetches_feedback_handle);
 
-    (parts, Rc::new((descs_token, fetch_token)))
+    (
+        parts,
+        Rc::new((descs_token, fetch_token, backpressure_token)),
+    )
 }
 
 /// Flow control configuration.
+/// TODO(guswynn): move to `persist_source`
 #[derive(Debug)]
 pub struct FlowControl<G: Scope> {
     /// Stream providing in-flight frontier updates.
@@ -144,6 +165,8 @@ pub struct FlowControl<G: Scope> {
     pub progress_stream: Stream<G, Infallible>,
     /// Maximum number of in-flight bytes.
     pub max_inflight_bytes: usize,
+    /// TODO(guswynn): explain
+    pub summary: <G::Timestamp as Timestamp>::Summary,
 }
 
 #[derive(Debug)]
@@ -159,15 +182,14 @@ impl Drop for ActivateOnDrop {
     }
 }
 
-pub(crate) fn shard_source_descs<K, V, D, F, G>(
+pub(crate) fn shard_source_descs<T, K, V, D, F, G, R>(
     scope: &G,
     name: &str,
     clients: Arc<PersistClientCache>,
     location: PersistLocation,
     shard_id: ShardId,
-    as_of: Option<Antichain<G::Timestamp>>,
-    until: Antichain<G::Timestamp>,
-    flow_control: Option<FlowControl<G>>,
+    as_of: Option<Antichain<T>>,
+    until: Antichain<T>,
     completed_fetches_stream: Stream<G, SerdeLeasedBatchPart>,
     chosen_worker: usize,
     key_schema: Arc<K::Schema>,
@@ -179,9 +201,10 @@ where
     V: Debug + Codec,
     D: Semigroup + Codec64 + Send + Sync,
     F: FnMut(&PartStats) -> bool + 'static,
-    G: Scope,
+    G: Scope<Timestamp = R>,
+    R: Refines<T>,
     // TODO: Figure out how to get rid of the TotalOrder bound :(.
-    G::Timestamp: Timestamp + Lattice + Codec64 + TotalOrder,
+    T: Timestamp + Lattice + Codec64 + TotalOrder,
 {
     let cfg = clients.cfg().clone();
     let metrics = Arc::clone(&clients.metrics);
@@ -192,30 +215,10 @@ where
     // values that are `yield`-ed from it's body.
     let name_owned = name.to_owned();
 
-    let (flow_control_stream, flow_control_bytes) = match flow_control {
-        Some(fc) => (fc.progress_stream, Some(fc.max_inflight_bytes)),
-        None => (
-            timely::dataflow::operators::generic::operator::empty(scope),
-            None,
-        ),
-    };
-
     let mut builder =
         AsyncOperatorBuilder::new(format!("shard_source_descs({})", name), scope.clone());
     let (mut descs_output, descs_stream) = builder.new_output();
 
-    let mut flow_control_input = builder.new_input_connection(
-        &flow_control_stream,
-        Pipeline,
-        // Disconnect the flow_control_input from the output capabilities of the
-        // operator. We could leave it connected without risking deadlock so
-        // long as there is a non zero summary on the feedback edge. But it may
-        // be less efficient because the pipeline will be moving in increments
-        // of SUMMARY even though we have potentially dumped a lot more data in
-        // the pipeline because of batch boundaries. Leaving it unconnected
-        // means the pipeline will be able to retire bigger chunks of work.
-        vec![Antichain::new()],
-    );
     let mut completed_fetches = builder.new_input_connection(
         &completed_fetches_stream,
         // We must ensure all completed fetches are fed into
@@ -246,11 +249,6 @@ where
     let _shutdown_button = builder.build(move |caps| async move {
         let mut cap_set = CapabilitySet::from_elem(caps.into_element());
 
-        let mut inflight_bytes = 0;
-        let mut inflight_parts: Vec<(Antichain<G::Timestamp>, usize)> = Vec::new();
-
-        let max_inflight_bytes = flow_control_bytes.unwrap_or(usize::MAX);
-
         // Only one worker is responsible for distributing parts
         if worker_index != chosen_worker {
             trace!(
@@ -269,7 +267,7 @@ where
                 .await
                 .expect("location should be valid");
             let read = client
-                .open_leased_reader::<K, V, G::Timestamp, D>(
+                .open_leased_reader::<K, V, T, D>(
                     shard_id,
                     &format!("shard_source({})", name_owned),
                     key_schema,
@@ -293,7 +291,7 @@ where
                 // The token dropped before we finished creating our `ReadHandle.
                 // We can return immediately, as we could not have emitted any
                 // parts to fetch.
-                cap_set.downgrade(&[]);
+                cap_set.downgrade::<G::Timestamp, _>([]);
                 return;
             }
             Either::Right((read, _)) => {
@@ -320,7 +318,7 @@ where
         // NOTE: We have to do this before our `subscribe()` call (which
         // internally calls `snapshot()` because that call will block when there
         // is no data yet available in the shard.
-        cap_set.downgrade(as_of.clone());
+        cap_set.downgrade(refine_antichain::<_, G::Timestamp>(&as_of));
         let mut current_ts = match as_of.clone().into_option() {
             Some(ts) => ts,
             None => {
@@ -346,7 +344,7 @@ where
                 // the token dropped before we finished creating our Subscribe.
                 // we can return immediately, as we could not have emitted any
                 // parts to fetch.
-                cap_set.downgrade(&[]);
+                cap_set.downgrade::<G::Timestamp, _>([]);
                 return;
             }
             Either::Right((subscription, _)) => {
@@ -393,11 +391,6 @@ where
         loop {
             // Notes on this select!:
             //
-            // We have two mutually exclusive preconditions based on our flow
-            // control state to determine whether we emit new batch parts, vs
-            // applying flow control and waiting for downstream operators to
-            // complete their work.
-            //
             // We use a `biased` select, not for correctness, but to minimize
             // the work we need to do (e.g. check if the dataflow has been
             // dropped before reading more data from CRDB).
@@ -409,7 +402,7 @@ where
                 //
                 // NB: Reading from a channel is cancel safe.
                 _ = token_tx.closed() => {
-                    cap_set.downgrade(&[]);
+                    cap_set.downgrade::<G::Timestamp, _>([]);
                     break 'emitting_parts;
                 }
                 // Return the leases of any parts that the following stage,
@@ -421,7 +414,7 @@ where
                     match completed_fetch {
                         Some(Event::Data(_cap, data)) => {
                             for part in data.drain(..) {
-                                lease_returner.return_leased_part(lease_returner.leased_part_from_exchangeable::<G::Timestamp>(part));
+                                lease_returner.return_leased_part(lease_returner.leased_part_from_exchangeable::<T>(part));
                             }
                         }
                         Some(Event::Progress(frontier)) => {
@@ -435,86 +428,68 @@ where
                         }
                     }
                 }
-                // While we have budget left for fetching more parts, read from the
-                // subscription and pass them on.
+                // Read from the subscription and pass them on.
                 //
                 // NB: StreamExt::next is cancel safe
-                event = subscription_stream.next(), if inflight_bytes < max_inflight_bytes => {
+                event = subscription_stream.next() => {
                     match event {
                         Some(ListenEvent::Updates(mut parts)) => {
                             batch_parts.append(&mut parts);
                         }
                         Some(ListenEvent::Progress(progress)) => {
-                            let session_cap = cap_set.delayed(&current_ts);
+                            // Emit the part at the `(ts, 0)` time. The `granular_backpressure`
+                            // operator will refine this further, if its enabled.
+                            let session_cap = cap_set.delayed(&Refines::to_inner(current_ts));
 
-                            let bytes_emitted = {
-                                let mut bytes_emitted = 0;
-                                for mut part_desc in std::mem::take(&mut batch_parts) {
-                                    // TODO: Push the filter down into the Subscribe?
-                                    if cfg.dynamic.stats_filter_enabled() {
-                                        let should_fetch = part_desc.stats.as_ref().map_or(true, |stats| {
-                                            should_fetch_part(&stats.decode())
-                                        });
-                                        let bytes = u64::cast_from(part_desc.encoded_size_bytes);
-                                        if should_fetch {
-                                            metrics.pushdown.parts_fetched_count.inc();
-                                            metrics.pushdown.parts_fetched_bytes.inc_by(bytes);
+                            for mut part_desc in std::mem::take(&mut batch_parts) {
+                                // TODO: Push the filter down into the Subscribe?
+                                if cfg.dynamic.stats_filter_enabled() {
+                                    let should_fetch = part_desc.stats.as_ref().map_or(true, |stats| {
+                                        should_fetch_part(&stats.decode())
+                                    });
+                                    let bytes = u64::cast_from(part_desc.encoded_size_bytes);
+                                    if should_fetch {
+                                        metrics.pushdown.parts_fetched_count.inc();
+                                        metrics.pushdown.parts_fetched_bytes.inc_by(bytes);
+                                    } else {
+                                        metrics.pushdown.parts_filtered_count.inc();
+                                        metrics.pushdown.parts_filtered_bytes.inc_by(bytes);
+                                        let should_audit = {
+                                            let mut h = DefaultHasher::new();
+                                            part_desc.key.hash(&mut h);
+                                            usize::cast_from(h.finish()) % 100 < cfg.dynamic.stats_audit_percent()
+                                        };
+                                        if should_audit {
+                                            metrics.pushdown.parts_audited_count.inc();
+                                            metrics.pushdown.parts_audited_bytes.inc_by(bytes);
+                                            part_desc.request_filter_pushdown_audit();
                                         } else {
-                                            metrics.pushdown.parts_filtered_count.inc();
-                                            metrics.pushdown.parts_filtered_bytes.inc_by(bytes);
-                                            let should_audit = {
-                                                let mut h = DefaultHasher::new();
-                                                part_desc.key.hash(&mut h);
-                                                usize::cast_from(h.finish()) % 100 < cfg.dynamic.stats_audit_percent()
-                                            };
-                                            if should_audit {
-                                                metrics.pushdown.parts_audited_count.inc();
-                                                metrics.pushdown.parts_audited_bytes.inc_by(bytes);
-                                                part_desc.request_filter_pushdown_audit();
-                                            } else {
-                                                debug!("skipping part because of stats filter {:?}", part_desc.stats);
-                                                lease_returner.return_leased_part(part_desc);
-                                                continue;
-                                            }
+                                            debug!("skipping part because of stats filter {:?}", part_desc.stats);
+                                            lease_returner.return_leased_part(part_desc);
+                                            continue;
                                         }
                                     }
-
-                                    bytes_emitted += part_desc.encoded_size_bytes();
-                                    // Give the part to a random worker. This isn't
-                                    // round robin in an attempt to avoid skew issues:
-                                    // if your parts alternate size large, small, then
-                                    // you'll end up only using half of your workers.
-                                    //
-                                    // There's certainly some other things we could be
-                                    // doing instead here, but this has seemed to work
-                                    // okay so far. Continue to revisit as necessary.
-                                    let worker_idx = usize::cast_from(Instant::now().hashed()) % num_workers;
-                                    descs_output.give(&session_cap, (worker_idx, part_desc.into_exchangeable_part())).await;
                                 }
-                                bytes_emitted
-                            };
 
-                            // Only track in-flight parts if flow control is enabled. Otherwise we
-                            // would leak memory, as tracked parts would never be drained.
-                            if flow_control_bytes.is_some() && bytes_emitted > 0 {
-                                inflight_parts.push((progress.clone(), bytes_emitted));
-                                inflight_bytes += bytes_emitted;
-                                trace!(
-                                    "shard {} putting {} bytes inflight. total: {}. batch frontier {:?}",
-                                    shard_id,
-                                    bytes_emitted,
-                                    inflight_bytes,
-                                    progress,
-                                );
+                                // Give the part to a random worker. This isn't
+                                // round robin in an attempt to avoid skew issues:
+                                // if your parts alternate size large, small, then
+                                // you'll end up only using half of your workers.
+                                //
+                                // There's certainly some other things we could be
+                                // doing instead here, but this has seemed to work
+                                // okay so far. Continue to revisit as necessary.
+                                let worker_idx = usize::cast_from(Instant::now().hashed()) % num_workers;
+                                descs_output.give(&session_cap, (worker_idx, part_desc.into_exchangeable_part())).await;
                             }
 
-                            cap_set.downgrade(progress.iter());
+                            cap_set.downgrade(refine_antichain(&progress).iter());
                             match progress.into_option() {
                                 Some(ts) => {
                                     current_ts = ts;
                                 }
                                 None => {
-                                    cap_set.downgrade(&[]);
+                                    cap_set.downgrade::<G::Timestamp, _>([]);
                                     break 'emitting_parts;
                                 }
                             }
@@ -522,48 +497,10 @@ where
                         // We never expect any further output from our subscribe,
                         // so propagate that information downstream.
                         None => {
-                            cap_set.downgrade(&[]);
+                            cap_set.downgrade::<G::Timestamp, _>([]);
                             break 'emitting_parts;
                         }
                     }
-                }
-                // We've exhausted our budget, listen for updates to the flow_control
-                // input's frontier until we free up new budget. Progress ChangeBatches
-                // are consumed even if you don't interact with the handle, so even if
-                // we never make it to this block (e.g. budget of usize::MAX), because
-                // the stream has no data, we don't cause unbounded buffering in timely.
-                //
-                // NB: AsyncInputHandle::next is cancel safe
-                flow_control_upper = flow_control_input.next(), if inflight_bytes >= max_inflight_bytes => {
-                    // We can never get here when flow control is disabled, as we are not tracking
-                    // in-flight bytes in this case.
-                    assert!(flow_control_bytes.is_some());
-
-                    // Get an upper bound until which we should produce data
-                    let flow_control_upper = match flow_control_upper {
-                        Some(Event::Progress(frontier)) => frontier,
-                        Some(Event::Data(_, _)) => unreachable!("flow_control_input should not contain data"),
-                        None => Antichain::new(),
-                    };
-
-                    let retired_parts = inflight_parts.drain_filter_swapping(|(upper, _size)| {
-                        PartialOrder::less_equal(&*upper, &flow_control_upper)
-                    });
-
-                    for (_upper, size_in_bytes) in retired_parts {
-                        inflight_bytes -= size_in_bytes;
-                        trace!(
-                            "shard {} returning {} bytes. total: {}. batch frontier {:?} less_equal to {:?}",
-                            shard_id,
-                            size_in_bytes,
-                            inflight_bytes,
-                            _upper,
-                            flow_control_upper,
-                        );
-                    }
-                }
-                else => {
-                    break 'emitting_parts;
                 }
             }
         }
@@ -578,7 +515,7 @@ where
             match completed_fetch {
                 Event::Data(_cap, data) => {
                     for part in data.drain(..) {
-                        lease_returner.return_leased_part(lease_returner.leased_part_from_exchangeable::<G::Timestamp>(part));
+                        lease_returner.return_leased_part(lease_returner.leased_part_from_exchangeable::<T>(part));
                     }
                 }
                 Event::Progress(frontier) => {
@@ -611,7 +548,8 @@ where
     V: Debug + Codec,
     T: Timestamp + Lattice + Codec64,
     D: Semigroup + Codec64 + Send + Sync,
-    G: Scope<Timestamp = T>,
+    G: Scope,
+    G::Timestamp: Refines<T>,
 {
     let mut builder =
         AsyncOperatorBuilder::new(format!("shard_source_fetch({})", name), descs.scope());
@@ -667,9 +605,12 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::sync::Arc;
 
+    use timely::dataflow::operators::Leave;
     use timely::dataflow::operators::Probe;
+    use timely::dataflow::Scope;
     use timely::progress::Antichain;
 
     use crate::cache::PersistClientCache;
@@ -702,19 +643,30 @@ mod tests {
             let until = Antichain::new();
 
             let (probe, _token) = worker.dataflow::<u64, _, _>(|scope| {
-                let (stream, token) = shard_source::<String, String, u64, _, _>(
-                    scope,
-                    "test_source",
-                    persist_clients,
-                    location,
-                    shard_id,
-                    None, // No explicit as_of!
-                    until,
-                    None,
-                    Arc::new(<std::string::String as mz_persist_types::Codec>::Schema::default()),
-                    Arc::new(<std::string::String as mz_persist_types::Codec>::Schema::default()),
-                    |_fetch| true,
-                );
+                let (stream, token) = scope.scoped("hybrid", |scope| {
+                    let transformer = move |_, descs: &Stream<_, _>, _| {
+                        let token: Rc<dyn Any> = Rc::new(());
+                        (descs.clone(), token)
+                    };
+                    let (stream, token) = shard_source::<u64, String, String, u64, _, _, _, u64>(
+                        scope,
+                        "test_source",
+                        persist_clients,
+                        location,
+                        shard_id,
+                        None, // No explicit as_of!
+                        until,
+                        Some(transformer),
+                        Arc::new(
+                            <std::string::String as mz_persist_types::Codec>::Schema::default(),
+                        ),
+                        Arc::new(
+                            <std::string::String as mz_persist_types::Codec>::Schema::default(),
+                        ),
+                        |_fetch| true,
+                    );
+                    (stream.leave(), token)
+                });
 
                 let probe = stream.probe();
 
@@ -760,19 +712,30 @@ mod tests {
             let until = Antichain::new();
 
             let (probe, _token) = worker.dataflow::<u64, _, _>(|scope| {
-                let (stream, token) = shard_source::<String, String, u64, _, _>(
-                    scope,
-                    "test_source",
-                    persist_clients,
-                    location,
-                    shard_id,
-                    Some(as_of), // We specify the as_of explicitly!
-                    until,
-                    None,
-                    Arc::new(<std::string::String as mz_persist_types::Codec>::Schema::default()),
-                    Arc::new(<std::string::String as mz_persist_types::Codec>::Schema::default()),
-                    |_fetch| true,
-                );
+                let (stream, token) = scope.scoped("hybrid", |scope| {
+                    let transformer = move |_, descs: &Stream<_, _>, _| {
+                        let token: Rc<dyn Any> = Rc::new(());
+                        (descs.clone(), token)
+                    };
+                    let (stream, token) = shard_source::<u64, String, String, u64, _, _, _, u64>(
+                        scope,
+                        "test_source",
+                        persist_clients,
+                        location,
+                        shard_id,
+                        Some(as_of), // We specify the as_of explicitly!
+                        until,
+                        Some(transformer),
+                        Arc::new(
+                            <std::string::String as mz_persist_types::Codec>::Schema::default(),
+                        ),
+                        Arc::new(
+                            <std::string::String as mz_persist_types::Codec>::Schema::default(),
+                        ),
+                        |_fetch| true,
+                    );
+                    (stream.leave(), token)
+                });
 
                 let probe = stream.probe();
 

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -66,7 +66,7 @@ use crate::{PersistLocation, ShardId};
 /// using [`timely::dataflow::operators::generic::operator::empty`].
 ///
 /// [advanced by]: differential_dataflow::lattice::Lattice::advance_by
-pub fn shard_source<T, K, V, D, F, DT, G, R>(
+pub fn shard_source<K, V, T, D, F, DT, G>(
     scope: &mut G,
     name: &str,
     clients: Arc<PersistClientCache>,
@@ -84,8 +84,8 @@ where
     V: Debug + Codec,
     D: Semigroup + Codec64 + Send + Sync,
     F: FnMut(&PartStats) -> bool + 'static,
-    G: Scope<Timestamp = R>,
-    R: Refines<T>,
+    G: Scope,
+    G::Timestamp: Refines<T>,
     // TODO: Figure out how to get rid of the TotalOrder bound :(.
     T: Timestamp + Lattice + Codec64 + TotalOrder,
     DT: FnOnce(
@@ -116,7 +116,7 @@ where
     let (completed_fetches_feedback_handle, completed_fetches_feedback_stream) =
         scope.feedback(<<G as ScopeParent>::Timestamp as Timestamp>::Summary::default());
 
-    let (descs, descs_token) = shard_source_descs::<T, K, V, D, _, G, R>(
+    let (descs, descs_token) = shard_source_descs::<K, V, T, D, _, G>(
         scope,
         name,
         Arc::clone(&clients),
@@ -134,11 +134,7 @@ where
         Some(desc_transformer) => desc_transformer(scope.clone(), &descs, chosen_worker),
         None => {
             let token: Rc<dyn Any> = Rc::new(());
-            // Just coercing to trait object
-            #[allow(clippy::as_conversions)]
-            {
-                (descs, token)
-            }
+            (descs, token)
         }
     };
 
@@ -182,7 +178,7 @@ impl Drop for ActivateOnDrop {
     }
 }
 
-pub(crate) fn shard_source_descs<T, K, V, D, F, G, R>(
+pub(crate) fn shard_source_descs<K, V, T, D, F, G>(
     scope: &G,
     name: &str,
     clients: Arc<PersistClientCache>,
@@ -201,8 +197,8 @@ where
     V: Debug + Codec,
     D: Semigroup + Codec64 + Send + Sync,
     F: FnMut(&PartStats) -> bool + 'static,
-    G: Scope<Timestamp = R>,
-    R: Refines<T>,
+    G: Scope,
+    G::Timestamp: Refines<T>,
     // TODO: Figure out how to get rid of the TotalOrder bound :(.
     T: Timestamp + Lattice + Codec64 + TotalOrder,
 {
@@ -643,12 +639,12 @@ mod tests {
             let until = Antichain::new();
 
             let (probe, _token) = worker.dataflow::<u64, _, _>(|scope| {
-                let (stream, token) = scope.scoped("hybrid", |scope| {
+                let (stream, token) = scope.scoped::<u64, _, _>("hybrid", |scope| {
                     let transformer = move |_, descs: &Stream<_, _>, _| {
                         let token: Rc<dyn Any> = Rc::new(());
                         (descs.clone(), token)
                     };
-                    let (stream, token) = shard_source::<u64, String, String, u64, _, _, _, u64>(
+                    let (stream, token) = shard_source::<String, String, u64, u64, _, _, _>(
                         scope,
                         "test_source",
                         persist_clients,
@@ -712,12 +708,12 @@ mod tests {
             let until = Antichain::new();
 
             let (probe, _token) = worker.dataflow::<u64, _, _>(|scope| {
-                let (stream, token) = scope.scoped("hybrid", |scope| {
+                let (stream, token) = scope.scoped::<u64, _, _>("hybrid", |scope| {
                     let transformer = move |_, descs: &Stream<_, _>, _| {
                         let token: Rc<dyn Any> = Rc::new(());
                         (descs.clone(), token)
                     };
-                    let (stream, token) = shard_source::<u64, String, String, u64, _, _, _, u64>(
+                    let (stream, token) = shard_source::<String, String, u64, u64, _, _, _>(
                         scope,
                         "test_source",
                         persist_clients,

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -27,10 +27,10 @@ use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_persist_types::{Codec, Codec64};
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
-use mz_timely_util::order::refine_antichain;
 use timely::dataflow::channels::pact::Exchange;
-use timely::dataflow::operators::{CapabilitySet, ConnectLoop, Feedback};
-use timely::dataflow::{Scope, ScopeParent, Stream};
+use timely::dataflow::operators::{CapabilitySet, ConnectLoop, Enter, Feedback, Leave};
+use timely::dataflow::scopes::Child;
+use timely::dataflow::{Scope, Stream};
 use timely::order::TotalOrder;
 use timely::progress::{timestamp::Refines, Antichain, Timestamp};
 use timely::scheduling::Activator;
@@ -66,33 +66,39 @@ use crate::{PersistLocation, ShardId};
 /// using [`timely::dataflow::operators::generic::operator::empty`].
 ///
 /// [advanced by]: differential_dataflow::lattice::Lattice::advance_by
-pub fn shard_source<K, V, T, D, F, DT, G>(
-    scope: &mut G,
+pub fn shard_source<'g, K, V, T, D, F, DT, G>(
+    scope: &mut Child<'g, G, T>,
     name: &str,
     clients: Arc<PersistClientCache>,
     location: PersistLocation,
     shard_id: ShardId,
-    as_of: Option<Antichain<T>>,
-    until: Antichain<T>,
+    as_of: Option<Antichain<G::Timestamp>>,
+    until: Antichain<G::Timestamp>,
     desc_transformer: Option<DT>,
     key_schema: Arc<K::Schema>,
     val_schema: Arc<V::Schema>,
     should_fetch_part: F,
-) -> (Stream<G, FetchedPart<K, V, T, D>>, Rc<dyn Any>)
+) -> (
+    Stream<Child<'g, G, T>, FetchedPart<K, V, G::Timestamp, D>>,
+    Rc<dyn Any>,
+)
 where
     K: Debug + Codec,
     V: Debug + Codec,
     D: Semigroup + Codec64 + Send + Sync,
     F: FnMut(&PartStats) -> bool + 'static,
     G: Scope,
-    G::Timestamp: Refines<T>,
     // TODO: Figure out how to get rid of the TotalOrder bound :(.
-    T: Timestamp + Lattice + Codec64 + TotalOrder,
+    G::Timestamp: Timestamp + Lattice + Codec64 + TotalOrder,
+    T: Refines<G::Timestamp>,
     DT: FnOnce(
-        G,
-        &Stream<G, (usize, SerdeLeasedBatchPart)>,
+        Child<'g, G, T>,
+        &Stream<Child<'g, G, T>, (usize, SerdeLeasedBatchPart)>,
         usize,
-    ) -> (Stream<G, (usize, SerdeLeasedBatchPart)>, Rc<dyn Any>),
+    ) -> (
+        Stream<Child<'g, G, T>, (usize, SerdeLeasedBatchPart)>,
+        Rc<dyn Any>,
+    ),
 {
     // WARNING! If emulating any of this code, you should read the doc string on
     // [`LeasedBatchPart`] and [`Subscribe`] or will likely run into intentional
@@ -114,22 +120,23 @@ where
     // we can safely pass along a zero summary from this feedback edge,
     // as the input is disconnected from the operator's output
     let (completed_fetches_feedback_handle, completed_fetches_feedback_stream) =
-        scope.feedback(<<G as ScopeParent>::Timestamp as Timestamp>::Summary::default());
+        scope.feedback(T::Summary::default());
 
-    let (descs, descs_token) = shard_source_descs::<K, V, T, D, _, G>(
-        scope,
+    let (descs, descs_token) = shard_source_descs::<K, V, D, _, G>(
+        &scope.parent,
         name,
         Arc::clone(&clients),
         location.clone(),
         shard_id.clone(),
         as_of,
         until,
-        completed_fetches_feedback_stream,
+        completed_fetches_feedback_stream.leave(),
         chosen_worker,
         Arc::clone(&key_schema),
         Arc::clone(&val_schema),
         should_fetch_part,
     );
+    let descs = descs.enter(scope);
     let (descs, backpressure_token) = match desc_transformer {
         Some(desc_transformer) => desc_transformer(scope.clone(), &descs, chosen_worker),
         None => {
@@ -178,14 +185,14 @@ impl Drop for ActivateOnDrop {
     }
 }
 
-pub(crate) fn shard_source_descs<K, V, T, D, F, G>(
+pub(crate) fn shard_source_descs<K, V, D, F, G>(
     scope: &G,
     name: &str,
     clients: Arc<PersistClientCache>,
     location: PersistLocation,
     shard_id: ShardId,
-    as_of: Option<Antichain<T>>,
-    until: Antichain<T>,
+    as_of: Option<Antichain<G::Timestamp>>,
+    until: Antichain<G::Timestamp>,
     completed_fetches_stream: Stream<G, SerdeLeasedBatchPart>,
     chosen_worker: usize,
     key_schema: Arc<K::Schema>,
@@ -198,9 +205,8 @@ where
     D: Semigroup + Codec64 + Send + Sync,
     F: FnMut(&PartStats) -> bool + 'static,
     G: Scope,
-    G::Timestamp: Refines<T>,
     // TODO: Figure out how to get rid of the TotalOrder bound :(.
-    T: Timestamp + Lattice + Codec64 + TotalOrder,
+    G::Timestamp: Timestamp + Lattice + Codec64 + TotalOrder,
 {
     let cfg = clients.cfg().clone();
     let metrics = Arc::clone(&clients.metrics);
@@ -263,7 +269,7 @@ where
                 .await
                 .expect("location should be valid");
             let read = client
-                .open_leased_reader::<K, V, T, D>(
+                .open_leased_reader::<K, V, G::Timestamp, D>(
                     shard_id,
                     &format!("shard_source({})", name_owned),
                     key_schema,
@@ -287,7 +293,7 @@ where
                 // The token dropped before we finished creating our `ReadHandle.
                 // We can return immediately, as we could not have emitted any
                 // parts to fetch.
-                cap_set.downgrade::<G::Timestamp, _>([]);
+                cap_set.downgrade(&[]);
                 return;
             }
             Either::Right((read, _)) => {
@@ -314,7 +320,7 @@ where
         // NOTE: We have to do this before our `subscribe()` call (which
         // internally calls `snapshot()` because that call will block when there
         // is no data yet available in the shard.
-        cap_set.downgrade(refine_antichain::<_, G::Timestamp>(&as_of));
+        cap_set.downgrade(as_of.clone());
         let mut current_ts = match as_of.clone().into_option() {
             Some(ts) => ts,
             None => {
@@ -340,7 +346,7 @@ where
                 // the token dropped before we finished creating our Subscribe.
                 // we can return immediately, as we could not have emitted any
                 // parts to fetch.
-                cap_set.downgrade::<G::Timestamp, _>([]);
+                cap_set.downgrade(&[]);
                 return;
             }
             Either::Right((subscription, _)) => {
@@ -398,7 +404,7 @@ where
                 //
                 // NB: Reading from a channel is cancel safe.
                 _ = token_tx.closed() => {
-                    cap_set.downgrade::<G::Timestamp, _>([]);
+                    cap_set.downgrade(&[]);
                     break 'emitting_parts;
                 }
                 // Return the leases of any parts that the following stage,
@@ -410,7 +416,7 @@ where
                     match completed_fetch {
                         Some(Event::Data(_cap, data)) => {
                             for part in data.drain(..) {
-                                lease_returner.return_leased_part(lease_returner.leased_part_from_exchangeable::<T>(part));
+                                lease_returner.return_leased_part(lease_returner.leased_part_from_exchangeable::<G::Timestamp>(part));
                             }
                         }
                         Some(Event::Progress(frontier)) => {
@@ -435,7 +441,7 @@ where
                         Some(ListenEvent::Progress(progress)) => {
                             // Emit the part at the `(ts, 0)` time. The `granular_backpressure`
                             // operator will refine this further, if its enabled.
-                            let session_cap = cap_set.delayed(&Refines::to_inner(current_ts));
+                            let session_cap = cap_set.delayed(&current_ts);
 
                             for mut part_desc in std::mem::take(&mut batch_parts) {
                                 // TODO: Push the filter down into the Subscribe?
@@ -479,13 +485,13 @@ where
                                 descs_output.give(&session_cap, (worker_idx, part_desc.into_exchangeable_part())).await;
                             }
 
-                            cap_set.downgrade(refine_antichain(&progress).iter());
+                            cap_set.downgrade(progress.iter());
                             match progress.into_option() {
                                 Some(ts) => {
                                     current_ts = ts;
                                 }
                                 None => {
-                                    cap_set.downgrade::<G::Timestamp, _>([]);
+                                    cap_set.downgrade(&[]);
                                     break 'emitting_parts;
                                 }
                             }
@@ -493,7 +499,7 @@ where
                         // We never expect any further output from our subscribe,
                         // so propagate that information downstream.
                         None => {
-                            cap_set.downgrade::<G::Timestamp, _>([]);
+                            cap_set.downgrade(&[]);
                             break 'emitting_parts;
                         }
                     }
@@ -511,7 +517,7 @@ where
             match completed_fetch {
                 Event::Data(_cap, data) => {
                     for part in data.drain(..) {
-                        lease_returner.return_leased_part(lease_returner.leased_part_from_exchangeable::<T>(part));
+                        lease_returner.return_leased_part(lease_returner.leased_part_from_exchangeable::<G::Timestamp>(part));
                     }
                 }
                 Event::Progress(frontier) => {

--- a/src/storage-client/src/source/persist_source.rs
+++ b/src/storage-client/src/source/persist_source.rs
@@ -14,9 +14,14 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Instant;
 
+use differential_dataflow::lattice::Lattice;
+use futures::{future::Either, StreamExt};
 use mz_expr::{ColumnSpecs, Interpreter, MfpPlan, ResultSpec, UnmaterializableFunc};
+use mz_ore::collections::CollectionExt;
+use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::fetch::FetchedPart;
+use mz_persist_client::fetch::SerdeLeasedBatchPart;
 use mz_persist_client::operators::shard_source::shard_source;
 pub use mz_persist_client::operators::shard_source::FlowControl;
 use mz_persist_client::stats::PartStats;
@@ -24,22 +29,32 @@ use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::columnar::Data;
 use mz_persist_types::dyn_struct::DynStruct;
 use mz_persist_types::stats::{BytesStats, ColumnStats, DynStats, JsonStats};
-
+use mz_persist_types::Codec64;
 use mz_repr::adt::jsonb::Jsonb;
 use mz_repr::{
     ColumnType, Datum, DatumToPersist, DatumToPersistFn, DatumVec, Diff, GlobalId, RelationDesc,
     RelationType, Row, RowArena, ScalarType, Timestamp,
 };
 use mz_timely_util::buffer::ConsolidateBuffer;
+use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
 use timely::communication::Push;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::channels::Bundle;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::{Capability, OkErr};
+use timely::dataflow::operators::{CapabilitySet, ConnectLoop, Feedback};
+use timely::dataflow::operators::{Enter, Leave};
 use timely::dataflow::{Scope, Stream};
+use timely::order::TotalOrder;
+use timely::progress::timestamp::PathSummary;
+use timely::progress::timestamp::Refines;
 use timely::progress::Antichain;
+use timely::progress::Timestamp as TimelyTimestamp;
 use timely::scheduling::Activator;
+use timely::PartialOrder;
+use tokio::sync::mpsc::UnboundedSender;
 use tracing::error;
+use tracing::trace;
 
 use crate::controller::CollectionMetadata;
 use crate::types::errors::DataflowError;
@@ -68,7 +83,7 @@ use crate::types::sources::SourceData;
 ///
 /// [advanced by]: differential_dataflow::lattice::Lattice::advance_by
 pub fn persist_source<G, YFn>(
-    scope: &G,
+    scope: &mut G,
     source_id: GlobalId,
     persist_clients: Arc<PersistClientCache>,
     metadata: CollectionMetadata,
@@ -86,20 +101,30 @@ where
     G: Scope<Timestamp = mz_repr::Timestamp>,
     YFn: Fn(Instant, usize) -> bool + 'static,
 {
-    let (stream, token) = persist_source_core(
-        scope,
-        source_id,
-        persist_clients,
-        metadata,
-        as_of,
-        until,
-        map_filter_project,
-        flow_control,
-        yield_fn,
+    let (stream, token) = scope.scoped(
+        &format!("skip_granular_backpressure({})", source_id),
+        |scope| {
+            let (stream, token) = persist_source_core(
+                scope,
+                source_id,
+                persist_clients,
+                metadata,
+                as_of,
+                until,
+                map_filter_project,
+                flow_control.map(|fc| FlowControl {
+                    progress_stream: fc.progress_stream.enter(scope),
+                    max_inflight_bytes: fc.max_inflight_bytes,
+                    summary: Refines::to_inner(fc.summary),
+                }),
+                yield_fn,
+            );
+            (stream.leave(), token)
+        },
     );
     let (ok_stream, err_stream) = stream.ok_err(|(d, t, r)| match d {
-        Ok(row) => Ok((row, t, r)),
-        Err(err) => Err((err, t, r)),
+        Ok(row) => Ok((row, t.0, r)),
+        Err(err) => Err((err, t.0, r)),
     });
     (ok_stream, err_stream, token)
 }
@@ -122,11 +147,11 @@ pub fn persist_source_core<G, YFn>(
     flow_control: Option<FlowControl<G>>,
     yield_fn: YFn,
 ) -> (
-    Stream<G, (Result<Row, DataflowError>, Timestamp, Diff)>,
+    Stream<G, (Result<Row, DataflowError>, G::Timestamp, Diff)>,
     Rc<dyn Any>,
 )
 where
-    G: Scope<Timestamp = mz_repr::Timestamp>,
+    G: Scope<Timestamp = (mz_repr::Timestamp, u64)>,
     YFn: Fn(Instant, usize) -> bool + 'static,
 {
     let name = source_id.to_string();
@@ -142,6 +167,21 @@ where
     } else {
         ResultSpec::anything()
     };
+
+    let desc_transformer = match flow_control {
+        Some(flow_control) => Some(move |mut scope: G, descs: &Stream<G, _>, chosen_worker| {
+            backpressure(
+                &mut scope,
+                &format!("backpressure({source_id})"),
+                descs,
+                flow_control,
+                chosen_worker,
+                None,
+            )
+        }),
+        None => None,
+    };
+
     let (fetched, token) = shard_source(
         &mut scope.clone(),
         &name,
@@ -150,7 +190,7 @@ where
         metadata.data_shard,
         as_of,
         until.clone(),
-        flow_control,
+        desc_transformer,
         Arc::new(metadata.relation_desc),
         Arc::new(UnitSchema),
         move |stats| {
@@ -196,9 +236,9 @@ pub fn decode_and_mfp<G, YFn>(
     until: Antichain<Timestamp>,
     mut map_filter_project: Option<&mut MfpPlan>,
     yield_fn: YFn,
-) -> Stream<G, (Result<Row, DataflowError>, Timestamp, Diff)>
+) -> Stream<G, (Result<Row, DataflowError>, G::Timestamp, Diff)>
 where
-    G: Scope<Timestamp = mz_repr::Timestamp>,
+    G: Scope<Timestamp = (mz_repr::Timestamp, u64)>,
     YFn: Fn(Instant, usize) -> bool + 'static,
 {
     let scope = fetched.scope();
@@ -271,7 +311,7 @@ where
 /// Pending work to read from fetched parts
 struct PendingWork {
     /// The time at which the work should happen.
-    capability: Capability<Timestamp>,
+    capability: Capability<(mz_repr::Timestamp, u64)>,
     /// Pending fetched part.
     fetched_part: FetchedPart<SourceData, (), Timestamp, Diff>,
 }
@@ -289,10 +329,20 @@ impl PendingWork {
         map_filter_project: Option<&MfpPlan>,
         datum_vec: &mut DatumVec,
         row_builder: &mut Row,
-        output: &mut ConsolidateBuffer<Timestamp, Result<Row, DataflowError>, Diff, P>,
+        output: &mut ConsolidateBuffer<
+            (mz_repr::Timestamp, u64),
+            Result<Row, DataflowError>,
+            Diff,
+            P,
+        >,
     ) -> bool
     where
-        P: Push<Bundle<Timestamp, (Result<Row, DataflowError>, Timestamp, Diff)>>,
+        P: Push<
+            Bundle<
+                (mz_repr::Timestamp, u64),
+                (Result<Row, DataflowError>, (mz_repr::Timestamp, u64), Diff),
+            >,
+        >,
         YFn: Fn(Instant, usize) -> bool,
     {
         let is_filter_pushdown_audit = self.fetched_part.is_filter_pushdown_audit();
@@ -320,26 +370,36 @@ impl PendingWork {
                                 Ok((row, time, diff)) => {
                                     // Additional `until` filtering due to temporal filters.
                                     if !until.less_equal(&time) {
-                                        output.give_at(&self.capability, (Ok(row), time, diff));
+                                        let mut emit_time = *self.capability.time();
+                                        emit_time.0 = time;
+                                        output
+                                            .give_at(&self.capability, (Ok(row), emit_time, diff));
                                         *work += 1;
                                     }
                                 }
                                 Err((err, time, diff)) => {
                                     // Additional `until` filtering due to temporal filters.
                                     if !until.less_equal(&time) {
-                                        output.give_at(&self.capability, (Err(err), time, diff));
+                                        let mut emit_time = *self.capability.time();
+                                        emit_time.0 = time;
+                                        output
+                                            .give_at(&self.capability, (Err(err), emit_time, diff));
                                         *work += 1;
                                     }
                                 }
                             }
                         }
                     } else {
-                        output.give_at(&self.capability, (Ok(row), time, diff));
+                        let mut emit_time = *self.capability.time();
+                        emit_time.0 = time;
+                        output.give_at(&self.capability, (Ok(row), emit_time, diff));
                         *work += 1;
                     }
                 }
                 (Ok(SourceData(Err(err))), Ok(())) => {
-                    output.give_at(&self.capability, (Err(err), time, diff));
+                    let mut emit_time = *self.capability.time();
+                    emit_time.0 = time;
+                    output.give_at(&self.capability, (Err(err), emit_time, diff));
                     *work += 1;
                 }
                 // TODO(petrosagg): error handling
@@ -528,18 +588,270 @@ impl PersistSourceDataStats<'_> {
     }
 }
 
+/// A trait representing a type that can be used in `backpressure`.
+pub trait Backpressureable: Clone + 'static {
+    /// Return the weight of the object, in bytes.
+    fn byte_size(&self) -> usize;
+}
+
+impl Backpressureable for (usize, SerdeLeasedBatchPart) {
+    fn byte_size(&self) -> usize {
+        self.1.encoded_size_bytes()
+    }
+}
+
+/// Apply flow control to the `data` input, based on the given `FlowControl`.
+///
+/// The `FlowControl` should have a `progress_stream` that is the pristine, unaltered
+/// frontier of the downstream operator we want to backpressure from, a `max_inflight_bytes`,
+/// and a `summary`. Note that the `data` input expects all the second part of the tuple
+/// timestamp to be 0, and all data to be on the `chosen_worker` worker.
+///
+/// The `summary` represents the _minimum_ range of timestamp's that needs to be emitted before
+/// reasoning about `max_inflight_bytes`. In practice this means that we may overshoot
+/// `max_inflight_bytes`.
+///
+/// The implementation of this operator is very subtle. Many inline comments have been added.
+pub fn backpressure<T, G, O>(
+    scope: &mut G,
+    name: &str,
+    data: &Stream<G, O>,
+    flow_control: FlowControl<G>,
+    chosen_worker: usize,
+    // A probe used to inspect this operator during unit-testing
+    probe: Option<UnboundedSender<(Antichain<(T, u64)>, usize, usize)>>,
+) -> (Stream<G, O>, Rc<dyn Any>)
+where
+    T: TimelyTimestamp + Lattice + Codec64 + TotalOrder,
+    G: Scope<Timestamp = (T, u64)>,
+    O: Backpressureable + std::fmt::Debug,
+{
+    let worker_index = scope.index();
+
+    let (flow_control_stream, flow_control_max_bytes) = (
+        flow_control.progress_stream,
+        flow_control.max_inflight_bytes,
+    );
+
+    // Both the `flow_control` input and the data input are disconnected from the output. We manually
+    // manage the output's frontier using a `CapabilitySet`. Note that we also adjust the
+    // `flow_control` progress stream using the `summary` here, using a `feedback` operator in a
+    // non-circular fashion.
+    let (handle, summaried_flow) = scope.feedback(flow_control.summary.clone());
+    flow_control_stream.connect_loop(handle);
+
+    let mut builder = AsyncOperatorBuilder::new(
+        format!("persist_source_backpressure({})", name),
+        scope.clone(),
+    );
+    let (mut data_output, data_stream) = builder.new_output();
+
+    let mut data_input = builder.new_input_connection(data, Pipeline, vec![Antichain::new()]);
+    let mut flow_control_input =
+        builder.new_input_connection(&summaried_flow, Pipeline, vec![Antichain::new()]);
+
+    // _Refine_ the data stream by amending the second input with the part number. This also
+    // ensures that we order the parts by time.
+    let data_input = async_stream::stream!({
+        let mut part_number = 0;
+        let mut parts: Vec<((T, u64), O)> = Vec::new();
+        loop {
+            match data_input.next_mut().await {
+                None => {
+                    parts.sort_by_key(|val| val.0.clone());
+                    for (mut part_time, d) in parts.drain(..) {
+                        part_time.1 = part_number;
+                        part_number += 1;
+                        yield Either::Right((part_time, d))
+                    }
+                    break;
+                }
+                Some(Event::Data(cap, data)) => {
+                    for d in data.drain(..) {
+                        parts.push((cap.time().clone(), d));
+                    }
+                }
+                Some(Event::Progress(prog)) => {
+                    let mut i = 0;
+                    parts.sort_by_key(|val| val.0.clone());
+                    // This can be replaced with `Vec::drain_filter` when it stabilizes.
+                    // `drain_filter_swapping` doesn't work as it reorders the vec.
+                    while i < parts.len() {
+                        if !prog.less_equal(&parts[i].0) {
+                            let (mut part_time, d) = parts.remove(i);
+                            part_time.1 = part_number;
+                            part_number += 1;
+                            yield Either::Right((part_time, d))
+                        } else {
+                            i += 1;
+                        }
+                    }
+                    yield Either::Left(prog)
+                }
+            }
+        }
+    });
+    let shutdown_button = builder.build(move |caps| async move {
+        // The output capability.
+        let mut cap_set = CapabilitySet::from_elem(caps.into_element());
+
+        // The frontier of our output. This matches the `CapabilitySet` above.
+        let mut output_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
+        // The frontier of the `flow_control` input.
+        let mut flow_control_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
+
+        // Parts we have emitted, but have not yet retired (based on the `flow_control` edge).
+        let mut inflight_parts = Vec::new();
+        // Parts we have not yet emitted, but do participate in the `input_frontier`.
+        let mut pending_parts = std::collections::VecDeque::new();
+
+        // Only one worker is responsible for distributing parts
+        if worker_index != chosen_worker {
+            trace!(
+                "We are not the chosen worker ({}), exiting...",
+                chosen_worker
+            );
+            return;
+        }
+        tokio::pin!(data_input);
+        'emitting_parts: loop {
+            // At the beginning of our main loop, we determine the total size of
+            // inflight parts.
+            let inflight_bytes: usize = inflight_parts.iter().map(|(_, size)| size).sum();
+
+            // There are 2 main cases where we can continue to emit parts:
+            // - The total emitted bytes is less than `flow_control_max_bytes`.
+            // - We have not yet reached the `flow_control_frontier`
+            //
+            // SUBTLE: in the latter case, we may arbitrarily go into the backpressure `else`
+            // block, as we wait for progress tracking to keep the `flow_control` frontier
+            // up-to-date. This is tested in unit-tests.
+            if inflight_bytes < flow_control_max_bytes
+                || PartialOrder::less_than(&output_frontier, &flow_control_frontier)
+            {
+                let (time, part) = if let Some((time, part)) = pending_parts.pop_front() {
+                    (time, part)
+                } else {
+                    match data_input.next().await {
+                        Some(Either::Right((time, part))) => {
+                            // Downgrade the output frontier to this part's time. This is useful
+                            // "close" timestamp's from previous parts, even if we don't yet
+                            // emit this part. Note that this is safe because `data_input` ensures
+                            // time-ordering.
+                            output_frontier = Antichain::from_elem(time.clone());
+                            cap_set.downgrade(output_frontier.iter());
+
+                            // If the most recent value's time is _beyond_ the
+                            // `flow_control` frontier (which takes into account the `summary`), we
+                            // have emitted an entire `summary` worth of data, and can store this
+                            // value for later.
+                            if inflight_bytes >= flow_control_max_bytes
+                                && !PartialOrder::less_than(
+                                    &output_frontier,
+                                    &flow_control_frontier,
+                                )
+                            {
+                                pending_parts.push_back((time, part));
+                                continue 'emitting_parts;
+                            }
+                            (time, part)
+                        }
+                        Some(Either::Left(prog)) => {
+                            output_frontier = prog;
+                            cap_set.downgrade(output_frontier.iter());
+                            continue 'emitting_parts;
+                        }
+                        None => {
+                            if pending_parts.is_empty() {
+                                break 'emitting_parts;
+                            } else {
+                                continue 'emitting_parts;
+                            }
+                        }
+                    }
+                };
+
+                // Store the value with the _frontier_ the `flow_control_input` must reach
+                // to retire it. Note that if this `results_in` is `None`, then we
+                // are at `T::MAX`, and give up on flow_control entirely.
+                //
+                // SUBTLE: If we stop storing these parts, we will likely never check the
+                // `flow_control_input` ever again. This won't pile up data as that input
+                // only has frontier updates. There may be spurious activations from it though.
+                //
+                // Also note that we don't attempt to handle overflowing the `u64` part counter.
+                if let Some(emission_ts) = flow_control.summary.results_in(&time) {
+                    inflight_parts.push((emission_ts, part.byte_size()));
+                }
+
+                // Emit the data at the given time, and update the frontier and capabilities
+                // to just beyond the part.
+                data_output.give(&cap_set.delayed(&time), part).await;
+                let mut just_beyond = time.clone();
+                just_beyond.1 += 1;
+                output_frontier = Antichain::from_elem(just_beyond);
+                cap_set.downgrade(output_frontier.iter())
+            } else {
+                let parts_count = inflight_parts.len();
+                // We've exhausted our budget, listen for updates to the flow_control
+                // input's frontier until we free up new budget. Progress ChangeBatches
+                // are consumed even if you don't interact with the handle, so even if
+                // we never make it to this block (e.g. budget of usize::MAX), because
+                // the stream has no data, we don't cause unbounded buffering in timely.
+                let new_flow_control_frontier = match flow_control_input.next().await {
+                    Some(Event::Progress(frontier)) => frontier,
+                    Some(Event::Data(_, _)) => {
+                        unreachable!("flow_control_input should not contain data")
+                    }
+                    None => Antichain::new(),
+                };
+
+                // Update the `flow_control_frontier` if its advanced.
+                if PartialOrder::less_than(&flow_control_frontier, &new_flow_control_frontier) {
+                    flow_control_frontier = new_flow_control_frontier.clone();
+                }
+
+                // Retire parts that are processed downstream.
+                let retired_parts = inflight_parts
+                    .drain_filter_swapping(|(ts, _size)| !flow_control_frontier.less_equal(ts));
+                let (retired_size, retired_count): (usize, usize) = retired_parts
+                    .fold((0, 0), |(accum_size, accum_count), (_ts, size)| {
+                        (accum_size + size, accum_count + 1)
+                    });
+                trace!(
+                    "returning {} parts with {} bytes, frontier: {:?}",
+                    retired_count,
+                    retired_size,
+                    flow_control_frontier,
+                );
+
+                // Optionally emit some information for tests to examine.
+                if let Some(probe) = probe.as_ref() {
+                    let _ = probe.send((new_flow_control_frontier, parts_count, retired_count));
+                }
+            }
+        }
+    });
+    (data_stream, Rc::new(shutdown_button.press_on_drop()))
+}
+
 #[cfg(test)]
 mod tests {
     use mz_persist_client::stats::PartStats;
     use mz_persist_types::codec_impls::UnitSchema;
     use mz_persist_types::columnar::{PartEncoder, Schema};
     use mz_persist_types::part::PartBuilder;
+    use timely::dataflow::operators::Probe;
+    use tokio::sync::mpsc::unbounded_channel;
+    use tokio::sync::oneshot;
+
     use mz_repr::{
         is_no_stats_type, ColumnType, Datum, DatumToPersist, DatumToPersistFn, RelationDesc, Row,
         RowArena, ScalarType,
     };
     use proptest::prelude::*;
 
+    use super::*;
     use crate::source::persist_source::PersistSourceDataStats;
     use crate::types::sources::SourceData;
 
@@ -603,5 +915,474 @@ mod tests {
             // The proptest! macro interferes with rustfmt.
             scalar_type_stats_roundtrip(scalar_type)
         });
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // Reports undefined behavior
+    fn test_backpressure_non_granular() {
+        use Step::*;
+        backpressure_runner(
+            vec![(50, Part(101)), (50, Part(102)), (100, Part(1))],
+            100,
+            (1, 0),
+            vec![
+                // Assert we backpressure only after we have emitted
+                // the entire timestamp.
+                AssertOutputFrontier((50, 2)),
+                AssertBackpressured {
+                    frontier: (1, 0),
+                    inflight_parts: 1,
+                    retired_parts: 0,
+                },
+                AssertBackpressured {
+                    frontier: (51, 0),
+                    inflight_parts: 1,
+                    retired_parts: 0,
+                },
+                ProcessXParts(2),
+                AssertBackpressured {
+                    frontier: (101, 0),
+                    inflight_parts: 2,
+                    retired_parts: 2,
+                },
+                // Assert we make later progress once processing
+                // the parts.
+                AssertOutputFrontier((100, 3)),
+            ],
+            true,
+        );
+
+        backpressure_runner(
+            vec![
+                (50, Part(10)),
+                (50, Part(10)),
+                (51, Part(100)),
+                (52, Part(1000)),
+            ],
+            50,
+            (1, 0),
+            vec![
+                // Assert we backpressure only after we emitted enough bytes
+                AssertOutputFrontier((51, 3)),
+                AssertBackpressured {
+                    frontier: (1, 0),
+                    inflight_parts: 3,
+                    retired_parts: 0,
+                },
+                ProcessXParts(3),
+                AssertBackpressured {
+                    frontier: (52, 0),
+                    inflight_parts: 3,
+                    retired_parts: 2,
+                },
+                AssertBackpressured {
+                    frontier: (53, 0),
+                    inflight_parts: 1,
+                    retired_parts: 1,
+                },
+                // Assert we make later progress once processing
+                // the parts.
+                AssertOutputFrontier((52, 4)),
+            ],
+            true,
+        );
+
+        backpressure_runner(
+            vec![
+                (50, Part(98)),
+                (50, Part(1)),
+                (51, Part(10)),
+                (52, Part(100)),
+                // Additional parts at the same timestamp
+                (52, Part(10)),
+                (52, Part(10)),
+                (52, Part(10)),
+                (52, Part(100)),
+                // A later part with a later ts.
+                (100, Part(100)),
+            ],
+            100,
+            (1, 0),
+            vec![
+                AssertOutputFrontier((51, 3)),
+                // Assert we backpressure after we have emitted enough bytes.
+                // We assert twice here because we get updates as
+                // `flow_control` progresses from `(0, 0)`->`(0, 1)`-> a real frontier.
+                AssertBackpressured {
+                    frontier: (1, 0),
+                    inflight_parts: 3,
+                    retired_parts: 0,
+                },
+                AssertBackpressured {
+                    frontier: (51, 0),
+                    inflight_parts: 3,
+                    retired_parts: 0,
+                },
+                ProcessXParts(1),
+                // Our output frontier doesn't move, as the downstream frontier hasn't moved past
+                // 50.
+                AssertOutputFrontier((51, 3)),
+                // After we process all of `50`, we can start emitting data at `52`, but only until
+                // we exhaust out budget. We don't need to emit all of `52` because we have emitted
+                // all of `51`.
+                ProcessXParts(1),
+                AssertOutputFrontier((52, 4)),
+                AssertBackpressured {
+                    frontier: (52, 0),
+                    inflight_parts: 3,
+                    retired_parts: 2,
+                },
+                // After processing `50` and `51`, the minimum time is `52`, so we ensure that,
+                // regardless of byte count, we emit the entire time (but do NOT emit the part at
+                // time `100`.
+                ProcessXParts(1),
+                // Clear the previous `51` part, and start filling up `inflight_parts` with other
+                // parts at `52`
+                // This is an intermediate state.
+                AssertBackpressured {
+                    frontier: (53, 0),
+                    inflight_parts: 2,
+                    retired_parts: 1,
+                },
+                // After we process all of `52`, we can continue to the next time.
+                ProcessXParts(5),
+                AssertBackpressured {
+                    frontier: (101, 0),
+                    inflight_parts: 5,
+                    retired_parts: 5,
+                },
+                AssertOutputFrontier((100, 9)),
+            ],
+            true,
+        );
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // Reports undefined behavior
+    fn test_backpressure_granular() {
+        use Step::*;
+        backpressure_runner(
+            vec![(50, Part(101)), (50, Part(101))],
+            100,
+            (0, 1),
+            vec![
+                // Advance our frontier to outputting a single part.
+                AssertOutputFrontier((50, 1)),
+                // Receive backpressure updates until our frontier is up-to-date but
+                // not beyond the parts (while considering the summary).
+                AssertBackpressured {
+                    frontier: (0, 1),
+                    inflight_parts: 1,
+                    retired_parts: 0,
+                },
+                AssertBackpressured {
+                    frontier: (50, 1),
+                    inflight_parts: 1,
+                    retired_parts: 0,
+                },
+                // Process that part.
+                ProcessXParts(1),
+                // Assert that we clear the backpressure status
+                AssertBackpressured {
+                    frontier: (50, 2),
+                    inflight_parts: 1,
+                    retired_parts: 1,
+                },
+                // Ensure we make progress to the next part.
+                AssertOutputFrontier((50, 2)),
+            ],
+            false,
+        );
+
+        backpressure_runner(
+            vec![
+                (50, Part(10)),
+                (50, Part(10)),
+                (51, Part(35)),
+                (52, Part(100)),
+            ],
+            50,
+            (0, 1),
+            vec![
+                // we can emit 3 parts before we hit the backpressure limit
+                AssertOutputFrontier((51, 3)),
+                AssertBackpressured {
+                    frontier: (0, 1),
+                    inflight_parts: 3,
+                    retired_parts: 0,
+                },
+                AssertBackpressured {
+                    frontier: (50, 1),
+                    inflight_parts: 3,
+                    retired_parts: 0,
+                },
+                // Retire the single part.
+                ProcessXParts(1),
+                AssertBackpressured {
+                    frontier: (50, 2),
+                    inflight_parts: 3,
+                    retired_parts: 1,
+                },
+                // Ensure we make progress, and then
+                // can retire the next 2 parts.
+                AssertOutputFrontier((52, 4)),
+                ProcessXParts(2),
+                AssertBackpressured {
+                    frontier: (52, 4),
+                    inflight_parts: 3,
+                    retired_parts: 2,
+                },
+            ],
+            false,
+        );
+    }
+
+    type Time = (u64, u64);
+    #[derive(Clone, Debug)]
+    struct Part(usize);
+    impl Backpressureable for Part {
+        fn byte_size(&self) -> usize {
+            self.0
+        }
+    }
+
+    /// Actions taken by `backpressure_runner`.
+    enum Step {
+        /// Assert that the output frontier of the `backpressure` operator has AT LEAST made it
+        /// this far. This is a single time because we assume
+        AssertOutputFrontier(Time),
+        /// Assert that we have entered the backpressure flow in the `backpressure` operator. This
+        /// allows us to assert what feedback frontier we got to, and how many inflight parts we
+        /// retired.
+        AssertBackpressured {
+            frontier: Time,
+            inflight_parts: usize,
+            retired_parts: usize,
+        },
+        /// Process X parts in the downstream operator. This affects the feedback frontier.
+        ProcessXParts(usize),
+    }
+
+    /// A function that runs the `steps` to ensure that `backpressure` works as expected.
+    fn backpressure_runner(
+        // The input data to the `backpressure` operator
+        input: Vec<(u64, Part)>,
+        // The maximum inflight bytes the `backpressure` operator allows through.
+        max_inflight_bytes: usize,
+        // The feedback summary used by the `backpressure` operator.
+        summary: Time,
+        // List of steps to run through.
+        steps: Vec<Step>,
+        // Whether or not to consume records in the non-granular scope. This is useful when the
+        // `summary` is something like `(1, 0)`.
+        non_granular_consumer: bool,
+    ) {
+        timely::execute::execute_directly(move |worker| {
+            let (backpressure_probe, consumer_tx, mut backpressure_status_rx, finalizer_tx, _token) =
+                // Set up the top-level non-granular scope.
+                worker.dataflow::<u64, _, _>(|scope| {
+                    let (non_granular_feedback_handle, non_granular_feedback) =
+                        if non_granular_consumer {
+                            let (h, f) = scope.feedback(Default::default());
+                            (Some(h), Some(f))
+                        } else {
+                            (None, None)
+                        };
+                    let (
+                        backpressure_probe,
+                        consumer_tx,
+                        backpressure_status_rx,
+                        token,
+                        backpressured,
+                        finalizer_tx,
+                    ) = scope.scoped::<(u64, u64), _, _>("hybrid", |scope| {
+                        let (input, finalizer_tx) =
+                            iterator_operator(scope.clone(), input.into_iter());
+
+                        let (flow_control, granular_feedback_handle) = if non_granular_consumer {
+                            (
+                                FlowControl {
+                                    progress_stream: non_granular_feedback.unwrap().enter(scope),
+                                    max_inflight_bytes,
+                                    summary,
+                                },
+                                None,
+                            )
+                        } else {
+                            let (granular_feedback_handle, granular_feedback) =
+                                scope.feedback(Default::default());
+                            (
+                                FlowControl {
+                                    progress_stream: granular_feedback,
+                                    max_inflight_bytes,
+                                    summary,
+                                },
+                                Some(granular_feedback_handle),
+                            )
+                        };
+
+                        let (backpressure_status_tx, backpressure_status_rx) = unbounded_channel();
+
+                        let (backpressured, token) = backpressure(
+                            scope,
+                            "test",
+                            &input,
+                            flow_control,
+                            0,
+                            Some(backpressure_status_tx),
+                        );
+
+                        // If we want to granularly consume the output, we setup the consumer here.
+                        let tx = if !non_granular_consumer {
+                            Some(consumer_operator(
+                                scope.clone(),
+                                &backpressured,
+                                granular_feedback_handle.unwrap(),
+                            ))
+                        } else {
+                            None
+                        };
+
+                        (
+                            backpressured.probe(),
+                            tx,
+                            backpressure_status_rx,
+                            token,
+                            backpressured.leave(),
+                            finalizer_tx,
+                        )
+                    });
+
+                    // If we want to non-granularly consume the output, we setup the consumer here.
+                    let consumer_tx = if non_granular_consumer {
+                        consumer_operator(
+                            scope.clone(),
+                            &backpressured,
+                            non_granular_feedback_handle.unwrap(),
+                        )
+                    } else {
+                        consumer_tx.unwrap()
+                    };
+
+                    (
+                        backpressure_probe,
+                        consumer_tx,
+                        backpressure_status_rx,
+                        finalizer_tx,
+                        token,
+                    )
+                });
+
+            use Step::*;
+            for step in steps {
+                match step {
+                    AssertOutputFrontier(time) => {
+                        eprintln!("checking advance to {time:?}");
+                        backpressure_probe.with_frontier(|front| {
+                            eprintln!("current backpressure output frontier: {front:?}");
+                        });
+                        while backpressure_probe.less_than(&time) {
+                            worker.step();
+                            backpressure_probe.with_frontier(|front| {
+                                eprintln!("current backpressure output frontier: {front:?}");
+                            });
+                            std::thread::sleep(std::time::Duration::from_millis(25));
+                        }
+                    }
+                    ProcessXParts(parts) => {
+                        eprintln!("processing {parts:?} parts");
+                        for _ in 0..parts {
+                            consumer_tx.send(()).unwrap();
+                        }
+                    }
+                    AssertBackpressured {
+                        frontier,
+                        inflight_parts,
+                        retired_parts,
+                    } => {
+                        let frontier = Antichain::from_elem(frontier);
+                        eprintln!(
+                            "asserting backpressured at {frontier:?}, with {inflight_parts:?} inflight parts \
+                            and {retired_parts:?} retired"
+                        );
+                        let (new_frontier, new_count, new_retired_count) = loop {
+                            if let Ok(val) = backpressure_status_rx.try_recv() {
+                                break val;
+                            }
+                            worker.step();
+                            std::thread::sleep(std::time::Duration::from_millis(25));
+                        };
+                        assert_eq!(
+                            (frontier, inflight_parts, retired_parts),
+                            (new_frontier, new_count, new_retired_count)
+                        );
+                    }
+                }
+            }
+            // Send the input to the empty frontier.
+            let _ = finalizer_tx.send(());
+        });
+    }
+
+    /// An operator that emits `Part`'s at the specified timestamps. Does not
+    /// drop its capability until it gets a signal from the `Sender` it returns.
+    fn iterator_operator<
+        G: Scope<Timestamp = (u64, u64)>,
+        I: Iterator<Item = (u64, Part)> + 'static,
+    >(
+        scope: G,
+        mut input: I,
+    ) -> (Stream<G, Part>, oneshot::Sender<()>) {
+        let (finalizer_tx, finalizer_rx) = oneshot::channel();
+        let mut iterator = AsyncOperatorBuilder::new("iterator".to_string(), scope);
+        let (mut output_handle, output) = iterator.new_output::<Vec<Part>>();
+
+        iterator.build(|mut caps| async move {
+            let mut capability = Some(caps.pop().unwrap());
+            let mut last = None;
+            while let Some(element) = input.next() {
+                let time = element.0.clone();
+                let part = element.1;
+                last = Some((time, 0));
+                output_handle
+                    .give(&capability.as_ref().unwrap().delayed(&last.unwrap()), part)
+                    .await;
+            }
+            if let Some(last) = last {
+                capability
+                    .as_mut()
+                    .unwrap()
+                    .downgrade(&(last.0 + 1, last.1));
+            }
+
+            let _ = finalizer_rx.await;
+            capability.take();
+        });
+
+        (output, finalizer_tx)
+    }
+
+    /// An operator that consumes its input ONLY when given a signal to do from
+    /// the `UnboundedSender` it returns. Each `send` corresponds with 1 `Data` event
+    /// being processed. Also connects the `feedback` handle to its output.
+    fn consumer_operator<G: Scope, O: Backpressureable + std::fmt::Debug>(
+        scope: G,
+        input: &Stream<G, O>,
+        feedback: timely::dataflow::operators::feedback::Handle<G, std::convert::Infallible>,
+    ) -> UnboundedSender<()> {
+        let (tx, mut rx) = unbounded_channel::<()>();
+        let mut consumer = AsyncOperatorBuilder::new("consumer".to_string(), scope);
+        let mut input = consumer.new_input(input, Pipeline);
+        let (_output_handle, output) = consumer.new_output::<Vec<std::convert::Infallible>>();
+
+        consumer.build(|_caps| async move {
+            while let Some(()) = rx.recv().await {
+                // Consume exactly one messages (unless the input is exhausted).
+                while let Some(Event::Progress(_)) = input.next().await {}
+            }
+        });
+        output.connect_loop(feedback);
+
+        tx
     }
 }

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -26,6 +26,7 @@ message ProtoStorageParameters {
     uint64 keep_n_sink_status_history_entries = 7;
     mz_tracing.params.ProtoTracingParameters tracing = 8;
     ProtoUpsertAutoSpillConfig upsert_auto_spill_config = 9;
+    optional uint64 storage_dataflow_max_inflight_bytes = 10;
 }
 
 

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -40,7 +40,9 @@ pub struct StorageParameters {
     pub tracing: TracingParameters,
     /// A set of parameters used configure auto spill behaviour if disk is used.
     pub upsert_auto_spill_config: UpsertAutoSpillConfig,
+    pub storage_dataflow_max_inflight_bytes: Option<usize>,
 }
+
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct UpsertAutoSpillConfig {
     /// A flag to whether allow automatically spilling to disk or not
@@ -78,6 +80,7 @@ impl StorageParameters {
             finalize_shards,
             tracing,
             upsert_auto_spill_config,
+            storage_dataflow_max_inflight_bytes,
         }: StorageParameters,
     ) {
         self.persist.update(persist);
@@ -87,7 +90,9 @@ impl StorageParameters {
         self.upsert_rocksdb_tuning_config = upsert_rocksdb_tuning_config;
         self.finalize_shards = finalize_shards;
         self.tracing.update(tracing);
+        self.finalize_shards = finalize_shards;
         self.upsert_auto_spill_config = upsert_auto_spill_config;
+        self.storage_dataflow_max_inflight_bytes = storage_dataflow_max_inflight_bytes;
     }
 }
 
@@ -106,6 +111,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             finalize_shards: self.finalize_shards,
             tracing: Some(self.tracing.into_proto()),
             upsert_auto_spill_config: Some(self.upsert_auto_spill_config.into_proto()),
+            storage_dataflow_max_inflight_bytes: self
+                .storage_dataflow_max_inflight_bytes
+                .map(u64::cast_from),
         }
     }
 
@@ -133,6 +141,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             upsert_auto_spill_config: proto
                 .upsert_auto_spill_config
                 .into_rust_if_some("ProtoStorageParameters::upsert_auto_spill_config")?,
+            storage_dataflow_max_inflight_bytes: proto
+                .storage_dataflow_max_inflight_bytes
+                .map(usize::cast_from),
         })
     }
 }

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -26,9 +26,10 @@ use mz_storage_client::types::errors::{
 use mz_storage_client::types::sources::encoding::*;
 use mz_storage_client::types::sources::*;
 use mz_timely_util::operator::CollectionExt;
+use mz_timely_util::order::refine_antichain;
 use serde::{Deserialize, Serialize};
 use timely::dataflow::operators::generic::operator::empty;
-use timely::dataflow::operators::{Concat, Exchange, Leave, OkErr};
+use timely::dataflow::operators::{Concat, ConnectLoop, Exchange, Feedback, Leave, OkErr};
 use timely::dataflow::scopes::{Child, Scope};
 use timely::dataflow::Stream;
 use timely::progress::{Antichain, Timestamp as _};
@@ -363,34 +364,82 @@ where
                         .as_option()
                         .expect("resuming an already finished ingestion")
                         .clone();
-                    let (previous, previous_token) = if Timestamp::minimum() < upper_ts {
-                        let as_of = Antichain::from_elem(upper_ts.saturating_sub(1));
+                    let (upsert, health_update) = scope.scoped(
+                        &format!("upsert_rehydration_backpressure({})", id),
+                        |scope| {
+                            let (previous, previous_token, feedback_handle) =
+                                if Timestamp::minimum() < upper_ts {
+                                    let as_of = Antichain::from_elem(upper_ts.saturating_sub(1));
 
-                        let (stream, tok) = persist_source::persist_source_core(
-                            scope,
-                            id,
-                            persist_clients,
-                            description.ingestion_metadata,
-                            Some(as_of),
-                            Antichain::new(),
-                            None,
-                            None,
-                            // Copy the logic in DeltaJoin/Get/Join to start.
-                            |_timer, count| count > 1_000_000,
-                        );
-                        (stream.as_collection(), Some(tok))
-                    } else {
-                        (Collection::new(empty(scope)), None)
-                    };
-                    let (upsert, health_update) = crate::render::upsert::upsert(
-                        &upsert_input,
-                        upsert_envelope.clone(),
-                        resume_upper,
-                        previous,
-                        previous_token,
-                        base_source_config,
-                        &storage_state.instance_context,
-                        &storage_state.dataflow_parameters,
+                                    let (feedback_handle, flow_control) =
+                                        if let Some(storage_dataflow_max_inflight_bytes) =
+                                            storage_state
+                                                .dataflow_parameters
+                                                .storage_dataflow_max_inflight_bytes
+                                        {
+                                            let (feedback_handle, feedback_data) =
+                                                scope.feedback(Default::default());
+
+                                            (
+                                                Some(feedback_handle),
+                                                Some(persist_source::FlowControl {
+                                                    progress_stream: feedback_data,
+                                                    max_inflight_bytes:
+                                                        storage_dataflow_max_inflight_bytes,
+                                                    summary: (Default::default(), 1),
+                                                }),
+                                            )
+                                        } else {
+                                            (None, None)
+                                        };
+                                    let (stream, tok) = persist_source::persist_source_core(
+                                        scope,
+                                        id,
+                                        persist_clients,
+                                        description.ingestion_metadata,
+                                        Some(as_of),
+                                        Antichain::new(),
+                                        None,
+                                        flow_control,
+                                        // Copy the logic in DeltaJoin/Get/Join to start.
+                                        |_timer, count| count > 1_000_000,
+                                    );
+                                    (stream.as_collection(), Some(tok), feedback_handle)
+                                } else {
+                                    (Collection::new(empty(scope)), None, None)
+                                };
+                            let (upsert, health_update) = crate::render::upsert::upsert(
+                                &upsert_input.enter(scope),
+                                upsert_envelope.clone(),
+                                refine_antichain(&resume_upper),
+                                previous,
+                                previous_token,
+                                base_source_config,
+                                &storage_state.instance_context,
+                                &storage_state.dataflow_parameters,
+                            );
+
+                            // If backpressure is enabled, we probe the upsert operator's
+                            // output, which is the easiest way to extract frontier information.
+                            let upsert = match feedback_handle {
+                                Some(feedback_handle) => {
+                                    use mz_timely_util::probe::ProbeNotify;
+                                    let handle = mz_timely_util::probe::Handle::default();
+                                    let upsert =
+                                        upsert.inner.probe_notify_with(vec![handle.clone()]);
+                                    mz_timely_util::probe::source(
+                                        scope.clone(),
+                                        format!("upsert_probe({id})"),
+                                        handle,
+                                    )
+                                    .connect_loop(feedback_handle);
+                                    upsert.as_collection()
+                                }
+                                None => upsert,
+                            };
+
+                            (upsert.leave(), health_update.leave())
+                        },
                     );
 
                     let (upsert_ok, upsert_err) = upsert.inner.ok_err(split_ok_err);

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -350,7 +350,11 @@ where
                 )
                 .await
             {
-                Ok(_) => {}
+                Ok(_) => {
+                    if let Some(ts) = snapshot_upper.clone().into_option() {
+                        output_cap.downgrade(&ts);
+                    }
+                }
                 Err(e) => {
                     process_upsert_state_error::<G>(
                         "Failed to rehydrate state".to_string(),

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -848,7 +848,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 pg,
                 rocksdb,
                 storage_dataflow_max_inflight_bytes,
-                auto_spill_config
+                auto_spill_config,
             } => self.storage_state.dataflow_parameters.update(
                 pg,
                 rocksdb,
@@ -1168,7 +1168,7 @@ impl StorageState {
                         rocksdb: params.upsert_rocksdb_tuning_config,
                         storage_dataflow_max_inflight_bytes: params
                             .storage_dataflow_max_inflight_bytes,
-                        auto_spill_config:params.upsert_auto_spill_config,
+                        auto_spill_config: params.upsert_auto_spill_config,
                     })
                 }
             }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -843,10 +843,17 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 // control flow from external command to this internal command.
                 self.storage_state.dropped_ids.extend(ids);
             }
-            InternalStorageCommand::UpdateConfiguration(pg, rocksdb, auto_spill_config) => self
-                .storage_state
-                .dataflow_parameters
-                .update(pg, rocksdb, auto_spill_config),
+            InternalStorageCommand::UpdateConfiguration {
+                pg,
+                rocksdb,
+                storage_dataflow_max_inflight_bytes,
+                auto_spill_config
+            } => self.storage_state.dataflow_parameters.update(
+                pg,
+                rocksdb,
+                auto_spill_config,
+                storage_dataflow_max_inflight_bytes,
+            ),
         }
     }
 
@@ -1155,11 +1162,13 @@ impl StorageState {
                 // the internal command fabric, to ensure consistent
                 // ordering of dataflow rendering across all workers.
                 if worker_index == 0 {
-                    internal_cmd_tx.broadcast(InternalStorageCommand::UpdateConfiguration(
-                        params.pg_replication_timeouts,
-                        params.upsert_rocksdb_tuning_config,
-                        params.upsert_auto_spill_config,
-                    ))
+                    internal_cmd_tx.broadcast(InternalStorageCommand::UpdateConfiguration {
+                        pg: params.pg_replication_timeouts,
+                        rocksdb: params.upsert_rocksdb_tuning_config,
+                        storage_dataflow_max_inflight_bytes: params
+                            .storage_dataflow_max_inflight_bytes,
+                        auto_spill_config:params.upsert_auto_spill_config,
+                    })
                 }
             }
             StorageCommand::RunIngestions(ingestions) => {

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -720,10 +720,11 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 source_resume_uppers,
             } => {
                 info!(
-                    "worker {}/{} trying to (re-)start ingestion {ingestion_id} at resumption frontier {:?}",
+                    ?as_of,
+                    ?resume_uppers,
+                    "worker {}/{} trying to (re-)start ingestion {ingestion_id}",
                     self.timely_worker.index(),
                     self.timely_worker.peers(),
-                    as_of
                 );
 
                 for (export_id, export) in ingestion_description.source_exports.iter() {

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -166,6 +166,7 @@ struct NextFut<'handle, T: Timestamp, D: Container, P: Pull<BundleCore<T, D>> + 
 }
 
 /// An event of an input stream
+#[derive(Debug)]
 pub enum Event<T: Timestamp, D> {
     /// A data event
     Data(InputCapability<T>, D),

--- a/src/timely-util/src/order.rs
+++ b/src/timely-util/src/order.rs
@@ -22,6 +22,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use timely::order::Product;
 use timely::progress::timestamp::{PathSummary, Refines, Timestamp};
+use timely::progress::Antichain;
 use timely::PartialOrder;
 
 /// A partially ordered timestamp that is partitioned by an arbitrary number of partitions
@@ -552,4 +553,13 @@ mod test {
         // Different Point summaries result into nothing
         assert_eq!(part_summary1.results_in(&ts4), None);
     }
+}
+
+/// Refine an `Antichain<T>` into a `Antichain<Inner>`, using a `Refines`
+/// implementation (in the case of tuple-style timestamps, this usually
+/// means appending a minimum time).
+pub fn refine_antichain<T: Timestamp, Inner: Timestamp + Refines<T>>(
+    frontier: &Antichain<T>,
+) -> Antichain<Inner> {
+    Antichain::from_iter(frontier.iter().map(|t| Refines::to_inner(t.clone())))
 }

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -177,7 +177,7 @@ def workflow_rehydration(c: Composition) -> None:
                 options=[
                     "--scratch-directory=/scratch",
                 ],
-            )
+            ),
         ),
         (
             "without DISK",

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -165,12 +165,20 @@ def workflow_rehydration(c: Composition) -> None:
                 options=[
                     "--scratch-directory=/scratch",
                 ],
+                additional_system_parameter_defaults={
+                    # Force backpressure to be enabled.
+                    "storage_dataflow_max_inflight_bytes": "1",
+                },
             ),
         ),
         (
             "without DISK",
             Clusterd(
                 name="clusterd1",
+                additional_system_parameter_defaults={
+                    # Force backpressure to be enabled.
+                    "storage_dataflow_max_inflight_bytes": "1",
+                },
             ),
         ),
     ]:

--- a/test/upsert/rehydration/02-source-setup.td
+++ b/test/upsert/rehydration/02-source-setup.td
@@ -71,3 +71,14 @@ mammalmore    moose    2
   GROUP BY s.name
   ORDER BY s.name
 true 3
+
+# Write another part to test backpressure
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"} {"f1": "fish", "f2": 1001}
+
+> SELECT * from upsert
+key           f1       f2
+---------------------------
+fish          fish     1001
+birdmore      geese    56
+mammalmore    moose    2

--- a/test/upsert/rehydration/03-after-rehydration.td
+++ b/test/upsert/rehydration/03-after-rehydration.td
@@ -28,7 +28,7 @@ $ set schema={
 > SELECT * from upsert
 key           f1       f2
 ---------------------------
-fish          fish     1000
+fish          fish     1001
 birdmore      geese    56
 mammalmore    moose    2
 


### PR DESCRIPTION
As part of the Upsert Spill2Disk work, its become increasingly clear that we need _backpressure_ from the upsert operator to the source reader operators and the `persist_source_core` operator. The latter is used during rehydration of upsert source, which this pr implements (but does not tune or turn on). Note that this is distinct from the existing backpressure mechanism, which operates at the `mz_repr::Timestamp` scope, as storage needs backpressure at a sub-timestamp granularity. This is because snapshots are produced at singular timestamps (in addition to compaction consolidating large amounts of data into singular timestamps.

There are a couple of subtle points in this pr, that I want to make clear:
- The first few pr's are just setting up an initial setup in the source pipeline and `shard_source`. This means adding a lexographically-ordered timestamp (thanks @bkirwi !!), and introducing a sub-scope that we render the `persist_source` and the upsert operator in.
  - `persist_source`, used only by compute, which does not support granular backpressure, simply strips this
- If granular backpressure is turned on, a new operator (called `granular_backpressure`) is rendered in between `shard_source_descs` and `shard_source_fetch`. This inherits the singular-worker data from `shard_source_descs` and slow emitting parts to `shard_source_fetch` based on the flow control input
- I chose to start with `max_inflight_bytes` instead of `max_inflight_update`. Part of this is convenience, as getting an update count requires https://github.com/MaterializeInc/materialize/pull/19650, or doing backpressure in `shard_source_fetch` (which is multi-worker, which complicates things), and also because in practice I think we will appreciate being able to control
  - Either technique has tradeoffs that depend on the workload. Worst case rehydration is too slow
  - How to tune this is unknown to me. It will probably end up being something like `<max part size>*worker_count/2`. We can possibly make a more global decision across sources in the future.
- Testing uses the `upsert` workflow. Note that I don't confirm that backpressure was triggered, I'll have to add metrics for that. For now, I wanted to pr up so people can take a look.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

see above

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
https://github.com/MaterializeInc/materialize/issues/17067
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):