### PR TITLE
tracing: replace Targets with EnvFilter for span filtering

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -579,6 +579,18 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: storage-usage
 
+  - id: tracing
+    label: "Tracing Fast Path"
+    depends_on: build-x86_64
+    timeout_in_minutes: 10
+    inputs: [test/tracing]
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: tracing
+    agents:
+      queue: linux-x86_64
+
   - id: lang-csharp
     label: ":csharp: tests"
     depends_on: build-x86_64

--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -298,7 +298,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         },
         SYSTEM_TIME.clone(),
         ConnectionContext::from_cli_args(
-            args.tracing.log_filter.inner_ref(),
+            args.tracing.log_filter.as_ref(),
             args.aws_external_id,
             secrets_reader,
         ),

--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -298,7 +298,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         },
         SYSTEM_TIME.clone(),
         ConnectionContext::from_cli_args(
-            &args.tracing.log_filter.inner,
+            args.tracing.log_filter.inner_ref(),
             args.aws_external_id,
             secrets_reader,
         ),

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -856,7 +856,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             .collect(),
         availability_zones: args.availability_zone,
         connection_context: ConnectionContext::from_cli_args(
-            args.tracing.log_filter.inner_ref(),
+            args.tracing.log_filter.as_ref(),
             args.aws_external_id_prefix,
             secrets_reader,
         ),

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -856,7 +856,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             .collect(),
         availability_zones: args.availability_zone,
         connection_context: ConnectionContext::from_cli_args(
-            &args.tracing.log_filter.inner,
+            args.tracing.log_filter.inner_ref(),
             args.aws_external_id_prefix,
             secrets_reader,
         ),

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -116,7 +116,7 @@ use tokio_postgres::config::Host;
 use tokio_postgres::Client;
 use tokio_stream::wrappers::TcpListenerStream;
 use tower_http::cors::AllowOrigin;
-use tracing_subscriber::filter::Targets;
+use tracing_subscriber::EnvFilter;
 use tungstenite::stream::MaybeTlsStream;
 use tungstenite::{Message, WebSocket};
 
@@ -355,12 +355,12 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             service_name: "environmentd",
             stderr_log: StderrLogConfig {
                 format: StderrLogFormat::Json,
-                filter: Targets::default(),
+                filter: EnvFilter::default(),
             },
             opentelemetry: Some(OpenTelemetryConfig {
                 endpoint: "http://fake_address_for_testing:8080".to_string(),
                 headers: http::HeaderMap::new(),
-                filter: Targets::default().with_default(tracing_core::Level::DEBUG),
+                filter: EnvFilter::default().add_directive("debug".parse().expect("directive")),
                 resource: opentelemetry::sdk::resource::Resource::default(),
                 start_enabled: true,
             }),

--- a/src/http-util/src/lib.rs
+++ b/src/http-util/src/lib.rs
@@ -87,7 +87,7 @@ use prometheus::Encoder;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tower_http::cors::AllowOrigin;
-use tracing_subscriber::filter::Targets;
+use tracing_subscriber::EnvFilter;
 
 /// Renders a template into an HTTP response.
 pub fn template_response<T>(template: T) -> Html<String>
