### PR TITLE
sql: add some redshift-only options to COPY

### DIFF
--- a/doc/user/content/sql/copy-from.md
+++ b/doc/user/content/sql/copy-from.md
@@ -30,7 +30,9 @@ Name | Value type | Default value | Description
 `NULL` | Single-quoted strings | Format-dependent | Specifies the string that represents a _NULL_ value.
 `QUOTE` | Single-quoted one-byte character | `"` | Specifies the character to signal a quoted string, which may contain the `DELIMITER` value (without beginning new columns). To include the `QUOTE` character itself in column, wrap the column's value in the `QUOTE` character and prefix all instance of the value you want to literally interpret with the `ESCAPE` value. _`FORMAT CSV` only_
 `ESCAPE` | Single-quoted strings | `QUOTE`'s value | Specifies the character to allow instances of the `QUOTE` character to be parsed literally as part of a column's value. _`FORMAT CSV` only_
-`HEADER`  | `boolean`   | `boolean`  | Specifies that the file contains a header line with the names of each column in the file. The first line is ignored on input.  _`FORMAT CSV` only._
+`HEADER`  | `boolean`   | `false`  | Specifies that the file contains a header line with the names of each column in the file. The first line is ignored on input.  _`FORMAT CSV` only._
+`IGNOREHEADER`  | `uint4`   | `0`  | Skips the specified number of rows at the start of the input.  _`FORMAT CSV` only._
+`TRUNCATECOLUMNS`  | `boolean`   | `false`  | Truncates any `VARCHAR(n)` column in the input to `n` chars.  _`FORMAT CSV` only._
 
 Note that `DELIMITER` and `QUOTE` must use distinct values.
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -256,23 +256,35 @@ impl_display!(CopyTarget);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CopyOptionName {
-    Format,
+    Acceptinvchars,
+    Csv,
+    Dateformat,
     Delimiter,
-    Null,
     Escape,
-    Quote,
+    Format,
     Header,
+    Ignoreheader,
+    Null,
+    Quote,
+    Timeformat,
+    Truncatecolumns,
 }
 
 impl AstDisplay for CopyOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
-            CopyOptionName::Format => "FORMAT",
+            CopyOptionName::Acceptinvchars => "ACCEPTINVCHARS ",
+            CopyOptionName::Csv => "CSV",
+            CopyOptionName::Dateformat => "DATEFORMAT",
             CopyOptionName::Delimiter => "DELIMITER",
-            CopyOptionName::Null => "NULL",
             CopyOptionName::Escape => "ESCAPE",
-            CopyOptionName::Quote => "QUOTE",
+            CopyOptionName::Format => "FORMAT",
             CopyOptionName::Header => "HEADER",
+            CopyOptionName::Ignoreheader => "IGNOREHEADER",
+            CopyOptionName::Null => "NULL",
+            CopyOptionName::Quote => "QUOTE",
+            CopyOptionName::Timeformat => "TIMEFORMAT",
+            CopyOptionName::Truncatecolumns => "TRUNCATECOLUMNS",
         })
     }
 }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -23,6 +23,7 @@
 #
 # For details on the code that is generated, see keywords.rs.
 
+Acceptinvchars
 Access
 Acks
 Addresses
@@ -91,6 +92,7 @@ Current
 Cursor
 Database
 Databases
+Dateformat
 Datums
 Day
 Days
@@ -164,6 +166,7 @@ Idempotence
 Idle
 If
 Ignore
+Ignoreheader
 Ilike
 In
 Include
@@ -355,6 +358,7 @@ Then
 Tick
 Ties
 Time
+Timeformat
 Timeline
 Timeout
 Timestamp
@@ -367,6 +371,7 @@ Trailing
 Transaction
 Trim
 True
