### PR TITLE
doc: Correct replication lag query in Postgres guides

### DIFF
--- a/doc/user/layouts/shortcodes/postgres-direct/right-size-the-cluster.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/right-size-the-cluster.html
@@ -26,10 +26,31 @@ After the snapshotting phase, Materialize starts ingesting change events from th
     (1 row)
     ```
 
-1. Going forward, you can verify that your new replica size is sufficient by checking the replica lag in your PostgreSQL database:
+1. Going forward, you can verify that your new replica size is sufficient as follows:
 
-    ```sql
-    SELECT extract(epoch from now() - pg_last_xact_replay_timestamp()) AS replica_lag;
-    ```
+    1. In Materialize, get the replication slot name associated with your PostgreSQL source from the [`mz_internal.mz_postgres_sources`](/sql/system-catalog/mz_internal/#mz_postgres_sources) table:
 
-    A high value can indicate that the source has fallen behind and that you might need to scale up your ingestion cluster.
+        ```sql
+        SELECT
+            d.name AS database_name,
+            n.name AS schema_name,
+            s.name AS source_name,
+            pgs.replication_slot
+        FROM
+            mz_sources AS s
+            JOIN mz_internal.mz_postgres_sources AS pgs ON s.id = pgs.id
+            JOIN mz_schemas AS n ON n.id = s.schema_id
+            JOIN mz_databases AS d ON d.id = n.database_id;
+        ```
+
+    1. In PostgreSQL, check the replication slot lag, using the replication slot name from the previous step:
+
+        ```sql
+        SELECT
+            pg_size_pretty(pg_current_wal_lsn() - confirmed_flush_lsn)
+            AS replication_lag_bytes
+        FROM pg_replication_slots
+        WHERE slot_name = '<slot_name>';
+        ```
+
+        The result of this query is the amount of data your PostgreSQL cluster must retain in its replication log because of this replication slot. Typically, this means Materialize has not yet communicated back to PostgreSQL that it has committed this data. A high value can indicate that the source has fallen behind and that you might need to scale up your ingestion cluster.


### PR DESCRIPTION
The previous query only worked in RDS and didn't have the correct semantics.

Fixes: #19880

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
