### PR TITLE
test: Prevent SLT from falsely passing queries

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -61,7 +61,7 @@ use mz_repr::adt::mz_acl_item::MzAclItem;
 use mz_repr::adt::numeric;
 use mz_repr::ColumnName;
 use mz_secrets::SecretsController;
-use mz_sql::ast::{Expr, Raw, ShowStatement, Statement};
+use mz_sql::ast::{Expr, Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{CreateIndexStatement, RawItemName, Statement as AstStatement};
@@ -1175,17 +1175,6 @@ impl RunnerInner {
             [statement] => statement,
             _ => bail!("Got multiple statements: {:?}", statements),
         };
-        match statement {
-            Statement::CreateView { .. }
-            | Statement::Select { .. }
-            | Statement::Show(ShowStatement::ShowObjects(..)) => (),
-            _ => {
-                if output.is_err() {
-                    // We're not interested in testing our hacky handling of INSERT etc
-                    return Ok(Outcome::Success);
-                }
-            }
-        }
 
         match output {
             Ok(_) => {

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -9,13 +9,13 @@
 
 mode cockroach
 
-query error system schema 'mz_catalog.mz_tables' cannot be modified
+query error system schema 'mz_catalog' cannot be modified
 ALTER TABLE mz_tables RENAME TO foo;
 
-query error system schema 'mz_internal.mz_storage_shards' cannot be modified
+query error system schema 'mz_internal' cannot be modified
 ALTER SOURCE mz_internal.mz_storage_shards RENAME TO foo;
 
-query error system schema 'mz_internal.mz_storage_shards' cannot be modified
+query error cannot ALTER this type of source
 ALTER SOURCE mz_internal.mz_storage_shards RESET (size);
 
 statement ok

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -451,7 +451,7 @@ DROP CLUSTER REPLICA IF EXISTS bar.foo
 statement ok
 DROP CLUSTER REPLICA IF EXISTS default.foo
 
-query error CLUSTER foo has no CLUSTER REPLICA named foo
+query error CLUSTER foo has no CLUSTER REPLICA named "foo"
 DROP CLUSTER REPLICA default.size_1, foo.foo
 
 statement ok

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -247,7 +247,7 @@ SELECT * FROM kv GROUP BY v, count(DISTINCT w)
 query error aggregate functions are not allowed in GROUP BY
 SELECT count(DISTINCT w) FROM kv GROUP BY 1
 
-query error Expected end of statement, found identifier
+query error aggregate functions are not allowed in RETURNING clause \(function pg_catalog.sum\)
 INSERT INTO kv (k, v) VALUES (99, 100) RETURNING sum(v)
 
 query error LIMIT must be an integer constant

--- a/test/sqllogictest/cockroach/case_sensitive_names.slt
+++ b/test/sqllogictest/cockroach/case_sensitive_names.slt
@@ -229,7 +229,7 @@ SHOW CREATE VIEW xv
 materialize.public.xv
 CREATE VIEW "materialize"."public"."xv" AS SELECT "x", "Y" FROM "materialize"."public"."foo"
 
-query error pgcode 42P01 relation "XV" does not exist
+query error unknown catalog item 'XV'
 SHOW CREATE VIEW "XV"
 
 statement ok
@@ -241,7 +241,7 @@ SHOW CREATE VIEW "YV"
 materialize.public.YV
 CREATE VIEW "materialize"."public"."YV" AS SELECT "x", "Y" FROM "materialize"."public"."foo"
 
-query error pgcode 42P01 relation "yv" does not exist
+query error unknown catalog item 'yv'
 SHOW CREATE VIEW YV
 
 mode cockroach

--- a/test/sqllogictest/introspection/system_object_errors.slt
+++ b/test/sqllogictest/introspection/system_object_errors.slt
@@ -12,5 +12,5 @@ mode cockroach
 query error cannot show create for system object mz_internal.mz_dataflow_channels
 SHOW CREATE SOURCE mz_internal.mz_dataflow_channels
 
-query error system schema 'mz_internal.mz_dataflow_channels' cannot be modified
+query error "mz_internal.mz_dataflow_channels" is a view not a source
 ALTER SOURCE mz_internal.mz_dataflow_channels RENAME TO foo;

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1986,10 +1986,10 @@ SELECT '{1}'::float4 list = '{2}'::float8 list
 query error ELEMENT TYPE must be of class type, but received pg_catalog.pg_enum which is of class view
 CREATE TYPE tbl_list AS LIST (ELEMENT TYPE=pg_enum)
 
-query error CREATE TYPE ... AS LIST option "ELEMENT TYPE" cannot accept type modifier on numeric, you must use the default type
+query error CREATE TYPE ... AS LIST option ELEMENT TYPE cannot accept type modifier on pg_catalog.numeric, you must use the default type
 CREATE TYPE typ_mod_list AS LIST (ELEMENT TYPE=numeric(38,0))
 
-query error CREATE TYPE ... AS LIST option "ELEMENT TYPE" can only use named data types, but found unnamed data type int4 list. Use CREATE TYPE to create a named type first
+query error CREATE TYPE ... AS LIST option ELEMENT TYPE can only use named data types, but found unnamed data type \[s20 AS pg_catalog.int4\] list. Use CREATE TYPE to create a named type first
 CREATE TYPE unnamed_element_list AS LIST (ELEMENT TYPE=int4 list)
 
 statement ok
@@ -2023,10 +2023,10 @@ SELECT '{{1,2}}'::int4_list_list_c::text;
 ----
 {{1,2}}
 
-query error unknown catalog item bool list
+query error unknown catalog item 'bool list'
 CREATE TYPE nested_list AS LIST (ELEMENT TYPE = "bool list")
 
-query error unknown catalog item list
+statement ok
 CREATE TYPE nested_list AS LIST (ELEMENT TYPE = list)
 
 # 🔬🔬 Check each valid non-array element type

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -18,10 +18,10 @@ mode cockroach
 # we just convert everything to `text`.
 
 # Test basic string to map casts.
-query error VALUE TYPE   parameter required
+query error VALUE TYPE option is required
 CREATE TYPE custom AS MAP (KEY TYPE = text)
 
-query error KEY TYPE parameter required
+query error KEY TYPE option is required
 CREATE TYPE custom AS MAP (VALUE TYPE = bool)
 
 query error Expected one of KEY or VALUE, found identifier "extra_type"
@@ -33,13 +33,13 @@ CREATE TYPE tbl_map AS MAP (KEY TYPE = pg_enum, VALUE TYPE = text)
 query error VALUE TYPE must be of class type, but received pg_catalog.pg_enum which is of class view
 CREATE TYPE tbl_map AS MAP (KEY TYPE = text, VALUE TYPE = pg_enum)
 
-query error CREATE TYPE ... AS MAP option "VALUE TYPE "  cannot accept type modifier on numeric, you must use the default type
+query error CREATE TYPE ... AS MAP option VALUE TYPE cannot accept type modifier on pg_catalog.numeric, you must use the default type
 CREATE TYPE typ_mod_map AS MAP (KEY TYPE = text, VALUE TYPE = numeric(38,0))
 
-query error CREATE TYPE ... AS LIST option "VALUE TYPE "  can only use named data types, but found unnamed data type int4 list. Use CREATE TYPE to create a named type first
+query error CREATE TYPE ... AS MAP option VALUE TYPE can only use named data types, but found unnamed data type \[s20 AS pg_catalog.int4\] list. Use CREATE TYPE to create a named type first
 CREATE TYPE unnamed_element_map AS MAP (KEY TYPE = text, VALUE TYPE = int4 list)
 
-query error CREATE TYPE not yet supported
+statement ok
 CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool)
 
 query error expected '\{', found a: "a=>1"


### PR DESCRIPTION
Previously, if a query was parsed successfully, and it was not a CREATE VIEW, SELECT, or SHOW query then it passed the SLT test no matter what.

This commit updates SLT to check the result of those queries.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
