### PR TITLE
sql[-parser]: support IS [NOT] DISTINCT FROM

### DIFF
--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -65,7 +65,7 @@ pub enum Expr<T: AstInfo> {
     /// `IS {NULL, TRUE, FALSE, UNKNOWN}` expression
     IsExpr {
         expr: Box<Expr<T>>,
-        construct: IsExprConstruct,
+        construct: IsExprConstruct<T>,
         negated: bool,
     },
     /// `[ NOT ] IN (val1, val2, ...)`
@@ -864,31 +864,27 @@ impl<T: AstInfo> AstDisplay for FunctionArgs<T> {
 }
 impl_display_t!(FunctionArgs);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum IsExprConstruct {
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum IsExprConstruct<T: AstInfo> {
     Null,
     True,
     False,
     Unknown,
+    DistinctFrom(Box<Expr<T>>),
 }
 
-impl IsExprConstruct {
-    pub fn requires_boolean_expr(&self) -> bool {
-        match self {
-            IsExprConstruct::Null => false,
-            IsExprConstruct::True | IsExprConstruct::False | IsExprConstruct::Unknown => true,
-        }
-    }
-}
-
-impl AstDisplay for IsExprConstruct {
+impl<T: AstInfo> AstDisplay for IsExprConstruct<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             IsExprConstruct::Null => f.write_str("NULL"),
             IsExprConstruct::True => f.write_str("TRUE"),
             IsExprConstruct::False => f.write_str("FALSE"),
             IsExprConstruct::Unknown => f.write_str("UNKNOWN"),
+            IsExprConstruct::DistinctFrom(e) => {
+                f.write_str("DISTINCT FROM ");
+                e.fmt(f);
+            }
         }
     }
 }
-impl_display!(IsExprConstruct);
+impl_display_t!(IsExprConstruct);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1044,7 +1044,7 @@ impl<'a> Parser<'a> {
                 IS => {
                     let negated = self.parse_keyword(NOT);
                     if let Some(construct) =
-                        self.parse_one_of_keywords(&[NULL, TRUE, FALSE, UNKNOWN])
+                        self.parse_one_of_keywords(&[NULL, TRUE, FALSE, UNKNOWN, DISTINCT])
                     {
                         Ok(Expr::IsExpr {
                             expr: Box::new(expr),
@@ -1054,6 +1054,11 @@ impl<'a> Parser<'a> {
                                 TRUE => IsExprConstruct::True,
                                 FALSE => IsExprConstruct::False,
                                 UNKNOWN => IsExprConstruct::Unknown,
+                                DISTINCT => {
+                                    self.expect_keyword(FROM)?;
+                                    let expr = self.parse_expr()?;
+                                    IsExprConstruct::DistinctFrom(Box::new(expr))
+                                }
                                 _ => unreachable!(),
                             },
                         })

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -111,6 +111,23 @@ name IS NOT UNKNOWN
 IsExpr { expr: Identifier([Ident("name")]), construct: Unknown, negated: true }
 
 parse-scalar
+1 + 1 IS DISTINCT FROM 1 + 2
+----
+IsExpr { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, construct: DistinctFrom(Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }), negated: false }
+
+parse-scalar
+1 + 1 IS NOT DISTINCT FROM 1 + 2
+----
+IsExpr { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, construct: DistinctFrom(Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }), negated: true }
+
+parse-scalar
+1 + 1 IS DISTINCT NOT FROM 1 + 2
+----
+error: Expected FROM, found NOT
+1 + 1 IS DISTINCT NOT FROM 1 + 2
+                  ^
+
+parse-scalar
 a ~ 'foo'
 ----
 Op { op: Op { namespace: [], op: "~" }, expr1: Identifier([Ident("a")]), expr2: Some(Value(String("foo"))) }

--- a/test/sqllogictest/distinct_from.slt
+++ b/test/sqllogictest/distinct_from.slt
@@ -1,0 +1,60 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+query T
+SELECT 1 IS DISTINCT FROM 1
+----
+false
+
+query T
+SELECT 1 IS DISTINCT FROM 2
+----
+true
+
+query T
+SELECT 1 IS DISTINCT FROM NULL
+----
+true
+
+query T
+SELECT NULL IS DISTINCT FROM 1
+----
+true
+
+query T
+SELECT NULL IS DISTINCT FROM NULL
+----
+false
+
+query T
+SELECT 1 IS NOT DISTINCT FROM 1
+----
+true
+
+query T
+SELECT 1 IS NOT DISTINCT FROM 2
+----
+false
+
+query T
+SELECT 1 IS NOT DISTINCT FROM NULL
+----
+false
+
+query T
+SELECT NULL IS NOT DISTINCT FROM 1
+----
+false
+
+query T
+SELECT NULL IS NOT DISTINCT FROM NULL
+----
+true


### PR DESCRIPTION
Add support for the PostgreSQL `IS DISTINCT FROM` operator. This operator is like `<>`, except that it treats `NULL` like a normal value that compares equal to itself and not equal to all other values.

Fix #1050.
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add support for the PostgreSQL `IS DISTINCT FROM` operator. This operator is like `<>`, except that it treats `NULL` like a normal value that compares equal to itself and not equal to all other values.
