### PR TITLE
environmentd: send BackendKeyData during WS init

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -273,7 +273,21 @@ fn test_http_sql() {
         ))
         .unwrap();
         let (mut ws, _resp) = tungstenite::connect(ws_url).unwrap();
-        util::auth_with_ws(&mut ws, BTreeMap::default()).unwrap();
+        let ws_init = util::auth_with_ws(&mut ws, BTreeMap::default()).unwrap();
+
+        // Verify ws_init contains roughly what we expect. This varies (rng secret and version
+        // numbers), so easier to test here instead of in the ws file.
+        assert!(
+            ws_init
+                .iter()
+                .filter(|m| matches!(m, WebSocketResponse::ParameterStatus(_)))
+                .count()
+                > 1
+        );
+        assert!(matches!(
+            ws_init.last(),
+            Some(WebSocketResponse::BackendKeyData(_))
+        ));
 
         f.run(|tc| {
             let msg = match tc.directive.as_str() {


### PR DESCRIPTION
 This will allow for websockets to cancel queries.

 See #19773

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a