### PR TITLE
Output consistency tests: adapt message normalization

### DIFF
--- a/misc/python/materialize/output_consistency/validation/error_message_normalizer.py
+++ b/misc/python/materialize/output_consistency/validation/error_message_normalizer.py
@@ -27,7 +27,7 @@ class ErrorMessageNormalizer:
             normalized_message,
         )
 
-        if normalized_message.startswith("mz_timestamp out of range ("):
+        if normalized_message.__contains__("mz_timestamp out of range ("):
             normalized_message = normalized_message[0 : normalized_message.index(" (")]
 
         return normalized_message

--- a/misc/python/materialize/output_consistency/validation/error_message_normalizer.py
+++ b/misc/python/materialize/output_consistency/validation/error_message_normalizer.py
@@ -28,6 +28,7 @@ class ErrorMessageNormalizer:
         )
 
         if normalized_message.__contains__("mz_timestamp out of range ("):
+            # tracked with https://github.com/MaterializeInc/materialize/issues/19822
             normalized_message = normalized_message[0 : normalized_message.index(" (")]
 
         return normalized_message


### PR DESCRIPTION
This adapts to a changed error message style (before: `'mz_timestamp out of range'`, now: `'"0000-12-31 16:00:00 UTC" mz_timestamp out of range'`) detected in the nightly build (https://buildkite.com/materialize/nightlies/builds/2570#0188accd-7355-4002-a6ad-41acd2ddc811).

