### PR TITLE
scratch: Add new small config

### DIFF
--- a/misc/scratch/small.json
+++ b/misc/scratch/small.json
@@ -1,0 +1,8 @@
+{
+  "name": "small",
+  "launch_script": "true",
+  "instance_type": "t3.small",
+  "ami": "ami-09d56f8956ab235b3",
+  "size_gb": 64,
+  "tags": {}
+}


### PR DESCRIPTION
### Motivation

While doing some experimentation I only needed a small EC2 instance, all of the existing scratch instances are relatively large. This PR adds a new config for small scratch instances.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a