### PR TITLE
storage: Retry retry-able rocksdb errors

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -7247,7 +7247,7 @@ impl Catalog {
                     self.system_config()
                         .upsert_rocksdb_bottommost_compression_type(),
                     self.system_config().upsert_rocksdb_batch_size(),
-                    self.system_config().upsert_rocksdb_retry_duration_s(),
+                    self.system_config().upsert_rocksdb_retry_duration(),
                 ) {
                     Ok(u) => u,
                     Err(e) => {

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -7247,6 +7247,7 @@ impl Catalog {
                     self.system_config()
                         .upsert_rocksdb_bottommost_compression_type(),
                     self.system_config().upsert_rocksdb_batch_size(),
+                    self.system_config().upsert_rocksdb_retry_duration_s(),
                 ) {
                     Ok(u) => u,
                     Err(e) => {

--- a/src/rocksdb/build.rs
+++ b/src/rocksdb/build.rs
@@ -88,6 +88,7 @@ fn main() {
         // is to re-run if any file in the crate changes; that's still a bit too
         // broad, but it's better.
         .emit_rerun_if_changed(false)
+        .extern_path(".mz_proto", "::mz_proto")
         .compile_with_config(config, &["rocksdb/src/config.proto"], &[".."])
         .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/rocksdb/src/config.proto
+++ b/src/rocksdb/src/config.proto
@@ -10,6 +10,7 @@
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
+import "proto/src/proto.proto";
 
 package mz_rocksdb.config;
 
@@ -39,5 +40,5 @@ message ProtoRocksDbTuningParameters {
     ProtoCompressionType compression_type = 6;
     ProtoCompressionType bottommost_compression_type = 7;
     uint64 batch_size = 8;
-    uint32 retry_max_duration_s = 9;
+    mz_proto.ProtoDuration retry_max_duration = 9;
 }

--- a/src/rocksdb/src/config.proto
+++ b/src/rocksdb/src/config.proto
@@ -39,4 +39,5 @@ message ProtoRocksDbTuningParameters {
     ProtoCompressionType compression_type = 6;
     ProtoCompressionType bottommost_compression_type = 7;
     uint64 batch_size = 8;
+    uint32 retry_max_duration_s = 9;
 }

--- a/src/rocksdb/src/config.rs
+++ b/src/rocksdb/src/config.rs
@@ -124,6 +124,9 @@ pub struct RocksDBTuningParameters {
 
     /// The size of the `multi_get` and `multi_put` batches sent to RocksDB. The default is 1024.
     pub batch_size: usize,
+
+    /// The maximum duration in seconds for the retries when performing rocksdb actions in case of retry-able errors.
+    pub retry_max_duration_s: u32,
 }
 
 impl Default for RocksDBTuningParameters {
@@ -139,6 +142,7 @@ impl Default for RocksDBTuningParameters {
             compression_type: defaults::DEFAULT_COMPRESSION_TYPE,
             bottommost_compression_type: defaults::DEFAULT_BOTTOMMOST_COMPRESSION_TYPE,
             batch_size: defaults::DEFAULT_BATCH_SIZE,
+            retry_max_duration_s: defaults::DEFAULT_RETRY_DURATION_S,
         }
     }
 }
@@ -154,6 +158,7 @@ impl RocksDBTuningParameters {
         compression_type: CompressionType,
         bottommost_compression_type: CompressionType,
         batch_size: usize,
+        retry_max_duration_s: u32,
     ) -> Result<Self, anyhow::Error> {
         Ok(Self {
             compaction_style,
@@ -182,6 +187,7 @@ impl RocksDBTuningParameters {
             compression_type,
             bottommost_compression_type,
             batch_size,
+            retry_max_duration_s,
         })
     }
 }
@@ -315,6 +321,7 @@ impl RustType<ProtoRocksDbTuningParameters> for RocksDBTuningParameters {
                 &self.bottommost_compression_type,
             )),
             batch_size: u64::cast_from(self.batch_size),
+            retry_max_duration_s: self.retry_max_duration_s,
         }
     }
 
@@ -376,6 +383,7 @@ impl RustType<ProtoRocksDbTuningParameters> for RocksDBTuningParameters {
             compression_type: compression_from_proto(proto.compression_type)?,
             bottommost_compression_type: compression_from_proto(proto.bottommost_compression_type)?,
             batch_size: usize::cast_from(proto.batch_size),
+            retry_max_duration_s: proto.retry_max_duration_s,
         })
     }
 }
