### PR TITLE
sql: Add multiple roles to GRANT/REVOKE role

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/grant-role.svg
+++ b/doc/user/layouts/partials/sql-grammar/grant-role.svg
@@ -1,46 +1,54 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="339" height="179">
-   <polygon points="11 17 3 13 3 21"/>
-   <polygon points="19 17 11 13 11 21"/>
-   <rect x="33" y="3" width="70" height="32" rx="10"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="339" height="223">
+   <polygon points="11 61 3 57 3 65"/>
+   <polygon points="19 61 11 57 11 65"/>
+   <rect x="33" y="47" width="70" height="32" rx="10"/>
    <rect x="31"
-         y="1"
+         y="45"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="21">GRANT</text>
-   <rect x="123" y="3" width="88" height="32"/>
-   <rect x="121" y="1" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="131" y="21">role_name</text>
-   <rect x="231" y="3" width="40" height="32" rx="10"/>
-   <rect x="229"
+   <text class="terminal" x="41" y="65">GRANT</text>
+   <rect x="143" y="47" width="88" height="32"/>
+   <rect x="141" y="45" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="151" y="65">role_name</text>
+   <rect x="143" y="3" width="24" height="32" rx="10"/>
+   <rect x="141"
          y="1"
-         width="40"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="239" y="21">TO</text>
-   <rect x="65" y="145" width="70" height="32" rx="10"/>
-   <rect x="63"
-         y="143"
-         width="70"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="73" y="163">GROUP</text>
-   <rect x="175" y="113" width="116" height="32"/>
-   <rect x="173" y="111" width="116" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="183" y="131">member_name</text>
-   <rect x="45" y="69" width="24" height="32" rx="10"/>
-   <rect x="43"
-         y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="87">,</text>
+   <text class="terminal" x="151" y="21">,</text>
+   <rect x="271" y="47" width="40" height="32" rx="10"/>
+   <rect x="269"
+         y="45"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="279" y="65">TO</text>
+   <rect x="65" y="189" width="70" height="32" rx="10"/>
+   <rect x="63"
+         y="187"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="207">GROUP</text>
+   <rect x="175" y="157" width="116" height="32"/>
+   <rect x="173" y="155" width="116" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="183" y="175">member_name</text>
+   <rect x="45" y="113" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="111"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="131">,</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-290 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m20 -32 h10 m116 0 h10 m-286 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m266 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-266 0 h10 m24 0 h10 m0 0 h222 m23 44 h-3"/>
-   <polygon points="329 127 337 123 337 131"/>
-   <polygon points="329 127 321 123 321 131"/>
+         d="m19 61 h2 m0 0 h10 m70 0 h10 m20 0 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m20 44 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-330 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m20 -32 h10 m116 0 h10 m-286 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m266 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-266 0 h10 m24 0 h10 m0 0 h222 m23 44 h-3"/>
+   <polygon points="329 171 337 167 337 175"/>
+   <polygon points="329 171 321 167 321 175"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/revoke-role.svg
+++ b/doc/user/layouts/partials/sql-grammar/revoke-role.svg
@@ -1,46 +1,54 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="339" height="179">
-   <polygon points="11 17 3 13 3 21"/>
-   <polygon points="19 17 11 13 11 21"/>
-   <rect x="33" y="3" width="78" height="32" rx="10"/>
-   <rect x="31"
-         y="1"
+<svg xmlns="http://www.w3.org/2000/svg" width="359" height="223">
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="78" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="21">REVOKE</text>
-   <rect x="131" y="3" width="88" height="32"/>
-   <rect x="129" y="1" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="139" y="21">role_name</text>
-   <rect x="239" y="3" width="60" height="32" rx="10"/>
-   <rect x="237"
+   <text class="terminal" x="39" y="65">REVOKE</text>
+   <rect x="149" y="47" width="88" height="32"/>
+   <rect x="147" y="45" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="157" y="65">role_name</text>
+   <rect x="149" y="3" width="24" height="32" rx="10"/>
+   <rect x="147"
          y="1"
