### PR TITLE
environmentd: remove waiting_on_leader_promotion testing knob

### DIFF
--- a/src/environmentd/src/server.rs
+++ b/src/environmentd/src/server.rs
@@ -71,7 +71,7 @@ impl ListenerHandle {
 /// closed, and the stream of incoming connections terminates.
 pub async fn listen(
     addr: SocketAddr,
-) -> Result<(ListenerHandle, impl ConnectionStream), io::Error> {
+) -> Result<(ListenerHandle, Pin<Box<dyn ConnectionStream>>), io::Error> {
     let listener = TcpListener::bind(addr).await?;
     let local_addr = listener.local_addr()?;
     let (trigger, tripwire) = oneshot::channel();
@@ -82,7 +82,7 @@ pub async fn listen(
     // TODO(benesch): replace `TCPListenerStream`s with `listener.incoming()` if
     // that is restored when the `Stream` trait stabilizes.
     let stream = TcpListenerStream::new(listener).take_until(tripwire);
-    Ok((handle, stream))
+    Ok((handle, Box::pin(stream)))
 }
 
 /// Serves incoming TCP connections from `conns` using `server`.


### PR DESCRIPTION
This commit removes the `waiting_on_leader_promotion` testing knob from environmentd configuration. The knob was added to support the new upgrade orchestration in #19754 so that a Rust unit test could ascertain the server's internal HTTP address before the server was fully booted.

We prefer to avoid testing knobs whenever possible, and this one turns out to be easy to avoid with a small refactoring to the environmentd server initialization API. The new API is split into two functions: one for creating the listeners, and one for booting the server from those listeners. The caller can ask the listeners for its bound addresses before booting the server.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

_Definitely_ view this one with whitespace changes suppressed. The diffstat is not scary with whitespace suppressed:

```
159 insertions(+), 95 deletions(-)
```

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
