### PR TITLE
[persist] Attach the writer version to a batch

### DIFF
--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -49,7 +49,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 sentry-tracing = "0.29.1"
-semver = "1.0.16"
+semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.89"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -72,6 +72,7 @@ pub struct CompactRes<T> {
 #[derive(Debug, Clone)]
 pub struct CompactConfig {
     pub(crate) compaction_memory_bound_bytes: usize,
+    pub(crate) version: semver::Version,
     pub(crate) batch: BatchBuilderConfig,
 }
 
@@ -79,6 +80,7 @@ impl From<&PersistConfig> for CompactConfig {
     fn from(value: &PersistConfig) -> Self {
         CompactConfig {
             compaction_memory_bound_bytes: value.dynamic.compaction_memory_bound_bytes(),
+            version: value.build_version.clone(),
             batch: BatchBuilderConfig::from(value),
         }
     }
@@ -693,6 +695,7 @@ where
             Arc::clone(&blob),
             cpu_heavy_runtime,
             shard_id.clone(),
+            cfg.version.clone(),
             writer_id,
             desc.since().clone(),
             Some(desc.upper().clone()),

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1150,6 +1150,7 @@ impl<T: Timestamp + Codec64> RustType<ProtoU64Antichain> for Antichain<T> {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SerdeWriterEnrichedHollowBatch {
     pub(crate) shard_id: ShardId,
+    pub(crate) version: Version,
     pub(crate) batch: Vec<u8>,
 }
 
@@ -1157,6 +1158,7 @@ impl<T: Timestamp + Codec64> From<WriterEnrichedHollowBatch<T>> for SerdeWriterE
     fn from(x: WriterEnrichedHollowBatch<T>) -> Self {
         SerdeWriterEnrichedHollowBatch {
             shard_id: x.shard_id,
+            version: x.version,
             batch: x.batch.into_proto().encode_to_vec(),
         }
     }
@@ -1164,13 +1166,19 @@ impl<T: Timestamp + Codec64> From<WriterEnrichedHollowBatch<T>> for SerdeWriterE
 
 impl<T: Timestamp + Codec64> From<SerdeWriterEnrichedHollowBatch> for WriterEnrichedHollowBatch<T> {
     fn from(x: SerdeWriterEnrichedHollowBatch) -> Self {
-        let proto_batch = ProtoHollowBatch::decode(x.batch.as_slice())
+        let SerdeWriterEnrichedHollowBatch {
+            shard_id,
+            version,
+            batch,
+        } = x;
+        let proto_batch = ProtoHollowBatch::decode(batch.as_slice())
             .expect("internal error: could not decode WriterEnrichedHollowBatch");
         let batch = proto_batch
             .into_rust()
             .expect("internal error: could not decode WriterEnrichedHollowBatch");
         WriterEnrichedHollowBatch {
-            shard_id: x.shard_id,
+            shard_id,
+            version,
             batch,
         }
     }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1371,6 +1371,7 @@ pub mod datadriven {
             Arc::clone(&datadriven.client.blob),
             Arc::clone(&datadriven.client.cpu_heavy_runtime),
             datadriven.shard_id.clone(),
+            datadriven.client.cfg.build_version.clone(),
             WriterId::new(),
             since,
             Some(upper.clone()),

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -27,7 +27,7 @@ use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
-use tracing::{debug_span, instrument, warn, Instrument};
+use tracing::{debug_span, error, instrument, warn, Instrument};
 use uuid::Uuid;
 
 use crate::batch::{
@@ -442,6 +442,15 @@ where
                     batch_shard: batch.shard_id(),
                     handle_shard: self.machine.shard_id(),
                 });
+            }
+            if self.cfg.build_version != batch.version {
+                error!(
+                    shard_id =? self.machine.shard_id(),
+                    batch_version =? batch.version,
+                    writer_version =? self.cfg.build_version,
+                    "Appending batch with a version that does not match the current build. \
+                    This may fail in the future."
+                )
             }
         }
 

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -101,6 +101,7 @@ impl WriterId {
 )]
 pub struct WriterEnrichedHollowBatch<T> {
     pub(crate) shard_id: ShardId,
+    pub(crate) version: semver::Version,
     pub(crate) batch: HollowBatch<T>,
 }
 
@@ -512,6 +513,7 @@ where
         );
         Batch {
             shard_id: self.machine.shard_id(),
+            version: hollow.version,
             batch: hollow.batch,
             _blob: Arc::clone(&self.blob),
             _phantom: std::marker::PhantomData,
@@ -541,6 +543,7 @@ where
             Arc::clone(&self.blob),
             Arc::clone(&self.cpu_heavy_runtime),
             self.machine.shard_id().clone(),
+            self.cfg.build_version.clone(),
             self.writer_id.clone(),
             Antichain::from_elem(T::minimum()),
             None,


### PR DESCRIPTION
This stores the code version at the time that a batch is written, threads it through as the batch is (de)serialized, and adds a check that the write handle's version matches.

### Motivation

Known-desirable improvement from #19292; this is a step towards being able to replace the writer leases with a version check.

### Tips for reviewer

Rationale: if we want to use the current version of the shard to infer what part blobs can be cleaned up, it would be bad if a part written under an old version could be newly appended to the state under a new version.

Right now we never run mixed-version clusters or write batches down anywhere, so this may be paranoid. But since we'll need to know the version id at batch-write time, it feels like a fine way to validate assumptions.

The followup steps I have in mind are:
- Change the batch part key to include the version number. (Or put it in the metadata; but putting it in the key makes life easier.)
- Add a `persistcli` command that first enumerates, and later deletes, stale batches.
- Remove the writer leases from state.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
