### PR TITLE
adapter: Refactor PrivilegeMap to hide impl

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -23,7 +23,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::jsonb::Jsonb;
-use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap};
+use mz_repr::adt::mz_acl_item::{AclMode, PrivilegeMap};
 use mz_repr::role_id::RoleId;
 use mz_repr::{Datum, Diff, GlobalId, Row};
 use mz_sql::ast::{CreateIndexStatement, Statement};
@@ -1313,7 +1313,7 @@ impl CatalogState {
 
     fn pack_privilege_array_row(&self, privileges: &PrivilegeMap) -> Row {
         let mut row = Row::default();
-        let flat_privileges = MzAclItem::flatten(privileges);
+        let flat_privileges: Vec<_> = privileges.all_values_owned().collect();
         row.packer()
             .push_array(
                 &[ArrayDimension {

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -1519,7 +1519,7 @@ impl<'a> Transaction<'a> {
                     name: cluster.name().to_string(),
                     linked_object_id: cluster.linked_object_id(),
                     owner_id: cluster.owner_id,
-                    privileges: MzAclItem::flatten(cluster.privileges()),
+                    privileges: cluster.privileges().all_values_owned().collect(),
                     config: cluster.config.clone(),
                 })
             } else {
@@ -1582,7 +1582,7 @@ impl<'a> Transaction<'a> {
                 Some(DatabaseValue {
                     name: database.name().to_string(),
                     owner_id: database.owner_id,
-                    privileges: MzAclItem::flatten(database.privileges()),
+                    privileges: database.privileges().all_values_owned().collect(),
                 })
             } else {
                 None
@@ -1614,7 +1614,7 @@ impl<'a> Transaction<'a> {
                     database_id,
                     name: schema.name().schema.clone(),
                     owner_id: schema.owner_id,
-                    privileges: MzAclItem::flatten(schema.privileges()),
+                    privileges: schema.privileges().all_values_owned().collect(),
                 })
             } else {
                 None

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -1401,8 +1401,7 @@ fn check_object_privileges(
             .expect("only object types with privileges will generate required privileges");
         let role_privileges = role_membership
             .iter()
-            .filter_map(|role_id| object_privileges.0.get(role_id))
-            .flat_map(|mz_acl_items| mz_acl_items.iter())
+            .flat_map(|role_id| object_privileges.get_acl_items_for_grantee(role_id))
             .map(|mz_acl_item| mz_acl_item.acl_mode)
             .fold(AclMode::empty(), |accum, acl_mode| accum.union(acl_mode));
         if !role_privileges.contains(acl_mode) {


### PR DESCRIPTION
This commit refactors the `PrivilegeMap` type so that the inner `BTreeMap` is private. It also adds various methods on `PrivilegeMap` that replaces all the current direct accesses to the inner `BTreeMap`. This makes using `PrivilegeMap` a bit cleaner and hides the implementation details from callers.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
