### PR TITLE
Return after NoCredentialsError

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -258,6 +258,7 @@ class S3UploadDebuginfo(PreImage):
                 s3.upload_fileobj(exe, self.bucket, exe_object_name)
             except NoCredentialsError:
                 print("Failed to find S3 credentials; not uploading build.")
+                return
             print(
                 f"Attempting to upload debug info to s3://{self.bucket}/{dbg_object_name}"
             )


### PR DESCRIPTION
This should make it possible to use `mzbuild` locally without having S3 credentials.

This is how I intended it to work; leaving out the `return` was simply an oversight.