### PR TITLE
storage: optionally spill upsert stat to disk only if size exceeds threshold

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -11,7 +11,7 @@ use mz_compute_client::protocol::command::ComputeParameters;
 use mz_ore::error::ErrorExt;
 use mz_persist_client::cfg::{PersistParameters, RetryParameters};
 use mz_sql::session::vars::SystemVars;
-use mz_storage_client::types::parameters::{AutoSpillConfig, StorageParameters};
+use mz_storage_client::types::parameters::{StorageParameters, UpsertAutoSpillConfig};
 use mz_tracing::params::TracingParameters;
 
 /// Return the current compute configuration, derived from the system configuration.
@@ -64,9 +64,9 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
         },
         finalize_shards: config.enable_storage_shard_finalization(),
         tracing: tracing_config(config),
-        upsert_auto_spill_config: AutoSpillConfig {
-            allow_spilling_to_disk: config.upsert_source_auto_spill_to_disk(),
-            spill_to_disk_threshold_bytes: config.upsert_source_auto_spill_threshold_bytes(),
+        upsert_auto_spill_config: UpsertAutoSpillConfig {
+            allow_spilling_to_disk: config.upsert_rocksdb_auto_spill_to_disk(),
+            spill_to_disk_threshold_bytes: config.upsert_rocksdb_auto_spill_threshold_bytes(),
         },
     }
 }

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -11,7 +11,7 @@ use mz_compute_client::protocol::command::ComputeParameters;
 use mz_ore::error::ErrorExt;
 use mz_persist_client::cfg::{PersistParameters, RetryParameters};
 use mz_sql::session::vars::SystemVars;
-use mz_storage_client::types::parameters::StorageParameters;
+use mz_storage_client::types::parameters::{AutoSpillConfig, StorageParameters};
 use mz_tracing::params::TracingParameters;
 
 /// Return the current compute configuration, derived from the system configuration.
@@ -64,6 +64,10 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
         },
         finalize_shards: config.enable_storage_shard_finalization(),
         tracing: tracing_config(config),
+        upsert_auto_spill_config: AutoSpillConfig {
+            allow_spilling_to_disk: config.upsert_source_auto_spill_to_disk(),
+            spill_to_disk_threshold_bytes: config.upsert_source_auto_spill_threshold_bytes(),
+        },
     }
 }
 

--- a/src/rocksdb-types/src/config.rs
+++ b/src/rocksdb-types/src/config.rs
@@ -488,6 +488,15 @@ pub mod defaults {
 
     /// The default max duration for retrying the retry-able errors in rocksdb.
     pub const DEFAULT_RETRY_DURATION: Duration = Duration::from_secs(1);
+
+    /// The default for spilling from memory to rocksdb is 2 write buffers. Some initial tests
+    /// found that 2 write buffers were the minimum memory usage of rocksdb when processing small
+    /// amounts of data.
+    ///
+    /// The calculation is based on the `MEMTABLE_BUDGET`, and is inverting the logic here:
+    /// <https://github.com/facebook/rocksdb/blob/bc0db33483d5e79b281ba3137ebf286b2d1efd8d/options/options.cc#L632-L637>
+    pub const DEFAULT_AUTO_SPILL_MEMORY_THRESHOLD: usize =
+        DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET / 4 * 2;
 }
 
 #[cfg(test)]

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -603,24 +603,6 @@ const DISK_CLUSTER_REPLICAS_DEFAULT: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
-/// Controls whether automatic spill to disk should be turned on when using `DISK`.
-const UPSERT_SOURCE_AUTO_SPILL_TO_DISK: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("upsert_source_auto_spill_to_disk"),
-    value: &false,
-    description: "Controls whether automatic spill to disk should be turned on when using `DISK`",
-    internal: true,
-};
-
-/// The upsert in memory state size threshold after which it will spill to disk.
-/// The default is 256 MB = 268435456 bytes
-const UPSERT_SOURCE_AUTO_SPILL_THRESHOLD_BYTES: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("upsert_source_auto_spill_threshold_bytes"),
-    value: &268435456,
-    description:
-        "The upsert in-memory state size threshold in bytes after which it will spill to disk",
-    internal: true,
-};
-
 /// Tuning for RocksDB used by `UPSERT` sources that takes effect on restart.
 mod upsert_rocksdb {
     use std::str::FromStr;
@@ -737,6 +719,25 @@ mod upsert_rocksdb {
         description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
                   sources. Described in the `mz_rocksdb_types::config` module. \
                   Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+
+    /// Controls whether automatic spill to disk should be turned on when using `DISK`.
+    pub const UPSERT_ROCKSDB_AUTO_SPILL_TO_DISK: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_auto_spill_to_disk"),
+        value: &false,
+        description:
+            "Controls whether automatic spill to disk should be turned on when using `DISK`",
+        internal: true,
+    };
+
+    /// The upsert in memory state size threshold after which it will spill to disk.
+    /// The default is 256 MB = 268435456 bytes
+    pub const UPSERT_ROCKSDB_AUTO_SPILL_THRESHOLD_BYTES: ServerVar<usize> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_auto_spill_threshold_bytes"),
+        value: &mz_rocksdb_types::defaults::DEFAULT_AUTO_SPILL_MEMORY_THRESHOLD,
+        description:
+            "The upsert in-memory state size threshold in bytes after which it will spill to disk",
         internal: true,
     };
 }
