### PR TITLE
Compute protocol and controller state metrics

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -543,6 +543,11 @@ where
 
     /// Processes the work queued by [`ComputeController::ready`].
     pub fn process(&mut self) -> Option<ComputeControllerResponse<T>> {
+        // Update controller state metrics.
+        for instance in self.compute.instances.values_mut() {
+            instance.refresh_state_metrics();
+        }
+
         // Rehydrate any failed replicas.
         for instance in self.compute.instances.values_mut() {
             instance.activate(self.storage).rehydrate_failed_replicas();

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -11,11 +11,11 @@
 
 use std::sync::Arc;
 
-use mz_ore::cast::{CastFrom, TryCastFrom};
+use mz_ore::cast::CastFrom;
 use mz_ore::metric;
-use mz_ore::metrics::{DeleteOnDropHistogram, HistogramVecExt, MetricsRegistry};
-use mz_ore::stats::HISTOGRAM_BYTE_BUCKETS;
+use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, IntCounterVec, MetricsRegistry};
 use mz_service::codec::StatsCollector;
+use prometheus::core::AtomicU64;
 
 use crate::controller::{ComputeInstanceId, ReplicaId};
 use crate::protocol::command::ProtoComputeCommand;
@@ -24,33 +24,30 @@ use crate::protocol::response::ProtoComputeResponse;
 /// Compute controller metrics
 #[derive(Debug, Clone)]
 pub struct ComputeControllerMetrics {
-    messages_sent_bytes: prometheus::HistogramVec,
-    messages_received_bytes: prometheus::HistogramVec,
+    command_message_bytes_total: IntCounterVec,
+    response_message_bytes_total: IntCounterVec,
 }
 
 impl ComputeControllerMetrics {
     pub fn new(metrics_registry: MetricsRegistry) -> Self {
         ComputeControllerMetrics {
-            messages_sent_bytes: metrics_registry.register(metric!(
-                name: "mz_compute_messages_sent_bytes",
-                help: "size of compute messages sent",
-                var_labels: ["instance", "replica"],
-                buckets: HISTOGRAM_BYTE_BUCKETS.to_vec()
+            command_message_bytes_total: metrics_registry.register(metric!(
+                name: "mz_compute_command_message_bytes_total",
+                help: "The total number of bytes sent in compute command messages.",
+                var_labels: ["instance_id", "replica_id", "command_type"],
             )),
-            messages_received_bytes: metrics_registry.register(metric!(
-                name: "mz_compute_messages_received_bytes",
-                help: "size of compute messages received",
-                var_labels: ["instance", "replica"],
-                buckets: HISTOGRAM_BYTE_BUCKETS.to_vec()
+            response_message_bytes_total: metrics_registry.register(metric!(
+                name: "mz_compute_response_message_bytes_total",
+                help: "The total number of bytes sent in compute response messages.",
+                var_labels: ["instance_id", "replica_id", "response_type"],
             )),
         }
     }
 
     pub fn for_instance(&self, instance_id: ComputeInstanceId) -> InstanceMetrics {
         InstanceMetrics {
-            messages_sent_bytes: self.messages_sent_bytes.clone(),
-            messages_received_bytes: self.messages_received_bytes.clone(),
             instance_id,
+            metrics: self.clone(),
         }
     }
 }
@@ -58,34 +55,34 @@ impl ComputeControllerMetrics {
 /// Per-instance metrics
 #[derive(Debug, Clone)]
 pub struct InstanceMetrics {
-    messages_sent_bytes: prometheus::HistogramVec,
-    messages_received_bytes: prometheus::HistogramVec,
     instance_id: ComputeInstanceId,
+    metrics: ComputeControllerMetrics,
 }
 
 impl InstanceMetrics {
     pub fn for_replica(&self, replica_id: ReplicaId) -> ReplicaMetrics {
-        let labels = vec![self.instance_id.to_string(), replica_id.to_string()];
-        let messages_sent_bytes = self
-            .messages_sent_bytes
-            .get_delete_on_drop_histogram(labels.clone());
-        let messages_received_bytes = self
-            .messages_received_bytes
-            .get_delete_on_drop_histogram(labels);
+        let instance_id = self.instance_id.to_string();
+        let replica_id = replica_id.to_string();
 
+        let command_message_bytes_total = CommandMetrics::build(|typ| {
+            let labels = vec![instance_id.clone(), replica_id.clone(), typ.into()];
+            self.metrics
+                .command_message_bytes_total
+                .get_delete_on_drop_counter(labels)
+        });
+        let response_message_bytes_total = ResponseMetrics::build(|typ| {
+            let labels = vec![instance_id.clone(), replica_id.clone(), typ.into()];
+            self.metrics
+                .response_message_bytes_total
+                .get_delete_on_drop_counter(labels)
+        });
         ReplicaMetrics {
             inner: Arc::new(ReplicaMetricsInner {
-                messages_sent_bytes,
-                messages_received_bytes,
+                command_message_bytes_total,
+                response_message_bytes_total,
             }),
         }
     }
-}
-
-#[derive(Debug)]
-struct ReplicaMetricsInner {
-    messages_sent_bytes: DeleteOnDropHistogram<'static, Vec<String>>,
-    messages_received_bytes: DeleteOnDropHistogram<'static, Vec<String>>,
 }
 
 /// Per-replica metrics.
@@ -94,25 +91,104 @@ pub struct ReplicaMetrics {
     inner: Arc<ReplicaMetricsInner>,
 }
 
-/// Make ReplicaConnectionMetric pluggable into the gRPC connection.
+type IntCounter = DeleteOnDropCounter<'static, AtomicU64, Vec<String>>;
+
+#[derive(Debug)]
+struct ReplicaMetricsInner {
+    command_message_bytes_total: CommandMetrics<IntCounter>,
+    response_message_bytes_total: ResponseMetrics<IntCounter>,
+}
+
+/// Make [`ReplicaMetrics`] pluggable into the gRPC connection.
 impl StatsCollector<ProtoComputeCommand, ProtoComputeResponse> for ReplicaMetrics {
-    fn send_event(&self, _item: &ProtoComputeCommand, size: usize) {
-        match f64::try_cast_from(u64::cast_from(size)) {
-            Some(x) => self.inner.messages_sent_bytes.observe(x),
-            None => tracing::warn!(
-                "{} has no precise representation as f64, ignoring message",
-                size
-            ),
+    fn send_event(&self, item: &ProtoComputeCommand, size: usize) {
+        self.inner
+            .command_message_bytes_total
+            .for_proto_command(item)
+            .inc_by(u64::cast_from(size));
+    }
+
+    fn receive_event(&self, item: &ProtoComputeResponse, size: usize) {
+        self.inner
+            .response_message_bytes_total
+            .for_proto_response(item)
+            .inc_by(u64::cast_from(size));
+    }
+}
+
+/// Metrics keyed by `ComputeCommand` type.
+#[derive(Debug)]
+struct CommandMetrics<M> {
+    create_timely: M,
+    create_instance: M,
+    create_dataflows: M,
+    allow_compaction: M,
+    peek: M,
+    cancel_peeks: M,
+    initialization_complete: M,
+    update_configuration: M,
+}
+
+impl<M> CommandMetrics<M> {
+    fn build<F>(build_metric: F) -> Self
+    where
+        F: Fn(&str) -> M,
+    {
+        Self {
+            create_timely: build_metric("create_timely"),
+            create_instance: build_metric("create_instance"),
+            create_dataflows: build_metric("create_dataflows"),
+            allow_compaction: build_metric("allow_compaction"),
+            peek: build_metric("peek"),
+            cancel_peeks: build_metric("cancel_peeks"),
+            initialization_complete: build_metric("initialization_complete"),
+            update_configuration: build_metric("update_configuration"),
         }
     }
 
-    fn receive_event(&self, _item: &ProtoComputeResponse, size: usize) {
-        match f64::try_cast_from(u64::cast_from(size)) {
-            Some(x) => self.inner.messages_received_bytes.observe(x),
-            None => tracing::warn!(
-                "{} has no precise representation as f64, ignoring message",
-                size
-            ),
+    fn for_proto_command(&self, proto: &ProtoComputeCommand) -> &M {
+        use crate::protocol::command::proto_compute_command::Kind::*;
+
+        match proto.kind.as_ref().unwrap() {
+            CreateTimely(_) => &self.create_timely,
+            CreateInstance(_) => &self.create_instance,
+            CreateDataflows(_) => &self.create_dataflows,
+            AllowCompaction(_) => &self.allow_compaction,
+            Peek(_) => &self.peek,
+            CancelPeeks(_) => &self.cancel_peeks,
+            InitializationComplete(_) => &self.initialization_complete,
+            UpdateConfiguration(_) => &self.update_configuration,
+        }
+    }
+}
+
+/// Metrics keyed by `ComputeResponse` type.
+#[derive(Debug)]
+struct ResponseMetrics<M> {
+    frontier_uppers: M,
+    peek_response: M,
+    subscribe_response: M,
+}
+
+impl<M> ResponseMetrics<M> {
+    fn build<F>(build_metric: F) -> Self
+    where
+        F: Fn(&str) -> M,
+    {
+        Self {
+            frontier_uppers: build_metric("frontier_uppers"),
+            peek_response: build_metric("peek_response"),
+            subscribe_response: build_metric("subscribe_response"),
+        }
+    }
+
+    fn for_proto_response(&self, proto: &ProtoComputeResponse) -> &M {
+        use crate::protocol::response::proto_compute_response::Kind::*;
+
+        match proto.kind.as_ref().unwrap() {
+            FrontierUppers(_) => &self.frontier_uppers,
+            PeekResponse(_) => &self.peek_response,
+            SubscribeResponse(_) => &self.subscribe_response,
         }
     }
 }


### PR DESCRIPTION
This PR adds some compute controller metrics described in the design doc (https://github.com/MaterializeInc/materialize/pull/19717), specifically the ones in the sections "Compute protocol" and "Controller state".

It builds on the existing metrics support in the compute controller but modifies the existing message size metrics significantly (first commit). It then adds metrics for:
* message counts (commit 2)
* instance controller state (commit 3)
* command/response queue sizes (commit 4)

The code makes use of the delete-on-drop metric types from `mz_ore::metrics` to ensure that metrics are removed when their instance or replica is dropped. 

### Motivation

  * This PR adds a known-desirable feature.

Part of #18745.
Part of #16026.

### Tips for reviewer

Look at the commits separately!

What are your thoughts about testing this? We could write any number of mzcompose-based tests I think, but I'm unsure how much CI time we want to invest on a strictly internal feature. It seems that persist doesn't test their metrics, so perhaps they arrived at the conclusion that it's not worth it.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
