### PR TITLE
Avoid divergence of hash state in consolidation

### DIFF
--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-ahash = "0.8.0"
+ahash = { version = "0.8.0", default_features = false }
 anyhow = "1.0.66"
 async-trait = "0.1.68"
 bytesize = "1.1.0"

--- a/src/compute/src/extensions/collection.rs
+++ b/src/compute/src/extensions/collection.rs
@@ -84,9 +84,10 @@ where
         // bins is small (as is our case), so we'd have a theoretical guarantee.
         // NOTE: We fix the seeds of a RandomState instance explicity with the same
         // seeds that would be given by `AHash` via ahash::AHasher::default() so as
-        // to avoid a different selection due to compilation flags being differently
+        // to avoid a different selection due to compile-time features being differently
         // selected in other dependencies using `AHash` vis-à-vis cargo's strategy
-        // of unioning compilation flags.
+        // of unioning features. This implies that we end up employ the fallback
+        // hasher of `AHash`, but it should be sufficient for our needs.
         let random_state = ahash::RandomState::with_seeds(
             0x243f_6a88_85a3_08d3,
             0x1319_8a2e_0370_7344,

--- a/src/compute/src/extensions/collection.rs
+++ b/src/compute/src/extensions/collection.rs
@@ -60,26 +60,7 @@ where
         Arranged<G, TraceAgent<Tr>>: ArrangementSize,
     {
         if must_consolidate {
-            // We employ AHash below instead of the default hasher in DD to obtain
-            // a better distribution of data to workers. AHash claims empirically
-            // both speed and high quality, according to
-            // https://github.com/tkaitchuck/aHash/blob/master/compare/readme.md.
-            // TODO(vmarcos): Consider here if it is worth it to spend the time to
-            // implement twisted tabulation hashing as proposed in Mihai Patrascu,
-            // Mikkel Thorup: Twisted Tabulation Hashing. SODA 2013: 209-228, available
-            // at https://epubs.siam.org/doi/epdf/10.1137/1.9781611973105.16. The latter
-            // would provide good bounds for balls-into-bins problems when the number of
-            // bins is small (as is our case), so we'd have a theoretical guarantee.
-            let random_state = ahash::RandomState::new();
-            let mut h = random_state.build_hasher();
-            let exchange = Exchange::new(move |update: &((D1, _), G::Timestamp, R)| {
-                let data = &(update.0).0;
-                data.hash(&mut h);
-                h.finish()
-            });
-            self.map(|k| (k, ()))
-                .mz_arrange_core::<_, Tr>(exchange, name)
-                .as_collection(|d: &D1, _| d.clone())
+            self.mz_consolidate(name)
         } else {
             self.clone()
         }
@@ -91,8 +72,35 @@ where
         Tr::Batch: Batch,
         Arranged<G, TraceAgent<Tr>>: ArrangementSize,
     {
+        // We employ AHash below instead of the default hasher in DD to obtain
+        // a better distribution of data to workers. AHash claims empirically
+        // both speed and high quality, according to
+        // https://github.com/tkaitchuck/aHash/blob/master/compare/readme.md.
+        // TODO(vmarcos): Consider here if it is worth it to spend the time to
+        // implement twisted tabulation hashing as proposed in Mihai Patrascu,
+        // Mikkel Thorup: Twisted Tabulation Hashing. SODA 2013: 209-228, available
+        // at https://epubs.siam.org/doi/epdf/10.1137/1.9781611973105.16. The latter
+        // would provide good bounds for balls-into-bins problems when the number of
+        // bins is small (as is our case), so we'd have a theoretical guarantee.
+        // NOTE: We fix the seeds of a RandomState instance explicity with the same
+        // seeds that would be given by `AHash` via ahash::AHasher::default() so as
+        // to avoid a different selection due to compilation flags being differently
+        // selected in other dependencies using `AHash` vis-à-vis cargo's strategy
+        // of unioning compilation flags.
+        let random_state = ahash::RandomState::with_seeds(
+            0x243f_6a88_85a3_08d3,
+            0x1319_8a2e_0370_7344,
+            0xa409_3822_299f_31d0,
+            0x082e_fa98_ec4e_6c89,
+        );
+        let exchange = Exchange::new(move |update: &((D1, _), G::Timestamp, R)| {
+            let data = &(update.0).0;
+            let mut h = random_state.build_hasher();
+            data.hash(&mut h);
+            h.finish()
+        });
         self.map(|k| (k, ()))
-            .mz_arrange::<Tr>(name)
+            .mz_arrange_core::<_, Tr>(exchange, name)
             .as_collection(|d: &D1, _| d.clone())
     }
 }


### PR DESCRIPTION
This PR fixes a correctness bug in the usage of the hashing API, in particular `AHash`'s, in the `Exchange` pact of `mz_consolidate_if`. Additionally, the commit extends the patched usage of the hash function to `mz_consolidate`, thus increasing our confidence on good distribution of rows to workers given the use of a higher quality hash function than the DD's default `FnvHasher`. The bug was caused by: (a) initializing the hash function with a method that would employ randomness, thus leading to divergent hash state across workers; (b) not reinitializing, but reusing the hash function across invocations, thus computing from a hash state that was not well-defined.

Fixes #19610.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/19610

### Tips for reviewer

The method `ahash::AHasher::default()` should construct an instance of the hash function with fixed seeding, but this depends on the `cfg` attributes given. Since `AHash` is used extensively, relying on such attributes may be fragile, so I tried to employ a method that is unconditionally seeding the input `RandomState` with fixed seeds (see [comments](https://github.com/MaterializeInc/materialize/pull/19848#issuecomment-1591259633) [below](https://github.com/MaterializeInc/materialize/pull/19848#issuecomment-1592722178)). By reading the code of `AHash`, this usage seems to imply that we end up with the fallback hasher, unfortunately. However, this hash function [should be sufficient](https://github.com/tkaitchuck/aHash/blob/master/FAQ.md#how-is-ahash-so-fast) for our requirements.

Additionally, as per the reasons articulated above, the call to obtain a new hash function instance from this fixed `RandomState` must be performed at each invocation of the `Exchange` closure. Note that this is exactly the same usage pattern of the hash function employed in DD's code with `FnvHasher`, except that in the case of the `FnvHasher` the `Default::default()` implementation has unconditionally assigned fixed seeds.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20230421_stabilize_monotonic_select.md).
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
