### PR TITLE
persist: add real DatumToPersist impls for more column types

### DIFF
--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -27,8 +27,8 @@ message ProtoHollowBatchPart {
     string key = 1;
     uint64 encoded_size_bytes = 2;
 
-    optional bytes key_stats = 536870907;
-    reserved 536870908 to 536870911;
+    optional bytes key_stats = 536870906;
+    reserved 536870907 to 536870911;
 }
 
 message ProtoHollowBatch {

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -115,7 +115,8 @@ pub use crate::relation::{
     ProtoRelationType, RelationDesc, RelationType,
 };
 pub use crate::row::encoding::{
-    DatumDecoderT, DatumEncoderT, DatumToPersist, DatumToPersistFn, RowDecoder, RowEncoder,
+    is_no_stats_type, DatumDecoderT, DatumEncoderT, DatumToPersist, DatumToPersistFn, RowDecoder,
+    RowEncoder,
 };
 pub use crate::row::{
     datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, ProtoRow, Row,

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -2682,6 +2682,7 @@ impl Schema<SourceData> for RelationDesc {
 
 #[cfg(test)]
 mod tests {
+    use mz_repr::is_no_stats_type;
     use proptest::prelude::*;
 
     use crate::types::errors::EnvelopeError;
@@ -2702,6 +2703,11 @@ mod tests {
     }
 
     fn scalar_type_columnar_roundtrip(scalar_type: ScalarType) {
+        // Skip types that we don't keep stats for (yet).
+        if is_no_stats_type(&scalar_type) {
+            return;
+        }
+
         use mz_persist_types::columnar::validate_roundtrip;
         let mut rows = Vec::new();
         for datum in scalar_type.interesting_datums() {


### PR DESCRIPTION
Date, MzTimestamp

Also, entirely skip ScalarTypes that we don't keep useful stats for.

Touches #12684 

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
