### PR TITLE
clippy: add lint for holding span guards across awaits

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,6 @@
 await-holding-invalid-types = [
     { path = "tracing::span::Entered", reason = "use `tracing::instrument`, `tracing::Instrument::instrument`, or `tracing::Span::in_scope` instead" },
+    { path = "tracing::span::EnteredSpan", reason = "use `tracing::instrument`, `tracing::Instrument::instrument`, or `tracing::Span::in_scope` instead" },
 ]
 
 disallowed-methods = [

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,7 @@
+await-holding-invalid-types = [
+    { path = "tracing::span::Entered", reason = "use `tracing::instrument`, `tracing::Instrument::instrument`, or `tracing::Span::in_scope` instead" },
+]
+
 disallowed-methods = [
     { path = "std::panic::catch_unwind", reason = "use `mz_ore::panic::catch_unwind` instead" },
     { path = "futures::FutureExt::catch_unwind", reason = "use `mz_ore::future::FutureExt::catch_unwind` instead" },

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1428,12 +1428,11 @@ impl Coordinator {
                 }
             };
 
-            // All message processing functions trace. Start a parent span for them to make
-            // it easy to find slow messages.
-            let span = span!(Level::DEBUG, "coordinator message processing");
-            let _enter = span.enter();
-
-            self.handle_message(msg).await;
+            self.handle_message(msg)
+                // All message processing functions trace. Start a parent span for them to make
+                // it easy to find slow messages.
+                .instrument(span!(Level::DEBUG, "coordinator message processing"))
+                .await;
         }
     }
 

--- a/src/persist-client/examples/service.rs
+++ b/src/persist-client/examples/service.rs
@@ -25,7 +25,7 @@ use mz_persist_client::rpc::{
     GrpcPubSubClient, PersistGrpcPubSubServer, PersistPubSubClient, PersistPubSubClientConfig,
 };
 use mz_persist_client::ShardId;
-use tracing::{info, Span};
+use tracing::info;
 
 use crate::BUILD_INFO;
 
@@ -48,12 +48,10 @@ pub struct Args {
 }
 
 pub async fn run(args: Args) -> Result<(), anyhow::Error> {
-    let span = Span::current();
     let shard_id = ShardId::from_str("s00000000-0000-0000-0000-000000000000").expect("shard id");
     let config = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone());
     match args.role {
         Role::Server => {
-            let _guard = span.enter();
             info!("listening on {}", args.listen_addr);
             PersistGrpcPubSubServer::new(&config, &MetricsRegistry::new())
                 .serve(args.listen_addr.clone())


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

`tracing::Span::enter` is sneakily [not safe to use across await points](https://docs.rs/tracing/latest/tracing/span/struct.Span.html#in-asynchronous-code), and may cause spans to get mixed up between tasks. The clippy lint `await-holding-invalid-types` was added for pretty much this exact problem, so this PR introduces it to our lints + fixes the existing use cases.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