@@ -1778,8 +1779,8 @@ impl SystemVars {
             .with_var(&MAX_RESULT_SIZE)
             .with_var(&ALLOWED_CLUSTER_REPLICA_SIZES)
             .with_var(&DISK_CLUSTER_REPLICAS_DEFAULT)
-            .with_var(&UPSERT_SOURCE_AUTO_SPILL_TO_DISK)
-            .with_var(&UPSERT_SOURCE_AUTO_SPILL_THRESHOLD_BYTES)
+            .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_AUTO_SPILL_TO_DISK)
+            .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_AUTO_SPILL_THRESHOLD_BYTES)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_COMPACTION_STYLE)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES)
@@ -2130,12 +2131,12 @@ impl SystemVars {
         *self.expect_value(&DISK_CLUSTER_REPLICAS_DEFAULT)
     }
 
-    pub fn upsert_source_auto_spill_to_disk(&self) -> bool {
-        *self.expect_value(&UPSERT_SOURCE_AUTO_SPILL_TO_DISK)
+    pub fn upsert_rocksdb_auto_spill_to_disk(&self) -> bool {
+        *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_AUTO_SPILL_TO_DISK)
     }
 
-    pub fn upsert_source_auto_spill_threshold_bytes(&self) -> usize {
-        *self.expect_value(&UPSERT_SOURCE_AUTO_SPILL_THRESHOLD_BYTES)
+    pub fn upsert_rocksdb_auto_spill_threshold_bytes(&self) -> usize {
+        *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_AUTO_SPILL_THRESHOLD_BYTES)
     }
 
     pub fn upsert_rocksdb_compaction_style(&self) -> mz_rocksdb_types::config::CompactionStyle {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -603,6 +603,24 @@ const DISK_CLUSTER_REPLICAS_DEFAULT: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
+/// Controls whether automatic spill to disk should be turned on when using `DISK`.
+const UPSERT_SOURCE_AUTO_SPILL_TO_DISK: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("upsert_source_auto_spill_to_disk"),
+    value: &false,
+    description: "Controls whether automatic spill to disk should be turned on when using `DISK`",
+    internal: true,
+};
+
+/// The upsert in memory state size threshold after which it will spill to disk.
+/// The default is 256 MB = 268435456 bytes
+const UPSERT_SOURCE_AUTO_SPILL_THRESHOLD_BYTES: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("upsert_source_auto_spill_threshold_bytes"),
+    value: &268435456,
+    description:
+        "The upsert in-memory state size threshold in bytes after which it will spill to disk",
+    internal: true,
+};
+
 /// Tuning for RocksDB used by `UPSERT` sources that takes effect on restart.
 mod upsert_rocksdb {
     use std::str::FromStr;
@@ -1760,6 +1778,8 @@ impl SystemVars {
             .with_var(&MAX_RESULT_SIZE)
             .with_var(&ALLOWED_CLUSTER_REPLICA_SIZES)
             .with_var(&DISK_CLUSTER_REPLICAS_DEFAULT)
+            .with_var(&UPSERT_SOURCE_AUTO_SPILL_TO_DISK)
+            .with_var(&UPSERT_SOURCE_AUTO_SPILL_THRESHOLD_BYTES)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_COMPACTION_STYLE)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES)
@@ -2108,6 +2128,14 @@ impl SystemVars {
     /// Returns the `disk_cluster_replicas_default` configuration parameter.
     pub fn disk_cluster_replicas_default(&self) -> bool {
         *self.expect_value(&DISK_CLUSTER_REPLICAS_DEFAULT)
+    }
+
+    pub fn upsert_source_auto_spill_to_disk(&self) -> bool {
+        *self.expect_value(&UPSERT_SOURCE_AUTO_SPILL_TO_DISK)
+    }
+
+    pub fn upsert_source_auto_spill_threshold_bytes(&self) -> usize {
+        *self.expect_value(&UPSERT_SOURCE_AUTO_SPILL_THRESHOLD_BYTES)
     }
 
     pub fn upsert_rocksdb_compaction_style(&self) -> mz_rocksdb_types::config::CompactionStyle {

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -25,6 +25,7 @@ message ProtoStorageParameters {
     bool finalize_shards = 6;
     uint64 keep_n_sink_status_history_entries = 7;
     mz_tracing.params.ProtoTracingParameters tracing = 8;
+    ProtoUpsertAutoSpillConfig upsert_auto_spill_config = 9;
 }
 
 
@@ -34,4 +35,9 @@ message ProtoPgReplicationTimeouts {
     optional mz_proto.ProtoDuration keepalives_idle = 3;
     optional mz_proto.ProtoDuration keepalives_interval = 4;
     optional mz_proto.ProtoDuration tcp_user_timeout = 5;
+}
+
+message ProtoUpsertAutoSpillConfig {
+    bool allow_spilling_to_disk = 1;
+    uint64 spill_to_disk_threshold_bytes = 2;
 }

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -38,6 +38,31 @@ pub struct StorageParameters {
     /// finalization.
     pub finalize_shards: bool,
     pub tracing: TracingParameters,
+    /// A set of parameters used configure auto spill behaviour if disk is used.
+    pub upsert_auto_spill_config: AutoSpillConfig,
+}
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct AutoSpillConfig {
+    /// A flag to whether allow automatically spilling to disk or not
+    pub allow_spilling_to_disk: bool,
+    /// The size in bytes of the upsert state after which rocksdb will be used
+    /// instead of in memory hashmap
+    pub spill_to_disk_threshold_bytes: usize,
+}
+
+impl RustType<ProtoUpsertAutoSpillConfig> for AutoSpillConfig {
+    fn into_proto(&self) -> ProtoUpsertAutoSpillConfig {
+        ProtoUpsertAutoSpillConfig {
+            allow_spilling_to_disk: self.allow_spilling_to_disk,
+            spill_to_disk_threshold_bytes: u64::cast_from(self.spill_to_disk_threshold_bytes),
+        }
+    }
+    fn from_proto(proto: ProtoUpsertAutoSpillConfig) -> Result<Self, TryFromProtoError> {
+        Ok(Self {
+            allow_spilling_to_disk: proto.allow_spilling_to_disk,
+            spill_to_disk_threshold_bytes: usize::cast_from(proto.spill_to_disk_threshold_bytes),
+        })
+    }
 }
 
 impl StorageParameters {
@@ -52,6 +77,7 @@ impl StorageParameters {
             upsert_rocksdb_tuning_config,
             finalize_shards,
             tracing,
+            upsert_auto_spill_config,
         }: StorageParameters,
     ) {
         self.persist.update(persist);
@@ -61,6 +87,7 @@ impl StorageParameters {
         self.upsert_rocksdb_tuning_config = upsert_rocksdb_tuning_config;
         self.finalize_shards = finalize_shards;
         self.tracing.update(tracing);
+        self.upsert_auto_spill_config = upsert_auto_spill_config;
     }
 }
 
@@ -78,6 +105,7 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             upsert_rocksdb_tuning_config: Some(self.upsert_rocksdb_tuning_config.into_proto()),
             finalize_shards: self.finalize_shards,
             tracing: Some(self.tracing.into_proto()),
+            upsert_auto_spill_config: Some(self.upsert_auto_spill_config.into_proto()),
         }
     }
 
