### PR TITLE
don't pull in workspace-hack via mz-test-macro

### DIFF
--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "3.2.24", features = ["env"], optional = true }
 ctor = { version = "0.1.26", optional = true }
 either = "1.8.0"
 futures = { version = "0.3.25", optional = true }
-mz-test-macro = { path = "../test-macro" }
+mz-test-macro = { path = "../test-macro", default-features = false }
 once_cell = "1.16.0"
 # The vendored feature is transitively depended upon by tokio-openssl.
 openssl = { version = "0.10.48", features = ["vendored"], optional = true }


### PR DESCRIPTION
### Motivation

avoid pulling workspace-hack into cloud

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