@@ -403,6 +411,7 @@ pub struct RocksDBConfig {
     parallelism: Option<i32>,
     compression_type: CompressionType,
     bottommost_compression_type: CompressionType,
+    pub(crate) retry_max_duration_s: u32,
     pub(crate) dynamic: RocksDBDynamicConfig,
 }
 
@@ -423,6 +432,7 @@ impl RocksDBConfig {
             compression_type,
             bottommost_compression_type,
             batch_size,
+            retry_max_duration_s,
         } = params;
 
         Self {
@@ -433,6 +443,7 @@ impl RocksDBConfig {
             parallelism,
             compression_type,
             bottommost_compression_type,
+            retry_max_duration_s,
             dynamic: RocksDBDynamicConfig {
                 batch_size: Arc::new(AtomicUsize::new(batch_size)),
             },
@@ -451,6 +462,7 @@ impl RocksDBConfig {
             compression_type,
             bottommost_compression_type,
             batch_size,
+            retry_max_duration_s,
         } = params;
 
         self.compaction_style = compaction_style;
@@ -460,6 +472,7 @@ impl RocksDBConfig {
         self.parallelism = parallelism;
         self.compression_type = compression_type;
         self.bottommost_compression_type = bottommost_compression_type;
+        self.retry_max_duration_s = retry_max_duration_s;
 
         // SeqCst is probably not required here, but its the easiest to reason about
         self.dynamic.batch_size.store(batch_size, Ordering::SeqCst);
@@ -476,6 +489,7 @@ impl RocksDBConfig {
             parallelism,
             compression_type,
             bottommost_compression_type,
+            retry_max_duration_s: _,
             dynamic: _,
         } = self;
 
@@ -544,6 +558,9 @@ pub mod defaults {
     /// A reasonable default batch size for gets and puts in RocksDB. Based
     /// on advice here: <https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ>.
     pub const DEFAULT_BATCH_SIZE: usize = 1024;
+
+    /// The default max duration in seconds for retrying the retry-able errors in rocksdb.
+    pub const DEFAULT_RETRY_DURATION_S: u32 = 1;
 }
 
 #[cfg(test)]
@@ -564,6 +581,7 @@ mod tests {
             defaults::DEFAULT_COMPRESSION_TYPE,
             defaults::DEFAULT_BOTTOMMOST_COMPRESSION_TYPE,
             defaults::DEFAULT_BATCH_SIZE,
+            defaults::DEFAULT_RETRY_DURATION_S,
         )
         .unwrap();
 

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -85,7 +85,7 @@
 use std::convert::AsRef;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use itertools::Itertools;
 use mz_ore::cast::{CastFrom, CastLossy};
@@ -500,7 +500,7 @@ fn rocksdb_core_loop<K, V, M, O>(
     M: Deref<Target = RocksDBMetrics> + Send + 'static,
     O: bincode::Options + Copy + Send + Sync + 'static,
 {
-    let retry_max_duration = Duration::from_secs(tuning_config.retry_max_duration_s.into());
+    let retry_max_duration = tuning_config.retry_max_duration;
     let rocksdb_options = options.as_rocksdb_options(&tuning_config);
 
     let retry_result = Retry::default()

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -257,8 +257,8 @@ pub struct RocksDBInstance<K, V> {
 
 impl<K, V> RocksDBInstance<K, V>
 where
-    K: AsRef<[u8]> + Send + Sync + Clone + 'static,
-    V: Serialize + DeserializeOwned + Send + Sync + Clone + 'static,
+    K: AsRef<[u8]> + Send + Sync + 'static,
+    V: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
     /// Start a new RocksDB instance at the path, using
     /// the `Options` and `RocksDBTuningParameters` to
@@ -495,8 +495,8 @@ fn rocksdb_core_loop<K, V, M, O>(
     creation_error_tx: oneshot::Sender<Error>,
     enc_opts: O,
 ) where
-    K: AsRef<[u8]> + Send + Sync + Clone + 'static,
-    V: Serialize + DeserializeOwned + Send + Sync + Clone + 'static,
+    K: AsRef<[u8]> + Send + Sync + 'static,
+    V: Serialize + DeserializeOwned + Send + Sync + 'static,
     M: Deref<Target = RocksDBMetrics> + Send + 'static,
     O: bincode::Options + Copy + Send + Sync + 'static,
 {

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -612,6 +612,7 @@ fn rocksdb_core_loop<K, V, M, O>(
                 for _ in buf_size..batch_size {
                     encoded_batch_buffers.push(Some(Vec::new()));
                 }
+                assert!(batch_size <= encoded_batch_buffers.len());
 
                 // TODO(guswynn): sort by key before writing.
                 for ((key, value), encode_buf) in

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -85,7 +85,7 @@
 use std::convert::AsRef;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use itertools::Itertools;
 use mz_ore::cast::{CastFrom, CastLossy};
@@ -502,16 +502,15 @@ fn rocksdb_core_loop<K, V, M, O>(
 {
     let rocksdb_options = options.as_rocksdb_options(&tuning_config);
 
-    let retry_result =
-        Retry::default()
-            .max_tries(3)
-            .retry(|_| match DB::open(&rocksdb_options, &instance_path) {
-                Ok(db) => RetryResult::Ok(db),
-                Err(e) => match e.kind() {
-                    ErrorKind::TryAgain => RetryResult::RetryableErr(Error::RocksDB(e)),
-                    _ => RetryResult::FatalErr(Error::RocksDB(e)),
-                },
-            });
+    let retry_result = Retry::default()
+        .max_duration(Duration::from_secs(1))
+        .retry(|_| match DB::open(&rocksdb_options, &instance_path) {
+            Ok(db) => RetryResult::Ok(db),
+            Err(e) => match e.kind() {
+                ErrorKind::TryAgain => RetryResult::RetryableErr(Error::RocksDB(e)),
+                _ => RetryResult::FatalErr(Error::RocksDB(e)),
+            },
+        });
 
     let db: DB = match retry_result {
         Ok(db) => {
@@ -547,27 +546,32 @@ fn rocksdb_core_loop<K, V, M, O>(
 
                 // Perform the multi_get and record metrics, if there wasn't an error.
                 let now = Instant::now();
-                let retry_result = Retry::default().max_tries(3).retry(|_| {
-                    let gets = db.multi_get(batch.iter());
-                    let latency = now.elapsed();
+                let retry_result =
+                    Retry::default()
+                        .max_duration(Duration::from_secs(1))
+                        .retry(|_| {
+                            let gets = db.multi_get(batch.iter());
+                            let latency = now.elapsed();
 
-                    let gets: Result<Vec<_>, _> = gets.into_iter().collect();
-                    match gets {
-                        Ok(gets) => {
-                            metrics.multi_get_latency.observe(latency.as_secs_f64());
-                            metrics.multi_get_size.observe(f64::cast_lossy(batch_size));
-                            let result = MultiGetResult {
-                                processed_gets: gets.len().try_into().unwrap(),
-                            };
+                            let gets: Result<Vec<_>, _> = gets.into_iter().collect();
+                            match gets {
+                                Ok(gets) => {
+                                    metrics.multi_get_latency.observe(latency.as_secs_f64());
+                                    metrics.multi_get_size.observe(f64::cast_lossy(batch_size));
+                                    let result = MultiGetResult {
+                                        processed_gets: gets.len().try_into().unwrap(),
+                                    };
 
-                            RetryResult::Ok((result, gets))
-                        }
-                        Err(e) => match e.kind() {
-                            ErrorKind::TryAgain => RetryResult::RetryableErr(Error::RocksDB(e)),
-                            _ => RetryResult::FatalErr(Error::RocksDB(e)),
-                        },
-                    }
-                });
+                                    RetryResult::Ok((result, gets))
+                                }
+                                Err(e) => match e.kind() {
+                                    ErrorKind::TryAgain => {
+                                        RetryResult::RetryableErr(Error::RocksDB(e))
+                                    }
+                                    _ => RetryResult::FatalErr(Error::RocksDB(e)),
+                                },
+                            }
+                        });
 
                 let _ = match retry_result {
                     Ok((result, gets)) => {
@@ -641,29 +645,34 @@ fn rocksdb_core_loop<K, V, M, O>(
                 }
                 // Perform the multi_put and record metrics, if there wasn't an error.
                 let now = Instant::now();
-                let retry_result = Retry::default().max_tries(3).retry(|_| {
-                    let mut writes = rocksdb::WriteBatch::default();
+                let retry_result =
+                    Retry::default()
+                        .max_duration(Duration::from_secs(1))
+                        .retry(|_| {
+                            let mut writes = rocksdb::WriteBatch::default();
 
-                    for (key, value) in encoded_batch.iter() {
-                        match value {
-                            Some(update) => writes.put(key, update),
-                            None => writes.delete(key),
-                        }
-                    }
+                            for (key, value) in encoded_batch.iter() {
+                                match value {
+                                    Some(update) => writes.put(key, update),
+                                    None => writes.delete(key),
+                                }
+                            }
 
-                    match db.write_opt(writes, &wo) {
-                        Ok(()) => {
-                            let latency = now.elapsed();
-                            metrics.multi_put_latency.observe(latency.as_secs_f64());
-                            metrics.multi_put_size.observe(f64::cast_lossy(batch_size));
-                            RetryResult::Ok(())
-                        }
-                        Err(e) => match e.kind() {
-                            ErrorKind::TryAgain => RetryResult::RetryableErr(Error::RocksDB(e)),
-                            _ => RetryResult::FatalErr(Error::RocksDB(e)),
-                        },
-                    }
-                });
+                            match db.write_opt(writes, &wo) {
+                                Ok(()) => {
+                                    let latency = now.elapsed();
+                                    metrics.multi_put_latency.observe(latency.as_secs_f64());
+                                    metrics.multi_put_size.observe(f64::cast_lossy(batch_size));
+                                    RetryResult::Ok(())
+                                }
+                                Err(e) => match e.kind() {
+                                    ErrorKind::TryAgain => {
+                                        RetryResult::RetryableErr(Error::RocksDB(e))
+                                    }
+                                    _ => RetryResult::FatalErr(Error::RocksDB(e)),
+                                },
+                            }
+                        });
 
                 // put back the values in the buffer so we don't lose allocation
                 for (i, (_, encoded_buffer)) in encoded_batch.drain(..).enumerate() {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -693,6 +693,15 @@ mod upsert_rocksdb {
                   Can be changed dynamically (Materialize).",
         internal: true,
     };
+
+    pub static UPSERT_ROCKSDB_RETRY_DURATION_S: ServerVar<u32> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_retry_duration_s"),
+        value: &mz_rocksdb::defaults::DEFAULT_RETRY_DURATION_S,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
 }
 
 /// Controls the connect_timeout setting when connecting to PG via replication.
@@ -1691,6 +1700,7 @@ impl SystemVars {
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_COMPRESSION_TYPE)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_BATCH_SIZE)
+            .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_RETRY_DURATION_S)
             .with_var(&PERSIST_BLOB_TARGET_SIZE)
             .with_var(&PERSIST_BLOB_CACHE_MEM_LIMIT_BYTES)
             .with_var(&PERSIST_COMPACTION_MINIMUM_TIMEOUT)
@@ -2057,6 +2067,10 @@ impl SystemVars {
 
     pub fn upsert_rocksdb_batch_size(&self) -> usize {
         *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_BATCH_SIZE)
+    }
+
+    pub fn upsert_rocksdb_retry_duration_s(&self) -> u32 {
+        *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_RETRY_DURATION_S)
     }
 
     /// Returns the `persist_blob_target_size` configuration parameter.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -694,9 +694,9 @@ mod upsert_rocksdb {
         internal: true,
     };
 
-    pub static UPSERT_ROCKSDB_RETRY_DURATION_S: ServerVar<u32> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_retry_duration_s"),
-        value: &mz_rocksdb::defaults::DEFAULT_RETRY_DURATION_S,
+    pub static UPSERT_ROCKSDB_RETRY_DURATION: ServerVar<Duration> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_retry_duration"),
+        value: &mz_rocksdb::defaults::DEFAULT_RETRY_DURATION,
         description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
                   sources. Described in the `mz_rocksdb::config` module. \
                   Only takes effect on source restart (Materialize).",
@@ -1700,7 +1700,7 @@ impl SystemVars {
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_COMPRESSION_TYPE)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_BATCH_SIZE)
-            .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_RETRY_DURATION_S)
+            .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_RETRY_DURATION)
             .with_var(&PERSIST_BLOB_TARGET_SIZE)
             .with_var(&PERSIST_BLOB_CACHE_MEM_LIMIT_BYTES)
             .with_var(&PERSIST_COMPACTION_MINIMUM_TIMEOUT)
@@ -2069,8 +2069,8 @@ impl SystemVars {
         *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_BATCH_SIZE)
     }
 
-    pub fn upsert_rocksdb_retry_duration_s(&self) -> u32 {
-        *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_RETRY_DURATION_S)
+    pub fn upsert_rocksdb_retry_duration(&self) -> Duration {
+        *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_RETRY_DURATION)
     }
 
     /// Returns the `persist_blob_target_size` configuration parameter.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Making changes so that we retry the retry-able errors in rocksdb. The maximum duration of the retries is configurable via a flag.

Tested the changes manually via the following scenarios:
- Changed code to throw RetryableError in the first iteration, as expected, it ran fine upon retry
- Changed code to always throw FatalError, and as expected it resulted into an error which eventually stalled the source
- Changed code to always throw RetryableError, and as expected it went above the max_duration and resulted into an error as well
- Also, checked that the `upsert_rocksdb_retry_duration` is truly configurable and could update it via `system-parameter-default`

### Motivation
Part of https://github.com/MaterializeInc/materialize/issues/17067
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