@@ -102,6 +130,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             tracing: proto
                 .tracing
                 .into_rust_if_some("ProtoStorageParameters::tracing")?,
+            upsert_auto_spill_config: proto
+                .upsert_auto_spill_config
+                .into_rust_if_some("ProtoStorageParameters::upsert_auto_spill_config")?,
         })
     }
 }

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -39,10 +39,10 @@ pub struct StorageParameters {
     pub finalize_shards: bool,
     pub tracing: TracingParameters,
     /// A set of parameters used configure auto spill behaviour if disk is used.
-    pub upsert_auto_spill_config: AutoSpillConfig,
+    pub upsert_auto_spill_config: UpsertAutoSpillConfig,
 }
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
-pub struct AutoSpillConfig {
+pub struct UpsertAutoSpillConfig {
     /// A flag to whether allow automatically spilling to disk or not
     pub allow_spilling_to_disk: bool,
     /// The size in bytes of the upsert state after which rocksdb will be used
@@ -50,7 +50,7 @@ pub struct AutoSpillConfig {
     pub spill_to_disk_threshold_bytes: usize,
 }
 
-impl RustType<ProtoUpsertAutoSpillConfig> for AutoSpillConfig {
+impl RustType<ProtoUpsertAutoSpillConfig> for UpsertAutoSpillConfig {
     fn into_proto(&self) -> ProtoUpsertAutoSpillConfig {
         ProtoUpsertAutoSpillConfig {
             allow_spilling_to_disk: self.allow_spilling_to_disk,

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -29,6 +29,9 @@ pub struct DataflowParameters {
     /// A set of parameters used to tune RocksDB when used with `UPSERT` sources.
     /// `None` means the defaults.
     pub upsert_rocksdb_tuning_config: mz_rocksdb::RocksDBConfig,
+    /// A set of parameters to configure auto spill to disk behaviour for a `DISK`
+    /// enabled upsert source
+    pub auto_spill_config: mz_storage_client::types::parameters::AutoSpillConfig,
 }
 
 impl DataflowParameters {
@@ -37,9 +40,11 @@ impl DataflowParameters {
         &mut self,
         pg_replication_timeouts: mz_postgres_util::ReplicationTimeouts,
         rocksdb_params: mz_rocksdb::RocksDBTuningParameters,
+        auto_spill_config: mz_storage_client::types::parameters::AutoSpillConfig,
     ) {
         self.pg_replication_timeouts = pg_replication_timeouts;
-        self.upsert_rocksdb_tuning_config.apply(rocksdb_params)
+        self.upsert_rocksdb_tuning_config.apply(rocksdb_params);
+        self.auto_spill_config = auto_spill_config;
     }
 }
 
@@ -83,6 +88,7 @@ pub enum InternalStorageCommand {
     UpdateConfiguration(
         mz_postgres_util::ReplicationTimeouts,
         mz_rocksdb::RocksDBTuningParameters,
+        mz_storage_client::types::parameters::AutoSpillConfig,
     ),
 }
 

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -31,7 +31,7 @@ pub struct DataflowParameters {
     pub upsert_rocksdb_tuning_config: mz_rocksdb::RocksDBConfig,
     /// A set of parameters to configure auto spill to disk behaviour for a `DISK`
     /// enabled upsert source
-    pub auto_spill_config: mz_storage_client::types::parameters::AutoSpillConfig,
+    pub auto_spill_config: mz_storage_client::types::parameters::UpsertAutoSpillConfig,
 }
 
 impl DataflowParameters {
@@ -40,7 +40,7 @@ impl DataflowParameters {
         &mut self,
         pg_replication_timeouts: mz_postgres_util::ReplicationTimeouts,
         rocksdb_params: mz_rocksdb::RocksDBTuningParameters,
-        auto_spill_config: mz_storage_client::types::parameters::AutoSpillConfig,
+        auto_spill_config: mz_storage_client::types::parameters::UpsertAutoSpillConfig,
     ) {
         self.pg_replication_timeouts = pg_replication_timeouts;
         self.upsert_rocksdb_tuning_config.apply(rocksdb_params);
@@ -88,7 +88,7 @@ pub enum InternalStorageCommand {
     UpdateConfiguration(
         mz_postgres_util::ReplicationTimeouts,
         mz_rocksdb::RocksDBTuningParameters,
-        mz_storage_client::types::parameters::AutoSpillConfig,
+        mz_storage_client::types::parameters::UpsertAutoSpillConfig,
     ),
 }
 

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -181,6 +181,8 @@ where
 
         let env = instance_context.rocksdb_env.clone();
 
+        let rocksdb_in_use_metric = Arc::clone(&upsert_metrics.rocksdb_autospill_in_use);
+
         if allow_auto_spill {
             upsert_inner(
                 input,
@@ -199,6 +201,7 @@ where
                             metrics: rocksdb_metrics,
                         },
                         spill_threshold,
+                        rocksdb_in_use_metric,
                     )
                 },
             )

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -167,6 +167,8 @@ where
             .auto_spill_config
             .spill_to_disk_threshold_bytes;
 
+        let worker_id = source_config.worker_id;
+
         tracing::info!(
             ?tuning,
             ?dataflow_paramters.auto_spill_config,
@@ -199,6 +201,7 @@ where
                             metrics: rocksdb_metrics,
                         },
                         spill_threshold,
+                        worker_id,
                     )
                 },
             )

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -167,8 +167,6 @@ where
             .auto_spill_config
             .spill_to_disk_threshold_bytes;
 
-        let worker_id = source_config.worker_id;
-
         tracing::info!(
             ?tuning,
             ?dataflow_paramters.auto_spill_config,
@@ -201,7 +199,6 @@ where
                             metrics: rocksdb_metrics,
                         },
                         spill_threshold,
-                        worker_id,
                     )
                 },
             )

