### PR TITLE
Fix nightly Rust build of prost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease",
+ "prettyplease 0.2.4",
  "proc-macro2",
  "quote",
  "regex",
@@ -6078,6 +6078,16 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "prettyplease"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
@@ -6188,7 +6198,8 @@ dependencies = [
 [[package]]
 name = "prost"
 version = "0.11.9"
-source = "git+https://github.com/MaterializeInc/prost#17cc373ba4416f69eef12857a02002838d9fa330"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -6197,7 +6208,8 @@ dependencies = [
 [[package]]
 name = "prost-build"
 version = "0.11.9"
-source = "git+https://github.com/MaterializeInc/prost#17cc373ba4416f69eef12857a02002838d9fa330"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
@@ -6206,11 +6218,11 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.1.25",
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.18",
+ "syn 1.0.107",
  "tempfile",
  "which",
 ]
@@ -6218,7 +6230,8 @@ dependencies = [
 [[package]]
 name = "prost-derive"
 version = "0.11.9"
-source = "git+https://github.com/MaterializeInc/prost#17cc373ba4416f69eef12857a02002838d9fa330"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -6229,11 +6242,12 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.9.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d378290cd658b119ce87621931ef448017ef1a0044d7b681159d779e7e07b8f6"
+checksum = "000e1e05ebf7b26e1eba298e66fe4eee6eb19c567d0ffb35e0dd34231cdac4c8"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
+ "once_cell",
  "prost",
  "prost-types",
  "serde",
@@ -6243,7 +6257,8 @@ dependencies = [
 [[package]]
 name = "prost-types"
 version = "0.11.9"
-source = "git+https://github.com/MaterializeInc/prost#17cc373ba4416f69eef12857a02002838d9fa330"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
 ]
@@ -7867,7 +7882,7 @@ name = "tonic-build"
 version = "0.8.2"
 source = "git+https://github.com/MaterializeInc/tonic#76489bf665af99d6e0e83f81648fcac283ea57e1"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.2.4",
  "proc-macro2",
  "prost-build",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,13 +145,6 @@ serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 # dependency on arrayvec v0.5.2 via a dependency on vte v0.10.1.
 vte = { git = "https://github.com/MaterializeInc/vte", rev = "45670c47cebd7af050def2f80a307bdeec7caba3" }
 
-# Waiting on https://github.com/tokio-rs/prost/pull/833 to make it into a
-# release.
-prost = { git = "https://github.com/MaterializeInc/prost" }
-prost-build = { git = "https://github.com/MaterializeInc/prost" }
-prost-derive = { git = "https://github.com/MaterializeInc/prost" }
-prost-types = { git = "https://github.com/MaterializeInc/prost" }
-
 # Waiting on https://github.com/hyperium/tonic/pull/1398.
 tonic-build = { git = "https://github.com/MaterializeInc/tonic" }
 

--- a/deny.toml
+++ b/deny.toml
@@ -38,6 +38,10 @@ skip = [
     # Waiting for <https://github.com/blackbeam/rust_mysql_common/commit/2a6419aef2ff609cd35a5ce41a9eb48253a8214d>
     # to be released.
     { name = "bindgen", version = "0.59.2" },
+
+    # Waiting on https://github.com/tokio-rs/prost/pull/833 to make it into a
+    # release. (not yet in v0.11.9)
+    { name = "prettyplease", version = "0.1.25" },
 ]
 
 # Use `tracing` instead.

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -27,7 +27,7 @@ mz-ore = { path = "../ore", features = ["network"] }
 mz-repr = { path = "../repr" }
 ordered-float = { version = "3.4.0", features = ["serde"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
-prost-reflect = "0.9.2"
+prost-reflect = "0.11.4"
 serde_json = "1.0.89"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -47,7 +47,7 @@ mz-sql-parser = { path = "../sql-parser" }
 mz-stash = { path = "../stash" }
 postgres_array = { version = "0.11.0" }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
-prost-reflect = { version = "0.9.2", features = ["serde"] }
+prost-reflect = { version = "0.11.4", features = ["serde"] }
 protobuf-src = "1.1.0"
 rand = "0.8.5"
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -75,9 +75,9 @@ phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 proc-macro2 = { version = "1.0.59", features = ["span-locations"] }
-prost = { git = "https://github.com/MaterializeInc/prost", features = ["no-recursion-limit"] }
-prost-reflect = { version = "0.9.2", default-features = false, features = ["serde"] }
-prost-types = { git = "https://github.com/MaterializeInc/prost" }
+prost = { version = "0.11.9", features = ["no-recursion-limit"] }
+prost-reflect = { version = "0.11.4", default-features = false, features = ["serde"] }
+prost-types = { version = "0.11.9" }
 quote = { version = "1.0.28" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
@@ -175,9 +175,9 @@ phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 proc-macro2 = { version = "1.0.59", features = ["span-locations"] }
-prost = { git = "https://github.com/MaterializeInc/prost", features = ["no-recursion-limit"] }
-prost-reflect = { version = "0.9.2", default-features = false, features = ["serde"] }
-prost-types = { git = "https://github.com/MaterializeInc/prost" }
+prost = { version = "0.11.9", features = ["no-recursion-limit"] }
+prost-reflect = { version = "0.11.4", default-features = false, features = ["serde"] }
+prost-types = { version = "0.11.9" }
 quote = { version = "1.0.28" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }


### PR DESCRIPTION
Uses https://github.com/MaterializeInc/prost/pull/4
```
error: failed to load source for dependency `prost`

Caused by:
  Unable to update https://github.com/MaterializeInc/prost#17cc373b

Caused by:
  failed to update submodule `prost-build/third-party/protobuf`

Caused by:
  failed to parse url for submodule `prost-build/third-party/protobuf`: `git@github.com:protocolbuffers/protobuf`

Caused by:
  relative URL without a base
```

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
