### PR TITLE
sqlancer: Use new main branch

### DIFF
--- a/test/sqlancer/Dockerfile
+++ b/test/sqlancer/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     maven
 
 # Rebuild since SQLancer repo might have changed
-ADD https://api.github.com/repos/sqlancer/sqlancer/git/refs/heads/master version.json
+ADD https://api.github.com/repos/sqlancer/sqlancer/git/refs/heads/main version.json
 
 # Build SQLancer
 RUN git clone --depth=1 --single-branch https://github.com/sqlancer/sqlancer \


### PR DESCRIPTION
Has been renamed from master: https://github.com/sqlancer/sqlancer
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
