### PR TITLE
transform: Spec tests on typechecking

### DIFF
--- a/src/expr-parser/tests/test_mir_parser/arrange_by.spec
+++ b/src/expr-parser/tests/test_mir_parser/arrange_by.spec
@@ -7,7 +7,17 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# TopK
+# ArrangeBy
+
+roundtrip
+ArrangeBy keys=[[#0], [#1]]
+  Constant // { types: "(bigint, bigint)" }
+    - (1, 2)
+    - (3, 4)
+----
+roundtrip OK
+
+# NB this doesn't typecheck, but the parser still accepts it
 roundtrip
 ArrangeBy keys=[[#1], [#2, #3]]
   Constant // { types: "(bigint, bigint)" }

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -1506,11 +1506,14 @@ impl<'a> TypeError<'a> {
                 input_type,
             } => {
                 let col = order.column;
+                let num_cols = input_type.len();
+                let are = if num_cols == 1 { "is" } else { "are" };
+                let s = if num_cols == 1 { "" } else { "s" };
                 let input_type = columns_pretty(input_type, humanizer);
 
                 writeln!(
                     f,
-                    "TopK ordering {order} references invalid column {col} orderings\ncolumns: {input_type}")?
+                    "TopK ordering {order} references invalid column {col}\nthere {are} {num_cols} column{s}: {input_type}")?
             }
             BadLetRecBindings { source: _ } => {
                 writeln!(f, "LetRec ids and definitions don't line up")?

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -1239,7 +1239,8 @@ impl crate::Transform for Typecheck {
     }
 }
 
-fn columns_pretty<H>(cols: &[ColumnType], humanizer: &H) -> String
+/// Prints a type prettily with a given `ExprHumanizer`
+pub fn columns_pretty<H>(cols: &[ColumnType], humanizer: &H) -> String
 where
     H: ExprHumanizer,
 {
@@ -1339,9 +1340,42 @@ impl ColumnTypeDifference {
     }
 }
 
+/// Wrapper struct for a `Display` instance for `TypeError`s with a given `ExprHumanizer`
+#[allow(missing_debug_implementations)]
+pub struct TypeErrorHumanizer<'a, 'b, H>
+where
+    H: ExprHumanizer,
+{
+    err: &'a TypeError<'a>,
+    humanizer: &'b H,
+}
+
+impl<'a, 'b, H> TypeErrorHumanizer<'a, 'b, H>
+where
+    H: ExprHumanizer,
+{
+    /// Create a `Display`-shim struct for a given `TypeError`/`ExprHumanizer` pair
+    pub fn new(err: &'a TypeError, humanizer: &'b H) -> Self {
+        Self { err, humanizer }
+    }
+}
+
+impl<'a, 'b, H> std::fmt::Display for TypeErrorHumanizer<'a, 'b, H>
+where
+    H: ExprHumanizer,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.err.humanize(self.humanizer, f)
+    }
+}
+
 impl<'a> std::fmt::Display for TypeError<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.humanize(&DummyHumanizer, f)
+        TypeErrorHumanizer {
+            err: self,
+            humanizer: &DummyHumanizer,
+        }
+        .fmt(f)
     }
 }
 

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -690,21 +690,6 @@ impl Typecheck {
                         // TODO(mgree) this imprecision should be resolved, but we need to fix the optimizer
                         ::tracing::debug!("{err}");
                     }
-
-                    // if a single column in the equivalence class is non-nullable, then we can consider all columns non-nullable
-                    let col_inds = eq_class
-                        .iter()
-                        .filter_map(|expr| match expr {
-                            MirScalarExpr::Column(col) => Some(*col),
-                            _ => None,
-                        })
-                        .collect_vec();
-
-                    if col_inds.iter().any(|i| !t_in_global.get(*i).unwrap().nullable) {
-                        for i in col_inds {
-                            t_in_global.get_mut(i).unwrap().nullable = false;
-                        }
-                    }
                 }
 
                 // check that the join implementation is consistent

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -690,6 +690,21 @@ impl Typecheck {
                         // TODO(mgree) this imprecision should be resolved, but we need to fix the optimizer
                         ::tracing::debug!("{err}");
                     }
