### PR TITLE
upgrade tests: Revert back to using version information from the docs

### DIFF
--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -19,9 +19,9 @@ from materialize.checks.mzcompose_actions import (
 )
 from materialize.checks.scenarios import Scenario
 from materialize.util import MzVersion
-from materialize.version_list import VersionsFromGit
+from materialize.version_list import VersionsFromDocs
 
-version_list = VersionsFromGit()
+version_list = VersionsFromDocs()
 minor_versions = version_list.minor_versions()
 previous_version, last_version = minor_versions[-2:]
 

--- a/test/upgrade-matrix/mzcompose.py
+++ b/test/upgrade-matrix/mzcompose.py
@@ -47,7 +47,7 @@ from materialize.mzcompose.services import (
 )
 from materialize.mzcompose.services import Testdrive as TestdriveService
 from materialize.util import MzVersion
-from materialize.version_list import VersionsFromGit
+from materialize.version_list import VersionsFromDocs
 
 SERVICES = [
     Cockroach(setup_materialize=True),
@@ -137,7 +137,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     executor = MzcomposeExecutor(composition=c)
 
     versions = list(
-        [v for v in VersionsFromGit().minor_versions() if v >= args.min_version]
+        [v for v in VersionsFromDocs().minor_versions() if v >= args.min_version]
     )
     print(
         "--- Testing upgrade scenarios involving the following versions: "


### PR DESCRIPTION
Previously, some tests were switched to use information about released Mz versions from the git tags in the repository. Unfortunately several of those git tags lack a corresponding DockerHub container, so upgrade tests are failing.

Until a general solution is found, revert back to using the pages in doc/user/content/releases in order to determine what Mz versions actually exist.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Nightly was failing with "image not found" errors.