--- a/src/storage/src/render/upsert/types.rs
+++ b/src/storage/src/render/upsert/types.rs
@@ -468,20 +468,14 @@ pub struct AutoSpillBackend {
     backend_type: BackendType,
     rockdsdb_params: RocksDBParams,
     auto_spill_threshold_bytes: usize,
-    worker_id: usize,
 }
 
 impl AutoSpillBackend {
-    pub(crate) fn new(
-        rockdsdb_params: RocksDBParams,
-        auto_spill_threshold_bytes: usize,
-        worker_id: usize,
-    ) -> Self {
+    pub(crate) fn new(rockdsdb_params: RocksDBParams, auto_spill_threshold_bytes: usize) -> Self {
         Self {
             backend_type: BackendType::InMemory(InMemoryHashMap::default()),
             rockdsdb_params,
             auto_spill_threshold_bytes,
-            worker_id,
         }
     }
 

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -259,7 +259,7 @@ impl UpsertMetrics {
                 var_labels: ["source_id", "worker_id"],
             )),
             rocksdb_autospill_in_use: registry.register(metric!(
-                name: "mz_storage_upsert_state_rocksdb_autospill_is_use",
+                name: "mz_storage_upsert_state_rocksdb_autospill_in_use",
                 help: "Flag to denote whether upsert state has spilled to rocksdb \
                     or using in-memory state",
                 var_labels: ["source_id", "worker_id"],

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -205,6 +205,10 @@ pub(super) struct UpsertMetrics {
     pub(super) rehydration_total: UIntGaugeVec,
     pub(super) rehydration_updates: UIntGaugeVec,
 
+    // Metric will contain either 0 to denote in-memory state usage,
+    // and 1 to denote auto spill to rocksdb
+    pub(super) rocksdb_autospill_in_use: UIntGaugeVec,
+
     // These are used by `shared`.
     pub(super) merge_snapshot_latency: HistogramVec,
     pub(super) merge_snapshot_updates: HistogramVec,
@@ -252,6 +256,12 @@ impl UpsertMetrics {
                 help: "The number of updates (both negative and positive), \
                     per-worker, rehydrated into the upsert state for \
                     this source",
+                var_labels: ["source_id", "worker_id"],
+            )),
+            rocksdb_autospill_in_use: registry.register(metric!(
+                name: "mz_storage_upsert_state_rocksdb_autospill_is_use",
+                help: "Flag to denote whether upsert state has spilled to rocksdb \
+                    or using in-memory state",
                 var_labels: ["source_id", "worker_id"],
             )),
             // Choose a relatively low number of representative buckets.

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -487,6 +487,7 @@ pub struct UpsertMetrics {
     pub(crate) rehydration_latency: DeleteOnDropGauge<'static, AtomicF64, Vec<String>>,
     pub(crate) rehydration_total: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     pub(crate) rehydration_updates: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    pub(crate) rocksdb_autospill_in_use: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     pub(crate) shared: Arc<UpsertSharedMetrics>,
     pub(crate) rocksdb: Arc<mz_rocksdb::RocksDBMetrics>,
 }
@@ -505,6 +506,9 @@ impl UpsertMetrics {
                 .get_delete_on_drop_gauge(vec![source_id_s.clone(), worker_id.clone()]),
             rehydration_updates: base
                 .rehydration_updates
+                .get_delete_on_drop_gauge(vec![source_id_s.clone(), worker_id.clone()]),
+            rocksdb_autospill_in_use: base
+                .rocksdb_autospill_in_use
                 .get_delete_on_drop_gauge(vec![source_id_s, worker_id]),
             shared: base.shared(&source_id),
             rocksdb: base.rocksdb(&source_id),

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -487,7 +487,7 @@ pub struct UpsertMetrics {
     pub(crate) rehydration_latency: DeleteOnDropGauge<'static, AtomicF64, Vec<String>>,
     pub(crate) rehydration_total: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     pub(crate) rehydration_updates: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub(crate) rocksdb_autospill_in_use: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    pub(crate) rocksdb_autospill_in_use: Arc<DeleteOnDropGauge<'static, AtomicU64, Vec<String>>>,
     pub(crate) shared: Arc<UpsertSharedMetrics>,
     pub(crate) rocksdb: Arc<mz_rocksdb::RocksDBMetrics>,
 }
@@ -507,9 +507,10 @@ impl UpsertMetrics {
             rehydration_updates: base
                 .rehydration_updates
                 .get_delete_on_drop_gauge(vec![source_id_s.clone(), worker_id.clone()]),
-            rocksdb_autospill_in_use: base
-                .rocksdb_autospill_in_use
-                .get_delete_on_drop_gauge(vec![source_id_s, worker_id]),
+            rocksdb_autospill_in_use: Arc::new(
+                base.rocksdb_autospill_in_use
+                    .get_delete_on_drop_gauge(vec![source_id_s, worker_id]),
+            ),
             shared: base.shared(&source_id),
             rocksdb: base.rocksdb(&source_id),
         }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -843,9 +843,10 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 // control flow from external command to this internal command.
                 self.storage_state.dropped_ids.extend(ids);
             }
-            InternalStorageCommand::UpdateConfiguration(pg, rocksdb) => {
-                self.storage_state.dataflow_parameters.update(pg, rocksdb)
-            }
+            InternalStorageCommand::UpdateConfiguration(pg, rocksdb, auto_spill_config) => self
+                .storage_state
+                .dataflow_parameters
+                .update(pg, rocksdb, auto_spill_config),
         }
     }
 
@@ -1157,6 +1158,7 @@ impl StorageState {
                     internal_cmd_tx.broadcast(InternalStorageCommand::UpdateConfiguration(
                         params.pg_replication_timeouts,
                         params.upsert_rocksdb_tuning_config,
+                        params.upsert_auto_spill_config,
                     ))
                 }
             }

