### PR TITLE
adapter: Clarify comment in sequencer

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -41,10 +41,13 @@ use crate::util::{send_immediate_rows, ClientTransmitter};
 // plans in `sequence_plan` and guarantee that no caller can circumvent
 // that logic.
 //
-// The one exception is creating a role during connection startup. In
-// this scenario, the session has not been properly initialized and we
-// need to skip directly to creating role. We have a specific method,
+// The two exceptions are:
+//
+// - Creating a role during connection startup. In this scenario, the session has not been properly
+// initialized and we need to skip directly to creating role. We have a specific method,
 // `sequence_create_role_for_startup` for this purpose.
+// - Methods that continue the execution of some plan that was being run asynchronously, such as
+// `sequence_peek_stage`.
 mod cluster;
 mod inner;
 mod linked_cluster;

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1725,7 +1725,7 @@ impl Coordinator {
     /// be a simple read out of an existing arrangement, or required a new dataflow to build
     /// the results to return.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) async fn sequence_peek(
+    pub(super) async fn sequence_peek(
         &mut self,
         tx: ClientTransmitter<ExecuteResponse>,
         session: Session,


### PR DESCRIPTION
### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