-         width="60"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="247" y="21">FROM</text>
-   <rect x="65" y="145" width="70" height="32" rx="10"/>
-   <rect x="63"
-         y="143"
-         width="70"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="73" y="163">GROUP</text>
-   <rect x="175" y="113" width="116" height="32"/>
-   <rect x="173" y="111" width="116" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="183" y="131">member_name</text>
-   <rect x="45" y="69" width="24" height="32" rx="10"/>
-   <rect x="43"
-         y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="87">,</text>
+   <text class="terminal" x="157" y="21">,</text>
+   <rect x="277" y="47" width="60" height="32" rx="10"/>
+   <rect x="275"
+         y="45"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="285" y="65">FROM</text>
+   <rect x="85" y="189" width="70" height="32" rx="10"/>
+   <rect x="83"
+         y="187"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="93" y="207">GROUP</text>
+   <rect x="195" y="157" width="116" height="32"/>
+   <rect x="193" y="155" width="116" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="203" y="175">member_name</text>
+   <rect x="65" y="113" width="24" height="32" rx="10"/>
+   <rect x="63"
+         y="111"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="131">,</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m78 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-318 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m20 -32 h10 m116 0 h10 m-286 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m266 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-266 0 h10 m24 0 h10 m0 0 h222 m23 44 h-3"/>
-   <polygon points="329 127 337 123 337 131"/>
-   <polygon points="329 127 321 123 321 131"/>
+         d="m17 61 h2 m0 0 h10 m78 0 h10 m20 0 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m20 44 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-336 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m20 -32 h10 m116 0 h10 m-286 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m266 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-266 0 h10 m24 0 h10 m0 0 h222 m23 44 h-3"/>
+   <polygon points="349 171 357 167 357 175"/>
+   <polygon points="349 171 341 167 341 175"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -224,7 +224,7 @@ format_spec ::=
 grant_privilege ::=
   'GRANT' ((privilege (',' privilege)*) | 'ALL' 'PRIVILEGES'? ) ON ( ('TABLE'? | 'TYPE' | 'SECRET' | 'CONNECTION' | 'DATABASE' | 'SCHEMA' | 'CLUSTER') object_name (',' object_name)* | 'ALL' ('TABLES' | 'TYPES' | 'SECRETS' | 'CONNECTIONS') 'IN' 'SCHEMA' schema_name (',' schema_name)* | 'ALL' ('TABLES' | 'TYPES' | 'SECRETS' | 'CONNECTIONS' | 'SCHEMAS') 'IN' 'DATABASE' database_name (',' database_name)* | 'ALL' ('TABLES' | 'TYPES' | 'SECRETS' | 'CONNECTIONS' | 'DATABASES' | 'SCHEMAS' | 'CLUSTERS') ) 'TO' 'GROUP'? role_name ( ',' 'GROUP'? role_name )*
 grant_role ::=
-  'GRANT' role_name 'TO' 'GROUP'? member_name ( ',' 'GROUP'? member_name )*
+  'GRANT' role_name ( ',' role_name )* 'TO' 'GROUP'? member_name ( ',' 'GROUP'? member_name )*
 key_strat ::=
   'KEY STRATEGY' strat
 val_strat ::=
@@ -300,7 +300,7 @@ reset_session_variable ::=
 revoke_privilege ::=
   'REVOKE' ((privilege (',' privilege)*) | 'ALL' 'PRIVILEGES'? ) ON ( ('TABLE'? | 'TYPE' | 'SECRET' | 'CONNECTION' | 'DATABASE' | 'SCHEMA' | 'CLUSTER') object_name (',' object_name)* | 'ALL' ('TABLES' | 'TYPES' | 'SECRETS' | 'CONNECTIONS') 'IN' 'SCHEMA' schema_name (',' schema_name)* | 'ALL' ('TABLES' | 'TYPES' | 'SECRETS' | 'CONNECTIONS' | 'SCHEMAS') 'IN' 'DATABASE' database_name (',' database_name)* | 'ALL' ('TABLES' | 'TYPES' | 'SECRETS' | 'CONNECTIONS' | 'DATABASES' | 'SCHEMAS' | 'CLUSTERS') ) 'FROM' 'GROUP'? role_name ( ',' 'GROUP'? role_name )*
 revoke_role ::=
