### PR TITLE
Generate full debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,13 +99,7 @@ object = { opt-level = 3 }
 rustc-demangle = { opt-level = 3 }
 
 [profile.release]
-# Emit only the line info tables, not full debug info, in release builds, to
-# substantially reduce the size of the debug info. Line info tables are enough
-# to correctly symbolicate a backtrace, but do not produce an ideal interactive
-# debugger experience. This seems to be the right tradeoff for release builds:
-# it's unlikely we're going to get interactive access to a debugger in
-# production installations, but we still want useful crash reports.
-debug = 1
+debug = 2
 
 # IMPORTANT: when patching a dependency, you should only depend on "main",
 # "master", or an upstream release branch (e.g., "v7.x"). Do *not* depend on a


### PR DESCRIPTION
Recently, @petrosagg and @antiguru tried to debug a release blocker in staging using a core dump, and found themselves unable to do so, because the core dump didn't contain information about local variables. This PR should mitigate that issue.

To check the impact on CI times, I experimented setting `RUSTFLAGS="-C debuginfo=2"` and comparing with debuginfo=1.

Here are the results on my home desktop:

| Measurement | debuginfo=2 | debuginfo=1 |
|--------|--------|--------|
| `rm -rf target && time cargo build --release` | 13:39.95 | 10:24.29 |
| `du -hs target/release/clusterd` | 3.6G | 2.0G |
| `du -hs target/release/environmentd` | 2.3G | 1.3G |
| `du -hs target` | 27G | 18G |

In conclusion, the build is a few minutes slower, and we produce a bit bigger binaries. However, I think the improved ability to debug issues in prod or staging is worth the cost.