### PR TITLE
Revisit single-time dataflow test

### DIFF
--- a/src/compute-client/src/types/dataflows.rs
+++ b/src/compute-client/src/types/dataflows.rs
@@ -67,17 +67,18 @@ pub struct DataflowDescription<P, S: 'static = (), T = mz_repr::Timestamp> {
 
 impl<T> DataflowDescription<Plan<T>, (), mz_repr::Timestamp> {
     /// Tests if the dataflow refers to a single timestamp, namely
-    /// that both `as_of` and `until` have a single coordinate and that
-    /// the `until` value corresponds to the `as_of` value plus one.
+    /// that `as_of` has a single coordinate and that the `until`
+    /// value corresponds to the `as_of` value plus one.
     pub fn is_single_time(&self) -> bool {
         // TODO: this would be much easier to check if `until` was a strict lower bound,
         // and we would be testing that `until == as_of`.
-        match (self.as_of.as_ref(), self.until.as_option()) {
-            (Some(as_of), Some(until)) => {
-                as_of.as_option().and_then(|as_of| as_of.checked_add(1)) == Some(*until)
-            }
-            _ => false,
-        }
+        let Some(as_of) = self.as_of.as_ref() else { return false; };
+        !as_of.is_empty()
+            && as_of
+                .as_option()
+                .and_then(|as_of| as_of.checked_add(1))
+                .as_ref()
+                == self.until.as_option()
     }
 }
 

--- a/test/sqllogictest/github-19290.slt
+++ b/test/sqllogictest/github-19290.slt
@@ -1,0 +1,52 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for #19290.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
+statement ok
+CREATE SOURCE tpch
+              FROM LOAD GENERATOR TPCH (SCALE FACTOR 0.00001)
+              FOR ALL TABLES
+              WITH (SIZE = '1');
+
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR
+  SELECT DISTINCT ON(l_linenumber) l_linenumber, l_discount
+  FROM lineitem
+  ORDER BY l_linenumber, l_orderkey;
+----
+Explained Query:
+  Finish order_by=[#3 asc nulls_last, #0 asc nulls_last] output=[#3, #6]
+    TopK::MonotonicTop1 group_by=[#3] order_by=[#0 asc nulls_last] must_consolidate
+      Get::PassArrangements materialize.public.lineitem
+        raw=true
+
+EOF
+
+statement ok
+SET transaction_isolation = 'serializable'
+
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR
+  SELECT DISTINCT ON(l_linenumber) l_linenumber, l_discount
+  FROM lineitem
+  ORDER BY l_linenumber, l_orderkey;
+----
+Explained Query:
+  Finish order_by=[#3 asc nulls_last, #0 asc nulls_last] output=[#3, #6]
+    TopK::MonotonicTop1 group_by=[#3] order_by=[#0 asc nulls_last] must_consolidate
+      Get::PassArrangements materialize.public.lineitem
+        raw=true
+
+EOF


### PR DESCRIPTION
This PR revisits the test that determines whether a dataflow is evaluated over a single time. The test previously did not consider a corner case where the `as_of` would contain the maximum integer value for the timestamp and the `until` would be empty. In this case, it was incorrectly determined that the dataflow was not single-time, as illustrated in #19290. A fix is provided along with a regression test.

Fix #19290. 

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/19290

### Tips for reviewer

Please consider https://github.com/MaterializeInc/materialize/issues/19290#issuecomment-1599099028. The PR takes the path of keeping the semantics of `until` unchanged, and only patching the single-time test to fix the issue. I would argue that this be of significantly lower effort to derive a fix than changing the semantics of `until`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20230421_stabilize_monotonic_select.md).
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A (since monotonic one-shot `SELECT`s are still gated behind a feature flag.
