### PR TITLE
adapter: add `mz_object_dependencies_transitive` view

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -179,6 +179,17 @@ all database objects in the system.
 | `object_id`             | [`text`]     | The ID of the dependent object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects).  |
 | `referenced_object_id`  | [`text`]     | The ID of the referenced object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects). |
 
+### `mz_object_transitive_dependencies`
+
+The `mz_object_transitive_dependencies` table describes the transitive dependency structure between
+all database objects in the system.
+This table is the transitive closure of [`mz_object_dependencies`](#mz_object_dependencies).
+
+| Field                   | Type         | Meaning                                                                                                               |
+| ----------------------- | ------------ | --------                                                                                                              |
+| `object_id`             | [`text`]     | The ID of the dependent object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects).                          |
+| `referenced_object_id`  | [`text`]     | The ID of the (possibly transitively) referenced object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects). |
+
 ### `mz_postgres_sources`
 
 The `mz_postgres_sources` table contains a row for each PostgreSQL source in the

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -429,6 +429,10 @@ mz_object_dependencies
 BASE TABLE
 materialize
 mz_internal
+mz_object_transitive_dependencies
+VIEW
+materialize
+mz_internal
 mz_peek_durations_histogram
 VIEW
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -598,6 +598,7 @@ mz_dataflows
 mz_dataflows_per_worker
 mz_message_counts
 mz_message_counts_per_worker
+mz_object_transitive_dependencies
 mz_peek_durations_histogram
 mz_peek_durations_histogram_per_worker
 mz_records_per_dataflow


### PR DESCRIPTION
For better UI/UX, we want to expose not only direct, but transitive object dependencies.

With the advancement of #17012, I believe that it is now safe to expose this information directly behind an `mz_internal` view that uses `WITH MUTUALLY RECURSIVE`. 

I'm not sure whether we want to have an index on that view or not.

### Motivation
  * This PR adds a known-desirable feature.

This was requested as part of our efforts to improve the overall system observability.

### Tips for reviewer

* @ggnall, @umanwizard, and @RobinClowers can be potential users for that view, so I'm tagging them as reviewers in order to get some feedback whether the current definition is sufficient (it's just the transitive closure of the `mz_object_dependencies` table represented as a pair of `object_id` references).
* Tagging @teskje for consistency checks in the table and column naming and typing conventions for the newly defined view. It's also unclear to me whether I should document this view somewhere, since it lives under `mz_internal` (but other views in that schema have public documentation).


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
