### PR TITLE
sql: Implement ALTER DEFAULT PRIVILEGES

### DIFF
--- a/doc/user/content/sql/alter-default-privileges.md
+++ b/doc/user/content/sql/alter-default-privileges.md
@@ -1,0 +1,86 @@
+---
+title: "ALTER DEFAULT PRIVILEGES"
+description: "`ALTER DEFAULT PRIVILEGES` defines default privileges that will be applied to objects created in the future."
+menu:
+  main:
+    parent: commands
+---
+
+`ALTER DEFAULT PRIVILEGES` defines default privileges that will be applied to objects created in
+the future. It does not affect any existing objects.
+
+Default privileges are specified for a certain object type and can be applied to all objects of
+that type, all objects of that type created within a specific set of databases, or all objects of
+that type created within a specific set of schemas. Default privileges are also specified for
+objects created by a certain set of roles, if no roles are specified then it is assumed to be the
+current role.
+
+`ALTER DEFAULT PRIVILEGES` cannot be used to revoke the default owner privileges on objects. Those
+privileges must be revoked manually after the object is created. Though owners can always re-grant
+themselves any privilege on an object that they own.
+
+The `REVOKE` variant of `ALTER DEFAULT PRIVILEGES` is used to revoke previously created default
+privileges on objects created in the future. It will not revoke any privileges on objects that have
+already been created.
+
+## Syntax
+
+{{< diagram "alter-default-privileges.svg" >}}
+
+### `abreviated_grant`
+
+{{< diagram "abbreviated-grant.svg" >}}
+
+### `abbreviated_revoke`
+
+{{< diagram "abbreviated-revoke.svg" >}}
+
+### `privilege`
+
+{{< diagram "privilege.svg" >}}
+
+Field              | Use
+-------------------|--------------------------------------------------
+_target_role_      | The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed.
+_schema_name_      | The default privilege will apply only to objects created in this schema, if specified.
+_database_name_    | The default privilege will apply only to objects created in this database, if specified.
+**SELECT**         | Allows reading rows from an object. The abbreviation for this privilege is 'r' (read).
+**INSERT**         | Allows inserting into an object. The abbreviation for this privilege is 'a' (append).
+**UPDATE**         | Allows updating an object (requires **SELECT** if a read is necessary). The abbreviation for this privilege is 'w' (write).
+**DELETE**         | Allows deleting from an object (requires **SELECT** if a read is necessary). The abbreviation for this privilege is 'd'.
+**CREATE**         | Allows creating a new object within another object. The abbreviation for this privilege is 'C'.
+**USAGE**          | Allows using an object or looking up members of an object. The abbreviation for this privilege is 'U'.
+**ALL PRIVILEGES** | All applicable privileges for the provided object type.
+_grantee_          | The role name that will gain the default privilege. Use the `PUBLIC` pseudo-role to grant privileges to all roles.
+_revokee_          | The role name that will not gain the default privilege. Use the `PUBLIC` pseudo-role to remove default privileges previously granted to `PUBLIC`.
+
+### Compatibility
+
+For PostgreSQL compatibility reasons, you must specify `TABLES` as the object
+type for sources, views, and materialized views.
+
+## Examples
+
+```sql
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO joe;
+```
+
+```sql
+ALTER DEFAULT PRIVILEGES FOR interns IN DATABASE dev GRANT ALL PRIVILEGES ON TABLES TO intern_managers;
+```
+
+```sql
+ALTER DEFAULT PRIVILEGES FOR developers REVOKE USAGE ON SECRETS FROM project_managers;
+```
+
+## Related pages
+
+- [CREATE ROLE](../create-role)
+- [ALTER ROLE](../alter-role)
+- [DROP ROLE](../drop-role)
+- [DROP USER](../drop-user)
+- [GRANT ROLE](../grant-role)
+- [REVOKE ROLE](../revoke-role)
+- [ALTER OWNER](../alter-owner)
+- [GRANT PRIVILEGE](../grant-privilege)
+- [REVOKE PRIVILEGE](../revoke-privilege)

--- a/doc/user/content/sql/grant-privilege.md
+++ b/doc/user/content/sql/grant-privilege.md
@@ -90,3 +90,4 @@ GRANT ALL ON CLUSTER dev TO joe;
 - [REVOKE ROLE](../revoke-role)
 - [ALTER OWNER](../alter-owner)
 - [REVOKE PRIVILEGE](../revoke-privilege)
+- [ALTER DEFAULT PRIVILEGES](../alter-default-privileges)

--- a/doc/user/content/sql/revoke-privilege.md
+++ b/doc/user/content/sql/revoke-privilege.md
@@ -92,3 +92,4 @@ REVOKE ALL ON CLUSTER dev FROM joe;
 - [REVOKE ROLE](../revoke-role)
 - [ALTER OWNER](../alter-owner)
 - [GRANT PRIVILEGE](../revoke-privilege)
+- [ALTER DEFAULT PRIVILEGES](../alter-default-privileges)

--- a/doc/user/layouts/partials/sql-grammar/alter-default-privileges.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-default-privileges.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="463" height="519">
+<svg xmlns="http://www.w3.org/2000/svg" width="463" height="531">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="66" height="32" rx="10"/>
@@ -25,87 +25,95 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="229" y="21">PRIVILEGES</text>
-   <rect x="119" y="85" width="48" height="32" rx="10"/>
-   <rect x="117"
-         y="83"
+   <rect x="76" y="113" width="48" height="32" rx="10"/>
+   <rect x="74"
+         y="111"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="127" y="103">FOR</text>
-   <rect x="207" y="117" width="56" height="32" rx="10"/>
-   <rect x="205"
-         y="115"
+   <text class="terminal" x="84" y="131">FOR</text>
+   <rect x="164" y="113" width="56" height="32" rx="10"/>
+   <rect x="162"
+         y="111"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="215" y="135">ROLE</text>
-   <rect x="207" y="161" width="56" height="32" rx="10"/>
-   <rect x="205"
-         y="159"
+   <text class="terminal" x="172" y="131">ROLE</text>
+   <rect x="164" y="157" width="56" height="32" rx="10"/>
+   <rect x="162"
+         y="155"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="215" y="179">USER</text>
-   <rect x="303" y="85" width="44" height="32"/>
-   <rect x="301" y="83" width="44" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="311" y="103">role</text>
-   <rect x="45" y="271" width="34" height="32" rx="10"/>
+   <text class="terminal" x="172" y="175">USER</text>
+   <rect x="280" y="113" width="90" height="32"/>
+   <rect x="278" y="111" width="90" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="288" y="131">target_role</text>
+   <rect x="280" y="69" width="24" height="32" rx="10"/>
+   <rect x="278"
+         y="67"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="288" y="87">,</text>
+   <rect x="45" y="283" width="34" height="32" rx="10"/>
    <rect x="43"
-         y="269"
+         y="281"
          width="34"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="289">IN</text>
-   <rect x="119" y="271" width="82" height="32" rx="10"/>
+   <text class="terminal" x="53" y="301">IN</text>
+   <rect x="119" y="283" width="82" height="32" rx="10"/>
    <rect x="117"
-         y="269"
+         y="281"
          width="82"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="127" y="289">SCHEMA</text>
-   <rect x="241" y="271" width="114" height="32"/>
-   <rect x="239" y="269" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="249" y="289">schema_name</text>
-   <rect x="241" y="227" width="24" height="32" rx="10"/>
+   <text class="terminal" x="127" y="301">SCHEMA</text>
+   <rect x="241" y="283" width="114" height="32"/>
+   <rect x="239" y="281" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="249" y="301">schema_name</text>
+   <rect x="241" y="239" width="24" height="32" rx="10"/>
    <rect x="239"
-         y="225"
+         y="237"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="249" y="245">,</text>
-   <rect x="119" y="359" width="98" height="32" rx="10"/>
+   <text class="terminal" x="249" y="257">,</text>
+   <rect x="119" y="371" width="98" height="32" rx="10"/>
    <rect x="117"
-         y="357"
+         y="369"
          width="98"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="127" y="377">DATABASE</text>
-   <rect x="257" y="359" width="124" height="32"/>
-   <rect x="255" y="357" width="124" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="265" y="377">database_name</text>
-   <rect x="257" y="315" width="24" height="32" rx="10"/>
+   <text class="terminal" x="127" y="389">DATABASE</text>
+   <rect x="257" y="371" width="124" height="32"/>
+   <rect x="255" y="369" width="124" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="265" y="389">database_name</text>
+   <rect x="257" y="327" width="24" height="32" rx="10"/>
    <rect x="255"
-         y="313"
+         y="325"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="265" y="333">,</text>
-   <rect x="265" y="441" width="140" height="32"/>
-   <rect x="263" y="439" width="140" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="273" y="459">abbreviated_grant</text>
-   <rect x="265" y="485" width="150" height="32"/>
-   <rect x="263" y="483" width="150" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="273" y="503">abbreviated_revoke</text>
+   <text class="terminal" x="265" y="345">,</text>
+   <rect x="265" y="453" width="140" height="32"/>
+   <rect x="263" y="451" width="140" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="273" y="471">abbreviated_grant</text>
+   <rect x="265" y="497" width="150" height="32"/>
+   <rect x="263" y="495" width="150" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="273" y="515">abbreviated_revoke</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-268 50 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h238 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v12 m268 0 v-12 m-268 12 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m48 0 h10 m20 0 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m20 -76 h10 m44 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-386 218 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m34 0 h10 m20 0 h10 m82 0 h10 m20 0 h10 m114 0 h10 m-154 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m134 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-134 0 h10 m24 0 h10 m0 0 h90 m20 44 h26 m-322 0 h20 m302 0 h20 m-342 0 q10 0 10 10 m322 0 q0 -10 10 -10 m-332 10 v68 m322 0 v-68 m-322 68 q0 10 10 10 m302 0 q10 0 10 -10 m-312 10 h10 m98 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m144 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-144 0 h10 m24 0 h10 m0 0 h100 m-376 -44 h20 m396 0 h20 m-436 0 q10 0 10 10 m416 0 q0 -10 10 -10 m-426 10 v102 m416 0 v-102 m-416 102 q0 10 10 10 m396 0 q10 0 10 -10 m-406 10 h10 m0 0 h386 m22 -122 l2 0 m2 0 l2 0 m2 0 l2 0 m-240 170 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m140 0 h10 m0 0 h10 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v24 m190 0 v-24 m-190 24 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m150 0 h10 m23 -44 h-3"/>
-   <polygon points="453 455 461 451 461 459"/>
-   <polygon points="453 455 445 451 445 459"/>
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-311 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m20 0 h10 m56 0 h10 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m40 -44 h10 m90 0 h10 m-130 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m110 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-110 0 h10 m24 0 h10 m0 0 h66 m-334 44 h20 m334 0 h20 m-374 0 q10 0 10 10 m354 0 q0 -10 10 -10 m-364 10 v58 m354 0 v-58 m-354 58 q0 10 10 10 m334 0 q10 0 10 -10 m-344 10 h10 m0 0 h324 m22 -78 l2 0 m2 0 l2 0 m2 0 l2 0 m-429 170 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m34 0 h10 m20 0 h10 m82 0 h10 m20 0 h10 m114 0 h10 m-154 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m134 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-134 0 h10 m24 0 h10 m0 0 h90 m20 44 h26 m-322 0 h20 m302 0 h20 m-342 0 q10 0 10 10 m322 0 q0 -10 10 -10 m-332 10 v68 m322 0 v-68 m-322 68 q0 10 10 10 m302 0 q10 0 10 -10 m-312 10 h10 m98 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m144 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-144 0 h10 m24 0 h10 m0 0 h100 m-376 -44 h20 m396 0 h20 m-436 0 q10 0 10 10 m416 0 q0 -10 10 -10 m-426 10 v102 m416 0 v-102 m-416 102 q0 10 10 10 m396 0 q10 0 10 -10 m-406 10 h10 m0 0 h386 m22 -122 l2 0 m2 0 l2 0 m2 0 l2 0 m-240 170 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m140 0 h10 m0 0 h10 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v24 m190 0 v-24 m-190 24 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m150 0 h10 m23 -44 h-3"/>
+   <polygon points="453 467 461 463 461 471"/>
+   <polygon points="453 467 445 463 445 471"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -2,7 +2,7 @@ aggregate_with_filter ::= aggregate_name '(' expression ')' ('FILTER' '(' 'WHERE
 alter_connection ::=
   'ALTER' 'CONNECTION' 'IF EXISTS'? name 'ROTATE' 'KEYS'
 alter_default_privileges ::=
-  'ALTER' 'DEFAULT' 'PRIVILEGES' ( 'FOR' ( 'ROLE' | 'USER' )? role )? ( 'IN' 'SCHEMA' schema_name (',' schema_name)* | 'IN' 'DATABASE' database_name (',' database_name)* )? ( abbreviated_grant | abbreviated_revoke )
+  'ALTER' 'DEFAULT' 'PRIVILEGES' ( 'FOR' ( 'ROLE' | 'USER' ) target_role (',' target_role)* )? ( 'IN' 'SCHEMA' schema_name (',' schema_name)* | 'IN' 'DATABASE' database_name (',' database_name)* )? ( abbreviated_grant | abbreviated_revoke )
 abbreviated_grant ::=
   'GRANT' ((privilege (',' privilege)*) | 'ALL' 'PRIVILEGES'? ) ON ('TABLES' | 'TYPES' | 'SECRETS' | 'CONNECTIONS' | 'DATABASES' | 'SCHEMAS' | 'CLUSTERS') 'TO' 'GROUP'? grantee (',' grantee)*
 abbreviated_revoke ::=

--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -20,6 +20,7 @@ from materialize.checks.create_index import *  # noqa: F401 F403
 from materialize.checks.create_table import *  # noqa: F401 F403
 from materialize.checks.databases import *  # noqa: F401 F403
 from materialize.checks.debezium import *  # noqa: F401 F403
+from materialize.checks.default_privileges import *  # noqa: F401 F403
 from materialize.checks.delete import *  # noqa: F401 F403
 from materialize.checks.drop_index import *  # noqa: F401 F403
 from materialize.checks.drop_table import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/default_privileges.py
+++ b/misc/python/materialize/checks/default_privileges.py
@@ -1,0 +1,90 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+from typing import List
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.util import MzVersion
+
+
+class DefaultPrivileges(Check):
+    def _can_run(self) -> bool:
+        return self.base_version >= MzVersion.parse("0.58.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+            > CREATE DATABASE defpriv_db
+            > SET DATABASE = defpriv_db
+            > CREATE SCHEMA defpriv_schema
+            > SET SCHEMA defpriv_schema
+            > CREATE ROLE defpriv_role1 CREATEDB CREATECLUSTER
+            > CREATE TABLE defpriv_table1 (c int)
+            """
+            )
+        )
+
+    def manipulate(self) -> List[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > SET DATABASE = defpriv_db
+                > SET SCHEMA defpriv_schema
+                > ALTER DEFAULT PRIVILEGES IN SCHEMA defpriv_db.defpriv_schema GRANT ALL PRIVILEGES ON TABLES TO defpriv_role1;
+                > CREATE ROLE defpriv_role2 CREATEDB CREATECLUSTER
+                > CREATE TABLE defpriv_table2 (c int)
+                """,
+                """
+                > SET DATABASE = defpriv_db
+                > SET SCHEMA defpriv_schema
+                > ALTER DEFAULT PRIVILEGES IN SCHEMA defpriv_db.defpriv_schema GRANT ALL PRIVILEGES ON TABLES TO defpriv_role2;
+                > CREATE ROLE defpriv_role3 CREATEDB CREATECLUSTER
+                > CREATE TABLE defpriv_table3 (c int)
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SET DATABASE = defpriv_db
+                > SET SCHEMA defpriv_schema
+                > ALTER DEFAULT PRIVILEGES IN SCHEMA defpriv_db.defpriv_schema GRANT ALL PRIVILEGES ON TABLES TO defpriv_role3;
+                > SELECT
+                    (CASE defaults.role_id WHEN 'p' THEN 'PUBLIC' ELSE roles.name END) AS role_name,
+                    databases.name AS database_name,
+                    schemas.name AS schema_name,
+                    defaults.object_type AS object_type,
+                    (CASE defaults.grantee WHEN 'p' THEN 'PUBLIC' ELSE grantees.name END) AS grantee_name,
+                    defaults.privileges AS privileges
+                  FROM mz_default_privileges defaults
+                  LEFT JOIN mz_roles AS roles ON defaults.role_id = roles.id
+                  LEFT JOIN mz_roles AS grantees ON defaults.grantee = grantees.id
+                  LEFT JOIN mz_databases AS databases ON defaults.database_id = databases.id
+                  LEFT JOIN mz_schemas AS schemas ON defaults.schema_id = schemas.id
+                  ORDER BY role_name, grantee_name;
+                PUBLIC <null> <null> TYPE PUBLIC U
+                materialize defpriv_db defpriv_schema TABLE defpriv_role1 arwd
+                materialize defpriv_db defpriv_schema TABLE defpriv_role2 arwd
+                materialize defpriv_db defpriv_schema TABLE defpriv_role3 arwd
+
+                > SELECT name, unnest(privileges)::text FROM mz_tables WHERE name LIKE 'defpriv_table%'
+                defpriv_table1 materialize=arwd/materialize
+                defpriv_table2 defpriv_role1=arwd/materialize
+                defpriv_table2 materialize=arwd/materialize
+                defpriv_table3 defpriv_role1=arwd/materialize
+                defpriv_table3 defpriv_role2=arwd/materialize
+                defpriv_table3 materialize=arwd/materialize
+                """
+            )
+        )

