### PR TITLE
Split cluster and linked cluster planning to separate modules

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -45,7 +45,9 @@ use crate::util::{send_immediate_rows, ClientTransmitter};
 // this scenario, the session has not been properly initialized and we
 // need to skip directly to creating role. We have a specific method,
 // `sequence_create_role_for_startup` for this purpose.
+mod cluster;
 mod inner;
+mod linked_cluster;
 
 impl Coordinator {
     #[tracing::instrument(level = "debug", skip_all)]

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -1,0 +1,371 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+
+use mz_compute_client::controller::ComputeReplicaConfig;
+use mz_controller::clusters::{
+    ClusterConfig, ClusterId, CreateReplicaConfig, ReplicaConfig, ReplicaId, ReplicaLogging,
+};
+use mz_sql::catalog::{
+    CatalogCluster, CatalogDatabase, CatalogItem as SqlCatalogItem, CatalogItemType, CatalogRole,
+    CatalogSchema, ObjectType, SessionCatalog,
+};
+use mz_sql::plan::{
+    AlterClusterRenamePlan, AlterClusterReplicaRenamePlan, CreateClusterPlan,
+    CreateClusterReplicaPlan,
+};
+
+use crate::catalog::{self, Op, SerializedReplicaLocation};
+use crate::command::ExecuteResponse;
+use crate::coord::{Coordinator, DEFAULT_LOGICAL_COMPACTION_WINDOW_TS};
+use crate::error::AdapterError;
+use crate::session::Session;
+
+impl Coordinator {
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(super) async fn sequence_create_cluster(
+        &mut self,
+        session: &Session,
+        CreateClusterPlan { name, replicas }: CreateClusterPlan,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        tracing::debug!("sequence_create_cluster");
+
+        let id = self.catalog_mut().allocate_user_cluster_id().await?;
+        // The catalog items for the introspection sources are shared between all replicas
+        // of a compute instance, so we create them unconditionally during instance creation.
+        // Whether a replica actually maintains introspection arrangements is determined by the
+        // per-replica introspection configuration.
+        let introspection_sources = self.catalog_mut().allocate_introspection_sources().await;
+        let mut ops = vec![catalog::Op::CreateCluster {
+            id,
+            name: name.clone(),
+            linked_object_id: None,
+            introspection_sources,
+            owner_id: *session.current_role_id(),
+        }];
+
+        let azs = self.catalog().state().availability_zones();
+        let mut n_replicas_per_az = azs
+            .iter()
+            .map(|s| (s.clone(), 0))
+            .collect::<BTreeMap<_, _>>();
+        for (_name, r) in replicas.iter() {
+            if let mz_sql::plan::ReplicaConfig::Managed {
+                availability_zone: Some(az),
+                ..
+            } = r
+            {
+                let ct: &mut usize = n_replicas_per_az.get_mut(az).ok_or_else(|| {
+                    AdapterError::InvalidClusterReplicaAz {
+                        az: az.to_string(),
+                        expected: azs.to_vec(),
+                    }
+                })?;
+                *ct += 1
+            }
+        }
+
+        for (replica_name, replica_config) in replicas {
+            // If the AZ was not specified, choose one, round-robin, from the ones with
+            // the lowest number of configured replicas for this cluster.
+            let (compute, location) = match replica_config {
+                mz_sql::plan::ReplicaConfig::Unmanaged {
+                    storagectl_addrs,
+                    storage_addrs,
+                    computectl_addrs,
+                    compute_addrs,
+                    workers,
+                    compute,
+                } => {
+                    let location = SerializedReplicaLocation::Unmanaged {
+                        storagectl_addrs,
+                        storage_addrs,
+                        computectl_addrs,
+                        compute_addrs,
+                        workers,
+                    };
+                    (compute, location)
+                }
+                mz_sql::plan::ReplicaConfig::Managed {
+                    size,
+                    availability_zone,
+                    compute,
+                } => {
+                    let (availability_zone, user_specified) =
+                        availability_zone.map(|az| (az, true)).unwrap_or_else(|| {
+                            let az = Self::choose_az(&n_replicas_per_az);
+                            *n_replicas_per_az
+                                .get_mut(&az)
+                                .expect("availability zone does not exist") += 1;
+                            (az, false)
+                        });
+                    let location = SerializedReplicaLocation::Managed {
+                        size: size.clone(),
+                        availability_zone,
+                        az_user_specified: user_specified,
+                    };
+                    (compute, location)
+                }
+            };
+
+            let logging = if let Some(config) = compute.introspection {
+                ReplicaLogging {
+                    log_logging: config.debugging,
+                    interval: Some(config.interval),
+                }
+            } else {
+                ReplicaLogging::default()
+            };
+
+            let config = ReplicaConfig {
+                location: self.catalog().concretize_replica_location(
+                    location,
+                    &self
+                        .catalog()
+                        .system_config()
+                        .allowed_cluster_replica_sizes(),
+                )?,
+                compute: ComputeReplicaConfig {
+                    logging,
+                    idle_arrangement_merge_effort: compute.idle_arrangement_merge_effort,
+                },
+            };
+
+            ops.push(catalog::Op::CreateClusterReplica {
+                cluster_id: id,
+                id: self.catalog_mut().allocate_replica_id().await?,
+                name: replica_name.clone(),
+                config,
+                owner_id: *session.current_role_id(),
+            });
+        }
+
+        self.catalog_transact(Some(session), ops).await?;
+
+        self.create_cluster(id).await;
+
+        Ok(ExecuteResponse::CreatedCluster)
+    }
+
+    pub(crate) async fn create_cluster(&mut self, cluster_id: ClusterId) {
+        let (catalog, controller) = self.catalog_and_controller_mut();
+        let cluster = catalog.get_cluster(cluster_id);
+        let cluster_id = cluster.id;
+        let introspection_source_ids: Vec<_> =
+            cluster.log_indexes.iter().map(|(_, id)| *id).collect();
+
+        controller
+            .create_cluster(
+                cluster_id,
+                ClusterConfig {
+                    arranged_logs: cluster.log_indexes.clone(),
+                },
+            )
+            .expect("creating cluster must not fail");
+
+        let replicas: Vec<_> = cluster
+            .replicas_by_id
+            .keys()
+            .copied()
+            .map(|r| (cluster_id, r))
+            .collect();
+        self.create_cluster_replicas(&replicas).await;
+
+        if !introspection_source_ids.is_empty() {
+            self.initialize_compute_read_policies(
+                introspection_source_ids,
+                cluster_id,
+                Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS),
+            )
+            .await;
+        }
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(super) async fn sequence_create_cluster_replica(
+        &mut self,
+        session: &Session,
+        CreateClusterReplicaPlan {
+            name,
+            cluster_id,
+            config,
+        }: CreateClusterReplicaPlan,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        // Choose default AZ if necessary
+        let (compute, location) = match config {
+            mz_sql::plan::ReplicaConfig::Unmanaged {
+                storagectl_addrs,
+                storage_addrs,
+                computectl_addrs,
+                compute_addrs,
+                workers,
+                compute,
+            } => {
+                let location = SerializedReplicaLocation::Unmanaged {
+                    storagectl_addrs,
+                    storage_addrs,
+                    computectl_addrs,
+                    compute_addrs,
+                    workers,
+                };
+                (compute, location)
+            }
+            mz_sql::plan::ReplicaConfig::Managed {
+                size,
+                availability_zone,
+                compute,
+            } => {
+                let (availability_zone, user_specified) = match availability_zone {
+                    Some(az) => {
+                        let azs = self.catalog().state().availability_zones();
+                        if !azs.contains(&az) {
+                            return Err(AdapterError::InvalidClusterReplicaAz {
+                                az,
+                                expected: azs.to_vec(),
+                            });
+                        }
+                        (az, true)
+                    }
+                    None => {
+                        // Choose the least popular AZ among all replicas of this cluster as the default
+                        // if none was specified. If there is a tie for "least popular", pick the first one.
+                        // That is globally unbiased (for Materialize, not necessarily for this customer)
+                        // because we shuffle the AZs on boot in `crate::serve`.
+                        let cluster = self.catalog().get_cluster(cluster_id);
+                        let azs = self.catalog().state().availability_zones();
+                        let mut n_replicas_per_az = azs
+                            .iter()
+                            .map(|s| (s.clone(), 0))
+                            .collect::<BTreeMap<_, _>>();
+                        for r in cluster.replicas_by_id.values() {
+                            if let Some(az) = r.config.location.availability_zone() {
+                                *n_replicas_per_az.get_mut(az).expect("unknown AZ") += 1;
+                            }
+                        }
+                        let az = Self::choose_az(&n_replicas_per_az);
+                        (az, false)
+                    }
+                };
+                let location = SerializedReplicaLocation::Managed {
+                    size,
+                    availability_zone,
+                    az_user_specified: user_specified,
+                };
+                (compute, location)
+            }
+        };
+
+        let logging = if let Some(config) = compute.introspection {
+            ReplicaLogging {
+                log_logging: config.debugging,
+                interval: Some(config.interval),
+            }
+        } else {
+            ReplicaLogging::default()
+        };
+
+        let config = ReplicaConfig {
+            location: self.catalog().concretize_replica_location(
+                location,
+                &self
+                    .catalog()
+                    .system_config()
+                    .allowed_cluster_replica_sizes(),
+            )?,
+            compute: ComputeReplicaConfig {
+                logging,
+                idle_arrangement_merge_effort: compute.idle_arrangement_merge_effort,
+            },
+        };
+
+        let id = self.catalog_mut().allocate_replica_id().await?;
+        let op = catalog::Op::CreateClusterReplica {
+            cluster_id,
+            id,
+            name: name.clone(),
+            config,
+            owner_id: *session.current_role_id(),
+        };
+
+        self.catalog_transact(Some(session), vec![op]).await?;
+
+        self.create_cluster_replicas(&[(cluster_id, id)]).await;
+
+        Ok(ExecuteResponse::CreatedClusterReplica)
+    }
+
+    pub(crate) async fn create_cluster_replicas(&mut self, replicas: &[(ClusterId, ReplicaId)]) {
+        let mut replicas_to_start = Vec::new();
+
+        for (cluster_id, replica_id) in replicas.iter().copied() {
+            let cluster = self.catalog().get_cluster(cluster_id);
+            let role = cluster.role();
+            let replica_config = cluster.replicas_by_id[&replica_id].config.clone();
+
+            replicas_to_start.push(CreateReplicaConfig {
+                cluster_id,
+                replica_id,
+                role,
+                config: replica_config,
+            });
+        }
+
+        self.controller
+            .create_replicas(replicas_to_start)
+            .await
+            .expect("creating replicas must not fail");
+    }
+
+    pub(super) async fn sequence_alter_cluster_rename(
+        &mut self,
+        session: &Session,
+        AlterClusterRenamePlan { id, name, to_name }: AlterClusterRenamePlan,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        let op = Op::RenameCluster { id, name, to_name };
+        match self.catalog_transact(Some(session), vec![op]).await {
+            Ok(()) => Ok(ExecuteResponse::AlteredObject(ObjectType::Cluster)),
+            Err(err) => Err(err),
+        }
+    }
+
+    pub(super) async fn sequence_alter_cluster_replica_rename(
+        &mut self,
+        session: &Session,
+        AlterClusterReplicaRenamePlan {
+            cluster_id,
+            replica_id,
+            name,
+            to_name,
+        }: AlterClusterReplicaRenamePlan,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        let op = catalog::Op::RenameClusterReplica {
+            cluster_id,
+            replica_id,
+            name,
+            to_name,
+        };
+        match self.catalog_transact(Some(session), vec![op]).await {
+            Ok(()) => Ok(ExecuteResponse::AlteredObject(ObjectType::ClusterReplica)),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Returns whether the given cluster exclusively maintains items
+    /// that were formerly maintained on `computed`.
+    pub(crate) fn is_compute_cluster(&self, id: ClusterId) -> bool {
+        let cluster = self.catalog().get_cluster(id);
+        cluster.bound_objects().iter().all(|id| {
+            matches!(
+                self.catalog().get_entry(id).item_type(),
+                CatalogItemType::Index | CatalogItemType::MaterializedView
+            )
+        })
+    }
+}

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -7,16 +7,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! Coordinator functionality to sequence cluster-related plans
+
 use std::collections::BTreeMap;
 
 use mz_compute_client::controller::ComputeReplicaConfig;
 use mz_controller::clusters::{
     ClusterConfig, ClusterId, CreateReplicaConfig, ReplicaConfig, ReplicaId, ReplicaLogging,
 };
-use mz_sql::catalog::{
-    CatalogCluster, CatalogDatabase, CatalogItem as SqlCatalogItem, CatalogItemType, CatalogRole,
-    CatalogSchema, ObjectType, SessionCatalog,
-};
+use mz_sql::catalog::{CatalogCluster, CatalogItem as SqlCatalogItem, CatalogItemType, ObjectType};
 use mz_sql::plan::{
     AlterClusterRenamePlan, AlterClusterReplicaRenamePlan, CreateClusterPlan,
     CreateClusterReplicaPlan,
@@ -301,7 +300,7 @@ impl Coordinator {
         Ok(ExecuteResponse::CreatedClusterReplica)
     }
 
-    pub(crate) async fn create_cluster_replicas(&mut self, replicas: &[(ClusterId, ReplicaId)]) {
+    pub(super) async fn create_cluster_replicas(&mut self, replicas: &[(ClusterId, ReplicaId)]) {
         let mut replicas_to_start = Vec::new();
 
         for (cluster_id, replica_id) in replicas.iter().copied() {
@@ -359,7 +358,7 @@ impl Coordinator {
 
     /// Returns whether the given cluster exclusively maintains items
     /// that were formerly maintained on `computed`.
-    pub(crate) fn is_compute_cluster(&self, id: ClusterId) -> bool {
+    pub(super) fn is_compute_cluster(&self, id: ClusterId) -> bool {
         let cluster = self.catalog().get_cluster(id);
         cluster.bound_objects().iter().all(|id| {
             matches!(

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -18,15 +18,11 @@ use anyhow::anyhow;
 use futures::future::BoxFuture;
 use maplit::btreeset;
 use mz_cloud_resources::VpcEndpointConfig;
-use mz_compute_client::controller::ComputeReplicaConfig;
 use mz_compute_client::types::dataflows::{DataflowDesc, DataflowDescription, IndexDesc};
 use mz_compute_client::types::sinks::{
     ComputeSinkConnection, ComputeSinkDesc, SubscribeSinkConnection,
 };
-use mz_controller::clusters::{
-    ClusterConfig, ClusterId, CreateReplicaConfig, ReplicaAllocation, ReplicaConfig, ReplicaId,
-    ReplicaLogging, DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS,
-};
+use mz_controller::clusters::{ClusterId, ReplicaId};
 use mz_expr::{
     permutation_for_arrangement, CollectionPlan, MirRelationExpr, MirScalarExpr,
     OptimizedMirRelationExpr, RowSetFinishing,
@@ -46,10 +42,9 @@ use mz_sql::catalog::{
 };
 use mz_sql::names::{ObjectId, QualifiedItemName};
 use mz_sql::plan::{
-    AlterClusterRenamePlan, AlterClusterReplicaRenamePlan, AlterIndexResetOptionsPlan,
-    AlterIndexSetOptionsPlan, AlterItemRenamePlan, AlterOptionParameter, AlterOwnerPlan,
-    AlterRolePlan, AlterSecretPlan, AlterSinkPlan, AlterSourcePlan, AlterSystemResetAllPlan,
-    AlterSystemResetPlan, AlterSystemSetPlan, CreateClusterPlan, CreateClusterReplicaPlan,
+    AlterIndexResetOptionsPlan, AlterIndexSetOptionsPlan, AlterItemRenamePlan,
+    AlterOptionParameter, AlterOwnerPlan, AlterRolePlan, AlterSecretPlan, AlterSinkPlan,
+    AlterSourcePlan, AlterSystemResetAllPlan, AlterSystemResetPlan, AlterSystemSetPlan,
     CreateConnectionPlan, CreateDatabasePlan, CreateIndexPlan, CreateMaterializedViewPlan,
     CreateRolePlan, CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan, CreateSourcePlan,
     CreateTablePlan, CreateTypePlan, CreateViewPlan, DropObjectsPlan, DropOwnedPlan, ExecutePlan,
@@ -76,8 +71,8 @@ use tokio::sync::{mpsc, oneshot, OwnedMutexGuard};
 use tracing::{event, warn, Level};
 
 use crate::catalog::{
-    self, Catalog, CatalogItem, Cluster, Connection, DataSourceDesc, Op, SerializedReplicaLocation,
-    StorageSinkConnectionState, UpdatePrivilegeVariant, LINKED_CLUSTER_REPLICA_NAME,
+    self, Catalog, CatalogItem, Cluster, Connection, DataSourceDesc, Op,
+    StorageSinkConnectionState, UpdatePrivilegeVariant,
 };
 use crate::command::{ExecuteResponse, Response};
 use crate::coord::appends::{Deferred, DeferredPlan, PendingWriteTxn};
@@ -464,7 +459,7 @@ impl Coordinator {
     // I put this in the `Coordinator`'s impl block in case we ever want to
     // change the logic and make it depend on some other state, but for now it's
     // a pure function of the `n_replicas_per_az` state.
-    fn choose_az<'a>(n_replicas_per_az: &'a BTreeMap<String, usize>) -> String {
+    pub(crate) fn choose_az<'a>(n_replicas_per_az: &'a BTreeMap<String, usize>) -> String {
         let min = *n_replicas_per_az
             .values()
             .min()
@@ -478,300 +473,6 @@ impl Coordinator {
             .expect("Must have at least one value corresponding to `min`");
 
         (*arbitrary_argmin).clone()
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub(super) async fn sequence_create_cluster(
-        &mut self,
-        session: &Session,
-        CreateClusterPlan { name, replicas }: CreateClusterPlan,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        tracing::debug!("sequence_create_cluster");
-
-        let id = self.catalog_mut().allocate_user_cluster_id().await?;
-        // The catalog items for the introspection sources are shared between all replicas
-        // of a compute instance, so we create them unconditionally during instance creation.
-        // Whether a replica actually maintains introspection arrangements is determined by the
-        // per-replica introspection configuration.
-        let introspection_sources = self.catalog_mut().allocate_introspection_sources().await;
-        let mut ops = vec![catalog::Op::CreateCluster {
-            id,
-            name: name.clone(),
-            linked_object_id: None,
-            introspection_sources,
-            owner_id: *session.current_role_id(),
-        }];
-
-        let azs = self.catalog().state().availability_zones();
-        let mut n_replicas_per_az = azs
-            .iter()
-            .map(|s| (s.clone(), 0))
-            .collect::<BTreeMap<_, _>>();
-        for (_name, r) in replicas.iter() {
-            if let mz_sql::plan::ReplicaConfig::Managed {
-                availability_zone: Some(az),
-                ..
-            } = r
-            {
-                let ct: &mut usize = n_replicas_per_az.get_mut(az).ok_or_else(|| {
-                    AdapterError::InvalidClusterReplicaAz {
-                        az: az.to_string(),
-                        expected: azs.to_vec(),
-                    }
-                })?;
-                *ct += 1
-            }
-        }
-
-        for (replica_name, replica_config) in replicas {
-            // If the AZ was not specified, choose one, round-robin, from the ones with
-            // the lowest number of configured replicas for this cluster.
-            let (compute, location) = match replica_config {
-                mz_sql::plan::ReplicaConfig::Unmanaged {
-                    storagectl_addrs,
-                    storage_addrs,
-                    computectl_addrs,
-                    compute_addrs,
-                    workers,
-                    compute,
-                } => {
-                    let location = SerializedReplicaLocation::Unmanaged {
-                        storagectl_addrs,
-                        storage_addrs,
-                        computectl_addrs,
-                        compute_addrs,
-                        workers,
-                    };
-                    (compute, location)
-                }
-                mz_sql::plan::ReplicaConfig::Managed {
-                    size,
-                    availability_zone,
-                    compute,
-                } => {
-                    let (availability_zone, user_specified) =
-                        availability_zone.map(|az| (az, true)).unwrap_or_else(|| {
-                            let az = Self::choose_az(&n_replicas_per_az);
-                            *n_replicas_per_az
-                                .get_mut(&az)
-                                .expect("availability zone does not exist") += 1;
-                            (az, false)
-                        });
-                    let location = SerializedReplicaLocation::Managed {
-                        size: size.clone(),
-                        availability_zone,
-                        az_user_specified: user_specified,
-                    };
-                    (compute, location)
-                }
-            };
-
-            let logging = if let Some(config) = compute.introspection {
-                ReplicaLogging {
-                    log_logging: config.debugging,
-                    interval: Some(config.interval),
-                }
-            } else {
-                ReplicaLogging::default()
-            };
-
-            let config = ReplicaConfig {
-                location: self.catalog().concretize_replica_location(
-                    location,
-                    &self
-                        .catalog()
-                        .system_config()
-                        .allowed_cluster_replica_sizes(),
-                )?,
-                compute: ComputeReplicaConfig {
-                    logging,
-                    idle_arrangement_merge_effort: compute.idle_arrangement_merge_effort,
-                },
-            };
-
-            ops.push(catalog::Op::CreateClusterReplica {
-                cluster_id: id,
-                id: self.catalog_mut().allocate_replica_id().await?,
-                name: replica_name.clone(),
-                config,
-                owner_id: *session.current_role_id(),
-            });
-        }
-
-        self.catalog_transact(Some(session), ops).await?;
-
-        self.create_cluster(id).await;
-
-        Ok(ExecuteResponse::CreatedCluster)
-    }
-
-    async fn create_cluster(&mut self, cluster_id: ClusterId) {
-        let (catalog, controller) = self.catalog_and_controller_mut();
-        let cluster = catalog.get_cluster(cluster_id);
-        let cluster_id = cluster.id;
-        let introspection_source_ids: Vec<_> =
-            cluster.log_indexes.iter().map(|(_, id)| *id).collect();
-
-        controller
-            .create_cluster(
-                cluster_id,
-                ClusterConfig {
-                    arranged_logs: cluster.log_indexes.clone(),
-                },
-            )
-            .expect("creating cluster must not fail");
-
-        let replicas: Vec<_> = cluster
-            .replicas_by_id
-            .keys()
-            .copied()
-            .map(|r| (cluster_id, r))
-            .collect();
-        self.create_cluster_replicas(&replicas).await;
-
-        if !introspection_source_ids.is_empty() {
-            self.initialize_compute_read_policies(
-                introspection_source_ids,
-                cluster_id,
-                Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS),
-            )
-            .await;
-        }
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub(super) async fn sequence_create_cluster_replica(
-        &mut self,
-        session: &Session,
-        CreateClusterReplicaPlan {
-            name,
-            cluster_id,
-            config,
-        }: CreateClusterReplicaPlan,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        // Choose default AZ if necessary
-        let (compute, location) = match config {
-            mz_sql::plan::ReplicaConfig::Unmanaged {
-                storagectl_addrs,
-                storage_addrs,
-                computectl_addrs,
-                compute_addrs,
-                workers,
-                compute,
-            } => {
-                let location = SerializedReplicaLocation::Unmanaged {
-                    storagectl_addrs,
-                    storage_addrs,
-                    computectl_addrs,
-                    compute_addrs,
-                    workers,
-                };
-                (compute, location)
-            }
-            mz_sql::plan::ReplicaConfig::Managed {
-                size,
-                availability_zone,
-                compute,
-            } => {
-                let (availability_zone, user_specified) = match availability_zone {
-                    Some(az) => {
-                        let azs = self.catalog().state().availability_zones();
-                        if !azs.contains(&az) {
-                            return Err(AdapterError::InvalidClusterReplicaAz {
-                                az,
-                                expected: azs.to_vec(),
-                            });
-                        }
-                        (az, true)
-                    }
-                    None => {
-                        // Choose the least popular AZ among all replicas of this cluster as the default
-                        // if none was specified. If there is a tie for "least popular", pick the first one.
-                        // That is globally unbiased (for Materialize, not necessarily for this customer)
-                        // because we shuffle the AZs on boot in `crate::serve`.
-                        let cluster = self.catalog().get_cluster(cluster_id);
-                        let azs = self.catalog().state().availability_zones();
-                        let mut n_replicas_per_az = azs
-                            .iter()
-                            .map(|s| (s.clone(), 0))
-                            .collect::<BTreeMap<_, _>>();
-                        for r in cluster.replicas_by_id.values() {
-                            if let Some(az) = r.config.location.availability_zone() {
-                                *n_replicas_per_az.get_mut(az).expect("unknown AZ") += 1;
-                            }
-                        }
-                        let az = Self::choose_az(&n_replicas_per_az);
-                        (az, false)
-                    }
-                };
-                let location = SerializedReplicaLocation::Managed {
-                    size,
-                    availability_zone,
-                    az_user_specified: user_specified,
-                };
-                (compute, location)
-            }
-        };
-
-        let logging = if let Some(config) = compute.introspection {
-            ReplicaLogging {
-                log_logging: config.debugging,
-                interval: Some(config.interval),
-            }
-        } else {
-            ReplicaLogging::default()
-        };
-
-        let config = ReplicaConfig {
-            location: self.catalog().concretize_replica_location(
-                location,
-                &self
-                    .catalog()
-                    .system_config()
-                    .allowed_cluster_replica_sizes(),
-            )?,
-            compute: ComputeReplicaConfig {
-                logging,
-                idle_arrangement_merge_effort: compute.idle_arrangement_merge_effort,
-            },
-        };
-
-        let id = self.catalog_mut().allocate_replica_id().await?;
-        let op = catalog::Op::CreateClusterReplica {
-            cluster_id,
-            id,
-            name: name.clone(),
-            config,
-            owner_id: *session.current_role_id(),
-        };
-
-        self.catalog_transact(Some(session), vec![op]).await?;
-
-        self.create_cluster_replicas(&[(cluster_id, id)]).await;
-
-        Ok(ExecuteResponse::CreatedClusterReplica)
-    }
-
-    async fn create_cluster_replicas(&mut self, replicas: &[(ClusterId, ReplicaId)]) {
-        let mut replicas_to_start = Vec::new();
-
-        for (cluster_id, replica_id) in replicas.iter().copied() {
-            let cluster = self.catalog().get_cluster(cluster_id);
-            let role = cluster.role();
-            let replica_config = cluster.replicas_by_id[&replica_id].config.clone();
-
-            replicas_to_start.push(CreateReplicaConfig {
-                cluster_id,
-                replica_id,
-                role,
-                config: replica_config,
-            });
-        }
-
-        self.controller
-            .create_replicas(replicas_to_start)
-            .await
-            .expect("creating replicas must not fail");
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -3736,40 +3437,6 @@ impl Coordinator {
         });
     }
 
-    pub(super) async fn sequence_alter_cluster_rename(
-        &mut self,
-        session: &Session,
-        AlterClusterRenamePlan { id, name, to_name }: AlterClusterRenamePlan,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        let op = Op::RenameCluster { id, name, to_name };
-        match self.catalog_transact(Some(session), vec![op]).await {
-            Ok(()) => Ok(ExecuteResponse::AlteredObject(ObjectType::Cluster)),
-            Err(err) => Err(err),
-        }
-    }
-
-    pub(super) async fn sequence_alter_cluster_replica_rename(
-        &mut self,
-        session: &Session,
-        AlterClusterReplicaRenamePlan {
-            cluster_id,
-            replica_id,
-            name,
-            to_name,
-        }: AlterClusterReplicaRenamePlan,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        let op = Op::RenameClusterReplica {
-            cluster_id,
-            replica_id,
-            name,
-            to_name,
-        };
-        match self.catalog_transact(Some(session), vec![op]).await {
-            Ok(()) => Ok(ExecuteResponse::AlteredObject(ObjectType::ClusterReplica)),
-            Err(err) => Err(err),
-        }
-    }
-
     pub(super) async fn sequence_alter_item_rename(
         &mut self,
         session: &Session,
@@ -4374,198 +4041,6 @@ impl Coordinator {
         self.catalog_transact(Some(session), ops)
             .await
             .map(|_| ExecuteResponse::ReassignOwned)
-    }
-
-    /// Generates the catalog operations to create a linked cluster for the
-    /// source or sink with the given name.
-    ///
-    /// The operations are written to the provided `ops` vector. The ID
-    /// allocated for the linked cluster is returned.
-    async fn create_linked_cluster_ops(
-        &mut self,
-        linked_object_id: GlobalId,
-        name: &QualifiedItemName,
-        config: &SourceSinkClusterConfig,
-        ops: &mut Vec<catalog::Op>,
-        session: &Session,
-    ) -> Result<ClusterId, AdapterError> {
-        let size = match config {
-            SourceSinkClusterConfig::Linked { size } => size.clone(),
-            SourceSinkClusterConfig::Undefined => self.default_linked_cluster_size()?,
-            SourceSinkClusterConfig::Existing { id } => return Ok(*id),
-        };
-        let id = self.catalog().allocate_user_cluster_id().await?;
-        let name = self.catalog().resolve_full_name(name, None);
-        let name = format!("{}_{}_{}", name.database, name.schema, name.item);
-        let name = self.catalog().find_available_cluster_name(&name);
-        let introspection_sources = self.catalog().allocate_introspection_sources().await;
-        ops.push(catalog::Op::CreateCluster {
-            id,
-            name: name.clone(),
-            linked_object_id: Some(linked_object_id),
-            introspection_sources,
-            owner_id: *session.current_role_id(),
-        });
-        self.create_linked_cluster_replica_op(id, size, ops, *session.current_role_id())
-            .await?;
-        Ok(id)
-    }
-
-    /// Generates the catalog operation to create a replica of the given linked
-    /// cluster for the given storage cluster configuration.
-    async fn create_linked_cluster_replica_op(
-        &mut self,
-        cluster_id: ClusterId,
-        size: String,
-        ops: &mut Vec<catalog::Op>,
-        owner_id: RoleId,
-    ) -> Result<(), AdapterError> {
-        let availability_zone = {
-            let azs = self.catalog().state().availability_zones();
-            let n_replicas_per_az = azs
-                .iter()
-                .map(|az| (az.clone(), 0))
-                .collect::<BTreeMap<_, _>>();
-            Self::choose_az(&n_replicas_per_az)
-        };
-        let location = SerializedReplicaLocation::Managed {
-            size: size.to_string(),
-            availability_zone,
-            az_user_specified: false,
-        };
-        let location = self.catalog().concretize_replica_location(
-            location,
-            &self
-                .catalog()
-                .system_config()
-                .allowed_cluster_replica_sizes(),
-        )?;
-        let logging = {
-            ReplicaLogging {
-                log_logging: false,
-                interval: Some(Duration::from_micros(
-                    DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS.into(),
-                )),
-            }
-        };
-        ops.push(catalog::Op::CreateClusterReplica {
-            cluster_id,
-            id: self.catalog().allocate_replica_id().await?,
-            name: LINKED_CLUSTER_REPLICA_NAME.into(),
-            config: ReplicaConfig {
-                location,
-                compute: ComputeReplicaConfig {
-                    logging,
-                    idle_arrangement_merge_effort: None,
-                },
-            },
-            owner_id,
-        });
-        Ok(())
-    }
-
-    /// Generates the catalog operations to alter the linked cluster for the
-    /// source or sink with the given ID, if such a cluster exists.
-    async fn alter_linked_cluster_ops(
-        &mut self,
-        linked_object_id: GlobalId,
-        config: &SourceSinkClusterConfig,
-    ) -> Result<Vec<catalog::Op>, AdapterError> {
-        let mut ops = vec![];
-        match self.catalog().get_linked_cluster(linked_object_id) {
-            None => {
-                coord_bail!("cannot change the size of a source or sink created with IN CLUSTER");
-            }
-            Some(linked_cluster) => {
-                for id in linked_cluster.replicas_by_id.keys() {
-                    ops.extend(
-                        self.catalog()
-                            .cluster_replica_dependents(linked_cluster.id(), *id)
-                            .into_iter()
-                            .map(catalog::Op::DropObject),
-                    );
-                }
-                let size = match config {
-                    SourceSinkClusterConfig::Linked { size } => size.clone(),
-                    SourceSinkClusterConfig::Undefined => self.default_linked_cluster_size()?,
-                    SourceSinkClusterConfig::Existing { .. } => {
-                        coord_bail!("cannot change the cluster of a source or sink")
-                    }
-                };
-                self.create_linked_cluster_replica_op(
-                    linked_cluster.id,
-                    size,
-                    &mut ops,
-                    linked_cluster.owner_id,
-                )
-                .await?;
-            }
-        }
-        Ok(ops)
-    }
-
-    fn default_linked_cluster_size(&self) -> Result<String, AdapterError> {
-        if !self.catalog().system_config().allow_unsafe() {
-            let mut entries = self
-                .catalog()
-                .cluster_replica_sizes()
-                .0
-                .iter()
-                .collect::<Vec<_>>();
-            entries.sort_by_key(
-                |(
-                    _name,
-                    ReplicaAllocation {
-                        scale,
-                        workers,
-                        memory_limit,
-                        ..
-                    },
-                )| (scale, workers, memory_limit),
-            );
-            let expected = entries.into_iter().map(|(name, _)| name.clone()).collect();
-            return Err(AdapterError::SourceOrSinkSizeRequired { expected });
-        }
-        Ok(self.catalog().default_linked_cluster_size())
-    }
-
-    /// Creates the cluster linked to the specified object after a create
-    /// operation, if such a linked cluster exists.
-    async fn maybe_create_linked_cluster(&mut self, linked_object_id: GlobalId) {
-        if let Some(cluster) = self.catalog().get_linked_cluster(linked_object_id) {
-            self.create_cluster(cluster.id).await;
-        }
-    }
-
-    /// Updates the replicas of the cluster linked to the specified object after
-    /// an alter operation, if such a linked cluster exists.
-    async fn maybe_alter_linked_cluster(&mut self, linked_object_id: GlobalId) {
-        if let Some(cluster) = self.catalog().get_linked_cluster(linked_object_id) {
-            // The old replicas of the linked cluster will have been dropped by
-            // `catalog_transact`, both from the catalog state and from the
-            // controller. The new replicas will be in the catalog state, and
-            // need to be recreated in the controller.
-            let cluster_id = cluster.id;
-            let replicas: Vec<_> = cluster
-                .replicas_by_id
-                .keys()
-                .copied()
-                .map(|r| (cluster_id, r))
-                .collect();
-            self.create_cluster_replicas(&replicas).await;
-        }
-    }
-
-    /// Returns whether the given cluster exclusively maintains items
-    /// that were formerly maintained on `computed`.
-    fn is_compute_cluster(&self, id: ClusterId) -> bool {
-        let cluster = self.catalog().get_cluster(id);
-        cluster.bound_objects().iter().all(|id| {
-            matches!(
-                self.catalog().get_entry(id).item_type(),
-                CatalogItemType::Index | CatalogItemType::MaterializedView
-            )
-        })
     }
 }
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -37,8 +37,8 @@ use mz_repr::role_id::RoleId;
 use mz_repr::{Datum, Diff, GlobalId, RelationDesc, RelationType, Row, RowArena, Timestamp};
 use mz_sql::ast::{ExplainStage, IndexOptionName};
 use mz_sql::catalog::{
-    CatalogCluster, CatalogDatabase, CatalogError, CatalogItem as SqlCatalogItem, CatalogItemType,
-    CatalogRole, CatalogSchema, CatalogTypeDetails, ObjectType, SessionCatalog,
+    CatalogCluster, CatalogDatabase, CatalogError, CatalogItemType, CatalogRole, CatalogSchema,
+    CatalogTypeDetails, ObjectType, SessionCatalog,
 };
 use mz_sql::names::{ObjectId, QualifiedItemName};
 use mz_sql::plan::{

--- a/src/adapter/src/coord/sequencer/linked_cluster.rs
+++ b/src/adapter/src/coord/sequencer/linked_cluster.rs
@@ -1,0 +1,212 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use mz_compute_client::controller::ComputeReplicaConfig;
+use mz_controller::clusters::{
+    ClusterId, ReplicaAllocation, ReplicaConfig, ReplicaLogging,
+    DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS,
+};
+use mz_repr::role_id::RoleId;
+use mz_repr::GlobalId;
+use mz_sql::catalog::{
+    CatalogCluster, CatalogDatabase, CatalogItem as SqlCatalogItem, CatalogRole, CatalogSchema,
+    SessionCatalog,
+};
+use mz_sql::names::QualifiedItemName;
+use mz_sql::plan::SourceSinkClusterConfig;
+
+use crate::catalog::{self, SerializedReplicaLocation, LINKED_CLUSTER_REPLICA_NAME};
+use crate::coord::Coordinator;
+use crate::error::AdapterError;
+use crate::session::Session;
+
+impl Coordinator {
+    /// Generates the catalog operations to create a linked cluster for the
+    /// source or sink with the given name.
+    ///
+    /// The operations are written to the provided `ops` vector. The ID
+    /// allocated for the linked cluster is returned.
+    pub(super) async fn create_linked_cluster_ops(
+        &mut self,
+        linked_object_id: GlobalId,
+        name: &QualifiedItemName,
+        config: &SourceSinkClusterConfig,
+        ops: &mut Vec<catalog::Op>,
+        session: &Session,
+    ) -> Result<ClusterId, AdapterError> {
+        let size = match config {
+            SourceSinkClusterConfig::Linked { size } => size.clone(),
+            SourceSinkClusterConfig::Undefined => self.default_linked_cluster_size()?,
+            SourceSinkClusterConfig::Existing { id } => return Ok(*id),
+        };
+        let id = self.catalog().allocate_user_cluster_id().await?;
+        let name = self.catalog().resolve_full_name(name, None);
+        let name = format!("{}_{}_{}", name.database, name.schema, name.item);
+        let name = self.catalog().find_available_cluster_name(&name);
+        let introspection_sources = self.catalog().allocate_introspection_sources().await;
+        ops.push(catalog::Op::CreateCluster {
+            id,
+            name: name.clone(),
+            linked_object_id: Some(linked_object_id),
+            introspection_sources,
+            owner_id: *session.current_role_id(),
+        });
+        self.create_linked_cluster_replica_op(id, size, ops, *session.current_role_id())
+            .await?;
+        Ok(id)
+    }
+
+    /// Generates the catalog operation to create a replica of the given linked
+    /// cluster for the given storage cluster configuration.
+    async fn create_linked_cluster_replica_op(
+        &mut self,
+        cluster_id: ClusterId,
+        size: String,
+        ops: &mut Vec<catalog::Op>,
+        owner_id: RoleId,
+    ) -> Result<(), AdapterError> {
+        let availability_zone = {
+            let azs = self.catalog().state().availability_zones();
+            let n_replicas_per_az = azs
+                .iter()
+                .map(|az| (az.clone(), 0))
+                .collect::<BTreeMap<_, _>>();
+            Self::choose_az(&n_replicas_per_az)
+        };
+        let location = SerializedReplicaLocation::Managed {
+            size: size.to_string(),
+            availability_zone,
+            az_user_specified: false,
+        };
+        let location = self.catalog().concretize_replica_location(
+            location,
+            &self
+                .catalog()
+                .system_config()
+                .allowed_cluster_replica_sizes(),
+        )?;
+        let logging = {
+            ReplicaLogging {
+                log_logging: false,
+                interval: Some(Duration::from_micros(
+                    DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS.into(),
+                )),
+            }
+        };
+        ops.push(catalog::Op::CreateClusterReplica {
+            cluster_id,
+            id: self.catalog().allocate_replica_id().await?,
+            name: LINKED_CLUSTER_REPLICA_NAME.into(),
+            config: ReplicaConfig {
+                location,
+                compute: ComputeReplicaConfig {
+                    logging,
+                    idle_arrangement_merge_effort: None,
+                },
+            },
+            owner_id,
+        });
+        Ok(())
+    }
+
+    /// Generates the catalog operations to alter the linked cluster for the
+    /// source or sink with the given ID, if such a cluster exists.
+    pub(crate) async fn alter_linked_cluster_ops(
+        &mut self,
+        linked_object_id: GlobalId,
+        config: &SourceSinkClusterConfig,
+    ) -> Result<Vec<catalog::Op>, AdapterError> {
+        let mut ops = vec![];
+        match self.catalog().get_linked_cluster(linked_object_id) {
+            None => {
+                coord_bail!("cannot change the size of a source or sink created with IN CLUSTER");
+            }
+            Some(linked_cluster) => {
+                for id in linked_cluster.replicas_by_id.keys() {
+                    ops.extend(
+                        self.catalog()
+                            .cluster_replica_dependents(linked_cluster.id(), *id)
+                            .into_iter()
+                            .map(catalog::Op::DropObject),
+                    );
+                }
+                let size = match config {
+                    SourceSinkClusterConfig::Linked { size } => size.clone(),
+                    SourceSinkClusterConfig::Undefined => self.default_linked_cluster_size()?,
+                    SourceSinkClusterConfig::Existing { .. } => {
+                        coord_bail!("cannot change the cluster of a source or sink")
+                    }
+                };
+                self.create_linked_cluster_replica_op(
+                    linked_cluster.id,
+                    size,
+                    &mut ops,
+                    linked_cluster.owner_id,
+                )
+                .await?;
+            }
+        }
+        Ok(ops)
+    }
+
+    fn default_linked_cluster_size(&self) -> Result<String, AdapterError> {
+        if !self.catalog().system_config().allow_unsafe() {
+            let mut entries = self
+                .catalog()
+                .cluster_replica_sizes()
+                .0
+                .iter()
+                .collect::<Vec<_>>();
+            entries.sort_by_key(
+                |(
+                    _name,
+                    ReplicaAllocation {
+                        scale,
+                        workers,
+                        memory_limit,
+                        ..
+                    },
+                )| (scale, workers, memory_limit),
+            );
+            let expected = entries.into_iter().map(|(name, _)| name.clone()).collect();
+            return Err(AdapterError::SourceOrSinkSizeRequired { expected });
+        }
+        Ok(self.catalog().default_linked_cluster_size())
+    }
+
+    /// Creates the cluster linked to the specified object after a create
+    /// operation, if such a linked cluster exists.
+    pub(super) async fn maybe_create_linked_cluster(&mut self, linked_object_id: GlobalId) {
+        if let Some(cluster) = self.catalog().get_linked_cluster(linked_object_id) {
+            self.create_cluster(cluster.id).await;
+        }
+    }
+
+    /// Updates the replicas of the cluster linked to the specified object after
+    /// an alter operation, if such a linked cluster exists.
+    pub(crate) async fn maybe_alter_linked_cluster(&mut self, linked_object_id: GlobalId) {
+        if let Some(cluster) = self.catalog().get_linked_cluster(linked_object_id) {
+            // The old replicas of the linked cluster will have been dropped by
+            // `catalog_transact`, both from the catalog state and from the
+            // controller. The new replicas will be in the catalog state, and
+            // need to be recreated in the controller.
+            let cluster_id = cluster.id;
+            let replicas: Vec<_> = cluster
+                .replicas_by_id
+                .keys()
+                .copied()
+                .map(|r| (cluster_id, r))
+                .collect();
+            self.create_cluster_replicas(&replicas).await;
+        }
+    }
+}

--- a/src/adapter/src/coord/sequencer/linked_cluster.rs
+++ b/src/adapter/src/coord/sequencer/linked_cluster.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! Coordinator functionality to sequence linked-cluster-related plans
+
 use std::collections::BTreeMap;
 use std::time::Duration;
 
@@ -17,10 +19,7 @@ use mz_controller::clusters::{
 };
 use mz_repr::role_id::RoleId;
 use mz_repr::GlobalId;
-use mz_sql::catalog::{
-    CatalogCluster, CatalogDatabase, CatalogItem as SqlCatalogItem, CatalogRole, CatalogSchema,
-    SessionCatalog,
-};
+use mz_sql::catalog::CatalogCluster;
 use mz_sql::names::QualifiedItemName;
 use mz_sql::plan::SourceSinkClusterConfig;
 
@@ -120,7 +119,7 @@ impl Coordinator {
 
     /// Generates the catalog operations to alter the linked cluster for the
     /// source or sink with the given ID, if such a cluster exists.
-    pub(crate) async fn alter_linked_cluster_ops(
+    pub(super) async fn alter_linked_cluster_ops(
         &mut self,
         linked_object_id: GlobalId,
         config: &SourceSinkClusterConfig,
@@ -193,7 +192,7 @@ impl Coordinator {
 
     /// Updates the replicas of the cluster linked to the specified object after
     /// an alter operation, if such a linked cluster exists.
-    pub(crate) async fn maybe_alter_linked_cluster(&mut self, linked_object_id: GlobalId) {
+    pub(super) async fn maybe_alter_linked_cluster(&mut self, linked_object_id: GlobalId) {
         if let Some(cluster) = self.catalog().get_linked_cluster(linked_object_id) {
             // The old replicas of the linked cluster will have been dropped by
             // `catalog_transact`, both from the catalog state and from the


### PR DESCRIPTION


### Motivation
   * This PR refactors existing code: It extracts cluster and linked cluster planning into separate files.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
