### PR TITLE
sql: support concat_ws

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -272,6 +272,12 @@
       Only supports codepoints that can be encoded in UTF-8.
       The NULL (0) character is not allowed.
 
+  - signature: 'concat(f: any, r: any...) -> text'
+    description: Concatenates the text representation of non-NULL arguments`.
+
+  - signature: 'concat_ws(sep: str, f: any, r: any...) -> text'
+    description: Concatenates the text representation of non-NULL arguments from `f` and `r` separated by `sep`.
+
   - signature: 'convert_from(b: bytea, src_encoding: text) -> text'
     description: Convert data `b` from original encoding specified by `src_encoding` into `text`.
 

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -653,6 +653,7 @@ message ProtoVariadicFunc {
         google.protobuf.Empty translate = 29;
         google.protobuf.Empty array_position = 30;
         mz_repr.relation_and_scalar.ProtoScalarType array_fill = 31;
+        google.protobuf.Empty concat_ws = 32;
     }
 }
 

--- a/test/sqllogictest/array_fill.slt
+++ b/test/sqllogictest/array_fill.slt
@@ -80,13 +80,7 @@ SELECT array_fill(5, array[3, 1], array[]::int[])
 # Reveal structure of array
 query T
 SELECT
-    concat(
-        o,
-        ' ',
-        i,
-        ' ',
-        COALESCE(((array_fill(5, ARRAY[3, 2]))[o][i])::text, 'null')
-    )
+    concat_ws(' ', o, i, COALESCE(((array_fill(5, ARRAY[3, 2]))[o][i])::text, 'null'))
 FROM generate_series(1, 4) AS o, generate_series(1, 4) AS i
 ORDER BY 1;
 ----
@@ -115,13 +109,7 @@ SELECT array_fill(5, array[3, 2], array[2, 3])
 # Reveal structure of 2D array
 query T
 SELECT
-    concat(
-        o,
-        ' ',
-        i,
-        ' ',
-        COALESCE(((array_fill(5, ARRAY[3, 2], ARRAY[2, 3]))[o][i])::text, 'null')
-    )
+    concat_ws(' ', o, i, COALESCE(((array_fill(5, ARRAY[3, 2], ARRAY[2, 3]))[o][i])::text, 'null'))
 FROM generate_series(1, 4) AS o, generate_series(1, 4) AS i
 ORDER BY 1;
 ----
@@ -145,15 +133,7 @@ ORDER BY 1;
 # Reveal structure of 3D array
 query T
 SELECT
-    concat(
-        a,
-        ' ',
-        b,
-        ' ',
-        c,
-        ' ',
-        COALESCE(((array_fill(5, ARRAY[3, 2, 1], ARRAY[1, 2, 3]))[a][b][c])::text, 'null')
-    )
+    concat_ws(' ', a, b, c, COALESCE(((array_fill(5, ARRAY[3, 2, 1], ARRAY[1, 2, 3]))[a][b][c])::text, 'null'))
 FROM
     generate_series(1, 3) AS a,
     generate_series(1, 3) AS b,
@@ -376,13 +356,7 @@ SELECT (array_fill(3, ARRAY[2], ARRAY[-3]))[-3];
 
 query T
 SELECT
-    concat(
-        o,
-        E'\t',
-        i,
-        E'\t',
-        COALESCE(((array_fill(5, ARRAY[2, 2], ARRAY[-2, -1]))[o][i])::text, 'null')
-    )
+    concat_ws(E'\t', o, i, COALESCE(((array_fill(5, ARRAY[2, 2], ARRAY[-2, -1]))[o][i])::text, 'null'))
 FROM generate_series(-3, 0) AS o, generate_series(-2, 0) AS i
 ORDER BY o, i;
 ----

--- a/test/sqllogictest/mz-resolve-object-name.slt
+++ b/test/sqllogictest/mz-resolve-object-name.slt
@@ -30,7 +30,7 @@ CREATE TABLE d.s.t (a int);
 
 # This goofy structure is because we can't just return the record from mz_resolve_object_name.
 query T
-SELECT concat(o.id, ' ', o.schema_id, ' ', o.name, ' ', o.type, ' ', o.owner_id, ' ', o.privileges::text) FROM (
+SELECT concat_ws(' ', o.id, o.schema_id, o.name, o.type, o.owner_id, o.privileges::text) FROM (
     SELECT * FROM mz_internal.mz_resolve_object_name('t')
 ) AS o;
 ----
@@ -217,7 +217,7 @@ NULL
 # Check many objects with same GlobalId
 
 query T
-SELECT concat(id LIKE 's%', ' ', oid) FROM mz_internal.mz_resolve_object_name('abs');
+SELECT concat_ws(' ', id LIKE 's%', oid) FROM mz_internal.mz_resolve_object_name('abs');
 ----
 t 1394
 t 1395
@@ -238,7 +238,7 @@ CREATE TABLE public.abs (a int);
 # Ensure that competing names in items lower in the search path do not creep in.
 
 query T
-SELECT concat(id LIKE 's%', ' ', oid) FROM mz_internal.mz_resolve_object_name('abs');
+SELECT concat_ws(' ', id LIKE 's%', oid) FROM mz_internal.mz_resolve_object_name('abs');
 ----
 t 1394
 t 1395

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -725,6 +725,54 @@ SELECT '你' || '好'
 query error db error: ERROR: operator does not exist: boolean \|\| boolean
 SELECT true || false
 
+# concat_ws
+
+query error db error: ERROR: function concat_ws\(\) does not exist
+SELECT concat_ws();
+
+query error db error: ERROR: function concat_ws\(unknown\) does not exist
+SELECT concat_ws('a');
+
+query T
+SELECT concat_ws('', 'a', 'b') AS word;
+----
+ab
+
+query T
+SELECT concat_ws(E'\t', 'S', 'M', 'T');
+----
+S	M	T
+
+query T
+SELECT concat_ws(', ', interval '1d', 1.23::numeric, 4.56::float);
+----
+1 day, 1.23, 4.56
+
+query T
+SELECT concat_ws(', ', interval '1d', null, 1.23::numeric, null, 4.57::float);
+----
+1 day, 1.23, 4.57
+
+query T
+SELECT concat_ws(', ', interval '1d', null, 1.23::numeric, null, 4.57::float, null);
+----
+1 day, 1.23, 4.57
+
+query T
+SELECT concat_ws(null, interval '1d', null, 1.23::numeric, null, 4.57::float, null);
+----
+NULL
+
+query T
+SELECT concat_ws(null, null);
+----
+NULL
+
+query T
+SELECT concat_ws('x', null);
+----
+(empty)
+
 query T
 SELECT split_part('abc~@~def~@~ghi', '~@~', 2)
 ----


### PR DESCRIPTION
Support `concat_ws`, which also requires learning how to support functions with a static number of leading elements followed by their variadic params.

### Motivation

This PR adds a known-desirable feature. More SQL functions.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support the `concat_ws` function.
