### PR TITLE
Clean up rocksdb scratch directory

### DIFF
--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -529,11 +529,11 @@ impl NamespacedProcessOrchestrator {
 
             // Clean up scratch directory when the service is terminated.
             // This is best effort as a development and testing convenience.
-            // Because the process orchestrator is not used in production, we 
+            // Because the process orchestrator is not used in production, we
             // don't need to be perfectly robust with the cleanup.
             let _guard = scopeguard::guard((), |_| {
                 if let Some(scratch) = scratch_directory {
-                    info!("cleaning up scratch directory", scratch_dir = %scratch.display());
+                    info!(scratch_dir = %scratch.display(), "cleaning up scratch directory");
                     if let Err(e) = std::fs::remove_dir_all(scratch) {
                         warn!(
                             "Error cleaning up scratch directory: {}",

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -527,10 +527,13 @@ impl NamespacedProcessOrchestrator {
                 }
             }
 
-            // Adding scope guard to clean up scratch directory
+            // Clean up scratch directory when the service is terminated.
+            // This is best effort as a development and testing convenience.
+            // Because the process orchestrator is not used in production, we 
+            // don't need to be perfectly robust with the cleanup.
             let _guard = scopeguard::guard((), |_| {
                 if let Some(scratch) = scratch_directory {
-                    info!("Cleaning up scratch directory {}", scratch.display());
+                    info!("cleaning up scratch directory", scratch_dir = %scratch.display());
                     if let Err(e) = std::fs::remove_dir_all(scratch) {
                         warn!(
                             "Error cleaning up scratch directory: {}",

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -91,8 +91,8 @@ use anyhow::{bail, Context};
 use async_stream::stream;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use futures::future;
 use futures::stream::{BoxStream, FuturesUnordered, TryStreamExt};
+use futures::{future, TryFutureExt};
 use itertools::Itertools;
 use libc::{SIGABRT, SIGBUS, SIGILL, SIGSEGV, SIGTRAP};
 use maplit::btreemap;
@@ -537,7 +537,12 @@ impl NamespacedProcessOrchestrator {
                     info!(scratch_dir = %scratch.display(), "cleaning up scratch directory");
                     task::spawn(
                         || "clean_cluster_scratch_directory",
-                        remove_dir_all(scratch),
+                        remove_dir_all(scratch).map_err(|error| {
+                            warn!(
+                                "Error cleaning up scratch directory: {}",
+                                error.display_with_causes()
+                            )
+                        }),
                     );
                 }
             });

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -127,10 +127,6 @@ pub struct InstanceOptions {
     /// path before starting.
     pub cleanup_on_new: bool,
 
-    /// Whether or not to clear state at the instance
-    /// after the client is dropped.
-    pub cleanup_on_drop: bool,
-
     /// Whether or not to write writes
     /// to the wal. This is not in `RocksDBTuningParameters` because it
     /// applies to `WriteOptions` when creating `WriteBatch`es.
@@ -145,7 +141,6 @@ impl InstanceOptions {
     pub fn defaults_with_env(env: rocksdb::Env) -> Self {
         InstanceOptions {
             cleanup_on_new: true,
-            cleanup_on_drop: true,
             use_wal: false,
             env,
         }

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -322,7 +322,7 @@ def workflow_rocksdb_cleanup(c: Composition) -> None:
     ]
     c.up(*dependencies)
 
-    def rocksdb_path(source_name) -> tuple[str, str]:
+    def rocksdb_path(source_name: str) -> tuple[str, str]:
         (source_id, cluster_id, replica_id) = c.sql_query(
             f"select s.id, s.cluster_id, c.id from mz_sources s join mz_cluster_replicas c on s.cluster_id = c.cluster_id where s.name ='{source_name}'"
         )[0]
@@ -330,7 +330,7 @@ def workflow_rocksdb_cleanup(c: Composition) -> None:
         cluster_prefix = f"{cluster_id}-replica-{replica_id[1:]}"
         return f"{prefix}/{cluster_prefix}", f"{prefix}/{cluster_prefix}/{source_id}"
 
-    def files_at_path(path) -> int:
+    def files_at_path(path: str) -> int:
         num_files = c.exec(
             "materialized", "bash", "-c", f"find {path} -type f | wc -l", capture=True
         ).stdout.strip()
@@ -364,4 +364,4 @@ def workflow_rocksdb_cleanup(c: Composition) -> None:
             else:
                 assert files_at_path(dropped_source_path) == 0
 
-        c.testdrive("# reset testdrive")
+        c.testdrive("#reset testdrive")

--- a/test/upsert/rocksdb-cleanup/drop-cluster-cascade.td
+++ b/test/upsert/rocksdb-cleanup/drop-cluster-cascade.td
@@ -12,11 +12,18 @@ $ kafka-create-topic topic=upsert
 > CREATE CONNECTION conn
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
 
+> CREATE SOURCE kept_upsert
+  FROM KAFKA CONNECTION conn (TOPIC
+  'testdrive-upsert-${testdrive.seed}'
+  )
+  KEY FORMAT TEXT VALUE FORMAT TEXT
+  ENVELOPE UPSERT
+
 > DROP CLUSTER IF EXISTS c1 CASCADE;
 
 > CREATE CLUSTER c1 REPLICAS (replica1 (SIZE '1'));
 
-> CREATE SOURCE upsert
+> CREATE SOURCE dropped_upsert
   IN CLUSTER c1
   FROM KAFKA CONNECTION conn (TOPIC
   'testdrive-upsert-${testdrive.seed}'
@@ -29,7 +36,8 @@ fish:fish
 bird:goose
 animal:whale
 
-> SELECT count(*) from upsert;
+> SELECT count(*) from dropped_upsert;
 3
 
-> DROP CLUSTER c1 CASCADE;
+> SELECT count(*) from kept_upsert;
+3

--- a/test/upsert/rocksdb-cleanup/drop-cluster-cascade.td
+++ b/test/upsert/rocksdb-cleanup/drop-cluster-cascade.td
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-create-topic topic=upsert
+
+> CREATE CONNECTION conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+
+> DROP CLUSTER IF EXISTS c1 CASCADE;
+
+> CREATE CLUSTER c1 REPLICAS (replica1 (SIZE '1'));
+
+> CREATE SOURCE upsert
+  IN CLUSTER c1
+  FROM KAFKA CONNECTION conn (TOPIC
+  'testdrive-upsert-${testdrive.seed}'
+  )
+  KEY FORMAT TEXT VALUE FORMAT TEXT
+  ENVELOPE UPSERT
+
+$ kafka-ingest format=bytes topic=upsert key-format=bytes key-terminator=:
+fish:fish
+bird:goose
+animal:whale
+
+> SELECT count(*) from upsert;
+3
+
+> DROP CLUSTER c1 CASCADE;

--- a/test/upsert/rocksdb-cleanup/drop-source-in-cluster.td
+++ b/test/upsert/rocksdb-cleanup/drop-source-in-cluster.td
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-create-topic topic=upsert
+
+> CREATE CONNECTION conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+
+> DROP CLUSTER IF EXISTS c1 CASCADE;
+
+> CREATE CLUSTER c1 REPLICAS (replica1 (SIZE '1'));
+
+> CREATE SOURCE upsert
+  IN CLUSTER c1
+  FROM KAFKA CONNECTION conn (TOPIC
+  'testdrive-upsert-${testdrive.seed}'
+  )
+  KEY FORMAT TEXT VALUE FORMAT TEXT
+  ENVELOPE UPSERT
+
+$ kafka-ingest format=bytes topic=upsert key-format=bytes key-terminator=:
+fish:fish
+bird:goose
+animal:whale
+
+> SELECT count(*) from upsert;
+3
+
+> DROP SOURCE upsert;

--- a/test/upsert/rocksdb-cleanup/drop-source-in-cluster.td
+++ b/test/upsert/rocksdb-cleanup/drop-source-in-cluster.td
@@ -16,7 +16,15 @@ $ kafka-create-topic topic=upsert
 
 > CREATE CLUSTER c1 REPLICAS (replica1 (SIZE '1'));
 
-> CREATE SOURCE upsert
+> CREATE SOURCE kept_upsert
+  IN CLUSTER c1
+  FROM KAFKA CONNECTION conn (TOPIC
+  'testdrive-upsert-${testdrive.seed}'
+  )
+  KEY FORMAT TEXT VALUE FORMAT TEXT
+  ENVELOPE UPSERT
+
+> CREATE SOURCE dropped_upsert
   IN CLUSTER c1
   FROM KAFKA CONNECTION conn (TOPIC
   'testdrive-upsert-${testdrive.seed}'
@@ -29,7 +37,8 @@ fish:fish
 bird:goose
 animal:whale
 
-> SELECT count(*) from upsert;
+> SELECT count(*) from dropped_upsert;
 3
 
-> DROP SOURCE upsert;
+> SELECT count(*) from dropped_upsert;
+3

--- a/test/upsert/rocksdb-cleanup/drop-source.td
+++ b/test/upsert/rocksdb-cleanup/drop-source.td
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-create-topic topic=upsert
+
+> CREATE CONNECTION conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+
+> CREATE SOURCE upsert
+  FROM KAFKA CONNECTION conn (TOPIC
+  'testdrive-upsert-${testdrive.seed}'
+  )
+  KEY FORMAT TEXT VALUE FORMAT TEXT
+  ENVELOPE UPSERT
+
+$ kafka-ingest format=bytes topic=upsert key-format=bytes key-terminator=:
+fish:fish
+bird:goose
+animal:whale
+
+> SELECT count(*) from upsert;
+3
+
+> DROP SOURCE upsert;

--- a/test/upsert/rocksdb-cleanup/drop-source.td
+++ b/test/upsert/rocksdb-cleanup/drop-source.td
@@ -12,7 +12,14 @@ $ kafka-create-topic topic=upsert
 > CREATE CONNECTION conn
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
 
-> CREATE SOURCE upsert
+> CREATE SOURCE kept_upsert
+  FROM KAFKA CONNECTION conn (TOPIC
+  'testdrive-upsert-${testdrive.seed}'
+  )
+  KEY FORMAT TEXT VALUE FORMAT TEXT
+  ENVELOPE UPSERT
+
+> CREATE SOURCE dropped_upsert
   FROM KAFKA CONNECTION conn (TOPIC
   'testdrive-upsert-${testdrive.seed}'
   )
@@ -24,7 +31,8 @@ fish:fish
 bird:goose
 animal:whale
 
-> SELECT count(*) from upsert;
+> SELECT count(*) from dropped_upsert;
 3
 
-> DROP SOURCE upsert;
+> SELECT count(*) from kept_upsert;
+3


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->
Made changes to handle clean up of the rocksdb scratch directories.

### Motivation
Fixes https://github.com/MaterializeInc/materialize/issues/19558

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

`DROP SOURCE` for source created in a cluster was already cleaning up properly, just added test for that. 

`DROP SOURCE` with linked cluster and `DROP CLUSTER` is handled by the scope guard added in the process orchestrator. Added test for that as well.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
