### PR TITLE
stash+storage: remove remap shard from DurableCollectionMetadata

### DIFF
--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "672b055fa99fff2284a5f4465474f8d1"
+    "md5": "d0a50a214cd50661262397a54a35809f"
   },
   {
     "name": "objects_v15.proto",
@@ -30,5 +30,9 @@
   {
     "name": "objects_v21.proto",
     "md5": "4a6148628f3a460187afbece2417b302"
+  },
+  {
+    "name": "objects_v22.proto",
+    "md5": "64a606a4e034cb9ab0e30f8ad02d4d02"
   }
 ]

--- a/src/stash/protos/objects_v22.proto
+++ b/src/stash/protos/objects_v22.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto3";
 
-package objects;
+package objects_v22;
 
 message ConfigKey {
     string key = 1;

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -102,7 +102,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 21;
+pub const STASH_VERSION: u64 = 22;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -950,6 +950,7 @@ impl Stash {
                             18 => upgrade::v18_to_v19::upgrade(&mut tx).await?,
                             19 => upgrade::v19_to_v20::upgrade(&mut tx).await?,
                             20 => upgrade::v20_to_v21::upgrade(&mut tx).await?,
+                            21 => upgrade::v21_to_v22::upgrade(&mut tx).await?,
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -56,6 +56,7 @@ pub mod v17_to_v18;
 pub mod v18_to_v19;
 pub mod v19_to_v20;
 pub mod v20_to_v21;
+pub mod v21_to_v22;
 
 pub use json_to_proto::migrate_json_to_proto;
 

--- a/src/stash/src/upgrade/v21_to_v22.rs
+++ b/src/stash/src/upgrade/v21_to_v22.rs
@@ -1,0 +1,145 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::upgrade::MigrationAction;
+use crate::{StashError, Transaction, TypedCollection};
+
+pub mod objects_v21 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v21.rs"));
+}
+pub mod objects_v22 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v22.rs"));
+}
+
+/// Project away remap_shard from DurableCollectionMetadata.
+pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {
+    const METADATA_COLLECTION: TypedCollection<
+        objects_v21::GlobalId,
+        objects_v21::DurableCollectionMetadata,
+    > = TypedCollection::new("storage-collection-metadata");
+
+    METADATA_COLLECTION
+        .migrate_to(tx, |entries| {
+            let mut updates = vec![];
+
+            for (global_id, durable_collection_metadata) in entries {
+                let new_key = objects_v22::GlobalId::from(global_id.clone());
+                let new_value = objects_v22::DurableCollectionMetadata {
+                    data_shard: durable_collection_metadata.data_shard.clone(),
+                };
+                updates.push(MigrationAction::<
+                    objects_v21::GlobalId,
+                    objects_v22::GlobalId,
+                    objects_v22::DurableCollectionMetadata,
+                >::Update(
+                    global_id.clone(), (new_key, new_value)
+                ));
+            }
+            updates
+        })
+        .await?;
+
+    Ok(())
+}
+
+impl From<objects_v21::GlobalId> for objects_v22::GlobalId {
+    fn from(id: objects_v21::GlobalId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v21::global_id::Value::User(id)) => {
+                Some(objects_v22::global_id::Value::User(id))
+            }
+            Some(objects_v21::global_id::Value::System(id)) => {
+                Some(objects_v22::global_id::Value::System(id))
+            }
+            Some(objects_v21::global_id::Value::Transient(id)) => {
+                Some(objects_v22::global_id::Value::Transient(id))
+            }
+            Some(objects_v21::global_id::Value::Explain(_)) => {
+                Some(objects_v22::global_id::Value::Explain(Default::default()))
+            }
+        };
+        objects_v22::GlobalId { value }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::objects_v21::{
+        self, DurableCollectionMetadata as DurableCollectionMetadataV20, GlobalId as GlobalIdV20,
+    };
+    use super::objects_v22::{
+        self, DurableCollectionMetadata as DurableCollectionMetadataV21, GlobalId as GlobalIdV21,
+    };
+    use super::upgrade;
+
+    use crate::{DebugStashFactory, TypedCollection};
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn smoke_test() {
+        // Connect to the Stash.
+        let factory = DebugStashFactory::new().await;
+        let mut stash = factory.open_debug().await;
+
+        // Insert some items.
+        let metadata_collection_v21: TypedCollection<GlobalIdV20, DurableCollectionMetadataV20> =
+            TypedCollection::new("storage-collection-metadata");
+        metadata_collection_v21
+            .insert_without_overwrite(
+                &mut stash,
+                vec![(
+                    GlobalIdV20 {
+                        value: Some(objects_v21::global_id::Value::User(8)),
+                    },
+                    DurableCollectionMetadataV20 {
+                        remap_shard: None,
+                        data_shard: "lidsacae".to_string(),
+                    },
+                )],
+            )
+            .await
+            .unwrap();
+
+        // Run our migration.
+        stash
+            .with_transaction(|mut tx| {
+                Box::pin(async move {
+                    upgrade(&mut tx).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .expect("migration failed");
+
+        // Read back the values.
+        let metadata_collection_v22: TypedCollection<GlobalIdV21, DurableCollectionMetadataV21> =
+            TypedCollection::new("storage-collection-metadata");
+        let metadata = metadata_collection_v22.iter(&mut stash).await.unwrap();
+
+        // Project away the time and diff.
+        let mut ids: Vec<_> = metadata
+            .into_iter()
+            .map(|((key, value), _, _)| (key, value))
+            .collect();
+        ids.sort();
+
+        assert_eq!(
+            ids,
+            vec![(
+                GlobalIdV21 {
+                    value: Some(objects_v22::global_id::Value::User(8)),
+                },
+                DurableCollectionMetadataV21 {
+                    data_shard: "lidsacae".to_string(),
+                }
+            )]
+        );
+    }
+}

--- a/src/storage-client/src/controller.proto
+++ b/src/storage-client/src/controller.proto
@@ -27,7 +27,8 @@ message ProtoCollectionMetadata {
 
 message ProtoDurableCollectionMetadata {
     // This message is persisted to disk. Changes must be backwards compatible.
-    reserved 1, 2, 5;
+    reserved 1, 2, 4, 5;
+    reserved "remap_shard";
     string data_shard = 3;
-    optional string remap_shard = 4;
+    // optional string remap_shard = 4;
 }


### PR DESCRIPTION
Wu used to track the remap shard ID in each collection. However, we refactored the way that dependency is expressed in v0.44, so this field has been `None` for a long time and is safe to unilaterally remove it.

@ParkMyCar this is the first migration I've written and had some feedback:
- I would not have minded if I had to explicitly state what the migration result's types were. I had a copypasta bug that took me 10 minutes to figure out because my migration was going from (K, V) to (V, K). It was unexpected that at no time did I get a compilation warning that I had mangled these types, especially because I have to so diligently import and express the types elsewhere.
- It would be nice if there were a simple means of expressing a  "nop migration" case, e.g. in my migration the `GlobalId` stuff. Maybe those are auto-generated elsewhere but I couldn't figure out how to pull them in.

### Motivation

This PR refactors existing code.

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
