### PR TITLE
sql: implement pg_cancel_backend

### DIFF
--- a/doc/user/content/sql/functions/_index.md
+++ b/doc/user/content/sql/functions/_index.md
@@ -25,6 +25,25 @@ one-off [`SELECT`](/sql/select) statements.
 
 Unmaterializable functions are marked as such in the table below.
 
+### Side-effecting functions
+
+Several functions in Materialize are **side-effecting** because their evaluation
+changes system state. For example, the `pg_cancel_backend` function allows
+canceling a query running on another connection.
+
+Materialize offers only limited support for these functions. They may be called
+only at the top level of a `SELECT` statement, like so:
+
+```sql
+SELECT side_effecting_function(arg, ...);
+```
+
+You cannot manipulate or alias the function call expression, call multiple
+side-effecting functions in the same `SELECT` statement, nor add any additional
+clauses to the `SELECT` statement (e.g., `FROM`, `WHERE`).
+
+Side-effecting functions are marked as such in the table below.
+
 {{< fnlist >}}
 
 ## Operators

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -778,6 +778,11 @@
   - signature: 'pg_backend_pid() -> int'
     description: Returns the internal connection ID.
     unmaterializable: true
+  - signature: 'pg_cancel_backend(connection_id: int) -> bool'
+    description: >-
+      Cancels an in-progress query on the specified connection ID.
+      Returns whether the connection ID existed (not if it cancelled a query).
+    side_effecting: true
   - signature: 'pg_column_size(expr: any) -> int'
     description: Returns the number of bytes used to store any individual data value.
   - signature: 'pg_get_constraintdef(oid: oid[, pretty: bool]) -> text'

--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -42,6 +42,10 @@
       {{ if .unmaterializable }}
         <br><br><b>Note:</b> This function is <a href="#unmaterializable-functions">unmaterializable</a>.
       {{ end }}
+
+      {{ if .side_effecting }}
+        <br><br><b>Note:</b> This function is <a href="#side-effecting-functions">side-effecting</a>.
+      {{ end }}
     </td>
   </tr>
   {{ end }} {{/*  {{ range .functions }} */}}

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -535,6 +535,7 @@ impl ExecuteResponse {
             }
             PlanKind::Subscribe => vec![Subscribing, CopyTo],
             StartTransaction => vec![StartedTransaction],
+            SideEffectingFunc => vec![SendingRows],
         }
     }
 }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -339,6 +339,8 @@ impl Coordinator {
                 secret_key: session.secret_key(),
                 notice_tx: session.retain_notice_transmitter(),
                 drop_sinks: Vec::new(),
+                // TODO: Switch to authenticated role once implemented.
+                authenticated_role: session.session_role_id().clone(),
             },
         );
         let update = self.catalog().state().pack_session_update(&session, 1);
