### PR TITLE
stash: Initialize new stash collections

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -202,9 +202,11 @@ impl Connection {
 
             Connection { stash, boot_ts }
         } else {
-            // Before we do anything with the Stash, we need to run any pending upgrades.
+            // Before we do anything with the Stash, we need to run any pending upgrades and
+            // initialize new collections.
             if !stash.is_readonly() {
                 stash.upgrade().await?;
+                initialize_stash(&mut stash).await?;
             }
 
             // Choose a time at which to boot. This is the time at which we will run


### PR DESCRIPTION
0341b20949f73f646d80ce800e7e1bb5ee0ad468 migrated the stash from JSON to Protobuf. In the process, we accidentally removed the logic that initializes new collections when an already initialized stash starts up. This commit adds that logic back in.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