-  'REVOKE' role_name 'FROM' 'GROUP'? member_name ( ',' 'GROUP'? member_name )*
+  'REVOKE' role_name ( ',' role_name )* 'FROM' 'GROUP'? member_name ( ',' 'GROUP'? member_name )*
 rollback ::=
   'ROLLBACK'
 select_stmt ::=

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3891,32 +3891,34 @@ impl Coordinator {
         &mut self,
         session: &mut Session,
         GrantRolePlan {
-            role_id,
+            role_ids,
             member_ids,
             grantor_id,
         }: GrantRolePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let catalog = self.catalog();
-        let mut ops = Vec::new();
-        for member_id in member_ids {
-            let member_membership: BTreeSet<_> =
-                catalog.get_role(&member_id).membership().keys().collect();
-            if member_membership.contains(&role_id) {
-                let role_name = catalog.get_role(&role_id).name().to_string();
-                let member_name = catalog.get_role(&member_id).name().to_string();
-                // We need this check so we don't accidentally return a success on a reserved role.
-                catalog.ensure_not_reserved_role(&member_id)?;
-                catalog.ensure_not_reserved_role(&role_id)?;
-                session.add_notice(AdapterNotice::RoleMembershipAlreadyExists {
-                    role_name,
-                    member_name,
-                });
-            } else {
-                ops.push(catalog::Op::GrantRole {
-                    role_id,
-                    member_id,
-                    grantor_id,
-                });
+        let mut ops = Vec::with_capacity(role_ids.len() * member_ids.len());
+        for role_id in role_ids {
+            for member_id in &member_ids {
+                let member_membership: BTreeSet<_> =
+                    catalog.get_role(member_id).membership().keys().collect();
+                if member_membership.contains(&role_id) {
+                    let role_name = catalog.get_role(&role_id).name().to_string();
+                    let member_name = catalog.get_role(member_id).name().to_string();
+                    // We need this check so we don't accidentally return a success on a reserved role.
+                    catalog.ensure_not_reserved_role(member_id)?;
+                    catalog.ensure_not_reserved_role(&role_id)?;
+                    session.add_notice(AdapterNotice::RoleMembershipAlreadyExists {
+                        role_name,
+                        member_name,
+                    });
+                } else {
+                    ops.push(catalog::Op::GrantRole {
+                        role_id,
+                        member_id: *member_id,
+                        grantor_id,
+                    });
+                }
             }
         }
 
@@ -3933,32 +3935,34 @@ impl Coordinator {
         &mut self,
         session: &mut Session,
         RevokeRolePlan {
-            role_id,
+            role_ids,
             member_ids,
             grantor_id,
         }: RevokeRolePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let catalog = self.catalog();
-        let mut ops = Vec::new();
-        for member_id in member_ids {
-            let member_membership: BTreeSet<_> =
-                catalog.get_role(&member_id).membership().keys().collect();
-            if !member_membership.contains(&role_id) {
-                let role_name = catalog.get_role(&role_id).name().to_string();
-                let member_name = catalog.get_role(&member_id).name().to_string();
-                // We need this check so we don't accidentally return a success on a reserved role.
-                catalog.ensure_not_reserved_role(&member_id)?;
-                catalog.ensure_not_reserved_role(&role_id)?;
-                session.add_notice(AdapterNotice::RoleMembershipDoesNotExists {
-                    role_name,
-                    member_name,
-                });
-            } else {
-                ops.push(catalog::Op::RevokeRole {
-                    role_id,
-                    member_id,
-                    grantor_id,
-                });
+        let mut ops = Vec::with_capacity(role_ids.len() * member_ids.len());
+        for role_id in role_ids {
+            for member_id in &member_ids {
+                let member_membership: BTreeSet<_> =
+                    catalog.get_role(member_id).membership().keys().collect();
+                if !member_membership.contains(&role_id) {
+                    let role_name = catalog.get_role(&role_id).name().to_string();
+                    let member_name = catalog.get_role(member_id).name().to_string();
+                    // We need this check so we don't accidentally return a success on a reserved role.
+                    catalog.ensure_not_reserved_role(member_id)?;
+                    catalog.ensure_not_reserved_role(&role_id)?;
+                    session.add_notice(AdapterNotice::RoleMembershipDoesNotExists {
+                        role_name,
+                        member_name,
+                    });
+                } else {
+                    ops.push(catalog::Op::RevokeRole {
+                        role_id,
+                        member_id: *member_id,
+                        grantor_id,
+                    });
+                }
             }
         }
 

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -1180,12 +1180,12 @@ fn generate_required_privileges(
         | Plan::Deallocate(DeallocatePlan { name: _ })
         | Plan::Raise(RaisePlan { severity: _ })
         | Plan::GrantRole(GrantRolePlan {
-            role_id: _,
+            role_ids: _,
             member_ids: _,
             grantor_id: _,
         })
         | Plan::RevokeRole(RevokeRolePlan {
-            role_id: _,
+            role_ids: _,
             member_ids: _,
             grantor_id: _,
         })

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2860,8 +2860,8 @@ impl_display_t!(ShowStatement);
 /// `GRANT ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GrantRoleStatement<T: AstInfo> {
-    /// The role that is gaining a member.
-    pub role_name: T::RoleName,
+    /// The roles that are gaining members.
+    pub role_names: Vec<T::RoleName>,
     /// The roles that will be added to `role_name`.
     pub member_names: Vec<T::RoleName>,
 }
@@ -2869,7 +2869,7 @@ pub struct GrantRoleStatement<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for GrantRoleStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("GRANT ");
-        f.write_node(&self.role_name);
+        f.write_node(&display::comma_separated(&self.role_names));
         f.write_str(" TO ");
         f.write_node(&display::comma_separated(&self.member_names));
     }
@@ -2879,16 +2879,16 @@ impl_display_t!(GrantRoleStatement);
 /// `REVOKE ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RevokeRoleStatement<T: AstInfo> {
-    /// The role that is losing a member.
-    pub role_name: T::RoleName,
-    /// The role that will be removed from `role_name`.
+    /// The roles that are losing members.
+    pub role_names: Vec<T::RoleName>,
+    /// The roles that will be removed from `role_name`.
     pub member_names: Vec<T::RoleName>,
 }
 
 impl<T: AstInfo> AstDisplay for RevokeRoleStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("REVOKE ");
-        f.write_node(&self.role_name);
+        f.write_node(&display::comma_separated(&self.role_names));
         f.write_str(" FROM ");
         f.write_node(&display::comma_separated(&self.member_names));
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -6168,11 +6168,11 @@ impl<'a> Parser<'a> {
     /// Parse a `GRANT ROLE` statement, assuming that the `GRANT` token
     /// has already been consumed.
     fn parse_grant_role(&mut self) -> Result<Statement<Raw>, ParserError> {
-        let role_name = self.parse_identifier()?;
+        let role_names = self.parse_comma_separated(Parser::parse_identifier)?;
         self.expect_keyword(TO)?;
         let member_names = self.parse_comma_separated(Parser::expect_role_specification)?;
         Ok(Statement::GrantRole(GrantRoleStatement {
-            role_name,
+            role_names,
             member_names,
         }))
     }
@@ -6206,11 +6206,11 @@ impl<'a> Parser<'a> {
     /// Parse a `REVOKE ROLE` statement, assuming that the `REVOKE` token
     /// has already been consumed.
     fn parse_revoke_role(&mut self) -> Result<Statement<Raw>, ParserError> {
-        let role_name = self.parse_identifier()?;
+        let role_names = self.parse_comma_separated(Parser::parse_identifier)?;
         self.expect_keyword(FROM)?;
         let member_names = self.parse_comma_separated(Parser::expect_role_specification)?;
         Ok(Statement::RevokeRole(RevokeRoleStatement {
-            role_name,
+            role_names,
             member_names,
         }))
     }

--- a/src/sql-parser/tests/testdata/acl
+++ b/src/sql-parser/tests/testdata/acl
@@ -23,98 +23,112 @@ GRANT admin TO joe
 ----
 GRANT admin TO joe
 =>
-GrantRole(GrantRoleStatement { role_name: Ident("admin"), member_names: [Ident("joe")] })
+GrantRole(GrantRoleStatement { role_names: [Ident("admin")], member_names: [Ident("joe")] })
 
 parse-statement
 GRANT scientist TO GROUP joseph
 ----
 GRANT scientist TO joseph
 =>
-GrantRole(GrantRoleStatement { role_name: Ident("scientist"), member_names: [Ident("joseph")] })
+GrantRole(GrantRoleStatement { role_names: [Ident("scientist")], member_names: [Ident("joseph")] })
 
 parse-statement
 GRANT admin TO joe, mike
 ----
 GRANT admin TO joe, mike
 =>
-GrantRole(GrantRoleStatement { role_name: Ident("admin"), member_names: [Ident("joe"), Ident("mike")] })
+GrantRole(GrantRoleStatement { role_names: [Ident("admin")], member_names: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 GRANT scientist TO GROUP joseph, michael
 ----
 GRANT scientist TO joseph, michael
 =>
-GrantRole(GrantRoleStatement { role_name: Ident("scientist"), member_names: [Ident("joseph"), Ident("michael")] })
+GrantRole(GrantRoleStatement { role_names: [Ident("scientist")], member_names: [Ident("joseph"), Ident("michael")] })
 
 parse-statement
 GRANT scientist TO GROUP joseph, GROUP michael
 ----
 GRANT scientist TO joseph, michael
 =>
-GrantRole(GrantRoleStatement { role_name: Ident("scientist"), member_names: [Ident("joseph"), Ident("michael")] })
+GrantRole(GrantRoleStatement { role_names: [Ident("scientist")], member_names: [Ident("joseph"), Ident("michael")] })
 
 parse-statement
 GRANT scientist TO joseph, GROUP michael
 ----
 GRANT scientist TO joseph, michael
 =>
-GrantRole(GrantRoleStatement { role_name: Ident("scientist"), member_names: [Ident("joseph"), Ident("michael")] })
+GrantRole(GrantRoleStatement { role_names: [Ident("scientist")], member_names: [Ident("joseph"), Ident("michael")] })
 
 parse-statement
 GRANT scientist TO GROUP joseph, GROUP michael, GROUP yisachar
 ----
 GRANT scientist TO joseph, michael, yisachar
 =>
-GrantRole(GrantRoleStatement { role_name: Ident("scientist"), member_names: [Ident("joseph"), Ident("michael"), Ident("yisachar")] })
+GrantRole(GrantRoleStatement { role_names: [Ident("scientist")], member_names: [Ident("joseph"), Ident("michael"), Ident("yisachar")] })
+
+parse-statement
+GRANT surfaces, member_of_technical_staff TO joe
+----
+GRANT surfaces, member_of_technical_staff TO joe
+=>
+GrantRole(GrantRoleStatement { role_names: [Ident("surfaces"), Ident("member_of_technical_staff")], member_names: [Ident("joe")] })
 
 parse-statement
 REVOKE doctor FROM joe
 ----
 REVOKE doctor FROM joe
 =>
-RevokeRole(RevokeRoleStatement { role_name: Ident("doctor"), member_names: [Ident("joe")] })
+RevokeRole(RevokeRoleStatement { role_names: [Ident("doctor")], member_names: [Ident("joe")] })
 
 parse-statement
 REVOKE ability_to_practice_law_in_arkansas FROM GROUP joseph
 ----
 REVOKE ability_to_practice_law_in_arkansas FROM joseph
 =>
-RevokeRole(RevokeRoleStatement { role_name: Ident("ability_to_practice_law_in_arkansas"), member_names: [Ident("joseph")] })
+RevokeRole(RevokeRoleStatement { role_names: [Ident("ability_to_practice_law_in_arkansas")], member_names: [Ident("joseph")] })
 
 parse-statement
 REVOKE doctor FROM joe, mike
 ----
 REVOKE doctor FROM joe, mike
 =>
-RevokeRole(RevokeRoleStatement { role_name: Ident("doctor"), member_names: [Ident("joe"), Ident("mike")] })
+RevokeRole(RevokeRoleStatement { role_names: [Ident("doctor")], member_names: [Ident("joe"), Ident("mike")] })
 
 parse-statement
 REVOKE ability_to_practice_law_in_arkansas FROM GROUP joseph, michael
 ----
 REVOKE ability_to_practice_law_in_arkansas FROM joseph, michael
 =>
-RevokeRole(RevokeRoleStatement { role_name: Ident("ability_to_practice_law_in_arkansas"), member_names: [Ident("joseph"), Ident("michael")] })
+RevokeRole(RevokeRoleStatement { role_names: [Ident("ability_to_practice_law_in_arkansas")], member_names: [Ident("joseph"), Ident("michael")] })
 
 parse-statement
 REVOKE ability_to_practice_law_in_arkansas FROM joseph, GROUP michael
 ----
 REVOKE ability_to_practice_law_in_arkansas FROM joseph, michael
 =>
-RevokeRole(RevokeRoleStatement { role_name: Ident("ability_to_practice_law_in_arkansas"), member_names: [Ident("joseph"), Ident("michael")] })
+RevokeRole(RevokeRoleStatement { role_names: [Ident("ability_to_practice_law_in_arkansas")], member_names: [Ident("joseph"), Ident("michael")] })
 
 parse-statement
 REVOKE ability_to_practice_law_in_arkansas FROM GROUP joseph, GROUP michael
 ----
 REVOKE ability_to_practice_law_in_arkansas FROM joseph, michael
 =>
-RevokeRole(RevokeRoleStatement { role_name: Ident("ability_to_practice_law_in_arkansas"), member_names: [Ident("joseph"), Ident("michael")] })
+RevokeRole(RevokeRoleStatement { role_names: [Ident("ability_to_practice_law_in_arkansas")], member_names: [Ident("joseph"), Ident("michael")] })
 
 parse-statement
 REVOKE ability_to_practice_law_in_arkansas FROM GROUP joseph, GROUP michael, GROUP yisachar
 ----
 REVOKE ability_to_practice_law_in_arkansas FROM joseph, michael, yisachar
 =>
-RevokeRole(RevokeRoleStatement { role_name: Ident("ability_to_practice_law_in_arkansas"), member_names: [Ident("joseph"), Ident("michael"), Ident("yisachar")] })
+RevokeRole(RevokeRoleStatement { role_names: [Ident("ability_to_practice_law_in_arkansas")], member_names: [Ident("joseph"), Ident("michael"), Ident("yisachar")] })
+
+parse-statement
+REVOKE surfaces, member_of_technical_staff FROM joe
+----
+REVOKE surfaces, member_of_technical_staff FROM joe
+=>
+RevokeRole(RevokeRoleStatement { role_names: [Ident("surfaces"), Ident("member_of_technical_staff")], member_names: [Ident("joe")] })
 
 parse-statement
 ALTER CLUSTER foo OWNER TO joe

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -889,8 +889,8 @@ pub struct RaisePlan {
 
 #[derive(Debug)]
 pub struct GrantRolePlan {
-    /// The role that is gaining a member.
-    pub role_id: RoleId,
+    /// The roles that are gaining members.
+    pub role_ids: Vec<RoleId>,
     /// The roles that will be added to `role_id`.
     pub member_ids: Vec<RoleId>,
     /// The role that granted the membership.
@@ -899,8 +899,8 @@ pub struct GrantRolePlan {
 
 #[derive(Debug)]
 pub struct RevokeRolePlan {
-    /// The role that is losing a member.
-    pub role_id: RoleId,
+    /// The roles that are losing members.
+    pub role_ids: Vec<RoleId>,
     /// The roles that will be removed from `role_id`.
     pub member_ids: Vec<RoleId>,
     /// The role that revoked the membership.

--- a/src/sql/src/plan/statement/acl.rs
+++ b/src/sql/src/plan/statement/acl.rs
@@ -229,7 +229,7 @@ pub fn describe_grant_role(
 pub fn plan_grant_role(
     scx: &StatementContext,
     GrantRoleStatement {
-        role_name,
+        role_names,
         member_names,
     }: GrantRoleStatement<Aug>,
 ) -> Result<Plan, PlanError> {
@@ -244,7 +244,10 @@ pub fn plan_grant_role(
         .expect("system user must exist")
         .id();
     Ok(Plan::GrantRole(GrantRolePlan {
-        role_id: role_name.id,
+        role_ids: role_names
+            .into_iter()
+            .map(|role_name| role_name.id)
+            .collect(),
         member_ids: member_names
             .into_iter()
             .map(|member_name| member_name.id)
@@ -263,7 +266,7 @@ pub fn describe_revoke_role(
 pub fn plan_revoke_role(
     scx: &StatementContext,
     RevokeRoleStatement {
-        role_name,
+        role_names,
         member_names,
     }: RevokeRoleStatement<Aug>,
 ) -> Result<Plan, PlanError> {
@@ -280,7 +283,10 @@ pub fn plan_revoke_role(
         .expect("system user must exist")
         .id();
     Ok(Plan::RevokeRole(RevokeRolePlan {
-        role_id: role_name.id,
+        role_ids: role_names
+            .into_iter()
+            .map(|role_name| role_name.id)
+            .collect(),
         member_ids: member_names
             .into_iter()
             .map(|member_name| member_name.id)

--- a/test/sqllogictest/role_membership.slt
+++ b/test/sqllogictest/role_membership.slt
@@ -331,6 +331,68 @@ group3  joe     mz_system  false
 group3  group1  mz_system  false
 group3  group2  mz_system  false
 
+statement ok
+DROP ROLE group1
+
+statement ok
+DROP ROLE group2
+
+statement ok
+DROP ROLE group3
+
+statement ok
+DROP ROLE joe
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+CREATE ROLE mike
+
+statement ok
+CREATE ROLE group1
+
+statement ok
+CREATE ROLE group2
+
+statement ok
+GRANT group1, group2 TO joe, mike
+
+query TTTB
+SELECT role.name, member.name, grantor.name, members.admin_option
+FROM pg_auth_members members
+LEFT JOIN mz_roles role ON members.roleid = role.oid
+LEFT JOIN mz_roles member ON members.member = member.oid
+LEFT JOIN mz_roles grantor ON members.grantor = grantor.oid
+----
+group1  joe     mz_system  false
+group2  joe     mz_system  false
+group1  mike    mz_system  false
+group2  mike    mz_system  false
+
+statement ok
+REVOKE group1, group2 FROM joe, mike
+
+query TTTB
+SELECT role.name, member.name, grantor.name, members.admin_option
+FROM pg_auth_members members
+LEFT JOIN mz_roles role ON members.roleid = role.oid
+LEFT JOIN mz_roles member ON members.member = member.oid
+LEFT JOIN mz_roles grantor ON members.grantor = grantor.oid
+----
+
+statement ok
+DROP ROLE group1
+
+statement ok
+DROP ROLE group2
+
+statement ok
+DROP ROLE joe
+
+statement ok
+DROP ROLE mike
+
 # Disable RBAC checks
 
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
This commit adds the ability to specify multiple role names in GRANT/REVOKE role statements.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add the ability to specify multiple role names in GRANT/REVOKE role statements.
