### PR TITLE
stash: Cleanup some TODOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,6 +3431,7 @@ dependencies = [
  "opentelemetry",
  "prometheus",
  "proptest",
+ "proptest-derive",
  "prost",
  "rand",
  "rdkafka",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -50,6 +50,8 @@ mz-transform = { path = "../transform" }
 mz-cloud-resources = { path = "../cloud-resources" }
 opentelemetry = { version = "0.19.0", features = ["rt-tokio", "trace"] }
 prometheus = { version = "0.13.3", default-features = false }
+proptest = { version = "1.0.0", default-features = false, features = ["std"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
@@ -74,7 +76,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }
 datadriven = "0.6.0"
-proptest = { version = "1.0.0", default-features = false, features = ["std"]}
+
 
 [[bench]]
 name = "catalog"

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -88,6 +88,7 @@ use mz_storage_client::types::sinks::{
 use mz_storage_client::types::sources::{SourceConnection, SourceDesc, SourceEnvelope, Timeline};
 use mz_transform::Optimizer;
 use once_cell::sync::Lazy;
+use proptest_derive::Arbitrary;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tokio::sync::MutexGuard;
@@ -7494,7 +7495,7 @@ pub enum Op {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
 pub enum SerializedCatalogItem {
     V1 { create_sql: String },
 }

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -2013,50 +2013,50 @@ mod test {
     use super::{DatabaseKey, DatabaseValue, ItemKey, ItemValue, SchemaKey, SchemaValue};
 
     proptest! {
-        #[test]
+        #[mz_ore::test]
         fn proptest_database_key_roundtrip(key: DatabaseKey) {
             let proto = key.into_proto();
-            let round = proto.into_rust().unwrap();
+            let round = proto.into_rust().expect("to roundtrip");
 
             prop_assert_eq!(key, round);
         }
 
-        #[test]
+        #[mz_ore::test]
         fn proptest_database_value_roundtrip(value: DatabaseValue) {
             let proto = value.into_proto();
-            let round = proto.into_rust().unwrap();
+            let round = proto.into_rust().expect("to roundtrip");
 
             prop_assert_eq!(value, round);
         }
 
-        #[test]
+        #[mz_ore::test]
         fn proptest_schema_key_roundtrip(key: SchemaKey) {
             let proto = key.into_proto();
-            let round = proto.into_rust().unwrap();
+            let round = proto.into_rust().expect("to roundtrip");
 
             prop_assert_eq!(key, round);
         }
 
-        #[test]
+        #[mz_ore::test]
         fn proptest_schema_value_roundtrip(value: SchemaValue) {
             let proto = value.into_proto();
-            let round = proto.into_rust().unwrap();
+            let round = proto.into_rust().expect("to roundtrip");
 
             prop_assert_eq!(value, round);
         }
 
-        #[test]
+        #[mz_ore::test]
         fn proptest_item_key_roundtrip(key: ItemKey) {
             let proto = key.into_proto();
-            let round = proto.into_rust().unwrap();
+            let round = proto.into_rust().expect("to roundtrip");
 
             prop_assert_eq!(key, round);
         }
 
-        #[test]
+        #[mz_ore::test]
         fn proptest_item_value_roundtrip(value: ItemValue) {
             let proto = value.into_proto();
-            let round = proto.into_rust().unwrap();
+            let round = proto.into_rust().expect("to roundtrip");
 
             prop_assert_eq!(value, round);
         }

--- a/src/adapter/src/catalog/storage/objects.rs
+++ b/src/adapter/src/catalog/storage/objects.rs
@@ -152,12 +152,7 @@ impl RustType<proto::ClusterValue> for ClusterValue {
             name: self.name.to_string(),
             linked_object_id: self.linked_object_id.into_proto(),
             owner_id: Some(self.owner_id.into_proto()),
-            privileges: self
-                .privileges
-                .as_ref()
-                .cloned()
-                .unwrap_or_default()
-                .into_proto(),
+            privileges: self.privileges.into_proto(),
         }
     }
 
@@ -166,7 +161,7 @@ impl RustType<proto::ClusterValue> for ClusterValue {
             name: proto.name,
             linked_object_id: proto.linked_object_id.into_rust()?,
             owner_id: proto.owner_id.into_rust_if_some("ClusterValue::owner_id")?,
-            privileges: Some(proto.privileges.into_rust()?),
+            privileges: proto.privileges.into_rust()?,
         })
     }
 }
@@ -377,12 +372,7 @@ impl RustType<proto::DatabaseValue> for DatabaseValue {
         proto::DatabaseValue {
             name: self.name.clone(),
             owner_id: Some(self.owner_id.into_proto()),
-            privileges: self
-                .privileges
-                .as_ref()
-                .cloned()
-                .unwrap_or_default()
-                .into_proto(),
+            privileges: self.privileges.into_proto(),
         }
     }
 
@@ -392,7 +382,7 @@ impl RustType<proto::DatabaseValue> for DatabaseValue {
             owner_id: (proto
                 .owner_id
                 .into_rust_if_some("DatabaseValue::owner_id")?),
-            privileges: Some(proto.privileges.into_rust()?),
+            privileges: proto.privileges.into_rust()?,
         })
     }
 }

