### PR TITLE
Documentation updates for managed clusters

### DIFF
--- a/doc/user/content/get-started/key-concepts.md
+++ b/doc/user/content/get-started/key-concepts.md
@@ -183,6 +183,8 @@ meaning that on a given physical replica, objects in the cluster are in
 contention for the same physical resources. To achieve the performance you need,
 this might require setting up more than one cluster.
 
+See the [`CREATE CLUSTER`](/sql/create-cluster/) documentation for more details.
+
 ### Cluster deployment options
 
 When building your Materialize deployment, you can change its performance

--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -62,5 +62,7 @@ compute-specific settings. If needed, these can be set explicitly.
 
 ## See also
 
+- [`CREATE CLUSTER`](/sql/create-cluster/)
+- [`CREATE CLUSTER REPLICA`](/sql/create-cluster-replica)
 - [`CREATE SINK`](/sql/create-sink/)
 - [`SHOW SINKS`](/sql/show-sinks)

--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -1,0 +1,66 @@
+---
+title: "ALTER CLUSTER"
+description: "`ALTER CLUSTER` changes the configuration of a cluster."
+menu:
+  main:
+    parent: 'commands'
+---
+
+`ALTER CLUSTER` changes the configuration of a cluster.
+
+## Syntax
+
+{{< diagram "alter-cluster-set.svg" >}}
+
+{{< diagram "alter-cluster-reset.svg" >}}
+
+{{% cluster-options %}}
+
+## Examples
+
+### Replication factor
+
+Alter cluster to two replicas:
+
+```sql
+ALTER CLUSTER c1 SET (REPLICATION FACTOR 2);
+```
+
+### Size
+
+Alter cluster to size `xsmall`:
+
+```sql
+ALTER CLUSTER c1 SET (SIZE 'xsmall');
+```
+
+### Converting managed to unmanaged clusters
+Alter the `managed` status of a cluster to unmanaged:
+
+```sql
+ALTER CLUSTER c1 SET (MANAGED false);
+```
+
+### Converting unmanaged to managed clusters
+
+Alter the `managed` status of a cluster to unmanaged:
+
+```sql
+ALTER CLUSTER c1 SET (MANAGED);
+```
+
+Materialize permits converting an unmanged cluster to a managed cluster if
+the following conditions are met:
+
+* The cluster replica names are `r1`, `r2`, ..., `rN`.
+* All replicas have the same size.
+* If there are no replicas, `SIZE` needs to be specified.
+* If specified, the replication factor must match the number of replicas.
+
+Note that the cluster will not have settings for the availability zones, and
+compute-specific settings. If needed, these can be set explicitly.
+
+## See also
+
+- [`CREATE SINK`](/sql/create-sink/)
+- [`SHOW SINKS`](/sql/show-sinks)

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -55,6 +55,33 @@ Clusters containing sources and sinks can have at most one replica.
 We plan to remove this restriction in a future version of Materialize.
 {{< /warning >}}
 
+## Managed and unmanaged clusters
+
+A managed cluster is one with a declared size and replication factor, where
+Materialize is responsible for ensuring the replica set matches the declared
+size and replication factor. The replicas of a managed cluster are visible in
+the system catalog, but cannot be directly modified by users.
+
+An unmanaged cluster requires you to manage replicas manually, by creating and
+dropping replicas to achieve the desired replication factor and replica size.
+The replicas of unmanaged clusters appear in the system catalog and can be
+modified by users.
+
+
+{{< warning >}}
+Managed clusters with sources and sinks only support a replication factor of zero or one.
+
+We plan to remove this restriction in a future version of Materialize.
+{{< /warning >}}
+
+## Syntax
+
+{{< diagram "create-managed-cluster.svg" >}}
+
+### Cluster options
+
+{{% cluster-options %}}
+
 ## Syntax
 
 {{< diagram "create-cluster.svg" >}}