+Truncatecolumns
 Tunnel
 Type
 Types

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4192,16 +4192,34 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_copy_option(&mut self) -> Result<CopyOption<Raw>, ParserError> {
-        let name =
-            match self.expect_one_of_keywords(&[FORMAT, DELIMITER, NULL, ESCAPE, QUOTE, HEADER])? {
-                FORMAT => CopyOptionName::Format,
-                DELIMITER => CopyOptionName::Delimiter,
-                NULL => CopyOptionName::Null,
-                ESCAPE => CopyOptionName::Escape,
-                QUOTE => CopyOptionName::Quote,
-                HEADER => CopyOptionName::Header,
-                _ => unreachable!(),
-            };
+        let name = match self.expect_one_of_keywords(&[
+            ACCEPTINVCHARS,
+            CSV,
+            DATEFORMAT,
+            DELIMITER,
+            ESCAPE,
+            FORMAT,
+            HEADER,
+            IGNOREHEADER,
+            NULL,
+            QUOTE,
+            TIMEFORMAT,
+            TRUNCATECOLUMNS,
+        ])? {
+            ACCEPTINVCHARS => CopyOptionName::Acceptinvchars,
+            CSV => CopyOptionName::Csv,
+            DATEFORMAT => CopyOptionName::Dateformat,
+            DELIMITER => CopyOptionName::Delimiter,
+            ESCAPE => CopyOptionName::Escape,
+            FORMAT => CopyOptionName::Format,
+            HEADER => CopyOptionName::Header,
+            IGNOREHEADER => CopyOptionName::Ignoreheader,
+            NULL => CopyOptionName::Null,
+            QUOTE => CopyOptionName::Quote,
+            TIMEFORMAT => CopyOptionName::Timeformat,
+            TRUNCATECOLUMNS => CopyOptionName::Truncatecolumns,
+            _ => unreachable!(),
+        };
         let value = self.parse_optional_option_value()?;
         Ok(CopyOption { name, value })
     }

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -63,9 +63,16 @@ COPY t TO STDOUT WITH (FORMAT = text)
 Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Ident(Ident("text"))) }] })
 
 parse-statement
+COPY t TO STDOUT (csv, acceptinvchars, dateformat = 'auto', timeformat = 'auto', ignoreheader = 10, truncatecolumns)
+----
+COPY t TO STDOUT WITH (CSV, ACCEPTINVCHARS , DATEFORMAT = 'auto', TIMEFORMAT = 'auto', IGNOREHEADER = 10, TRUNCATECOLUMNS)
+=>
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Csv, value: None }, CopyOption { name: Acceptinvchars, value: None }, CopyOption { name: Dateformat, value: Some(Value(String("auto"))) }, CopyOption { name: Timeformat, value: Some(Value(String("auto"))) }, CopyOption { name: Ignoreheader, value: Some(Value(Number("10"))) }, CopyOption { name: Truncatecolumns, value: None }] })
+
+parse-statement
 COPY t TO STDOUT ()
 ----
-error: Expected one of FORMAT or DELIMITER or NULL or ESCAPE or QUOTE or HEADER, found right parenthesis
+error: Expected one of ACCEPTINVCHARS or CSV or DATEFORMAT or DELIMITER or ESCAPE or FORMAT or HEADER or IGNOREHEADER or NULL or QUOTE or TIMEFORMAT or TRUNCATECOLUMNS, found right parenthesis
 COPY t TO STDOUT ()
                   ^
 

--- a/test/pgtest-mz/copy-redshift.pt
+++ b/test/pgtest-mz/copy-redshift.pt
@@ -1,0 +1,40 @@
+# Test COPY options supported only by redshift.
+
+send
+Query {"query": "DROP TABLE IF EXISTS t"}
+Query {"query": "CREATE TABLE t (i INT8, t TEXT, v VARCHAR(3))"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "DELETE FROM t"}
+Query {"query": "COPY t FROM STDIN WITH (CSV, ACCEPTINVCHARS, DATEFORMAT='auto', TIMEFORMAT='auto', IGNOREHEADER=2, TRUNCATECOLUMNS)"}
+CopyData "0,Ignored,Ignored\n"
+CopyData "0,Ignored,Ignored\n"
+CopyData "1,abc,efgh\n"
+CopyDone
+Query {"query": "SELECT * FROM t ORDER BY i"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DELETE 0"}
+ReadyForQuery {"status":"I"}
+CopyIn {"format":"text","column_formats":["text","text","text"]}
+CommandComplete {"tag":"COPY 1"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"i"},{"name":"t"},{"name":"v"}]}
+DataRow {"fields":["1","abc","efg"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Some of these have minimal implementations that allow for us to support fivetran's redshift queries.

`IGNOREHEADER` and `TRUNCATECOLUMNS` are actual features. The other three are no-ops but are supported for clients that would like to type them at us.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a