### PR TITLE
ci: Collect and analyze core dumps for mzcompose-based tests

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
     gawk \
     g++ \
     gcc \
+    gdb \
     gnupg2 \
     help2man \
     libc-dev \

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -13,6 +13,14 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
+cores="$HOME"/cores
+rm -rf "$cores"
+mkdir -m 777 "$cores"
+# Max 128 characters, so don't use $PWD which will make it too long
+sudo sysctl -w kernel.core_pattern="|/usr/bin/env tee $cores/core.%e.%p"
+echo -n "Core pattern: "
+cat /proc/sys/kernel/core_pattern
+
 mzcompose() {
     bin/ci-builder run stable bin/mzcompose --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
 }
@@ -24,8 +32,6 @@ if read_list BUILDKITE_PLUGIN_MZCOMPOSE_ARGS; then
         run_args+=("$arg")
     done
 fi
-
-sar -q 60 > sar.log &
 
 date +"%Y-%m-%d %H:%M:%S" > step_start_timestamp
 

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -70,7 +70,27 @@ netstat -panelot > netstat-panelot.log
 ps aux > ps-aux.log
 docker ps -a --no-trunc > docker-ps-a.log
 
-artifacts=(run.log services.log journalctl-merge.log netstat-ant.log netstat-panelot.log ps-aux.log docker-ps-a.log docker-inspect.log sar.log)
+mv "$HOME"/cores .
+
+if find cores -name 'core.*' | grep -q .; then
+    # Best effort attempt to fetch interesting executables to get backtrace of core files
+    run cp sqllogictest:/usr/local/bin/sqllogictest cores/ || true
+    run cp sqllogictest:/usr/local/bin/clusterd cores/ || true
+    run cp materialized:/usr/local/bin/environmentd cores/ || true
+    run cp materialized:/usr/local/bin/clusterd cores/ || true
+    run cp testdrive:/usr/local/bin/testdrive cores/ || true
+fi
+
+find cores -name 'core.*' | while read -r core; do
+    exe=$(echo "$core" | sed -e "s/core\.\(.*\)\.[0-9][0-9]*/\1/")
+    bin/ci-builder run stable gdb cores/"$exe" "$core" --batch -ex bt full -ex quit > "$core".txt || true
+    buildkite-agent artifact upload "$core".txt
+    buildkite-agent artifact upload "$core"
+done
+# can be huge, clean up
+rm -rf cores
+
+artifacts=(run.log services.log journalctl-merge.log netstat-ant.log netstat-panelot.log ps-aux.log docker-ps-a.log docker-inspect.log)
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 buildkite-agent artifact upload "$artifacts_str"
 bin/ci-builder run stable bin/ci-logged-errors-detect "${artifacts[@]}"


### PR DESCRIPTION
Upload the backtrace as a txt file as well as the full core dump file
for later analysis

### Motivation

We have been seeing flaky segfaults in timely/clusterd in CI, which were impossible to reproduce locally. This will help with finding the crashing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
