### PR TITLE
[persist/expr] Fix a bug when handling associative variadic functions

### DIFF
--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -793,7 +793,7 @@ impl<'a> Interpreter for ColumnSpecs<'a> {
                 func: func.clone(),
                 exprs: vec![
                     Self::placeholder(col_type.clone()),
-                    Self::placeholder(col_type),
+                    Self::placeholder(col_type.clone()),
                 ],
             };
             let is_monotone = func.is_monotone();
@@ -807,6 +807,7 @@ impl<'a> Interpreter for ColumnSpecs<'a> {
                             self.eval_result(expr.eval(&[], self.arena))
                         })
                     })
+                    .intersect(ResultSpec::has_type(&col_type, true))
                 })
                 .expect("reduce over non-empty argument list")
         } else if args.len() >= Self::MAX_EVAL_ARGS {

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -1312,6 +1312,24 @@ mod tests {
     }
 
     #[mz_ore::test]
+    fn test_concat() {
+        let expr = MirScalarExpr::CallVariadic {
+            func: VariadicFunc::Concat,
+            exprs: vec![
+                MirScalarExpr::Column(0),
+                MirScalarExpr::literal_ok(Datum::String("a"), ScalarType::String),
+                MirScalarExpr::literal_ok(Datum::String("b"), ScalarType::String),
+            ],
+        };
+
+        let relation = RelationType::new(vec![ScalarType::String.nullable(false)]);
+        let arena = RowArena::new();
+        let interpreter = ColumnSpecs::new(&relation, &arena);
+        let spec = interpreter.expr(&expr);
+        assert!(spec.range.may_contain(Datum::String("blab")));
+    }
+
+    #[mz_ore::test]
     fn test_eval_range() {
         // Example inspired by the tumbling windows temporal filter in the docs
         let period_ms = MirScalarExpr::Literal(


### PR DESCRIPTION
This bug is an bad interaction between two recently-added features:
- In `ColumnSpecs::variadic`, we check if a function is associative; if so, we evaluate it as a series of nested calls. 
- To support lazy variadic funcs - which means that arguments to functions can be `Err`s -  we evaluate functions by passing arguments as literals instead of using column references. To make this efficient, we allocate a single expression and update the literals in place, checking that we don't pass a type we didn't expect up front.

In brief, the associative optimization thinks that some nested calls may return null, but the type in our placeholder does not expect null. I've left inline comments that try to walk through the issue.

This PR includes some test improvements, as well as two fixes:
- The first fix fixes the bug in a targeted way by filtering the result to only results that match the output type. Since the output type does not include `null`, we'll never end up trying to set `null` in the placeholder.
- The second replaces our special logic with calls to the regular `variadic` function. (Since every call to `variadic` already checks the type at the end, this is equivalent.)

Both approaches pass tests, but I find the second one leaves the code in a more readable state.

### Motivation

Should fix: https://github.com/MaterializeInc/materialize/issues/19899.

### Tips for reviewer

While this bug isn't specific to `concat`, `concat` is the ~only non-monotonic associative variadic function, so this ends up being something of a corner case. (One I forgot to add to our randomized testing; now fixed.)

I found this confusing to think about. In case you feel similarly, happy to chat it through sync if that's helpful.

~I still need to validate this fix in staging; will follow up once that's done.~ Works!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
