### PR TITLE
surfaces: prepare for some `ALTER SOURCE` work

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2054,8 +2054,7 @@ pub struct Ingestion {
     pub subsource_exports: BTreeMap<GlobalId, usize>,
     pub cluster_id: ClusterId,
     /// The ID of this collection's remap/progress collection.
-    // MIGRATION: v0.44 This can be converted to a `GlobalId` in v0.46
-    pub remap_collection_id: Option<GlobalId>,
+    pub remap_collection_id: GlobalId,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -2564,11 +2563,7 @@ impl CatalogEntry {
                     .subsource_exports
                     .keys()
                     .copied()
-                    .chain(std::iter::once(
-                        ingestion
-                            .remap_collection_id
-                            .expect("remap collection must named by this point"),
-                    ))
+                    .chain(std::iter::once(ingestion.remap_collection_id))
                     .collect(),
                 DataSourceDesc::Introspection(_)
                 | DataSourceDesc::Progress

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2556,7 +2556,7 @@ impl CatalogEntry {
     }
 
     /// Returns the `GlobalId` of all of this entry's subsources.
-    pub fn subsources(&self) -> Vec<GlobalId> {
+    pub fn subsources(&self) -> BTreeSet<GlobalId> {
         match &self.item() {
             CatalogItem::Source(source) => match &source.data_source {
                 DataSourceDesc::Ingestion(ingestion) => ingestion
@@ -2567,7 +2567,7 @@ impl CatalogEntry {
                     .collect(),
                 DataSourceDesc::Introspection(_)
                 | DataSourceDesc::Progress
-                | DataSourceDesc::Source => vec![],
+                | DataSourceDesc::Source => BTreeSet::new(),
             },
             CatalogItem::Table(_)
             | CatalogItem::Log(_)
@@ -2578,7 +2578,7 @@ impl CatalogEntry {
             | CatalogItem::Type(_)
             | CatalogItem::Func(_)
             | CatalogItem::Secret(_)
-            | CatalogItem::Connection(_) => vec![],
+            | CatalogItem::Connection(_) => BTreeSet::new(),
         }
     }
 
@@ -8423,7 +8423,7 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
         self.used_by()
     }
 
-    fn subsources(&self) -> Vec<GlobalId> {
+    fn subsources(&self) -> BTreeSet<GlobalId> {
         self.subsources()
     }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -109,7 +109,7 @@ use mz_storage_client::controller::{
 };
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::sinks::StorageSinkConnection;
-use mz_storage_client::types::sources::{IngestionDescription, SourceExport, Timeline};
+use mz_storage_client::types::sources::Timeline;
 use mz_transform::Optimizer;
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
@@ -1002,44 +1002,15 @@ impl Coordinator {
         let mut collections_to_create = Vec::new();
 
         fn source_desc<T>(
-            id: GlobalId,
             source_status_collection_id: Option<GlobalId>,
             source: &Source,
         ) -> CollectionDescription<T> {
             let (data_source, status_collection_id) = match &source.data_source {
                 // Re-announce the source description.
-                DataSourceDesc::Ingestion(ingestion) => {
-                    let mut source_imports = BTreeMap::new();
-                    for source_import in &ingestion.source_imports {
-                        source_imports.insert(*source_import, ());
-                    }
-
-                    let mut source_exports = BTreeMap::new();
-                    // By convention the first output corresponds to the main source object
-                    let main_export = SourceExport {
-                        output_index: 0,
-                        storage_metadata: (),
-                    };
-                    source_exports.insert(id, main_export);
-                    for (subsource, output_index) in ingestion.subsource_exports.clone() {
-                        let export = SourceExport {
-                            output_index,
-                            storage_metadata: (),
-                        };
-                        source_exports.insert(subsource, export);
-                    }
-                    (
-                        DataSource::Ingestion(IngestionDescription {
-                            desc: ingestion.desc.clone(),
-                            ingestion_metadata: (),
-                            source_imports,
-                            source_exports,
-                            instance_id: ingestion.cluster_id,
-                            remap_collection_id: ingestion.remap_collection_id,
-                        }),
-                        source_status_collection_id,
-                    )
-                }
+                DataSourceDesc::Ingestion(ingestion) => (
+                    DataSource::Ingestion(ingestion.clone()),
+                    source_status_collection_id,
+                ),
                 // Subsources use source statuses.
                 DataSourceDesc::Source => (DataSource::Other, source_status_collection_id),
                 DataSourceDesc::Progress => (DataSource::Progress, None),
@@ -1061,10 +1032,9 @@ impl Coordinator {
                 entries
                     .iter()
                     .filter_map(|entry| match entry.item() {
-                        CatalogItem::Source(source) => Some((
-                            entry.id(),
-                            source_desc(entry.id(), source_status_collection_id, source),
-                        )),
+                        CatalogItem::Source(source) => {
+                            Some((entry.id(), source_desc(source_status_collection_id, source)))
+                        }
                         CatalogItem::Table(table) => {
                             let collection_desc = table.desc.clone().into();
                             Some((entry.id(), collection_desc))
@@ -1093,10 +1063,8 @@ impl Coordinator {
                 // User sources can have dependencies, so do avoid them in the
                 // batch.
                 CatalogItem::Source(source) if entry.id().is_system() => {
-                    collections_to_create.push((
-                        entry.id(),
-                        source_desc(entry.id(), source_status_collection_id, source),
-                    ));
+                    collections_to_create
+                        .push((entry.id(), source_desc(source_status_collection_id, source)));
                 }
                 _ => {
                     // No collections to create.
@@ -1137,8 +1105,7 @@ impl Coordinator {
                 CatalogItem::Source(source) => {
                     // System sources were created above, add others here.
                     if !entry.id().is_system() {
-                        let source_desc =
-                            source_desc(entry.id(), source_status_collection_id, source);
+                        let source_desc = source_desc(source_status_collection_id, source);
                         self.controller
                             .storage
                             .create_collections(vec![(entry.id(), source_desc)])

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -945,12 +945,9 @@ impl Coordinator {
                     if let Some(waiting_on_this_dependent) = entries_awaiting_dependent.remove(&id)
                     {
                         mz_ore::soft_assert! {{
-                            let mut subsources =  entry.subsources();
-                            subsources.sort();
-                            let mut w: Vec<_> = waiting_on_this_dependent.iter().map(|e| e.id()).collect();
-                            w.sort();
-
-                            subsources == w
+                            let subsources =  entry.subsources();
+                            let w: Vec<_> = waiting_on_this_dependent.iter().map(|e| e.id()).collect();
+                            w.iter().all(|w| subsources.contains(w))
                         }, "expect that items are exactly source's subsources"}
 
                         // Re-enqueue objects and continue.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1038,9 +1038,7 @@ impl Coordinator {
                             source_imports,
                             source_exports,
                             instance_id: ingestion.cluster_id,
-                            remap_collection_id: ingestion.remap_collection_id.expect(
-                                "ingestion-based collection must name remap collection before going to storage",
-                            ),
+                            remap_collection_id: ingestion.remap_collection_id,
                         }),
                         source_status_collection_id,
                     )

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -236,9 +236,7 @@ impl Coordinator {
                                     source_imports,
                                     source_exports,
                                     instance_id: ingestion.cluster_id,
-                                    remap_collection_id: ingestion.remap_collection_id.expect(
-                                        "ingestion-based collection must name remap collection before going to storage",
-                                    ),
+                                    remap_collection_id: ingestion.remap_collection_id,
                                 }),
                                 source_status_collection_id,
                             )

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -651,6 +651,9 @@ pub trait CatalogItem {
     /// If this catalog item is a source, it return the IDs of its subsources
     fn subsources(&self) -> BTreeSet<GlobalId>;
 
+    /// If this catalog item is a source, it return the IDs of its progress collection.
+    fn progress_id(&self) -> Option<GlobalId>;
+
     /// Returns the index details associated with the catalog item, if the
     /// catalog item is an index.
     fn index_details(&self) -> Option<(&[MirScalarExpr], GlobalId)>;

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -649,7 +649,7 @@ pub trait CatalogItem {
     fn used_by(&self) -> &[GlobalId];
 
     /// If this catalog item is a source, it return the IDs of its subsources
-    fn subsources(&self) -> Vec<GlobalId>;
+    fn subsources(&self) -> BTreeSet<GlobalId>;
 
     /// Returns the index details associated with the catalog item, if the
     /// catalog item is an index.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1023,8 +1023,7 @@ pub struct Ingestion {
     pub desc: SourceDesc,
     pub source_imports: BTreeSet<GlobalId>,
     pub subsource_exports: BTreeMap<GlobalId, usize>,
-    // MIGRATION: v0.44 This can be converted to a `GlobalId` in v0.46
-    pub progress_subsource: Option<GlobalId>,
+    pub progress_subsource: GlobalId,
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1051,12 +1051,10 @@ pub fn plan_create_source(
         timestamp_interval,
     };
 
-    // MIGRATION: v0.44 This can be converted to an unwrap in v0.46
-    let progress_subsource = progress_subsource
-        .as_ref()
-        .map(|name| match name {
+    let progress_subsource = match progress_subsource {
+        Some(name) => match name {
             DeferredItemName::Named(name) => match name {
-                ResolvedItemName::Item { id, .. } => Ok(*id),
+                ResolvedItemName::Item { id, .. } => *id,
                 ResolvedItemName::Cte { .. } | ResolvedItemName::Error => {
                     sql_bail!("[internal error] invalid target id")
                 }
@@ -1064,8 +1062,9 @@ pub fn plan_create_source(
             DeferredItemName::Deferred(_) => {
                 sql_bail!("[internal error] progress subsource must be named during purification")
             }
-        })
-        .transpose()?;
+        },
+        _ => sql_bail!("[internal error] progress subsource must be named during purification"),
+    };
 
     let if_not_exists = *if_not_exists;
     let name = scx.allocate_qualified_name(normalize::unresolved_item_name(name.clone())?)?;

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -79,6 +79,12 @@ pub struct IngestionDescription<S = (), C = GenericSourceConnection> {
     /// Additional storage controller metadata needed to ingest this source
     pub ingestion_metadata: S,
     /// Collections to be exported by this ingestion.
+    ///
+    /// This field includes the primary source's ID, which must be filtered out
+    /// to understand which exports are data-bearing subsources.
+    ///
+    /// Note that this does _not_ include the remap collection, which is tracked
+    /// in its own field.
     pub source_exports: BTreeMap<GlobalId, SourceExport<S>>,
     /// The ID of the instance in which to install the source.
     pub instance_id: StorageInstanceId,


### PR DESCRIPTION
misc. cleanup in support of some larger work on `ALTER SOURCE`; this was separable and seemed unobjectionable so hoping to simplify review of the complex parts of the PR.

### Motivation

This PR refactors existing code.

### Tips for reviewer

These are relatively disjoint code changes that I'm bundling just to save on CI cycles. Probably review commit by commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
