### PR TITLE
planner: Fix function column name invention

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2802,10 +2802,7 @@ fn invent_column_name(
                         .qcx
                         .scx
                         .catalog
-                        .resolve_schema(
-                            Some("materialize"),
-                            mz_repr::namespaces::MZ_INTERNAL_SCHEMA,
-                        )
+                        .resolve_schema(None, mz_repr::namespaces::MZ_INTERNAL_SCHEMA)
                         .expect("mz_internal schema must exist")
                         .id()
                 {

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -286,6 +286,20 @@ def workflow_allowed_cluster_replica_sizes(c: Composition) -> None:
     )
 
 
+def workflow_drop_materialize_database(c: Composition) -> None:
+    c.up("materialized")
+
+    # Drop materialize database
+    c.sql("DROP DATABASE materialize")
+
+    # Restart mz.
+    c.kill("materialized")
+    c.up("materialized")
+
+    # Verify that materialize hasn't blown up
+    c.sql("SELECT 1")
+
+
 def workflow_default(c: Composition) -> None:
     c.workflow("github-17578")
     c.workflow("github-8021")
@@ -293,3 +307,4 @@ def workflow_default(c: Composition) -> None:
     c.workflow("timelines")
     c.workflow("stash")
     c.workflow("allowed-cluster-replica-sizes")
+    c.workflow("drop-materialize-database")

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -290,7 +290,11 @@ def workflow_drop_materialize_database(c: Composition) -> None:
     c.up("materialized")
 
     # Drop materialize database
-    c.sql("DROP DATABASE materialize")
+    c.sql(
+        "DROP DATABASE materialize",
+        port=6877,
+        user="mz_system",
+    )
 
     # Restart mz.
     c.kill("materialized")


### PR DESCRIPTION
Previously, in the planner when inventing a column name for the result of certain functions we would check if the schema id of the function matched the schema id of the mz_internal schema. When looking up the schema id of the mz_internal schema, we would mistakenly look for it in the materialize database. If someone deleted the materialize database, this code path would cause a panic.

This commit fixes this logic to look for the mz_internal schema in the ambient database which avoids the panic when the materialize database doesn't exist.

Fixes #19871

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
