### PR TITLE
adapter: Avoid duplicate role membership revokes

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1334,13 +1334,12 @@ impl Coordinator {
         session: &mut Session,
         ids: Vec<ObjectId>,
     ) -> Result<DropOps, AdapterError> {
-        let mut ops = Vec::new();
         let mut dropped_active_db = false;
         let mut dropped_active_cluster = false;
         // Dropping either the group role or the member role of a role membership will trigger a
-        // revoke role. We keep track of the already seen revoked roles to avoid trying to attempt
-        // to revoke the same role membership twice.
-        let mut seen_revokes = BTreeSet::new();
+        // revoke role. We use a Set for the revokes to avoid trying to attempt to revoke the same
+        // role membership twice.
+        let mut revokes = BTreeSet::new();
 
         let mut dropped_roles: BTreeMap<_, _> = ids
             .iter()
@@ -1363,17 +1362,15 @@ impl Coordinator {
             for dropped_role_id in
                 dropped_role_ids.intersection(&role.membership.map.keys().collect())
             {
-                if seen_revokes.insert((**dropped_role_id, role.id())) {
-                    ops.push(catalog::Op::RevokeRole {
-                        role_id: **dropped_role_id,
-                        member_id: role.id(),
-                        grantor_id: *role
-                            .membership
-                            .map
-                            .get(*dropped_role_id)
-                            .expect("included in keys above"),
-                    });
-                }
+                revokes.insert((
+                    **dropped_role_id,
+                    role.id(),
+                    *role
+                        .membership
+                        .map
+                        .get(*dropped_role_id)
+                        .expect("included in keys above"),
+                ));
             }
         }
 
@@ -1403,20 +1400,22 @@ impl Coordinator {
                     dropped_roles.insert(*id, name);
                     // We must revoke all role memberships that the dropped roles belongs to.
                     for (group_id, grantor_id) in &role.membership.map {
-                        if seen_revokes.insert((*group_id, *id)) {
-                            ops.push(catalog::Op::RevokeRole {
-                                role_id: *group_id,
-                                member_id: *id,
-                                grantor_id: *grantor_id,
-                            });
-                        }
+                        revokes.insert((*group_id, *id, *grantor_id));
                     }
                 }
                 _ => {}
             }
         }
 
-        ops.extend(ids.into_iter().map(catalog::Op::DropObject));
+        let ops = revokes
+            .into_iter()
+            .map(|(role_id, member_id, grantor_id)| catalog::Op::RevokeRole {
+                role_id,
+                member_id,
+                grantor_id,
+            })
+            .chain(ids.into_iter().map(catalog::Op::DropObject))
+            .collect();
 
         Ok(DropOps {
             ops,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1409,7 +1409,6 @@ impl Coordinator {
                                 member_id: *id,
                                 grantor_id: *grantor_id,
                             });
-                            seen_revokes.insert((*group_id, *id));
                         }
                     }
                 }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1363,7 +1363,7 @@ impl Coordinator {
             for dropped_role_id in
                 dropped_role_ids.intersection(&role.membership.map.keys().collect())
             {
-                if !seen_revokes.contains(&(**dropped_role_id, role.id())) {
+                if seen_revokes.insert((**dropped_role_id, role.id())) {
                     ops.push(catalog::Op::RevokeRole {
                         role_id: **dropped_role_id,
                         member_id: role.id(),

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1373,7 +1373,6 @@ impl Coordinator {
                             .get(*dropped_role_id)
                             .expect("included in keys above"),
                     });
-                    seen_revokes.insert((**dropped_role_id, role.id()));
                 }
             }
         }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1403,7 +1403,7 @@ impl Coordinator {
                     dropped_roles.insert(*id, name);
                     // We must revoke all role memberships that the dropped roles belongs to.
                     for (group_id, grantor_id) in &role.membership.map {
-                        if !seen_revokes.contains(&(*group_id, *id)) {
+                        if seen_revokes.insert((*group_id, *id)) {
                             ops.push(catalog::Op::RevokeRole {
                                 role_id: *group_id,
                                 member_id: *id,

--- a/test/sqllogictest/role_membership.slt
+++ b/test/sqllogictest/role_membership.slt
@@ -331,6 +331,9 @@ group3  joe     mz_system  false
 group3  group1  mz_system  false
 group3  group2  mz_system  false
 
+statement ok
+DROP ROLE group1, group2, group3, joe
+
 # Disable RBAC checks
 
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
When either the group role or the member role of a role membership is dropped, then the role membership is automatically revoked. For example if role r1 is a member of role r2, if either r1 or r2 are dropped, then we automatically revoke r2 from r1.

Previously, when both r1 and r2 were dropped in the same statement, we would try to revoke r2 from r1 twice, causing a panic. This commit fixes that issue so the role membership is only ever revoked once.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
