### PR TITLE
cloud-api: add retry + timeout to the environment disable method

### DIFF
--- a/src/cloud-api/src/client/environment.rs
+++ b/src/cloud-api/src/client/environment.rs
@@ -15,8 +15,10 @@
 //! For a better experience retrieving all the available
 //! environments, use [`Client::get_all_environments()`]
 
+use std::time::Duration;
+
 use reqwest::Method;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::client::cloud_provider::CloudProvider;
 use crate::client::region::Region;
@@ -108,15 +110,68 @@ impl Client {
         self.send_request(req).await
     }
 
-    /// Deletes an environment in a particular region for the current user
-    pub async fn delete_environment(&self, cloud_provider: CloudProvider) -> Result<Region, Error> {
-        let req = self
-            .build_region_request(
-                Method::DELETE,
-                ["api", "environmentassignment"],
-                cloud_provider,
-            )
-            .await?;
-        self.send_request(req).await
+    /// Deletes an environment in a particular region for the current user.
+    ///
+    /// This operation has a long duration, it can take
+    /// several minutes to complete.
+    /// The first few requests will return a 504,
+    /// indicating that the API is working on the deletion.
+    /// A request returning a 202 indicates that
+    /// no environment is available to delete (the delete request is complete.)
+    pub async fn delete_environment(&self, cloud_provider: CloudProvider) -> Result<(), Error> {
+        /// A struct that deserializes nothing.
+        ///
+        /// Useful for deserializing empty response bodies.
+        pub struct Empty;
+
+        impl<'de> Deserialize<'de> for Empty {
+            fn deserialize<D>(_: D) -> Result<Empty, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Ok(Empty)
+            }
+        }
+
+        // We need to continuously try to delete the environment
+        // until it succeeds (Status code: 202) or an unexpected error occurs.
+        let mut loops = 0;
+        loop {
+            loops += 1;
+
+            let req = self
+                .build_region_request(
+                    Method::DELETE,
+                    ["api", "environmentassignment"],
+                    cloud_provider.clone(),
+                )
+                .await?;
+
+            // This timeout corresponds to the same in our cloud services tests.
+            let req = req.timeout(Duration::from_secs(305));
+
+            match self.send_request::<Empty>(req).await {
+                Ok(_) => break Ok(()), // The request was successful, no environment is available to delete anymore.
+                Err(Error::Api(err)) => {
+                    if err.status_code != 504 {
+                        // The error was not a timeout (status code 504), so it's unexpected and we should return it
+                        return Err(Error::Api(err));
+                    }
+                    // If the error was a timeout, it means the API is still working on deleting the environment.
+                }
+                Err(Error::Transport(e)) => {
+                    if !e.is_timeout() {
+                        return Err(Error::Transport(e));
+                    }
+                }
+                // The request failed with a non-API error, so we should return it
+                Err(e) => return Err(e),
+            }
+
+            // Too many requests/timeouts were reached.
+            if loops == 10 {
+                return Err(Error::TimeoutError);
+            }
+        }
     }
 }

--- a/src/cloud-api/src/client/environment.rs
+++ b/src/cloud-api/src/client/environment.rs
@@ -122,7 +122,7 @@ impl Client {
         /// A struct that deserializes nothing.
         ///
         /// Useful for deserializing empty response bodies.
-        pub struct Empty;
+        struct Empty;
 
         impl<'de> Deserialize<'de> for Empty {
             fn deserialize<D>(_: D) -> Result<Empty, D::Error>

--- a/src/cloud-api/src/error.rs
+++ b/src/cloud-api/src/error.rs
@@ -90,4 +90,7 @@ pub enum Error {
     /// Indicates the URL is cannot-be-a-base.
     #[error("Error while manipulating URL. The URL is cannot-be-a-base.")]
     UrlBaseError,
+    /// Indicates that a timeout has been reached.
+    #[error("Timeout reached.")]
+    TimeoutError,
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR adds logic to handle correctly all the responses when deleting an environment.

* Accepts a `504` as a response but waits until the response is a success.
* Timesout after ten tries getting a `504` as an answer. (10 * 305 secs = ~50 minutes)
* Handles timeouts and errors.

For more context: https://materializeinc.slack.com/archives/CL68GT3AT/p1686146560548549

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I'm unhappy with copying the `Struct Empty` from the Frontegg client. Should this structure live in a shared package?
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
