### PR TITLE
Output consistency tests: ignore log error message deviations

### DIFF
--- a/misc/python/materialize/output_consistency/runner/test_runner.py
+++ b/misc/python/materialize/output_consistency/runner/test_runner.py
@@ -78,6 +78,7 @@ class ConsistencyTestRunner:
             if expression_count > 0 and expression_count % 200 == 0:
                 self.output_printer.print_status(
                     f"Status: Expression {expression_count}..."
+                    f" (last executed query #{self.execution_manager.query_counter})"
                 )
 
             operation = self.expression_generator.pick_random_operation(True)

--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -194,9 +194,19 @@ class ResultComparator:
 
     def normalize_error_message(self, error_message: str) -> str:
         # replace source prefix in column
+        normalized_message = error_message
         normalized_message = re.sub(
-            'column "[^.]*\\.', 'column "<source>.', error_message
+            'column "[^.]*\\.', 'column "<source>.', normalized_message
         )
+
+        # This will replace ln, log, and log10 mentions with log
+        # see https://github.com/MaterializeInc/materialize/issues/19815
+        normalized_message = re.sub(
+            "(?<=function )(ln|log|log10)(?= is not defined for zero)",
+            "log",
+            normalized_message,
+        )
+
         normalized_message = normalized_message.replace("Evaluation error: ", "")
         return normalized_message
 


### PR DESCRIPTION
Needed due to https://github.com/MaterializeInc/materialize/issues/19815.
Identified in https://buildkite.com/materialize/nightlies/builds/2553#01889834-6bbb-4a81-ab2e-8a8b70be9562.

### Verified locally

#### Nightly
```
[2023-06-07T23:44:58Z] -- SELECT
[2023-06-07T23:44:58Z] --   ln(count(CASE WHEN bool_null THEN least(int8_zero, cbrt(decimal_39_8_tiny), int8_zero) ELSE log(uint2_zero, int8_neg_max) END))
[2023-06-07T23:44:58Z] -- FROM
[2023-06-07T23:44:58Z] --   <source>_horiz;
[2023-06-07T23:44:58Z] -- Test with query #8961.2.1.1 FAILED.
[2023-06-07T23:44:58Z] -- Errors:
[2023-06-07T23:44:58Z] -- * ValidationErrorType.ERROR_MISMATCH: Error message differs.
[2023-06-07T23:44:58Z] --   Value 1 (Dataflow rendering): 'function ln is not defined for zero' (type: <class 'str'>)
[2023-06-07T23:44:58Z] --   Value 2 (Constant folding): 'function log is not defined for zero' (type: <class 'str'>)
[2023-06-07T23:44:58Z] --   Query 1: SELECT ln(count(CASE WHEN bool_null THEN least(int8_zero, cbrt(decimal_39_8_tiny), int8_zero) ELSE log(uint2_zero, int8_neg_max) END)) FROM t_dfr_horiz;
[2023-06-07T23:44:58Z] --   Query 2: SELECT ln(count(CASE WHEN bool_null THEN least(int8_zero, cbrt(decimal_39_8_tiny), int8_zero) ELSE log(uint2_zero, int8_neg_max) END)) FROM v_ctf_horiz;
```

#### Locally after fix
```
--- Test query #8961.2.1.1
-- SELECT
--   ln(count(CASE WHEN bool_null THEN least(int8_zero, cbrt(decimal_39_8_tiny), int8_zero) ELSE log(uint2_zero, int8_neg_max) END))
-- FROM
--   <source>_horiz;
-- Test with query #8961.2.1.1 PASSED (error message matches).
-- Remarks:
-- * DB error in 'Dataflow rendering' was: Evaluation error: function ln is not defined for zero
```