+
+                    // if a single column in the equivalence class is non-nullable, then we can consider all columns non-nullable
+                    let col_inds = eq_class
+                        .iter()
+                        .filter_map(|expr| match expr {
+                            MirScalarExpr::Column(col) => Some(*col),
+                            _ => None,
+                        })
+                        .collect_vec();
+
+                    if col_inds.iter().any(|i| !t_in_global.get(*i).unwrap().nullable) {
+                        for i in col_inds {
+                            t_in_global.get_mut(i).unwrap().nullable = false;
+                        }
+                    }
                 }
 
                 // check that the join implementation is consistent

--- a/src/transform/tests/test_transforms/typecheck.spec
+++ b/src/transform/tests/test_transforms/typecheck.spec
@@ -16,7 +16,7 @@
 #  union of incompatible types (parser panics)
 #  strict join equivalence checking (typechecker is imprecise, we only log debug messages)
 #
-# missing scalar/tablefunc/aggregate type errors: 
+# missing scalar/tablefunc/aggregate type errors:
 #   bad column (parser rules out)
 #   mismatched then/else branches in an if (parser doesn't support as of 2023-06-09)
 #   bad input type (not checkable---we don't know input types as of 2023-06-09)
@@ -68,8 +68,8 @@ Get t1
 typecheck
 Return
   Get l0
-With 
-  cte l0 = 
+With
+  cte l0 =
     Get t0
 ----
 (Int64, Int64?, String)
@@ -78,8 +78,8 @@ With
 typecheck
 Return
   Get l0
-With 
-  cte l0 = 
+With
+  cte l0 =
     Return
       Get l0
     With
@@ -92,10 +92,10 @@ With
 typecheck
 Return
   Get l0
-With 
-  cte l0 = 
+With
+  cte l0 =
     Get t0
-  cte l0 = 
+  cte l0 =
     Get t1
 ----
 ----

--- a/src/transform/tests/test_transforms/typecheck.spec
+++ b/src/transform/tests/test_transforms/typecheck.spec
@@ -7,6 +7,20 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# TODO(mgree): need to relax the parser to write more type errors
+#
+# missing relation type errors:
+#  unbouned variables (parser panics)
+#  bad type annotation on Get (parser panics)
+#  project of non-existent column (parser panics)
+#  union of incompatible types (parser panics)
+#  strict join equivalence checking (typechecker is imprecise, we only log debug messages)
+#
+# missing scalar/tablefunc/aggregate type errors: 
+#   bad column (parser rules out)
+#   mismatched then/else branches in an if (parser doesn't support as of 2023-06-09)
+#   bad input type (not checkable---we don't know input types as of 2023-06-09)
+
 # Source definitions
 # ------------------
 
@@ -28,13 +42,12 @@ DefSource name=t1
 ----
 Source defined as t1
 
-# TODO: Constant, Let, LetRec, Map, FlatMap, Filter, Join, Reduce, TopK, Negate, Threshold, Union, ArrangeBy
+# TODO: Join, Reduce, TopK
+# Negate and Threshold are boring
 
 ############################################################################
 # Case: Get
 ############################################################################
-# TODO(mgree): would be good to include unbound variables, but the expr-parser doesn't support that
-# TODO(mgree): would be good to include a case where the annotated type is wrong, but the parser currently fills in the correct type
 
 # Present
 typecheck
@@ -47,6 +60,151 @@ typecheck
 Get t1
 ----
 (String, Int64, Bool)
