### PR TITLE
stash: Use DebugStashFactory in test

### DIFF
--- a/src/stash/src/upgrade/v18_to_v19.rs
+++ b/src/stash/src/upgrade/v18_to_v19.rs
@@ -183,9 +183,6 @@ impl From<objects_v18::AclMode> for objects_v19::AclMode {
 
 #[cfg(test)]
 mod tests {
-    use mz_ore::metrics::MetricsRegistry;
-    use tokio_postgres::Config;
-
     use super::objects_v18::{
         self, global_id::Value as GlobalIdInnerV18, schema_id::Value as SchemaIdInnerV18,
         GlobalId as GlobalIdV18, ItemKey as ItemKeyV18, ItemValue as ItemValueV18,
@@ -197,17 +194,14 @@ mod tests {
     };
     use super::upgrade;
 
-    use crate::{StashFactory, TypedCollection};
+    use crate::{DebugStashFactory, TypedCollection};
 
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn smoke_test() {
         // Connect to the Stash.
-        let tls = mz_postgres_util::make_tls(&Config::new()).unwrap();
-        let factory = StashFactory::new(&MetricsRegistry::new());
-
-        let connstr = std::env::var("COCKROACH_URL").expect("COCKROACH_URL must be set");
-        let mut stash = factory.open(connstr.to_string(), None, tls).await.unwrap();
+        let factory = DebugStashFactory::new().await;
+        let mut stash = factory.open_debug().await;
 
         // Insert some items.
         let items_v18: TypedCollection<objects_v18::ItemKey, objects_v18::ItemValue> =


### PR DESCRIPTION
### Motivation

Previously there was no schema provided, which collided with other tests and caused flakiness 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
