### PR TITLE
storage: reconcile away ingestion descriptions == to cur running

### DIFF
--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1047,16 +1047,20 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         } else {
                             stale_ingestions.remove(&ingestion.id);
 
-                            let running =
-                                self.storage_state.ingestions.get(&ingestion.id).is_some();
+                            let running_ingestion =
+                                self.storage_state.ingestions.get(&ingestion.id);
 
                             // Ingestion statements are only considered updates if they are
                             // currently running.
-                            ingestion.update = running;
+                            ingestion.update = running_ingestion.is_some();
 
-                            // We only keep the most recent version of the ingestion, which is why
-                            // these commands are run in reverse.
+                            // We keep only:
+                            // - The most recent version of the ingestion, which
+                            //   is why these commands are run in reverse.
+                            // - Ingestions whose descriptions are not exactly
+                            //   those that are currently running.
                             seen_most_recent_ingestion.insert(ingestion.id)
+                                && running_ingestion != Some(&ingestion.description)
                         }
                     })
                 }


### PR DESCRIPTION
In #19310, we did not reconcile away ingestion descriptions that had not changed, which is something we previously did.

I hadn't realized that would cause a problem, however it interacts poorly with RocksDB (#19999), so change the reconciliation logic to behave more like the prior code.

cc @guswynn Something here surprised me––rescheduling the same ingestion causes a deadlock in RocksDB. Seems like rescheduling the same ingestion isn't something we want to do, but also seems unexpected that all of the code works besides releasing the RocksDB hold. Not a huge deal but wanted to flag.

cc @def- Validated that this fixes the broken test but more runs are welcome.

### Motivation

This PR fixes a recognized bug. Fixes ##19999

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