+
+############################################################################
+# Case: Let
+############################################################################
+
+typecheck
+Return
+  Get l0
+With 
+  cte l0 = 
+    Get t0
+----
+(Int64, Int64?, String)
+
+# no shadowing
+typecheck
+Return
+  Get l0
+With 
+  cte l0 = 
+    Return
+      Get l0
+    With
+      cte l0 =
+        Get t0
+----
+(Int64, Int64?, String)
+
+# shadowing
+typecheck
+Return
+  Get l0
+With 
+  cte l0 = 
+    Get t0
+  cte l0 = 
+    Get t1
+----
+----
+In the MIR term:
+Return
+  Get l0
+With
+  cte l0 =
+    Get t0
+
+
+id l0 is shadowed
+----
+----
+
+
+############################################################################
+# Case: Project
+############################################################################
+
+# no shadowing
+typecheck
+Return
+  Map ("return_inner")
+    Get l1
+With Mutually Recursive
+  cte l1 = // { types: "(bigint, bigint?, text)" }
+    Return
+      Union
+        Get l1
+        Filter (#0 > 1)
+          Get l0
+    With Mutually Recursive
+      cte l0 = // { types: "(bigint, bigint?, text)" }
+        Union
+          Get l0
+          Filter (#0 > 42)
+            Get t0
+----
+(Int64, Int64?, String, String)
+
+typecheck
+Return
+  Get l0
+With Mutually Recursive
+  cte l0 = // { types: "(bigint, bigint?, text)" }
+    Return
+      Union
+        Get l0
+        Filter (#0 > 1)
+          Get l0
+    With Mutually Recursive
+      cte l0 = // { types: "(bigint, bigint?, text)" }
+        Union
+          Get l0
+          Filter (#0 > 42)
+            Get t0
+----
+----
+In the MIR term:
+Return
+  Union
+    Get l0
+    Filter (#0 > 1)
+      Get l0
+With Mutually Recursive
+  cte l0 =
+    Union
+      Get l0
+      Filter (#0 > 42)
+        Get t0
+
+
+id l0 is shadowed
+----
+----
+
+# type annotations don't match
+typecheck
+Return
+  Filter #0 AND #1
+    Get l0
+With Mutually Recursive
+  cte l0 = // { types: "(boolean?, boolean)" }
+    Constant // { types: "(bigint, bigint)" }
+      - (1, 3)
+  cte l1 = // { types: "(boolean, boolean?)" }
+    Get l1
+----
+----
+In the MIR term:
+Return
+  Filter #0 AND #1
+    Get l0
+With Mutually Recursive
+  cte l0 =
+    Constant
+      - (1, 3)
+  cte l1 =
+    Get l1
+
+
+mismatched column types: couldn't compute union of column types in let rec: Can't union types: Bool and Int64
+      got Int64
+expected Bool?
+  Bool is a not a subtype of Int64
+  Bool? is nullable but Int64 is not
+----
+----
 
 ############################################################################
 # Case: Project
@@ -70,6 +228,55 @@ Project ()
 #  Get t0
 #----
 #error
+
+############################################################################
+# Case: Map
+############################################################################
+
+typecheck
+Map (#0 + #1)
+  Get t0
+----
+(Int64, Int64?, String, Int64?)
+
+# ok constant
+typecheck
+Map (#0 + #1)
+  Constant // { types: "(bigint, bigint)" }
+    - (1, 3)
+    - (2, 4)
+----
+(Int64, Int64, Int64)
+
+# bad constant
+typecheck
+Map (#0 + #1)
+  Constant // { types: "(bigint, bigint)" }
+    - (1, 3)
+    - (2, "uh oh")
+----
+----
+In the MIR term:
+Constant
+  - (1, 3)
+  - (2, "uh oh")
+
+
+bad constant row
+      got (2, "uh oh")
+expected row of type (Int64, Int64)
+----
+----
+
+############################################################################
+# Case: FlatMap
+############################################################################
+
+typecheck
+FlatMap generate_series(#0, #1 + 3, 5)
+  Get t0
+----
+(Int64, Int64?, String, Int64)
 
 ############################################################################
 # Case: Filter
@@ -114,5 +321,119 @@ mismatched column types: expected boolean condition
       got String
 expected Bool?
   String is a not a subtype of Bool
+----
+----
+
+############################################################################
+# Case: Join
+############################################################################
+
+typecheck
+Join on=(eq(#0, #3))
+  Get t0
+  Get t0
+----
+(Int64, Int64?, String, Int64, Int64?, String)
+
+typecheck
+Join on=(eq(#0, #1, #3, #4))
+  Get t0
+  Get t0
+----
+(Int64, Int64, String, Int64, Int64, String)
+
+############################################################################
+# Case: Union
+############################################################################
+
+
+typecheck
+Union
+  Project (#0)
+    Get t0
+  Project (#1)
+    Get t1
+----
+(Int64)
+
+typecheck
+Union
+  Project (#0)
+    Get t0
+  Filter #0 IS NOT NULL
+    Project (#1)
+      Get t0
+  Project (#1)
+    Get t1
+----
+(Int64)
+
+
+# appropriate union types (widening nullability)
+typecheck
+Union
+  Project (#0)
+    Get t0
+  Project (#1)
+    Get t0
+  Project (#1)
+    Get t1
+----
+(Int64?)
+
+# TODO(mgree): another parser rejection
+# union of incompatible types
+#typecheck
+#Union
+#  Get t0
+#  Get t1
+#----
+#----
+#error
+#----
+#----
+
+# another union of incompatible types
+#typecheck
+#Union
+#  Project (#0)
+#    Get t0
+#  Project (#1)
+#    Get t0
+#  Project (#0)
+#    Get t1
+#----
+#----
+#error
+#----
+#----
+
+############################################################################
+# Case: Arrange
+############################################################################
+
+typecheck
+ArrangeBy keys=[[#0], [#1]]
+  Constant // { types: "(bigint, bigint)" }
+    - (1, 2)
+    - (3, 4)
+----
+(Int64, Int64)
+
+typecheck
+ArrangeBy keys=[[#2]]
+  Constant // { types: "(bigint, bigint)" }
+    - (1, 2)
+    - (3, 4)
+----
+----
+In the MIR term:
+ArrangeBy keys=[[#2]]
+  Constant
+    - (1, 2)
+    - (3, 4)
+
+
+#2 references non-existent column 2
 ----
 ----

--- a/src/transform/tests/test_transforms/typecheck.spec
+++ b/src/transform/tests/test_transforms/typecheck.spec
@@ -1,0 +1,118 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Source definitions
+# ------------------
+
+# Define t0 source
+define
+DefSource name=t0
+  - bigint
+  - bigint?
+  - text
+----
+Source defined as t0
+
+# Define t1 source
+define
+DefSource name=t1
+  - text
+  - bigint
+  - boolean
+----
+Source defined as t1
+
+# TODO: Constant, Let, LetRec, Map, FlatMap, Filter, Join, Reduce, TopK, Negate, Threshold, Union, ArrangeBy
+
+############################################################################
+# Case: Get
+############################################################################
+# TODO(mgree): would be good to include unbound variables, but the expr-parser doesn't support that
+# TODO(mgree): would be good to include a case where the annotated type is wrong, but the parser currently fills in the correct type
+
+# Present
+typecheck
+Get t0
+----
+(Int64, Int64?, String)
+
+
+typecheck
+Get t1
+----
+(String, Int64, Bool)
+
+############################################################################
+# Case: Project
+############################################################################
+
+typecheck
+Project (#0, #2)
+  Get t0
+----
+(Int64, String)
+
+typecheck
+Project ()
+  Get t0
+----
+()
+
+# TODO(mgree): would be good to test this, but the parser dies in `col_with_input_cols` before we get to the typechecker, i.e., the other typechecker beats us to the punch
+#typecheck
+#Project (#0, #5, #1)
+#  Get t0
+#----
+#error
+
+############################################################################
+# Case: Filter
+############################################################################
+
+# nullability narrowing
+typecheck
+Filter (#0 = #1)
+  Get t0
+----
+(Int64, Int64, String)
+
+
+# nullability narrowing
+typecheck
+Filter (#0 > #1)
+  Get t0
+----
+(Int64, Int64, String)
+
+
+# multiple predicates
+typecheck
+Filter (#0 = "hi" AND #1 > 2 AND #2)
+  Get t1
+----
+(String, Int64, Bool)
+
+
+# bad predicate
+typecheck
+Filter #2
+  Get t0
+----
+----
+In the MIR term:
+Filter #2
+  Get t0
+
+
+mismatched column types: expected boolean condition
+      got String
+expected Bool?
+  String is a not a subtype of Bool
+----
+----

--- a/src/transform/tests/test_transforms/typecheck.spec
+++ b/src/transform/tests/test_transforms/typecheck.spec
@@ -340,7 +340,7 @@ Join on=(eq(#0, #1, #3, #4))
   Get t0
   Get t0
 ----
-(Int64, Int64, String, Int64, Int64, String)
+(Int64, Int64?, String, Int64, Int64?, String)
 
 ############################################################################
 # Case: Union


### PR DESCRIPTION
With #18714, we can write tests directly on MIR. This PR adds some tests on typechecking. (It also slightly refactors some pretty printing code for errors in the typechecker.)

### Tips for Reviewers

  - `src/transform/tests/test_transforms/typecheck.spec` has a list at the top of type errors we can't currently check in the spec tests, mostly because other code is too thorough/will panic if given malformed input.

### Motivation

  * This PR adds a known-desirable feature. #18666 introduced typechecking, which has a good testing surface for _successful_ typechecking, but none to ensure that certain errors are detected. This PR adds tests to ensure that the typechecker rejects appropriate programs.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): there are no user-facing behavior changes.