### PR TITLE
github: fix design doc notification format

### DIFF
--- a/.github/workflows/slack_notify_design_doc.yml
+++ b/.github/workflows/slack_notify_design_doc.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           channel: eng-design-docs
+          color: blue
           custom_payload: |
             {
               "blocks": [
@@ -71,14 +72,14 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "• *PR:* [${{ github.event.pull_request.title }}](${{ github.event.pull_request.url }})"
+                    "text": "• *PR:* <${{ github.event.pull_request.url }}|${{ github.event.pull_request.title }}>"
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "• *Author:* ${{ github.event.pull_request.user.name }} (${{ github.event.pull_request.user.login }})"
+                    "text": "• *Author:* <${{ github.event.pull_request.user.url }}|${{ github.event.pull_request.user.login }}>"
                   }
                 }
               ]


### PR DESCRIPTION
This commit adjusts the format used for design doc Slack notifications in the following ways:

* Fixes the PR link (I hope!). Apparently Slack's 'mrkdwn' doesn't support all kinds of markdown links.
* Makes the author login a link and stops attempting to display the author name. The name was empty in my test and it is not clear to me under which conditions it is non-empty.
* Adds blue color, to make the notifications stand out more in a perhaps busy Slack channel.

### Motivation

   * This PR improves Slack notifications.

### Tips for reviewer

We can't test this without merging to main.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