--- a/src/adapter/src/catalog/storage/objects.rs
+++ b/src/adapter/src/catalog/storage/objects.rs
@@ -17,11 +17,11 @@ use crate::catalog::{RoleMembership, SerializedCatalogItem, SerializedRole};
 use super::{
     AuditLogKey, ClusterIntrospectionSourceIndexKey, ClusterIntrospectionSourceIndexValue,
     ClusterKey, ClusterReplicaKey, ClusterReplicaValue, ClusterValue, ConfigKey, ConfigValue,
-    DatabaseKey, DatabaseNamespace, DatabaseValue, GidMappingKey, GidMappingValue, IdAllocKey,
-    IdAllocValue, ItemKey, ItemValue, RoleKey, RoleValue, SchemaKey, SchemaNamespace, SchemaValue,
-    SerializedReplicaConfig, SerializedReplicaLocation, SerializedReplicaLogging,
-    ServerConfigurationKey, ServerConfigurationValue, SettingKey, SettingValue, StorageUsageKey,
-    TimestampKey, TimestampValue,
+    DatabaseKey, DatabaseValue, GidMappingKey, GidMappingValue, IdAllocKey, IdAllocValue, ItemKey,
+    ItemValue, RoleKey, RoleValue, SchemaKey, SchemaValue, SerializedReplicaConfig,
+    SerializedReplicaLocation, SerializedReplicaLogging, ServerConfigurationKey,
+    ServerConfigurationValue, SettingKey, SettingValue, StorageUsageKey, TimestampKey,
+    TimestampValue,
 };
 
 impl RustType<proto::ConfigKey> for ConfigKey {
@@ -339,31 +339,15 @@ impl RustType<proto::replica_config::Location> for SerializedReplicaLocation {
 
 impl RustType<proto::DatabaseKey> for DatabaseKey {
     fn into_proto(&self) -> proto::DatabaseKey {
-        let value = match self.ns {
-            None | Some(DatabaseNamespace::User) => proto::database_id::Value::User(self.id),
-            Some(DatabaseNamespace::System) => proto::database_id::Value::System(self.id),
-        };
-
         proto::DatabaseKey {
-            id: Some(proto::DatabaseId { value: Some(value) }),
+            id: Some(self.id.into_proto()),
         }
     }
 
     fn from_proto(proto: proto::DatabaseKey) -> Result<Self, TryFromProtoError> {
-        let id = proto
-            .id
-            .ok_or_else(|| TryFromProtoError::missing_field("DatabaseKey::id"))?;
-        match id.value {
-            Some(proto::database_id::Value::User(id)) => Ok(DatabaseKey {
-                id,
-                ns: Some(DatabaseNamespace::User),
-            }),
-            Some(proto::database_id::Value::System(id)) => Ok(DatabaseKey {
-                id,
-                ns: Some(DatabaseNamespace::System),
-            }),
-            None => Err(TryFromProtoError::missing_field("DatabaseId::value")),
-        }
+        Ok(DatabaseKey {
+            id: proto.id.into_rust_if_some("DatabaseKey::value")?,
+        })
     }
 }
 
@@ -389,88 +373,36 @@ impl RustType<proto::DatabaseValue> for DatabaseValue {
 
 impl RustType<proto::SchemaKey> for SchemaKey {
     fn into_proto(&self) -> proto::SchemaKey {
-        let value = match self.ns {
-            None | Some(SchemaNamespace::User) => proto::schema_id::Value::User(self.id),
-            Some(SchemaNamespace::System) => proto::schema_id::Value::System(self.id),
-        };
-
         proto::SchemaKey {
-            id: Some(proto::SchemaId { value: Some(value) }),
+            id: Some(self.id.into_proto()),
         }
     }
 
     fn from_proto(proto: proto::SchemaKey) -> Result<Self, TryFromProtoError> {
-        let id = proto
-            .id
-            .ok_or_else(|| TryFromProtoError::missing_field("SchemaKey::id"))?;
-        match id.value {
-            Some(proto::schema_id::Value::User(id)) => Ok(SchemaKey {
-                id,
-                ns: Some(SchemaNamespace::User),
-            }),
-            Some(proto::schema_id::Value::System(id)) => Ok(SchemaKey {
-                id,
-                ns: Some(SchemaNamespace::System),
-            }),
-            None => Err(TryFromProtoError::missing_field("SchemaKey::value")),
-        }
+        Ok(SchemaKey {
+            id: proto.id.into_rust_if_some("SchemaKey::id")?,
+        })
     }
 }
 
 impl RustType<proto::SchemaValue> for SchemaValue {
     fn into_proto(&self) -> proto::SchemaValue {
-        let database_id = match (self.database_id, self.database_ns) {
-            (Some(id), Some(DatabaseNamespace::User)) | (Some(id), None) => {
-                Some(proto::DatabaseId {
-                    value: Some(proto::database_id::Value::User(id)),
-                })
-            }
-            (Some(id), Some(DatabaseNamespace::System)) => Some(proto::DatabaseId {
-                value: Some(proto::database_id::Value::System(id)),
-            }),
-            // Note: it's valid for a schema to not be associated with a database.
-            (None, _) => None,
-        };
-
         proto::SchemaValue {
             name: self.name.clone(),
-            database_id,
+            database_id: self.database_id.map(|id| id.into_proto()),
             owner_id: Some(self.owner_id.into_proto()),
-            privileges: self
-                .privileges
-                .as_ref()
-                .cloned()
-                .unwrap_or_default()
-                .into_proto(),
+            privileges: self.privileges.into_proto(),
         }
     }
 
     fn from_proto(proto: proto::SchemaValue) -> Result<Self, TryFromProtoError> {
-        let (database_id, database_ns) = match proto.database_id {
-            // Note: it's valid for a schema to not be associated with a database.
-            None => (None, None),
-            Some(proto::DatabaseId { value }) => {
-                let value =
-                    value.ok_or_else(|| TryFromProtoError::missing_field("DatabaseId::value"))?;
-                match value {
-                    proto::database_id::Value::User(id) => {
-                        (Some(id), Some(DatabaseNamespace::User))
-                    }
-                    proto::database_id::Value::System(id) => {
-                        (Some(id), Some(DatabaseNamespace::System))
-                    }
-                }
-            }
-        };
-
         Ok(SchemaValue {
             name: proto.name,
-            database_id,
-            database_ns,
+            database_id: proto.database_id.into_rust()?,
             owner_id: (proto
                 .owner_id
                 .into_rust_if_some("DatabaseValue::owner_id")?),
-            privileges: Some(proto.privileges.into_rust()?),
+            privileges: proto.privileges.into_rust()?,
         })
     }
 }
@@ -514,48 +446,24 @@ impl RustType<proto::CatalogItem> for SerializedCatalogItem {
 
 impl RustType<proto::ItemValue> for ItemValue {
     fn into_proto(&self) -> proto::ItemValue {
-        let schema_id = match self.schema_ns {
-            None | Some(SchemaNamespace::User) => proto::SchemaId {
-                value: Some(proto::schema_id::Value::User(self.schema_id)),
-            },
-            Some(SchemaNamespace::System) => proto::SchemaId {
-                value: Some(proto::schema_id::Value::System(self.schema_id)),
-            },
-        };
-
         proto::ItemValue {
-            schema_id: Some(schema_id),
+            schema_id: Some(self.schema_id.into_proto()),
             name: self.name.to_string(),
             definition: Some(self.definition.into_proto()),
             owner_id: Some(self.owner_id.into_proto()),
-            privileges: self
-                .privileges
-                .as_ref()
-                .cloned()
-                .unwrap_or_default()
-                .into_proto(),
+            privileges: self.privileges.into_proto(),
         }
     }
 
     fn from_proto(proto: proto::ItemValue) -> Result<Self, TryFromProtoError> {
-        let schema_id = proto
-            .schema_id
-            .ok_or_else(|| TryFromProtoError::missing_field("ItemValue::schema_id"))?;
-        let (schema_id, schema_ns) = match schema_id.value {
-            Some(proto::schema_id::Value::User(id)) => (id, SchemaNamespace::User),
-            Some(proto::schema_id::Value::System(id)) => (id, SchemaNamespace::System),
-            None => return Err(TryFromProtoError::missing_field("SchemaId::value")),
-        };
-
         Ok(ItemValue {
-            schema_id,
-            schema_ns: Some(schema_ns),
+            schema_id: proto.schema_id.into_rust_if_some("ItemValue::schema_id")?,
             name: proto.name,
             definition: proto
                 .definition
                 .into_rust_if_some("ItemValue::definition")?,
             owner_id: proto.owner_id.into_rust_if_some("ItemValue::owner_id")?,
-            privileges: Some(proto.privileges.into_rust()?),
+            privileges: proto.privileges.into_rust()?,
         })
     }
 }

--- a/src/repr/src/adt/mz_acl_item.rs
+++ b/src/repr/src/adt/mz_acl_item.rs
@@ -186,7 +186,9 @@ impl Arbitrary for AclMode {
 /// because we don't use OID as persistent identifiers for roles.
 ///
 /// See: <https://github.com/postgres/postgres/blob/7f5b19817eaf38e70ad1153db4e644ee9456853e/src/include/utils/acl.h#L48-L59>
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Hash, Deserialize, Arbitrary)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Hash, Deserialize, Arbitrary,
+)]
 pub struct MzAclItem {
     /// Role that this item grants privileges to.
     pub grantee: RoleId,

--- a/src/repr/src/adt/mz_acl_item.rs
+++ b/src/repr/src/adt/mz_acl_item.rs
@@ -20,6 +20,9 @@ use bitflags::bitflags;
 use columnation::{CloneRegion, Columnation};
 use mz_ore::str::StrExt;
 use mz_proto::{RustType, TryFromProtoError};
+use proptest::arbitrary::Arbitrary;
+use proptest::strategy::{BoxedStrategy, Strategy};
+use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use crate::role_id::RoleId;
@@ -161,8 +164,20 @@ impl RustType<ProtoAclMode> for AclMode {
         })
     }
 }
