### PR TITLE
Fix alias for redirecting old postgres direct URL

### DIFF
--- a/doc/user/content/ingest-data/postgres-amazon-rds.md
+++ b/doc/user/content/ingest-data/postgres-amazon-rds.md
@@ -4,7 +4,7 @@ description: "How to stream data from Amazon RDS for PostgreSQL to Materialize"
 aliases:
   - /guides/cdc-postgres/
   - /integrations/cdc-postgres/
-  - /connect-sources/cdc-postgres-direct.md
+  - /connect-sources/cdc-postgres-direct
 menu:
   main:
     parent: "postgresql"

--- a/doc/user/layouts/shortcodes/postgres-direct/check-the-ingestion-status.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/check-the-ingestion-status.html
@@ -25,7 +25,7 @@ In this step, you'll first verify that the source is running and then check the 
 
     For each `subsource`, make sure the `status` is `running`. If you see `stalled` or `failed`, there's likely a configuration issue for you to fix. Check the `error` field for details and fix the issue before moving on. Also, if the `status` of any subsource is `starting` for more than a few minutes, [contact our team](/support/).
 
-2. Once the source is running, use the [`mz_source_statistics`](/sql/system-catalog/mz_internal/#mz_source_statistics) table to check the status of the initial snapshot.
+2. Once the source is running, use the [`mz_source_statistics`](/sql/system-catalog/mz_internal/#mz_source_statistics) table to check the status of the initial snapshot:
 
     ```sql
     WITH

--- a/doc/user/layouts/shortcodes/postgres-direct/right-size-the-cluster.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/right-size-the-cluster.html
@@ -20,8 +20,8 @@ After the snapshotting phase, Materialize starts ingesting change events from th
     <p></p>
 
     ```nofmt
-           cluster       | replica |  size  | ready
-    ---------------------+---------+--------+-------
+         cluster     | replica |  size  | ready
+    -----------------+---------+--------+-------
      ingest_postgres | r1      | xsmall | t
     (1 row)
     ```


### PR DESCRIPTION
In https://github.com/MaterializeInc/materialize/pull/19453, I included an invalid alias to redirect traffic from the previous postgres direct page. This PR fixes that alias.