### PR TITLE
persist: add Data impls for [u8;8], [u8;12], [u8;16]

### DIFF
--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 arrow2 = { version = "0.16.0", features = ["compute_aggregate", "io_ipc", "io_parquet"] }
 bytes = "1.3.0"
-mz-ore = { path = "../ore", features = [] }
+mz-ore = { path = "../ore", features = ["test"] }
 mz-proto = { path = "../proto" }
 parquet2 = { version = "0.17.1", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -221,7 +221,12 @@ pub enum ColumnFormat {
     String,
     /// A column of type [crate::dyn_struct::DynStruct].
     Struct(DynStructCfg),
-    // TODO: FixedSizedBytes for UUIDs?
+    /// A column of type `[u8; 8]`.
+    FixedSizeBytes8,
+    /// A column of type `[u8; 12]`.
+    FixedSizeBytes12,
+    /// A column of type `[u8; 16]`.
+    FixedSizeBytes16,
 }
 
 /// An encoder for values of a fixed schema

--- a/src/persist-types/src/dyn_col.rs
+++ b/src/persist-types/src/dyn_col.rs
@@ -241,6 +241,12 @@ impl DataType {
             (true, ColumnFormat::Bytes) => logic.call::<Option<Vec<u8>>>(&()),
             (false, ColumnFormat::String) => logic.call::<String>(&()),
             (true, ColumnFormat::String) => logic.call::<Option<String>>(&()),
+            (false, ColumnFormat::FixedSizeBytes8) => logic.call::<[u8; 8]>(&()),
+            (true, ColumnFormat::FixedSizeBytes8) => logic.call::<Option<[u8; 8]>>(&()),
+            (false, ColumnFormat::FixedSizeBytes12) => logic.call::<[u8; 12]>(&()),
+            (true, ColumnFormat::FixedSizeBytes12) => logic.call::<Option<[u8; 12]>>(&()),
+            (false, ColumnFormat::FixedSizeBytes16) => logic.call::<[u8; 16]>(&()),
+            (true, ColumnFormat::FixedSizeBytes16) => logic.call::<Option<[u8; 16]>>(&()),
             (false, ColumnFormat::Struct(cfg)) => logic.call::<DynStruct>(cfg),
             (true, ColumnFormat::Struct(cfg)) => logic.call::<Option<DynStruct>>(cfg),
         }

--- a/src/persist-types/src/stats.proto
+++ b/src/persist-types/src/stats.proto
@@ -50,6 +50,9 @@ message ProtoPrimitiveStats {
         float lower_f32 = 10;
         double lower_f64 = 11;
         string lower_string = 13;
+        bytes lower_fixed_size_bytes_8 = 27;
+        bytes lower_fixed_size_bytes_12 = 28;
+        bytes lower_fixed_size_bytes_16 = 29;
     }
     oneof upper {
         bool upper_bool = 14;
@@ -64,6 +67,9 @@ message ProtoPrimitiveStats {
         float upper_f32 = 23;
         double upper_f64 = 24;
         string upper_string = 26;
+        bytes upper_fixed_size_bytes_8 = 30;
+        bytes upper_fixed_size_bytes_12 = 31;
+        bytes upper_fixed_size_bytes_16 = 32;
     }
 }
 


### PR DESCRIPTION
These will be used in an upcoming PR as a more permanent columnar schema for various Datums (in contrast to the current ProtoDatum placeholder serialization).

Touches MaterializeInc/database-issues#3657 

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
