### PR TITLE
sql: Add parsing for ALTER DEFAULT PRIVILEGES

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/abbreviated-grant.svg
+++ b/doc/user/layouts/partials/sql-grammar/abbreviated-grant.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="537" height="531">
+   <polygon points="11 61 3 57 3 65"/>
+   <polygon points="19 61 11 57 11 65"/>
+   <rect x="33" y="47" width="70" height="32" rx="10"/>
+   <rect x="31"
+         y="45"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="65">GRANT</text>
+   <rect x="163" y="47" width="76" height="32"/>
+   <rect x="161" y="45" width="76" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="171" y="65">privilege</text>
+   <rect x="163" y="3" width="24" height="32" rx="10"/>
+   <rect x="161"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="171" y="21">,</text>
+   <rect x="143" y="91" width="46" height="32" rx="10"/>
+   <rect x="141"
+         y="89"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="109">ALL</text>
+   <rect x="229" y="123" width="102" height="32" rx="10"/>
+   <rect x="227"
+         y="121"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="237" y="141">PRIVILEGES</text>
+   <rect x="391" y="47" width="40" height="32"/>
+   <rect x="389" y="45" width="40" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="399" y="65">ON</text>
+   <rect x="45" y="233" width="74" height="32" rx="10"/>
+   <rect x="43"
+         y="231"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="251">TABLES</text>
+   <rect x="45" y="277" width="66" height="32" rx="10"/>
+   <rect x="43"
+         y="275"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="295">TYPES</text>
+   <rect x="45" y="321" width="84" height="32" rx="10"/>
+   <rect x="43"
+         y="319"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="339">SECRETS</text>
+   <rect x="45" y="365" width="124" height="32" rx="10"/>
+   <rect x="43"
+         y="363"
+         width="124"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="383">CONNECTIONS</text>
+   <rect x="45" y="409" width="106" height="32" rx="10"/>
+   <rect x="43"
+         y="407"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="427">DATABASES</text>
+   <rect x="45" y="453" width="90" height="32" rx="10"/>
+   <rect x="43"
+         y="451"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="471">SCHEMAS</text>
+   <rect x="45" y="497" width="94" height="32" rx="10"/>
+   <rect x="43"
+         y="495"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="515">CLUSTERS</text>
+   <rect x="209" y="233" width="40" height="32" rx="10"/>
+   <rect x="207"
+         y="231"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="217" y="251">TO</text>
+   <rect x="289" y="265" width="70" height="32" rx="10"/>
+   <rect x="287"
+         y="263"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="297" y="283">GROUP</text>
+   <rect x="419" y="233" width="70" height="32"/>
+   <rect x="417" y="231" width="70" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="427" y="251">grantee</text>
+   <rect x="419" y="189" width="24" height="32" rx="10"/>
+   <rect x="417"
+         y="187"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="427" y="207">,</text>
+   <path class="line"
+         d="m19 61 h2 m0 0 h10 m70 0 h10 m40 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m20 44 h92 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m46 0 h10 m20 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m40 -76 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-450 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m74 0 h10 m0 0 h50 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m66 0 h10 m0 0 h58 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m84 0 h10 m0 0 h40 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m124 0 h10 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m106 0 h10 m0 0 h18 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m90 0 h10 m0 0 h34 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m94 0 h10 m0 0 h30 m20 -264 h10 m40 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m40 -32 h10 m70 0 h10 m-110 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m90 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-90 0 h10 m24 0 h10 m0 0 h46 m23 44 h-3"/>
+   <polygon points="527 247 535 243 535 251"/>
+   <polygon points="527 247 519 243 519 251"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/abbreviated-revoke.svg
+++ b/doc/user/layouts/partials/sql-grammar/abbreviated-revoke.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="559" height="531">
+   <polygon points="11 61 3 57 3 65"/>
+   <polygon points="19 61 11 57 11 65"/>
+   <rect x="33" y="47" width="78" height="32" rx="10"/>
+   <rect x="31"
+         y="45"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="65">REVOKE</text>
+   <rect x="171" y="47" width="76" height="32"/>
+   <rect x="169" y="45" width="76" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="179" y="65">privilege</text>
+   <rect x="171" y="3" width="24" height="32" rx="10"/>
+   <rect x="169"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="179" y="21">,</text>
+   <rect x="151" y="91" width="46" height="32" rx="10"/>
+   <rect x="149"
+         y="89"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="159" y="109">ALL</text>
+   <rect x="237" y="123" width="102" height="32" rx="10"/>
+   <rect x="235"
+         y="121"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="245" y="141">PRIVILEGES</text>
+   <rect x="399" y="47" width="40" height="32"/>
+   <rect x="397" y="45" width="40" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="407" y="65">ON</text>
+   <rect x="45" y="233" width="74" height="32" rx="10"/>
+   <rect x="43"
+         y="231"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="251">TABLES</text>
+   <rect x="45" y="277" width="66" height="32" rx="10"/>
+   <rect x="43"
+         y="275"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="295">TYPES</text>
+   <rect x="45" y="321" width="84" height="32" rx="10"/>
+   <rect x="43"
+         y="319"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="339">SECRETS</text>
+   <rect x="45" y="365" width="124" height="32" rx="10"/>
+   <rect x="43"
+         y="363"
+         width="124"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="383">CONNECTIONS</text>
+   <rect x="45" y="409" width="106" height="32" rx="10"/>
+   <rect x="43"
+         y="407"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="427">DATABASES</text>
+   <rect x="45" y="453" width="90" height="32" rx="10"/>
+   <rect x="43"
+         y="451"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="471">SCHEMAS</text>
+   <rect x="45" y="497" width="94" height="32" rx="10"/>
+   <rect x="43"
+         y="495"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="515">CLUSTERS</text>
+   <rect x="209" y="233" width="60" height="32" rx="10"/>
+   <rect x="207"
+         y="231"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="217" y="251">FROM</text>
+   <rect x="309" y="265" width="70" height="32" rx="10"/>
+   <rect x="307"
+         y="263"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="317" y="283">GROUP</text>
+   <rect x="439" y="233" width="72" height="32"/>
+   <rect x="437" y="231" width="72" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="447" y="251">revokee</text>
+   <rect x="439" y="189" width="24" height="32" rx="10"/>
+   <rect x="437"
+         y="187"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="447" y="207">,</text>
+   <path class="line"
+         d="m19 61 h2 m0 0 h10 m78 0 h10 m40 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m20 44 h92 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m46 0 h10 m20 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m40 -76 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-458 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m74 0 h10 m0 0 h50 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m66 0 h10 m0 0 h58 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m84 0 h10 m0 0 h40 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m124 0 h10 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m106 0 h10 m0 0 h18 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m90 0 h10 m0 0 h34 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m94 0 h10 m0 0 h30 m20 -264 h10 m60 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m40 -32 h10 m72 0 h10 m-112 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m92 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-92 0 h10 m24 0 h10 m0 0 h48 m23 44 h-3"/>
+   <polygon points="549 247 557 243 557 251"/>
+   <polygon points="549 247 541 243 541 251"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/alter-default-privileges.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-default-privileges.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="463" height="519">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="66" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">ALTER</text>
+   <rect x="117" y="3" width="84" height="32" rx="10"/>
+   <rect x="115"
+         y="1"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="125" y="21">DEFAULT</text>
+   <rect x="221" y="3" width="102" height="32" rx="10"/>
+   <rect x="219"
+         y="1"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="21">PRIVILEGES</text>
+   <rect x="119" y="85" width="48" height="32" rx="10"/>
+   <rect x="117"
+         y="83"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="127" y="103">FOR</text>
+   <rect x="207" y="117" width="56" height="32" rx="10"/>
+   <rect x="205"
+         y="115"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="215" y="135">ROLE</text>
+   <rect x="207" y="161" width="56" height="32" rx="10"/>
+   <rect x="205"
+         y="159"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="215" y="179">USER</text>
+   <rect x="303" y="85" width="44" height="32"/>
+   <rect x="301" y="83" width="44" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="311" y="103">role</text>
+   <rect x="45" y="271" width="34" height="32" rx="10"/>
+   <rect x="43"
+         y="269"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="289">IN</text>
+   <rect x="119" y="271" width="82" height="32" rx="10"/>
+   <rect x="117"
+         y="269"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="127" y="289">SCHEMA</text>
+   <rect x="241" y="271" width="114" height="32"/>
+   <rect x="239" y="269" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="249" y="289">schema_name</text>
+   <rect x="241" y="227" width="24" height="32" rx="10"/>
+   <rect x="239"
+         y="225"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="249" y="245">,</text>
+   <rect x="119" y="359" width="98" height="32" rx="10"/>
+   <rect x="117"
+         y="357"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="127" y="377">DATABASE</text>
+   <rect x="257" y="359" width="124" height="32"/>
+   <rect x="255" y="357" width="124" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="265" y="377">database_name</text>
+   <rect x="257" y="315" width="24" height="32" rx="10"/>
+   <rect x="255"
+         y="313"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="333">,</text>
+   <rect x="265" y="441" width="140" height="32"/>
+   <rect x="263" y="439" width="140" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="273" y="459">abbreviated_grant</text>
+   <rect x="265" y="485" width="150" height="32"/>
+   <rect x="263" y="483" width="150" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="273" y="503">abbreviated_revoke</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-268 50 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h238 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v12 m268 0 v-12 m-268 12 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m48 0 h10 m20 0 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m20 -76 h10 m44 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-386 218 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m34 0 h10 m20 0 h10 m82 0 h10 m20 0 h10 m114 0 h10 m-154 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m134 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-134 0 h10 m24 0 h10 m0 0 h90 m20 44 h26 m-322 0 h20 m302 0 h20 m-342 0 q10 0 10 10 m322 0 q0 -10 10 -10 m-332 10 v68 m322 0 v-68 m-322 68 q0 10 10 10 m302 0 q10 0 10 -10 m-312 10 h10 m98 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m144 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-144 0 h10 m24 0 h10 m0 0 h100 m-376 -44 h20 m396 0 h20 m-436 0 q10 0 10 10 m416 0 q0 -10 10 -10 m-426 10 v102 m416 0 v-102 m-416 102 q0 10 10 10 m396 0 q10 0 10 -10 m-406 10 h10 m0 0 h386 m22 -122 l2 0 m2 0 l2 0 m2 0 l2 0 m-240 170 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m140 0 h10 m0 0 h10 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v24 m190 0 v-24 m-190 24 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m150 0 h10 m23 -44 h-3"/>
+   <polygon points="453 455 461 451 461 459"/>
+   <polygon points="453 455 445 451 445 459"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -1,6 +1,12 @@
 aggregate_with_filter ::= aggregate_name '(' expression ')' ('FILTER' '(' 'WHERE' filter_clause ')')?
 alter_connection ::=
   'ALTER' 'CONNECTION' 'IF EXISTS'? name 'ROTATE' 'KEYS'
