### PR TITLE
persist: force apply diffs on hostname

### DIFF
--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -20,7 +20,7 @@ use mz_persist_types::Codec64;
 use mz_proto::TryFromProtoError;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
-use tracing::debug;
+use tracing::{debug, error};
 
 use crate::critical::CriticalReaderId;
 use crate::internal::paths::PartialRollupKey;
@@ -328,7 +328,7 @@ impl<T: Timestamp + Lattice + Codec64> State<T> {
         self.seqno = diff_seqno_to;
         self.applier_version = diff_applier_version;
         self.walltime_ms = diff_walltime_ms;
-        apply_diffs_single("hostname", diff_hostname, &mut self.hostname)?;
+        force_apply_diffs_single("hostname", diff_hostname, &mut self.hostname)?;
 
         // Deconstruct collections so we get a compile failure if new fields are
         // added.
@@ -412,6 +412,44 @@ fn apply_diff_single<X: PartialEq + Debug>(
                     "{} update didn't match: {:?} vs {:?}",
                     name, single, &from
                 ));
+            }
+            *single = to
+        }
+        Insert(_) => return Err(format!("cannot insert {} field", name)),
+        Delete(_) => return Err(format!("cannot delete {} field", name)),
+    }
+    Ok(())
+}
+
+// A hack to force apply a diff, making `single` equal to
+// the Update `to` value, ignoring a mismatch on `from`.
+// Used to migrate forward after writing down incorrect
+// diffs.
+//
+// TODO: delete this once `hostname` has zero mismatches
+fn force_apply_diffs_single<X: PartialEq + Debug>(
+    name: &str,
+    diffs: Vec<StateFieldDiff<(), X>>,
+    single: &mut X,
+) -> Result<(), String> {
+    for diff in diffs {
+        force_apply_diff_single(name, diff, single)?;
+    }
+    Ok(())
+}
+
+fn force_apply_diff_single<X: PartialEq + Debug>(
+    name: &str,
+    diff: StateFieldDiff<(), X>,
+    single: &mut X,
+) -> Result<(), String> {
+    match diff.val {
+        Update(from, to) => {
+            if single != &from {
+                error!(
+                    "{} update didn't match: {:?} vs {:?}, continuing to force apply diff...",
+                    name, single, &from
+                );
             }
             *single = to
         }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Rolling forward to fix a bug in https://github.com/MaterializeInc/materialize/pull/19833 -- `hostname` is modeled as a differential update, but the in-mem vs rollup States can differ due to prior incorrectly persisted state, meaning that the `from` redaction may not match across processes (or even between the StateCache vs GC).

This PR introduces a hack to force apply `hostname`'s `to` value. After running this through a release and clearing out the bad state (and verifying the errors go away right after release!) we can turn this back into a normal `apply_diffs_single`.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
