### PR TITLE
persist: address last two TODO(mfp)

### DIFF
--- a/src/persist-types/src/dyn_struct.rs
+++ b/src/persist-types/src/dyn_struct.rs
@@ -338,6 +338,11 @@ impl ColumnPush<Option<DynStruct>> for DynStructMut {
 }
 
 impl DynStructMut {
+    /// Returns the number of elements in this column
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
     /// Explodes this _non-optional_ struct column into its component fields.
     ///
     /// Panics if this struct is optional.

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -241,6 +241,10 @@ impl PartBuilder {
 
     /// Returns a [PartMut] for this in-progress part.
     pub fn get_mut<'a>(&'a mut self) -> PartMut<'a> {
+        let len = self.diff.len();
+        debug_assert_eq!(self.key.len(), len);
+        debug_assert_eq!(self.val.len(), len);
+        debug_assert_eq!(self.ts.len(), len);
         PartMut {
             key: self.key.as_mut(),
             val: self.val.as_mut(),
@@ -270,9 +274,6 @@ impl PartBuilder {
 }
 
 /// Mutable access to the columns in a [PartBuilder].
-///
-/// TODO(mfp): In debug_assertions, verify that the lengths match when this is
-/// created and when it is dropped.
 pub struct PartMut<'a> {
     /// The key column.
     pub key: ColumnsMut<'a>,

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -2658,7 +2658,6 @@ impl Schema<SourceData> for RelationDesc {
                     optional: true,
                     format: ColumnFormat::Bytes,
                 },
-                // TODO(mfp): We likely only care if there were errors or not.
                 StatsFn::Default,
             ),
         ];


### PR DESCRIPTION
- It doesn't seem worth adding a special BytesStats variant for the error stats, so just remove that one.
- Added asserts for equal key, val, ts, diff lengths on PartMut construction. We already checked that they're equal when finalizing the PartMut into a Part, which is the important time, so don't do anything on PartMut drop.

Touches #12684 

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
