### PR TITLE
ci/test: force-overwrite docs preview on every build

### DIFF
--- a/ci/test/preview-docs.sh
+++ b/ci/test/preview-docs.sh
@@ -26,7 +26,7 @@ cat > config.deployment.toml <<EOF
 name = "preview"
 url = "s3://materialize-website-previews?region=us-east-1&prefix=materialize/$BUILDKITE_PULL_REQUEST/"
 EOF
-hugo deploy --config config.toml,config.deployment.toml
+hugo deploy --config config.toml,config.deployment.toml --force
 
 curl -fsSL \
     -H "Authorization: Bearer $GITHUB_TOKEN" \


### PR DESCRIPTION
The docs preview bucket is configured to delete files after 30 days. The intent is that PRs that have not seen updates (i.e., new commits pushed) in 30 days vanish from the docs preview bucket.

@jseldess discovered an edge case here: a PR that is continually updated for more than 30 days will result in a partially rendered preview on the 31st day. The issue is that `hugo deploy` does not overwrite unchanged files. So the first PR preview uploads all files, and then subsequent commits pushed at the PR upload only *changed* files. On the 31st day, all files that have been unchanged since the first preview go missing. These files are usually the base CSS styling, images, etc, resulting in a preview that looks terribly broken.

This commit fixes the issue by passing the `--force` flag to `hugo deploy`, which instructs Hugo to overwrite all files on every deploy. That way, every PR preview will reset the 30-day clock on all files.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported by @jseldess on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
