### PR TITLE
cloud canary test: Make .td files more suitable for load testing

### DIFF
--- a/test/cloud-canary/canary-clusters.td
+++ b/test/cloud-canary/canary-clusters.td
@@ -13,10 +13,7 @@
 
 > SET cluster=cluster1;
 
-> SHOW CLUSTERS;
-mz_system
-mz_introspection
-default
+> SHOW CLUSTERS LIKE 'cluster1';
 cluster1
 
 > SHOW CLUSTER REPLICAS WHERE cluster = 'cluster1';
@@ -29,5 +26,3 @@ cluster1 replica2 3xsmall true
 
 > SELECT cnt > 0 FROM cluster_view1;
 true
-
-> DROP CLUSTER cluster1 CASCADE;

--- a/test/cloud-canary/canary-sources.td
+++ b/test/cloud-canary/canary-sources.td
@@ -11,7 +11,7 @@
 # topic creation
 # $ kafka-create-topic topic=bytes
 
-$ kafka-ingest format=bytes key-terminator=: key-format=bytes topic=bytes repeat=1000
+$ kafka-ingest format=bytes key-terminator=: key-format=bytes topic=bytes repeat=100
 abc:abc
 
 > DROP SOURCE IF EXISTS bytes CASCADE;
@@ -36,7 +36,9 @@ abc:abc
   ENVELOPE NONE
   WITH (SIZE '3xsmall');
 
-> CREATE DEFAULT INDEX ON bytes;
+> CREATE MATERIALIZED VIEW bytes_view AS SELECT COUNT(*) AS cnt FROM bytes;
 
-> SELECT COUNT(*) > 0 from bytes
+> CREATE DEFAULT INDEX ON bytes_view;
+
+> SELECT cnt > 0 from bytes_view
 true

--- a/test/cloud-canary/canary-tables.td
+++ b/test/cloud-canary/canary-tables.td
@@ -11,15 +11,13 @@
 
 > CREATE TABLE table1 (f1 INTEGER);
 
-> INSERT INTO table1 VALUES (1);
+> INSERT INTO table1 SELECT generate_series FROM generate_series(1, 10000);
 
 > CREATE MATERIALIZED VIEW table_view1 AS SELECT COUNT(*) FROM table1;
 
 > CREATE DEFAULT INDEX ON table_view1;
 
-> INSERT INTO table1 VALUES (2);
+> INSERT INTO table1 SELECT generate_series FROM generate_series(1, 10000);
 
 > SELECT * FROM table_view1;
-2
-
-> DROP TABLE table1 CASCADE;
+20000

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -133,7 +133,7 @@ def wait_for_cloud(c: Composition) -> None:
         port=6875,
         query="SELECT 1",
         expected=[[1]],
-        timeout_secs=600,
+        timeout_secs=900,
         dbname="materialize",
         ssl_context=ssl.SSLContext(),
         # print_result=True


### PR DESCRIPTION
The .td files in test/cloud-canary are also used for the cloud load test, where they are run for every environment out of many. To achieve a better cloud load test, the following changes are being made:

- Insert actual data into the participating table
- Ingest a smaller number of records into the Kafka topic (as the topic is shared between all environments in the cloud load test, any ingestion into the topic must be processed by all participating environments)
- do not drop any database objects at the end of the test so that they continue to stay around and load the cloud
- make sure that every source has a materialized view
- make sure every materialized view has an index
- increase the maximum waiting time for an environment to come up to 15 min.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Those changes came out from the cloud load test that is currently in progress. I decided to not use a separate set of .td files for the cloud canary and the load test, but instead produce a single set of .td files that are good for both purposes.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
