### PR TITLE
[TESTING] github: add design doc notification workflow

### DIFF
--- a/.github/workflows/slack_notify_design_doc.yml
+++ b/.github/workflows/slack_notify_design_doc.yml
@@ -1,0 +1,85 @@
+# Copyright 2020 The Actions Ecosystem Authors
+# Modifications Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Portions of this file are derived from the README examples in the Action
+# Slack Notifier project. The original source code was retrieved on
+# January 5, 2022 from:
+#
+#     https://github.com/actions-ecosystem/action-slack-notifier/blob/fc778468d09c43a6f4d1b8cccaca59766656996a/README.md
+
+# Send a notification to the #eng-design-docs Slack channel when a new
+# design doc is added.
+#
+# A notification is sent when all of these conditions are true:
+#   * A ready-to-review PR is (re-)opened, or a PR is moved from draft
+#     to ready-to-review.
+#   * The PR adds an '.md' document under 'doc/developer/design/'.
+
+name: Slack Design Doc Notifications
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+    paths:
+      - "doc/developer/design/*.md"
+
+jobs:
+  notify:
+    name: "Notify about new design docs"
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - name: "Path filter"
+        id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            new-design:
+              - added: "doc/developer/design/*.md"
+      - name: "Push to Slack"
+        if: steps.filter.outputs.new-design == 'true'
+        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          channel: eng-design-docs
+          custom_payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "A new design doc is ready for review!"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "• *PR:* [${{ github.event.pull_request.title }}](${{ github.event.pull_request.url }})"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "• *Author:* ${{ github.event.pull_request.user.name }} (${{ github.event.pull_request.user.login }})"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that pushes a notification to the #eng-design-docs Slack channel when a new design doc is added in a PR.

### Motivation

* This PR adds new automation.

### Tips for reviewer

GitHub does not allow actions invoked through the `pull_request` event to access secrets, like the Slack token. So this workflow uses `pull_request_target`, which unfortunately means that we have to merge it to main before we can actually test it.

I tried to reduce the FPs this will generate as much as possible. It can still happen that we receive multiple notifications for the same design doc if a PR is moved to a draft and back to ready-for-review, or if a PR is closed and reopened. That's probably not too bad since presumably the author would like new eyes on the design doc in these cases anyway.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
