### PR TITLE
Bundle execution finalization state into `ExecutionContext`.

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -349,8 +349,8 @@ impl SessionClient {
     /// - `Some(n > 1)`: InTransactionImplicit
     /// - `Some(0)`: no change
     pub fn start_transaction(&mut self, implicit: Option<usize>) -> Result<(), AdapterError> {
-        let mut session = self.session.take().expect("session invariant violated");
         let now = self.now_datetime();
+        let session = self.session.as_mut().expect("session invariant violated");
         let result = match implicit {
             None => session.start_transaction(now, None, None),
             Some(stmts) => {
@@ -358,7 +358,6 @@ impl SessionClient {
                 Ok(())
             }
         };
-        self.session = Some(session);
         result
     }
 
@@ -485,7 +484,7 @@ impl SessionClient {
             // - execute reports success of dataflow execution
             match cmd {
                 Command::Declare { .. } => typ = Some("declare"),
-                Command::Execute { .. } | Command::ExecuteInner { .. } => typ = Some("execute"),
+                Command::Execute { .. } => typ = Some("execute"),
                 Command::Startup { .. }
                 | Command::Prepare { .. }
                 | Command::VerifyPreparedStatement { .. }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -30,6 +30,7 @@ use tokio::sync::{oneshot, watch};
 
 use crate::client::{ConnectionId, ConnectionIdType};
 use crate::coord::peek::PeekResponseUnary;
+use crate::coord::{ExecuteContext, ExecuteContextExtra};
 use crate::error::AdapterError;
 use crate::session::{EndTransactionAction, RowBatchStream, Session};
 use crate::util::Transmittable;
@@ -62,6 +63,13 @@ pub enum Command {
         name: String,
         session: Session,
         tx: oneshot::Sender<Response<()>>,
+    },
+
+    // ExecuteInner is like Execute, but its context has already been allocated.
+    ExecuteInner {
+        portal_name: String,
+        ctx: ExecuteContext,
+        span: tracing::Span,
     },
 
     Execute {
@@ -97,6 +105,7 @@ pub enum Command {
         rows: Vec<Row>,
         session: Session,
         tx: oneshot::Sender<Response<ExecuteResponse>>,
+        ctx_extra: ExecuteContextExtra,
     },
 
     GetSystemVars {
@@ -130,6 +139,7 @@ impl Command {
             | Command::GetSystemVars { session, .. }
             | Command::SetSystemVars { session, .. }
             | Command::Terminate { session, .. } => Some(session),
+            Command::ExecuteInner { ctx, .. } => Some(ctx.session()),
             Command::CancelRequest { .. } | Command::PrivilegedCancelRequest { .. } => None,
         }
     }
@@ -147,34 +157,8 @@ impl Command {
             | Command::GetSystemVars { session, .. }
             | Command::SetSystemVars { session, .. }
             | Command::Terminate { session, .. } => Some(session),
+            Command::ExecuteInner { ctx, .. } => Some(ctx.session_mut()),
             Command::CancelRequest { .. } | Command::PrivilegedCancelRequest { .. } => None,
-        }
-    }
-
-    pub fn send_error(self, e: AdapterError) {
-        fn send<T>(tx: oneshot::Sender<Response<T>>, session: Session, e: AdapterError) {
-            let _ = tx.send(Response::<T> {
-                result: Err(e),
-                session,
-            });
-        }
-        match self {
-            Command::Startup { tx, session, .. } => send(tx, session, e),
-            Command::Declare { tx, session, .. } => send(tx, session, e),
-            Command::Prepare { tx, session, .. } => send(tx, session, e),
-            Command::VerifyPreparedStatement { tx, session, .. } => send(tx, session, e),
-            Command::Execute { tx, session, .. } => send(tx, session, e),
-            Command::Commit { tx, session, .. } => send(tx, session, e),
-            Command::CancelRequest { .. } | Command::PrivilegedCancelRequest { .. } => {}
-            Command::DumpCatalog { tx, session, .. } => send(tx, session, e),
-            Command::CopyRows { tx, session, .. } => send(tx, session, e),
-            Command::GetSystemVars { tx, session, .. } => send(tx, session, e),
-            Command::SetSystemVars { tx, session, .. } => send(tx, session, e),
-            Command::Terminate { tx, session, .. } => {
-                if let Some(tx) = tx {
-                    send(tx, session, e)
-                }
-            }
         }
     }
 }
@@ -316,6 +300,7 @@ pub enum ExecuteResponse {
         id: GlobalId,
         columns: Vec<usize>,
         params: CopyFormatParams<'static>,
+        ctx_extra: ExecuteContextExtra,
     },
     /// The requested connection was created.
     CreatedConnection,

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -30,7 +30,7 @@ use tokio::sync::{oneshot, watch};
 
 use crate::client::{ConnectionId, ConnectionIdType};
 use crate::coord::peek::PeekResponseUnary;
-use crate::coord::{ExecuteContext, ExecuteContextExtra};
+use crate::coord::ExecuteContextExtra;
 use crate::error::AdapterError;
 use crate::session::{EndTransactionAction, RowBatchStream, Session};
 use crate::util::Transmittable;
@@ -63,13 +63,6 @@ pub enum Command {
         name: String,
         session: Session,
         tx: oneshot::Sender<Response<()>>,
-    },
-
-    // ExecuteInner is like Execute, but its context has already been allocated.
-    ExecuteInner {
-        portal_name: String,
-        ctx: ExecuteContext,
-        span: tracing::Span,
     },
 
     Execute {
@@ -139,7 +132,6 @@ impl Command {
             | Command::GetSystemVars { session, .. }
             | Command::SetSystemVars { session, .. }
             | Command::Terminate { session, .. } => Some(session),
-            Command::ExecuteInner { ctx, .. } => Some(ctx.session()),
             Command::CancelRequest { .. } | Command::PrivilegedCancelRequest { .. } => None,
         }
     }
@@ -157,7 +149,6 @@ impl Command {
             | Command::GetSystemVars { session, .. }
             | Command::SetSystemVars { session, .. }
             | Command::Terminate { session, .. } => Some(session),
-            Command::ExecuteInner { ctx, .. } => Some(ctx.session_mut()),
             Command::CancelRequest { .. } | Command::PrivilegedCancelRequest { .. } => None,
         }
     }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -192,7 +192,7 @@ pub enum Message<T = mz_repr::Timestamp> {
         /// Timestamp of the writes in the group commit.
         T,
         /// Clients waiting on responses from the group commit.
-        Vec<CompletedClientTransmitter<ExecuteResponse>>,
+        Vec<CompletedClientTransmitter>,
         /// Optional lock if the group commit contained writes to user tables.
         Option<OwnedMutexGuard<()>>,
     ),
@@ -209,14 +209,18 @@ pub enum Message<T = mz_repr::Timestamp> {
         real_time_recency_ts: Timestamp,
         validity: PeekValidity,
     },
+    /// Performs any cleanup and logging actions necessary for
+    /// finalizing a statement execution.
+    RetireExecute {
+        data: ExecuteContextExtra,
+    },
 }
 
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct CreateSourceStatementReady {
-    pub session: Session,
     #[derivative(Debug = "ignore")]
-    pub tx: ClientTransmitter<ExecuteResponse>,
+    pub ctx: ExecuteContext,
     pub result: Result<
         (
             Vec<(GlobalId, CreateSubsourceStatement<Aug>)>,
@@ -234,7 +238,7 @@ pub struct CreateSourceStatementReady {
 #[derivative(Debug)]
 pub struct SinkConnectionReady {
     #[derivative(Debug = "ignore")]
-    pub session_and_tx: Option<(Session, ClientTransmitter<ExecuteResponse>)>,
+    pub ctx: Option<ExecuteContext>,
     pub id: GlobalId,
     pub oid: u32,
     pub create_export_token: CreateExportToken,
@@ -244,19 +248,17 @@ pub struct SinkConnectionReady {
 #[derive(Debug)]
 pub enum RealTimeRecencyContext {
     ExplainTimestamp {
-        tx: ClientTransmitter<ExecuteResponse>,
-        session: Session,
+        ctx: ExecuteContext,
         format: ExplainFormat,
         cluster_id: ClusterId,
         optimized_plan: OptimizedMirRelationExpr,
         id_bundle: CollectionIdBundle,
     },
     Peek {
-        tx: ClientTransmitter<ExecuteResponse>,
+        ctx: ExecuteContext,
         finishing: RowSetFinishing,
         copy_to: Option<CopyFormat>,
         dataflow: DataflowDescription<OptimizedMirRelationExpr>,
-        session: Session,
         cluster_id: ClusterId,
         when: QueryWhen,
         target_replica: Option<ReplicaId>,
@@ -271,10 +273,10 @@ pub enum RealTimeRecencyContext {
 }
 
 impl RealTimeRecencyContext {
-    pub(crate) fn take_tx_and_session(self) -> (ClientTransmitter<ExecuteResponse>, Session) {
+    pub(crate) fn take_context(self) -> ExecuteContext {
         match self {
-            RealTimeRecencyContext::ExplainTimestamp { tx, session, .. }
-            | RealTimeRecencyContext::Peek { tx, session, .. } => (tx, session),
+            RealTimeRecencyContext::ExplainTimestamp { ctx, .. }
+            | RealTimeRecencyContext::Peek { ctx, .. } => ctx,
         }
     }
 }
@@ -476,12 +478,10 @@ struct ConnMeta {
 #[derive(Debug)]
 /// A pending transaction waiting to be committed.
 pub struct PendingTxn {
-    /// Transmitter used to send a response back to the client.
-    client_transmitter: ClientTransmitter<ExecuteResponse>,
+    /// Context used to send a response back to the client.
+    ctx: ExecuteContext,
     /// Client response for transaction.
     response: Result<PendingTxnResponse, AdapterError>,
-    /// Session of the client who initiated the transaction.
-    session: Session,
     /// The action to take at the end of the transaction.
     action: EndTransactionAction,
 }
@@ -555,31 +555,158 @@ impl PendingReadTxn {
     }
 
     /// Alert the client that the read has been linearized.
-    pub fn finish(self) {
+    ///
+    /// If it is necessary to finalize an execute, return the state necessary to do so
+    /// (execution context and result)
+    pub fn finish(self) -> Option<(ExecuteContext, Result<ExecuteResponse, AdapterError>)> {
         match self {
             PendingReadTxn::Read {
                 txn:
                     PendingTxn {
-                        client_transmitter,
+                        mut ctx,
                         response,
-                        mut session,
                         action,
                     },
                 ..
             } => {
-                let changed = session.vars_mut().end_transaction(action);
+                let changed = ctx.session_mut().vars_mut().end_transaction(action);
                 // Append any parameters that changed to the response.
                 let response = response.map(|mut r| {
                     r.extend_params(changed);
                     ExecuteResponse::from(r)
                 });
 
-                client_transmitter.send(response, session);
+                Some((ctx, response))
             }
             PendingReadTxn::ReadThenWrite { tx, .. } => {
                 // Ignore errors if the caller has hung up.
                 let _ = tx.send(());
+                None
             }
+        }
+    }
+}
+
+/// State that the coordinator must process as part of retiring
+/// command execution.  `ExecuteContextExtra::Default` is guaranteed
+/// to produce a value that will cause the coordinator to do nothing, and
+/// is intended for use by code that invokes the execution processing flow
+/// (i.e., `sequence_plan`) without actually being a statement execution
+// Currently nothing; planned to be data related to statement logging
+// at some point in the future.
+#[derive(Debug, Default)]
+pub struct ExecuteContextExtra;
+
+/// Bundle of state related to statement execution.
+///
+/// This struct collects a bundle of state that needs to be threaded
+/// through various functions as part of statement execution.
+/// Currently, it is only used to finalize execution, by calling one
+/// of the methods `retire` or `retire_aysnc`. Finalizing execution
+/// involves sending the session back to the pgwire layer so that it
+/// may be used to process further commands. In the future, it will
+/// also involve performing some work on the main coordinator thread
+/// (e.g., recording the time at which the statement finished
+/// executing) the state necessary to perform this work is bundled in
+/// the `ExecuteContextExtra` object (today, it is simply empty).
+#[derive(Debug)]
+pub struct ExecuteContext {
+    tx: ClientTransmitter<ExecuteResponse>,
+    internal_cmd_tx: mpsc::UnboundedSender<Message>,
+    session: Session,
+    extra: ExecuteContextExtra,
+}
+
+impl ExecuteContext {
+    pub fn session(&self) -> &Session {
+        &self.session
+    }
+
+    pub fn session_mut(&mut self) -> &mut Session {
+        &mut self.session
+    }
+
+    pub fn tx(&self) -> &ClientTransmitter<ExecuteResponse> {
+        &self.tx
+    }
+
+    pub fn tx_mut(&mut self) -> &mut ClientTransmitter<ExecuteResponse> {
+        &mut self.tx
+    }
+
+    pub fn from_parts(
+        tx: ClientTransmitter<ExecuteResponse>,
+        internal_cmd_tx: mpsc::UnboundedSender<Message>,
+        session: Session,
+        extra: ExecuteContextExtra,
+    ) -> Self {
+        Self {
+            tx,
+            session,
+            extra,
+            internal_cmd_tx,
+        }
+    }
+
+    /// By calling this function, the caller takes responsibility for
+    /// dealing with the instance of `ExecuteContextExtra`. This is
+    /// intended to support protocols (like `COPY FROM`) that involve
+    /// multiple passes of sending the session back and forth between
+    /// the coordinator and the pgwire layer. As part of any such
+    /// protocol, we must ensure that the `ExecuteContextExtra`
+    /// (possibly wrapped in a new `ExecuteContext`) is passed back to the coordinator for
+    /// eventual retirement.
+    pub fn into_parts(
+        self,
+    ) -> (
+        ClientTransmitter<ExecuteResponse>,
+        mpsc::UnboundedSender<Message>,
+        Session,
+        ExecuteContextExtra,
+    ) {
+        let Self {
+            tx,
+            internal_cmd_tx,
+            session,
+            extra,
+        } = self;
+        (tx, internal_cmd_tx, session, extra)
+    }
+
+    /// Retire the execution, with access to the coordinator.
+    ///
+    /// Since the caller provides us with exclusive access to the coordinator, we are
+    /// able to perform whatever action necessary synchronously on the main coordinator task.
+    ///
+    /// If you find yourself in a context where you don't have exclusive access to the coordinator,
+    /// use `retire_aysnc` instead.
+    pub fn retire(self, result: Result<ExecuteResponse, AdapterError>, coord: &mut Coordinator) {
+        let Self {
+            tx,
+            internal_cmd_tx: _,
+            session,
+            extra,
+        } = self;
+        tx.send(result, session);
+        coord.retire_execute(extra);
+    }
+
+    /// Retire the execution, _without_ access to the coordinator.
+    ///
+    /// This function is intended for when statement execution ends on a task that
+    /// does not have exclusive access to the coordinator. Because the coordinator may need to
+    /// perform some per-statement logging or cleanup work, this function sends a message to the
+    /// coordinator informing it that the statement execution is being retired.
+    pub fn retire_async(self, result: Result<ExecuteResponse, AdapterError>) {
+        let Self {
+            tx,
+            internal_cmd_tx,
+            session,
+            extra,
+        } = self;
+        tx.send(result, session);
+        if let Err(e) = internal_cmd_tx.send(Message::RetireExecute { data: extra }) {
+            warn!("internal_cmd_rx dropped before we could send: {:?}", e);
         }
     }
 }
@@ -1146,7 +1273,7 @@ impl Coordinator {
                             // It is not an error for sink connections to become ready after `internal_cmd_rx` is dropped.
                             let result = internal_cmd_tx.send(Message::SinkConnectionReady(
                                 SinkConnectionReady {
-                                    session_and_tx: None,
+                                    ctx: None,
                                     id,
                                     oid,
                                     create_export_token,

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -26,8 +26,8 @@ use crate::catalog::BuiltinTableUpdate;
 use crate::coord::timeline::WriteTimestamp;
 use crate::coord::{Coordinator, Message, PendingTxn};
 use crate::session::{Session, WriteOp};
-use crate::util::{ClientTransmitter, CompletedClientTransmitter, ResultExt};
-use crate::ExecuteResponse;
+use crate::util::{CompletedClientTransmitter, ResultExt};
+use crate::ExecuteContext;
 
 /// An operation that is deferred while waiting for a lock.
 #[derive(Debug)]
@@ -42,8 +42,7 @@ pub(crate) enum Deferred {
 #[derivative(Debug)]
 pub(crate) struct DeferredPlan {
     #[derivative(Debug = "ignore")]
-    pub tx: ClientTransmitter<ExecuteResponse>,
-    pub session: Session,
+    pub ctx: ExecuteContext,
     pub plan: Plan,
 }
 
@@ -117,12 +116,14 @@ impl PendingWriteTxn {
 /// deferring work.
 #[macro_export]
 macro_rules! guard_write_critical_section {
-    ($coord:expr, $tx:expr, $session:expr, $plan_to_defer: expr) => {
-        if !$session.has_write_lock() {
-            if $coord.try_grant_session_write_lock(&mut $session).is_err() {
+    ($coord:expr, $ctx:expr, $plan_to_defer: expr) => {
+        if !$ctx.session().has_write_lock() {
+            if $coord
+                .try_grant_session_write_lock($ctx.session_mut())
+                .is_err()
+            {
                 $coord.defer_write(Deferred::Plan(DeferredPlan {
-                    tx: $tx,
-                    session: $session,
+                    ctx: $ctx,
                     plan: $plan_to_defer,
                 }));
                 return;
@@ -252,9 +253,8 @@ impl Coordinator {
                     write_lock_guard: _,
                     pending_txn:
                         PendingTxn {
-                            client_transmitter,
+                            ctx,
                             response,
-                            session,
                             action,
                         },
                 } => {
@@ -268,12 +268,7 @@ impl Coordinator {
                             appends.entry(id).or_default().extend(rows);
                         }
                     }
-                    responses.push(CompletedClientTransmitter::new(
-                        client_transmitter,
-                        response,
-                        session,
-                        action,
-                    ));
+                    responses.push(CompletedClientTransmitter::new(ctx, response, action));
                 }
                 PendingWriteTxn::System { updates, .. } => {
                     for update in updates {
@@ -356,12 +351,13 @@ impl Coordinator {
     pub(crate) async fn group_commit_apply(
         &mut self,
         timestamp: Timestamp,
-        responses: Vec<CompletedClientTransmitter<ExecuteResponse>>,
+        responses: Vec<CompletedClientTransmitter>,
         _write_lock_guard: Option<OwnedMutexGuard<()>>,
     ) {
         self.apply_local_write(timestamp).await;
         for response in responses {
-            response.send();
+            let (ctx, result) = response.finalize();
+            ctx.retire(result, self);
         }
 
         // Advancing timelines will update all timeline read holds, and update the read timestamps
@@ -421,7 +417,7 @@ impl Coordinator {
     /// return after calling it.
     pub(crate) fn defer_write(&mut self, deferred: Deferred) {
         let id = match &deferred {
-            Deferred::Plan(plan) => plan.session.conn_id().to_string(),
+            Deferred::Plan(plan) => plan.ctx.session().conn_id().to_string(),
             Deferred::GroupCommit => "group_commit".to_string(),
         };
         self.write_lock_wait_group.push_back(deferred);

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -357,7 +357,7 @@ impl Coordinator {
         self.apply_local_write(timestamp).await;
         for response in responses {
             let (ctx, result) = response.finalize();
-            ctx.retire(result, self);
+            ctx.retire(result);
         }
 
         // Advancing timelines will update all timeline read holds, and update the read timestamps

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -43,15 +43,51 @@ use crate::error::AdapterError;
 use crate::notice::AdapterNotice;
 use crate::session::{PreparedStatement, Session, TransactionStatus};
 use crate::util::{ClientTransmitter, ResultExt};
-use crate::{catalog, metrics, rbac};
+use crate::{catalog, metrics, rbac, ExecuteContext};
+
+use super::ExecuteContextExtra;
 
 impl Coordinator {
+    pub(crate) fn retire_execute(&mut self, _data: ExecuteContextExtra) {
+        // Do nothing, for now.
+        // In the future this is where we will log that statement execution finished.
+    }
+    fn send_error(&mut self, cmd: Command, e: AdapterError) {
+        fn send<T>(tx: oneshot::Sender<Response<T>>, session: Session, e: AdapterError) {
+            let _ = tx.send(Response::<T> {
+                result: Err(e),
+                session,
+            });
+        }
+        match cmd {
+            Command::Startup { tx, session, .. } => send(tx, session, e),
+            Command::Declare { tx, session, .. } => send(tx, session, e),
+            Command::Prepare { tx, session, .. } => send(tx, session, e),
+            Command::VerifyPreparedStatement { tx, session, .. } => send(tx, session, e),
+            Command::Execute { tx, session, .. } => send(tx, session, e),
+            Command::ExecuteInner { ctx, .. } => {
+                ctx.retire(Err(e), self);
+            }
+            Command::Commit { tx, session, .. } => send(tx, session, e),
+            Command::CancelRequest { .. } | Command::PrivilegedCancelRequest { .. } => {}
+            Command::DumpCatalog { tx, session, .. } => send(tx, session, e),
+            Command::CopyRows { tx, session, .. } => send(tx, session, e),
+            Command::GetSystemVars { tx, session, .. } => send(tx, session, e),
+            Command::SetSystemVars { tx, session, .. } => send(tx, session, e),
+            Command::Terminate { tx, session, .. } => {
+                if let Some(tx) = tx {
+                    send(tx, session, e)
+                }
+            }
+        }
+    }
+
     pub(crate) async fn handle_command(&mut self, mut cmd: Command) {
         if let Some(session) = cmd.session_mut() {
             session.apply_external_metadata_updates();
         }
         if let Err(e) = rbac::check_command(self.catalog(), &cmd) {
-            cmd.send_error(e.into());
+            self.send_error(cmd, e.into());
             return;
         }
         match cmd {
@@ -65,6 +101,15 @@ impl Coordinator {
                 self.handle_startup(session, cancel_tx, tx).await;
             }
 
+            Command::ExecuteInner {
+                portal_name,
+                ctx,
+                span,
+            } => {
+                let span = tracing::debug_span!(parent: &span, "message_command (execute inner)");
+                self.handle_execute(portal_name, ctx).instrument(span).await;
+            }
+
             Command::Execute {
                 portal_name,
                 session,
@@ -72,11 +117,15 @@ impl Coordinator {
                 span,
             } => {
                 let tx = ClientTransmitter::new(tx, self.internal_cmd_tx.clone());
+                let ctx = ExecuteContext::from_parts(
+                    tx,
+                    self.internal_cmd_tx.clone(),
+                    session,
+                    ExecuteContextExtra,
+                );
 
                 let span = tracing::debug_span!(parent: &span, "message_command (execute)");
-                self.handle_execute(portal_name, session, tx)
-                    .instrument(span)
-                    .await;
+                self.handle_execute(portal_name, ctx).instrument(span).await;
             }
 
             Command::Declare {
@@ -87,7 +136,13 @@ impl Coordinator {
                 tx,
             } => {
                 let tx = ClientTransmitter::new(tx, self.internal_cmd_tx.clone());
-                self.declare(tx, session, name, stmt, param_types);
+                let ctx = ExecuteContext::from_parts(
+                    tx,
+                    self.internal_cmd_tx.clone(),
+                    session,
+                    Default::default(),
+                );
+                self.declare(ctx, name, stmt, param_types);
             }
 
             Command::Prepare {
@@ -123,10 +178,16 @@ impl Coordinator {
                 rows,
                 session,
                 tx,
+                ctx_extra,
             } => {
-                self.sequence_plan(
+                let ctx = ExecuteContext::from_parts(
                     ClientTransmitter::new(tx, self.internal_cmd_tx.clone()),
+                    self.internal_cmd_tx.clone(),
                     session,
+                    ctx_extra,
+                );
+                self.sequence_plan(
+                    ctx,
                     Plan::CopyRows(CopyRowsPlan { id, columns, rows }),
                     Vec::new(),
                 )
@@ -182,6 +243,16 @@ impl Coordinator {
                 tx,
             } => {
                 let tx = ClientTransmitter::new(tx, self.internal_cmd_tx.clone());
+                // We reach here not through a statement execution, but from the
+                // "commit" pgwire command. Thus, we just generate a default statement
+                // execution context (once statement logging is implemented, this will cause nothing to be logged
+                // when the execution finishes.)
+                let ctx = ExecuteContext::from_parts(
+                    tx,
+                    self.internal_cmd_tx.clone(),
+                    session,
+                    Default::default(),
+                );
                 let plan = match action {
                     EndTransactionAction::Commit => {
                         Plan::CommitTransaction(CommitTransactionPlan {
@@ -194,7 +265,7 @@ impl Coordinator {
                         })
                     }
                 };
-                self.sequence_plan(tx, session, plan, Vec::new()).await;
+                self.sequence_plan(ctx, plan, Vec::new()).await;
             }
 
             Command::VerifyPreparedStatement {
@@ -291,39 +362,35 @@ impl Coordinator {
 
     /// Handles an execute command.
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn handle_execute(
-        &mut self,
-        portal_name: String,
-        mut session: Session,
-        tx: ClientTransmitter<ExecuteResponse>,
-    ) {
-        if session.vars().emit_trace_id_notice() {
+    async fn handle_execute(&mut self, portal_name: String, mut ctx: ExecuteContext) {
+        if ctx.session().vars().emit_trace_id_notice() {
             let span_context = tracing::Span::current()
                 .context()
                 .span()
                 .span_context()
                 .clone();
             if span_context.is_valid() {
-                session.add_notice(AdapterNotice::QueryTrace {
+                ctx.session().add_notice(AdapterNotice::QueryTrace {
                     trace_id: span_context.trace_id(),
                 });
             }
         }
 
-        if let Err(err) = self.verify_portal(&mut session, &portal_name) {
-            return tx.send(Err(err), session);
+        if let Err(err) = self.verify_portal(ctx.session_mut(), &portal_name) {
+            return ctx.retire(Err(err), self);
         }
 
-        let portal = session
+        let portal = ctx
+            .session()
             .get_portal_unverified(&portal_name)
             .expect("known to exist");
 
         let stmt = match &portal.stmt {
             Some(stmt) => stmt.clone(),
-            None => return tx.send(Ok(ExecuteResponse::EmptyQuery), session),
+            None => return ctx.retire(Ok(ExecuteResponse::EmptyQuery), self),
         };
 
-        let session_type = metrics::session_type_label_value(session.user());
+        let session_type = metrics::session_type_label_value(ctx.session().user());
         let stmt_type = metrics::statement_type_label_value(&stmt);
         self.metrics
             .query_total
@@ -347,20 +414,19 @@ impl Coordinator {
         }
 
         let params = portal.parameters.clone();
-        self.handle_execute_inner(stmt, params, session, tx).await
+        self.handle_execute_inner(stmt, params, ctx).await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, tx, session))]
+    #[tracing::instrument(level = "trace", skip(self, ctx))]
     pub(crate) async fn handle_execute_inner(
         &mut self,
         stmt: Statement<Raw>,
         params: Params,
-        mut session: Session,
-        tx: ClientTransmitter<ExecuteResponse>,
+        mut ctx: ExecuteContext,
     ) {
         // Verify that this statement type can be executed in the current
         // transaction state.
-        match session.transaction() {
+        match ctx.session().transaction() {
             // By this point we should be in a running transaction.
             TransactionStatus::Default => unreachable!(),
 
@@ -381,11 +447,11 @@ impl Coordinator {
                     // it, it will always result in nothing happening, since all portals will be
                     // immediately closed. Users don't know this detail, so this error helps them
                     // understand what's going wrong. Postgres does this too.
-                    return tx.send(
+                    return ctx.retire(
                         Err(AdapterError::OperationRequiresTransaction(
                             "DECLARE CURSOR".into(),
                         )),
-                        session,
+                        self,
                     );
                 }
 
@@ -485,11 +551,11 @@ impl Coordinator {
                     | Statement::RevokeRole(_)
                     | Statement::Update(_)
                     | Statement::ReassignOwned(_) => {
-                        return tx.send(
+                        return ctx.retire(
                             Err(AdapterError::OperationProhibitsTransaction(
                                 stmt.to_string(),
                             )),
-                            session,
+                            self,
                         )
                     }
                 }
@@ -497,11 +563,11 @@ impl Coordinator {
         }
 
         let catalog = self.catalog();
-        let catalog = catalog.for_session(&session);
+        let catalog = catalog.for_session(ctx.session());
         let original_stmt = stmt.clone();
         let (stmt, depends_on) = match mz_sql::names::resolve(&catalog, stmt) {
             Ok(resolved) => resolved,
-            Err(e) => return tx.send(Err(e.into()), session),
+            Err(e) => return ctx.retire(Err(e.into()), self),
         };
         let depends_on = depends_on.into_iter().collect();
         // N.B. The catalog can change during purification so we must validate that the dependencies still exist after
@@ -515,7 +581,7 @@ impl Coordinator {
             // coordinator thread of control.
             Statement::CreateSource(stmt) => {
                 let internal_cmd_tx = self.internal_cmd_tx.clone();
-                let conn_id = session.conn_id().clone();
+                let conn_id = ctx.session().conn_id().clone();
                 let purify_fut = mz_sql::pure::purify_create_source(
                     Box::new(catalog.into_owned()),
                     self.now(),
@@ -528,8 +594,7 @@ impl Coordinator {
                     // It is not an error for purification to complete after `internal_cmd_rx` is dropped.
                     let result = internal_cmd_tx.send(Message::CreateSourceStatementReady(
                         CreateSourceStatementReady {
-                            session,
-                            tx,
+                            ctx,
                             result,
                             params,
                             depends_on,
@@ -545,15 +610,15 @@ impl Coordinator {
 
             // `CREATE SUBSOURCE` statements are disallowed for users and are only generated
             // automatically as part of purification
-            Statement::CreateSubsource(_) => tx.send(
+            Statement::CreateSubsource(_) => ctx.retire(
                 Err(AdapterError::Unsupported("CREATE SUBSOURCE statements")),
-                session,
+                self,
             ),
 
             // All other statements are handled immediately.
-            _ => match self.plan_statement(&mut session, stmt, &params) {
-                Ok(plan) => self.sequence_plan(tx, session, plan, depends_on).await,
-                Err(e) => tx.send(Err(e), session),
+            _ => match self.plan_statement(ctx.session_mut(), stmt, &params) {
+                Ok(plan) => self.sequence_plan(ctx, plan, depends_on).await,
+                Err(e) => ctx.retire(Err(e), self),
             },
         }
     }
@@ -621,23 +686,19 @@ impl Coordinator {
     fn handle_privileged_cancel(&mut self, conn_id: ConnectionId) {
         if let Some(conn_meta) = self.active_conns.get(&conn_id) {
             // Cancel pending writes. There is at most one pending write per session.
+            let mut maybe_ctx = None;
             if let Some(idx) = self.pending_writes.iter().position(|pending_write_txn| {
                 matches!(pending_write_txn, PendingWriteTxn::User {
-                    pending_txn: PendingTxn { session, .. },
+                    pending_txn: PendingTxn { ctx, .. },
                     ..
-                } if *session.conn_id() == conn_id)
+                } if *ctx.session().conn_id() == conn_id)
             }) {
                 if let PendingWriteTxn::User {
-                    pending_txn:
-                        PendingTxn {
-                            client_transmitter,
-                            session,
-                            ..
-                        },
+                    pending_txn: PendingTxn { ctx, .. },
                     ..
                 } = self.pending_writes.remove(idx)
                 {
-                    let _ = client_transmitter.send(Ok(ExecuteResponse::Canceled), session);
+                    maybe_ctx = Some(ctx);
                 }
             }
 
@@ -645,11 +706,11 @@ impl Coordinator {
             if let Some(idx) = self
                 .write_lock_wait_group
                 .iter()
-                .position(|ready| matches!(ready, Deferred::Plan(ready) if *ready.session.conn_id() == conn_id))
+                .position(|ready| matches!(ready, Deferred::Plan(ready) if *ready.ctx.session().conn_id() == conn_id))
             {
                 let ready = self.write_lock_wait_group.remove(idx).expect("known to exist from call to `position` above");
                 if let Deferred::Plan(ready) = ready {
-                    ready.tx.send(Ok(ExecuteResponse::Canceled), ready.session);
+                    maybe_ctx = Some(ready.ctx);
                 }
             }
 
@@ -657,12 +718,20 @@ impl Coordinator {
             if let Some(real_time_recency_context) =
                 self.pending_real_time_recency_timestamp.remove(&conn_id)
             {
-                let (tx, session) = real_time_recency_context.take_tx_and_session();
-                tx.send(Ok(ExecuteResponse::Canceled), session);
+                let ctx = real_time_recency_context.take_context();
+                maybe_ctx = Some(ctx);
+            }
+
+            // Work around lifetime issues (we can't use `conn_meta`
+            // after we've borrowed `self` mutably to call `retire_execute`.)
+            let cancel_tx = Arc::clone(&conn_meta.cancel_tx);
+
+            if let Some(ctx) = maybe_ctx {
+                ctx.retire(Ok(ExecuteResponse::Canceled), self);
             }
 
             // Inform the target session (if it asks) about the cancellation.
-            let _ = conn_meta.cancel_tx.send(Canceled::Canceled);
+            let _ = cancel_tx.send(Canceled::Canceled);
 
             for PendingPeek {
                 sender: rows_tx,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -91,6 +91,9 @@ impl Coordinator {
                 self.message_real_time_recency_timestamp(conn_id, real_time_recency_ts, validity)
                     .await;
             }
+            Message::RetireExecute { data } => {
+                self.retire_execute(data);
+            }
         }
     }
 
@@ -343,12 +346,11 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self, tx, session))]
+    #[tracing::instrument(level = "debug", skip(self, ctx))]
     async fn message_create_source_statement_ready(
         &mut self,
         CreateSourceStatementReady {
-            mut session,
-            tx,
+            mut ctx,
             result,
             params,
             depends_on,
@@ -370,14 +372,13 @@ impl Coordinator {
             .iter()
             .all(|id| self.catalog().try_get_entry(id).is_some())
         {
-            self.handle_execute_inner(original_stmt, params, session, tx)
-                .await;
+            self.handle_execute_inner(original_stmt, params, ctx).await;
             return;
         }
 
         let (subsource_stmts, stmt) = match result {
             Ok(ok) => ok,
-            Err(e) => return tx.send(Err(e), session),
+            Err(e) => return ctx.retire(Err(e), self),
         };
 
         let mut plans: Vec<CreateSourcePlans> = vec![];
@@ -388,10 +389,10 @@ impl Coordinator {
             let depends_on = Vec::from_iter(mz_sql::names::visit_dependencies(&subsource_stmt));
             let source_id = match self.catalog_mut().allocate_user_id().await {
                 Ok(id) => id,
-                Err(e) => return tx.send(Err(e.into()), session),
+                Err(e) => return ctx.retire(Err(e.into()), self),
             };
             let plan = match self.plan_statement(
-                &mut session,
+                ctx.session_mut(),
                 Statement::CreateSubsource(subsource_stmt),
                 &params,
             ) {
@@ -399,7 +400,7 @@ impl Coordinator {
                 Ok(_) => {
                     unreachable!("planning CREATE SUBSOURCE must result in a Plan::CreateSource")
                 }
-                Err(e) => return tx.send(Err(e), session),
+                Err(e) => return ctx.retire(Err(e), self),
             };
             id_allocation.insert(transient_id, source_id);
             plans.push((source_id, plan, depends_on).into());
@@ -409,32 +410,33 @@ impl Coordinator {
         // plan it too
         let stmt = match mz_sql::names::resolve_transient_ids(&id_allocation, stmt) {
             Ok(ok) => ok,
-            Err(e) => return tx.send(Err(e.into()), session),
+            Err(e) => return ctx.retire(Err(e.into()), self),
         };
         let depends_on = Vec::from_iter(mz_sql::names::visit_dependencies(&stmt));
         let source_id = match self.catalog_mut().allocate_user_id().await {
             Ok(id) => id,
-            Err(e) => return tx.send(Err(e.into()), session),
+            Err(e) => return ctx.retire(Err(e.into()), self),
         };
-        let plan = match self.plan_statement(&mut session, Statement::CreateSource(stmt), &params) {
-            Ok(Plan::CreateSource(plan)) => plan,
-            Ok(_) => {
-                unreachable!("planning CREATE SOURCE must result in a Plan::CreateSource")
-            }
-            Err(e) => return tx.send(Err(e), session),
-        };
+        let plan =
+            match self.plan_statement(ctx.session_mut(), Statement::CreateSource(stmt), &params) {
+                Ok(Plan::CreateSource(plan)) => plan,
+                Ok(_) => {
+                    unreachable!("planning CREATE SOURCE must result in a Plan::CreateSource")
+                }
+                Err(e) => return ctx.retire(Err(e), self),
+            };
         plans.push((source_id, plan, depends_on).into());
 
         // Finally, sequence all plans in one go
-        self.sequence_plan(tx, session, Plan::CreateSources(plans), Vec::new())
+        self.sequence_plan(ctx, Plan::CreateSources(plans), Vec::new())
             .await;
     }
 
-    #[tracing::instrument(level = "debug", skip(self, session_and_tx))]
+    #[tracing::instrument(level = "debug", skip(self, ctx))]
     async fn message_sink_connection_ready(
         &mut self,
         SinkConnectionReady {
-            session_and_tx,
+            ctx,
             id,
             oid,
             create_export_token,
@@ -457,7 +459,7 @@ impl Coordinator {
                         oid,
                         connection,
                         create_export_token,
-                        session_and_tx.as_ref().map(|(ref session, _tx)| session),
+                        ctx.as_ref().map(|ctx| ctx.session()),
                     )
                     .await
                     // XXX(chae): I really don't like this -- especially as we're now doing cross
@@ -470,8 +472,8 @@ impl Coordinator {
                     // perspective we did, as there is state (e.g. a
                     // Kafka topic) they need to clean up.
                 }
-                if let Some((session, tx)) = session_and_tx {
-                    tx.send(Ok(ExecuteResponse::CreatedSink), session);
+                if let Some(ctx) = ctx {
+                    ctx.retire(Ok(ExecuteResponse::CreatedSink), self);
                 }
             }
             Err(e) => {
@@ -483,12 +485,9 @@ impl Coordinator {
                         .into_iter()
                         .map(catalog::Op::DropObject)
                         .collect();
-                    self.catalog_transact(
-                        session_and_tx.as_ref().map(|(ref session, _tx)| session),
-                        ops,
-                    )
-                    .await
-                    .expect("deleting placeholder sink cannot fail");
+                    self.catalog_transact(ctx.as_ref().map(|ctx| ctx.session()), ops)
+                        .await
+                        .expect("deleting placeholder sink cannot fail");
                 } else {
                     // Another session may have dropped the placeholder sink while we were
                     // attempting to create the connection, in which case we don't need to do
@@ -499,8 +498,8 @@ impl Coordinator {
                     .controller
                     .storage
                     .cancel_prepare_export(create_export_token);
-                if let Some((session, tx)) = session_and_tx {
-                    tx.send(Err(e), session);
+                if let Some(ctx) = ctx {
+                    ctx.retire(Err(e), self);
                 }
             }
         }
@@ -516,12 +515,11 @@ impl Coordinator {
         if let Some(ready) = self.write_lock_wait_group.pop_front() {
             match ready {
                 Deferred::Plan(mut ready) => {
-                    ready.session.grant_write_lock(write_lock_guard);
+                    ready.ctx.session_mut().grant_write_lock(write_lock_guard);
                     // Write statements never need to track catalog
                     // dependencies.
                     let depends_on = vec![];
-                    self.sequence_plan(ready.tx, ready.session, ready.plan, depends_on)
-                        .await;
+                    self.sequence_plan(ready.ctx, ready.plan, depends_on).await;
                 }
                 Deferred::GroupCommit => self.group_commit_initiate(Some(write_lock_guard)).await,
             }
@@ -606,7 +604,9 @@ impl Coordinator {
                 .await
                 .unwrap_or_terminate("unable to confirm leadership");
             for ready_txn in ready_txns {
-                ready_txn.finish();
+                if let Some((ctx, result)) = ready_txn.finish() {
+                    ctx.retire(result, self);
+                }
             }
         }
 
@@ -641,36 +641,34 @@ impl Coordinator {
             };
 
         if let Err(err) = validity.check(self.catalog()) {
-            let (tx, session) = real_time_recency_context.take_tx_and_session();
-            tx.send(Err(err), session);
+            let ctx = real_time_recency_context.take_context();
+            ctx.retire(Err(err), self);
             return;
         }
 
         match real_time_recency_context {
             RealTimeRecencyContext::ExplainTimestamp {
-                tx,
-                mut session,
+                mut ctx,
                 format,
                 cluster_id,
                 optimized_plan,
                 id_bundle,
-            } => tx.send(
-                self.sequence_explain_timestamp_finish(
-                    &mut session,
+            } => {
+                let result = self.sequence_explain_timestamp_finish(
+                    ctx.session_mut(),
                     format,
                     cluster_id,
                     optimized_plan,
                     id_bundle,
                     Some(real_time_recency_ts),
-                ),
-                session,
-            ),
+                );
+                ctx.retire(result, self);
+            }
             RealTimeRecencyContext::Peek {
-                tx,
+                ctx,
                 finishing,
                 copy_to,
                 dataflow,
-                session,
                 cluster_id,
                 when,
                 target_replica,
@@ -683,8 +681,7 @@ impl Coordinator {
                 typ,
             } => {
                 self.sequence_peek_stage(
-                    tx,
-                    session,
+                    ctx,
                     PeekStage::Finish(PeekStageFinish {
                         validity,
                         finishing,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -29,9 +29,9 @@ use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::{introspection, Coordinator, Message};
 use crate::error::AdapterError;
 use crate::notice::AdapterNotice;
-use crate::rbac;
 use crate::session::{EndTransactionAction, PreparedStatement, Session, TransactionStatus};
-use crate::util::{send_immediate_rows, ClientTransmitter};
+use crate::util::send_immediate_rows;
+use crate::{rbac, ExecuteContext};
 
 // DO NOT make this visible in anyway, i.e. do not add any version of
 // `pub` to this mod. The inner `sequence_X` methods are hidden in this
@@ -56,55 +56,53 @@ impl Coordinator {
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn sequence_plan(
         &mut self,
-        mut tx: ClientTransmitter<ExecuteResponse>,
-        mut session: Session,
+        mut ctx: ExecuteContext,
         plan: Plan,
         depends_on: Vec<GlobalId>,
     ) {
         event!(Level::TRACE, plan = format!("{:?}", plan));
         let responses = ExecuteResponse::generated_from(PlanKind::from(&plan));
-        tx.set_allowed(responses);
+        ctx.tx_mut().set_allowed(responses);
 
-        let session_catalog = self.catalog.for_session(&session);
+        let session_catalog = self.catalog.for_session(ctx.session());
 
         if let Err(e) =
-            introspection::user_privilege_hack(&session_catalog, &session, &plan, &depends_on)
+            introspection::user_privilege_hack(&session_catalog, ctx.session(), &plan, &depends_on)
         {
-            return tx.send(Err(e), session);
+            return ctx.retire(Err(e), self);
         }
         if let Err(e) = introspection::check_cluster_restrictions(&session_catalog, &plan) {
-            return tx.send(Err(e), session);
+            return ctx.retire(Err(e), self);
         }
 
         // If our query only depends on system tables, a LaunchDarkly flag is enabled, and a
         // session var is set, then we automatically run the query on the mz_introspection cluster.
         let target_cluster =
-            introspection::auto_run_on_introspection(&self.catalog, &session, &plan);
+            introspection::auto_run_on_introspection(&self.catalog, ctx.session(), &plan);
         let target_cluster_id = self
             .catalog()
-            .resolve_target_cluster(target_cluster, &session)
+            .resolve_target_cluster(target_cluster, ctx.session())
             .ok()
             .map(|cluster| cluster.id());
 
         if let Err(e) = rbac::check_plan(
             &session_catalog,
-            &session,
+            ctx.session(),
             &plan,
             target_cluster_id,
             &depends_on,
         ) {
-            return tx.send(Err(e), session);
+            return ctx.retire(Err(e), self);
         }
 
         match plan {
             Plan::CreateSource(plan) => {
                 let source_id =
-                    return_if_err!(self.catalog_mut().allocate_user_id().await, tx, session);
-                tx.send(
-                    self.sequence_create_source(&mut session, vec![(source_id, plan, depends_on)])
-                        .await,
-                    session,
-                );
+                    return_if_err!(self, self.catalog_mut().allocate_user_id().await, ctx);
+                let result = self
+                    .sequence_create_source(ctx.session_mut(), vec![(source_id, plan, depends_on)])
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::CreateSources(plans) => {
                 assert!(depends_on.is_empty(), "each plan has separate depends_on");
@@ -112,127 +110,122 @@ impl Coordinator {
                     .into_iter()
                     .map(|plan| (plan.source_id, plan.plan, plan.depends_on))
                     .collect();
-                tx.send(
-                    self.sequence_create_source(&mut session, plans).await,
-                    session,
-                );
+                let result = self.sequence_create_source(ctx.session_mut(), plans).await;
+                ctx.retire(result, self);
             }
             Plan::CreateConnection(plan) => {
-                tx.send(
-                    self.sequence_create_connection(&mut session, plan, depends_on)
-                        .await,
-                    session,
-                );
+                let result = self
+                    .sequence_create_connection(ctx.session_mut(), plan, depends_on)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::CreateDatabase(plan) => {
-                tx.send(
-                    self.sequence_create_database(&mut session, plan).await,
-                    session,
-                );
+                let result = self.sequence_create_database(ctx.session_mut(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::CreateSchema(plan) => {
-                tx.send(
-                    self.sequence_create_schema(&mut session, plan).await,
-                    session,
-                );
+                let result = self.sequence_create_schema(ctx.session_mut(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::CreateRole(plan) => {
-                let res = self.sequence_create_role(&session, plan).await;
-                if res.is_ok() {
-                    self.maybe_send_rbac_notice(&session);
+                let result = self.sequence_create_role(ctx.session(), plan).await;
+                if result.is_ok() {
+                    self.maybe_send_rbac_notice(ctx.session());
                 }
-                tx.send(res, session);
+                ctx.retire(result, self);
             }
             Plan::CreateCluster(plan) => {
-                tx.send(self.sequence_create_cluster(&session, plan).await, session);
+                let result = self.sequence_create_cluster(ctx.session(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::CreateClusterReplica(plan) => {
-                tx.send(
-                    self.sequence_create_cluster_replica(&session, plan).await,
-                    session,
-                );
+                let result = self
+                    .sequence_create_cluster_replica(ctx.session(), plan)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::CreateTable(plan) => {
-                tx.send(
-                    self.sequence_create_table(&mut session, plan, depends_on)
-                        .await,
-                    session,
-                );
+                let result = self
+                    .sequence_create_table(ctx.session_mut(), plan, depends_on)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::CreateSecret(plan) => {
-                tx.send(
-                    self.sequence_create_secret(&mut session, plan).await,
-                    session,
-                );
+                let result = self.sequence_create_secret(ctx.session_mut(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::CreateSink(plan) => {
-                self.sequence_create_sink(session, plan, depends_on, tx)
-                    .await;
+                self.sequence_create_sink(ctx, plan, depends_on).await;
             }
             Plan::CreateView(plan) => {
-                tx.send(
-                    self.sequence_create_view(&mut session, plan, depends_on)
-                        .await,
-                    session,
-                );
+                let result = self
+                    .sequence_create_view(ctx.session_mut(), plan, depends_on)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::CreateMaterializedView(plan) => {
-                tx.send(
-                    self.sequence_create_materialized_view(&mut session, plan)
-                        .await,
-                    session,
-                );
+                let result = self
+                    .sequence_create_materialized_view(ctx.session_mut(), plan)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::CreateIndex(plan) => {
-                tx.send(
-                    self.sequence_create_index(&mut session, plan, depends_on)
-                        .await,
-                    session,
-                );
+                let result = self
+                    .sequence_create_index(ctx.session_mut(), plan, depends_on)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::CreateType(plan) => {
-                tx.send(
-                    self.sequence_create_type(&session, plan, depends_on).await,
-                    session,
-                );
+                let result = self
+                    .sequence_create_type(ctx.session(), plan, depends_on)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::DropObjects(plan) => {
-                tx.send(
-                    self.sequence_drop_objects(&mut session, plan).await,
-                    session,
-                );
+                let result = self.sequence_drop_objects(ctx.session_mut(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::DropOwned(plan) => {
-                tx.send(self.sequence_drop_owned(&mut session, plan).await, session);
+                let result = self.sequence_drop_owned(ctx.session_mut(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::EmptyQuery => {
-                tx.send(Ok(ExecuteResponse::EmptyQuery), session);
+                ctx.retire(Ok(ExecuteResponse::EmptyQuery), self);
             }
             Plan::ShowAllVariables => {
-                tx.send(self.sequence_show_all_variables(&session), session);
+                let result = self.sequence_show_all_variables(ctx.session());
+                ctx.retire(result, self);
             }
             Plan::ShowVariable(plan) => {
-                tx.send(self.sequence_show_variable(&session, plan), session);
+                let result = self.sequence_show_variable(ctx.session(), plan);
+                ctx.retire(result, self);
             }
             Plan::SetVariable(plan) => {
-                tx.send(self.sequence_set_variable(&mut session, plan), session);
+                let result = self.sequence_set_variable(ctx.session_mut(), plan);
+                ctx.retire(result, self);
             }
             Plan::ResetVariable(plan) => {
-                tx.send(self.sequence_reset_variable(&mut session, plan), session);
+                let result = self.sequence_reset_variable(ctx.session_mut(), plan);
+                ctx.retire(result, self);
             }
             Plan::SetTransaction(plan) => {
-                tx.send(self.sequence_set_transaction(&mut session, plan), session);
+                let result = self.sequence_set_transaction(ctx.session_mut(), plan);
+                ctx.retire(result, self);
             }
             Plan::StartTransaction(plan) => {
-                if matches!(session.transaction(), TransactionStatus::InTransaction(_)) {
-                    session.add_notice(AdapterNotice::ExistingTransactionInProgress);
+                if matches!(
+                    ctx.session().transaction(),
+                    TransactionStatus::InTransaction(_)
+                ) {
+                    ctx.session()
+                        .add_notice(AdapterNotice::ExistingTransactionInProgress);
                 }
-                let (session, result) = session.start_transaction(
+                let result = ctx.session_mut().start_transaction(
                     self.now_datetime(),
                     plan.access,
                     plan.isolation_level,
                 );
-                tx.send(result.map(|_| ExecuteResponse::StartedTransaction), session)
+                ctx.retire(result.map(|_| ExecuteResponse::StartedTransaction), self)
             }
             Plan::CommitTransaction(CommitTransactionPlan {
                 ref transaction_type,
@@ -245,174 +238,171 @@ impl Coordinator {
                     Plan::AbortTransaction(_) => EndTransactionAction::Rollback,
                     _ => unreachable!(),
                 };
-                if session.transaction().is_implicit() && !transaction_type.is_implicit() {
+                if ctx.session().transaction().is_implicit() && !transaction_type.is_implicit() {
                     // In Postgres, if a user sends a COMMIT or ROLLBACK in an
                     // implicit transaction, a warning is sent warning them.
                     // (The transaction is still closed and a new implicit
                     // transaction started, though.)
-                    session
+                    ctx.session()
                         .add_notice(AdapterNotice::ExplicitTransactionControlInImplicitTransaction);
                 }
-                self.sequence_end_transaction(tx, session, action);
+                self.sequence_end_transaction(ctx, action);
             }
             Plan::Peek(plan) => {
-                self.sequence_peek(tx, session, plan, target_cluster).await;
+                self.sequence_peek(ctx, plan, target_cluster).await;
             }
             Plan::Subscribe(plan) => {
-                tx.send(
-                    self.sequence_subscribe(&mut session, plan, depends_on, target_cluster)
-                        .await,
-                    session,
-                );
+                let result = self
+                    .sequence_subscribe(ctx.session_mut(), plan, depends_on, target_cluster)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::ShowCreate(plan) => {
-                tx.send(Ok(send_immediate_rows(vec![plan.row])), session);
+                ctx.retire(Ok(send_immediate_rows(vec![plan.row])), self);
             }
             Plan::CopyFrom(plan) => {
+                let (tx, _, session, ctx_extra) = ctx.into_parts();
                 tx.send(
                     Ok(ExecuteResponse::CopyFrom {
                         id: plan.id,
                         columns: plan.columns,
                         params: plan.params,
+                        ctx_extra,
                     }),
                     session,
                 );
             }
             Plan::CopyRows(CopyRowsPlan { id, columns, rows }) => {
-                self.sequence_copy_rows(tx, session, id, columns, rows);
+                self.sequence_copy_rows(ctx, id, columns, rows);
             }
             Plan::Explain(plan) => {
-                self.sequence_explain(tx, session, plan, target_cluster);
+                self.sequence_explain(ctx, plan, target_cluster);
             }
             Plan::Insert(plan) => {
-                self.sequence_insert(tx, session, plan).await;
+                self.sequence_insert(ctx, plan).await;
             }
             Plan::ReadThenWrite(plan) => {
-                self.sequence_read_then_write(tx, session, plan).await;
+                self.sequence_read_then_write(ctx, plan).await;
             }
-            Plan::AlterNoop(mz_sql::plan::AlterNoopPlan { object_type }) => {
-                tx.send(Ok(ExecuteResponse::AlteredObject(object_type)), session);
+            Plan::AlterNoop(plan) => {
+                ctx.retire(Ok(ExecuteResponse::AlteredObject(plan.object_type)), self);
             }
             Plan::AlterCluster(plan) => {
                 tx.send(self.sequence_alter_cluster(&session, plan).await, session);
             }
             Plan::AlterClusterRename(plan) => {
-                tx.send(
-                    self.sequence_alter_cluster_rename(&session, plan).await,
-                    session,
-                );
+                let result = self
+                    .sequence_alter_cluster_rename(ctx.session(), plan)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::AlterClusterReplicaRename(plan) => {
-                tx.send(
-                    self.sequence_alter_cluster_replica_rename(&session, plan)
-                        .await,
-                    session,
-                );
+                let result = self
+                    .sequence_alter_cluster_replica_rename(ctx.session(), plan)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::AlterItemRename(plan) => {
-                tx.send(
-                    self.sequence_alter_item_rename(&session, plan).await,
-                    session,
-                );
+                let result = self.sequence_alter_item_rename(ctx.session(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::AlterIndexSetOptions(plan) => {
-                tx.send(self.sequence_alter_index_set_options(plan), session);
+                let result = self.sequence_alter_index_set_options(plan);
+                ctx.retire(result, self);
             }
             Plan::AlterIndexResetOptions(plan) => {
-                tx.send(self.sequence_alter_index_reset_options(plan), session);
+                let result = self.sequence_alter_index_reset_options(plan);
+                ctx.retire(result, self);
             }
             Plan::AlterRole(plan) => {
-                let res = self.sequence_alter_role(&session, plan).await;
-                if res.is_ok() {
-                    self.maybe_send_rbac_notice(&session);
+                let result = self.sequence_alter_role(ctx.session(), plan).await;
+                if result.is_ok() {
+                    self.maybe_send_rbac_notice(ctx.session());
                 }
-                tx.send(res, session);
+                ctx.retire(result, self);
             }
             Plan::AlterSecret(plan) => {
-                tx.send(self.sequence_alter_secret(&session, plan).await, session);
+                let result = self.sequence_alter_secret(ctx.session(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::AlterSink(plan) => {
-                tx.send(self.sequence_alter_sink(&session, plan).await, session);
+                let result = self.sequence_alter_sink(ctx.session(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::AlterSource(plan) => {
-                tx.send(self.sequence_alter_source(&session, plan).await, session);
+                let result = self.sequence_alter_source(ctx.session(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::AlterSystemSet(plan) => {
-                tx.send(
-                    self.sequence_alter_system_set(&session, plan).await,
-                    session,
-                );
+                let result = self.sequence_alter_system_set(ctx.session(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::AlterSystemReset(plan) => {
-                tx.send(
-                    self.sequence_alter_system_reset(&session, plan).await,
-                    session,
-                );
+                let result = self.sequence_alter_system_reset(ctx.session(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::AlterSystemResetAll(plan) => {
-                tx.send(
-                    self.sequence_alter_system_reset_all(&session, plan).await,
-                    session,
-                );
+                let result = self
+                    .sequence_alter_system_reset_all(ctx.session(), plan)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::DiscardTemp => {
-                self.drop_temp_items(&session).await;
-                tx.send(Ok(ExecuteResponse::DiscardedTemp), session);
+                self.drop_temp_items(ctx.session()).await;
+                ctx.retire(Ok(ExecuteResponse::DiscardedTemp), self);
             }
             Plan::DiscardAll => {
-                let ret = if let TransactionStatus::Started(_) = session.transaction() {
-                    self.drop_temp_items(&session).await;
+                let ret = if let TransactionStatus::Started(_) = ctx.session().transaction() {
+                    self.drop_temp_items(ctx.session()).await;
                     let conn_meta = self
                         .active_conns
-                        .get_mut(session.conn_id())
+                        .get_mut(ctx.session().conn_id())
                         .expect("must exist for active session");
                     let drop_sinks = std::mem::take(&mut conn_meta.drop_sinks);
                     self.drop_compute_sinks(drop_sinks);
-                    session.reset();
+                    ctx.session_mut().reset();
                     Ok(ExecuteResponse::DiscardedAll)
                 } else {
                     Err(AdapterError::OperationProhibitsTransaction(
                         "DISCARD ALL".into(),
                     ))
                 };
-                tx.send(ret, session);
+                ctx.retire(ret, self);
             }
             Plan::Declare(plan) => {
                 let param_types = vec![];
-                self.declare(tx, session, plan.name, plan.stmt, param_types);
+                self.declare(ctx, plan.name, plan.stmt, param_types);
             }
             Plan::Fetch(FetchPlan {
                 name,
                 count,
                 timeout,
             }) => {
-                tx.send(
+                ctx.retire(
                     Ok(ExecuteResponse::Fetch {
                         name,
                         count,
                         timeout,
                     }),
-                    session,
+                    self,
                 );
             }
             Plan::Close(plan) => {
-                if session.remove_portal(&plan.name) {
-                    tx.send(Ok(ExecuteResponse::ClosedCursor), session);
+                if ctx.session_mut().remove_portal(&plan.name) {
+                    ctx.retire(Ok(ExecuteResponse::ClosedCursor), self);
                 } else {
-                    tx.send(Err(AdapterError::UnknownCursor(plan.name)), session);
+                    ctx.retire(Err(AdapterError::UnknownCursor(plan.name)), self);
                 }
             }
             Plan::Prepare(plan) => {
-                if session
+                if ctx
+                    .session()
                     .get_prepared_statement_unverified(&plan.name)
                     .is_some()
                 {
-                    tx.send(
-                        Err(AdapterError::PreparedStatementExists(plan.name)),
-                        session,
-                    );
+                    ctx.retire(Err(AdapterError::PreparedStatementExists(plan.name)), self);
                 } else {
-                    session.set_prepared_statement(
+                    ctx.session_mut().set_prepared_statement(
                         plan.name,
                         PreparedStatement::new(
                             Some(plan.stmt),
@@ -420,55 +410,56 @@ impl Coordinator {
                             self.catalog().transient_revision(),
                         ),
                     );
-                    tx.send(Ok(ExecuteResponse::Prepare), session);
+                    ctx.retire(Ok(ExecuteResponse::Prepare), self);
                 }
             }
             Plan::Execute(plan) => {
-                match self.sequence_execute(&mut session, plan) {
+                match self.sequence_execute(ctx.session_mut(), plan) {
                     Ok(portal_name) => {
                         self.internal_cmd_tx
-                            .send(Message::Command(Command::Execute {
+                            .send(Message::Command(Command::ExecuteInner {
                                 portal_name,
-                                session,
-                                tx: tx.take(),
+                                ctx,
                                 span: tracing::Span::none(),
                             }))
                             .expect("sending to self.internal_cmd_tx cannot fail");
                     }
-                    Err(err) => tx.send(Err(err), session),
+                    Err(err) => ctx.retire(Err(err), self),
                 };
             }
             Plan::Deallocate(plan) => match plan.name {
                 Some(name) => {
-                    if session.remove_prepared_statement(&name) {
-                        tx.send(Ok(ExecuteResponse::Deallocate { all: false }), session);
+                    if ctx.session_mut().remove_prepared_statement(&name) {
+                        ctx.retire(Ok(ExecuteResponse::Deallocate { all: false }), self);
                     } else {
-                        tx.send(Err(AdapterError::UnknownPreparedStatement(name)), session);
+                        ctx.retire(Err(AdapterError::UnknownPreparedStatement(name)), self);
                     }
                 }
                 None => {
-                    session.remove_all_prepared_statements();
-                    tx.send(Ok(ExecuteResponse::Deallocate { all: true }), session);
+                    ctx.session_mut().remove_all_prepared_statements();
+                    ctx.retire(Ok(ExecuteResponse::Deallocate { all: true }), self);
                 }
             },
             Plan::Raise(RaisePlan { severity }) => {
-                session.add_notice(AdapterNotice::UserRequested { severity });
-                tx.send(Ok(ExecuteResponse::Raised), session);
+                ctx.session()
+                    .add_notice(AdapterNotice::UserRequested { severity });
+                ctx.retire(Ok(ExecuteResponse::Raised), self);
             }
             Plan::RotateKeys(RotateKeysPlan { id }) => {
-                tx.send(self.sequence_rotate_keys(&session, id).await, session);
+                let result = self.sequence_rotate_keys(ctx.session(), id).await;
+                ctx.retire(result, self);
             }
             Plan::GrantPrivileges(plan) => {
-                tx.send(
-                    self.sequence_grant_privileges(&mut session, plan).await,
-                    session,
-                );
+                let result = self
+                    .sequence_grant_privileges(ctx.session_mut(), plan)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::RevokePrivileges(plan) => {
-                tx.send(
-                    self.sequence_revoke_privileges(&mut session, plan).await,
-                    session,
-                );
+                let result = self
+                    .sequence_revoke_privileges(ctx.session_mut(), plan)
+                    .await;
+                ctx.retire(result, self);
             }
             Plan::AlterDefaultPrivileges(plan) => {
                 tx.send(
@@ -478,19 +469,20 @@ impl Coordinator {
                 );
             }
             Plan::GrantRole(plan) => {
-                tx.send(self.sequence_grant_role(&mut session, plan).await, session);
+                let result = self.sequence_grant_role(ctx.session_mut(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::RevokeRole(plan) => {
-                tx.send(self.sequence_revoke_role(&mut session, plan).await, session);
+                let result = self.sequence_revoke_role(ctx.session_mut(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::AlterOwner(plan) => {
-                tx.send(self.sequence_alter_owner(&mut session, plan).await, session);
+                let result = self.sequence_alter_owner(ctx.session_mut(), plan).await;
+                ctx.retire(result, self);
             }
             Plan::ReassignOwned(plan) => {
-                tx.send(
-                    self.sequence_reassign_owned(&mut session, plan).await,
-                    session,
-                );
+                let result = self.sequence_reassign_owned(ctx.session_mut(), plan).await;
+                ctx.retire(result, self);
             }
         }
     }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -84,9 +84,9 @@ use crate::coord::timestamp_selection::{
     TimestampContext, TimestampDetermination, TimestampProvider, TimestampSource,
 };
 use crate::coord::{
-    peek, Coordinator, Message, PeekStage, PeekStageFinish, PeekStageOptimize, PeekStageTimestamp,
-    PeekStageValidate, PeekValidity, PendingReadTxn, PendingTxn, PendingTxnResponse,
-    RealTimeRecencyContext, SinkConnectionReady, TargetCluster,
+    peek, Coordinator, ExecuteContext, Message, PeekStage, PeekStageFinish, PeekStageOptimize,
+    PeekStageTimestamp, PeekStageValidate, PeekValidity, PendingReadTxn, PendingTxn,
+    PendingTxnResponse, RealTimeRecencyContext, SinkConnectionReady, TargetCluster,
     DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
 };
 use crate::error::AdapterError;
@@ -103,10 +103,10 @@ use crate::{guard_write_critical_section, PeekResponseUnary, TimestampExplanatio
 /// Attempts to execute an expression. If an error is returned then the error is sent
 /// to the client and the function is exited.
 macro_rules! return_if_err {
-    ($expr:expr, $tx:expr, $session:expr) => {
+    ($this:expr, $expr:expr, $ctx:expr) => {
         match $expr {
             Ok(v) => v,
-            Err(e) => return $tx.send(Err(e.into()), $session),
+            Err(e) => return $ctx.retire(Err(e.into()), $this),
         }
     };
 }
@@ -590,13 +590,12 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self, tx))]
+    #[tracing::instrument(level = "debug", skip(self, ctx))]
     pub(super) async fn sequence_create_sink(
         &mut self,
-        session: Session,
+        ctx: ExecuteContext,
         plan: CreateSinkPlan,
         depends_on: Vec<GlobalId>,
-        tx: ClientTransmitter<ExecuteResponse>,
     ) {
         let CreateSinkPlan {
             name,
@@ -607,15 +606,21 @@ impl Coordinator {
         } = plan;
 
         // First try to allocate an ID and an OID. If either fails, we're done.
-        let id = return_if_err!(self.catalog_mut().allocate_user_id().await, tx, session);
-        let oid = return_if_err!(self.catalog_mut().allocate_oid(), tx, session);
+        let id = return_if_err!(self, self.catalog_mut().allocate_user_id().await, ctx);
+        let oid = return_if_err!(self, self.catalog_mut().allocate_oid(), ctx);
 
         let mut ops = vec![];
         let cluster_id = return_if_err!(
-            self.create_linked_cluster_ops(id, &name, &plan_cluster_config, &mut ops, &session)
-                .await,
-            tx,
-            session
+            self,
+            self.create_linked_cluster_ops(
+                id,
+                &name,
+                &plan_cluster_config,
+                &mut ops,
+                ctx.session()
+            )
+            .await,
+            ctx
         );
 
         // Knowing that we're only handling kafka sinks here helps us simplify.
@@ -646,14 +651,14 @@ impl Coordinator {
             oid,
             name: name.clone(),
             item: CatalogItem::Sink(catalog_sink.clone()),
-            owner_id: *session.current_role_id(),
+            owner_id: *ctx.session().current_role_id(),
         });
 
         let from = self.catalog().get_entry(&catalog_sink.from);
         let from_name = from.name().item.clone();
         let from_type = from.item().typ().to_string();
         let result = self
-            .catalog_transact_with(Some(&session), ops, move |txn| {
+            .catalog_transact_with(Some(ctx.session()), ops, move |txn| {
                 // Validate that the from collection is in fact a persist collection we can export.
                 txn.dataflow_client
                     .storage
@@ -674,15 +679,16 @@ impl Coordinator {
                 kind: catalog::ErrorKind::ItemAlreadyExists(_, _),
                 ..
             })) if if_not_exists => {
-                session.add_notice(AdapterNotice::ObjectAlreadyExists {
-                    name: name.item,
-                    ty: "sink",
-                });
-                tx.send(Ok(ExecuteResponse::CreatedSink), session);
+                ctx.session()
+                    .add_notice(AdapterNotice::ObjectAlreadyExists {
+                        name: name.item,
+                        ty: "sink",
+                    });
+                ctx.retire(Ok(ExecuteResponse::CreatedSink), self);
                 return;
             }
             Err(e) => {
-                tx.send(Err(e), session);
+                ctx.retire(Err(e), self);
                 return;
             }
         }
@@ -690,11 +696,11 @@ impl Coordinator {
         self.maybe_create_linked_cluster(id).await;
 
         let create_export_token = return_if_err!(
+            self,
             self.controller
                 .storage
                 .prepare_export(id, catalog_sink.from),
-            tx,
-            session
+            ctx
         );
 
         // Now we're ready to create the sink connection. Arrange to notify the
@@ -708,7 +714,7 @@ impl Coordinator {
                 // It is not an error for sink connections to become ready after `internal_cmd_rx` is dropped.
                 let result =
                     internal_cmd_tx.send(Message::SinkConnectionReady(SinkConnectionReady {
-                        session_and_tx: Some((session, tx)),
+                        ctx: Some(ctx),
                         id,
                         oid,
                         create_export_token,
@@ -1629,13 +1635,12 @@ impl Coordinator {
 
     pub(super) fn sequence_end_transaction(
         &mut self,
-        tx: ClientTransmitter<ExecuteResponse>,
-        mut session: Session,
+        mut ctx: ExecuteContext,
         mut action: EndTransactionAction,
     ) {
         // If the transaction has failed, we can only rollback.
         if let (EndTransactionAction::Commit, TransactionStatus::Failed(_)) =
-            (&action, session.transaction())
+            (&action, ctx.session().transaction())
         {
             action = EndTransactionAction::Rollback;
         }
@@ -1648,7 +1653,7 @@ impl Coordinator {
             }),
         };
 
-        let result = self.sequence_end_transaction_inner(&mut session, action);
+        let result = self.sequence_end_transaction_inner(ctx.session_mut(), action);
 
         let (response, action) = match result {
             Ok((Some(TransactionOps::Writes(writes)), _)) if writes.is_empty() => {
@@ -1659,24 +1664,22 @@ impl Coordinator {
                     writes,
                     write_lock_guard,
                     pending_txn: PendingTxn {
-                        client_transmitter: tx,
+                        ctx,
                         response,
-                        session,
                         action,
                     },
                 });
                 return;
             }
             Ok((Some(TransactionOps::Peeks(timestamp_context)), _))
-                if session.vars().transaction_isolation()
+                if ctx.session().vars().transaction_isolation()
                     == &IsolationLevel::StrictSerializable =>
             {
                 self.strict_serializable_reads_tx
                     .send(PendingReadTxn::Read {
                         txn: PendingTxn {
-                            client_transmitter: tx,
+                            ctx,
                             response,
-                            session,
                             action,
                         },
                         timestamp_context,
@@ -1687,14 +1690,14 @@ impl Coordinator {
             Ok((_, _)) => (response, action),
             Err(err) => (Err(err), EndTransactionAction::Rollback),
         };
-        let changed = session.vars_mut().end_transaction(action);
+        let changed = ctx.session_mut().vars_mut().end_transaction(action);
         // Append any parameters that changed to the response.
         let response = response.map(|mut r| {
             r.extend_params(changed);
             ExecuteResponse::from(r)
         });
 
-        tx.send(response, session);
+        ctx.retire(response, self);
     }
 
     fn sequence_end_transaction_inner(
@@ -1739,16 +1742,14 @@ impl Coordinator {
     #[tracing::instrument(level = "debug", skip_all)]
     pub(super) async fn sequence_peek(
         &mut self,
-        tx: ClientTransmitter<ExecuteResponse>,
-        session: Session,
+        ctx: ExecuteContext,
         plan: PeekPlan,
         target_cluster: TargetCluster,
     ) {
         event!(Level::TRACE, plan = format!("{:?}", plan));
 
         self.sequence_peek_stage(
-            tx,
-            session,
+            ctx,
             PeekStage::Validate(PeekStageValidate {
                 plan,
                 target_cluster,
@@ -1760,8 +1761,7 @@ impl Coordinator {
     /// Processes as many peek stages as possible.
     pub(crate) async fn sequence_peek_stage(
         &mut self,
-        mut tx: ClientTransmitter<ExecuteResponse>,
-        mut session: Session,
+        mut ctx: ExecuteContext,
         mut stage: PeekStage,
     ) {
         // Process the current stage and allow for processing the next.
@@ -1772,31 +1772,35 @@ impl Coordinator {
             // if we move any stages off thread.
             if let Some(validity) = stage.validity() {
                 if let Err(err) = validity.check(self.catalog()) {
-                    tx.send(Err(err), session);
+                    ctx.retire(Err(err), self);
                     return;
                 }
             }
 
-            (tx, session, stage) = match stage {
+            (ctx, stage) = match stage {
                 PeekStage::Validate(stage) => {
-                    let next =
-                        return_if_err!(self.peek_stage_validate(&mut session, stage), tx, session);
-                    (tx, session, PeekStage::Optimize(next))
+                    let next = return_if_err!(
+                        self,
+                        self.peek_stage_validate(ctx.session_mut(), stage),
+                        ctx
+                    );
+                    (ctx, PeekStage::Optimize(next))
                 }
                 PeekStage::Optimize(stage) => {
-                    let next =
-                        return_if_err!(self.peek_stage_optimize(&session, stage), tx, session);
-                    (tx, session, PeekStage::Timestamp(next))
+                    let next = return_if_err!(
+                        self,
+                        self.peek_stage_optimize(ctx.session_mut(), stage),
+                        ctx
+                    );
+                    (ctx, PeekStage::Timestamp(next))
                 }
-                PeekStage::Timestamp(stage) => {
-                    match self.peek_stage_timestamp(tx, session, stage) {
-                        Some((tx, session, next)) => (tx, session, PeekStage::Finish(next)),
-                        None => return,
-                    }
-                }
+                PeekStage::Timestamp(stage) => match self.peek_stage_timestamp(ctx, stage) {
+                    Some((ctx, next)) => (ctx, PeekStage::Finish(next)),
+                    None => return,
+                },
                 PeekStage::Finish(stage) => {
-                    let res = self.peek_stage_finish(&mut session, stage).await;
-                    tx.send(res, session);
+                    let res = self.peek_stage_finish(ctx.session_mut(), stage).await;
+                    ctx.retire(res, self);
                     return;
                 }
             }
@@ -1962,8 +1966,7 @@ impl Coordinator {
     #[tracing::instrument(level = "debug", skip_all)]
     fn peek_stage_timestamp(
         &mut self,
-        tx: ClientTransmitter<ExecuteResponse>,
-        session: Session,
+        ctx: ExecuteContext,
         PeekStageTimestamp {
             validity,
             dataflow,
@@ -1980,19 +1983,18 @@ impl Coordinator {
             key,
             typ,
         }: PeekStageTimestamp,
-    ) -> Option<(ClientTransmitter<ExecuteResponse>, Session, PeekStageFinish)> {
-        match self.recent_timestamp(&session, source_ids.iter().cloned()) {
+    ) -> Option<(ExecuteContext, PeekStageFinish)> {
+        match self.recent_timestamp(ctx.session(), source_ids.iter().cloned()) {
             Some(fut) => {
                 let internal_cmd_tx = self.internal_cmd_tx.clone();
-                let conn_id = session.conn_id().clone();
+                let conn_id = ctx.session().conn_id().clone();
                 self.pending_real_time_recency_timestamp.insert(
                     conn_id.clone(),
                     RealTimeRecencyContext::Peek {
-                        tx,
+                        ctx,
                         finishing,
                         copy_to,
                         dataflow,
-                        session,
                         cluster_id,
                         when,
                         target_replica,
@@ -2020,8 +2022,7 @@ impl Coordinator {
                 None
             }
             None => Some((
-                tx,
-                session,
+                ctx,
                 PeekStageFinish {
                     validity,
                     finishing,
@@ -2480,17 +2481,16 @@ impl Coordinator {
 
     pub(super) fn sequence_explain(
         &mut self,
-        tx: ClientTransmitter<ExecuteResponse>,
-        mut session: Session,
+        mut ctx: ExecuteContext,
         plan: ExplainPlan,
         target_cluster: TargetCluster,
     ) {
         match plan.stage {
-            ExplainStage::Timestamp => self.sequence_explain_timestamp_begin(tx, session, plan),
-            _ => tx.send(
-                self.sequence_explain_plan(&mut session, plan, target_cluster),
-                session,
-            ),
+            ExplainStage::Timestamp => self.sequence_explain_timestamp_begin(ctx, plan),
+            _ => {
+                let result = self.sequence_explain_plan(ctx.session_mut(), plan, target_cluster);
+                ctx.retire(result, self);
+            }
         }
     }
 
@@ -2746,18 +2746,13 @@ impl Coordinator {
         Ok(send_immediate_rows(rows))
     }
 
-    fn sequence_explain_timestamp_begin(
-        &mut self,
-        tx: ClientTransmitter<ExecuteResponse>,
-        mut session: Session,
-        plan: ExplainPlan,
-    ) {
+    fn sequence_explain_timestamp_begin(&mut self, mut ctx: ExecuteContext, plan: ExplainPlan) {
         let (format, source_ids, optimized_plan, cluster_id, id_bundle) = return_if_err!(
-            self.sequence_explain_timestamp_begin_inner(&session, plan),
-            tx,
-            session
+            self,
+            self.sequence_explain_timestamp_begin_inner(ctx.session(), plan),
+            ctx
         );
-        match self.recent_timestamp(&session, source_ids.iter().cloned()) {
+        match self.recent_timestamp(ctx.session(), source_ids.iter().cloned()) {
             Some(fut) => {
                 let validity = PeekValidity {
                     transient_revision: self.catalog().transient_revision(),
@@ -2766,12 +2761,11 @@ impl Coordinator {
                     replica_id: None,
                 };
                 let internal_cmd_tx = self.internal_cmd_tx.clone();
-                let conn_id = session.conn_id().clone();
+                let conn_id = ctx.session().conn_id().clone();
                 self.pending_real_time_recency_timestamp.insert(
                     conn_id.clone(),
                     RealTimeRecencyContext::ExplainTimestamp {
-                        tx,
-                        session,
+                        ctx,
                         format,
                         cluster_id,
                         optimized_plan,
@@ -2791,17 +2785,17 @@ impl Coordinator {
                     }
                 });
             }
-            None => tx.send(
-                self.sequence_explain_timestamp_finish_inner(
-                    &mut session,
+            None => {
+                let result = self.sequence_explain_timestamp_finish_inner(
+                    ctx.session_mut(),
                     format,
                     cluster_id,
                     optimized_plan,
                     id_bundle,
                     None,
-                ),
-                session,
-            ),
+                );
+                ctx.retire(result, self);
+            }
         }
     }
 
@@ -2995,28 +2989,26 @@ impl Coordinator {
         })
     }
 
-    pub(super) async fn sequence_insert(
-        &mut self,
-        tx: ClientTransmitter<ExecuteResponse>,
-        mut session: Session,
-        plan: InsertPlan,
-    ) {
+    pub(super) async fn sequence_insert(&mut self, mut ctx: ExecuteContext, plan: InsertPlan) {
         let optimized_mir = if let Some(..) = &plan.values.as_const() {
             // We don't perform any optimizations on an expression that is already
             // a constant for writes, as we want to maximize bulk-insert throughput.
             OptimizedMirRelationExpr(plan.values)
         } else {
-            return_if_err!(self.view_optimizer.optimize(plan.values), tx, session)
+            return_if_err!(self, self.view_optimizer.optimize(plan.values), ctx)
         };
 
         match optimized_mir.into_inner() {
             selection if selection.as_const().is_some() && plan.returning.is_empty() => {
                 let catalog = self.owned_catalog();
                 mz_ore::task::spawn(|| "coord::sequence_inner", async move {
-                    tx.send(
-                        Self::sequence_insert_constant(&catalog, &mut session, plan.id, selection),
-                        session,
-                    )
+                    let result = Self::sequence_insert_constant(
+                        &catalog,
+                        ctx.session_mut(),
+                        plan.id,
+                        selection,
+                    );
+                    ctx.retire_async(result);
                 });
             }
             // All non-constant values must be planned as read-then-writes.
@@ -3026,27 +3018,27 @@ impl Coordinator {
                         .desc(
                             &self
                                 .catalog()
-                                .resolve_full_name(table.name(), Some(session.conn_id())),
+                                .resolve_full_name(table.name(), Some(ctx.session().conn_id())),
                         )
                         .expect("desc called on table")
                         .arity(),
                     None => {
-                        tx.send(
+                        ctx.retire(
                             Err(AdapterError::SqlCatalog(CatalogError::UnknownItem(
                                 plan.id.to_string(),
                             ))),
-                            session,
+                            self,
                         );
                         return;
                     }
                 };
 
                 if selection.contains_temporal() {
-                    tx.send(
+                    ctx.retire(
                         Err(AdapterError::Unsupported(
                             "calls to mz_now in write statements",
                         )),
-                        session,
+                        self,
                     );
                     return;
                 }
@@ -3067,7 +3059,7 @@ impl Coordinator {
                     returning: plan.returning,
                 };
 
-                self.sequence_read_then_write(tx, session, read_then_write_plan)
+                self.sequence_read_then_write(ctx, read_then_write_plan)
                     .await;
             }
         }
@@ -3117,17 +3109,16 @@ impl Coordinator {
 
     pub(super) fn sequence_copy_rows(
         &mut self,
-        tx: ClientTransmitter<ExecuteResponse>,
-        mut session: Session,
+        mut ctx: ExecuteContext,
         id: GlobalId,
         columns: Vec<usize>,
         rows: Vec<Row>,
     ) {
         let catalog = self.owned_catalog();
         mz_ore::task::spawn(|| "coord::sequence_copy_rows", async move {
-            let conn_catalog = catalog.for_session(&session);
-            let res: Result<_, AdapterError> =
-                mz_sql::plan::plan_copy_from(session.pcx(), &conn_catalog, id, columns, rows)
+            let conn_catalog = catalog.for_session(ctx.session());
+            let result: Result<_, AdapterError> =
+                mz_sql::plan::plan_copy_from(ctx.session().pcx(), &conn_catalog, id, columns, rows)
                     .err_into()
                     .and_then(|values| values.lower().err_into())
                     .and_then(|values| {
@@ -3139,12 +3130,12 @@ impl Coordinator {
                         // Copied rows must always be constants.
                         Self::sequence_insert_constant(
                             &catalog,
-                            &mut session,
+                            ctx.session_mut(),
                             id,
                             values.into_inner(),
                         )
                     });
-            tx.send(res, session);
+            ctx.retire_async(result);
         });
     }
 
@@ -3154,11 +3145,10 @@ impl Coordinator {
     // serializability violation could occur.
     pub(super) async fn sequence_read_then_write(
         &mut self,
-        tx: ClientTransmitter<ExecuteResponse>,
-        mut session: Session,
+        mut ctx: ExecuteContext,
         plan: ReadThenWritePlan,
     ) {
-        guard_write_critical_section!(self, tx, session, Plan::ReadThenWrite(plan));
+        guard_write_critical_section!(self, ctx, Plan::ReadThenWrite(plan));
 
         let ReadThenWritePlan {
             id,
@@ -3175,16 +3165,16 @@ impl Coordinator {
                 .desc(
                     &self
                         .catalog()
-                        .resolve_full_name(table.name(), Some(session.conn_id())),
+                        .resolve_full_name(table.name(), Some(ctx.session().conn_id())),
                 )
                 .expect("desc called on table")
                 .into_owned(),
             None => {
-                tx.send(
+                ctx.retire(
                     Err(AdapterError::SqlCatalog(CatalogError::UnknownItem(
                         id.to_string(),
                     ))),
-                    session,
+                    self,
                 );
                 return;
             }
@@ -3227,16 +3217,22 @@ impl Coordinator {
 
         for id in selection.depends_on() {
             if !validate_read_dependencies(self.catalog(), &id) {
-                tx.send(Err(AdapterError::InvalidTableMutationSelection), session);
+                ctx.retire(Err(AdapterError::InvalidTableMutationSelection), self);
                 return;
             }
         }
 
         let (peek_tx, peek_rx) = oneshot::channel();
         let peek_client_tx = ClientTransmitter::new(peek_tx, self.internal_cmd_tx.clone());
-        self.sequence_peek(
+        let (tx, _, session, extra) = ctx.into_parts();
+        let peek_ctx = ExecuteContext::from_parts(
             peek_client_tx,
+            self.internal_cmd_tx.clone(),
             session,
+            Default::default(),
+        );
+        self.sequence_peek(
+            peek_ctx,
             PeekPlan {
                 source: selection,
                 when: QueryWhen::Freshest,
@@ -3251,7 +3247,7 @@ impl Coordinator {
         let strict_serializable_reads_tx = self.strict_serializable_reads_tx.clone();
         let max_result_size = self.catalog().system_config().max_result_size();
         task::spawn(|| format!("sequence_read_then_write:{id}"), async move {
-            let (peek_response, mut session) = match peek_rx.await {
+            let (peek_response, session) = match peek_rx.await {
                 Ok(Response {
                     result: Ok(resp),
                     session,
@@ -3259,11 +3255,17 @@ impl Coordinator {
                 Ok(Response {
                     result: Err(e),
                     session,
-                }) => return tx.send(Err(e), session),
+                }) => {
+                    let ctx =
+                        ExecuteContext::from_parts(tx, internal_cmd_tx.clone(), session, extra);
+                    ctx.retire_async(Err(e));
+                    return;
+                }
                 // It is not an error for these results to be ready after `peek_client_tx` has been dropped.
                 Err(e) => return warn!("internal_cmd_rx dropped before we could send: {:?}", e),
             };
-            let timeout_dur = *session.vars().statement_timeout();
+            let mut ctx = ExecuteContext::from_parts(tx, internal_cmd_tx.clone(), session, extra);
+            let timeout_dur = *ctx.session().vars().statement_timeout();
             let arena = RowArena::new();
             let diffs = match peek_response {
                 ExecuteResponse::SendingRows {
@@ -3337,7 +3339,7 @@ impl Coordinator {
                             // receive a response.
                             // It is not an error for this timeout to occur after `internal_cmd_rx` has been dropped.
                             let result = internal_cmd_tx.send(Message::RemovePendingPeeks {
-                                conn_id: session.conn_id().clone(),
+                                conn_id: ctx.session().conn_id().clone(),
                             });
                             if let Err(e) = result {
                                 warn!("internal_cmd_rx dropped before we could send: {:?}", e);
@@ -3346,7 +3348,10 @@ impl Coordinator {
                         }
                     }
                 }
-                resp @ ExecuteResponse::Canceled => return tx.send(Ok(resp), session),
+                resp @ ExecuteResponse::Canceled => {
+                    ctx.retire_async(Ok(resp));
+                    return;
+                }
                 resp => Err(AdapterError::Unstructured(anyhow!(
                     "unexpected peek response: {resp:?}"
                 ))),
@@ -3398,7 +3403,7 @@ impl Coordinator {
 
             // We need to clear out the timestamp context so the write doesn't fail due to a
             // read only transaction.
-            let timestamp_context = session.take_transaction_timestamp_context();
+            let timestamp_context = ctx.session_mut().take_transaction_timestamp_context();
             // No matter what isolation level the client is using, we must linearize this
             // read. The write will be performed right after this, as part of a single
             // transaction, so the write must have a timestamp greater than or equal to the
@@ -3435,22 +3440,20 @@ impl Coordinator {
 
             match diffs {
                 Ok(diffs) => {
-                    tx.send(
-                        Self::sequence_send_diffs(
-                            &mut session,
-                            SendDiffsPlan {
-                                id,
-                                updates: diffs,
-                                kind,
-                                returning: returning_rows,
-                                max_result_size,
-                            },
-                        ),
-                        session,
+                    let result = Self::sequence_send_diffs(
+                        ctx.session_mut(),
+                        SendDiffsPlan {
+                            id,
+                            updates: diffs,
+                            kind,
+                            returning: returning_rows,
+                            max_result_size,
+                        },
                     );
+                    ctx.retire_async(result);
                 }
                 Err(e) => {
-                    tx.send(Err(e), session);
+                    ctx.retire_async(Err(e));
                 }
             }
         });

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -19,8 +19,8 @@ use crate::catalog::Catalog;
 use crate::coord::Coordinator;
 use crate::session::{Session, TransactionStatus};
 use crate::subscribe::ActiveSubscribe;
-use crate::util::{describe, ClientTransmitter};
-use crate::{metrics, AdapterError, ExecuteResponse};
+use crate::util::describe;
+use crate::{metrics, AdapterError, ExecuteContext, ExecuteResponse};
 
 impl Coordinator {
     pub(crate) fn plan_statement(
@@ -37,17 +37,16 @@ impl Coordinator {
 
     pub(crate) fn declare(
         &self,
-        tx: ClientTransmitter<ExecuteResponse>,
-        mut session: Session,
+        mut ctx: ExecuteContext,
         name: String,
         stmt: Statement<Raw>,
         param_types: Vec<Option<ScalarType>>,
     ) {
         let catalog = self.owned_catalog();
         mz_ore::task::spawn(|| "coord::declare", async move {
-            let res = Self::declare_inner(&mut session, &catalog, name, stmt, param_types)
+            let result = Self::declare_inner(ctx.session_mut(), &catalog, name, stmt, param_types)
                 .map(|()| ExecuteResponse::DeclaredCursor);
-            tx.send(res, session);
+            ctx.retire_async(result);
         });
     }
 

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -46,7 +46,7 @@ impl Coordinator {
         mz_ore::task::spawn(|| "coord::declare", async move {
             let result = Self::declare_inner(ctx.session_mut(), &catalog, name, stmt, param_types)
                 .map(|()| ExecuteResponse::DeclaredCursor);
-            ctx.retire_async(result);
+            ctx.retire(result);
         });
     }
 

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -129,6 +129,8 @@ pub use crate::coord::timeline::TimelineContext;
 pub use crate::coord::timestamp_selection::{
     TimestampContext, TimestampExplanation, TimestampProvider,
 };
+pub use crate::coord::ExecuteContext;
+pub use crate::coord::ExecuteContextExtra;
 pub use crate::coord::{serve, Config, DUMMY_AVAILABILITY_ZONE};
 pub use crate::error::AdapterError;
 pub use crate::notice::AdapterNotice;

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -133,6 +133,7 @@ pub fn check_command(catalog: &Catalog, cmd: &Command) -> Result<(), Unauthorize
         | Command::Prepare { .. }
         | Command::VerifyPreparedStatement { .. }
         | Command::Execute { .. }
+        | Command::ExecuteInner { .. }
         | Command::Commit { .. }
         | Command::CancelRequest { .. }
         | Command::PrivilegedCancelRequest { .. }

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -133,7 +133,7 @@ pub fn check_command(catalog: &Catalog, cmd: &Command) -> Result<(), Unauthorize
         | Command::Prepare { .. }
         | Command::VerifyPreparedStatement { .. }
         | Command::Execute { .. }
-        | Command::ExecuteInner { .. }
+        // | Command::ExecuteInner { .. }
         | Command::Commit { .. }
         | Command::CancelRequest { .. }
         | Command::PrivilegedCancelRequest { .. }

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -133,7 +133,6 @@ pub fn check_command(catalog: &Catalog, cmd: &Command) -> Result<(), Unauthorize
         | Command::Prepare { .. }
         | Command::VerifyPreparedStatement { .. }
         | Command::Execute { .. }
-        // | Command::ExecuteInner { .. }
         | Command::Commit { .. }
         | Command::CancelRequest { .. }
         | Command::PrivilegedCancelRequest { .. }

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -301,9 +301,13 @@ fn test_timestamp_selection() {
                 }
                 "determine" => {
                     let det: Determine = serde_json::from_str(&tc.input).unwrap();
-                    let session = Session::dummy()
-                        .start_transaction(mz_ore::now::to_datetime(0), None, Some(isolation))
-                        .0;
+                    let mut session = Session::dummy();
+                    let _ = session.start_transaction(
+                        mz_ore::now::to_datetime(0),
+                        None,
+                        Some(isolation),
+                    );
+
                     let ts = f
                         .determine_timestamp_for(
                             &catalog,


### PR DESCRIPTION
We pass a `tx` and `session` around various functions as part of the statement logging lifecycle; at the end of statement execution, we need to send the `session` back through the `tx` so that the `pgwire` layer can have access to it again.

As part of statement logging, there will be some more tasks we need to perform at the end of each execution, so as a precursor to that, I bundled that logic into one struct, `ExecuteContext`, which must be "retired" at the end of statement lifecycle. This involved replacing every `tx.send((session, result))` with a call to either `retire` or `retire_async`.

Each of these functions returns the `session` back through the `tx`, and then notifies the coordinator so that it can perform any other cleanup/logging work as necessary. The difference between them is that `retire` requires `&mut` access to the coordinator, whereas `retire_async` communicates with it by sending a message.

Currently, the extra work that the coordinator does is nothing, but that will change soon.

For more details, see the comments on `ExecuteContext` and `ExecuteContextExtra`.