### PR TITLE
[sinks] Notify the user if they're using a possibly-non-unique key

### DIFF
--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -440,6 +440,7 @@ impl ErrorResponse {
             AdapterNotice::NonApplicablePrivilegeTypes { .. } => SqlState::WARNING,
             AdapterNotice::PlanNotice(plan) => match plan {
                 PlanNotice::ObjectDoesNotExist { .. } => SqlState::UNDEFINED_OBJECT,
+                PlanNotice::KeyNotEnforced { .. } => SqlState::WARNING,
             },
         };
         ErrorResponse {
@@ -609,6 +610,7 @@ impl Severity {
             AdapterNotice::NonApplicablePrivilegeTypes { .. } => Severity::Notice,
             AdapterNotice::PlanNotice(notice) => match notice {
                 PlanNotice::ObjectDoesNotExist { .. } => Severity::Notice,
+                PlanNotice::KeyNotEnforced { .. } => Severity::Warning,
             },
         }
     }


### PR DESCRIPTION
Change a warning log (which users do not see) to a notice (which they might).

I've also rewritten the warning slightly; #16487 means this no longer panics, so we might as well be more precise about the behaviour we expect.

### Motivation

Some combination of #9333 and #19143.

### Tips for reviewer

Here's what the generated notice looks like to a user:

```
WARNING:  cannot verify key ("column_name") for sink "sink_name"; sunk updates may not be unique by key
```

I don't think the wording is very good; please feel free to suggest improvements.

I'm not sure if there's any good way to test notices. The existing tests do a decent job of ensuring that I'm not changing any other behaviour, though.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
