### PR TITLE
ci: Try using persist flags from Launch Darkly env

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -112,6 +112,10 @@ class Materialized(Service):
                 "persist_stats_audit_percent": "100",
                 "enable_ld_rbac_checks": "true",
                 "enable_rbac_checks": "true",
+                # Following values are set based on Load Test environment to
+                # reduce CRDB load as we are struggling with it in CI:
+                "persist_next_listen_batch_retryer_clamp": "100ms",
+                "persist_next_listen_batch_retryer_initial_backoff": "1200ms",
             }
 
         if additional_system_parameter_defaults is not None:


### PR DESCRIPTION
@pH14 Are those the correct flags to reduce CRDB system load?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
