### PR TITLE
adapter: Fix default privilege stash migrations

### DIFF
--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -17,6 +17,6 @@
   },
   {
     "name": "objects_v18.proto",
-    "md5": "f2c205025d39a5c36f912a5a747a73e8"
+    "md5": "5028cbe7b84e974a46d4f7c00c8575f6"
   }
 ]

--- a/src/stash/protos/objects_v18.proto
+++ b/src/stash/protos/objects_v18.proto
@@ -334,6 +334,37 @@ message TimestampAntichain {
     repeated Timestamp elements = 1;
 }
 
+enum ObjectType {
+    OBJECT_TYPE_UNKNOWN = 0;
+    OBJECT_TYPE_TABLE = 1;
+    OBJECT_TYPE_VIEW = 2;
+    OBJECT_TYPE_MATERIALIZED_VIEW = 3;
+    OBJECT_TYPE_SOURCE = 4;
+    OBJECT_TYPE_SINK = 5;
+    OBJECT_TYPE_INDEX = 6;
+    OBJECT_TYPE_TYPE = 7;
+    OBJECT_TYPE_ROLE = 8;
+    OBJECT_TYPE_CLUSTER = 9;
+    OBJECT_TYPE_CLUSTER_REPLICA = 10;
+    OBJECT_TYPE_SECRET = 11;
+    OBJECT_TYPE_CONNECTION = 12;
+    OBJECT_TYPE_DATABASE = 13;
+    OBJECT_TYPE_SCHEMA = 14;
+    OBJECT_TYPE_FUNC = 15;
+}
+
+message DefaultPrivilegesKey {
+    RoleId role_id = 1;
+    DatabaseId database_id = 2;
+    SchemaId schema_id = 3;
+    ObjectType object_type = 4;
+    RoleId grantee = 5;
+}
+
+message DefaultPrivilegesValue {
+    AclMode privileges = 1;
+}
+
 message AuditLogEventV1 {
     enum EventType {
         EVENT_TYPE_UNKNOWN = 0;

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -946,7 +946,7 @@ impl Stash {
                             14 => upgrade::v14_to_v15::upgrade(),
                             15 => upgrade::v15_to_v16::upgrade(&mut tx).await?,
                             16 => upgrade::v16_to_v17::upgrade(),
-                            17 => upgrade::v17_to_v18::upgrade(),
+                            17 => upgrade::v17_to_v18::upgrade(&mut tx).await?,
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade/v17_to_v18.rs
+++ b/src/stash/src/upgrade/v17_to_v18.rs
@@ -7,5 +7,42 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-/// No-op migration. Just need to bump the version number after adding default privileges.
-pub fn upgrade() {}
+use crate::{StashError, Transaction, TypedCollection};
+
+pub mod objects_v18 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v18.rs"));
+}
+
+/// Migration that adds USAGE privileges on all types to the PUBLIC role in the default privileges
+/// cluster.
+///
+/// Author - jkosh44
+pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {
+    const DEFAULT_PRIVILEGES_COLLECTION: TypedCollection<
+        objects_v18::DefaultPrivilegesKey,
+        objects_v18::DefaultPrivilegesValue,
+    > = TypedCollection::new("default_privileges");
+    const ACL_MODE_USAGE: objects_v18::AclMode = objects_v18::AclMode { bitflags: 1 << 8 };
+
+    DEFAULT_PRIVILEGES_COLLECTION
+        .initialize(
+            tx,
+            vec![(
+                objects_v18::DefaultPrivilegesKey {
+                    role_id: Some(objects_v18::RoleId {
+                        value: Some(objects_v18::role_id::Value::Public(Default::default())),
+                    }),
+                    database_id: None,
+                    schema_id: None,
+                    object_type: objects_v18::ObjectType::Type.into(),
+                    grantee: Some(objects_v18::RoleId {
+                        value: Some(objects_v18::role_id::Value::Public(Default::default())),
+                    }),
+                },
+                objects_v18::DefaultPrivilegesValue {
+                    privileges: Some(ACL_MODE_USAGE),
+                },
+            )],
+        )
+        .await
+}


### PR DESCRIPTION
7e91d54e342a9cae3756b2a55db71202ea8678b5 Added a new stash collection for default privileges, and initialized it with a single USAGE privilege for all types. However, the initialization logic is only run on uninitialized stashes. As a result, stashes that were upgraded never got the single row with the USAGE privilege.

This commit updates the upgrade logic so that the USAGE privilege is added during stash upgrades.

Fixes #19811

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