--- a/test/upsert/autospill/bytes.td
+++ b/test/upsert/autospill/bytes.td
@@ -31,6 +31,9 @@ animal:whale
 $ kafka-ingest format=bytes topic=autospill key-format=bytes key-terminator=:
 fish:AREALLYBIGFISHAREALLYBIGFISHAREALLYBIGFISHAREALLYBIGFISH
 
+> SELECT count(*) from autospill;
+3
+
 > SELECT
     SUM(u.envelope_state_bytes) > 0,
     SUM(u.envelope_state_count)
@@ -46,6 +49,9 @@ $ kafka-ingest format=bytes topic=autospill key-format=bytes key-terminator=:
 fish:
 bird:
 animal:
+
+> SELECT count(*) from autospill;
+0
 
 # Both envelope_state_bytes and envelope_state_count should be zero
 > SELECT

--- a/test/upsert/autospill/bytes.td
+++ b/test/upsert/autospill/bytes.td
@@ -1,0 +1,59 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-create-topic topic=autospill
+
+> CREATE CONNECTION conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+
+> CREATE SOURCE autospill
+  FROM KAFKA CONNECTION conn (TOPIC
+  'testdrive-autospill-${testdrive.seed}'
+  )
+  KEY FORMAT TEXT VALUE FORMAT TEXT
+  ENVELOPE UPSERT
+
+
+$ kafka-ingest format=bytes topic=autospill key-format=bytes key-terminator=:
+bird:goose
+animal:whale
+
+> SELECT count(*) from autospill;
+2
+
+# Inserting large value should trigger auto spill
+$ kafka-ingest format=bytes topic=autospill key-format=bytes key-terminator=:
+fish:AREALLYBIGFISHAREALLYBIGFISHAREALLYBIGFISHAREALLYBIGFISH
+
+> SELECT
+    SUM(u.envelope_state_bytes) > 0,
+    SUM(u.envelope_state_count)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('autospill')
+  GROUP BY s.name
+  ORDER BY s.name
+true 3
+
+# Removing all the inserted keys
+$ kafka-ingest format=bytes topic=autospill key-format=bytes key-terminator=:
+fish:
+bird:
+animal:
+
+# Both envelope_state_bytes and envelope_state_count should be zero
+> SELECT
+    SUM(u.envelope_state_bytes),
+    SUM(u.envelope_state_count)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('autospill')
+  GROUP BY s.name
+  ORDER BY s.name
+0 0

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -384,8 +384,8 @@ def workflow_autospill(c: Composition) -> None:
             ],
             additional_system_parameter_defaults={
                 "upsert_source_disk_default": "true",
-                "upsert_source_auto_spill_to_disk": "true",
-                "upsert_source_auto_spill_threshold_bytes": "200",
+                "upsert_rocksdb_auto_spill_to_disk": "true",
+                "upsert_rocksdb_auto_spill_threshold_bytes": "200",
             },
         ),
     ):

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -63,6 +63,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "failpoint",
         "incident-49",
         "rocksdb-cleanup",
