### PR TITLE
persist: fix bug where apply_diff wasn't updating some State fields

### DIFF
--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -300,16 +300,35 @@ impl<T: Timestamp + Lattice + Codec64> State<T> {
     // Intentionally not even pub(crate) because all callers should use
     // [Self::apply_diffs].
     fn apply_diff(&mut self, metrics: &Metrics, diff: StateDiff<T>) -> Result<(), String> {
-        if self.seqno == diff.seqno_to {
+        // Deconstruct diff so we get a compile failure if new fields are added.
+        let StateDiff {
+            applier_version: diff_applier_version,
+            seqno_from: diff_seqno_from,
+            seqno_to: diff_seqno_to,
+            walltime_ms: diff_walltime_ms,
+            latest_rollup_key: _,
+            rollups: diff_rollups,
+            hostname: diff_hostname,
+            last_gc_req: diff_last_gc_req,
+            leased_readers: diff_leased_readers,
+            critical_readers: diff_critical_readers,
+            writers: diff_writers,
+            since: diff_since,
+            spine: diff_spine,
+        } = diff;
+        if self.seqno == diff_seqno_to {
             return Ok(());
         }
-        if self.seqno != diff.seqno_from {
+        if self.seqno != diff_seqno_from {
             return Err(format!(
                 "could not apply diff {} -> {} to state {}",
-                diff.seqno_from, diff.seqno_to, self.seqno
+                diff_seqno_from, diff_seqno_to, self.seqno
             ));
         }
-        self.seqno = diff.seqno_to;
+        self.seqno = diff_seqno_to;
+        self.applier_version = diff_applier_version;
+        self.walltime_ms = diff_walltime_ms;
+        apply_diffs_single("hostname", diff_hostname, &mut self.hostname)?;
 
         // Deconstruct collections so we get a compile failure if new fields are
         // added.
@@ -322,13 +341,13 @@ impl<T: Timestamp + Lattice + Codec64> State<T> {
             trace,
         } = &mut self.collections;
 
-        apply_diffs_map("rollups", diff.rollups, rollups)?;
-        apply_diffs_single("last_gc_req", diff.last_gc_req, last_gc_req)?;
-        apply_diffs_map("leased_readers", diff.leased_readers, leased_readers)?;
-        apply_diffs_map("critical_readers", diff.critical_readers, critical_readers)?;
-        apply_diffs_map("writers", diff.writers, writers)?;
+        apply_diffs_map("rollups", diff_rollups, rollups)?;
+        apply_diffs_single("last_gc_req", diff_last_gc_req, last_gc_req)?;
+        apply_diffs_map("leased_readers", diff_leased_readers, leased_readers)?;
+        apply_diffs_map("critical_readers", diff_critical_readers, critical_readers)?;
+        apply_diffs_map("writers", diff_writers, writers)?;
 
-        for x in diff.since {
+        for x in diff_since {
             match x.val {
                 Update(from, to) => {
                     if trace.since() != &from {
@@ -344,7 +363,7 @@ impl<T: Timestamp + Lattice + Codec64> State<T> {
                 Delete(_) => return Err("cannot delete since field".to_string()),
             }
         }
-        apply_diffs_spine(metrics, diff.spine, trace)?;
+        apply_diffs_spine(metrics, diff_spine, trace)?;
 
         // There's various sanity checks that this method could run (e.g. since,
         // upper, seqno_since, etc don't regress or that diff.latest_rollup ==


### PR DESCRIPTION
In particular, it was missing applier_version, walltime_ms, and hostname. Categorically avoid this sort of bug in the future by deconstructing StateDiff so new fields become compile errors.

We _could_ write a regression test for this, but it wouldn't catch any later bugs of the same category (unless we did the same destructuring trick), so it's not worth it. OTOH, running [this assertion] in release would be expensive but would have caught this bug immediately.

[this assertion]: https://github.com/MaterializeInc/materialize/blob/f427dc87d88dc5699b5c3d259be772df0cbad92c/src/persist-client/src/internal/apply.rs#L438-L445

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
