### PR TITLE
ci: Don't try to use v0.57.6 and v0.57.5

### DIFF
--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -19,9 +19,16 @@ from materialize.util import MzVersion
 
 ROOT = Path(os.environ["MZ_ROOT"])
 
-INVALID_VERSIONS = [
-    MzVersion.parse_mz("v0.56.0"),  # not released on Docker
-]
+# not released on Docker
+INVALID_VERSIONS = {
+    MzVersion.parse_mz("v0.52.1"),
+    MzVersion.parse_mz("v0.55.6"),
+    MzVersion.parse_mz("v0.56.0"),
+    MzVersion.parse_mz("v0.57.1"),
+    MzVersion.parse_mz("v0.57.2"),
+    MzVersion.parse_mz("v0.57.5"),
+    MzVersion.parse_mz("v0.57.6"),
+}
 
 
 class VersionList:
@@ -65,14 +72,17 @@ class VersionsFromGit(VersionList):
     True
 
     >>> len(VersionsFromGit().patch_versions(minor_version=MzVersion.parse("0.52.0")))
-    5
+    4
 
     >>> min(VersionsFromGit().all_versions())
     MzVersion(major=0, minor=1, patch=0, prerelease='rc', build=None)
     """
 
     def __init__(self) -> None:
-        self.versions = [MzVersion.from_semver(t) for t in get_version_tags(fetch=True)]
+        self.versions = list(
+            {MzVersion.from_semver(t) for t in get_version_tags(fetch=True)}
+            - INVALID_VERSIONS
+        )
         self.versions.sort()
 
 
@@ -89,7 +99,7 @@ class VersionsFromDocs(VersionList):
     True
 
     >>> len(VersionsFromDocs().patch_versions(minor_version=MzVersion.parse("0.52.0")))
-    5
+    4
 
     >>> min(VersionsFromDocs().all_versions())
     MzVersion(major=0, minor=27, patch=0, prerelease=None, build=None)


### PR DESCRIPTION
> Error response from daemon: manifest for materialize/materialized:v0.57.6 not found: manifest unknown: manifest unknown

Probably just short-term since Philip is working on using cloud/.github/ISSUE_TEMPLATE/*release* instead.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
