### PR TITLE
[expr] Associativity fixes for concat

### DIFF
--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -787,7 +787,7 @@ impl<'a> Interpreter for ColumnSpecs<'a> {
     }
 
     fn variadic(&self, func: &VariadicFunc, args: Vec<Self::Summary>) -> Self::Summary {
-        let mapped_spec = if func.is_associative() && !args.is_empty() {
+        let mapped_spec = if func.is_associative() && args.len() >= 2 {
             let col_type = func.output_type(args.iter().map(|cs| cs.col_type.clone()).collect());
             let mut expr = MirScalarExpr::CallVariadic {
                 func: func.clone(),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -7207,12 +7207,12 @@ impl VariadicFunc {
             | VariadicFunc::Greatest
             | VariadicFunc::Least
             | VariadicFunc::Concat
-            | VariadicFunc::ConcatWs
             | VariadicFunc::And
             | VariadicFunc::Or => true,
 
             VariadicFunc::MakeTimestamp
             | VariadicFunc::PadLeading
+            | VariadicFunc::ConcatWs
             | VariadicFunc::Substr
             | VariadicFunc::Replace
             | VariadicFunc::Translate


### PR DESCRIPTION
Enable testing `concat` and `concat_ws` in the interpreter and fix two related bugs:
- The brand-new `concat_ws` function is marked as associative, but is not actually: `concat_ws(a, b, c)` and `concat_ws(a, concat_ws(b, c))` return different results. (Fix: change the annotation.)
- The interpreter returns `null` for `concat(null)`, but the correct result is `''`. (Fix: don't use our associativity optimization for <2 arguments.)

### Motivation

This fixes a couple previously unknown bugs.

Fixes: https://github.com/MaterializeInc/materialize/issues/19899

### Tips for reviewer

I found these issues in response to a [thread in our internal Slack](https://materializeinc.slack.com/archives/C04DJT084KA/p1686584287325329), but we've been unable to get an exact reproduction of that issue so far, so I'm not confident either of these problems is involved. Nevertheless: both worth fixing.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