+        "autospill",
     ]:
         with c.test_case(name):
             c.workflow(name)
@@ -364,3 +365,29 @@ def workflow_rocksdb_cleanup(c: Composition) -> None:
                 assert num_files(dropped_source_path) == 0
 
         c.testdrive("#reset testdrive")
+
+
+def workflow_autospill(c: Composition) -> None:
+    """Testing auto spill to disk"""
+    c.down(destroy_volumes=True)
+    dependencies = [
+        "zookeeper",
+        "kafka",
+        "materialized",
+        "schema-registry",
+    ]
+
+    with c.override(
+        Materialized(
+            options=[
+                "--orchestrator-process-scratch-directory=/mzdata/source_data",
+            ],
+            additional_system_parameter_defaults={
+                "upsert_source_disk_default": "true",
+                "upsert_source_auto_spill_to_disk": "true",
+                "upsert_source_auto_spill_threshold_bytes": "200",
+            },
+        ),
+    ):
+        c.up(*dependencies)
+        c.run("testdrive", "autospill/bytes.td")


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Added behaviour to use in-memory hashmap till a configurable threashold and only spill to disk to use rocksdb after the threshold is exceeded. This will be behind a flag as well.

### Motivation
Part of https://github.com/MaterializeInc/materialize/issues/17067

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
