### PR TITLE
proto: Remove exception in linter

### DIFF
--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -22,10 +22,6 @@ breaking:
     - stash
     # still under active development
     - persist-types
-  ignore_only:
-    # TODO(parkmycar): Remove this after #19736 merges.
-    FIELD_WIRE_COMPATIBLE_TYPE:
-      - expr/src/
 lint:
   use:
     - DEFAULT


### PR DESCRIPTION
### Motivation

To land #19736 I had to add an exception to the protobuf linter because it detecting a breaking change that wasn't actually a breaking change. I filed and issue against the linter to fix this.

This PR removes the exception from our lint config since it's no longer needed.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
