### PR TITLE
[persist] Store JSON numeric stats as ProtoDatums

### DIFF
--- a/src/persist-types/src/stats.proto
+++ b/src/persist-types/src/stats.proto
@@ -80,10 +80,11 @@ message ProtoJsonStats {
         google.protobuf.Empty json_nulls = 3;
         ProtoPrimitiveStats bools = 4;
         ProtoPrimitiveStats strings = 5;
-        ProtoPrimitiveStats numerics = 6;
+        ProtoPrimitiveBytesStats numerics = 9;
         google.protobuf.Empty lists = 7;
         ProtoJsonMapStats maps = 8;
     }
+    reserved 6;
 }
 
 message ProtoJsonMapStats {

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -291,9 +291,9 @@ pub enum JsonStats {
     /// The min and max strings, or None if there were none.
     Strings(PrimitiveStats<String>),
     /// The min and max numerics, or None if there were none.
-    ///
-    /// TODO(mfp): Storing this as an f64 is not correct.
-    Numerics(PrimitiveStats<f64>),
+    /// Since we don't have a decimal type here yet, this is stored in serialized
+    /// form.
+    Numerics(PrimitiveStats<Vec<u8>>),
     /// A sentinel that indicates all elements were `Datum::List`s.
     ///
     /// TODO: We could also do something for list indexes analogous to what we
@@ -1037,7 +1037,8 @@ mod impls {
                     }
                     JsonStats::Maps(elements)
                 }
-                None => return Err(TryFromProtoError::missing_field("ProtoJsonStats::values")),
+                // Unknown JSON stats type: assume this might have any value.
+                None => JsonStats::Mixed,
             })
         }
     }


### PR DESCRIPTION
Previously, JSON numeric stats were stored as floats. It's fine that stats were a little lossy, because we only need rough bounds on the true value. However, it was difficult to guarantee that the bounds were correct, and that roundtripping the numeric bounds through float made them strictly wider.

For top-level numerics we just use the ProtoDatum encoding, which is lossless and ~fine. So let's use that here too.

This does mean that we can't use the stats type as an intermediate representation while computing JSON stats, unless we want to be constantly serializing and deserializing proto datums, so we introduce a small `JsonDatums` helper to aggregate and then render out stats.

### Motivation

MFP burndown: https://github.com/MaterializeInc/materialize/issues/19292.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