@@ -102,6 +129,12 @@ Adding replicas to clusters | See [Cluster replica scaling](/sql/create-cluster#
 Create a cluster with two medium replicas:
 
 ```sql
+CREATE CLUSTER c1 SIZE = 'medium', REPLICATION FACTOR = 2;
+```
+
+Alternatively, the cluster can be created as an unmanaged cluster:
+
+```sql
 CREATE CLUSTER c1 REPLICAS (
     r1 (SIZE = 'medium'),
     r2 (SIZE = 'medium')
@@ -111,6 +144,12 @@ CREATE CLUSTER c1 REPLICAS (
 ### Introspection disabled
 
 Create a cluster with a single replica with introspection disabled:
+
+```sql
+CREATE CLUSTER c  SIZE = 'xsmall', INTROSPECTION INTERVAL = 0;
+```
+
+Alternatively, the cluster can be created as an unmanaged cluster:
 
 ```sql
 CREATE CLUSTER c REPLICAS (
@@ -125,6 +164,10 @@ that cluster replica.
 ### Empty
 
 Create a cluster with no replicas:
+
+```sql
+CREATE CLUSTER c1 SIZE 'xsmall', REPLICATION FACTOR 0;
+```
 
 ```sql
 CREATE CLUSTER c1 REPLICAS ();

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -126,13 +126,13 @@ Adding replicas to clusters | See [Cluster replica scaling](/sql/create-cluster#
 
 ### Basic
 
-Create a cluster with two medium replicas:
+Create a managed cluster with two medium replicas:
 
 ```sql
 CREATE CLUSTER c1 SIZE = 'medium', REPLICATION FACTOR = 2;
 ```
 
-Alternatively, the cluster can be created as an unmanaged cluster:
+Alternatively, you can create an unmanaged cluster:
 
 ```sql
 CREATE CLUSTER c1 REPLICAS (
@@ -143,13 +143,13 @@ CREATE CLUSTER c1 REPLICAS (
 
 ### Introspection disabled
 
-Create a cluster with a single replica with introspection disabled:
+Create a managed cluster with a single replica with introspection disabled:
 
 ```sql
 CREATE CLUSTER c  SIZE = 'xsmall', INTROSPECTION INTERVAL = 0;
 ```
 
-Alternatively, the cluster can be created as an unmanaged cluster:
+Alternatively, you can create an unmanaged cluster:
 
 ```sql
 CREATE CLUSTER c REPLICAS (
@@ -163,17 +163,28 @@ that cluster replica.
 
 ### Empty
 
-Create a cluster with no replicas:
+Create a managed cluster with no replicas:
 
 ```sql
 CREATE CLUSTER c1 SIZE 'xsmall', REPLICATION FACTOR 0;
 ```
 
+You can later add replicas to this managed cluster with [`ALTER CLUSTER`](/sql/alter-cluster/.
+)
+
+Alternatively, you can create an unmanaged cluster:
+
 ```sql
 CREATE CLUSTER c1 REPLICAS ();
 ```
 
-You can later add replicas to this cluster with [`CREATE CLUSTER
+You can later add replicas to this unmanaged cluster with [`CREATE CLUSTER
 REPLICA`](../create-cluster-replica).
 
-[AWS availability zone ID]: https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html
+## See also
+
+- [`CREATE CLUSTER REPLICA`](/sql/create-cluster-replica)
+- [`ALTER CLUSTER`](/sql/alter-cluster/)
+- [`DROP CLUSTER`](/sql/drop-cluster/)
+
+[AWS availability zone IDs]: https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html

--- a/doc/user/layouts/partials/sql-grammar/alter-cluster-reset.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-cluster-reset.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="429" height="137">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="66" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">ALTER</text>
+   <rect x="117" y="3" width="84" height="32" rx="10"/>
+   <rect x="115"
+         y="1"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="125" y="21">CLUSTER</text>
+   <rect x="221" y="3" width="56" height="32"/>
+   <rect x="219" y="1" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="229" y="21">name</text>
+   <rect x="297" y="3" width="64" height="32" rx="10"/>
+   <rect x="295"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="305" y="21">RESET</text>
+   <rect x="381" y="3" width="26" height="32" rx="10"/>
+   <rect x="379"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="389" y="21">(</text>
+   <rect x="179" y="69" width="156" height="32"/>
+   <rect x="177" y="67" width="156" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="187" y="87">cluster_option_name</text>
+   <rect x="375" y="103" width="26" height="32" rx="10"/>
+   <rect x="373"
+         y="101"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="383" y="121">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-292 100 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h166 m-196 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m176 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-176 0 h10 m156 0 h10 m20 34 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="419 117 427 113 427 121"/>
+   <polygon points="419 117 411 113 411 121"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/alter-cluster-set.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-cluster-set.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="413" height="135">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="66" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">ALTER</text>
+   <rect x="119" y="3" width="84" height="32" rx="10"/>
+   <rect x="117"
+         y="1"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="127" y="21">CLUSTER</text>
+   <rect x="223" y="3" width="56" height="32"/>
+   <rect x="221" y="1" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="231" y="21">name</text>
+   <rect x="299" y="3" width="46" height="32" rx="10"/>
+   <rect x="297"
+         y="1"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="307" y="21">SET</text>
+   <rect x="365" y="3" width="26" height="32" rx="10"/>
+   <rect x="363"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="373" y="21">(</text>
+   <rect x="65" y="85" width="112" height="32"/>
+   <rect x="63" y="83" width="112" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="73" y="103">cluster_option</text>
+   <rect x="197" y="85" width="28" height="32" rx="10"/>
+   <rect x="195"
+         y="83"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="205" y="103">=</text>
+   <rect x="245" y="85" width="54" height="32"/>
+   <rect x="243" y="83" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="253" y="103">value</text>
+   <rect x="359" y="85" width="26" height="32" rx="10"/>
+   <rect x="357"
+         y="83"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="367" y="103">)</text>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-410 82 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m112 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m-274 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m254 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-254 0 h10 m0 0 h244 m-294 32 h20 m294 0 h20 m-334 0 q10 0 10 10 m314 0 q0 -10 10 -10 m-324 10 v14 m314 0 v-14 m-314 14 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m0 0 h284 m20 -34 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="403 99 411 95 411 103"/>
+   <polygon points="403 99 395 95 395 103"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/create-managed-cluster.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-managed-cluster.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="469" height="135">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="76" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">CREATE</text>
+   <rect x="127" y="3" width="84" height="32" rx="10"/>
+   <rect x="125"
+         y="1"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="135" y="21">CLUSTER</text>
+   <rect x="231" y="3" width="56" height="32"/>
+   <rect x="229" y="1" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="239" y="21">name</text>
+   <rect x="307" y="3" width="26" height="32" rx="10"/>
+   <rect x="305"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="315" y="21">(</text>
+   <rect x="353" y="3" width="94" height="32" rx="10"/>
+   <rect x="351"
+         y="1"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="361" y="21">MANAGED</text>
+   <rect x="77" y="85" width="24" height="32" rx="10"/>
+   <rect x="75"
+         y="83"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="85" y="103">,</text>
+   <rect x="121" y="85" width="112" height="32"/>
+   <rect x="119" y="83" width="112" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="129" y="103">cluster_option</text>
+   <rect x="253" y="85" width="28" height="32" rx="10"/>
+   <rect x="251"
+         y="83"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="261" y="103">=</text>
+   <rect x="301" y="85" width="54" height="32"/>
+   <rect x="299" y="83" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="309" y="103">value</text>
+   <rect x="415" y="85" width="26" height="32" rx="10"/>
+   <rect x="413"
+         y="83"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="423" y="103">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m94 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 82 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m24 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m-318 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m298 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-298 0 h10 m0 0 h288 m-338 32 h20 m338 0 h20 m-378 0 q10 0 10 10 m358 0 q0 -10 10 -10 m-368 10 v14 m358 0 v-14 m-358 14 q0 10 10 10 m338 0 q10 0 10 -10 m-348 10 h10 m0 0 h328 m20 -34 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="459 99 467 95 467 103"/>
+   <polygon points="459 99 451 95 451 103"/>
+</svg>

--- a/doc/user/layouts/shortcodes/cluster-options.html
+++ b/doc/user/layouts/shortcodes/cluster-options.html
@@ -1,0 +1,9 @@
+Field                               | Value      | Description
+------------------------------------|------------|-------------------------------------
+`MANAGED`                           | `bool`     | Is the cluster a managed cluster?
+`SIZE`                              | `text`     | The size of the cluster replicas. For valid sizes, see [cluster replica sizes](/sql/create-cluster-replica#sizes).
+`REPLICATION FACTOR`                | `text`     | The replication factor of the cluster. Can be 0 to disable computations.
+`AVAILABILITY ZONES`                | `text[]`   | If you want the cluster replicas to reside in specific availability zones. You must specify a list of [AWS availability zone IDs] in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.
+`INTROSPECTION INTERVAL`            | `interval` | Default: `1s`. The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.
+`INTROSPECTION DEBUGGING`           | `bool`     | Default: `false`. Whether to introspect the gathering of the introspection data.
+`IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | The amount of effort the replica should exert on compacting arrangements during idle periods. *This is an unstable option! It may be changed or removed at any time.*

--- a/doc/user/layouts/shortcodes/cluster-options.html
+++ b/doc/user/layouts/shortcodes/cluster-options.html
@@ -1,9 +1,9 @@
 Field                               | Value      | Description
 ------------------------------------|------------|-------------------------------------
-`MANAGED`                           | `bool`     | Is the cluster a managed cluster?
+`MANAGED`                           | `bool`     | Default: `true`. Indicates whether the cluster is a [managed cluster](/sql/create-cluster/#managed-and-unmanaged-clusters).
 `SIZE`                              | `text`     | The size of the cluster replicas. For valid sizes, see [cluster replica sizes](/sql/create-cluster-replica#sizes).
 `REPLICATION FACTOR`                | `text`     | The replication factor of the cluster. Can be 0 to disable computations.
 `AVAILABILITY ZONES`                | `text[]`   | If you want the cluster replicas to reside in specific availability zones. You must specify a list of [AWS availability zone IDs] in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.
 `INTROSPECTION INTERVAL`            | `interval` | Default: `1s`. The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.
-`INTROSPECTION DEBUGGING`           | `bool`     | Default: `false`. Whether to introspect the gathering of the introspection data.
+`INTROSPECTION DEBUGGING`           | `bool`     | Default: `false`. Indicates whether to introspect the gathering of the introspection data.
 `IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | The amount of effort the replica should exert on compacting arrangements during idle periods. *This is an unstable option! It may be changed or removed at any time.*

--- a/doc/user/layouts/shortcodes/postgres-direct/create-an-ingestion-cluster.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/create-an-ingestion-cluster.html
@@ -1,11 +1,11 @@
-In Materialize, a [cluster](/get-started/key-concepts/#clusters) is an **isolated environment**, similar to a virtual warehouse in Snowflake. Within a cluster, you have [replicas](/get-started/key-concepts/#cluster-replicas), which are the **physical resources** for doing computational work. Clusters are completely isolated from each other, so replicas can be sized based on the specific task of the cluster, whether that is ingesting data from a source, computing always-up-to-date query results, serving results to clients, or a combination.
+In Materialize, a [cluster](/get-started/key-concepts/#clusters) is an isolated environment, similar to a virtual warehouse in Snowflake. When you create a cluster, you choose the size of its physical compute resource (i.e., [replica](/get-started/key-concepts/#cluster-replicas)) based on the work you need the cluster to do, whether ingesting data from a source, computing always-up-to-date query results, serving results to clients, or a combination.
 
-In this case, you'll create 1 new cluster containing 1 replica for ingesting source data from your PostgreSQL database.
+In this case, you'll create 1 new cluster containing 1 `medium` replica for ingesting source data from your PostgreSQL database.
 
-1. In the `psql` shell connected to Materialize, use the [`CREATE CLUSTER`](/sql/create-cluster/) command to create the new cluster and replica:
+1. In the `psql` shell connected to Materialize, use the [`CREATE CLUSTER`](/sql/create-cluster/) command to create the new cluster:
 
     ```sql
-    CREATE CLUSTER ingest_postgres REPLICAS (r1 (SIZE = 'medium'));
+    CREATE CLUSTER ingest_postgres SIZE = 'medium';
     ```
 
-    We recommend starting with a `medium` [size](/sql/create-cluster-replica/#sizes) replica or larger. This will help Materialize more quickly process the initial snapshot of the tables in your publication. Once the snapshot is finished, you'll right-size the cluster replica.
+    We recommend starting with a `medium` [size](/sql/create-cluster-replica/#sizes) replica or larger. This will help Materialize more quickly process the initial snapshot of the tables in your publication. Once the snapshot is finished, you'll right-size the cluster.

--- a/doc/user/layouts/shortcodes/postgres-direct/right-size-the-cluster.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/right-size-the-cluster.html
@@ -1,16 +1,12 @@
-After the snapshotting phase, Materialize starts ingesting change events from the PostgreSQL replication stream. For this work, Materialize generally performs well with an `xsmall` replica, so you can resize the replica in your ingestion cluster accordingly.
+After the snapshotting phase, Materialize starts ingesting change events from the PostgreSQL replication stream. For this work, Materialize generally performs well with an `xsmall` replica, so you can resize the cluster accordingly.
 
-1. Still in the `psql` shell connected to Materialize, remove the `medium` replica from the ingestion cluster:
-
-    ```sql
-    DROP CLUSTER REPLICA ingest_postgres.r1;
-    ```
-
-1. Add an `xsmall` replica to the ingestion cluster:
+1. Still in the `psql` shell connected to Materialize, use the [`ALTER CLUSTER`](/sql/alter-cluster/) command to downsize the cluster to `xsmall`:
 
     ```sql
-    CREATE CLUSTER REPLICA ingest_postgres.r1 SIZE 'xsmall';
+    ALTER CLUSTER ingest_postgres SET (SIZE 'xsmall');
     ```
+
+    Behind the scenes, this command adds a new `xsmall` replica and removes the `medium` replica.
 
 1. Use the [`SHOW CLUSTER REPLICAS`](/sql/show-cluster-replicas/) command to check the status of the new replica:
 

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -1,4 +1,8 @@
 aggregate_with_filter ::= aggregate_name '(' expression ')' ('FILTER' '(' 'WHERE' filter_clause ')')?
+alter_cluster_set ::=
+  'ALTER' 'CLUSTER' name 'SET' '(' (cluster_option '=' value)* ')'
+alter_cluster_reset ::=
+  'ALTER' 'CLUSTER' name 'RESET' '(' (cluster_option_name)* ')'
 alter_connection ::=
   'ALTER' 'CONNECTION' 'IF EXISTS'? name 'ROTATE' 'KEYS'
 alter_default_privileges ::=
@@ -44,6 +48,8 @@ create_cluster ::=
   'CREATE' 'CLUSTER' name (
     'REPLICAS' '(' (replica_definition (',' replica_definition)*)? ')'
   )?
+create_managed_cluster ::=
+  'CREATE' 'CLUSTER' name '(' 'MANAGED' (',' cluster_option '=' value)* ')'
 cluster_replica_def ::=
   replica_name '(' replica_option '=' value ( ',' replica_option '=' value )* ')'
 create_cluster_replica ::=


### PR DESCRIPTION
Update the documentation to include managed clusters. I split the content of this PR from #19762.

### Motivation

Part of #19547 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