+
 impl Columnation for AclMode {
     type InnerRegion = CloneRegion<AclMode>;
+}
+
+impl Arbitrary for AclMode {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<AclMode>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        proptest::bits::BitSetStrategy::masked(AclMode::all().bits)
+            .prop_map(|bits| AclMode::from_bits(bits).expect("invalid proptest implementation"))
+            .boxed()
+    }
 }
 
 /// A list of privileges granted to a role in Materialize.
@@ -171,7 +186,7 @@ impl Columnation for AclMode {
 /// because we don't use OID as persistent identifiers for roles.
 ///
 /// See: <https://github.com/postgres/postgres/blob/7f5b19817eaf38e70ad1153db4e644ee9456853e/src/include/utils/acl.h#L48-L59>
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Hash, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Hash, Deserialize, Arbitrary)]
 pub struct MzAclItem {
     /// Role that this item grants privileges to.
     pub grantee: RoleId,


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

This PR cleans up some of the Rust types in the Catalog, removing `Option<...>`s, removing `Serialize` and `Deserialize` impls that are no longer needed, and collapsing `DatabaseKey` and `SchemaKey` to be wrappers around `DatabaseId` and `SchemaId`, respectively. It also derives `proptest::Arbitrary` for the Rust types that were changed, and asserts that these types roundtrip through their serialized protobuf types.

Note: the serialized protobuf types were not changed, so we do not need a migration for this PR.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
