### PR TITLE
ci: Increase timeout for CRDB rolling restart

### DIFF
--- a/test/crdb-restarts/mzcompose.py
+++ b/test/crdb-restarts/mzcompose.py
@@ -17,7 +17,7 @@ from materialize.ui import UIError
 
 CRDB_NODE_COUNT = 4
 TESTDRIVE_TIMEOUT = (
-    "40s"  # We expect any CRDB disruption to not disrupt Mz for more than this timeout
+    "80s"  # We expect any CRDB disruption to not disrupt Mz for more than this timeout
 )
 
 COCKROACH_HEALTHCHECK_DISABLED = ServiceHealthcheck(


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/2567#0188a513-d114-416e-9f01-f9b0aed208ef

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
