### PR TITLE
Upload debuginfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "findshlibs"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d691fdb3f817632d259d09220d4cf0991dbb2c9e59e044a02a59194bf6e14484"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
 dependencies = [
  "cc",
  "lazy_static",
@@ -6792,6 +6792,7 @@ dependencies = [
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
+ "sentry-debug-images",
  "sentry-panic",
  "tokio",
  "ureq",
@@ -6834,6 +6835,17 @@ dependencies = [
  "sentry-types",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995208135571444b7d5a247f42bd36677553bb64185d85b317acdc1789749b3"
+dependencies = [
+ "findshlibs",
+ "once_cell",
+ "sentry-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ rustc-demangle = { opt-level = 3 }
 # debugger experience. This seems to be the right tradeoff for release builds:
 # it's unlikely we're going to get interactive access to a debugger in
 # production installations, but we still want useful crash reports.
-debug = 1
+debug = 2
 
 # IMPORTANT: when patching a dependency, you should only depend on "main",
 # "master", or an upstream release branch (e.g., "v7.x"). Do *not* depend on a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,12 +99,13 @@ object = { opt-level = 3 }
 rustc-demangle = { opt-level = 3 }
 
 [profile.release]
-# Emit only the line info tables, not full debug info, in release builds, to
-# substantially reduce the size of the debug info. Line info tables are enough
-# to correctly symbolicate a backtrace, but do not produce an ideal interactive
-# debugger experience. This seems to be the right tradeoff for release builds:
-# it's unlikely we're going to get interactive access to a debugger in
-# production installations, but we still want useful crash reports.
+# Emit full debug info, allowing us to easily analyze core dumps from
+# staging (and, in an emergency, also prod).
+#
+# This does not negatively impact the sizes of the main binaries
+# (clusterd and environmentd), since we split the debuginfo from those
+# and ship it separately to an s3 bucket before building their
+# docker containers.
 debug = 2
 
 # IMPORTANT: when patching a dependency, you should only depend on "main",

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -33,6 +33,7 @@ prettytable==3.5.0
 psutil==5.9.4
 # psycopg2 intentionally omitted. Use pg8000 instead.
 pydantic==1.10.4
+pyelftools==0.29
 PyMySQL==1.0.2
 pytest==7.2.1
 pytest-split==0.8.0

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -17,7 +17,8 @@ from materialize.xcompile import Arch
 
 def main() -> None:
     coverage = ui.env_is_truthy("CI_COVERAGE_ENABLED")
-    repo = mzbuild.Repository(Path("."), coverage=coverage)
+    stable = ui.env_is_truthy("BUILDKITE_TAG")
+    repo = mzbuild.Repository(Path("."), coverage=coverage, stable=stable)
 
     # Build and push any images that are not already available on Docker Hub,
     # so they are accessible to other build agents.

--- a/misc/python/materialize/elf.py
+++ b/misc/python/materialize/elf.py
@@ -12,6 +12,10 @@ from typing import BinaryIO
 # `stubgen -p elftools` doesn't work out of the box,
 # and manually writing stub files for all of `elftools`
 # seems like a large and error-prone project.
+#
+# If we start using pyelftools from more places, it might be useful to
+# have a stub file. A sketch of one can be found here:
+# https://github.com/MaterializeInc/materialize/pull/19960#discussion_r1231516060
 from elftools.elf.elffile import ELFFile, NoteSection  # type: ignore
 
 from materialize.ui import UIError

--- a/misc/python/materialize/elf.py
+++ b/misc/python/materialize/elf.py
@@ -1,9 +1,23 @@
-from elftools.elf.elffile import ELFFile, NoteSection
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import BinaryIO
+
+# `stubgen -p elftools` doesn't work out of the box,
+# and manually writing stub files for all of `elftools`
+# seems like a large and error-prone project.
+from elftools.elf.elffile import ELFFile, NoteSection  # type: ignore
 
 from materialize.ui import UIError
 
 
-def get_build_id(file) -> str:
+def get_build_id(file: BinaryIO) -> str:
     elf_file = ELFFile(file)
 
     build_id_section = elf_file.get_section_by_name(".note.gnu.build-id")
@@ -16,6 +30,6 @@ def get_build_id(file) -> str:
 
     for note in build_id_section.iter_notes():
         if note.n_type == "NT_GNU_BUILD_ID" and note.n_name == "GNU":
-            return note.n_desc
+            return str(note.n_desc)
 
     raise UIError(f"ELF file GNU build ID could not be found: {file}")

--- a/misc/python/materialize/elf.py
+++ b/misc/python/materialize/elf.py
@@ -1,0 +1,21 @@
+from elftools.elf.elffile import ELFFile, NoteSection
+
+from materialize.ui import UIError
+
+
+def get_build_id(file) -> str:
+    elf_file = ELFFile(file)
+
+    build_id_section = elf_file.get_section_by_name(".note.gnu.build-id")
+
+    if not build_id_section:
+        raise UIError(f"ELF file has no .note.gnu.build-id section: {file}")
+
+    if not isinstance(build_id_section, NoteSection):
+        raise UIError(f"ELF file .note.gnu.build-id section could not be read: {file}")
+
+    for note in build_id_section.iter_notes():
+        if note.n_type == "NT_GNU_BUILD_ID" and note.n_name == "GNU":
+            return note.n_desc
+
+    raise UIError(f"ELF file GNU build ID could not be found: {file}")

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -227,11 +227,11 @@ class S3Upload(PreImage):
             assert len(build_id) > 0
             exe.seek(0)
             object_name = f"buildid/{build_id}/executable"
-            print(f"Attempting to upload executable to s3://{self.bucket}/{object_name}")
+            print(
+                f"Attempting to upload executable to s3://{self.bucket}/{object_name}"
+            )
             try:
-                s3.upload_fileobj(
-                    exe, str(self.bucket), object_name
-                )
+                s3.upload_fileobj(exe, str(self.bucket), object_name)
             except NoCredentialsError:
                 print("Failed to find S3 credentials; not uploading build.")
 
@@ -245,10 +245,10 @@ class S3Upload(PreImage):
                     return
                 dbg.seek(0)
                 object_name = f"buildid/{build_id}/debuginfo"
-                print(f"Attempting to upload debug info to s3://{self.bucket}/{object_name}")
-                s3.upload_fileobj(
-                    dbg, str(self.bucket), object_name
+                print(
+                    f"Attempting to upload debug info to s3://{self.bucket}/{object_name}"
                 )
+                s3.upload_fileobj(dbg, str(self.bucket), object_name)
         except FileNotFoundError:
             print(f"WARNING: No debuginfo found at {self.dbg_path}.")
 

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -271,6 +271,9 @@ class S3UploadDebuginfo(PreImage):
                     Tagging={"TagSet": [{"Key": "ephemeral", "Value": ephemeral_str}]},
                 )
 
+    def inputs(self) -> Set[str]:
+        return {self.exe_path, self.dbg_path}
+
 
 class CargoPreImage(PreImage):
     """A `PreImage` action that uses Cargo."""

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -31,9 +31,12 @@ from pathlib import Path
 from tempfile import TemporaryFile
 from typing import IO, Any, Dict, Iterable, Iterator, List, Optional, Sequence, Set
 
+import boto3
 import yaml
+from botocore.exceptions import NoCredentialsError
 
 from materialize import cargo, git, rustc_flags, spawn, ui, xcompile
+from materialize.elf import get_build_id
 from materialize.xcompile import Arch
 
 
@@ -190,6 +193,65 @@ class Copy(PreImage):
         return set(git.expand_globs(self.rd.root, f"{self.source}/{self.matching}"))
 
 
+class S3Upload(PreImage):
+    """A `PreImage` action which uploads an executable to S3.
+
+    If no AWS credentials are configured in the environment, no action is taken.
+
+    Otherwise, the ELF file with the specified `NAME` is scanned to get its build ID,
+    then it is uploaded to the path `buildid/BUILDID/executable` in the specified bucket.
+
+    If an ELF file called `NAME.debug` exists, and if its build ID matches
+    that of the main executable, it is uploaded to the path `buildid/BUILDID/debuginfo`.
+    """
+
+    def __init__(self, rd: RepositoryDetails, path: Path, config: Dict[str, Any]):
+        super().__init__(rd, path)
+
+        bin = config.pop("bin", None)
+        if bin is None:
+            raise ValueError("mzbuild config is missing 'bin' argument")
+        self.exe_path = path / bin
+        self.dbg_path = self.exe_path.with_suffix(self.exe_path.suffix + ".debug")
+
+        self.bucket = config.pop("bucket", None)
+        if self.bucket is None:
+            raise ValueError("mzbuild config is missing 'bucket' argument")
+
+    def run(self) -> None:
+        super().run()
+        s3 = boto3.client("s3")
+        with open(self.exe_path, "rb") as exe:
+            build_id = get_build_id(exe)
+            assert build_id.isalnum()
+            assert len(build_id) > 0
+            exe.seek(0)
+            try:
+                s3.upload_fileobj(
+                    exe, str(self.bucket), f"buildid/{build_id}/executable"
+                )
+            except NoCredentialsError:
+                print("Failed to find S3 credentials; not uploading build.")
+
+        try:
+            with open(self.dbg_path, "rb") as dbg:
+                dbg_build_id = get_build_id(dbg)
+                if dbg_build_id != build_id:
+                    print(
+                        f"WARNING: debuginfo build id does not match executable: {dbg_build_id} vs. {build_id}. Not uploading debuginfo."
+                    )
+                    return
+                dbg.seek(0)
+                s3.upload_fileobj(
+                    dbg, str(self.bucket), f"buildid/{build_id}/debuginfo"
+                )
+        except FileNotFoundError:
+            print(f"WARNING: No debuginfo found at {self.dbg_path}.")
+
+    def inputs(self) -> Set[str]:
+        return {self.exe_path, self.dbg_path}
+
+
 class CargoPreImage(PreImage):
     """A `PreImage` action that uses Cargo."""
 
@@ -226,6 +288,7 @@ class CargoBuild(CargoPreImage):
         example = config.pop("example", [])
         self.examples = example if isinstance(example, list) else [example]
         self.strip = config.pop("strip", True)
+        self.split_debuginfo = config.pop("split_debuginfo", False)
         self.extract = config.pop("extract", {})
         self.rustflags = config.pop("rustflags", [])
         self.channel = None
@@ -250,10 +313,28 @@ class CargoBuild(CargoPreImage):
         cargo_profile = "release" if self.rd.release_mode else "debug"
 
         def copy(exe: Path) -> None:
-            (self.path / exe).parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy(
-                self.rd.cargo_target_dir() / cargo_profile / exe, self.path / exe
-            )
+            exe_path = self.path / exe
+            dbg_path = exe_path.with_suffix(exe_path.suffix + ".debug")
+            exe_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(self.rd.cargo_target_dir() / cargo_profile / exe, exe_path)
+
+            if self.split_debuginfo:
+                spawn.runv(
+                    [
+                        *self.rd.tool("objcopy"),
+                        exe_path,
+                        dbg_path,
+                        "--only-keep-debug",
+                    ],
+                    cwd=self.rd.root,
+                )
+                spawn.runv(
+                    [
+                        *self.rd.tool("objcopy"),
+                        exe_path,
+                        f"--add-gnu-debuglink={dbg_path}",
+                    ]
+                )
 
             if self.strip:
                 # NOTE(benesch): the debug information is large enough that it slows
@@ -261,7 +342,7 @@ class CargoBuild(CargoPreImage):
                 # images and shipping them around. A bit unfortunate, since it'd be
                 # nice to have useful backtraces if the binary crashes.
                 spawn.runv(
-                    [*self.rd.tool("strip"), "--strip-debug", self.path / exe],
+                    [*self.rd.tool("strip"), "--strip-debug", exe_path],
                     cwd=self.rd.root,
                 )
             else:
@@ -280,7 +361,7 @@ class CargoBuild(CargoPreImage):
                         ".debug_pubnames",
                         "-R",
                         ".debug_pubtypes",
-                        self.path / exe,
+                        exe_path,
                     ],
                     cwd=self.rd.root,
                 )
@@ -368,6 +449,8 @@ class Image:
                     self.pre_images.append(CargoBuild(self.rd, self.path, pre_image))
                 elif typ == "copy":
                     self.pre_images.append(Copy(self.rd, self.path, pre_image))
+                elif typ == "s3-upload":
+                    self.pre_images.append(S3Upload(self.rd, self.path, pre_image))
                 else:
                     raise ValueError(
                         f"mzbuild config in {self.path} has unknown pre-image type"

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -69,7 +69,9 @@ class RepositoryDetails:
 
     """
 
-    def __init__(self, root: Path, arch: Arch, release_mode: bool, coverage: bool, stable: bool):
+    def __init__(
+        self, root: Path, arch: Arch, release_mode: bool, coverage: bool, stable: bool
+    ):
         self.root = root
         self.arch = arch
         self.release_mode = release_mode
@@ -246,7 +248,7 @@ class S3UploadDebuginfo(PreImage):
             assert build_id == dbg_build_id
             exe.seek(0)
             dbg.seek(0)
-            
+
             exe_object_name = f"buildid/{build_id}/executable"
             dbg_object_name = f"buildid/{build_id}/debuginfo"
             print(
@@ -256,14 +258,18 @@ class S3UploadDebuginfo(PreImage):
                 s3.upload_fileobj(exe, self.bucket, exe_object_name)
             except NoCredentialsError:
                 print("Failed to find S3 credentials; not uploading build.")
-            print(f"Attempting to upload debug info to s3://{self.bucket}/{dbg_object_name}")
+            print(
+                f"Attempting to upload debug info to s3://{self.bucket}/{dbg_object_name}"
+            )
             s3.upload_fileobj(dbg, self.bucket, dbg_object_name)
 
-            ephemeral_str = 'false' if self.rd.stable else 'true'
+            ephemeral_str = "false" if self.rd.stable else "true"
             for key in [exe_object_name, dbg_object_name]:
-                s3.put_object_tagging(Bucket = self.bucket, Key = key, Tagging = {
-                    'TagSet': [{'Key': 'ephemeral', 'Value': ephemeral_str}]
-                })
+                s3.put_object_tagging(
+                    Bucket=self.bucket,
+                    Key=key,
+                    Tagging={"TagSet": [{"Key": "ephemeral", "Value": ephemeral_str}]},
+                )
 
 
 class CargoPreImage(PreImage):
@@ -460,7 +466,9 @@ class Image:
                 elif typ == "copy":
                     self.pre_images.append(Copy(self.rd, self.path, pre_image))
                 elif typ == "s3-upload-debuginfo":
-                    self.pre_images.append(S3UploadDebuginfo(self.rd, self.path, pre_image))
+                    self.pre_images.append(
+                        S3UploadDebuginfo(self.rd, self.path, pre_image)
+                    )
                 else:
                     raise ValueError(
                         f"mzbuild config in {self.path} has unknown pre-image type"

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -226,9 +226,11 @@ class S3Upload(PreImage):
             assert build_id.isalnum()
             assert len(build_id) > 0
             exe.seek(0)
+            object_name = f"buildid/{build_id}/executable"
+            print(f"Attempting to upload executable to s3://{self.bucket}/{object_name}")
             try:
                 s3.upload_fileobj(
-                    exe, str(self.bucket), f"buildid/{build_id}/executable"
+                    exe, str(self.bucket), object_name
                 )
             except NoCredentialsError:
                 print("Failed to find S3 credentials; not uploading build.")
@@ -242,8 +244,10 @@ class S3Upload(PreImage):
                     )
                     return
                 dbg.seek(0)
+                object_name = f"buildid/{build_id}/debuginfo"
+                print(f"Attempting to upload debug info to s3://{self.bucket}/{object_name}")
                 s3.upload_fileobj(
-                    dbg, str(self.bucket), f"buildid/{build_id}/debuginfo"
+                    dbg, str(self.bucket), object_name
                 )
         except FileNotFoundError:
             print(f"WARNING: No debuginfo found at {self.dbg_path}.")

--- a/src/clusterd/ci/mzbuild.yml
+++ b/src/clusterd/ci/mzbuild.yml
@@ -11,4 +11,8 @@ name: clusterd
 pre-image:
   - type: cargo-build
     bin: clusterd
-    strip: false
+    strip: true
+    split_debuginfo: true
+  - type: s3-upload
+    bin: clusterd
+    bucket: materialize-debuginfo

--- a/src/clusterd/ci/mzbuild.yml
+++ b/src/clusterd/ci/mzbuild.yml
@@ -13,6 +13,6 @@ pre-image:
     bin: clusterd
     strip: true
     split_debuginfo: true
-  - type: s3-upload
+  - type: s3-upload-debuginfo
     bin: clusterd
     bucket: materialize-debuginfo

--- a/src/environmentd/ci/mzbuild.yml
+++ b/src/environmentd/ci/mzbuild.yml
@@ -13,6 +13,6 @@ pre-image:
     bin: environmentd
     strip: true
     split_debuginfo: true
-  - type: s3-upload
+  - type: s3-upload-debuginfo
     bin: environmentd
     bucket: materialize-debuginfo

--- a/src/environmentd/ci/mzbuild.yml
+++ b/src/environmentd/ci/mzbuild.yml
@@ -11,4 +11,8 @@ name: environmentd
 pre-image:
   - type: cargo-build
     bin: environmentd
-    strip: false
+    strip: true
+    split_debuginfo: true
+  - type: s3-upload
+    bin: environmentd
+    bucket: materialize-debuginfo

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -31,7 +31,7 @@ pin-project = "1.0.12"
 prometheus = { version = "0.13.3", default-features = false, optional = true }
 smallvec = { version = "1.10.0", optional = true }
 stacker = { version = "0.1.15", optional = true }
-sentry = { version = "0.29.1", optional = true }
+sentry = { version = "0.29.1", optional = true, features = ["debug-images"] }
 serde = { version = "1.0.152", features = ["derive"], optional = true }
 tokio = { version = "1.24.2", features = ["io-util", "net", "rt-multi-thread", "time"], optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -34,6 +34,7 @@ use opentelemetry::propagation::{Extractor, Injector};
 use opentelemetry::sdk::propagation::TraceContextPropagator;
 use opentelemetry::sdk::{trace, Resource};
 use opentelemetry::{global, KeyValue};
+use sentry::integrations::debug_images::DebugImagesIntegration;
 use tonic::metadata::MetadataMap;
 use tonic::transport::Endpoint;
 use tracing::{Event, Level, Subscriber};
@@ -389,6 +390,7 @@ where
                 attach_stacktrace: true,
                 release: Some(config.build_version.into()),
                 environment: sentry_config.environment.map(Into::into),
+                integrations: vec![Arc::new(DebugImagesIntegration::new())],
                 ..Default::default()
             },
         ));


### PR DESCRIPTION
This commit makes the following changes:

* Switches to generating full debuginfo for environmentd and clusterd,
* Generates a debuginfo file for those binaries,
* Strips the main binary (after generating the debuginfo), and
* Uploads them to a publicly-accessible S3 bucket with a path that emulates that served by `debuginfod`.

This will allow analyzing production/staging core dumps, without forcing us to store a large amount of superfluous debug data in the binaries themselves.

The drawbacks are:

* About $1 * x new S3 spend per month (where `x` is the average number of buildkite builds per day),
* Somewhat increased build/link time for release builds (by a few minutes),
* Lack of line numbers in backtraces in production/staging crash logs, and
* Lack of line numbers in backtraces in production/staging crash reports in Sentry.

The last point can be mitigated by a follow-up PR to ship the debuginfo to Sentry.

### Motivation

  * This PR fixes a previously unreported bug.

    It is difficult to debug issues in production and staging because core dumps are of limited utility (due to lacking info about local variables).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  **Note**: Borderline case. This could maybe have used a design doc, but I think it's also fine to skip.
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None
