### PR TITLE
ci: Disable colors in kail

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -178,6 +178,7 @@ case "$cmd" in
             --env NIGHTLY_CANARY_APP_PASSWORD
             --env NIGHTLY_CANARY_CONFLUENT_CLOUD_API_KEY
             --env NIGHTLY_CANARY_CONFLUENT_CLOUD_API_SECRET
+            --env NO_COLOR
             --env PYPI_TOKEN
         )
 

--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -40,7 +40,7 @@ bin/ci-builder run stable test/cloudtest/reset
 rm -f kubectl-*.log
 
 ci_collapsed_heading "kail: Start a new instance"
-bin/ci-builder run stable --detach --name "kail" kail --context kind-cloudtest --log-level info
+NO_COLOR=1 bin/ci-builder run stable --detach --name "kail" kail --context kind-cloudtest --log-level info
 
 ci_uncollapsed_heading "cloudtest: Running \`bin/pytest ${run_args[*]}\`"
 bin/ci-builder run stable bin/pytest "${run_args[@]}" |& tee run.log


### PR DESCRIPTION
See https://github.com/fatih/color#disableenable-color

As seen in https://github.com/MaterializeInc/materialize/issues/19917, the color codes are a bit spammy outside of a terminal.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