+alter_default_privileges ::=
+  'ALTER' 'DEFAULT' 'PRIVILEGES' ( 'FOR' ( 'ROLE' | 'USER' )? role )? ( 'IN' 'SCHEMA' schema_name (',' schema_name)* | 'IN' 'DATABASE' database_name (',' database_name)* )? ( abbreviated_grant | abbreviated_revoke )
+abbreviated_grant ::=
+  'GRANT' ((privilege (',' privilege)*) | 'ALL' 'PRIVILEGES'? ) ON ('TABLES' | 'TYPES' | 'SECRETS' | 'CONNECTIONS' | 'DATABASES' | 'SCHEMAS' | 'CLUSTERS') 'TO' 'GROUP'? grantee (',' grantee)*
+abbreviated_revoke ::=
+  'REVOKE' ((privilege (',' privilege)*) | 'ALL' 'PRIVILEGES'? ) ON ('TABLES' | 'TYPES' | 'SECRETS' | 'CONNECTIONS' | 'DATABASES' | 'SCHEMAS' | 'CLUSTERS') 'FROM' 'GROUP'? revokee (',' revokee)*
 alter_owner ::=
   'ALTER' ('CLUSTER' | 'CLUSTER REPLICA' | 'CONNECTION' | 'DATABASE' | 'SCHEMA' | 'SOURCE' | 'SINK' | 'VIEW' | 'MATERIALIZED VIEW' | 'TABLE' | 'TYPE' | 'SECRET' ) name 'OWNER TO' new_owner
 alter_rename ::=

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -480,6 +480,7 @@ impl Coordinator {
                     | Statement::GrantRole(_)
                     | Statement::Insert(_)
                     | Statement::RevokePrivileges(_)
+                    | Statement::AlterDefaultPrivileges(_)
                     | Statement::RevokeRole(_)
                     | Statement::Update(_)
                     | Statement::ReassignOwned(_) => {

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -145,6 +145,7 @@ where
         StatementKind::RevokeRole => "revoke_role",
         StatementKind::GrantPrivileges => "grant_privileges",
         StatementKind::RevokePrivileges => "revoke_privileges",
+        StatementKind::AlterDefaultPrivileges => "alter_default_privileges",
         StatementKind::ReassignOwned => "reassign_owned",
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2220,7 +2220,7 @@ GRANT SELECT, INSERT ON ALL TABLES IN SCHEMA s1, d.s2 TO joe, mike
 ----
 GRANT SELECT, INSERT ON ALL TABLES IN SCHEMA s1, d.s2 TO joe, mike
 =>
-GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([SELECT, INSERT]), target: GrantTargetSpecification { object_type: Table, object_spec_inner: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] } }, roles: [Ident("joe"), Ident("mike")] })
+GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([SELECT, INSERT]), target: GrantTargetSpecification { object_type: Table, object_spec_inner: All(AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] }) }, roles: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 GRANT SELECT, INSERT ON ALL TABLE IN SCHEMA s1, d.s2 TO joe, mike
@@ -2234,7 +2234,7 @@ GRANT USAGE ON ALL TYPES IN SCHEMA s1, d.s2 TO joe, mike
 ----
 GRANT USAGE ON ALL TYPES IN SCHEMA s1, d.s2 TO joe, mike
 =>
-GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Type, object_spec_inner: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] } }, roles: [Ident("joe"), Ident("mike")] })
+GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Type, object_spec_inner: All(AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] }) }, roles: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 GRANT USAGE ON ALL TYPE IN SCHEMA s1, d.s2 TO joe, mike
@@ -2248,7 +2248,7 @@ GRANT USAGE ON ALL SECRETS IN SCHEMA s1, d.s2 TO joe, mike
 ----
 GRANT USAGE ON ALL SECRETS IN SCHEMA s1, d.s2 TO joe, mike
 =>
-GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Secret, object_spec_inner: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] } }, roles: [Ident("joe"), Ident("mike")] })
+GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Secret, object_spec_inner: All(AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] }) }, roles: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 GRANT USAGE ON ALL SECRET IN SCHEMA s1, d.s2 TO joe, mike
@@ -2262,7 +2262,7 @@ GRANT USAGE ON ALL SECRETS IN SCHEMA s1, d.s2 TO joe, mike
 ----
 GRANT USAGE ON ALL SECRETS IN SCHEMA s1, d.s2 TO joe, mike
 =>
-GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Secret, object_spec_inner: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] } }, roles: [Ident("joe"), Ident("mike")] })
+GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Secret, object_spec_inner: All(AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] }) }, roles: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 GRANT USAGE ON ALL SECRET IN SCHEMA s1, d.s2 TO joe, mike
@@ -2276,7 +2276,7 @@ GRANT USAGE ON ALL CONNECTIONS IN SCHEMA s1, d.s2 TO joe, mike
 ----
 GRANT USAGE ON ALL CONNECTIONS IN SCHEMA s1, d.s2 TO joe, mike
 =>
-GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Connection, object_spec_inner: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] } }, roles: [Ident("joe"), Ident("mike")] })
+GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Connection, object_spec_inner: All(AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] }) }, roles: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 GRANT USAGE ON ALL CONNECTION IN SCHEMA s1, d.s2 TO joe, mike
@@ -2304,14 +2304,14 @@ GRANT SELECT ON ALL TABLES IN DATABASE d1, d2 TO joe
 ----
 GRANT SELECT ON ALL TABLES IN DATABASE d1, d2 TO joe
 =>
-GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([SELECT]), target: GrantTargetSpecification { object_type: Table, object_spec_inner: AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1")), UnresolvedDatabaseName(Ident("d2"))] } }, roles: [Ident("joe")] })
+GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([SELECT]), target: GrantTargetSpecification { object_type: Table, object_spec_inner: All(AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1")), UnresolvedDatabaseName(Ident("d2"))] }) }, roles: [Ident("joe")] })
 
 parse-statement
 GRANT USAGE ON ALL SCHEMAS IN DATABASE d1, d2 TO joe
 ----
 GRANT USAGE ON ALL SCHEMAS IN DATABASE d1, d2 TO joe
 =>
-GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Schema, object_spec_inner: AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1")), UnresolvedDatabaseName(Ident("d2"))] } }, roles: [Ident("joe")] })
+GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Schema, object_spec_inner: All(AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1")), UnresolvedDatabaseName(Ident("d2"))] }) }, roles: [Ident("joe")] })
 
 parse-statement
 GRANT CREATE ON ALL CLUSTERS IN DATABASE d1, d2 TO joe
@@ -2332,21 +2332,21 @@ GRANT SELECT ON ALL TYPES TO joe
 ----
 GRANT SELECT ON ALL TYPES TO joe
 =>
-GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([SELECT]), target: GrantTargetSpecification { object_type: Type, object_spec_inner: All }, roles: [Ident("joe")] })
+GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([SELECT]), target: GrantTargetSpecification { object_type: Type, object_spec_inner: All(All) }, roles: [Ident("joe")] })
 
 parse-statement
 GRANT CREATE ON ALL DATABASES TO joe
 ----
 GRANT CREATE ON ALL DATABASES TO joe
 =>
-GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([CREATE]), target: GrantTargetSpecification { object_type: Database, object_spec_inner: All }, roles: [Ident("joe")] })
+GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([CREATE]), target: GrantTargetSpecification { object_type: Database, object_spec_inner: All(All) }, roles: [Ident("joe")] })
 
 parse-statement
 GRANT CREATE ON ALL CLUSTERS TO joe
 ----
 GRANT CREATE ON ALL CLUSTERS TO joe
 =>
-GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([CREATE]), target: GrantTargetSpecification { object_type: Cluster, object_spec_inner: All }, roles: [Ident("joe")] })
+GrantPrivileges(GrantPrivilegesStatement { privileges: Privileges([CREATE]), target: GrantTargetSpecification { object_type: Cluster, object_spec_inner: All(All) }, roles: [Ident("joe")] })
 
 parse-statement
 GRANT CREATE ON ALL CLUSTER TO joe
@@ -2514,7 +2514,7 @@ REVOKE SELECT, INSERT ON ALL TABLES IN SCHEMA s1, d.s2 FROM joe, mike
 ----
 REVOKE SELECT, INSERT ON ALL TABLES IN SCHEMA s1, d.s2 FROM joe, mike
 =>
-RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([SELECT, INSERT]), target: GrantTargetSpecification { object_type: Table, object_spec_inner: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] } }, roles: [Ident("joe"), Ident("mike")] })
+RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([SELECT, INSERT]), target: GrantTargetSpecification { object_type: Table, object_spec_inner: All(AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] }) }, roles: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 REVOKE SELECT, INSERT ON ALL TABLE IN SCHEMA s1, d.s2 FROM joe, mike
@@ -2528,7 +2528,7 @@ REVOKE USAGE ON ALL TYPES IN SCHEMA s1, d.s2 FROM joe, mike
 ----
 REVOKE USAGE ON ALL TYPES IN SCHEMA s1, d.s2 FROM joe, mike
 =>
-RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Type, object_spec_inner: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] } }, roles: [Ident("joe"), Ident("mike")] })
+RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Type, object_spec_inner: All(AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] }) }, roles: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 REVOKE USAGE ON ALL TYPE IN SCHEMA s1, d.s2 FROM joe, mike
@@ -2542,7 +2542,7 @@ REVOKE USAGE ON ALL SECRETS IN SCHEMA s1, d.s2 FROM joe, mike
 ----
 REVOKE USAGE ON ALL SECRETS IN SCHEMA s1, d.s2 FROM joe, mike
 =>
-RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Secret, object_spec_inner: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] } }, roles: [Ident("joe"), Ident("mike")] })
+RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Secret, object_spec_inner: All(AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] }) }, roles: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 REVOKE USAGE ON ALL SECRET IN SCHEMA s1, d.s2 FROM joe, mike
@@ -2556,7 +2556,7 @@ REVOKE USAGE ON ALL SECRETS IN SCHEMA s1, d.s2 FROM joe, mike
 ----
 REVOKE USAGE ON ALL SECRETS IN SCHEMA s1, d.s2 FROM joe, mike
 =>
-RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Secret, object_spec_inner: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] } }, roles: [Ident("joe"), Ident("mike")] })
+RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Secret, object_spec_inner: All(AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] }) }, roles: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 REVOKE USAGE ON ALL SECRET IN SCHEMA s1, d.s2 FROM joe, mike
@@ -2570,7 +2570,7 @@ REVOKE USAGE ON ALL CONNECTIONS IN SCHEMA s1, d.s2 FROM joe, mike
 ----
 REVOKE USAGE ON ALL CONNECTIONS IN SCHEMA s1, d.s2 FROM joe, mike
 =>
-RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Connection, object_spec_inner: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] } }, roles: [Ident("joe"), Ident("mike")] })
+RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Connection, object_spec_inner: All(AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d"), Ident("s2")])] }) }, roles: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 REVOKE USAGE ON ALL CONNECTION IN SCHEMA s1, d.s2 FROM joe, mike
@@ -2598,14 +2598,14 @@ REVOKE SELECT ON ALL TABLES IN DATABASE d1, d2 FROM joe
 ----
 REVOKE SELECT ON ALL TABLES IN DATABASE d1, d2 FROM joe
 =>
-RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([SELECT]), target: GrantTargetSpecification { object_type: Table, object_spec_inner: AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1")), UnresolvedDatabaseName(Ident("d2"))] } }, roles: [Ident("joe")] })
+RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([SELECT]), target: GrantTargetSpecification { object_type: Table, object_spec_inner: All(AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1")), UnresolvedDatabaseName(Ident("d2"))] }) }, roles: [Ident("joe")] })
 
 parse-statement
 REVOKE USAGE ON ALL SCHEMAS IN DATABASE d1, d2 FROM joe
 ----
 REVOKE USAGE ON ALL SCHEMAS IN DATABASE d1, d2 FROM joe
 =>
-RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Schema, object_spec_inner: AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1")), UnresolvedDatabaseName(Ident("d2"))] } }, roles: [Ident("joe")] })
+RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([USAGE]), target: GrantTargetSpecification { object_type: Schema, object_spec_inner: All(AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1")), UnresolvedDatabaseName(Ident("d2"))] }) }, roles: [Ident("joe")] })
 
 parse-statement
 REVOKE CREATE ON ALL CLUSTERS IN DATABASE d1, d2 FROM joe
@@ -2626,21 +2626,21 @@ REVOKE SELECT ON ALL TYPES FROM joe
 ----
 REVOKE SELECT ON ALL TYPES FROM joe
 =>
-RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([SELECT]), target: GrantTargetSpecification { object_type: Type, object_spec_inner: All }, roles: [Ident("joe")] })
+RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([SELECT]), target: GrantTargetSpecification { object_type: Type, object_spec_inner: All(All) }, roles: [Ident("joe")] })
 
 parse-statement
 REVOKE CREATE ON ALL DATABASES FROM joe
 ----
 REVOKE CREATE ON ALL DATABASES FROM joe
 =>
-RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([CREATE]), target: GrantTargetSpecification { object_type: Database, object_spec_inner: All }, roles: [Ident("joe")] })
+RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([CREATE]), target: GrantTargetSpecification { object_type: Database, object_spec_inner: All(All) }, roles: [Ident("joe")] })
 
 parse-statement
 REVOKE CREATE ON ALL CLUSTERS FROM joe
 ----
 REVOKE CREATE ON ALL CLUSTERS FROM joe
 =>
-RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([CREATE]), target: GrantTargetSpecification { object_type: Cluster, object_spec_inner: All }, roles: [Ident("joe")] })
+RevokePrivileges(RevokePrivilegesStatement { privileges: Privileges([CREATE]), target: GrantTargetSpecification { object_type: Cluster, object_spec_inner: All(All) }, roles: [Ident("joe")] })
 
 parse-statement
 REVOKE CREATE ON ALL CLUSTER FROM joe
@@ -2648,6 +2648,230 @@ REVOKE CREATE ON ALL CLUSTER FROM joe
 error: Expected one of TABLES or TYPES or SECRETS or CONNECTIONS or SCHEMAS or DATABASES or CLUSTERS, found CLUSTER
 REVOKE CREATE ON ALL CLUSTER FROM joe
                      ^