--- a/misc/python/materialize/checks/identifiers.py
+++ b/misc/python/materialize/checks/identifiers.py
@@ -251,7 +251,7 @@ class Identifiers(Check):
 
     def validate(self) -> Testdrive:
         cmds = f"""
-        > SHOW DATABASES WHERE name NOT LIKE 'to_be_created%' AND name NOT LIKE 'owner_db%';
+        > SHOW DATABASES WHERE name NOT LIKE 'to_be_created%' AND name NOT LIKE 'owner_db%' AND name <> 'defpriv_db';
         materialize
         {dq(self.ident["db"])}
 

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -1610,6 +1610,29 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    /// Set persisted default privilege.
+    pub fn set_default_privilege(
+        &mut self,
+        role_id: RoleId,
+        database_id: Option<DatabaseId>,
+        schema_id: Option<SchemaId>,
+        object_type: ObjectType,
+        grantee: RoleId,
+        privileges: Option<AclMode>,
+    ) -> Result<(), Error> {
+        self.default_privileges.set(
+            DefaultPrivilegesKey {
+                role_id,
+                database_id,
+                schema_id,
+                object_type,
+                grantee,
+            },
+            privileges.map(|privileges| DefaultPrivilegesValue { privileges }),
+        )?;
+        Ok(())
+    }
+
     /// Upserts persisted system configuration `name` to `value`.
     pub fn upsert_system_config(&mut self, name: &str, value: String) -> Result<(), Error> {
         let key = ServerConfigurationKey {

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -294,6 +294,8 @@ impl IntoIterator for GetVariablesResponse {
 #[derivative(Debug)]
 #[enum_kind(ExecuteResponseKind)]
 pub enum ExecuteResponse {
+    /// The default privileges were altered.
+    AlteredDefaultPrivileges,
     /// The requested object was altered.
     AlteredObject(ObjectType),
     /// The index was altered.
@@ -424,6 +426,7 @@ impl ExecuteResponse {
     pub fn tag(&self) -> Option<String> {
         use ExecuteResponse::*;
         match self {
+            AlteredDefaultPrivileges => Some("ALTER DEFAULT PRIVILEGES".into()),
             AlteredObject(o) => Some(format!("ALTER {}", o)),
             AlteredIndexLogicalCompaction => Some("ALTER INDEX".into()),
             AlteredRole => Some("ALTER ROLE".into()),
@@ -504,6 +507,7 @@ impl ExecuteResponse {
             | RotateKeys => {
                 vec![AlteredObject]
             }
+            AlterDefaultPrivileges => vec![AlteredDefaultPrivileges],
             AlterIndexSetOptions | AlterIndexResetOptions => {
                 vec![AlteredObject, AlteredIndexLogicalCompaction]
             }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -986,6 +986,7 @@ impl Coordinator {
                 | Op::AlterSource { .. }
                 | Op::DropTimeline(_)
                 | Op::UpdatePrivilege { .. }
+                | Op::UpdateDefaultPrivilege { .. }
                 | Op::GrantRole { .. }
                 | Op::RenameCluster { .. }
                 | Op::RenameClusterReplica { .. }

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -101,6 +101,7 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
         | Plan::RevokeRole(_)
         | Plan::GrantPrivileges(_)
         | Plan::RevokePrivileges(_)
+        | Plan::AlterDefaultPrivileges(_)
         | Plan::ReassignOwned(_) => return TargetCluster::Active,
     };
 
@@ -288,6 +289,7 @@ pub fn user_privilege_hack(
         | Plan::RevokeRole(_)
         | Plan::GrantPrivileges(_)
         | Plan::RevokePrivileges(_)
+        | Plan::AlterDefaultPrivileges(_)
         | Plan::CopyRows(_)
         | Plan::ReassignOwned(_) => {
             return Err(AdapterError::Unauthorized(

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -467,6 +467,13 @@ impl Coordinator {
                     session,
                 );
             }
+            Plan::AlterDefaultPrivileges(plan) => {
+                tx.send(
+                    self.sequence_alter_default_privileges(&mut session, plan)
+                        .await,
+                    session,
+                );
+            }
             Plan::GrantRole(plan) => {
                 tx.send(self.sequence_grant_role(&mut session, plan).await, session);
             }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -906,6 +906,7 @@ async fn execute_stmt<S: ResultSender>(
         | ExecuteResponse::Raised
         | ExecuteResponse::ReassignOwned
         | ExecuteResponse::RevokedPrivilege
+        | ExecuteResponse::AlteredDefaultPrivileges
         | ExecuteResponse::RevokedRole
         | ExecuteResponse::StartedTransaction { .. }
         | ExecuteResponse::Updated(_)

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1423,7 +1423,8 @@ where
                 command_complete!()
             }
 
-            ExecuteResponse::AlteredIndexLogicalCompaction
+            ExecuteResponse::AlteredDefaultPrivileges
+            | ExecuteResponse::AlteredIndexLogicalCompaction
             | ExecuteResponse::AlteredObject(..)
             | ExecuteResponse::AlteredRole
             | ExecuteResponse::AlteredSystemConfiguration

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2960,6 +2960,16 @@ pub enum GrantTargetAllSpecification<T: AstInfo> {
     AllSchemas { schemas: Vec<T::SchemaName> },
 }
 
+impl<T: AstInfo> GrantTargetAllSpecification<T> {
+    pub fn len(&self) -> usize {
+        match self {
+            GrantTargetAllSpecification::All => 1,
+            GrantTargetAllSpecification::AllDatabases { databases } => databases.len(),
+            GrantTargetAllSpecification::AllSchemas { schemas } => schemas.len(),
+        }
+    }
+}
+
 impl<T: AstInfo> AstDisplay for GrantTargetSpecification<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match &self.object_spec_inner {
@@ -3092,6 +3102,29 @@ pub enum AbbreviatedGrantOrRevokeStatement<T: AstInfo> {
     Revoke(AbbreviatedRevokeStatement<T>),
 }
 
+impl<T: AstInfo> AbbreviatedGrantOrRevokeStatement<T> {
+    pub fn privileges(&self) -> &PrivilegeSpecification {
+        match self {
+            AbbreviatedGrantOrRevokeStatement::Grant(grant) => &grant.privileges,
+            AbbreviatedGrantOrRevokeStatement::Revoke(revoke) => &revoke.privileges,
+        }
+    }
+
+    pub fn object_type(&self) -> &ObjectType {
+        match self {
+            AbbreviatedGrantOrRevokeStatement::Grant(grant) => &grant.object_type,
+            AbbreviatedGrantOrRevokeStatement::Revoke(revoke) => &revoke.object_type,
+        }
+    }
+
+    pub fn roles(&self) -> &Vec<T::RoleName> {
+        match self {
+            AbbreviatedGrantOrRevokeStatement::Grant(grant) => &grant.grantees,
+            AbbreviatedGrantOrRevokeStatement::Revoke(revoke) => &revoke.revokees,
+        }
+    }
+}
+
 impl<T: AstInfo> AstDisplay for AbbreviatedGrantOrRevokeStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
@@ -3117,7 +3150,7 @@ impl<T: AstInfo> AstDisplay for AlterDefaultPrivilegesStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("ALTER DEFAULT PRIVILEGES");
         if let Some(target_roles) = &self.target_roles {
-            f.write_str(" FOR ");
+            f.write_str(" FOR ROLE ");
             f.write_node(&display::comma_separated(target_roles));
         }
         match &self.target_objects {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4077,7 +4077,7 @@ impl<'a> Parser<'a> {
 
     fn parse_alter_default_privileges(&mut self) -> Result<Statement<Raw>, ParserError> {
         let target_roles = if self.parse_keyword(FOR) {
-            let _ = self.parse_one_of_keywords(&[ROLE, USER]);
+            let _ = self.expect_one_of_keywords(&[ROLE, USER])?;
             Some(self.parse_comma_separated(Parser::parse_identifier)?)
         } else {
             None

--- a/src/sql-parser/tests/testdata/acl
+++ b/src/sql-parser/tests/testdata/acl
@@ -952,42 +952,42 @@ AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, tar
 parse-statement
 ALTER DEFAULT PRIVILEGES FOR r1 GRANT ALL ON CLUSTERS TO joe
 ----
+error: Expected one of ROLE or USER, found identifier "r1"
 ALTER DEFAULT PRIVILEGES FOR r1 GRANT ALL ON CLUSTERS TO joe
-=>
-AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: All, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: All, object_type: Cluster, grantees: [Ident("joe")] }) })
+                             ^
 
 parse-statement
 ALTER DEFAULT PRIVILEGES FOR ROLE r1 GRANT ALL ON CLUSTERS TO joe
 ----
-ALTER DEFAULT PRIVILEGES FOR r1 GRANT ALL ON CLUSTERS TO joe
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 GRANT ALL ON CLUSTERS TO joe
 =>
 AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: All, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: All, object_type: Cluster, grantees: [Ident("joe")] }) })
 
 parse-statement
 ALTER DEFAULT PRIVILEGES FOR USER r1 GRANT ALL ON CLUSTERS TO joe
 ----
-ALTER DEFAULT PRIVILEGES FOR r1 GRANT ALL ON CLUSTERS TO joe
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 GRANT ALL ON CLUSTERS TO joe
 =>
 AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: All, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: All, object_type: Cluster, grantees: [Ident("joe")] }) })
 
 parse-statement
-ALTER DEFAULT PRIVILEGES FOR r1, r2 GRANT CREATE ON DATABASES TO joe, mike
+ALTER DEFAULT PRIVILEGES FOR ROLE r1, r2 GRANT CREATE ON DATABASES TO joe, mike
 ----
-ALTER DEFAULT PRIVILEGES FOR r1, r2 GRANT CREATE ON DATABASES TO joe, mike
+ALTER DEFAULT PRIVILEGES FOR ROLE r1, r2 GRANT CREATE ON DATABASES TO joe, mike
 =>
 AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1"), Ident("r2")]), target_objects: All, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: Privileges([CREATE]), object_type: Database, grantees: [Ident("joe"), Ident("mike")] }) })
 
 parse-statement
-ALTER DEFAULT PRIVILEGES FOR r1 IN SCHEMA s1 GRANT CREATE ON SCHEMAS TO joe
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 IN SCHEMA s1 GRANT CREATE ON SCHEMAS TO joe
 ----
-ALTER DEFAULT PRIVILEGES FOR r1 IN SCHEMA s1 GRANT CREATE ON SCHEMAS TO joe
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 IN SCHEMA s1 GRANT CREATE ON SCHEMAS TO joe
 =>
 AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")])] }, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: Privileges([CREATE]), object_type: Schema, grantees: [Ident("joe")] }) })
 
 parse-statement
-ALTER DEFAULT PRIVILEGES FOR r1 IN DATABASE d1 GRANT USAGE ON SECRETS TO joe
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 IN DATABASE d1 GRANT USAGE ON SECRETS TO joe
 ----
-ALTER DEFAULT PRIVILEGES FOR r1 IN DATABASE d1 GRANT USAGE ON SECRETS TO joe
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 IN DATABASE d1 GRANT USAGE ON SECRETS TO joe
 =>
 AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1"))] }, grant_or_revoke: Grant(AbbreviatedGrantStatement { privileges: Privileges([USAGE]), object_type: Secret, grantees: [Ident("joe")] }) })
 
@@ -1064,42 +1064,42 @@ AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: None, tar
 parse-statement
 ALTER DEFAULT PRIVILEGES FOR r1 REVOKE ALL ON CLUSTERS FROM joe
 ----
+error: Expected one of ROLE or USER, found identifier "r1"
 ALTER DEFAULT PRIVILEGES FOR r1 REVOKE ALL ON CLUSTERS FROM joe
-=>
-AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: All, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: All, object_type: Cluster, revokees: [Ident("joe")] }) })
+                             ^
 
 parse-statement
 ALTER DEFAULT PRIVILEGES FOR ROLE r1 REVOKE ALL ON CLUSTERS FROM joe
 ----
-ALTER DEFAULT PRIVILEGES FOR r1 REVOKE ALL ON CLUSTERS FROM joe
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 REVOKE ALL ON CLUSTERS FROM joe
 =>
 AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: All, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: All, object_type: Cluster, revokees: [Ident("joe")] }) })
 
 parse-statement
 ALTER DEFAULT PRIVILEGES FOR USER r1 REVOKE ALL ON CLUSTERS FROM joe
 ----
-ALTER DEFAULT PRIVILEGES FOR r1 REVOKE ALL ON CLUSTERS FROM joe
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 REVOKE ALL ON CLUSTERS FROM joe
 =>
 AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: All, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: All, object_type: Cluster, revokees: [Ident("joe")] }) })
 
 parse-statement
-ALTER DEFAULT PRIVILEGES FOR r1, r2 REVOKE CREATE ON DATABASES FROM joe, mike
+ALTER DEFAULT PRIVILEGES FOR ROLE r1, r2 REVOKE CREATE ON DATABASES FROM joe, mike
 ----
-ALTER DEFAULT PRIVILEGES FOR r1, r2 REVOKE CREATE ON DATABASES FROM joe, mike
+ALTER DEFAULT PRIVILEGES FOR ROLE r1, r2 REVOKE CREATE ON DATABASES FROM joe, mike
 =>
 AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1"), Ident("r2")]), target_objects: All, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: Privileges([CREATE]), object_type: Database, revokees: [Ident("joe"), Ident("mike")] }) })
 
 parse-statement
-ALTER DEFAULT PRIVILEGES FOR r1 IN SCHEMA s1 REVOKE CREATE ON SCHEMAS FROM joe
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 IN SCHEMA s1 REVOKE CREATE ON SCHEMAS FROM joe
 ----
-ALTER DEFAULT PRIVILEGES FOR r1 IN SCHEMA s1 REVOKE CREATE ON SCHEMAS FROM joe
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 IN SCHEMA s1 REVOKE CREATE ON SCHEMAS FROM joe
 =>
 AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: AllSchemas { schemas: [UnresolvedSchemaName([Ident("s1")])] }, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: Privileges([CREATE]), object_type: Schema, revokees: [Ident("joe")] }) })
 
 parse-statement
-ALTER DEFAULT PRIVILEGES FOR r1 IN DATABASE d1 REVOKE USAGE ON SECRETS FROM joe
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 IN DATABASE d1 REVOKE USAGE ON SECRETS FROM joe
 ----
-ALTER DEFAULT PRIVILEGES FOR r1 IN DATABASE d1 REVOKE USAGE ON SECRETS FROM joe
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 IN DATABASE d1 REVOKE USAGE ON SECRETS FROM joe
 =>
 AlterDefaultPrivileges(AlterDefaultPrivilegesStatement { target_roles: Some([Ident("r1")]), target_objects: AllDatabases { databases: [UnresolvedDatabaseName(Ident("d1"))] }, grant_or_revoke: Revoke(AbbreviatedRevokeStatement { privileges: Privileges([USAGE]), object_type: Secret, revokees: [Ident("joe")] }) })
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -25,7 +25,7 @@ use mz_build_info::BuildInfo;
 use mz_controller::clusters::{ClusterId, ReplicaId};
 use mz_expr::MirScalarExpr;
 use mz_ore::now::{EpochMillis, NowFn};
-use mz_repr::adt::mz_acl_item::{AclMode, PrivilegeMap};
+use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap};
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::role_id::RoleId;
 use mz_repr::{ColumnName, GlobalId, RelationDesc};
@@ -232,6 +232,11 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
 
     /// Gets all cluster replicas.
     fn get_cluster_replicas(&self) -> Vec<&dyn CatalogClusterReplica>;
+
+    /// Gets all default privileges.
+    fn get_default_privileges(
+        &self,
+    ) -> Vec<(&DefaultPrivilegeObject, Vec<&DefaultPrivilegeAclItem>)>;
 
     /// Finds a name like `name` that is not already in use.
     ///
@@ -1366,6 +1371,61 @@ impl RustType<proto::ObjectType> for ObjectType {
             proto::ObjectType::Unknown => Err(TryFromProtoError::unknown_enum_variant(
                 "ObjectType::Unknown",
             )),
+        }
+    }
+}
+
+/// Specification for objects that will be affected by a default privilege.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DefaultPrivilegeObject {
+    /// The role id that created the object.
+    pub role_id: RoleId,
+    /// The database that the object is created in if Some, otherwise all databases.
+    pub database_id: Option<DatabaseId>,
+    /// The schema that the object is created in if Some, otherwise all databases.
+    pub schema_id: Option<SchemaId>,
+    /// The type of object.
+    pub object_type: ObjectType,
+}
+
+impl DefaultPrivilegeObject {
+    /// Creates a new [`DefaultPrivilegeObject`].
+    pub fn new(
+        role_id: RoleId,
+        database_id: Option<DatabaseId>,
+        schema_id: Option<SchemaId>,
+        object_type: ObjectType,
+    ) -> DefaultPrivilegeObject {
+        DefaultPrivilegeObject {
+            role_id,
+            database_id,
+            schema_id,
+            object_type,
+        }
+    }
+}
+
+/// Specification for the privileges that will be granted from default privileges.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DefaultPrivilegeAclItem {
+    /// The role that will receive the privileges.
+    pub grantee: RoleId,
+    /// The specific privileges granted.
+    pub acl_mode: AclMode,
+}
+
+impl DefaultPrivilegeAclItem {
+    /// Creates a new [`DefaultPrivilegeAclItem`].
+    pub fn new(grantee: RoleId, acl_mode: AclMode) -> DefaultPrivilegeAclItem {
+        DefaultPrivilegeAclItem { grantee, acl_mode }
+    }
+
+    /// Converts this [`DefaultPrivilegeAclItem`] into an [`MzAclItem`].
+    pub fn mz_acl_item(self, grantor: RoleId) -> MzAclItem {
+        MzAclItem {
+            grantee: self.grantee,
+            grantor,
+            acl_mode: self.acl_mode,
         }
     }
 }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -295,6 +295,15 @@ impl From<DatabaseId> for ResolvedDatabaseSpecifier {
     }
 }
 
+impl From<Option<DatabaseId>> for ResolvedDatabaseSpecifier {
+    fn from(id: Option<DatabaseId>) -> Self {
+        match id {
+            Some(id) => Self::Id(id),
+            None => Self::Ambient,
+        }
+    }
+}
+
 /*
  * TODO(jkosh44) It's possible that in order to fix
  * https://github.com/MaterializeInc/materialize/issues/8805 we will need to assign temporary

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -94,7 +94,7 @@ pub enum PlanError {
     InvalidPrivilegeTypes {
         invalid_privileges: AclMode,
         object_type: ObjectType,
-        object_name: String,
+        object_name: Option<String>,
     },
     InvalidVarCharMaxLength(InvalidVarCharMaxLengthError),
     InvalidSecret(Box<ResolvedItemName>),
@@ -371,7 +371,8 @@ impl fmt::Display for PlanError {
             Self::InvalidObject(i) => write!(f, "{} is not a database object", i.full_name_str()),
             Self::InvalidObjectType{expected_type, actual_type, object_name} => write!(f, "{actual_type} {object_name} is not a {expected_type}"),
             Self::InvalidPrivilegeTypes{ invalid_privileges, object_type, object_name} => {
-                write!(f, "invalid privilege types {} for {} {}", invalid_privileges.to_error_string(), object_type, object_name.quoted())
+                let object_name = object_name.as_ref().map(|object_name| format!(" {}", object_name.quoted())).unwrap_or_else(||"".to_string());
+                write!(f, "invalid privilege types {} for {}{}", invalid_privileges.to_error_string(), object_type, object_name)
             },
             Self::InvalidSecret(i) => write!(f, "{} is not a secret", i.full_name_str()),
             Self::InvalidTemporarySchema => {

--- a/src/sql/src/plan/statement/acl.rs
+++ b/src/sql/src/plan/statement/acl.rs
@@ -17,7 +17,9 @@ use std::collections::BTreeSet;
 use itertools::Itertools;
 
 use crate::ast::{Ident, QualifiedReplica, UnresolvedDatabaseName};
-use crate::catalog::{CatalogItemType, ObjectType};
+use crate::catalog::{
+    CatalogItemType, DefaultPrivilegeAclItem, DefaultPrivilegeObject, ObjectType,
+};
 use crate::names::{Aug, ObjectId, ResolvedDatabaseSpecifier, ResolvedRoleName, SchemaSpecifier};
 use crate::plan::error::PlanError;
 use crate::plan::statement::ddl::{
@@ -25,19 +27,19 @@ use crate::plan::statement::ddl::{
 };
 use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::{
-    AlterNoopPlan, AlterOwnerPlan, GrantPrivilegesPlan, GrantRolePlan, Plan, ReassignOwnedPlan,
-    RevokePrivilegesPlan, RevokeRolePlan, UpdatePrivilege,
+    AlterDefaultPrivilegesPlan, AlterNoopPlan, AlterOwnerPlan, GrantPrivilegesPlan, GrantRolePlan,
+    Plan, ReassignOwnedPlan, RevokePrivilegesPlan, RevokeRolePlan, UpdatePrivilege,
 };
 use crate::session::user::SYSTEM_USER;
 use mz_ore::str::StrExt;
 use mz_repr::adt::mz_acl_item::AclMode;
 use mz_repr::role_id::RoleId;
 use mz_sql_parser::ast::{
-    AlterDefaultPrivilegesStatement, AlterOwnerStatement, GrantPrivilegesStatement,
-    GrantRoleStatement, GrantTargetAllSpecification, GrantTargetSpecification,
-    GrantTargetSpecificationInner, Privilege, PrivilegeSpecification, ReassignOwnedStatement,
-    RevokePrivilegesStatement, RevokeRoleStatement, UnresolvedItemName, UnresolvedObjectName,
-    UnresolvedSchemaName,
+    AbbreviatedGrantOrRevokeStatement, AlterDefaultPrivilegesStatement, AlterOwnerStatement,
+    GrantPrivilegesStatement, GrantRoleStatement, GrantTargetAllSpecification,
+    GrantTargetSpecification, GrantTargetSpecificationInner, Privilege, PrivilegeSpecification,
+    ReassignOwnedStatement, RevokePrivilegesStatement, RevokeRoleStatement, UnresolvedItemName,
+    UnresolvedObjectName, UnresolvedSchemaName,
 };
 
 pub fn describe_alter_owner(
@@ -455,14 +457,7 @@ fn plan_update_privilege(
         let actual_object_type = scx.get_object_type(&object_id);
         let mut reference_object_type = actual_object_type.clone();
 
-        let acl_mode = match &privileges {
-            PrivilegeSpecification::All => scx.catalog.all_object_privileges(actual_object_type),
-            PrivilegeSpecification::Privileges(privileges) => privileges
-                .into_iter()
-                .map(|privilege| privilege_to_acl_mode(privilege.clone()))
-                // PostgreSQL doesn't care about duplicate privileges, so we don't either.
-                .fold(AclMode::empty(), |accum, acl_mode| accum.union(acl_mode)),
-        };
+        let acl_mode = privilege_spec_to_acl_mode(scx, &privileges, actual_object_type);
 
         if let ObjectId::Item(id) = &object_id {
             let item = scx.get_item(id);
@@ -491,7 +486,7 @@ fn plan_update_privilege(
             return Err(PlanError::InvalidPrivilegeTypes {
                 invalid_privileges,
                 object_type: actual_object_type,
-                object_name,
+                object_name: Some(object_name),
             });
         }
 
@@ -521,6 +516,21 @@ fn plan_update_privilege(
     })
 }
 
+fn privilege_spec_to_acl_mode(
+    scx: &StatementContext,
+    privilege_spec: &PrivilegeSpecification,
+    object_type: ObjectType,
+) -> AclMode {
+    match privilege_spec {
+        PrivilegeSpecification::All => scx.catalog.all_object_privileges(object_type),
+        PrivilegeSpecification::Privileges(privileges) => privileges
+            .into_iter()
+            .map(|privilege| privilege_to_acl_mode(privilege.clone()))
+            // PostgreSQL doesn't care about duplicate privileges, so we don't either.
+            .fold(AclMode::empty(), |accum, acl_mode| accum.union(acl_mode)),
+    }
+}
+
 fn privilege_to_acl_mode(privilege: Privilege) -> AclMode {
     match privilege {
         Privilege::SELECT => AclMode::SELECT,
@@ -536,14 +546,117 @@ pub fn describe_alter_default_privileges(
     _: &StatementContext,
     _: AlterDefaultPrivilegesStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
-    bail_unsupported!("ALTER DEFAULT PRIVILEGES")
+    Ok(StatementDesc::new(None))
 }
 
 pub fn plan_alter_default_privileges(
-    _: &StatementContext,
-    _: AlterDefaultPrivilegesStatement<Aug>,
+    scx: &StatementContext,
+    AlterDefaultPrivilegesStatement {
+        target_roles,
+        target_objects,
+        grant_or_revoke,
+    }: AlterDefaultPrivilegesStatement<Aug>,
 ) -> Result<Plan, PlanError> {
-    bail_unsupported!("ALTER DEFAULT PRIVILEGES")
+    let object_type = (*grant_or_revoke.object_type()).into();
+    match object_type {
+        ObjectType::View | ObjectType::MaterializedView | ObjectType::Source => sql_bail!(
+            "{object_type}S is not valid for ALTER DEFAULT PRIVILEGES, use TABLES instead"
+        ),
+        ObjectType::Sink | ObjectType::ClusterReplica | ObjectType::Role | ObjectType::Func => {
+            sql_bail!("{object_type}S do not have privileges")
+        }
+        ObjectType::Cluster | ObjectType::Database
+            if matches!(
+                target_objects,
+                GrantTargetAllSpecification::AllDatabases { .. }
+            ) =>
+        {
+            sql_bail!("cannot specify {object_type}S and IN DATABASE")
+        }
+
+        ObjectType::Cluster | ObjectType::Database | ObjectType::Schema
+            if matches!(
+                target_objects,
+                GrantTargetAllSpecification::AllSchemas { .. }
+            ) =>
+        {
+            sql_bail!("cannot specify {object_type}S and IN SCHEMA")
+        }
+        ObjectType::Table
+        | ObjectType::Index
+        | ObjectType::Type
+        | ObjectType::Secret
+        | ObjectType::Connection
+        | ObjectType::Cluster
+        | ObjectType::Database
+        | ObjectType::Schema => {}
+    }
+
+    let acl_mode = privilege_spec_to_acl_mode(scx, grant_or_revoke.privileges(), object_type);
+    let all_object_privileges = scx.catalog.all_object_privileges(object_type);
+    let invalid_privileges = acl_mode.difference(all_object_privileges);
+    if !invalid_privileges.is_empty() {
+        return Err(PlanError::InvalidPrivilegeTypes {
+            invalid_privileges,
+            object_type,
+            object_name: None,
+        });
+    }
+
+    let target_roles = target_roles
+        .map(|target_roles| target_roles.into_iter().map(|role| role.id).collect())
+        .unwrap_or_else(|| vec![*scx.catalog.active_role_id()]);
+    let mut privilege_objects = Vec::with_capacity(target_roles.len() * target_objects.len());
+    for target_role in target_roles {
+        match &target_objects {
+            GrantTargetAllSpecification::All => privilege_objects.push(DefaultPrivilegeObject {
+                role_id: target_role,
+                database_id: None,
+                schema_id: None,
+                object_type,
+            }),
+            GrantTargetAllSpecification::AllDatabases { databases } => {
+                for database in databases {
+                    privilege_objects.push(DefaultPrivilegeObject {
+                        role_id: target_role,
+                        database_id: Some(*database.database_id()),
+                        schema_id: None,
+                        object_type,
+                    });
+                }
+            }
+            GrantTargetAllSpecification::AllSchemas { schemas } => {
+                for schema in schemas {
+                    privilege_objects.push(DefaultPrivilegeObject {
+                        role_id: target_role,
+                        database_id: schema.database_spec().id(),
+                        schema_id: Some(schema.schema_spec().into()),
+                        object_type,
+                    });
+                }
+            }
+        }
+    }
+
+    let privilege_acl_items = grant_or_revoke
+        .roles()
+        .into_iter()
+        .map(|grantee| DefaultPrivilegeAclItem {
+            grantee: grantee.id,
+            acl_mode,
+        })
+        .collect();
+
+    let is_grant = match grant_or_revoke {
+        AbbreviatedGrantOrRevokeStatement::Grant(_) => true,
+        AbbreviatedGrantOrRevokeStatement::Revoke(_) => false,
+    };
+
+    Ok(Plan::AlterDefaultPrivileges(AlterDefaultPrivilegesPlan {
+        privilege_objects,
+        privilege_acl_items,
+        is_grant,
+    }))
 }
 
 pub fn describe_reassign_owned(

--- a/test/sqllogictest/default_privileges.slt
+++ b/test/sqllogictest/default_privileges.slt
@@ -11,6 +11,19 @@ mode cockroach
 
 reset-server
 
+# Enable rbac checks.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_rbac_checks TO true;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_ld_rbac_checks TO true;
+----
+COMPLETE 0
+
+# Test pre-populated default privileges
+
 query TTTTTT
 SELECT * FROM mz_default_privileges
 ----
@@ -24,3 +37,4885 @@ SELECT unnest(privileges)::text FROM mz_types WHERE name = 'ty'
 ----
 =U/materialize
 materialize=U/materialize
+
+statement ok
+DROP TYPE ty
+
+# Create helper view
+statement ok
+CREATE VIEW default_privileges AS
+SELECT
+  (CASE defaults.role_id WHEN 'p' THEN 'PUBLIC' ELSE roles.name END) AS role_name,
+  databases.name AS database_name,
+  schemas.name AS schema_name,
+  defaults.object_type AS object_type,
+  (CASE defaults.grantee WHEN 'p' THEN 'PUBLIC' ELSE grantees.name END) AS grantee_name,
+  defaults.privileges AS privileges
+FROM mz_default_privileges defaults
+LEFT JOIN mz_roles AS roles ON defaults.role_id = roles.id
+LEFT JOIN mz_roles AS grantees ON defaults.grantee = grantees.id
+LEFT JOIN mz_databases AS databases ON defaults.database_id = databases.id
+LEFT JOIN mz_schemas AS schemas ON defaults.schema_id = schemas.id
+ORDER BY role_name, grantee_name
+
+# Test altering default privileges
+
+statement ok
+CREATE SCHEMA s0
+
+statement ok
+CREATE DATABASE d1
+
+statement ok
+CREATE SCHEMA d1.s1
+
+statement ok
+CREATE SCHEMA d1.s11
+
+statement ok
+CREATE DATABASE d2
+
+statement ok
+CREATE SCHEMA d2.s2
+
+statement ok
+CREATE SCHEMA d2.s22
+
+statement ok
+CREATE ROLE r1
+
+statement ok
+CREATE ROLE r2
+
+statement ok
+CREATE ROLE r3
+
+statement ok
+CREATE ROLE r4
+
+statement ok
+CREATE ROLE r5
+
+statement ok
+CREATE ROLE r6 CREATECLUSTER CREATEDB
+
+statement ok
+CREATE ROLE r7 CREATECLUSTER CREATEDB
+
+statement ok
+CREATE ROLE r8
+
+statement ok
+CREATE ROLE r9 CREATECLUSTER CREATEDB
+
+statement ok
+CREATE ROLE r10
+
+statement ok
+CREATE ROLE r11 CREATECLUSTER CREATEDB
+
+statement ok
+CREATE ROLE r12
+
+statement ok
+GRANT r6 TO materialize
+
+statement ok
+GRANT r7 TO materialize
+
+statement ok
+GRANT r9 TO materialize
+
+statement ok
+GRANT r11 TO materialize
+
+simple conn=mz_system,user=mz_system
+GRANT CREATE ON SCHEMA materialize.public TO r6, r7;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT CREATE, USAGE ON SCHEMA d1.s1, d1.s11, d2.s2, d2.s22 TO r9, r11;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON DATABASE d1, d2 TO r9, r11;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT CREATE ON DATABASE materialize, d1, d2 TO r6, r7, r9;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT CREATE ON CLUSTER default TO r6, r7, r9, r11;
+----
+COMPLETE 0
+
+## Relations
+
+### Grants
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+materialize  NULL  NULL  TABLE  r1      r
+materialize  NULL  NULL  TABLE  r2      r
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+materialize  NULL  NULL  TABLE  r1      r
+materialize  NULL  NULL  TABLE  r2      r
+materialize  NULL  NULL  TABLE  r3      arwd
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 GRANT INSERT ON TABLES TO r4
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+materialize  NULL  NULL  TABLE  r1      r
+materialize  NULL  NULL  TABLE  r2      r
+materialize  NULL  NULL  TABLE  r3      arwd
+materialize  d1    NULL  TABLE  r4      a
+materialize  d2    NULL  TABLE  r4      a
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA d1.s1, d2.s2 GRANT DELETE ON TABLES TO r5
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+materialize  NULL  NULL  TABLE  r1      r
+materialize  NULL  NULL  TABLE  r2      r
+materialize  NULL  NULL  TABLE  r3      arwd
+materialize  d1    NULL  TABLE  r4      a
+materialize  d2    NULL  TABLE  r4      a
+materialize  d1    s1    TABLE  r5      d
+materialize  d2    s2    TABLE  r5      d
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 GRANT SELECT ON TABLES TO r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TABLE  r8      r
+r7           NULL  NULL  TABLE  r8      r
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+materialize  NULL  NULL  TABLE  r1      r
+materialize  NULL  NULL  TABLE  r2      r
+materialize  NULL  NULL  TABLE  r3      arwd
+materialize  d1    NULL  TABLE  r4      a
+materialize  d2    NULL  TABLE  r4      a
+materialize  d1    s1    TABLE  r5      d
+materialize  d2    s2    TABLE  r5      d
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r9 IN DATABASE d1, d2 GRANT INSERT ON TABLES TO r10
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TABLE  r8      r
+r7           NULL  NULL  TABLE  r8      r
+r9           d1    NULL  TABLE  r10     a
+r9           d2    NULL  TABLE  r10     a
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+materialize  NULL  NULL  TABLE  r1      r
+materialize  NULL  NULL  TABLE  r2      r
+materialize  NULL  NULL  TABLE  r3      arwd
+materialize  d1    NULL  TABLE  r4      a
+materialize  d2    NULL  TABLE  r4      a
+materialize  d1    s1    TABLE  r5      d
+materialize  d2    s2    TABLE  r5      d
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r11 IN SCHEMA d1.s1, d2.s2 GRANT DELETE ON TABLES TO r12
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TABLE  r8      r
+r7           NULL  NULL  TABLE  r8      r
+r9           d1    NULL  TABLE  r10     a
+r9           d2    NULL  TABLE  r10     a
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+r11          d1    s1    TABLE  r12     d
+r11          d2    s2    TABLE  r12     d
+materialize  NULL  NULL  TABLE  r1      r
+materialize  NULL  NULL  TABLE  r2      r
+materialize  NULL  NULL  TABLE  r3      arwd
+materialize  d1    NULL  TABLE  r4      a
+materialize  d2    NULL  TABLE  r4      a
+materialize  d1    s1    TABLE  r5      d
+materialize  d2    s2    TABLE  r5      d
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT UPDATE ON TABLES TO PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TABLE  r8      r
+r7           NULL  NULL  TABLE  r8      r
+r9           d1    NULL  TABLE  r10     a
+r9           d2    NULL  TABLE  r10     a
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+r11          d1    s1    TABLE  r12     d
+r11          d2    s2    TABLE  r12     d
+materialize  NULL  NULL  TABLE  r1      r
+materialize  NULL  NULL  TABLE  r2      r
+materialize  NULL  NULL  TABLE  r3      arwd
+materialize  d1    NULL  TABLE  r4      a
+materialize  d2    NULL  TABLE  r4      a
+materialize  NULL  NULL  TABLE  PUBLIC  w
+materialize  d1    s1    TABLE  r5      d
+materialize  d2    s2    TABLE  r5      d
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO r1
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TABLE  r8      r
+r7           NULL  NULL  TABLE  r8      r
+r9           d1    NULL  TABLE  r10     a
+r9           d2    NULL  TABLE  r10     a
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+r11          d1    s1    TABLE  r12     d
+r11          d2    s2    TABLE  r12     d
+materialize  NULL  NULL  TABLE  r2      r
+materialize  NULL  NULL  TABLE  r1      ar
+materialize  NULL  NULL  TABLE  r3      arwd
+materialize  d1    NULL  TABLE  r4      a
+materialize  d2    NULL  TABLE  r4      a
+materialize  NULL  NULL  TABLE  PUBLIC  w
+materialize  d1    s1    TABLE  r5      d
+materialize  d2    s2    TABLE  r5      d
+
+statement ok
+CREATE TABLE materialize.public.t ()
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  =w/materialize
+t  r2=r/materialize
+t  r1=ar/materialize
+t  r3=arwd/materialize
+t  materialize=arwd/materialize
+
+statement ok
+DROP TABLE t
+
+statement ok
+CREATE VIEW materialize.public.v AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r1=r/materialize
+v  r2=r/materialize
+v  r3=r/materialize
+v  materialize=r/materialize
+
+statement ok
+DROP VIEW v
+
+statement ok
+CREATE MATERIALIZED VIEW materialize.public.mv AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r1=r/materialize
+mv  r2=r/materialize
+mv  r3=r/materialize
+mv  materialize=r/materialize
+
+statement ok
+DROP MATERIALIZED VIEW mv
+
+statement ok
+CREATE SOURCE materialize.public.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r1=r/materialize
+s  r2=r/materialize
+s  r3=r/materialize
+s  materialize=r/materialize
+
+statement ok
+DROP SOURCE s
+
+statement ok
+CREATE TABLE d1.s11.t ()
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  =w/materialize
+t  r2=r/materialize
+t  r4=a/materialize
+t  r1=ar/materialize
+t  r3=arwd/materialize
+t  materialize=arwd/materialize
+
+statement ok
+DROP TABLE d1.s11.t
+
+statement ok
+CREATE VIEW d1.s11.v AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r1=r/materialize
+v  r2=r/materialize
+v  r3=r/materialize
+v  materialize=r/materialize
+
+statement ok
+DROP VIEW d1.s11.v
+
+statement ok
+CREATE MATERIALIZED VIEW d1.s11.mv AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r1=r/materialize
+mv  r2=r/materialize
+mv  r3=r/materialize
+mv  materialize=r/materialize
+
+statement ok
+DROP MATERIALIZED VIEW d1.s11.mv
+
+statement ok
+CREATE SOURCE d1.s11.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r1=r/materialize
+s  r2=r/materialize
+s  r3=r/materialize
+s  materialize=r/materialize
+
+statement ok
+DROP SOURCE d1.s11.s
+
+statement ok
+CREATE TABLE d2.s22.t ()
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  =w/materialize
+t  r2=r/materialize
+t  r4=a/materialize
+t  r1=ar/materialize
+t  r3=arwd/materialize
+t  materialize=arwd/materialize
+
+statement ok
+DROP TABLE d2.s22.t
+
+statement ok
+CREATE VIEW d2.s22.v AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r1=r/materialize
+v  r2=r/materialize
+v  r3=r/materialize
+v  materialize=r/materialize
+
+statement ok
+DROP VIEW d2.s22.v
+
+statement ok
+CREATE MATERIALIZED VIEW d2.s22.mv AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r1=r/materialize
+mv  r2=r/materialize
+mv  r3=r/materialize
+mv  materialize=r/materialize
+
+statement ok
+DROP MATERIALIZED VIEW d2.s22.mv
+
+statement ok
+CREATE SOURCE d2.s22.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r1=r/materialize
+s  r2=r/materialize
+s  r3=r/materialize
+s  materialize=r/materialize
+
+statement ok
+DROP SOURCE d2.s22.s
+
+statement ok
+CREATE TABLE d1.s1.t ()
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  =w/materialize
+t  r2=r/materialize
+t  r4=a/materialize
+t  r5=d/materialize
+t  r1=ar/materialize
+t  r3=arwd/materialize
+t  materialize=arwd/materialize
+
+statement ok
+DROP TABLE d1.s1.t
+
+statement ok
+CREATE VIEW d1.s1.v AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r1=r/materialize
+v  r2=r/materialize
+v  r3=r/materialize
+v  materialize=r/materialize
+
+statement ok
+DROP VIEW d1.s1.v
+
+statement ok
+CREATE MATERIALIZED VIEW d1.s1.mv AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r1=r/materialize
+mv  r2=r/materialize
+mv  r3=r/materialize
+mv  materialize=r/materialize
+
+statement ok
+DROP MATERIALIZED VIEW d1.s1.mv
+
+statement ok
+CREATE SOURCE d1.s1.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r1=r/materialize
+s  r2=r/materialize
+s  r3=r/materialize
+s  materialize=r/materialize
+
+statement ok
+DROP SOURCE d1.s1.s
+
+statement ok
+CREATE TABLE d2.s2.t ()
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  =w/materialize
+t  r2=r/materialize
+t  r4=a/materialize
+t  r5=d/materialize
+t  r1=ar/materialize
+t  r3=arwd/materialize
+t  materialize=arwd/materialize
+
+statement ok
+DROP TABLE d2.s2.t
+
+statement ok
+CREATE VIEW d2.s2.v AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r1=r/materialize
+v  r2=r/materialize
+v  r3=r/materialize
+v  materialize=r/materialize
+
+statement ok
+DROP VIEW d2.s2.v
+
+statement ok
+CREATE MATERIALIZED VIEW d2.s2.mv AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r1=r/materialize
+mv  r2=r/materialize
+mv  r3=r/materialize
+mv  materialize=r/materialize
+
+statement ok
+DROP MATERIALIZED VIEW d2.s2.mv
+
+statement ok
+CREATE SOURCE d2.s2.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r1=r/materialize
+s  r2=r/materialize
+s  r3=r/materialize
+s  materialize=r/materialize
+
+statement ok
+DROP SOURCE d2.s2.s
+
+simple conn=r6,user=r6
+CREATE TABLE materialize.public.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r8=r/r6
+t  r6=arwd/r6
+
+simple conn=r6,user=r6
+DROP TABLE materialize.public.t;
+----
+COMPLETE 0
+
+simple conn=r6,user=r6
+CREATE VIEW materialize.public.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r6=r/r6
+v  r8=r/r6
+
+simple conn=r6,user=r6
+DROP VIEW materialize.public.v;
+----
+COMPLETE 0
+
+simple conn=r6,user=r6
+CREATE MATERIALIZED VIEW materialize.public.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r6=r/r6
+mv  r8=r/r6
+
+simple conn=r6,user=r6
+DROP MATERIALIZED VIEW materialize.public.mv;
+----
+COMPLETE 0
+
+simple conn=r6,user=r6
+CREATE SOURCE materialize.public.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r6=r/r6
+s  r8=r/r6
+
+simple conn=r6,user=r6
+DROP SOURCE materialize.public.s;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE TABLE materialize.public.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r8=r/r7
+t  r7=arwd/r7
+
+simple conn=r7,user=r7
+DROP TABLE materialize.public.t;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE VIEW materialize.public.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r7=r/r7
+v  r8=r/r7
+
+simple conn=r7,user=r7
+DROP VIEW materialize.public.v;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE MATERIALIZED VIEW materialize.public.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r7=r/r7
+mv  r8=r/r7
+
+simple conn=r7,user=r7
+DROP MATERIALIZED VIEW materialize.public.mv;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE SOURCE materialize.public.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r7=r/r7
+s  r8=r/r7
+
+simple conn=r7,user=r7
+DROP SOURCE materialize.public.s;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE TABLE d1.s1.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r10=a/r9
+t  r9=arwd/r9
+
+simple conn=r9,user=r9
+DROP TABLE d1.s1.t;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE VIEW d1.s1.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r9=r/r9
+
+simple conn=r9,user=r9
+DROP VIEW d1.s1.v;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE MATERIALIZED VIEW d1.s1.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r9=r/r9
+
+simple conn=r9,user=r9
+DROP MATERIALIZED VIEW d1.s1.mv;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE SOURCE d1.s1.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r9=r/r9
+
+simple conn=r9,user=r9
+DROP SOURCE d1.s1.s;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE TABLE d2.s2.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r10=a/r9
+t  r9=arwd/r9
+
+simple conn=r9,user=r9
+DROP TABLE d2.s2.t;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE VIEW d2.s2.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r9=r/r9
+
+simple conn=r9,user=r9
+DROP VIEW d2.s2.v;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE MATERIALIZED VIEW d2.s2.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r9=r/r9
+
+simple conn=r9,user=r9
+DROP MATERIALIZED VIEW d2.s2.mv;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE SOURCE d2.s2.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r9=r/r9
+
+simple conn=r9,user=r9
+DROP SOURCE d2.s2.s;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TABLE d1.s1.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r12=d/r11
+t  r11=arwd/r11
+
+simple conn=r11,user=r11
+DROP TABLE d1.s1.t;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE VIEW d1.s1.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r11=r/r11
+
+simple conn=r11,user=r11
+DROP VIEW d1.s1.v;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE MATERIALIZED VIEW d1.s1.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r11=r/r11
+
+simple conn=r11,user=r11
+DROP MATERIALIZED VIEW d1.s1.mv;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SOURCE d1.s1.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r11=r/r11
+
+simple conn=r11,user=r11
+DROP SOURCE d1.s1.s;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TABLE d1.s11.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r11=arwd/r11
+
+simple conn=r11,user=r11
+DROP TABLE d1.s11.t;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE VIEW d1.s11.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r11=r/r11
+
+simple conn=r11,user=r11
+DROP VIEW d1.s11.v;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE MATERIALIZED VIEW d1.s11.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r11=r/r11
+
+simple conn=r11,user=r11
+DROP MATERIALIZED VIEW d1.s11.mv;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SOURCE d1.s11.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r11=r/r11
+
+simple conn=r11,user=r11
+DROP SOURCE d1.s11.s;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TABLE d2.s2.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r12=d/r11
+t  r11=arwd/r11
+
+simple conn=r11,user=r11
+DROP TABLE d2.s2.t;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE VIEW d2.s2.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r11=r/r11
+
+simple conn=r11,user=r11
+DROP VIEW d2.s2.v;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE MATERIALIZED VIEW d2.s2.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r11=r/r11
+
+simple conn=r11,user=r11
+DROP MATERIALIZED VIEW d2.s2.mv;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SOURCE d2.s2.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r11=r/r11
+
+simple conn=r11,user=r11
+DROP SOURCE d2.s2.s;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TABLE d2.s22.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r11=arwd/r11
+
+simple conn=r11,user=r11
+DROP TABLE d2.s22.t;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE VIEW d2.s22.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r11=r/r11
+
+simple conn=r11,user=r11
+DROP VIEW d2.s22.v;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE MATERIALIZED VIEW d2.s22.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r11=r/r11
+
+simple conn=r11,user=r11
+DROP MATERIALIZED VIEW d2.s22.mv;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SOURCE d2.s22.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r11=r/r11
+
+simple conn=r11,user=r11
+DROP SOURCE d2.s22.s;
+----
+COMPLETE 0
+
+### Revokes
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TABLE  r8      r
+r7           NULL  NULL  TABLE  r8      r
+r9           d1    NULL  TABLE  r10     a
+r9           d2    NULL  TABLE  r10     a
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+r11          d1    s1    TABLE  r12     d
+r11          d2    s2    TABLE  r12     d
+materialize  NULL  NULL  TABLE  r1      a
+materialize  NULL  NULL  TABLE  r3      arwd
+materialize  d1    NULL  TABLE  r4      a
+materialize  d2    NULL  TABLE  r4      a
+materialize  NULL  NULL  TABLE  PUBLIC  w
+materialize  d1    s1    TABLE  r5      d
+materialize  d2    s2    TABLE  r5      d
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON TABLES FROM r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TABLE  r8      r
+r7           NULL  NULL  TABLE  r8      r
+r9           d1    NULL  TABLE  r10     a
+r9           d2    NULL  TABLE  r10     a
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+r11          d1    s1    TABLE  r12     d
+r11          d2    s2    TABLE  r12     d
+materialize  NULL  NULL  TABLE  r1      a
+materialize  d1    NULL  TABLE  r4      a
+materialize  d2    NULL  TABLE  r4      a
+materialize  NULL  NULL  TABLE  PUBLIC  w
+materialize  d1    s1    TABLE  r5      d
+materialize  d2    s2    TABLE  r5      d
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 REVOKE INSERT ON TABLES FROM r4
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TABLE  r8      r
+r7           NULL  NULL  TABLE  r8      r
+r9           d1    NULL  TABLE  r10     a
+r9           d2    NULL  TABLE  r10     a
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+r11          d1    s1    TABLE  r12     d
+r11          d2    s2    TABLE  r12     d
+materialize  NULL  NULL  TABLE  r1      a
+materialize  NULL  NULL  TABLE  PUBLIC  w
+materialize  d1    s1    TABLE  r5      d
+materialize  d2    s2    TABLE  r5      d
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA d1.s1, d2.s2 REVOKE DELETE ON TABLES FROM r5
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TABLE  r8      r
+r7           NULL  NULL  TABLE  r8      r
+r9           d1    NULL  TABLE  r10     a
+r9           d2    NULL  TABLE  r10     a
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+r11          d1    s1    TABLE  r12     d
+r11          d2    s2    TABLE  r12     d
+materialize  NULL  NULL  TABLE  r1      a
+materialize  NULL  NULL  TABLE  PUBLIC  w
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 REVOKE SELECT ON TABLES FROM r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r9           d1    NULL  TABLE  r10     a
+r9           d2    NULL  TABLE  r10     a
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+r11          d1    s1    TABLE  r12     d
+r11          d2    s2    TABLE  r12     d
+materialize  NULL  NULL  TABLE  r1      a
+materialize  NULL  NULL  TABLE  PUBLIC  w
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r9 IN DATABASE d1, d2 REVOKE INSERT ON TABLES FROM r10
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+r11          d1    s1    TABLE  r12     d
+r11          d2    s2    TABLE  r12     d
+materialize  NULL  NULL  TABLE  r1      a
+materialize  NULL  NULL  TABLE  PUBLIC  w
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r11 IN SCHEMA d1.s1, d2.s2 REVOKE DELETE ON TABLES FROM r12
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+materialize  NULL  NULL  TABLE  r1      a
+materialize  NULL  NULL  TABLE  PUBLIC  w
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE UPDATE ON TABLES FROM PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+materialize  NULL  NULL  TABLE  r1      a
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE INSERT ON TABLES FROM r1
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC NULL  NULL  TYPE   PUBLIC  U
+
+statement ok
+CREATE TABLE materialize.public.t ()
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  materialize=arwd/materialize
+
+statement ok
+DROP TABLE t
+
+statement ok
+CREATE VIEW materialize.public.v AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  materialize=r/materialize
+
+statement ok
+DROP VIEW v
+
+statement ok
+CREATE MATERIALIZED VIEW materialize.public.mv AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  materialize=r/materialize
+
+statement ok
+DROP MATERIALIZED VIEW mv
+
+statement ok
+CREATE SOURCE materialize.public.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  materialize=r/materialize
+
+statement ok
+DROP SOURCE s
+
+statement ok
+CREATE TABLE d1.s11.t ()
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  materialize=arwd/materialize
+
+statement ok
+DROP TABLE d1.s11.t
+
+statement ok
+CREATE VIEW d1.s11.v AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  materialize=r/materialize
+
+statement ok
+DROP VIEW d1.s11.v
+
+statement ok
+CREATE MATERIALIZED VIEW d1.s11.mv AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  materialize=r/materialize
+
+statement ok
+DROP MATERIALIZED VIEW d1.s11.mv
+
+statement ok
+CREATE SOURCE d1.s11.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  materialize=r/materialize
+
+statement ok
+DROP SOURCE d1.s11.s
+
+statement ok
+CREATE TABLE d2.s22.t ()
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  materialize=arwd/materialize
+
+statement ok
+DROP TABLE d2.s22.t
+
+statement ok
+CREATE VIEW d2.s22.v AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  materialize=r/materialize
+
+statement ok
+DROP VIEW d2.s22.v
+
+statement ok
+CREATE MATERIALIZED VIEW d2.s22.mv AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  materialize=r/materialize
+
+statement ok
+DROP MATERIALIZED VIEW d2.s22.mv
+
+statement ok
+CREATE SOURCE d2.s22.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  materialize=r/materialize
+
+statement ok
+DROP SOURCE d2.s22.s
+
+statement ok
+CREATE TABLE d1.s1.t ()
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  materialize=arwd/materialize
+
+statement ok
+DROP TABLE d1.s1.t
+
+statement ok
+CREATE VIEW d1.s1.v AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  materialize=r/materialize
+
+statement ok
+DROP VIEW d1.s1.v
+
+statement ok
+CREATE MATERIALIZED VIEW d1.s1.mv AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  materialize=r/materialize
+
+statement ok
+DROP MATERIALIZED VIEW d1.s1.mv
+
+statement ok
+CREATE SOURCE d1.s1.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  materialize=r/materialize
+
+statement ok
+DROP SOURCE d1.s1.s
+
+statement ok
+CREATE TABLE d2.s2.t ()
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  materialize=arwd/materialize
+
+statement ok
+DROP TABLE d2.s2.t
+
+statement ok
+CREATE VIEW d2.s2.v AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  materialize=r/materialize
+
+statement ok
+DROP VIEW d2.s2.v
+
+statement ok
+CREATE MATERIALIZED VIEW d2.s2.mv AS SELECT 1
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  materialize=r/materialize
+
+statement ok
+DROP MATERIALIZED VIEW d2.s2.mv
+
+statement ok
+CREATE SOURCE d2.s2.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  materialize=r/materialize
+
+statement ok
+DROP SOURCE d2.s2.s
+
+simple conn=r6,user=r6
+CREATE TABLE materialize.public.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r6=arwd/r6
+
+simple conn=r6,user=r6
+DROP TABLE materialize.public.t;
+----
+COMPLETE 0
+
+simple conn=r6,user=r6
+CREATE VIEW materialize.public.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r6=r/r6
+
+simple conn=r6,user=r6
+DROP VIEW materialize.public.v;
+----
+COMPLETE 0
+
+simple conn=r6,user=r6
+CREATE MATERIALIZED VIEW materialize.public.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r6=r/r6
+
+simple conn=r6,user=r6
+DROP MATERIALIZED VIEW materialize.public.mv;
+----
+COMPLETE 0
+
+simple conn=r6,user=r6
+CREATE SOURCE materialize.public.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r6=r/r6
+
+simple conn=r6,user=r6
+DROP SOURCE materialize.public.s;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE TABLE materialize.public.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r7=arwd/r7
+
+simple conn=r7,user=r7
+DROP TABLE materialize.public.t;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE VIEW materialize.public.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r7=r/r7
+
+simple conn=r7,user=r7
+DROP VIEW materialize.public.v;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE MATERIALIZED VIEW materialize.public.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r7=r/r7
+
+simple conn=r7,user=r7
+DROP MATERIALIZED VIEW materialize.public.mv;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE SOURCE materialize.public.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r7=r/r7
+
+simple conn=r7,user=r7
+DROP SOURCE materialize.public.s;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE TABLE d1.s1.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r9=arwd/r9
+
+simple conn=r9,user=r9
+DROP TABLE d1.s1.t;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE VIEW d1.s1.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r9=r/r9
+
+simple conn=r9,user=r9
+DROP VIEW d1.s1.v;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE MATERIALIZED VIEW d1.s1.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r9=r/r9
+
+simple conn=r9,user=r9
+DROP MATERIALIZED VIEW d1.s1.mv;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE SOURCE d1.s1.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r9=r/r9
+
+simple conn=r9,user=r9
+DROP SOURCE d1.s1.s;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE TABLE d2.s2.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r9=arwd/r9
+
+simple conn=r9,user=r9
+DROP TABLE d2.s2.t;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE VIEW d2.s2.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r9=r/r9
+
+simple conn=r9,user=r9
+DROP VIEW d2.s2.v;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE MATERIALIZED VIEW d2.s2.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r9=r/r9
+
+simple conn=r9,user=r9
+DROP MATERIALIZED VIEW d2.s2.mv;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE SOURCE d2.s2.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r9=r/r9
+
+simple conn=r9,user=r9
+DROP SOURCE d2.s2.s;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TABLE d1.s1.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r11=arwd/r11
+
+simple conn=r11,user=r11
+DROP TABLE d1.s1.t;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE VIEW d1.s1.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r11=r/r11
+
+simple conn=r11,user=r11
+DROP VIEW d1.s1.v;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE MATERIALIZED VIEW d1.s1.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r11=r/r11
+
+simple conn=r11,user=r11
+DROP MATERIALIZED VIEW d1.s1.mv;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SOURCE d1.s1.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r11=r/r11
+
+simple conn=r11,user=r11
+DROP SOURCE d1.s1.s;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TABLE d1.s11.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r11=arwd/r11
+
+simple conn=r11,user=r11
+DROP TABLE d1.s11.t;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE VIEW d1.s11.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r11=r/r11
+
+simple conn=r11,user=r11
+DROP VIEW d1.s11.v;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE MATERIALIZED VIEW d1.s11.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r11=r/r11
+
+simple conn=r11,user=r11
+DROP MATERIALIZED VIEW d1.s11.mv;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SOURCE d1.s11.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r11=r/r11
+
+simple conn=r11,user=r11
+DROP SOURCE d1.s11.s;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TABLE d2.s2.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r11=arwd/r11
+
+simple conn=r11,user=r11
+DROP TABLE d2.s2.t;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE VIEW d2.s2.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r11=r/r11
+
+simple conn=r11,user=r11
+DROP VIEW d2.s2.v;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE MATERIALIZED VIEW d2.s2.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r11=r/r11
+
+simple conn=r11,user=r11
+DROP MATERIALIZED VIEW d2.s2.mv;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SOURCE d2.s2.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r11=r/r11
+
+simple conn=r11,user=r11
+DROP SOURCE d2.s2.s;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TABLE d2.s22.t ();
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_tables WHERE name = 't'
+----
+t  r11=arwd/r11
+
+simple conn=r11,user=r11
+DROP TABLE d2.s22.t;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE VIEW d2.s22.v AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
+----
+v  r11=r/r11
+
+simple conn=r11,user=r11
+DROP VIEW d2.s22.v;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE MATERIALIZED VIEW d2.s22.mv AS SELECT 1;
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_materialized_views WHERE name = 'mv'
+----
+mv  r11=r/r11
+
+simple conn=r11,user=r11
+DROP MATERIALIZED VIEW d2.s22.mv;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SOURCE d2.s22.s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_sources WHERE name = 's'
+----
+s  r11=r/r11
+
+simple conn=r11,user=r11
+DROP SOURCE d2.s22.s;
+----
+COMPLETE 0
+
+## Types
+
+### Grants
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  r1      U
+materialize  NULL  NULL  TYPE  r2      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TYPES TO r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  r1      U
+materialize  NULL  NULL  TYPE  r2      U
+materialize  NULL  NULL  TYPE  r3      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 GRANT USAGE ON TYPES TO r4
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  r1      U
+materialize  NULL  NULL  TYPE  r2      U
+materialize  NULL  NULL  TYPE  r3      U
+materialize  d1    NULL  TYPE  r4      U
+materialize  d2    NULL  TYPE  r4      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA d1.s1, d2.s2 GRANT USAGE ON TYPES TO r5
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  r1      U
+materialize  NULL  NULL  TYPE  r2      U
+materialize  NULL  NULL  TYPE  r3      U
+materialize  d1    NULL  TYPE  r4      U
+materialize  d2    NULL  TYPE  r4      U
+materialize  d1    s1    TYPE  r5      U
+materialize  d2    s2    TYPE  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 GRANT USAGE ON TYPES TO r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TYPE  r8      U
+r7           NULL  NULL  TYPE  r8      U
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  r1      U
+materialize  NULL  NULL  TYPE  r2      U
+materialize  NULL  NULL  TYPE  r3      U
+materialize  d1    NULL  TYPE  r4      U
+materialize  d2    NULL  TYPE  r4      U
+materialize  d1    s1    TYPE  r5      U
+materialize  d2    s2    TYPE  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r9 IN DATABASE d1, d2 GRANT USAGE ON TYPES TO r10
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TYPE  r8      U
+r7           NULL  NULL  TYPE  r8      U
+r9           d1    NULL  TYPE  r10     U
+r9           d2    NULL  TYPE  r10     U
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  r1      U
+materialize  NULL  NULL  TYPE  r2      U
+materialize  NULL  NULL  TYPE  r3      U
+materialize  d1    NULL  TYPE  r4      U
+materialize  d2    NULL  TYPE  r4      U
+materialize  d1    s1    TYPE  r5      U
+materialize  d2    s2    TYPE  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r11 IN SCHEMA d1.s1, d2.s2 GRANT USAGE ON TYPES TO r12
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TYPE  r8      U
+r7           NULL  NULL  TYPE  r8      U
+r9           d1    NULL  TYPE  r10     U
+r9           d2    NULL  TYPE  r10     U
+r11          d1    s1    TYPE  r12     U
+r11          d2    s2    TYPE  r12     U
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  r1      U
+materialize  NULL  NULL  TYPE  r2      U
+materialize  NULL  NULL  TYPE  r3      U
+materialize  d1    NULL  TYPE  r4      U
+materialize  d2    NULL  TYPE  r4      U
+materialize  d1    s1    TYPE  r5      U
+materialize  d2    s2    TYPE  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TYPE  r8      U
+r7           NULL  NULL  TYPE  r8      U
+r9           d1    NULL  TYPE  r10     U
+r9           d2    NULL  TYPE  r10     U
+r11          d1    s1    TYPE  r12     U
+r11          d2    s2    TYPE  r12     U
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  r1      U
+materialize  NULL  NULL  TYPE  r2      U
+materialize  NULL  NULL  TYPE  r3      U
+materialize  d1    NULL  TYPE  r4      U
+materialize  d2    NULL  TYPE  r4      U
+materialize  NULL  NULL  TYPE  PUBLIC  U
+materialize  d1    s1    TYPE  r5      U
+materialize  d2    s2    TYPE  r5      U
+
+statement ok
+CREATE TYPE materialize.public.ty as (a int)
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  r1=U/materialize
+ty  r2=U/materialize
+ty  r3=U/materialize
+ty  materialize=U/materialize
+
+statement ok
+DROP TYPE ty
+
+statement ok
+CREATE TYPE d1.s11.ty as (a int)
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  r1=U/materialize
+ty  r2=U/materialize
+ty  r3=U/materialize
+ty  r4=U/materialize
+ty  materialize=U/materialize
+
+statement ok
+DROP TYPE d1.s11.ty
+
+statement ok
+CREATE TYPE d2.s22.ty as (a int)
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  r1=U/materialize
+ty  r2=U/materialize
+ty  r3=U/materialize
+ty  r4=U/materialize
+ty  materialize=U/materialize
+
+statement ok
+DROP TYPE d2.s22.ty
+
+statement ok
+CREATE TYPE d1.s1.ty as (a int)
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  r1=U/materialize
+ty  r2=U/materialize
+ty  r3=U/materialize
+ty  r4=U/materialize
+ty  r5=U/materialize
+ty  materialize=U/materialize
+
+statement ok
+DROP TYPE d1.s1.ty
+
+statement ok
+CREATE TYPE d2.s2.ty as (a int)
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  r1=U/materialize
+ty  r2=U/materialize
+ty  r3=U/materialize
+ty  r4=U/materialize
+ty  r5=U/materialize
+ty  materialize=U/materialize
+
+statement ok
+DROP TYPE d2.s2.ty
+
+simple conn=r6,user=r6
+CREATE TYPE materialize.public.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r6
+ty  r6=U/r6
+ty  r8=U/r6
+
+simple conn=r6,user=r6
+DROP TYPE materialize.public.ty;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE TYPE materialize.public.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r7
+ty  r7=U/r7
+ty  r8=U/r7
+
+simple conn=r7,user=r7
+DROP TYPE materialize.public.ty;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE TYPE d1.s1.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r9
+ty  r9=U/r9
+ty  r10=U/r9
+
+simple conn=r9,user=r9
+DROP TYPE d1.s1.ty;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE TYPE d2.s2.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r9
+ty  r9=U/r9
+ty  r10=U/r9
+
+simple conn=r9,user=r9
+DROP TYPE d2.s2.ty;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TYPE d1.s1.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r11
+ty  r11=U/r11
+ty  r12=U/r11
+
+simple conn=r11,user=r11
+DROP TYPE d1.s1.ty;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TYPE d1.s11.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r11
+ty  r11=U/r11
+
+simple conn=r11,user=r11
+DROP TYPE d1.s11.ty;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TYPE d2.s2.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r11
+ty  r11=U/r11
+ty  r12=U/r11
+
+simple conn=r11,user=r11
+DROP TYPE d2.s2.ty;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TYPE d2.s22.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r11
+ty  r11=U/r11
+
+simple conn=r11,user=r11
+DROP TYPE d2.s22.ty;
+----
+COMPLETE 0
+
+### Revokes
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON TYPES FROM r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TYPE  r8      U
+r7           NULL  NULL  TYPE  r8      U
+r9           d1    NULL  TYPE  r10     U
+r9           d2    NULL  TYPE  r10     U
+r11          d1    s1    TYPE  r12     U
+r11          d2    s2    TYPE  r12     U
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  r3      U
+materialize  d1    NULL  TYPE  r4      U
+materialize  d2    NULL  TYPE  r4      U
+materialize  NULL  NULL  TYPE  PUBLIC  U
+materialize  d1    s1    TYPE  r5      U
+materialize  d2    s2    TYPE  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON TYPES FROM r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TYPE  r8      U
+r7           NULL  NULL  TYPE  r8      U
+r9           d1    NULL  TYPE  r10     U
+r9           d2    NULL  TYPE  r10     U
+r11          d1    s1    TYPE  r12     U
+r11          d2    s2    TYPE  r12     U
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  d1    NULL  TYPE  r4      U
+materialize  d2    NULL  TYPE  r4      U
+materialize  NULL  NULL  TYPE  PUBLIC  U
+materialize  d1    s1    TYPE  r5      U
+materialize  d2    s2    TYPE  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 REVOKE USAGE ON TYPES FROM r4
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TYPE  r8      U
+r7           NULL  NULL  TYPE  r8      U
+r9           d1    NULL  TYPE  r10     U
+r9           d2    NULL  TYPE  r10     U
+r11          d1    s1    TYPE  r12     U
+r11          d2    s2    TYPE  r12     U
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  PUBLIC  U
+materialize  d1    s1    TYPE  r5      U
+materialize  d2    s2    TYPE  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA d1.s1, d2.s2 REVOKE USAGE ON TYPES FROM r5
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  TYPE  r8      U
+r7           NULL  NULL  TYPE  r8      U
+r9           d1    NULL  TYPE  r10     U
+r9           d2    NULL  TYPE  r10     U
+r11          d1    s1    TYPE  r12     U
+r11          d2    s2    TYPE  r12     U
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 REVOKE USAGE ON TYPES FROM r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r9           d1    NULL  TYPE  r10     U
+r9           d2    NULL  TYPE  r10     U
+r11          d1    s1    TYPE  r12     U
+r11          d2    s2    TYPE  r12     U
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r9 IN DATABASE d1, d2 REVOKE USAGE ON TYPES FROM r10
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r11          d1    s1    TYPE  r12     U
+r11          d2    s2    TYPE  r12     U
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r11 IN SCHEMA d1.s1, d2.s2 REVOKE USAGE ON TYPES FROM r12
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+materialize  NULL  NULL  TYPE  PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON TYPES FROM PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE  PUBLIC  U
+
+statement ok
+CREATE TYPE materialize.public.ty as (a int)
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  materialize=U/materialize
+
+statement ok
+DROP TYPE ty
+
+statement ok
+CREATE TYPE d1.s11.ty as (a int)
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  materialize=U/materialize
+
+statement ok
+DROP TYPE d1.s11.ty
+
+statement ok
+CREATE TYPE d2.s22.ty as (a int)
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  materialize=U/materialize
+
+statement ok
+DROP TYPE d2.s22.ty
+
+statement ok
+CREATE TYPE d1.s1.ty as (a int)
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  materialize=U/materialize
+
+statement ok
+DROP TYPE d1.s1.ty
+
+statement ok
+CREATE TYPE d2.s2.ty as (a int)
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/materialize
+ty  materialize=U/materialize
+
+statement ok
+DROP TYPE d2.s2.ty
+
+simple conn=r6,user=r6
+CREATE TYPE materialize.public.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r6
+ty  r6=U/r6
+
+simple conn=r6,user=r6
+DROP TYPE materialize.public.ty;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE TYPE materialize.public.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r7
+ty  r7=U/r7
+
+simple conn=r7,user=r7
+DROP TYPE materialize.public.ty;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE TYPE d1.s1.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r9
+ty  r9=U/r9
+
+simple conn=r9,user=r9
+DROP TYPE d1.s1.ty;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE TYPE d2.s2.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r9
+ty  r9=U/r9
+
+simple conn=r9,user=r9
+DROP TYPE d2.s2.ty;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TYPE d1.s1.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r11
+ty  r11=U/r11
+
+simple conn=r11,user=r11
+DROP TYPE d1.s1.ty;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TYPE d1.s11.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r11
+ty  r11=U/r11
+
+simple conn=r11,user=r11
+DROP TYPE d1.s11.ty;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TYPE d2.s2.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r11
+ty  r11=U/r11
+
+simple conn=r11,user=r11
+DROP TYPE d2.s2.ty;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE TYPE d2.s22.ty as (a int)
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_types WHERE name = 'ty'
+----
+ty  =U/r11
+ty  r11=U/r11
+
+simple conn=r11,user=r11
+DROP TYPE d2.s22.ty;
+----
+COMPLETE 0
+
+## Secrets
+
+### Grants
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON SECRETS TO r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SECRET  r1      U
+materialize  NULL  NULL  SECRET  r2      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON SECRETS TO r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SECRET  r1      U
+materialize  NULL  NULL  SECRET  r2      U
+materialize  NULL  NULL  SECRET  r3      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 GRANT USAGE ON SECRETS TO r4
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SECRET  r1      U
+materialize  NULL  NULL  SECRET  r2      U
+materialize  NULL  NULL  SECRET  r3      U
+materialize  d1    NULL  SECRET  r4      U
+materialize  d2    NULL  SECRET  r4      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA d1.s1, d2.s2 GRANT USAGE ON SECRETS TO r5
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SECRET  r1      U
+materialize  NULL  NULL  SECRET  r2      U
+materialize  NULL  NULL  SECRET  r3      U
+materialize  d1    NULL  SECRET  r4      U
+materialize  d2    NULL  SECRET  r4      U
+materialize  d1    s1    SECRET  r5      U
+materialize  d2    s2    SECRET  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 GRANT USAGE ON SECRETS TO r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SECRET  r8      U
+r7           NULL  NULL  SECRET  r8      U
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SECRET  r1      U
+materialize  NULL  NULL  SECRET  r2      U
+materialize  NULL  NULL  SECRET  r3      U
+materialize  d1    NULL  SECRET  r4      U
+materialize  d2    NULL  SECRET  r4      U
+materialize  d1    s1    SECRET  r5      U
+materialize  d2    s2    SECRET  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r9 IN DATABASE d1, d2 GRANT USAGE ON SECRETS TO r10
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SECRET  r8      U
+r7           NULL  NULL  SECRET  r8      U
+r9           d1    NULL  SECRET  r10     U
+r9           d2    NULL  SECRET  r10     U
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SECRET  r1      U
+materialize  NULL  NULL  SECRET  r2      U
+materialize  NULL  NULL  SECRET  r3      U
+materialize  d1    NULL  SECRET  r4      U
+materialize  d2    NULL  SECRET  r4      U
+materialize  d1    s1    SECRET  r5      U
+materialize  d2    s2    SECRET  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r11 IN SCHEMA d1.s1, d2.s2 GRANT USAGE ON SECRETS TO r12
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SECRET  r8      U
+r7           NULL  NULL  SECRET  r8      U
+r9           d1    NULL  SECRET  r10     U
+r9           d2    NULL  SECRET  r10     U
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+r11          d1    s1    SECRET  r12     U
+r11          d2    s2    SECRET  r12     U
+materialize  NULL  NULL  SECRET  r1      U
+materialize  NULL  NULL  SECRET  r2      U
+materialize  NULL  NULL  SECRET  r3      U
+materialize  d1    NULL  SECRET  r4      U
+materialize  d2    NULL  SECRET  r4      U
+materialize  d1    s1    SECRET  r5      U
+materialize  d2    s2    SECRET  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON SECRETS TO PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SECRET  r8      U
+r7           NULL  NULL  SECRET  r8      U
+r9           d1    NULL  SECRET  r10     U
+r9           d2    NULL  SECRET  r10     U
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+r11          d1    s1    SECRET  r12     U
+r11          d2    s2    SECRET  r12     U
+materialize  NULL  NULL  SECRET  r1      U
+materialize  NULL  NULL  SECRET  r2      U
+materialize  NULL  NULL  SECRET  r3      U
+materialize  d1    NULL  SECRET  r4      U
+materialize  d2    NULL  SECRET  r4      U
+materialize  NULL  NULL  SECRET  PUBLIC  U
+materialize  d1    s1    SECRET  r5      U
+materialize  d2    s2    SECRET  r5      U
+
+statement ok
+CREATE SECRET materialize.public.se AS decode('c2VjcmV0Cg==', 'base64')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  =U/materialize
+se  r1=U/materialize
+se  r2=U/materialize
+se  r3=U/materialize
+se  materialize=U/materialize
+
+statement ok
+DROP SECRET se
+
+statement ok
+CREATE SECRET d1.s11.se AS decode('c2VjcmV0Cg==', 'base64')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  =U/materialize
+se  r1=U/materialize
+se  r2=U/materialize
+se  r3=U/materialize
+se  r4=U/materialize
+se  materialize=U/materialize
+
+statement ok
+DROP SECRET d1.s11.se
+
+statement ok
+CREATE SECRET d2.s22.se AS decode('c2VjcmV0Cg==', 'base64')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  =U/materialize
+se  r1=U/materialize
+se  r2=U/materialize
+se  r3=U/materialize
+se  r4=U/materialize
+se  materialize=U/materialize
+
+statement ok
+DROP SECRET d2.s22.se
+
+statement ok
+CREATE SECRET d1.s1.se AS decode('c2VjcmV0Cg==', 'base64')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  =U/materialize
+se  r1=U/materialize
+se  r2=U/materialize
+se  r3=U/materialize
+se  r4=U/materialize
+se  r5=U/materialize
+se  materialize=U/materialize
+
+statement ok
+DROP SECRET d1.s1.se
+
+statement ok
+CREATE SECRET d2.s2.se AS decode('c2VjcmV0Cg==', 'base64')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  =U/materialize
+se  r1=U/materialize
+se  r2=U/materialize
+se  r3=U/materialize
+se  r4=U/materialize
+se  r5=U/materialize
+se  materialize=U/materialize
+
+statement ok
+DROP SECRET d2.s2.se
+
+simple conn=r6,user=r6
+CREATE SECRET materialize.public.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r6=U/r6
+se  r8=U/r6
+
+simple conn=r6,user=r6
+DROP SECRET materialize.public.se;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE SECRET materialize.public.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r7=U/r7
+se  r8=U/r7
+
+simple conn=r7,user=r7
+DROP SECRET materialize.public.se;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE SECRET d1.s1.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r9=U/r9
+se  r10=U/r9
+
+simple conn=r9,user=r9
+DROP SECRET d1.s1.se;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE SECRET d2.s2.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r9=U/r9
+se  r10=U/r9
+
+simple conn=r9,user=r9
+DROP SECRET d2.s2.se;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SECRET d1.s1.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r11=U/r11
+se  r12=U/r11
+
+simple conn=r11,user=r11
+DROP SECRET d1.s1.se;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SECRET d1.s11.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r11=U/r11
+
+simple conn=r11,user=r11
+DROP SECRET d1.s11.se;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SECRET d2.s2.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r11=U/r11
+se  r12=U/r11
+
+simple conn=r11,user=r11
+DROP SECRET d2.s2.se;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SECRET d2.s22.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r11=U/r11
+
+simple conn=r11,user=r11
+DROP SECRET d2.s22.se;
+----
+COMPLETE 0
+
+### Revokes
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON SECRETS FROM r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SECRET  r8      U
+r7           NULL  NULL  SECRET  r8      U
+r9           d1    NULL  SECRET  r10     U
+r9           d2    NULL  SECRET  r10     U
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+r11          d1    s1    SECRET  r12     U
+r11          d2    s2    SECRET  r12     U
+materialize  NULL  NULL  SECRET  r3      U
+materialize  d1    NULL  SECRET  r4      U
+materialize  d2    NULL  SECRET  r4      U
+materialize  NULL  NULL  SECRET  PUBLIC  U
+materialize  d1    s1    SECRET  r5      U
+materialize  d2    s2    SECRET  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON SECRETS FROM r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SECRET  r8      U
+r7           NULL  NULL  SECRET  r8      U
+r9           d1    NULL  SECRET  r10     U
+r9           d2    NULL  SECRET  r10     U
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+r11          d1    s1    SECRET  r12     U
+r11          d2    s2    SECRET  r12     U
+materialize  d1    NULL  SECRET  r4      U
+materialize  d2    NULL  SECRET  r4      U
+materialize  NULL  NULL  SECRET  PUBLIC  U
+materialize  d1    s1    SECRET  r5      U
+materialize  d2    s2    SECRET  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 REVOKE USAGE ON SECRETS FROM r4
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SECRET  r8      U
+r7           NULL  NULL  SECRET  r8      U
+r9           d1    NULL  SECRET  r10     U
+r9           d2    NULL  SECRET  r10     U
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+r11          d1    s1    SECRET  r12     U
+r11          d2    s2    SECRET  r12     U
+materialize  NULL  NULL  SECRET  PUBLIC  U
+materialize  d1    s1    SECRET  r5      U
+materialize  d2    s2    SECRET  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA d1.s1, d2.s2 REVOKE USAGE ON SECRETS FROM r5
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SECRET  r8      U
+r7           NULL  NULL  SECRET  r8      U
+r9           d1    NULL  SECRET  r10     U
+r9           d2    NULL  SECRET  r10     U
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+r11          d1    s1    SECRET  r12     U
+r11          d2    s2    SECRET  r12     U
+materialize  NULL  NULL  SECRET  PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 REVOKE USAGE ON SECRETS FROM r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r9           d1    NULL  SECRET  r10     U
+r9           d2    NULL  SECRET  r10     U
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+r11          d1    s1    SECRET  r12     U
+r11          d2    s2    SECRET  r12     U
+materialize  NULL  NULL  SECRET  PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r9 IN DATABASE d1, d2 REVOKE USAGE ON SECRETS FROM r10
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+r11          d1    s1    SECRET  r12     U
+r11          d2    s2    SECRET  r12     U
+materialize  NULL  NULL  SECRET  PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r11 IN SCHEMA d1.s1, d2.s2 REVOKE USAGE ON SECRETS FROM r12
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SECRET  PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON SECRETS FROM PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+
+statement ok
+CREATE SECRET materialize.public.se AS decode('c2VjcmV0Cg==', 'base64')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  materialize=U/materialize
+
+statement ok
+DROP SECRET se
+
+statement ok
+CREATE SECRET d1.s11.se AS decode('c2VjcmV0Cg==', 'base64')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  materialize=U/materialize
+
+statement ok
+DROP SECRET d1.s11.se
+
+statement ok
+CREATE SECRET d2.s22.se AS decode('c2VjcmV0Cg==', 'base64')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  materialize=U/materialize
+
+statement ok
+DROP SECRET d2.s22.se
+
+statement ok
+CREATE SECRET d1.s1.se AS decode('c2VjcmV0Cg==', 'base64')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  materialize=U/materialize
+
+statement ok
+DROP SECRET d1.s1.se
+
+statement ok
+CREATE SECRET d2.s2.se AS decode('c2VjcmV0Cg==', 'base64')
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  materialize=U/materialize
+
+statement ok
+DROP SECRET d2.s2.se
+
+simple conn=r6,user=r6
+CREATE SECRET materialize.public.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r6=U/r6
+
+simple conn=r6,user=r6
+DROP SECRET materialize.public.se;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE SECRET materialize.public.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r7=U/r7
+
+simple conn=r7,user=r7
+DROP SECRET materialize.public.se;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE SECRET d1.s1.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r9=U/r9
+
+simple conn=r9,user=r9
+DROP SECRET d1.s1.se;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE SECRET d2.s2.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r9=U/r9
+
+simple conn=r9,user=r9
+DROP SECRET d2.s2.se;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SECRET d1.s1.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r11=U/r11
+
+simple conn=r11,user=r11
+DROP SECRET d1.s1.se;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SECRET d1.s11.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r11=U/r11
+
+simple conn=r11,user=r11
+DROP SECRET d1.s11.se;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SECRET d2.s2.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r11=U/r11
+
+simple conn=r11,user=r11
+DROP SECRET d2.s2.se;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE SECRET d2.s22.se AS decode('c2VjcmV0Cg==', 'base64')
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_secrets WHERE name = 'se'
+----
+se  r11=U/r11
+
+simple conn=r11,user=r11
+DROP SECRET d2.s22.se;
+----
+COMPLETE 0
+
+## Connection
+
+### Grants
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON CONNECTIONS TO r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+materialize  NULL  NULL  CONNECTION  r1      U
+materialize  NULL  NULL  CONNECTION  r2      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON CONNECTIONS TO r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+materialize  NULL  NULL  CONNECTION  r1      U
+materialize  NULL  NULL  CONNECTION  r2      U
+materialize  NULL  NULL  CONNECTION  r3      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 GRANT USAGE ON CONNECTIONS TO r4
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+materialize  NULL  NULL  CONNECTION  r1      U
+materialize  NULL  NULL  CONNECTION  r2      U
+materialize  NULL  NULL  CONNECTION  r3      U
+materialize  d1    NULL  CONNECTION  r4      U
+materialize  d2    NULL  CONNECTION  r4      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA d1.s1, d2.s2 GRANT USAGE ON CONNECTIONS TO r5
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+materialize  NULL  NULL  CONNECTION  r1      U
+materialize  NULL  NULL  CONNECTION  r2      U
+materialize  NULL  NULL  CONNECTION  r3      U
+materialize  d1    NULL  CONNECTION  r4      U
+materialize  d2    NULL  CONNECTION  r4      U
+materialize  d1    s1    CONNECTION  r5      U
+materialize  d2    s2    CONNECTION  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 GRANT USAGE ON CONNECTIONS TO r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CONNECTION  r8      U
+r7           NULL  NULL  CONNECTION  r8      U
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+materialize  NULL  NULL  CONNECTION  r1      U
+materialize  NULL  NULL  CONNECTION  r2      U
+materialize  NULL  NULL  CONNECTION  r3      U
+materialize  d1    NULL  CONNECTION  r4      U
+materialize  d2    NULL  CONNECTION  r4      U
+materialize  d1    s1    CONNECTION  r5      U
+materialize  d2    s2    CONNECTION  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r9 IN DATABASE d1, d2 GRANT USAGE ON CONNECTIONS TO r10
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CONNECTION  r8      U
+r7           NULL  NULL  CONNECTION  r8      U
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+r9           d1    NULL  CONNECTION  r10     U
+r9           d2    NULL  CONNECTION  r10     U
+materialize  NULL  NULL  CONNECTION  r1      U
+materialize  NULL  NULL  CONNECTION  r2      U
+materialize  NULL  NULL  CONNECTION  r3      U
+materialize  d1    NULL  CONNECTION  r4      U
+materialize  d2    NULL  CONNECTION  r4      U
+materialize  d1    s1    CONNECTION  r5      U
+materialize  d2    s2    CONNECTION  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r11 IN SCHEMA d1.s1, d2.s2 GRANT USAGE ON CONNECTIONS TO r12
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CONNECTION  r8      U
+r7           NULL  NULL  CONNECTION  r8      U
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+r9           d1    NULL  CONNECTION  r10     U
+r9           d2    NULL  CONNECTION  r10     U
+r11          d1    s1    CONNECTION  r12     U
+r11          d2    s2    CONNECTION  r12     U
+materialize  NULL  NULL  CONNECTION  r1      U
+materialize  NULL  NULL  CONNECTION  r2      U
+materialize  NULL  NULL  CONNECTION  r3      U
+materialize  d1    NULL  CONNECTION  r4      U
+materialize  d2    NULL  CONNECTION  r4      U
+materialize  d1    s1    CONNECTION  r5      U
+materialize  d2    s2    CONNECTION  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON CONNECTIONS TO PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CONNECTION  r8      U
+r7           NULL  NULL  CONNECTION  r8      U
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+r9           d1    NULL  CONNECTION  r10     U
+r9           d2    NULL  CONNECTION  r10     U
+r11          d1    s1    CONNECTION  r12     U
+r11          d2    s2    CONNECTION  r12     U
+materialize  NULL  NULL  CONNECTION  r1      U
+materialize  NULL  NULL  CONNECTION  r2      U
+materialize  NULL  NULL  CONNECTION  r3      U
+materialize  d1    NULL  CONNECTION  r4      U
+materialize  d2    NULL  CONNECTION  r4      U
+materialize  NULL  NULL  CONNECTION  PUBLIC  U
+materialize  d1    s1    CONNECTION  r5      U
+materialize  d2    s2    CONNECTION  r5      U
+
+statement ok
+CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092');
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  =U/materialize
+c  r1=U/materialize
+c  r2=U/materialize
+c  r3=U/materialize
+c  materialize=U/materialize
+
+statement ok
+DROP CONNECTION c
+
+statement ok
+CREATE CONNECTION d1.s11.c TO KAFKA (BROKER 'localhost:9092');
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  =U/materialize
+c  r1=U/materialize
+c  r2=U/materialize
+c  r3=U/materialize
+c  r4=U/materialize
+c  materialize=U/materialize
+
+statement ok
+DROP CONNECTION d1.s11.c
+
+statement ok
+CREATE CONNECTION d2.s22.c TO KAFKA (BROKER 'localhost:9092');
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  =U/materialize
+c  r1=U/materialize
+c  r2=U/materialize
+c  r3=U/materialize
+c  r4=U/materialize
+c  materialize=U/materialize
+
+statement ok
+DROP CONNECTION d2.s22.c
+
+statement ok
+CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092');
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  =U/materialize
+c  r1=U/materialize
+c  r2=U/materialize
+c  r3=U/materialize
+c  r4=U/materialize
+c  r5=U/materialize
+c  materialize=U/materialize
+
+statement ok
+DROP CONNECTION d1.s1.c
+
+statement ok
+CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092');
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  =U/materialize
+c  r1=U/materialize
+c  r2=U/materialize
+c  r3=U/materialize
+c  r4=U/materialize
+c  r5=U/materialize
+c  materialize=U/materialize
+
+statement ok
+DROP CONNECTION d2.s2.c
+
+simple conn=r6,user=r6
+CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r6=U/r6
+c  r8=U/r6
+
+simple conn=r6,user=r6
+DROP CONNECTION materialize.public.c;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r7=U/r7
+c  r8=U/r7
+
+simple conn=r7,user=r7
+DROP CONNECTION materialize.public.c;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r9=U/r9
+c  r10=U/r9
+
+simple conn=r9,user=r9
+DROP CONNECTION d1.s1.c;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r9=U/r9
+c  r10=U/r9
+
+simple conn=r9,user=r9
+DROP CONNECTION d2.s2.c;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r11=U/r11
+c  r12=U/r11
+
+simple conn=r11,user=r11
+DROP CONNECTION d1.s1.c;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE CONNECTION d1.s11.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r11=U/r11
+
+simple conn=r11,user=r11
+DROP CONNECTION d1.s11.c;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r11=U/r11
+c  r12=U/r11
+
+simple conn=r11,user=r11
+DROP CONNECTION d2.s2.c;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE CONNECTION d2.s22.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r11=U/r11
+
+simple conn=r11,user=r11
+DROP CONNECTION d2.s22.c;
+----
+COMPLETE 0
+
+### Revokes
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON CONNECTIONS FROM r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CONNECTION  r8      U
+r7           NULL  NULL  CONNECTION  r8      U
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+r9           d1    NULL  CONNECTION  r10     U
+r9           d2    NULL  CONNECTION  r10     U
+r11          d1    s1    CONNECTION  r12     U
+r11          d2    s2    CONNECTION  r12     U
+materialize  NULL  NULL  CONNECTION  r3      U
+materialize  d1    NULL  CONNECTION  r4      U
+materialize  d2    NULL  CONNECTION  r4      U
+materialize  NULL  NULL  CONNECTION  PUBLIC  U
+materialize  d1    s1    CONNECTION  r5      U
+materialize  d2    s2    CONNECTION  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON CONNECTIONS FROM r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CONNECTION  r8      U
+r7           NULL  NULL  CONNECTION  r8      U
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+r9           d1    NULL  CONNECTION  r10     U
+r9           d2    NULL  CONNECTION  r10     U
+r11          d1    s1    CONNECTION  r12     U
+r11          d2    s2    CONNECTION  r12     U
+materialize  d1    NULL  CONNECTION  r4      U
+materialize  d2    NULL  CONNECTION  r4      U
+materialize  NULL  NULL  CONNECTION  PUBLIC  U
+materialize  d1    s1    CONNECTION  r5      U
+materialize  d2    s2    CONNECTION  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 REVOKE USAGE ON CONNECTIONS FROM r4
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CONNECTION  r8      U
+r7           NULL  NULL  CONNECTION  r8      U
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+r9           d1    NULL  CONNECTION  r10     U
+r9           d2    NULL  CONNECTION  r10     U
+r11          d1    s1    CONNECTION  r12     U
+r11          d2    s2    CONNECTION  r12     U
+materialize  NULL  NULL  CONNECTION  PUBLIC  U
+materialize  d1    s1    CONNECTION  r5      U
+materialize  d2    s2    CONNECTION  r5      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA d1.s1, d2.s2 REVOKE USAGE ON CONNECTIONS FROM r5
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CONNECTION  r8      U
+r7           NULL  NULL  CONNECTION  r8      U
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+r9           d1    NULL  CONNECTION  r10     U
+r9           d2    NULL  CONNECTION  r10     U
+r11          d1    s1    CONNECTION  r12     U
+r11          d2    s2    CONNECTION  r12     U
+materialize  NULL  NULL  CONNECTION  PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 REVOKE USAGE ON CONNECTIONS FROM r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+r9           d1    NULL  CONNECTION  r10     U
+r9           d2    NULL  CONNECTION  r10     U
+r11          d1    s1    CONNECTION  r12     U
+r11          d2    s2    CONNECTION  r12     U
+materialize  NULL  NULL  CONNECTION  PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r9 IN DATABASE d1, d2 REVOKE USAGE ON CONNECTIONS FROM r10
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+r11          d1    s1    CONNECTION  r12     U
+r11          d2    s2    CONNECTION  r12     U
+materialize  NULL  NULL  CONNECTION  PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r11 IN SCHEMA d1.s1, d2.s2 REVOKE USAGE ON CONNECTIONS FROM r12
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+materialize  NULL  NULL  CONNECTION  PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON CONNECTIONS FROM PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE        PUBLIC  U
+
+statement ok
+CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092');
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  materialize=U/materialize
+
+statement ok
+DROP CONNECTION c
+
+statement ok
+CREATE CONNECTION d1.s11.c TO KAFKA (BROKER 'localhost:9092');
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  materialize=U/materialize
+
+statement ok
+DROP CONNECTION d1.s11.c
+
+statement ok
+CREATE CONNECTION d2.s22.c TO KAFKA (BROKER 'localhost:9092');
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  materialize=U/materialize
+
+statement ok
+DROP CONNECTION d2.s22.c
+
+statement ok
+CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092');
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  materialize=U/materialize
+
+statement ok
+DROP CONNECTION d1.s1.c
+
+statement ok
+CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092');
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  materialize=U/materialize
+
+statement ok
+DROP CONNECTION d2.s2.c
+
+simple conn=r6,user=r6
+CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r6=U/r6
+
+simple conn=r6,user=r6
+DROP CONNECTION materialize.public.c;
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE CONNECTION materialize.public.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r7=U/r7
+
+simple conn=r7,user=r7
+DROP CONNECTION materialize.public.c;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r9=U/r9
+
+simple conn=r9,user=r9
+DROP CONNECTION d1.s1.c;
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r9=U/r9
+
+simple conn=r9,user=r9
+DROP CONNECTION d2.s2.c;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE CONNECTION d1.s1.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r11=U/r11
+
+simple conn=r11,user=r11
+DROP CONNECTION d1.s1.c;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE CONNECTION d1.s11.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r11=U/r11
+
+simple conn=r11,user=r11
+DROP CONNECTION d1.s11.c;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE CONNECTION d2.s2.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r11=U/r11
+
+simple conn=r11,user=r11
+DROP CONNECTION d2.s2.c;
+----
+COMPLETE 0
+
+simple conn=r11,user=r11
+CREATE CONNECTION d2.s22.c TO KAFKA (BROKER 'localhost:9092');
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_connections WHERE name = 'c'
+----
+c  r11=U/r11
+
+simple conn=r11,user=r11
+DROP CONNECTION d2.s22.c;
+----
+COMPLETE 0
+
+## Schemas
+
+### Grants
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r1      U
+materialize  NULL  NULL  SCHEMA  r2      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r1      U
+materialize  NULL  NULL  SCHEMA  r2      U
+materialize  NULL  NULL  SCHEMA  r3      UC
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 GRANT CREATE ON SCHEMAS TO r4
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r1      U
+materialize  NULL  NULL  SCHEMA  r2      U
+materialize  NULL  NULL  SCHEMA  r3      UC
+materialize  d1    NULL  SCHEMA  r4      C
+materialize  d2    NULL  SCHEMA  r4      C
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 GRANT CREATE ON SCHEMAS TO r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SCHEMA  r8      C
+r7           NULL  NULL  SCHEMA  r8      C
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r1      U
+materialize  NULL  NULL  SCHEMA  r2      U
+materialize  NULL  NULL  SCHEMA  r3      UC
+materialize  d1    NULL  SCHEMA  r4      C
+materialize  d2    NULL  SCHEMA  r4      C
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r9 IN DATABASE d1, d2 GRANT CREATE ON SCHEMAS TO r10
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SCHEMA  r8      C
+r7           NULL  NULL  SCHEMA  r8      C
+r9           d1    NULL  SCHEMA  r10     C
+r9           d2    NULL  SCHEMA  r10     C
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r1      U
+materialize  NULL  NULL  SCHEMA  r2      U
+materialize  NULL  NULL  SCHEMA  r3      UC
+materialize  d1    NULL  SCHEMA  r4      C
+materialize  d2    NULL  SCHEMA  r4      C
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT CREATE ON SCHEMAS TO PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SCHEMA  r8      C
+r7           NULL  NULL  SCHEMA  r8      C
+r9           d1    NULL  SCHEMA  r10     C
+r9           d2    NULL  SCHEMA  r10     C
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r1      U
+materialize  NULL  NULL  SCHEMA  r2      U
+materialize  NULL  NULL  SCHEMA  r3      UC
+materialize  d1    NULL  SCHEMA  r4      C
+materialize  d2    NULL  SCHEMA  r4      C
+materialize  NULL  NULL  SCHEMA  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT CREATE ON SCHEMAS TO r1
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SCHEMA  r8      C
+r7           NULL  NULL  SCHEMA  r8      C
+r9           d1    NULL  SCHEMA  r10     C
+r9           d2    NULL  SCHEMA  r10     C
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r2      U
+materialize  NULL  NULL  SCHEMA  r1      UC
+materialize  NULL  NULL  SCHEMA  r3      UC
+materialize  d1    NULL  SCHEMA  r4      C
+materialize  d2    NULL  SCHEMA  r4      C
+materialize  NULL  NULL  SCHEMA  PUBLIC  C
+
+statement ok
+CREATE SCHEMA materialize.sch
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  =C/materialize
+sch  r2=U/materialize
+sch  r1=UC/materialize
+sch  r3=UC/materialize
+sch  materialize=UC/materialize
+
+statement ok
+DROP SCHEMA sch
+
+statement ok
+CREATE SCHEMA d1.sch
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  =C/materialize
+sch  r2=U/materialize
+sch  r4=C/materialize
+sch  r1=UC/materialize
+sch  r3=UC/materialize
+sch  materialize=UC/materialize
+
+statement ok
+DROP SCHEMA d1.sch
+
+statement ok
+CREATE SCHEMA d2.sch
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  =C/materialize
+sch  r2=U/materialize
+sch  r4=C/materialize
+sch  r1=UC/materialize
+sch  r3=UC/materialize
+sch  materialize=UC/materialize
+
+statement ok
+DROP SCHEMA d2.sch
+
+simple conn=r6,user=r6
+CREATE SCHEMA materialize.sch
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  r8=C/r6
+sch  r6=UC/r6
+
+simple conn=r6,user=r6
+DROP SCHEMA materialize.sch
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE SCHEMA materialize.sch
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  r8=C/r7
+sch  r7=UC/r7
+
+simple conn=r7,user=r7
+DROP SCHEMA materialize.sch
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE SCHEMA d1.sch
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  r10=C/r9
+sch  r9=UC/r9
+
+simple conn=r9,user=r9
+DROP SCHEMA d1.sch
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE SCHEMA d2.sch
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  r10=C/r9
+sch  r9=UC/r9
+
+simple conn=r9,user=r9
+DROP SCHEMA d2.sch
+----
+COMPLETE 0
+
+### Revokes
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON SCHEMAS FROM r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SCHEMA  r8      C
+r7           NULL  NULL  SCHEMA  r8      C
+r9           d1    NULL  SCHEMA  r10     C
+r9           d2    NULL  SCHEMA  r10     C
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r1      C
+materialize  NULL  NULL  SCHEMA  r3      UC
+materialize  d1    NULL  SCHEMA  r4      C
+materialize  d2    NULL  SCHEMA  r4      C
+materialize  NULL  NULL  SCHEMA  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SCHEMA  r8      C
+r7           NULL  NULL  SCHEMA  r8      C
+r9           d1    NULL  SCHEMA  r10     C
+r9           d2    NULL  SCHEMA  r10     C
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r1      C
+materialize  d1    NULL  SCHEMA  r4      C
+materialize  d2    NULL  SCHEMA  r4      C
+materialize  NULL  NULL  SCHEMA  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN DATABASE d1, d2 REVOKE CREATE ON SCHEMAS FROM r4
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  SCHEMA  r8      C
+r7           NULL  NULL  SCHEMA  r8      C
+r9           d1    NULL  SCHEMA  r10     C
+r9           d2    NULL  SCHEMA  r10     C
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r1      C
+materialize  NULL  NULL  SCHEMA  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 REVOKE CREATE ON SCHEMAS FROM r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r9           d1    NULL  SCHEMA  r10     C
+r9           d2    NULL  SCHEMA  r10     C
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r1      C
+materialize  NULL  NULL  SCHEMA  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r9 IN DATABASE d1, d2 REVOKE CREATE ON SCHEMAS FROM r10
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r1      C
+materialize  NULL  NULL  SCHEMA  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE CREATE ON SCHEMAS FROM PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE    PUBLIC  U
+materialize  NULL  NULL  SCHEMA  r1      C
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE CREATE ON SCHEMAS FROM r1
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC NULL  NULL  TYPE   PUBLIC  U
+
+statement ok
+CREATE SCHEMA materialize.sch
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  materialize=UC/materialize
+
+statement ok
+DROP SCHEMA sch
+
+statement ok
+CREATE SCHEMA d1.sch
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  materialize=UC/materialize
+
+statement ok
+DROP SCHEMA d1.sch
+
+statement ok
+CREATE SCHEMA d2.sch
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  materialize=UC/materialize
+
+statement ok
+DROP SCHEMA d2.sch
+
+simple conn=r6,user=r6
+CREATE SCHEMA materialize.sch
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  r6=UC/r6
+
+simple conn=r6,user=r6
+DROP SCHEMA materialize.sch
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE SCHEMA materialize.sch
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  r7=UC/r7
+
+simple conn=r7,user=r7
+DROP SCHEMA materialize.sch
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE SCHEMA d1.sch
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  r9=UC/r9
+
+simple conn=r9,user=r9
+DROP SCHEMA d1.sch
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE SCHEMA d2.sch
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
+----
+sch  r9=UC/r9
+
+simple conn=r9,user=r9
+DROP SCHEMA d2.sch
+----
+COMPLETE 0
+
+## Databases
+
+### Grants
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON DATABASES TO r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE      PUBLIC  U
+materialize  NULL  NULL  DATABASE  r1      U
+materialize  NULL  NULL  DATABASE  r2      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL ON DATABASES TO r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE      PUBLIC  U
+materialize  NULL  NULL  DATABASE  r1      U
+materialize  NULL  NULL  DATABASE  r2      U
+materialize  NULL  NULL  DATABASE  r3      UC
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 GRANT CREATE ON DATABASES TO r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  DATABASE  r8      C
+r7           NULL  NULL  DATABASE  r8      C
+PUBLIC       NULL  NULL  TYPE      PUBLIC  U
+materialize  NULL  NULL  DATABASE  r1      U
+materialize  NULL  NULL  DATABASE  r2      U
+materialize  NULL  NULL  DATABASE  r3      UC
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT CREATE ON DATABASES TO PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  DATABASE  r8      C
+r7           NULL  NULL  DATABASE  r8      C
+PUBLIC       NULL  NULL  TYPE      PUBLIC  U
+materialize  NULL  NULL  DATABASE  r1      U
+materialize  NULL  NULL  DATABASE  r2      U
+materialize  NULL  NULL  DATABASE  r3      UC
+materialize  NULL  NULL  DATABASE  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT CREATE ON DATABASES TO r1
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  DATABASE  r8      C
+r7           NULL  NULL  DATABASE  r8      C
+PUBLIC       NULL  NULL  TYPE      PUBLIC  U
+materialize  NULL  NULL  DATABASE  r2      U
+materialize  NULL  NULL  DATABASE  r1      UC
+materialize  NULL  NULL  DATABASE  r3      UC
+materialize  NULL  NULL  DATABASE  PUBLIC  C
+
+statement ok
+CREATE DATABASE d
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
+----
+d  =C/materialize
+d  r2=U/materialize
+d  r1=UC/materialize
+d  r3=UC/materialize
+d  materialize=UC/materialize
+
+statement ok
+DROP DATABASE d
+
+simple conn=r6,user=r6
+CREATE DATABASE d
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
+----
+d  r8=C/r6
+d  r6=UC/r6
+
+simple conn=r6,user=r6
+DROP DATABASE d
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE DATABASE d
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
+----
+d  r8=C/r7
+d  r7=UC/r7
+
+simple conn=r7,user=r7
+DROP DATABASE d
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE DATABASE d
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
+----
+d  r9=UC/r9
+
+simple conn=r9,user=r9
+DROP DATABASE d
+----
+COMPLETE 0
+
+### Revokes
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON DATABASES FROM r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  DATABASE  r8      C
+r7           NULL  NULL  DATABASE  r8      C
+PUBLIC       NULL  NULL  TYPE      PUBLIC  U
+materialize  NULL  NULL  DATABASE  r1      C
+materialize  NULL  NULL  DATABASE  r3      UC
+materialize  NULL  NULL  DATABASE  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON DATABASES FROM r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  DATABASE  r8      C
+r7           NULL  NULL  DATABASE  r8      C
+PUBLIC       NULL  NULL  TYPE      PUBLIC  U
+materialize  NULL  NULL  DATABASE  r1      C
+materialize  NULL  NULL  DATABASE  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 REVOKE CREATE ON DATABASES FROM r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE      PUBLIC  U
+materialize  NULL  NULL  DATABASE  r1      C
+materialize  NULL  NULL  DATABASE  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE CREATE ON DATABASES FROM PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE      PUBLIC  U
+materialize  NULL  NULL  DATABASE  r1      C
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE CREATE ON DATABASES FROM r1
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC NULL  NULL  TYPE   PUBLIC  U
+
+statement ok
+CREATE DATABASE d
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
+----
+d  materialize=UC/materialize
+
+statement ok
+DROP DATABASE d
+
+simple conn=r6,user=r6
+CREATE DATABASE d
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
+----
+d  r6=UC/r6
+
+simple conn=r6,user=r6
+DROP DATABASE d
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE DATABASE d
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
+----
+d  r7=UC/r7
+
+simple conn=r7,user=r7
+DROP DATABASE d
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE DATABASE d
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
+----
+d  r9=UC/r9
+
+simple conn=r9,user=r9
+DROP DATABASE d
+----
+COMPLETE 0
+
+## Clusters
+
+### Grants
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON CLUSTERS TO r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE     PUBLIC  U
+materialize  NULL  NULL  CLUSTER  r1      U
+materialize  NULL  NULL  CLUSTER  r2      U
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL ON CLUSTERS TO r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE     PUBLIC  U
+materialize  NULL  NULL  CLUSTER  r1      U
+materialize  NULL  NULL  CLUSTER  r2      U
+materialize  NULL  NULL  CLUSTER  r3      UC
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 GRANT CREATE ON CLUSTERS TO r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CLUSTER  r8      C
+r7           NULL  NULL  CLUSTER  r8      C
+PUBLIC       NULL  NULL  TYPE     PUBLIC  U
+materialize  NULL  NULL  CLUSTER  r1      U
+materialize  NULL  NULL  CLUSTER  r2      U
+materialize  NULL  NULL  CLUSTER  r3      UC
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT CREATE ON CLUSTERS TO PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CLUSTER  r8      C
+r7           NULL  NULL  CLUSTER  r8      C
+PUBLIC       NULL  NULL  TYPE     PUBLIC  U
+materialize  NULL  NULL  CLUSTER  r1      U
+materialize  NULL  NULL  CLUSTER  r2      U
+materialize  NULL  NULL  CLUSTER  r3      UC
+materialize  NULL  NULL  CLUSTER  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT CREATE ON CLUSTERS TO r1
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CLUSTER  r8      C
+r7           NULL  NULL  CLUSTER  r8      C
+PUBLIC       NULL  NULL  TYPE     PUBLIC  U
+materialize  NULL  NULL  CLUSTER  r2      U
+materialize  NULL  NULL  CLUSTER  r1      UC
+materialize  NULL  NULL  CLUSTER  r3      UC
+materialize  NULL  NULL  CLUSTER  PUBLIC  C
+
+statement ok
+CREATE CLUSTER c REPLICAS (r1 (SIZE '1'))
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
+----
+c  =C/materialize
+c  r2=U/materialize
+c  r1=UC/materialize
+c  r3=UC/materialize
+c  materialize=UC/materialize
+
+statement ok
+DROP CLUSTER c
+
+simple conn=r6,user=r6
+CREATE CLUSTER c REPLICAS (r1 (SIZE '1'))
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
+----
+c  r8=C/r6
+c  r6=UC/r6
+
+simple conn=r6,user=r6
+DROP CLUSTER c
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE CLUSTER c REPLICAS (r1 (SIZE '1'))
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
+----
+c  r8=C/r7
+c  r7=UC/r7
+
+simple conn=r7,user=r7
+DROP CLUSTER c
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE CLUSTER c REPLICAS (r1 (SIZE '1'))
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
+----
+c  r9=UC/r9
+
+simple conn=r9,user=r9
+DROP CLUSTER c
+----
+COMPLETE 0
+
+### Revokes
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON CLUSTERS FROM r1, r2
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CLUSTER  r8      C
+r7           NULL  NULL  CLUSTER  r8      C
+PUBLIC       NULL  NULL  TYPE     PUBLIC  U
+materialize  NULL  NULL  CLUSTER  r1      C
+materialize  NULL  NULL  CLUSTER  r3      UC
+materialize  NULL  NULL  CLUSTER  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON CLUSTERS FROM r3
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+r6           NULL  NULL  CLUSTER  r8      C
+r7           NULL  NULL  CLUSTER  r8      C
+PUBLIC       NULL  NULL  TYPE     PUBLIC  U
+materialize  NULL  NULL  CLUSTER  r1      C
+materialize  NULL  NULL  CLUSTER  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r6, r7 REVOKE CREATE ON CLUSTERS FROM r8
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE     PUBLIC  U
+materialize  NULL  NULL  CLUSTER  r1      C
+materialize  NULL  NULL  CLUSTER  PUBLIC  C
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE CREATE ON CLUSTERS FROM PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE     PUBLIC  U
+materialize  NULL  NULL  CLUSTER  r1      C
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE CREATE ON CLUSTERS FROM r1
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC NULL  NULL  TYPE  PUBLIC  U
+
+statement ok
+CREATE CLUSTER c REPLICAS (r1 (SIZE '1'))
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
+----
+c  materialize=UC/materialize
+
+statement ok
+DROP CLUSTER c
+
+simple conn=r6,user=r6
+CREATE CLUSTER c REPLICAS (r1 (SIZE '1'))
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
+----
+c  r6=UC/r6
+
+simple conn=r6,user=r6
+DROP CLUSTER c
+----
+COMPLETE 0
+
+simple conn=r7,user=r7
+CREATE CLUSTER c REPLICAS (r1 (SIZE '1'))
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
+----
+c  r7=UC/r7
+
+simple conn=r7,user=r7
+DROP CLUSTER c
+----
+COMPLETE 0
+
+simple conn=r9,user=r9
+CREATE CLUSTER c REPLICAS (r1 (SIZE '1'))
+----
+COMPLETE 0
+
+query TT
+SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
+----
+c  r9=UC/r9
+
+simple conn=r9,user=r9
+DROP CLUSTER c
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE CREATE ON SCHEMA materialize.public FROM r6, r7;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE CREATE, USAGE ON SCHEMA d1.s1, d1.s11, d2.s2, d2.s22 FROM r9, r11;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON DATABASE d1, d2 FROM r9, r11;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE CREATE ON DATABASE materialize, d1, d2 FROM r6, r7, r9;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE CREATE ON CLUSTER default FROM r6, r7, r9, r11;
+----
+COMPLETE 0
+
+statement ok
+DROP ROLE r1
+
+statement ok
+DROP ROLE r2
+
+statement ok
+DROP ROLE r3
+
+statement ok
+DROP ROLE r4
+
+statement ok
+DROP ROLE r5
+
+statement ok
+DROP ROLE r6
+
+statement ok
+DROP ROLE r7
+
+statement ok
+DROP ROLE r8
+
+statement ok
+DROP ROLE r9
+
+statement ok
+DROP ROLE r10
+
+statement ok
+DROP ROLE r11
+
+statement ok
+DROP ROLE r12
+
+# Test that default privileges prevent dropping a role
+
+statement ok
+CREATE ROLE r1
+
+statement ok
+GRANT r1 TO materialize
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 GRANT SELECT ON TABLES TO materialize
+
+simple conn=materialize,user=materialize
+DROP ROLE r1
+----
+db error: ERROR: role "r1" cannot be dropped because some objects depend on it
+DETAIL: r1: default privileges on TABLES created by r1
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 REVOKE SELECT ON TABLES FROM materialize
+
+statement ok
+DROP ROLE r1
+
+statement ok
+CREATE ROLE r1
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON CONNECTIONS TO r1
+
+simple conn=materialize,user=materialize
+DROP ROLE r1
+----
+db error: ERROR: role "r1" cannot be dropped because some objects depend on it
+DETAIL: r1: default privileges on CONNECTIONS granted to r1
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON CONNECTIONS FROM r1
+
+statement ok
+DROP ROLE r1
+
+# Test that DROP OWNED drops default privileges
+
+statement ok
+CREATE ROLE r1
+
+statement ok
+GRANT r1 TO materialize
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 GRANT SELECT ON TABLES TO materialize
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC  NULL  NULL  TYPE   PUBLIC       U
+r1      NULL  NULL  TABLE  materialize  r
+
+statement ok
+DROP OWNED BY r1
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC  NULL  NULL  TYPE   PUBLIC  U
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO r1
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  TYPE   PUBLIC  U
+materialize  NULL  NULL  TABLE  r1      r
+
+statement ok
+DROP OWNED BY r1
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC  NULL  NULL  TYPE   PUBLIC  U
+
+statement ok
+DROP ROLE r1
+
+# Test error scenarios
+
+statement error For object type VIEW, you must specify 'TABLE' or omit the object type
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON VIEWS TO PUBLIC
+
+statement error For object type MATERIALIZED VIEW, you must specify 'TABLE' or omit the object type
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON MATERIALIZED VIEWS TO PUBLIC
+
+statement error For object type SOURCE, you must specify 'TABLE' or omit the object type
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON SOURCES TO PUBLIC
+
+statement error Unsupported GRANT on SINK
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON SINKS TO PUBLIC
+
+statement error Unsupported GRANT on CLUSTER REPLICA
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON CLUSTER REPLICAS TO PUBLIC
+
+statement error Unsupported GRANT on ROLE
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON ROLES TO PUBLIC
+
+statement error Unsupported GRANT on INDEX
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON INDEXES TO PUBLIC
+
+statement error Expected one of TABLES or TYPES or SECRETS or CONNECTIONS or SCHEMAS or DATABASES or CLUSTERS
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON FUNCTIONS TO PUBLIC
+
+statement error cannot specify CLUSTERS and IN DATABASE
+ALTER DEFAULT PRIVILEGES IN DATABASE materialize GRANT USAGE ON CLUSTERS TO PUBLIC
+
+statement error cannot specify DATABASES and IN DATABASE
+ALTER DEFAULT PRIVILEGES IN DATABASE materialize GRANT USAGE ON DATABASES TO PUBLIC
+
+statement error cannot specify CLUSTERS and IN SCHEMA
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON CLUSTERS TO PUBLIC
+
+statement error cannot specify DATABASES and IN SCHEMA
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON DATABASES TO PUBLIC
+
+statement error cannot specify SCHEMAS and IN SCHEMA
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SCHEMAS TO PUBLIC
+
+statement error invalid privilege types INSERT for TYPE
+ALTER DEFAULT PRIVILEGES GRANT INSERT ON TYPES TO PUBLIC
+
+statement error invalid privilege types DELETE for CLUSTER
+ALTER DEFAULT PRIVILEGES GRANT DELETE ON CLUSTERS TO PUBLIC
+
+simple conn=mz_system,user=mz_system
+ALTER DEFAULT PRIVILEGES FOR ROLE mz_introspection GRANT SELECT ON TABLES TO PUBLIC
+----
+db error: ERROR: role name "mz_introspection" is reserved
+DETAIL: The role "public" and the prefixes "mz_" and "pg_" are reserved for system roles.
+
+statement error system schema 'mz_catalog' cannot be modified
+ALTER DEFAULT PRIVILEGES IN SCHEMA mz_catalog GRANT INSERT ON TABLES TO PUBLIC
+
+statement error role name "mz_system" is reserved
+ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO mz_system
+
+statement error role name "public" is reserved
+ALTER DEFAULT PRIVILEGES FOR ROLE PUBLIC GRANT INSERT ON TABLES TO materialize
+
+# Disable rbac checks.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_rbac_checks TO false;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_ld_rbac_checks TO false;
+----
+COMPLETE 0


### PR DESCRIPTION
This commit implements the ALTER DEFAULT PRIVILEGES command which
allows users to configure the default privileges granted on newly
created objects.

Works towards resolving #19647

### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer

Once again the vast majority of the LOC is tests.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add the `ALTER DEFAULT PRIVILEGES` command which allows users to configure the default privileges for newly created objects.
