### PR TITLE
compute/timely-util: support summaries on probe::source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5208,7 +5208,7 @@ name = "mz-timely-util"
 version = "0.0.0"
 dependencies = [
  "differential-dataflow",
- "futures-util",
+ "futures",
  "mz-ore",
  "num-traits",
  "polonius-the-crab",

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -214,6 +214,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                         inner.clone(),
                         format!("flow_control_input({source_id})"),
                         probe.clone(),
+                        Timestamp::minimum(),
                     );
                     let flow_control = FlowControl {
                         progress_stream: flow_control_input,

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 
 [dependencies]
 differential-dataflow = "0.12.0"
-futures-util = "0.3.25"
+futures = "0.3.25"
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 serde = { version = "1.0.152", features = ["derive"] }
-mz-ore = { path = "../ore", features = ["tracing_"] }
+mz-ore = { path = "../ore", features = ["test", "tracing_"] }
 polonius-the-crab = "0.3.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -18,8 +18,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 
-use futures_util::task::ArcWake;
-use futures_util::FutureExt;
+use futures::task::ArcWake;
+use futures::FutureExt;
 use polonius_the_crab::{polonius, WithLifetime};
 use timely::communication::message::RefOrMut;
 use timely::communication::{Message, Pull, Push};
@@ -512,7 +512,7 @@ impl<G: Scope> OperatorBuilder<G> {
                     // Schedule the logic future if any of the wakers above marked the task as ready
                     if let Some(fut) = logic_fut.as_mut() {
                         if operator_waker.task_ready.load(Ordering::SeqCst) {
-                            let waker = futures_util::task::waker_ref(&operator_waker);
+                            let waker = futures::task::waker_ref(&operator_waker);
                             let mut cx = Context::from_waker(&waker);
                             operator_waker.task_ready.store(false, Ordering::SeqCst);
                             if Pin::new(fut).poll(&mut cx).is_ready() {


### PR DESCRIPTION
As part of https://www.notion.so/materialize/Granular-backpressure-in-the-source-pipeline-86c48e9a04544f0da0b1e793f1859ff1?showMoveTo=true&saveParent=true, we are adjusting the `flow_control` implementation for `persist_source`. As part of this, we expect to need a _non-zero_ summary for the feedback edges into the `persist_source` operator. This is fine in storage, which will use a direct `feedback` operator with a set summary, but in compute, only `mz_timely_util::probe::source` is used.

This pr adds summary support to `probe::source`, which brings its functionality inline with `feedback`.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