@@ -187,10 +187,10 @@ pub struct DynamicFilterTarget {
 #[allow(clippy::unused_async)]
 pub async fn handle_reload_tracing_filter(
     handle: &TracingHandle,
-    reload: fn(&TracingHandle, Targets) -> Result<(), anyhow::Error>,
+    reload: fn(&TracingHandle, EnvFilter) -> Result<(), anyhow::Error>,
     Json(cfg): Json<DynamicFilterTarget>,
 ) -> impl IntoResponse {
-    match cfg.targets.parse::<Targets>() {
+    match cfg.targets.parse::<EnvFilter>() {
         Ok(targets) => match reload(handle, targets) {
             Ok(()) => (StatusCode::OK, cfg.targets.to_string()),
             Err(e) => (StatusCode::BAD_REQUEST, e.to_string()),

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -24,6 +24,9 @@ tracing-subscriber = { version = "0.3.16", default-features = false }
 opentelemetry = { version = "0.19.0", features = ["rt-tokio", "trace"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
+[dev-dependencies]
+mz-ore = { path = "../ore", features = ["network", "test"] }
+
 [features]
 tokio-console = ["mz-ore/tokio-console", "mz-repr", "humantime"]
 

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -554,3 +554,24 @@ impl fmt::Display for LogFormat {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::CloneableEnvFilter;
+    use std::str::FromStr;
+
+    #[mz_ore::test]
+    fn roundtrips() {
+        let filter = CloneableEnvFilter::from_str(
+            "abc=debug,def=trace,[123],foo,baz[bar{a=b}]=debug,[{13=37}]=trace,info",
+        )
+        .expect("valid");
+        assert_eq!(
+            format!("{}", filter),
+            format!(
+                "{}",
+                CloneableEnvFilter::from_str(&format!("{}", filter)).expect("valid")
+            )
+        );
+    }
+}

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -507,6 +507,11 @@ impl CloneableEnvFilter {
 
 impl Clone for CloneableEnvFilter {
     fn clone(&self) -> Self {
+        // At the time of this implementation, `EnvFilter` does not implement Clone
+        // but is expected, without explicit documentation saying so, to roundtrip
+        // through its Display implementation [1].
+        //
+        // [1]: https://github.com/tokio-rs/tracing/blob/e603c2a254d157a25a7a1fbfd4da46ad7e05f555/tracing-subscriber/src/filter/env/mod.rs#L944-L953
         let filter = EnvFilter::from_str(&format!("{}", self.filter)).expect("roundtrips");
         Self { filter }
     }

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -78,6 +78,7 @@
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fmt;
+use std::fmt::Formatter;
 use std::str::FromStr;
 use std::sync::Arc;
 #[cfg(feature = "tokio-console")]
@@ -105,7 +106,7 @@ use mz_ore::tracing::{
 };
 use opentelemetry::sdk::resource::Resource;
 use opentelemetry::KeyValue;
-use tracing_subscriber::filter::Targets;
+use tracing_subscriber::EnvFilter;
 
 /// Command line arguments for application tracing.
 ///
@@ -149,7 +150,7 @@ pub struct TracingCliArgs {
         value_name = "FILTER",
         default_value = "info"
     )]
-    pub log_filter: SerializableTargets,
+    pub log_filter: CloneableEnvFilter,
     /// The format to use for stderr log messages.
     #[clap(long, env = "LOG_FORMAT", default_value_t, value_enum)]
     pub log_format: LogFormat,
@@ -207,7 +208,7 @@ pub struct TracingCliArgs {
         // TODO(guswynn): switch tokio_postgres logging to `trace` upstream
         default_value = "tokio_postgres=info,debug"
     )]
-    pub opentelemetry_filter: SerializableTargets,
+    pub opentelemetry_filter: CloneableEnvFilter,
     /// Additional key-value pairs to send with all opentelemetry traces.
     ///
     /// Requires that the `--opentelemetry-endpoint` option is specified.
@@ -287,7 +288,7 @@ impl TracingCliArgs {
                     },
                     LogFormat::Json => StderrLogFormat::Json,
                 },
-                filter: self.log_filter.inner.clone(),
+                filter: self.log_filter.clone().inner(),
             },
             opentelemetry: self.opentelemetry_endpoint.clone().map(|endpoint| {
                 OpenTelemetryConfig {
@@ -297,7 +298,7 @@ impl TracingCliArgs {
                         .iter()
                         .map(|header| (header.key.clone(), header.value.clone()))
                         .collect(),
-                    filter: self.opentelemetry_filter.inner.clone(),
+                    filter: self.opentelemetry_filter.clone().inner(),
                     resource: Resource::new(
                         self.opentelemetry_resource
                             .iter()
@@ -488,29 +489,41 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
     }
 }
 
-/// Wraps [`Targets`] to provide a [`Display`](fmt::Display) implementation.
-#[derive(Debug, Clone)]
-pub struct SerializableTargets {
-    /// The parsed targets.
-    pub inner: Targets,
-    /// A string representation of `inner`.
-    pub raw: String,
+/// Wraps [`EnvFilter`] to provide a [`Clone`] implementation.
+#[derive(Debug)]
+pub struct CloneableEnvFilter {
+    filter: EnvFilter,
 }
 
-impl FromStr for SerializableTargets {
-    type Err = tracing_subscriber::filter::ParseError;
+impl CloneableEnvFilter {
+    pub fn inner_ref(&self) -> &EnvFilter {
+        &self.filter
+    }
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(SerializableTargets {
-            inner: s.parse()?,
-            raw: s.into(),
-        })
+    pub fn inner(self) -> EnvFilter {
+        self.filter
     }
 }
 
-impl fmt::Display for SerializableTargets {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.raw)
+impl Clone for CloneableEnvFilter {
+    fn clone(&self) -> Self {
+        let filter = EnvFilter::from_str(&format!("{}", self.filter)).expect("roundtrips");
+        Self { filter }
+    }
+}
+
+impl FromStr for CloneableEnvFilter {
+    type Err = tracing_subscriber::filter::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let filter: EnvFilter = s.parse()?;
+        Ok(CloneableEnvFilter { filter })
+    }
+}
+
+impl std::fmt::Display for CloneableEnvFilter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.filter)
     }
 }
 

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -39,7 +39,7 @@ use sentry::integrations::debug_images::DebugImagesIntegration;
 use tonic::metadata::MetadataMap;
 use tonic::transport::Endpoint;
 use tracing::subscriber::Interest;
-use tracing::{info, warn, Callsite, Event, Level, Metadata, Subscriber};
+use tracing::{warn, Callsite, Event, Level, Metadata, Subscriber};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::filter::Directive;
 use tracing_subscriber::fmt::format::{format, Writer};

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -38,8 +38,7 @@ use opentelemetry::{global, KeyValue};
 use sentry::integrations::debug_images::DebugImagesIntegration;
 use tonic::metadata::MetadataMap;
 use tonic::transport::Endpoint;
-use tracing::subscriber::Interest;
-use tracing::{warn, Callsite, Event, Level, Metadata, Subscriber};
+use tracing::{warn, Event, Level, Subscriber};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::filter::Directive;
 use tracing_subscriber::fmt::format::{format, Writer};
@@ -457,17 +456,6 @@ where
     };
 
     Ok((handle, guard))
-}
-
-struct EmptyCallsite;
-impl Callsite for EmptyCallsite {
-    fn set_interest(&self, _: Interest) {
-        unreachable!("EmptyCallsite should never be accessed")
-    }
-
-    fn metadata(&self) -> &Metadata<'_> {
-        unreachable!("EmptyCallsite should never be accessed")
-    }
 }
 
 /// Returns the [`Level`] of a crate from an [`EnvFilter`] by performing an

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -328,7 +328,7 @@ where
         ];
 
         let (filter, filter_handle) = reload::Layer::new(if otel_config.start_enabled {
-            let mut filter = EnvFilter::from_str(&format!("{}", otel_config.filter)).expect("WIP");
+            let mut filter = otel_config.filter;
             for directive in &default_directives {
                 filter = filter.add_directive(directive.clone());
             }

--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -132,7 +132,7 @@ impl ConnectionContext {
     /// (e.g., via a configuration option in a SQL statement). See
     /// [`AwsExternalIdPrefix`] for details.
     pub fn from_cli_args(
-        filter: &tracing_subscriber::filter::Targets,
+        filter: &tracing_subscriber::filter::EnvFilter,
         aws_external_id_prefix: Option<AwsExternalIdPrefix>,
         secrets_reader: Arc<dyn SecretsReader>,
     ) -> ConnectionContext {

--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -137,7 +137,7 @@ impl ConnectionContext {
         secrets_reader: Arc<dyn SecretsReader>,
     ) -> ConnectionContext {
         ConnectionContext {
-            librdkafka_log_level: mz_ore::tracing::target_level(filter, "librdkafka"),
+            librdkafka_log_level: mz_ore::tracing::crate_level(filter, "librdkafka"),
             aws_external_id_prefix,
             secrets_reader,
             ssh_tunnel_manager: SshTunnelManager::default(),


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

`EnvFilter` allows us to filter logs / traces much more granularly, giving us knobs to filter events by span name and field names within spans. 

As an example, the following lets us view debug logging for all spans for a specific shard ID within `mz_persist_client`, and info logs for everything else:

```
./bin/environmentd -- --log-filter="mz_persist_client[{shard_id=s05ddcd2b-dba4-453b-96ea-a0bb0bc5a978}]=debug,info"
```

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
