### PR TITLE
storage: dont panic on sink creation

### DIFF
--- a/test/cluster/sink-failure/01-configure-sinks.td
+++ b/test/cluster/sink-failure/01-configure-sinks.td
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+
+> DROP SOURCE IF EXISTS mz_source CASCADE;
+> DROP SECRET IF EXISTS pgpass CASCADE;
+
+> CREATE CLUSTER storage REPLICAS (
+    r1 (
+      STORAGECTL ADDRESSES ['storage:2100'],
+      STORAGE ADDRESSES ['storage:2103'],
+      COMPUTECTL ADDRESSES ['storage:2101'],
+      COMPUTE ADDRESSES ['storage:2102'],
+      WORKERS 4
+    )
+  )
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> CREATE MATERIALIZED VIEW v1 AS
+  SELECT 1 as col
+
+> CREATE SINK snk
+  IN CLUSTER storage
+  FROM v1
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM

--- a/test/cluster/sink-failure/02-ensure-sink-down.td
+++ b/test/cluster/sink-failure/02-ensure-sink-down.td
@@ -1,0 +1,18 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT DISTINCT mz_sinks.name, error
+  FROM
+      mz_internal.mz_sink_status_history
+          JOIN mz_sinks ON sink_id = mz_sinks.id
+  WHERE
+      mz_sinks.name = 'snk'
+          AND
+      status = 'stalled';
+snk "synthetic error"

--- a/test/cluster/sink-failure/03-verify-data.td
+++ b/test/cluster/sink-failure/03-verify-data.td
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-verify-data format=avro sink=materialize.public.snk sort-messages=true
+{"before": null, "after": {"row":{"col": 1}}}


### PR DESCRIPTION
Closes: https://github.com/MaterializeInc/cloud/issues/6584
Doesn't yet solve: https://github.com/MaterializeInc/materialize/issues/19944

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