+
+parse-statement
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO joe
+----
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: All, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: Privileges([SELECT]), object_type: Table, grantees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLE TO joe
+----
+error: Expected one of TABLES or TYPES or SECRETS or CONNECTIONS or SCHEMAS or DATABASES or CLUSTERS, found TABLE
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLE TO joe
+                                         ^
+
+parse-statement
+ALTER DEFAULT PRIVILEGES GRANT USAGE, CREATE ON SCHEMAS TO joe, GROUP mike
+----
+ALTER DEFAULT PRIVILEGES GRANT USAGE, CREATE ON SCHEMAS TO joe, mike
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: All, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: Privileges([USAGE, CREATE]), object_type: Schema, grantees: [Ident("joe"), Ident("mike")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES GRANT ALL ON DATABASES TO GROUP joe
+----
+ALTER DEFAULT PRIVILEGES GRANT ALL ON DATABASES TO joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: All, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: All, object_type: Database, grantees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON CLUSTERS TO joe
+----
+ALTER DEFAULT PRIVILEGES GRANT ALL ON CLUSTERS TO joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: All, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: All, object_type: Cluster, grantees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES IN SCHEMA s1 GRANT USAGE ON TYPES TO joe
+----
+ALTER DEFAULT PRIVILEGES IN SCHEMA s1 GRANT USAGE ON TYPES TO joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")])] }, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: Privileges([USAGE]), object_type: Type, grantees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES IN SCHEMA s1, d1.s2 GRANT USAGE ON SECRETS TO joe
+----
+ALTER DEFAULT PRIVILEGES IN SCHEMA s1, d1.s2 GRANT USAGE ON SECRETS TO joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d1"), Ident("s2")])] }, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: Privileges([USAGE]), object_type: Secret, grantees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES IN DATABASE d1 GRANT USAGE ON CONNECTIONS TO joe
+----
+ALTER DEFAULT PRIVILEGES IN DATABASE d1 GRANT USAGE ON CONNECTIONS TO joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1"))] }, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: Privileges([USAGE]), object_type: Connection, grantees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 GRANT INSERT, DELETE ON TABLES TO joe
+----
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 GRANT INSERT, DELETE ON TABLES TO joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1")), UnresolvedDatabaseName(Ident("d2"))] }, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: Privileges([INSERT, DELETE]), object_type: Table, grantees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES FOR r1 GRANT ALL ON CLUSTERS TO joe
+----
+ALTER DEFAULT PRIVILEGES FOR r1 GRANT ALL ON CLUSTERS TO joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: All, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: All, object_type: Cluster, grantees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 GRANT ALL ON CLUSTERS TO joe
+----
+ALTER DEFAULT PRIVILEGES FOR r1 GRANT ALL ON CLUSTERS TO joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: All, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: All, object_type: Cluster, grantees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES FOR USER r1 GRANT ALL ON CLUSTERS TO joe
+----
+ALTER DEFAULT PRIVILEGES FOR r1 GRANT ALL ON CLUSTERS TO joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: All, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: All, object_type: Cluster, grantees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES FOR r1, r2 GRANT CREATE ON DATABASES TO joe, mike
+----
+ALTER DEFAULT PRIVILEGES FOR r1, r2 GRANT CREATE ON DATABASES TO joe, mike
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1"), Ident("r2")]), target_objects: All, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: Privileges([CREATE]), object_type: Database, grantees: [Ident("joe"), Ident("mike")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES FOR r1 IN SCHEMA s1 GRANT CREATE ON SCHEMAS TO joe
+----
+ALTER DEFAULT PRIVILEGES FOR r1 IN SCHEMA s1 GRANT CREATE ON SCHEMAS TO joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")])] }, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: Privileges([CREATE]), object_type: Schema, grantees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES FOR r1 IN DATABASE d1 GRANT USAGE ON SECRETS TO joe
+----
+ALTER DEFAULT PRIVILEGES FOR r1 IN DATABASE d1 GRANT USAGE ON SECRETS TO joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1"))] }, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: Privileges([USAGE]), object_type: Secret, grantees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES IN GRANT USAGE ON CONNECTIONS TO joe
+----
+error: Expected one of SCHEMA or DATABASE, found GRANT
+ALTER DEFAULT PRIVILEGES IN GRANT USAGE ON CONNECTIONS TO joe
+                            ^
+
+parse-statement
+ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM joe
+----
+ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: All, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: Privileges([SELECT]), object_type: Table, revokees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLE FROM joe
+----
+error: Expected one of TABLES or TYPES or SECRETS or CONNECTIONS or SCHEMAS or DATABASES or CLUSTERS, found TABLE
+ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLE FROM joe
+                                          ^
+
+parse-statement
+ALTER DEFAULT PRIVILEGES REVOKE USAGE, CREATE ON SCHEMAS FROM joe, GROUP mike
+----
+ALTER DEFAULT PRIVILEGES REVOKE USAGE, CREATE ON SCHEMAS FROM joe, mike
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: All, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: Privileges([USAGE, CREATE]), object_type: Schema, revokees: [Ident("joe"), Ident("mike")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON DATABASES FROM GROUP joe
+----
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON DATABASES FROM joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: All, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: All, object_type: Database, revokees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON CLUSTERS FROM joe
+----
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON CLUSTERS FROM joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: All, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: All, object_type: Cluster, revokees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES IN SCHEMA s1 REVOKE USAGE ON TYPES FROM joe
+----
+ALTER DEFAULT PRIVILEGES IN SCHEMA s1 REVOKE USAGE ON TYPES FROM joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")])] }, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: Privileges([USAGE]), object_type: Type, revokees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES IN SCHEMA s1, d1.s2 REVOKE USAGE ON SECRETS FROM joe
+----
+ALTER DEFAULT PRIVILEGES IN SCHEMA s1, d1.s2 REVOKE USAGE ON SECRETS FROM joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")]), UnresolvedSchemaName([Ident("d1"), Ident("s2")])] }, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: Privileges([USAGE]), object_type: Secret, revokees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES IN DATABASE d1 REVOKE USAGE ON CONNECTIONS FROM joe
+----
+ALTER DEFAULT PRIVILEGES IN DATABASE d1 REVOKE USAGE ON CONNECTIONS FROM joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1"))] }, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: Privileges([USAGE]), object_type: Connection, revokees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 REVOKE INSERT, DELETE ON TABLES FROM joe
+----
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 REVOKE INSERT, DELETE ON TABLES FROM joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, target_objects: AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1")), UnresolvedDatabaseName(Ident("d2"))] }, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: Privileges([INSERT, DELETE]), object_type: Table, revokees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES FOR r1 REVOKE ALL ON CLUSTERS FROM joe
+----
+ALTER DEFAULT PRIVILEGES FOR r1 REVOKE ALL ON CLUSTERS FROM joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: All, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: All, object_type: Cluster, revokees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 REVOKE ALL ON CLUSTERS FROM joe
+----
+ALTER DEFAULT PRIVILEGES FOR r1 REVOKE ALL ON CLUSTERS FROM joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: All, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: All, object_type: Cluster, revokees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES FOR USER r1 REVOKE ALL ON CLUSTERS FROM joe
+----
+ALTER DEFAULT PRIVILEGES FOR r1 REVOKE ALL ON CLUSTERS FROM joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: All, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: All, object_type: Cluster, revokees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES FOR r1, r2 REVOKE CREATE ON DATABASES FROM joe, mike
+----
+ALTER DEFAULT PRIVILEGES FOR r1, r2 REVOKE CREATE ON DATABASES FROM joe, mike
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1"), Ident("r2")]), target_objects: All, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: Privileges([CREATE]), object_type: Database, revokees: [Ident("joe"), Ident("mike")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES FOR r1 IN SCHEMA s1 REVOKE CREATE ON SCHEMAS FROM joe
+----
+ALTER DEFAULT PRIVILEGES FOR r1 IN SCHEMA s1 REVOKE CREATE ON SCHEMAS FROM joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")])] }, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: Privileges([CREATE]), object_type: Schema, revokees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES FOR r1 IN DATABASE d1 REVOKE USAGE ON SECRETS FROM joe
+----
+ALTER DEFAULT PRIVILEGES FOR r1 IN DATABASE d1 REVOKE USAGE ON SECRETS FROM joe
+=>
+AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1"))] }, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: Privileges([USAGE]), object_type: Secret, revokees: [Ident("joe")] }) })
+
+parse-statement
+ALTER DEFAULT PRIVILEGES IN REVOKE USAGE ON CONNECTIONS FROM joe
+----
+error: Expected one of SCHEMA or DATABASE, found REVOKE
+ALTER DEFAULT PRIVILEGES IN REVOKE USAGE ON CONNECTIONS FROM joe
+                            ^
 
 parse-statement
 REASSIGN OWNED BY joe TO yisachar

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -153,6 +153,7 @@ impl Plan {
     pub fn generated_from(stmt: StatementKind) -> Vec<PlanKind> {
         match stmt {
             StatementKind::AlterConnection => vec![PlanKind::AlterNoop, PlanKind::RotateKeys],
+            StatementKind::AlterDefaultPrivileges => vec![],
             StatementKind::AlterIndex => vec![
                 PlanKind::AlterIndexResetOptions,
                 PlanKind::AlterIndexSetOptions,

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -146,6 +146,9 @@ pub fn describe(
         Statement::RevokeRole(stmt) => ddl::describe_revoke_role(&scx, stmt)?,
         Statement::GrantPrivileges(stmt) => ddl::describe_grant_privileges(&scx, stmt)?,
         Statement::RevokePrivileges(stmt) => ddl::describe_revoke_privileges(&scx, stmt)?,
+        Statement::AlterDefaultPrivileges(stmt) => {
+            ddl::describe_alter_default_privileges(&scx, stmt)?
+        }
         Statement::ReassignOwned(stmt) => ddl::describe_reassign_owned(&scx, stmt)?,
 
         // `SHOW` statements.
@@ -283,6 +286,7 @@ pub fn plan(
         Statement::RevokeRole(stmt) => ddl::plan_revoke_role(scx, stmt),
         Statement::GrantPrivileges(stmt) => ddl::plan_grant_privileges(scx, stmt),
         Statement::RevokePrivileges(stmt) => ddl::plan_revoke_privileges(scx, stmt),
+        Statement::AlterDefaultPrivileges(stmt) => ddl::plan_alter_default_privileges(scx, stmt),
         Statement::ReassignOwned(stmt) => ddl::plan_reassign_owned(scx, stmt),
 
         // DML statements.


### PR DESCRIPTION
This commit adds the parsing logic for ALTER DEFAULT PRIVILEGES statements.

Works towards resolving #19647

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
