### PR TITLE
mzcompose: Bump the CockroachDB healthcheck timeout

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -541,7 +541,6 @@ class Cockroach(Service):
             healthcheck = {
                 # init_success is a file created by the Cockroach container entrypoint
                 "test": "[ -f init_success ] && curl --fail 'http://localhost:8080/health?ready=1'",
-                "timeout": "5s",
                 "interval": "1s",
                 "start_period": "30s",
             }


### PR DESCRIPTION
We are getting CI failures because the CockroachDB is deemed to have failed its healthcheck. This happens even when `start` is called on a CRDB instance that is already running.

Restore the default healthcheck timeout to see if this helps stabilize the CI.

### Motivation

Crdb is reported as unhealthy even though it should be running at the time, as it is not being disrupted in this particular test.