### PR TITLE
sql: get mz_global_id_to_name to work with functions

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3380,7 +3380,7 @@ pub static MZ_INTERNAL_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(
                 ELSE (
                     SELECT mz_internal.mz_error_if_null(
                         (
-                            SELECT concat(qual.d, qual.s, item.name)
+                            SELECT DISTINCT concat(qual.d, qual.s, item.name)
                             FROM
                                 mz_objects AS item
                             JOIN

--- a/test/sqllogictest/mz-resolve-object-name.slt
+++ b/test/sqllogictest/mz-resolve-object-name.slt
@@ -229,6 +229,12 @@ s86 1397
 s86 1398
 s86 1705
 
+query T
+SELECT DISTINCT mz_internal.mz_global_id_to_name(id) AS name
+FROM mz_internal.mz_resolve_object_name('abs');
+----
+pg_catalog.abs
+
 statement ok
 CREATE TABLE public.abs (a int);
 


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug.

If `mz_objects` had multiple entries with the same `GlobalId` (e.g. many function impls), `mz_global_id_to_name` would error.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