@@ -664,7 +666,7 @@ impl Coordinator {
 
     /// Unconditionally instructs the dataflow layer to cancel any ongoing,
     /// interactive work for the named `conn_id`.
-    fn handle_privileged_cancel(&mut self, conn_id: ConnectionId) {
+    pub(crate) fn handle_privileged_cancel(&mut self, conn_id: ConnectionId) {
         if let Some(conn_meta) = self.active_conns.get(&conn_id) {
             // Cancel pending writes. There is at most one pending write per session.
             let mut maybe_ctx = None;

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -103,7 +103,8 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
         | Plan::GrantPrivileges(_)
         | Plan::RevokePrivileges(_)
         | Plan::AlterDefaultPrivileges(_)
-        | Plan::ReassignOwned(_) => return TargetCluster::Active,
+        | Plan::ReassignOwned(_)
+        | Plan::SideEffectingFunc(_) => return TargetCluster::Active,
     };
 
     // Bail if the user has disabled it via the SessionVar.
@@ -247,7 +248,8 @@ pub fn user_privilege_hack(
         | Plan::Close(_)
         | Plan::Prepare(_)
         | Plan::Execute(_)
-        | Plan::Deallocate(_) => {}
+        | Plan::Deallocate(_)
+        | Plan::SideEffectingFunc(_) => {}
 
         Plan::CreateConnection(_)
         | Plan::CreateDatabase(_)

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -86,6 +86,7 @@ impl Coordinator {
             .map(|cluster| cluster.id());
 
         if let Err(e) = rbac::check_plan(
+            self,
             &session_catalog,
             ctx.session(),
             &plan,
@@ -255,6 +256,9 @@ impl Coordinator {
                     .sequence_subscribe(ctx.session_mut(), plan, depends_on, target_cluster)
                     .await;
                 ctx.retire(result);
+            }
+            Plan::SideEffectingFunc(plan) => {
+                ctx.retire(self.sequence_side_effecting_func(plan));
             }
             Plan::ShowCreate(plan) => {
                 ctx.retire(Ok(send_immediate_rows(vec![plan.row])));

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -2297,7 +2297,7 @@ impl<'a> ScalarType {
 
     /// Derives a column type from this scalar type with the specified
     /// nullability.
-    pub fn nullable(self, nullable: bool) -> ColumnType {
+    pub const fn nullable(self, nullable: bool) -> ColumnType {
         ColumnType {
             nullable,
             scalar_type: self,

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -357,6 +357,7 @@ pub fn sql_impl(
             relation_type: &RelationType::empty(),
             allow_aggregates: false,
             allow_subqueries: true,
+            allow_parameters: true,
             allow_windows: false,
         };
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -68,6 +68,7 @@ pub(crate) mod optimize;
 pub(crate) mod plan_utils;
 pub(crate) mod query;
 pub(crate) mod scope;
+pub(crate) mod side_effecting_func;
 pub(crate) mod statement;
 pub(crate) mod transform_ast;
 pub(crate) mod transform_expr;
@@ -81,6 +82,7 @@ pub use expr::{AggregateExpr, Hir, HirRelationExpr, HirScalarExpr, JoinKind, Win
 pub use notice::PlanNotice;
 pub use optimize::OptimizerConfig;
 pub use query::{QueryContext, QueryLifetime};
+pub use side_effecting_func::SideEffectingFunc;
 pub use statement::ddl::PlannedRoleAttributes;
 pub use statement::{describe, plan, plan_copy_from, StatementContext, StatementDesc};
 
@@ -153,6 +155,7 @@ pub enum Plan {
     RevokePrivileges(RevokePrivilegesPlan),
     AlterDefaultPrivileges(AlterDefaultPrivilegesPlan),
     ReassignOwned(ReassignOwnedPlan),
+    SideEffectingFunc(SideEffectingFunc),
 }
 
 impl Plan {
@@ -228,7 +231,7 @@ impl Plan {
             StatementKind::RevokePrivileges => vec![PlanKind::RevokePrivileges],
             StatementKind::RevokeRole => vec![PlanKind::RevokeRole],
             StatementKind::Rollback => vec![PlanKind::AbortTransaction],
-            StatementKind::Select => vec![PlanKind::Peek],
+            StatementKind::Select => vec![PlanKind::Peek, PlanKind::SideEffectingFunc],
             StatementKind::SetTransaction => vec![PlanKind::SetTransaction],
             StatementKind::SetVariable => vec![PlanKind::SetVariable],
             StatementKind::Show => vec![
@@ -363,6 +366,7 @@ impl Plan {
             Plan::RevokePrivileges(_) => "revoke privilege",
             Plan::AlterDefaultPrivileges(_) => "alter default privileges",
             Plan::ReassignOwned(_) => "reassign owned",
+            Plan::SideEffectingFunc(_) => "side effecting func",
         }
     }
 }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -333,6 +333,7 @@ pub fn plan_insert_query(
             relation_type: &typ,
             allow_aggregates: false,
             allow_subqueries: false,
+            allow_parameters: false,
             allow_windows: false,
         };
         let table_func_names = BTreeMap::new();
@@ -604,6 +605,7 @@ pub fn plan_mutation_query_inner(
                 relation_type: &relation_type,
                 allow_aggregates: false,
                 allow_subqueries: true,
+                allow_parameters: true,
                 allow_windows: false,
             };
             let expr = plan_expr(ecx, &expr)?.type_as(ecx, &ScalarType::Bool)?;
@@ -626,6 +628,7 @@ pub fn plan_mutation_query_inner(
                     relation_type: &relation_type,
                     allow_aggregates: false,
                     allow_subqueries: false,
+                    allow_parameters: false,
                     allow_windows: false,
                 };
                 let expr = plan_expr(ecx, &value)?.cast_to(
@@ -715,6 +718,7 @@ fn handle_mutation_using_clause(
             relation_type: &joined_relation_type,
             allow_aggregates: false,
             allow_subqueries: true,
+            allow_parameters: true,
             allow_windows: false,
         };
 
@@ -782,6 +786,7 @@ where
         relation_type: &qcx.relation_type(&expr),
         allow_aggregates: false,
         allow_subqueries: true,
+        allow_parameters: true,
         allow_windows: false,
     };
     let mut map_exprs = vec![];
@@ -830,6 +835,7 @@ pub fn plan_up_to(
         relation_type: desc.typ(),
         allow_aggregates: false,
         allow_subqueries: false,
+        allow_parameters: false,
         allow_windows: false,
     };
     plan_expr(ecx, &up_to)?
@@ -857,6 +863,7 @@ pub fn plan_as_of(
                     relation_type: desc.typ(),
                     allow_aggregates: false,
                     allow_subqueries: false,
+                    allow_parameters: false,
                     allow_windows: false,
                 };
                 let expr = plan_expr(ecx, expr)?
@@ -889,6 +896,7 @@ pub fn plan_secret_as(
         relation_type: desc.typ(),
         allow_aggregates: false,
         allow_subqueries: false,
+        allow_parameters: false,
         allow_windows: false,
     };
     let expr = plan_expr(ecx, &expr)?
@@ -910,6 +918,7 @@ pub fn plan_default_expr(
         relation_type: &RelationType::empty(),
         allow_aggregates: false,
         allow_subqueries: false,
+        allow_parameters: false,
         allow_windows: false,
     };
     let hir = plan_expr(ecx, expr)?.cast_to(ecx, CastContext::Assignment, target_ty)?;
@@ -947,6 +956,7 @@ pub fn plan_params<'a>(
             relation_type: &rel_type,
             allow_aggregates: false,
             allow_subqueries: false,
+            allow_parameters: false,
             allow_windows: false,
         };
         let ex = plan_expr(ecx, &expr)?.type_as_any(ecx)?;
@@ -981,6 +991,7 @@ pub fn plan_index_exprs<'a>(
         relation_type: on_desc.typ(),
         allow_aggregates: false,
         allow_subqueries: false,
+        allow_parameters: false,
         allow_windows: false,
     };
     let mut out = vec![];
@@ -1083,6 +1094,7 @@ fn plan_query_inner(
                 relation_type: &qcx.relation_type(&expr),
                 allow_aggregates: true,
                 allow_subqueries: true,
+                allow_parameters: true,
                 allow_windows: true,
             };
             let output_columns: Vec<_> = scope.column_names().enumerate().collect();
@@ -1342,6 +1354,7 @@ fn plan_set_expr(
                 relation_type: &left_type,
                 allow_aggregates: false,
                 allow_subqueries: false,
+                allow_parameters: false,
                 allow_windows: false,
             };
             let right_ecx = &ExprContext {
@@ -1351,6 +1364,7 @@ fn plan_set_expr(
                 relation_type: &right_type,
                 allow_aggregates: false,
                 allow_subqueries: false,
+                allow_parameters: false,
                 allow_windows: false,
             };
             let mut left_casts = vec![];
@@ -1524,6 +1538,7 @@ fn plan_values(
         relation_type: &RelationType::empty(),
         allow_aggregates: false,
         allow_subqueries: true,
+        allow_parameters: true,
         allow_windows: false,
     };
 
@@ -1612,6 +1627,7 @@ fn plan_values_insert(
         relation_type: &RelationType::empty(),
         allow_aggregates: false,
         allow_subqueries: true,
+        allow_parameters: true,
         allow_windows: false,
     };
 
@@ -1735,6 +1751,7 @@ fn plan_view_select(
             relation_type: &qcx.relation_type(&relation_expr),
             allow_aggregates: false,
             allow_subqueries: true,
+            allow_parameters: true,
             allow_windows: false,
         };
         let expr = plan_expr(ecx, selection)
@@ -1774,6 +1791,7 @@ fn plan_view_select(
             relation_type: &qcx.relation_type(&relation_expr),
             allow_aggregates: true,
             allow_subqueries: true,
+            allow_parameters: true,
             allow_windows: true,
         };
         let mut out = vec![];
@@ -1796,6 +1814,7 @@ fn plan_view_select(
             relation_type: &qcx.relation_type(&relation_expr),
             allow_aggregates: false,
             allow_subqueries: true,
+            allow_parameters: true,
             allow_windows: false,
         };
         let mut group_key = vec![];
@@ -1859,6 +1878,7 @@ fn plan_view_select(
             relation_type: &qcx.relation_type(&relation_expr.clone().map(group_hir_exprs.clone())),
             allow_aggregates: false,
             allow_subqueries: true,
+            allow_parameters: true,
             allow_windows: false,
         };
         let mut agg_exprs = vec![];
@@ -1908,6 +1928,7 @@ fn plan_view_select(
             relation_type: &qcx.relation_type(&relation_expr),
             allow_aggregates: true,
             allow_subqueries: true,
+            allow_parameters: true,
             allow_windows: false,
         };
         let expr = plan_expr(ecx, &having)
@@ -1929,6 +1950,7 @@ fn plan_view_select(
                 relation_type: &new_type,
                 allow_aggregates: true,
                 allow_subqueries: true,
+                allow_parameters: true,
                 allow_windows: true,
             };
             let expr = match select_item {
@@ -1978,6 +2000,7 @@ fn plan_view_select(
                 relation_type: &relation_type,
                 allow_aggregates: true,
                 allow_subqueries: true,
+                allow_parameters: true,
                 allow_windows: true,
             },
             &order_by_exprs,
@@ -2014,6 +2037,7 @@ fn plan_view_select(
                     relation_type: &qcx.relation_type(&relation_expr),
                     allow_aggregates: true,
                     allow_subqueries: true,
+                    allow_parameters: true,
                     allow_windows: true,
                 };
 
@@ -2619,6 +2643,7 @@ fn plan_table_function_internal(
         relation_type: &RelationType::empty(),
         allow_aggregates: false,
         allow_subqueries: true,
+        allow_parameters: true,
         allow_windows: false,
     };
 
@@ -3045,6 +3070,7 @@ fn plan_join(
                 ),
                 allow_aggregates: false,
                 allow_subqueries: true,
+                allow_parameters: true,
                 allow_windows: false,
             };
             let on = plan_expr(ecx, expr)?.type_as(ecx, &ScalarType::Bool)?;
@@ -3157,6 +3183,7 @@ fn plan_using_constraint(
         ),
         allow_aggregates: false,
         allow_subqueries: false,
+        allow_parameters: false,
         allow_windows: false,
     };
 
@@ -3383,10 +3410,11 @@ fn plan_expr_inner<'a>(
 }
 
 fn plan_parameter(ecx: &ExprContext, n: usize) -> Result<CoercibleScalarExpr, PlanError> {
-    if !ecx.allow_subqueries {
-        return Err(PlanError::SubqueriesDisallowed {
-            context: ecx.name.into(),
-        });
+    if !ecx.allow_parameters {
+        // It might be clearer to return an error like "cannot use parameter
+        // here", but this is how PostgreSQL does it, and so for now we follow
+        // PostgreSQL.
+        return Err(PlanError::UnknownParameter(n));
     }
     if n == 0 || n > 65536 {
         return Err(PlanError::UnknownParameter(n));
@@ -5416,6 +5444,8 @@ pub struct ExprContext<'a> {
     pub allow_aggregates: bool,
     /// Are subqueries allowed in this context
     pub allow_subqueries: bool,
+    /// Are parameters allowed in this context.
+    pub allow_parameters: bool,
     /// Are window functions allowed in this context
     pub allow_windows: bool,
 }

--- a/src/sql/src/plan/side_effecting_func.rs
+++ b/src/sql/src/plan/side_effecting_func.rs
@@ -1,0 +1,285 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Support for side-effecting functions.
+//!
+//! In PostgreSQL, these functions can appear anywhere in a query:
+//!
+//! ```sql
+//! SELECT 1 WHERE pg_cancel_backend(1234)
+//! ```
+//!
+//! In Materialize, our compute layer cannot execute functions with side
+//! effects. So we sniff out the common form of calls to side-effecting
+//! functions, i.e. at the top level of a `SELECT`
+//!
+//! ```sql
+//! SELECT side_effecting_function(...)
+//! ```
+//!
+//! where all arguments are literals or bound parameters, and plan them
+//! specially as a `Plan::SideEffectingFunc`. This gets us compatibility with
+//! PostgreSQL for most real-world use cases, without causing stress for the
+//! compute layer (optimizer, dataflow execution, etc.), as we can apply all the
+//! side effects entirely in the adapter layer.
+
+use std::collections::BTreeMap;
+
+use enum_kinds::EnumKind;
+use mz_ore::cast::ReinterpretCast;
+use mz_ore::collections::CollectionExt;
+use mz_ore::result::ResultExt;
+use mz_repr::RelationType;
+use mz_repr::{ColumnType, Datum, RelationDesc, RowArena, ScalarType};
+use mz_sql_parser::ast::{CteBlock, Expr, Function, FunctionArgs, Select, SelectItem, SetExpr};
+use once_cell::sync::Lazy;
+
+use crate::ast::{Query, SelectStatement};
+use crate::func::Func;
+use crate::names::Aug;
+use crate::plan::query::{self, ExprContext, QueryLifetime};
+use crate::plan::scope::Scope;
+use crate::plan::statement::StatementContext;
+use crate::plan::typeconv::CastContext;
+use crate::plan::{self, HirScalarExpr, Params};
+use crate::plan::{PlanError, QueryContext};
+
+/// A side-effecting function is a function whose evaluation triggers side
+/// effects.
+///
+/// See the module docs for details.
+#[derive(Debug, EnumKind)]
+#[enum_kind(SefKind)]
+pub enum SideEffectingFunc {
+    /// The `pg_cancel_backend` function, .
+    PgCancelBackend {
+        // The ID of the connection to cancel.
+        connection_id: u32,
+    },
+}
+
+/// Describes a `SELECT` if it contains calls to side-effecting functions.
+///
+/// See the module docs for details.
+pub fn describe_select_if_side_effecting(
+    scx: &StatementContext,
+    select: &SelectStatement<Aug>,
+) -> Result<Option<RelationDesc>, PlanError> {
+    let Some(sef_call) = extract_sef_call(scx, select)? else {
+        return Ok(None);
+    };
+
+    // We currently support only a single call to a side-effecting function
+    // without an alias, so there is always a single output column is named
+    // after the function.
+    let desc =
+        RelationDesc::empty().with_column(sef_call.imp.name, sef_call.imp.return_type.clone());
+
+    Ok(Some(desc))
+}
+
+/// Plans the `SELECT` if it contains calls to side-effecting functions.
+///
+/// See the module docs for details.
+pub fn plan_select_if_side_effecting(
+    scx: &StatementContext,
+    select: &SelectStatement<Aug>,
+    params: &Params,
+) -> Result<Option<SideEffectingFunc>, PlanError> {
+    let Some(sef_call) = extract_sef_call(scx, select)? else {
+        return Ok(None);
+    };
+
+    // Bind parameters and then eagerly evaluate each argument. Expressions that
+    // cannot be eagerly evaluated should have been rejected by `extract_sef_call`.
+    let temp_storage = RowArena::new();
+    let mut args = vec![];
+    for mut arg in sef_call.args {
+        arg.bind_parameters(params)?;
+        let arg = arg.lower_uncorrelated()?;
+        args.push(arg);
+    }
+    let mut datums = vec![];
+    for arg in &args {
+        let datum = arg.eval(&[], &temp_storage)?;
+        datums.push(datum);
+    }
+
+    let func = (sef_call.imp.plan_fn)(&datums);
+
+    Ok(Some(func))
+}
+
+/// Helper function used in both describing and planning a side-effecting
+/// `SELECT`.
+fn extract_sef_call(
+    scx: &StatementContext,
+    select: &SelectStatement<Aug>,
+) -> Result<Option<SefCall>, PlanError> {
+    // First check if the `SELECT` contains exactly one function call.
+    let SelectStatement {
+        query:
+            Query {
+                ctes: CteBlock::Simple(ctes),
+                body: SetExpr::Select(body),
+                order_by,
+                limit: None,
+                offset: None,
+            },
+        as_of: None,
+    } = select else {
+        return Ok(None)
+    };
+    if !ctes.is_empty() || !order_by.is_empty() {
+        return Ok(None);
+    }
+    let Select {
+        distinct: None,
+        projection,
+        from,
+        selection: None,
+        group_by,
+        having: None,
+        options,
+    } = &**body else {
+        return Ok(None);
+    };
+    if !from.is_empty() || !group_by.is_empty() || !options.is_empty() || projection.len() != 1 {
+        return Ok(None);
+    }
+    let [SelectItem::Expr {
+        expr:
+            Expr::Function(Function {
+                name,
+                args: FunctionArgs::Args { args, order_by },
+                filter: None,
+                over: None,
+                distinct: false,
+            }),
+        alias: None,
+    }] = &projection[..] else {
+        return Ok(None);
+    };
+    if !order_by.is_empty() {
+        return Ok(None);
+    }
+
+    // Check if the called function is a scalar function with exactly one
+    // implementation. All side-effecting functions have only a single
+    // implementation.
+    let Ok(func) = scx.get_item_by_resolved_name(name).and_then(|item| item.func().err_into()) else {
+        return Ok(None);
+    };
+    let func_impl = match func {
+        Func::Scalar(impls) if impls.len() == 1 => impls.into_element(),
+        _ => return Ok(None),
+    };
+
+    // Check whether the implementation is a known side-effecting function.
+    let Some(sef_impl) = PG_CATALOG_SEF_BUILTINS.get(&func_impl.oid) else {
+        return Ok(None);
+    };
+
+    // Check that the number of provided arguments matches the function
+    // signature.
+    if args.len() != sef_impl.param_types.len() {
+        // We return `Ok(None)` instead of an error for the same reason to let
+        // the function selection code produce the standard "no function matches
+        // the given name and argument types" error.
+        return Ok(None);
+    }
+
+    // Plan and coerce all argument expressions.
+    let mut args_out = vec![];
+    let pcx = plan::PlanContext::zero();
+    let qcx = QueryContext::root(scx, QueryLifetime::OneShot(&pcx));
+    let ecx = ExprContext {
+        qcx: &qcx,
+        name: sef_impl.name,
+        scope: &Scope::empty(),
+        relation_type: &RelationType::empty(),
+        allow_aggregates: false,
+        allow_subqueries: false,
+        allow_parameters: true,
+        allow_windows: false,
+    };
+    for (arg, ty) in args.iter().zip(sef_impl.param_types) {
+        // If we encounter an error when planning the argument expression, that
+        // error is unrelated to planning the function call and can be returned
+        // directly to the user.
+        let arg = query::plan_expr(&ecx, arg)?;
+
+        // Implicitly cast the argument to the correct type. This matches what
+        // the standard function selection code will do.
+        //
+        // If the cast fails, we give up on planning the side-effecting function but
+        // intentionally do not produce an error. This way, we fall into the
+        // standard function selection code, which will produce the correct "no
+        // function matches the given name and argument types" error rather than a
+        // "cast failed" error.
+        let Ok(arg) = arg.cast_to(&ecx, CastContext::Implicit, ty) else {
+            return Ok(None);
+        };
+
+        args_out.push(arg);
+    }
+
+    Ok(Some(SefCall {
+        imp: sef_impl,
+        args: args_out,
+    }))
+}
+
+struct SefCall {
+    imp: &'static SideEffectingFuncImpl,
+    args: Vec<HirScalarExpr>,
+}
+
+/// Defines the implementation of a side-effecting function.
+///
+/// This is a very restricted subset of the [`Func`] struct (no overloads, no
+/// variadic arguments, etc) to make side-effecting functions easier to plan.
+pub struct SideEffectingFuncImpl {
+    /// The name of the function.
+    pub name: &'static str,
+    /// The OID of the function.
+    pub oid: u32,
+    /// The parameter types for the function.
+    pub param_types: &'static [ScalarType],
+    /// The return type of the function.
+    pub return_type: ColumnType,
+    /// A function that will produce a `SideEffectingFunc` given arguments
+    /// that have been evaluated to `Datum`s.
+    pub plan_fn: fn(&[Datum]) -> SideEffectingFunc,
+}
+
+/// A map of the side-effecting functions in the `pg_catalog` schema, keyed by
+/// OID.
+pub static PG_CATALOG_SEF_BUILTINS: Lazy<BTreeMap<u32, SideEffectingFuncImpl>> = Lazy::new(|| {
+    [PG_CANCEL_BACKEND]
+        .into_iter()
+        .map(|f| (f.oid, f))
+        .collect()
+});
+
+// Implementations of each side-effecting function follow.
+//
+// If you add a new side-effecting function, be sure to add it to the map above.
+
+const PG_CANCEL_BACKEND: SideEffectingFuncImpl = SideEffectingFuncImpl {
+    name: "pg_cancel_backend",
+    oid: 2171,
+    param_types: &[ScalarType::Int32],
+    return_type: ScalarType::Bool.nullable(false),
+    plan_fn: |datums| -> SideEffectingFunc {
+        SideEffectingFunc::PgCancelBackend {
+            connection_id: u32::reinterpret_cast(datums[0].unwrap_int32()),
+        }
+    },
+};

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -667,6 +667,7 @@ pub fn plan_create_source(
                     },
                     allow_aggregates: false,
                     allow_subqueries: false,
+                    allow_parameters: false,
                     allow_windows: false,
                 };
 

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -34,16 +34,17 @@ use crate::ast::{
 };
 use crate::catalog::CatalogItemType;
 use crate::names::{self, Aug, ResolvedItemName};
+use crate::normalize;
 use crate::plan::query::{plan_up_to, ExprContext, QueryLifetime};
 use crate::plan::scope::Scope;
 use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::with_options::TryFromValue;
+use crate::plan::{self, side_effecting_func};
 use crate::plan::{
     query, CopyFormat, CopyFromPlan, ExplainPlan, InsertPlan, MutationKind, Params, PeekPlan, Plan,
     PlanError, QueryContext, ReadThenWritePlan, SubscribeFrom, SubscribePlan,
 };
 use crate::session::vars;
-use crate::{normalize, plan};
 
 // TODO(benesch): currently, describing a `SELECT` or `INSERT` query
 // plans the whole query to determine its shape and parameter types,
@@ -164,6 +165,10 @@ pub fn describe_select(
     scx: &StatementContext,
     stmt: SelectStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
+    if let Some(desc) = side_effecting_func::describe_select_if_side_effecting(scx, &stmt)? {
+        return Ok(StatementDesc::new(Some(desc)));
+    }
+
     let query::PlannedQuery { desc, .. } =
         query::plan_root_query(scx, stmt.query, QueryLifetime::OneShot(scx.pcx()?))?;
     Ok(StatementDesc::new(Some(desc)))
@@ -171,14 +176,23 @@ pub fn describe_select(
 
 pub fn plan_select(
     scx: &StatementContext,
-    SelectStatement { query, as_of }: SelectStatement<Aug>,
+    select: SelectStatement<Aug>,
     params: &Params,
     copy_to: Option<CopyFormat>,
 ) -> Result<Plan, PlanError> {
+    if let Some(f) = side_effecting_func::plan_select_if_side_effecting(scx, &select, params)? {
+        return Ok(Plan::SideEffectingFunc(f));
+    }
+
     let query::PlannedQuery {
         expr, finishing, ..
-    } = plan_query(scx, query, params, QueryLifetime::OneShot(scx.pcx()?))?;
-    let when = query::plan_as_of(scx, as_of)?;
+    } = plan_query(
+        scx,
+        select.query,
+        params,
+        QueryLifetime::OneShot(scx.pcx()?),
+    )?;
+    let when = query::plan_as_of(scx, select.as_of)?;
     Ok(Plan::Peek(PeekPlan {
         source: expr,
         when,

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -525,6 +525,7 @@ pub fn plan_subscribe(
         relation_type: desc.typ(),
         allow_aggregates: false,
         allow_subqueries: true,
+        allow_parameters: true,
         allow_windows: false,
     };
 

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -909,6 +909,7 @@ pub fn plan_hypothetical_cast(
         relation_type: &relation_type,
         allow_aggregates: false,
         allow_subqueries: true,
+        allow_parameters: true,
         allow_windows: false,
     };
 


### PR DESCRIPTION
Parameters don't work on it yet, but it's good enough to use with a hard coded parameter.

Fixes #19773.
Fixes #13129.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add `pg_cancel_backend()` to cancel queries from SQL.