### PR TITLE
expr,repr: standardize license headers for PostgreSQL-derivative files

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -7,8 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 //
-// The original source code is subject to the terms of the PostgreSQL license, a copy
-// of which can be found in the LICENSE file at the root of this repository.
+// Portions of this file are derived from the PostgreSQL project. The original
+// source code is subject to the terms of the PostgreSQL license, a copy of
+// which can be found in the LICENSE file at the root of this repository.
 
 use std::cmp::{self, Ordering};
 use std::convert::{TryFrom, TryInto};

--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -7,13 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 //
-// Portions of this file are derived from `timestamp.c` in the Postgres project.
-// The original source code was retrieved on June 1, 2023 from:
+// Portions of this file are derived from the PostgreSQL project. The original
+// source code was retrieved on June 1, 2023 from:
 //
 //     https://github.com/postgres/postgres/blob/REL_15_3/src/backend/utils/adt/timestamp.c
 //
-// The original source code is subject to the terms of the PostgreSQL license, a copy
-// of which can be found in the LICENSE file at the root of this repository.
+// The original source code is subject to the terms of the PostgreSQL license, a
+// copy of which can be found in the LICENSE file at the root of this
+// repository.
 
 //! Methods for checked timestamp operations.
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors license headers.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
