### PR TITLE
Implement IGNORE NULLS for LAG/LEAD

### DIFF
--- a/src/expr/src/relation.proto
+++ b/src/expr/src/relation.proto
@@ -68,6 +68,7 @@ message ProtoAggregateFunc {
             google.protobuf.Empty lag = 2;
             google.protobuf.Empty lead = 3;
         }
+        bool ignore_nulls = 4;
     };
 
     message ProtoWindowFrame {

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -19,6 +19,7 @@ use itertools::Itertools;
 use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
 
+use mz_ore::str::separated;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::date::Date;
@@ -758,6 +759,7 @@ fn lag_lead<'a, I>(
     temp_storage: &'a RowArena,
     order_by: &[ColumnOrder],
     lag_lead_type: &LagLeadType,
+    ignore_nulls: &bool,
 ) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
@@ -794,18 +796,50 @@ where
         let idx = i64::try_from(idx).expect("Array index does not fit in i64");
         let offset = i64::from(offset.unwrap_int32());
         // By default, offset is applied backwards (for `lag`): flip the sign if `lead` should run instead
-        let offset = match lag_lead_type {
-            LagLeadType::Lag => offset,
-            LagLeadType::Lead => -offset,
+        let (offset, decrement) = match lag_lead_type {
+            LagLeadType::Lag => (offset, 1),
+            LagLeadType::Lead => (-offset, -1),
         };
-        let vec_offset = idx - offset;
 
-        let lagged_value = match u64::try_from(vec_offset) {
-            Ok(vec_offset) => datums
-                .get(usize::cast_from(vec_offset))
-                .map(|d| d.0)
-                .unwrap_or(*default_value),
-            Err(_) => *default_value,
+        // Get a Datum from `datums`. Return None if index is out of range.
+        let datums_get = |i: i64| -> Option<Datum> {
+            match u64::try_from(i) {
+                Ok(i) => datums
+                    .get(usize::cast_from(i))
+                    .map(|d| Some(d.0)) // succeeded in getting a Datum from the vec
+                    .unwrap_or(None), // overindexing
+                Err(_) => None, // underindexing (negative index)
+            }
+        };
+
+        let lagged_value = if !ignore_nulls {
+            datums_get(idx - offset).unwrap_or(*default_value)
+        } else {
+            // We start j from idx, and step j until we have seen an abs(offset) number of non-null
+            // values.
+            //
+            // (This is a very naive implementation: We could avoid an inner loop, and instead step
+            // two indexes in one loop, with one index lagging behind. But a common use case is an
+            // offset of 1 and not too many nulls, for which this doesn't matter. And anyhow, the
+            // whole thing hopefully will be replaced by prefix sum soon.)
+            let mut to_go = num::abs(offset);
+            let mut j = idx;
+            loop {
+                j -= decrement;
+                match datums_get(j) {
+                    Some(datum) => {
+                        if !datum.is_null() {
+                            to_go -= 1;
+                            if to_go == 0 {
+                                break datum;
+                            }
+                        }
+                    }
+                    None => {
+                        break *default_value;
+                    }
+                };
+            }
         };
 
         result.push((lagged_value, *original_row));
@@ -1135,6 +1169,7 @@ pub enum AggregateFunc {
     LagLead {
         order_by: Vec<ColumnOrder>,
         lag_lead: LagLeadType,
+        ignore_nulls: bool,
     },
     FirstValue {
         order_by: Vec<ColumnOrder>,
@@ -1154,7 +1189,7 @@ pub enum AggregateFunc {
 /// An explicit [`Arbitrary`] implementation needed here because of a known
 /// `proptest` issue.
 ///
-/// Revert to the derive-macro impementation once the issue[^1] is fixed.
+/// Revert to the derive-macro implementation once the issue[^1] is fixed.
 ///
 /// [^1]: <https://github.com/AltSysrq/proptest/issues/152>
 impl Arbitrary for AggregateFunc {
@@ -1232,8 +1267,15 @@ impl Arbitrary for AggregateFunc {
             (
                 vec(proptest_any::<ColumnOrder>(), 1..4),
                 proptest_any::<LagLeadType>(),
+                proptest_any::<bool>(),
             )
-                .prop_map(|(order_by, lag_lead)| AggregateFunc::LagLead { order_by, lag_lead })
+                .prop_map(
+                    |(order_by, lag_lead, ignore_nulls)| AggregateFunc::LagLead {
+                        order_by,
+                        lag_lead,
+                        ignore_nulls,
+                    },
+                )
                 .boxed(),
             (
                 vec(proptest_any::<ColumnOrder>(), 1..4),
@@ -1327,19 +1369,20 @@ impl RustType<ProtoAggregateFunc> for AggregateFunc {
                 AggregateFunc::RowNumber { order_by } => Kind::RowNumber(order_by.into_proto()),
                 AggregateFunc::Rank { order_by } => Kind::Rank(order_by.into_proto()),
                 AggregateFunc::DenseRank { order_by } => Kind::DenseRank(order_by.into_proto()),
-                AggregateFunc::LagLead { order_by, lag_lead } => {
-                    Kind::LagLead(proto_aggregate_func::ProtoLagLead {
-                        order_by: Some(order_by.into_proto()),
-                        lag_lead: Some(match lag_lead {
-                            LagLeadType::Lag => {
-                                proto_aggregate_func::proto_lag_lead::LagLead::Lag(())
-                            }
-                            LagLeadType::Lead => {
-                                proto_aggregate_func::proto_lag_lead::LagLead::Lead(())
-                            }
-                        }),
-                    })
-                }
+                AggregateFunc::LagLead {
+                    order_by,
+                    lag_lead,
+                    ignore_nulls,
+                } => Kind::LagLead(proto_aggregate_func::ProtoLagLead {
+                    order_by: Some(order_by.into_proto()),
+                    lag_lead: Some(match lag_lead {
+                        LagLeadType::Lag => proto_aggregate_func::proto_lag_lead::LagLead::Lag(()),
+                        LagLeadType::Lead => {
+                            proto_aggregate_func::proto_lag_lead::LagLead::Lead(())
+                        }
+                    }),
+                    ignore_nulls: *ignore_nulls,
+                }),
                 AggregateFunc::FirstValue {
                     order_by,
                     window_frame,
@@ -1446,6 +1489,7 @@ impl RustType<ProtoAggregateFunc> for AggregateFunc {
                         ))
                     }
                 },
+                ignore_nulls: pll.ignore_nulls,
             },
             Kind::FirstValue(pfv) => AggregateFunc::FirstValue {
                 order_by: pfv
@@ -1529,7 +1573,8 @@ impl AggregateFunc {
             AggregateFunc::LagLead {
                 order_by,
                 lag_lead: lag_lead_type,
-            } => lag_lead(datums, temp_storage, order_by, lag_lead_type),
+                ignore_nulls,
+            } => lag_lead(datums, temp_storage, order_by, lag_lead_type, ignore_nulls),
             AggregateFunc::FirstValue {
                 order_by,
                 window_frame,
@@ -2009,24 +2054,84 @@ impl fmt::Display for AggregateFunc {
             AggregateFunc::Count => f.write_str("count"),
             AggregateFunc::Any => f.write_str("any"),
             AggregateFunc::All => f.write_str("all"),
-            AggregateFunc::JsonbAgg { .. } => f.write_str("jsonb_agg"),
-            AggregateFunc::JsonbObjectAgg { .. } => f.write_str("jsonb_object_agg"),
-            AggregateFunc::ArrayConcat { .. } => f.write_str("array_agg"),
-            AggregateFunc::ListConcat { .. } => f.write_str("list_agg"),
-            AggregateFunc::StringAgg { .. } => f.write_str("string_agg"),
-            AggregateFunc::RowNumber { .. } => f.write_str("row_number"),
-            AggregateFunc::Rank { .. } => f.write_str("rank"),
-            AggregateFunc::DenseRank { .. } => f.write_str("dense_rank"),
+            AggregateFunc::JsonbAgg { order_by } => {
+                write!(f, "jsonb_agg[order_by=[{}]]", separated(", ", order_by))
+            }
+            AggregateFunc::JsonbObjectAgg { order_by } => {
+                write!(
+                    f,
+                    "jsonb_object_agg[order_by=[{}]]",
+                    separated(", ", order_by)
+                )
+            }
+            AggregateFunc::ArrayConcat { order_by } => {
+                write!(f, "array_agg[order_by=[{}]]", separated(", ", order_by))
+            }
+            AggregateFunc::ListConcat { order_by } => {
+                write!(f, "list_agg[order_by=[{}]]", separated(", ", order_by))
+            }
+            AggregateFunc::StringAgg { order_by } => {
+                write!(f, "string_agg[order_by=[{}]]", separated(", ", order_by))
+            }
+            AggregateFunc::RowNumber { order_by } => {
+                write!(f, "row_number[order_by=[{}]]", separated(", ", order_by))
+            }
+            AggregateFunc::Rank { order_by } => {
+                write!(f, "rank[order_by=[{}]]", separated(", ", order_by))
+            }
+            AggregateFunc::DenseRank { order_by } => {
+                write!(f, "dense_rank[order_by=[{}]]", separated(", ", order_by))
+            }
             AggregateFunc::LagLead {
                 lag_lead: LagLeadType::Lag,
-                ..
-            } => f.write_str("lag"),
+                ignore_nulls,
+                order_by,
+            } => {
+                f.write_str("lag")?;
+                f.write_str("[")?;
+                if *ignore_nulls {
+                    f.write_str("ignore_nulls=true, ")?;
+                }
+                write!(f, "order_by=[{}]", separated(", ", order_by))?;
+                f.write_str("]")
+            }
             AggregateFunc::LagLead {
                 lag_lead: LagLeadType::Lead,
-                ..
-            } => f.write_str("lead"),
-            AggregateFunc::FirstValue { .. } => f.write_str("first_value"),
-            AggregateFunc::LastValue { .. } => f.write_str("last_value"),
+                ignore_nulls,
+                order_by,
+            } => {
+                f.write_str("lag")?;
+                f.write_str("[")?;
+                if *ignore_nulls {
+                    f.write_str("ignore_nulls=true, ")?;
+                }
+                write!(f, "order_by=[{}]", separated(", ", order_by))?;
+                f.write_str("]")
+            }
+            AggregateFunc::FirstValue {
+                order_by,
+                window_frame,
+            } => {
+                f.write_str("first_value")?;
+                f.write_str("[")?;
+                write!(f, "order_by=[{}]", separated(", ", order_by))?;
+                if *window_frame != WindowFrame::default() {
+                    write!(f, " {}", window_frame)?;
+                }
+                f.write_str("]")
+            }
+            AggregateFunc::LastValue {
+                order_by,
+                window_frame,
+            } => {
+                f.write_str("last_value")?;
+                f.write_str("[")?;
+                write!(f, "order_by=[{}]", separated(", ", order_by))?;
+                if *window_frame != WindowFrame::default() {
+                    write!(f, " {}", window_frame)?;
+                }
+                f.write_str("]")
+            }
             AggregateFunc::Dummy => f.write_str("dummy"),
         }
     }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -12,7 +12,7 @@
 use std::cmp::{max, Ordering};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 use std::num::{NonZeroU64, NonZeroUsize};
 
 use bytesize::ByteSize;
@@ -2204,6 +2204,7 @@ impl RustType<ProtoColumnOrder> for ColumnOrder {
 
 impl fmt::Display for ColumnOrder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // If you modify this, then please also attend to Display for ColumnOrderWithExpr!
         write!(
             f,
             "#{} {} {}",
@@ -2998,6 +2999,16 @@ pub struct WindowFrame {
     pub end_bound: WindowFrameBound,
 }
 
+impl Display for WindowFrame {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} between {} and {}",
+            self.units, self.start_bound, self.end_bound
+        )
+    }
+}
+
 impl WindowFrame {
     /// Return the default window frame used when one is not explicitly defined
     pub fn default() -> Self {
@@ -3094,6 +3105,16 @@ pub enum WindowFrameUnits {
     Groups,
 }
 
+impl Display for WindowFrameUnits {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            WindowFrameUnits::Rows => write!(f, "rows"),
+            WindowFrameUnits::Range => write!(f, "range"),
+            WindowFrameUnits::Groups => write!(f, "groups"),
+        }
+    }
+}
+
 impl RustType<proto_window_frame::ProtoWindowFrameUnits> for WindowFrameUnits {
     fn into_proto(&self) -> proto_window_frame::ProtoWindowFrameUnits {
         use proto_window_frame::proto_window_frame_units::Kind::*;
@@ -3141,6 +3162,18 @@ pub enum WindowFrameBound {
     OffsetFollowing(u64),
     /// `UNBOUNDED FOLLOWING`.
     UnboundedFollowing,
+}
+
+impl Display for WindowFrameBound {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            WindowFrameBound::UnboundedPreceding => write!(f, "unbounded preceding"),
+            WindowFrameBound::OffsetPreceding(offset) => write!(f, "{} preceding", offset),
+            WindowFrameBound::CurrentRow => write!(f, "current row"),
+            WindowFrameBound::OffsetFollowing(offset) => write!(f, "{} following", offset),
+            WindowFrameBound::UnboundedFollowing => write!(f, "unbounded following"),
+        }
+    }
 }
 
 impl RustType<proto_window_frame::ProtoWindowFrameBound> for WindowFrameBound {

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -293,6 +293,7 @@ Replica
 Replicas
 Replication
 Reset
+Respect
 Restrict
 Retention
 Return

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -535,9 +535,57 @@ SELECT row_number() OVER (ORDER BY dt DESC),
            RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING),
        max(baz) OVER (ORDER BY a
            ROWS UNBOUNDED PRECEDING)
-       FROM foo
+FROM foo
 ----
 SELECT row_number() OVER (ORDER BY dt DESC), sum(foo) OVER (PARTITION BY a, b ORDER BY c, d ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), avg(bar) OVER (ORDER BY a RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING), max(baz) OVER (ORDER BY a ROWS UNBOUNDED PRECEDING) FROM foo
+
+parse-statement roundtrip
+SELECT lag(x, 1) OVER (ORDER BY dt DESC) FROM foo
+----
+SELECT lag(x, 1) OVER (ORDER BY dt DESC) FROM foo
+
+parse-statement roundtrip
+SELECT lag(x, 1) IGNORE NULLS OVER (ORDER BY dt DESC) FROM foo
+----
+SELECT lag(x, 1) IGNORE NULLS OVER (ORDER BY dt DESC) FROM foo
+
+parse-statement roundtrip
+SELECT lag(x, 1) RESPECT NULLS OVER (ORDER BY dt DESC) FROM foo
+----
+SELECT lag(x, 1) RESPECT NULLS OVER (ORDER BY dt DESC) FROM foo
+
+parse-statement roundtrip
+SELECT lag(x, 1) IGNORE NULLS RESPECT NULLS OVER (ORDER BY dt DESC) FROM foo
+----
+SELECT lag(x, 1) IGNORE NULLS RESPECT NULLS OVER (ORDER BY dt DESC) FROM foo
+
+parse-statement roundtrip
+SELECT lag(x, 1) RESPECT NULLS IGNORE NULLS OVER (ORDER BY dt DESC) FROM foo
+----
+error: Expected OVER, found IGNORE
+SELECT lag(x, 1) RESPECT NULLS IGNORE NULLS OVER (ORDER BY dt DESC) FROM foo
+                               ^
+
+parse-statement roundtrip
+SELECT lag(x, 1) IGNORE OVER (ORDER BY dt DESC) FROM foo
+----
+error: Expected OVER, found IGNORE
+SELECT lag(x, 1) IGNORE OVER (ORDER BY dt DESC) FROM foo
+                 ^
+
+parse-statement roundtrip
+SELECT lag(x, 1) NULLS OVER (ORDER BY dt DESC) FROM foo
+----
+error: Expected end of statement, found OVER
+SELECT lag(x, 1) NULLS OVER (ORDER BY dt DESC) FROM foo
+                       ^
+
+parse-statement roundtrip
+SELECT lag(x, 1) OVER IGNORE NULLS (ORDER BY dt DESC) FROM foo
+----
+error: Expected left parenthesis, found IGNORE
+SELECT lag(x, 1) OVER IGNORE NULLS (ORDER BY dt DESC) FROM foo
+                      ^
 
 parse-statement roundtrip
 SELECT a, count(1), min(b), max(b) FROM foo GROUP BY a

--- a/src/sql/src/plan/explain/text.rs
+++ b/src/sql/src/plan/explain/text.rs
@@ -18,10 +18,11 @@
 //! 4. Exceptions in (1) can be made when virtual syntax is requested (done by
 //!    default, can be turned off with `WITH(raw_syntax)`).
 
+use itertools::Itertools;
 use std::fmt;
 
 use mz_expr::virtual_syntax::{AlgExcept, Except};
-use mz_expr::Id;
+use mz_expr::{Id, WindowFrame};
 use mz_ore::str::{separated, IndentLike};
 use mz_repr::explain::text::{fmt_text_constant_rows, DisplayText};
 use mz_repr::explain::{CompactScalarSeq, Indices, PlanRenderingContext};
@@ -332,19 +333,70 @@ impl fmt::Display for HirScalarExpr {
                 write!(f, "case when {} then {} else {} end", cond, then, els)
             }
             Windowing(expr) => {
-                match &expr.func {
-                    WindowExprType::Scalar(scalar) => {
-                        write!(f, "{}()", scalar.clone().into_expr())?
+                // First, print
+                // - the window function name
+                // - the arguments.
+                // Also, dig out some info from the `func`.
+                let (column_orders, ignore_nulls, window_frame) = match &expr.func {
+                    WindowExprType::Scalar(scalar_window_expr) => {
+                        write!(f, "{}()", scalar_window_expr.func)?;
+                        (&scalar_window_expr.order_by, false, None)
                     }
-                    WindowExprType::Value(scalar) => {
-                        write!(f, "{}({})", scalar.clone().into_expr(), scalar.expr)?
+                    WindowExprType::Value(value_window_expr) => {
+                        write!(f, "{}({})", value_window_expr.func, value_window_expr.args)?;
+                        (
+                            &value_window_expr.order_by,
+                            value_window_expr.ignore_nulls,
+                            Some(&value_window_expr.window_frame),
+                        )
                     }
-                }
-                write!(f, " over ({})", separated(", ", expr.partition.iter()))?;
+                };
 
-                if !expr.order_by.is_empty() {
-                    write!(f, " order by ({})", separated(", ", expr.order_by.iter()))?;
+                // Reconstruct the ORDER BY (see comment on `WindowExpr.order_by`).
+                // We assume that the `column_order.column`s refer to each of the expressions in
+                // `expr.order_by` in order. This is a consequence of how `plan_function_order_by`
+                // works.
+                assert!(column_orders
+                    .iter()
+                    .enumerate()
+                    .all(|(i, column_order)| i == column_order.column));
+                let order_by = column_orders
+                    .iter()
+                    .zip_eq(expr.order_by.iter())
+                    .map(|(column_order, expr)| {
+                        ColumnOrderWithExpr {
+                            expr: expr.clone(),
+                            desc: column_order.desc,
+                            nulls_last: column_order.nulls_last,
+                        }
+                        // (We can ignore column_order.column because of the above assert.)
+                    })
+                    .collect_vec();
+
+                // Print IGNORE NULLS if present.
+                if ignore_nulls {
+                    write!(f, " ignore nulls")?;
                 }
+
+                // Print the OVER clause.
+                // This is close to the SQL syntax, but we are adding some [] to make it easier to
+                // read.
+                write!(f, " over (")?;
+                if !expr.partition.is_empty() {
+                    write!(
+                        f,
+                        "partition by [{}] ",
+                        separated(", ", expr.partition.iter())
+                    )?;
+                }
+                write!(f, "order by [{}]", separated(", ", order_by.iter()))?;
+                if let Some(window_frame) = window_frame {
+                    if *window_frame != WindowFrame::default() {
+                        write!(f, " {}", window_frame)?;
+                    }
+                }
+                write!(f, ")")?;
+
                 Ok(())
             }
             Exists(expr) => match expr.as_ref() {
@@ -356,6 +408,34 @@ impl fmt::Display for HirScalarExpr {
                 _ => write!(f, "select(???)"),
             },
         }
+    }
+}
+
+/// This is like ColumnOrder, but contains a HirScalarExpr instead of just a column reference by
+/// index. (This is only used in EXPLAIN, when reconstructing an ORDER BY inside an OVER clause.)
+struct ColumnOrderWithExpr {
+    /// The scalar expression.
+    pub expr: HirScalarExpr,
+    /// Whether to sort in descending order.
+    pub desc: bool,
+    /// Whether to sort nulls last.
+    pub nulls_last: bool,
+}
+
+impl fmt::Display for ColumnOrderWithExpr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // If you modify this, then please also attend to Display for ColumnOrder!
+        write!(
+            f,
+            "{} {} {}",
+            self.expr,
+            if self.desc { "desc" } else { "asc" },
+            if self.nulls_last {
+                "nulls_last"
+            } else {
+                "nulls_first"
+            },
+        )
     }
 }
 

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1138,7 +1138,7 @@ impl HirScalarExpr {
                             SS::Column(inner.arity() - 1)
                         }
                         WindowExprType::Value(func) => {
-                            let hir_scalar_input = func.expr.clone();
+                            let hir_scalar_input = func.args.clone();
                             *inner = inner.take_dangerous().let_in_fallible(
                                 id_gen,
                                 |id_gen, mut get_inner| {

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -807,3 +807,31 @@ EXPLAIN SELECT * FROM t1, t2 WHERE t1.x || mz_internal.mz_session_id()  = t2.x |
 # Regression test for the join visitation part of #19177
 statement ok
 EXPLAIN SELECT * FROM t1, t2 WHERE t1.x || mz_now()  = t2.x || mz_now();
+
+query T multiline
+EXPLAIN
+SELECT lag(x, 3, 'default') IGNORE NULLS OVER (ORDER BY x || x)
+FROM t1;
+----
+Explained Query:
+  Project (#2)
+    Map (record_get[0](#1))
+      FlatMap unnest_list(#0)
+        Reduce aggregates=[lag[ignore_nulls=true, order_by=[#0 asc nulls_last]](row(row(row(#0), row(#0, 3, "default")), (#0 || #0)))]
+          Get materialize.public.t1
+
+EOF
+
+query T multiline
+EXPLAIN
+SELECT first_value(x) OVER (ORDER BY x || x ROWS BETWEEN 5 preceding AND CURRENT ROW)
+FROM t1;
+----
+Explained Query:
+  Project (#2)
+    Map (record_get[0](#1))
+      FlatMap unnest_list(#0)
+        Reduce aggregates=[first_value[order_by=[#0 asc nulls_last] rows between 5 preceding and current row](row(row(row(#0), #0), (#0 || #0)))]
+          Get materialize.public.t1
+
+EOF

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -472,8 +472,8 @@ GROUP BY a
 ----
 Explained Query:
   Reduce::Basic
-    aggrs[0]=(0, string_agg(row(row((integer_to_text(#1) || "1"), ","))))
-    aggrs[1]=(1, string_agg(row(row((integer_to_text(#1) || "2"), ","))))
+    aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
+    aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
     val_plan
       project=(#3, #4)
       map=(integer_to_text(#1), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
@@ -521,8 +521,8 @@ Explained Query:
   With
     cte l0 =
       Reduce::Basic
-        aggrs[0]=(0, string_agg(row(row((integer_to_text(#0) || "1"), ","))))
-        aggrs[1]=(1, string_agg(row(row((integer_to_text(#0) || "2"), ","))))
+        aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
+        aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
         val_plan
           project=(#2, #3)
           map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
@@ -564,8 +564,8 @@ Explained Query:
       skips=[2, 0]
       buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
     basic
-      aggrs[0]=(1, string_agg(row(row((integer_to_text(#1) || "1"), ","))))
-      aggrs[1]=(5, string_agg(row(row((integer_to_text(#1) || "2"), ","))))
+      aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
+      aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
     val_plan
       project=(#1, #3, #1, #1, #1, #4)
       map=(integer_to_text(#1), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
@@ -626,8 +626,8 @@ Explained Query:
           skips=[2, 0]
           buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
         basic
-          aggrs[0]=(1, string_agg(row(row((integer_to_text(#0) || "1"), ","))))
-          aggrs[1]=(5, string_agg(row(row((integer_to_text(#0) || "2"), ","))))
+          aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
+          aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
         val_plan
           project=(#0, #2, #0, #0, #0, #3)
           map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
@@ -906,5 +906,61 @@ Explained Query:
           key_plan=id
           Get::PassArrangements l0
             raw=true
+
+EOF
+
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+SELECT lead(b, 3, -5) IGNORE NULLS OVER () as l
+FROM t;
+----
+Explained Query:
+  FlatMap unnest_list(#0)
+    project=(#2)
+    map=(record_get[0](#1))
+    input_key=
+    Reduce::Basic
+      aggr=(0, lag[ignore_nulls=true, order_by=[]](row(row(row(#0, #1), row(#1, 3, -5)))))
+      val_plan
+        project=(#2)
+        map=(row(row(row(#0, #1), row(#1, 3, -5))))
+      key_plan
+        project=()
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+SELECT lag(b, 3, -5) IGNORE NULLS OVER (PARTITION BY b, a ORDER BY b+8, a-7) as l
+FROM t;
+----
+Explained Query:
+  FlatMap unnest_list(#0)
+    project=(#2)
+    map=(record_get[0](#1))
+    Mfp
+      project=(#2)
+      input_key=#0, #1
+      Reduce::Basic
+        aggr=(0, lag[ignore_nulls=true, order_by=[#0 asc nulls_last, #1 asc nulls_last]](row(row(row(#0, #1), row(#1, 3, -5)), (#1 + 8), (#0 - 7))))
+        val_plan
+          project=(#2)
+          map=(row(row(row(#0, #1), row(#1, 3, -5)), (#1 + 8), (#0 - 7)))
+        key_plan
+          project=(#1, #0)
+        input_key=#0
+        Get::PassArrangements materialize.public.t
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+
+Used Indexes:
+  - materialize.public.t_a_idx
 
 EOF

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -445,6 +445,85 @@ EOF
 
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
+SELECT lag(b, 3) OVER ()
+FROM t;
+----
+Project (#2)
+  Map (lag(row(#1, 3, null)) over (order by []))
+    Get materialize.public.t
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT lag(b, 333) RESPECT NULLS OVER ()
+FROM t;
+----
+Project (#2)
+  Map (lag(row(#1, 333, null)) over (order by []))
+    Get materialize.public.t
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT lag(b, 333) IGNORE NULLS OVER ()
+FROM t;
+----
+Project (#2)
+  Map (lag(row(#1, 333, null)) ignore nulls over (order by []))
+    Get materialize.public.t
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT row_number() OVER (ORDER BY r DESC)
+FROM (
+    SELECT row_number() OVER (PARTITION BY l) as r
+    FROM (
+        SELECT lag(b, 3) OVER (PARTITION BY b%2, a%3 ORDER BY a DESC, -b, 2*b + a NULLS FIRST) as l
+        FROM t
+    )
+);
+----
+Project (#1)
+  Map (row_number() over (order by [#0 desc nulls_first]))
+    Project (#1)
+      Map (row_number() over (partition by [#0] order by []))
+        Project (#2)
+          Map (lag(row(#1, 3, null)) over (partition by [(#1 % 2), (#0 % 3)] order by [#0 desc nulls_first, -(#1) asc nulls_last, ((2 * #1) + #0) asc nulls_first]))
+            Get materialize.public.t
+
+EOF
+
+# Default frame is not printed (even when explicitly specified by the user).
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT
+    first_value(b) over (partition by b%6 order by b + 33 asc range between unbounded preceding and current row)
+FROM t;
+----
+Project (#2)
+  Map (first_value(#1) over (partition by [(#1 % 6)] order by [(#1 + 33) asc nulls_last]))
+    Get materialize.public.t
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT
+    first_value(b) over (partition by b%6 order by b + 33 asc rows between 2 preceding and current row)
+FROM t;
+----
+Project (#2)
+  Map (first_value(#1) over (partition by [(#1 % 6)] order by [(#1 + 33) asc nulls_last] rows between 2 preceding and current row))
+    Get materialize.public.t
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
 WITH MUTUALLY RECURSIVE
     foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
     bar (a int) as (SELECT a FROM foo)

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -267,7 +267,7 @@ Explained Query:
                 - ()
   With
     cte l0 =
-      Reduce aggregates=[min(#0), max(#0), sum(#0), count(*), sum((integer_to_numeric(#0) * integer_to_numeric(#0))), sum(integer_to_numeric(#0)), count(integer_to_numeric(#0)), list_agg(row(list[#0]))] // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
+      Reduce aggregates=[min(#0), max(#0), sum(#0), count(*), sum((integer_to_numeric(#0) * integer_to_numeric(#0))), sum(integer_to_numeric(#0)), count(integer_to_numeric(#0)), list_agg[order_by=[]](row(list[#0]))] // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
         Project (#1) // { types: "(integer)" }
           Get materialize.public.int_table // { types: "(integer?, integer)" }
 

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1406,9 +1406,9 @@ Project (#5, #6)
     Project (#0, #1, #3..=#5)
       Map (coalesce(#2, #4))
         FullOuterJoin (#2 = #4)
-          Map (row_number() over (), #1)
+          Map (row_number() over (order by []), #1)
             CallTable jsonb_object_keys(text_to_jsonb("{\"1\":2}"))
-          Map (row_number() over ())
+          Map (row_number() over (order by []))
             CallTable jsonb_object_keys(text_to_jsonb("{\"3\":4}"))
 
 EOF

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -1569,7 +1569,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
 SELECT jsonb_object_agg(1::uint8, 2::int);
 ----
-Reduce aggregates=[jsonb_object_agg(row(row(uint8_to_text(integer_to_uint8(1)), jsonb_or_null_to_jsonb(integer_to_numeric(2)))))]
+Reduce aggregates=[jsonb_object_agg[order_by=[]](row(row(uint8_to_text(integer_to_uint8(1)), jsonb_or_null_to_jsonb(integer_to_numeric(2)))))]
   Constant
     - ()
 

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -113,7 +113,7 @@ ORDER BY row_number, x
 Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0, #1]
   Project (#2, #0)
     Return
-      Map (row_number() over (#0) order by (#0))
+      Map (row_number() over (partition by [#0] order by [#0 asc nulls_last]))
         Get l0
     With
       cte l0 =
@@ -134,7 +134,7 @@ Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0, #1]
         Project (#3..=#5) // { arity: 3 }
           Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[0](#2)) // { arity: 6 }
             FlatMap unnest_list(#1) // { arity: 3 }
-              Reduce group_by=[#0] aggregates=[row_number(row(list[row(#0, #1)], #0))] // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[row_number[order_by=[#0 asc nulls_last]](row(list[row(#0, #1)], #0))] // { arity: 2 }
                 FlatMap wrap2("a", 1, "b", 2, "c", 1) // { arity: 2 }
                   Constant // { arity: 0 }
                     - ()
@@ -202,7 +202,7 @@ With
               Project (#3..=#6) // { arity: 4 }
                 Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[2](record_get[1](#2)), record_get[0](#2)) // { arity: 7 }
                   FlatMap unnest_list(#1) // { arity: 3 }
-                    Reduce group_by=[#0] aggregates=[row_number(row(list[row(#0, #1, #2)]))] // { arity: 2 }
+                    Reduce group_by=[#0] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 2 }
                       CrossJoin // { arity: 3 }
                         Get l1 // { arity: 1 }
                         Get materialize.public.t2 // { arity: 2 }
@@ -236,7 +236,7 @@ Explained Query:
               Filter (integer_to_bigint(record_get[0](record_get[1](#1))) = record_get[0](#1)) // { arity: 2 }
                 FlatMap unnest_list(#0) // { arity: 2 }
                   Project (#1) // { arity: 1 }
-                    Reduce group_by=[#0] aggregates=[row_number(row(list[row(#0, #1, #2)]))] // { arity: 2 }
+                    Reduce group_by=[#0] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 2 }
                       CrossJoin type=differential // { arity: 3 }
                         implementation
                           %0[×] » %1:t2[×]
@@ -307,7 +307,7 @@ Return // { arity: 5 }
             Project (#3..=#6) // { arity: 4 }
               Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[2](record_get[1](#2)), record_get[0](#2)) // { arity: 7 }
                 FlatMap unnest_list(#1) // { arity: 3 }
-                  Reduce group_by=[#0] aggregates=[row_number(row(list[row(#0, #1, #2)]))] // { arity: 2 }
+                  Reduce group_by=[#0] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 2 }
                     Filter (#2 = #0) // { arity: 3 }
                       CrossJoin // { arity: 3 }
                         Distinct group_by=[#1] // { arity: 1 }
@@ -335,7 +335,7 @@ Return // { arity: 5 }
             Project (#4..=#7) // { arity: 4 }
               Map (record_get[0](record_get[1](#3)), record_get[1](record_get[1](#3)), record_get[2](record_get[1](#3)), record_get[0](#3)) // { arity: 8 }
                 FlatMap unnest_list(#2) // { arity: 4 }
-                  Reduce group_by=[#0, #1] aggregates=[row_number(row(list[row(#0, #1, #2)]))] // { arity: 3 }
+                  Reduce group_by=[#0, #1] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 3 }
                     Filter (#2 = #0) // { arity: 3 }
                       CrossJoin // { arity: 3 }
                         Distinct group_by=[#1] // { arity: 1 }
@@ -1984,6 +1984,85 @@ query II
 SELECT f1, lead(0, f1 , 0) OVER (PARTITION BY f1 ORDER BY f1) FROM t4 GROUP BY f1 ORDER BY 1
 ----
 NULL NULL
+
+## lag/lead ignore nulls
+
+statement ok
+create table t6(x int, y int);
+
+statement ok
+insert into t6 values (1,2), (3,null), (5,6), (7,8), (9, null), (11, null), (13, 14), (15, 16), (17, 18);
+
+query IIIIIIIIIIIIIII
+select
+  x,
+  y,
+  lag(y) over (order by x) as lag1,
+  lag(y) respect nulls over (order by x) as lag1_resp,
+  lag(y) ignore nulls over (order by x) as lag1_ign,
+  lead(y) over (order by x) as lead1,
+  lead(y) ignore nulls over (order by x) as lead1_ign,
+  lag(y, 2) over (order by x) as lag2,
+  lag(y, 2) ignore nulls over (order by x) as lag2_ign,
+  lead(y, 2) over (order by x) as lead2,
+  lead(y, 2) ignore nulls over (order by x) as lead2_ign,
+  lag(y, 2, -1) ignore nulls over (order by x) as lag2_ign_def,
+  lead(y, 2, -1) ignore nulls over (order by x) as lead2_ign_def,
+  lag(y, 2, 16) ignore nulls over (order by x) as lag2_ign_def16,
+  lead(y, 2, 16) ignore nulls over (order by x) as lead2_ign_def16
+from t6
+order by x;
+----
+1  2  NULL  NULL  NULL  NULL  6  NULL  NULL  6  8  -1  8  16  8
+3  NULL  2  2  2  6  6  NULL  NULL  8  8  -1  8  16  8
+5  6  NULL  NULL  2  8  8  2  NULL  NULL  14  -1  14  16  14
+7  8  6  6  6  NULL  14  NULL  2  NULL  16  2  16  2  16
+9  NULL  8  8  8  NULL  14  6  6  14  16  6  16  6  16
+11  NULL  NULL  NULL  8  14  14  8  6  16  16  6  16  6  16
+13  14  NULL  NULL  8  16  16  NULL  6  18  18  6  18  6  18
+15  16  14  14  14  18  18  NULL  8  NULL  NULL  8  -1  8  16
+17  18  16  16  16  NULL  NULL  14  14  NULL  NULL  14  -1  14  16
+
+# Same as above, but with a `partition by`
+
+query IIIIIIIIIIIIIII
+select
+  x,
+  y,
+  lag(y) over (partition by x%4 order by x) as lag1,
+  lag(y) respect nulls over (partition by x%4 order by x) as lag1_resp,
+  lag(y) ignore nulls over (partition by x%4 order by x) as lag1_ign,
+  lead(y) over (partition by x%4 order by x) as lead1,
+  lead(y) ignore nulls over (partition by x%4 order by x) as lead1_ign,
+  lag(y, 2) over (partition by x%4 order by x) as lag2,
+  lag(y, 2) ignore nulls over (partition by x%4 order by x) as lag2_ign,
+  lead(y, 2) over (partition by x%4 order by x) as lead2,
+  lead(y, 2) ignore nulls over (partition by x%4 order by x) as lead2_ign,
+  lag(y, 2, -1) ignore nulls over (partition by x%4 order by x) as lag2_ign_def,
+  lead(y, 2, -1) ignore nulls over (partition by x%4 order by x) as lead2_ign_def,
+  lag(y, 2, 16) ignore nulls over (partition by x%4 order by x) as lag2_ign_def16,
+  lead(y, 2, 16) ignore nulls over (partition by x%4 order by x) as lead2_ign_def16
+from t6
+order by x%4, x;
+----
+1  2  NULL  NULL  NULL  6  6  NULL  NULL  NULL  14  -1  14  16  14
+5  6  2  2  2  NULL  14  NULL  NULL  14  18  -1  18  16  18
+9  NULL  6  6  6  14  14  2  2  18  18  2  18  2  18
+13  14  NULL  NULL  6  18  18  6  2  NULL  NULL  2  -1  2  16
+17  18  14  14  14  NULL  NULL  NULL  6  NULL  NULL  6  -1  6  16
+3  NULL  NULL  NULL  NULL  8  8  NULL  NULL  NULL  16  -1  16  16  16
+7  8  NULL  NULL  NULL  NULL  16  NULL  NULL  16  NULL  -1  -1  16  16
+11  NULL  8  8  8  16  16  NULL  NULL  NULL  NULL  -1  -1  16  16
+15  16  NULL  NULL  8  NULL  NULL  8  NULL  NULL  NULL  -1  -1  16  16
+
+query error db error: ERROR: IGNORE NULLS and RESPECT NULLS options for functions other than LAG and LEAD not yet supported
+select first_value(x) ignore nulls over() from t6;
+
+query error db error: ERROR: IGNORE NULLS and RESPECT NULLS options for functions other than LAG and LEAD not yet supported
+select row_number() ignore nulls over();
+
+query error db error: ERROR: Both IGNORE NULLS and RESPECT NULLS were given\.
+select row_number() ignore nulls respect nulls over();
 
 ## window frames
 


### PR DESCRIPTION
Also, fix EXPLAIN for window functions to include all fields.
- The HIR EXPLAIN is made to resemble SQL syntax.
- The MIR/LIR EXPLAIN prints window function options on the aggregation functions.

Also, add ORDER BY to the EXPLAIN of all ordered aggregations (not just window functions).

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/materialize/issues/19869

### Tips for reviewer

Ignore whitespace, because of an indentation change.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
