### PR TITLE
expr: genericize sum implementation

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -9,6 +9,7 @@
 
 #![allow(missing_docs)]
 
+use std::iter::Sum;
 use std::ops::Deref;
 use std::{fmt, iter};
 
@@ -411,107 +412,21 @@ where
     Datum::from(x)
 }
 
-fn sum_int16<'a, I>(datums: I) -> Datum<'a>
+fn sum_datum<'a, I, DatumType, ResultType>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
+    DatumType: TryFrom<Datum<'a>>,
+    <DatumType as TryFrom<Datum<'a>>>::Error: std::fmt::Debug,
+    ResultType: From<DatumType> + Sum + Into<Datum<'a>>,
 {
     let mut datums = datums.into_iter().filter(|d| !d.is_null()).peekable();
     if datums.peek().is_none() {
         Datum::Null
     } else {
-        let x: i64 = datums.map(|d| i64::from(d.unwrap_int16())).sum();
-        Datum::from(x)
-    }
-}
-
-fn sum_int32<'a, I>(datums: I) -> Datum<'a>
-where
-    I: IntoIterator<Item = Datum<'a>>,
-{
-    let mut datums = datums.into_iter().filter(|d| !d.is_null()).peekable();
-    if datums.peek().is_none() {
-        Datum::Null
-    } else {
-        let x: i64 = datums.map(|d| i64::from(d.unwrap_int32())).sum();
-        Datum::from(x)
-    }
-}
-
-fn sum_int64<'a, I>(datums: I) -> Datum<'a>
-where
-    I: IntoIterator<Item = Datum<'a>>,
-{
-    let mut datums = datums.into_iter().filter(|d| !d.is_null()).peekable();
-    if datums.peek().is_none() {
-        Datum::Null
-    } else {
-        let x: i128 = datums.map(|d| i128::from(d.unwrap_int64())).sum();
-        Datum::from(x)
-    }
-}
-
-fn sum_uint16<'a, I>(datums: I) -> Datum<'a>
-where
-    I: IntoIterator<Item = Datum<'a>>,
-{
-    let mut datums = datums.into_iter().filter(|d| !d.is_null()).peekable();
-    if datums.peek().is_none() {
-        Datum::Null
-    } else {
-        let x: u64 = datums.map(|d| u64::from(d.unwrap_uint16())).sum();
-        Datum::from(x)
-    }
-}
-
-fn sum_uint32<'a, I>(datums: I) -> Datum<'a>
-where
-    I: IntoIterator<Item = Datum<'a>>,
-{
-    let mut datums = datums.into_iter().filter(|d| !d.is_null()).peekable();
-    if datums.peek().is_none() {
-        Datum::Null
-    } else {
-        let x: u64 = datums.map(|d| u64::from(d.unwrap_uint32())).sum();
-        Datum::from(x)
-    }
-}
-
-fn sum_uint64<'a, I>(datums: I) -> Datum<'a>
-where
-    I: IntoIterator<Item = Datum<'a>>,
-{
-    let mut datums = datums.into_iter().filter(|d| !d.is_null()).peekable();
-    if datums.peek().is_none() {
-        Datum::Null
-    } else {
-        let x: u128 = datums.map(|d| u128::from(d.unwrap_uint64())).sum();
-        Datum::from(x)
-    }
-}
-
-fn sum_float32<'a, I>(datums: I) -> Datum<'a>
-where
-    I: IntoIterator<Item = Datum<'a>>,
-{
-    let mut datums = datums.into_iter().filter(|d| !d.is_null()).peekable();
-    if datums.peek().is_none() {
-        Datum::Null
-    } else {
-        let x: f32 = datums.map(|d| d.unwrap_float32()).sum();
-        Datum::from(x)
-    }
-}
-
-fn sum_float64<'a, I>(datums: I) -> Datum<'a>
-where
-    I: IntoIterator<Item = Datum<'a>>,
-{
-    let mut datums = datums.into_iter().filter(|d| !d.is_null()).peekable();
-    if datums.peek().is_none() {
-        Datum::Null
-    } else {
-        let x: f64 = datums.map(|d| d.unwrap_float64()).sum();
-        Datum::from(x)
+        let x = datums
+            .map(|d| ResultType::from(DatumType::try_from(d).expect("unexpected type")))
+            .sum::<ResultType>();
+        x.into()
     }
 }
 
@@ -1588,14 +1503,14 @@ impl AggregateFunc {
             AggregateFunc::MinDate => min_date(datums),
             AggregateFunc::MinTimestamp => min_timestamp(datums),
             AggregateFunc::MinTimestampTz => min_timestamptz(datums),
-            AggregateFunc::SumInt16 => sum_int16(datums),
-            AggregateFunc::SumInt32 => sum_int32(datums),
-            AggregateFunc::SumInt64 => sum_int64(datums),
-            AggregateFunc::SumUInt16 => sum_uint16(datums),
-            AggregateFunc::SumUInt32 => sum_uint32(datums),
-            AggregateFunc::SumUInt64 => sum_uint64(datums),
-            AggregateFunc::SumFloat32 => sum_float32(datums),
-            AggregateFunc::SumFloat64 => sum_float64(datums),
+            AggregateFunc::SumInt16 => sum_datum::<'a, I, i16, i64>(datums),
+            AggregateFunc::SumInt32 => sum_datum::<'a, I, i32, i64>(datums),
+            AggregateFunc::SumInt64 => sum_datum::<'a, I, i64, i128>(datums),
+            AggregateFunc::SumUInt16 => sum_datum::<'a, I, u16, u64>(datums),
+            AggregateFunc::SumUInt32 => sum_datum::<'a, I, u32, u64>(datums),
+            AggregateFunc::SumUInt64 => sum_datum::<'a, I, u64, u128>(datums),
+            AggregateFunc::SumFloat32 => sum_datum::<'a, I, f32, f32>(datums),
+            AggregateFunc::SumFloat64 => sum_datum::<'a, I, f64, f64>(datums),
             AggregateFunc::SumNumeric => sum_numeric(datums),
             AggregateFunc::Count => count(datums),
             AggregateFunc::Any => any(datums),


### PR DESCRIPTION
Marking this as draft because it poses a question.

I am looking to remove some of our [AST rewrites for functions](https://github.com/MaterializeInc/materialize/blob/c3dd7af304ad8e128c14759d01d7cd51ef80aac8/src/sql/src/plan/transform_ast.rs#L130-L135) because they impede our ability to simply plan scalar funcs in table positions. (Removing the AST rewrites is not the only approach, but is one I prefer because it removes unexpected magic from SQL planning.)

Many of these functions rely on or express aggregates; before embarking on writing a bunch of boilerplate implementations for aggregate functions, I am curious if we would accept genericizing more aggregate functions in general.

If impact to compilation times are a worry, I could also achieve the same thing with a macro, though I acknowledge their maintenance is frowned upon.

If both are bad, glad to leave as-is but wanted to ask!

cc @benesch because you were the last person to touch a lot of this code

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
