### PR TITLE
storage-client: add param to disable shard finalization

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -7343,6 +7343,7 @@ impl Catalog {
                     }
                 }
             },
+            finalize_shards: self.system_config().enable_storage_shard_finalization(),
         }
     }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -959,6 +959,13 @@ const KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
     internal: true
 };
 
+const ENABLE_STORAGE_SHARD_FINALIZATION: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_storage_shard_finalization"),
+    value: &true,
+    description: "Whether to allow the storage client to finalize shards (Materialize).",
+    internal: true,
+};
+
 // Macro to simplify creating feature flags, i.e. boolean flags that we use to toggle the
 // availability of features.
 //
@@ -1721,7 +1728,8 @@ impl SystemVars {
             .with_var(&ENABLE_LAUNCHDARKLY)
             .with_var(&MAX_CONNECTIONS)
             .with_var(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
-            .with_var(&ENABLE_MZ_JOIN_CORE);
+            .with_var(&ENABLE_MZ_JOIN_CORE)
+            .with_var(&ENABLE_STORAGE_SHARD_FINALIZATION);
         vars.refresh_internal_state();
         vars
     }
@@ -2202,6 +2210,11 @@ impl SystemVars {
     /// Returns the `enable_mz_join_core` configuration parameter.
     pub fn enable_mz_join_core(&self) -> bool {
         *self.expect_value(&ENABLE_MZ_JOIN_CORE)
+    }
+
+    /// Returns the `enable_storage_shard_finalization` configuration parameter.
+    pub fn enable_storage_shard_finalization(&self) -> bool {
+        *self.expect_value(&ENABLE_STORAGE_SHARD_FINALIZATION)
     }
 }
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -2295,7 +2295,12 @@ where
                     .await
                     .expect("stash operation must succeed");
 
-                self.finalize_shards().await;
+                if self.state.config.finalize_shards {
+                    info!("triggering shard finalization due to dropped storage object");
+                    self.finalize_shards().await;
+                } else {
+                    info!("not triggering shard finalization due to dropped storage object because enable_storage_shard_finalization parameter is false")
+                }
             }
             Some(StorageResponse::StatisticsUpdates(source_stats, sink_stats)) => {
                 // Note we only hold the locks while moving some plain-old-data around here.

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -21,6 +21,7 @@ message ProtoStorageParameters {
     ProtoPgReplicationTimeouts pg_replication_timeouts = 3;
     uint64 keep_n_source_status_history_entries = 4;
     mz_rocksdb.config.ProtoRocksDbTuningParameters upsert_rocksdb_tuning_config = 5;
+    bool finalize_shards = 6;
 }
 
 

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -31,6 +31,10 @@ pub struct StorageParameters {
     pub keep_n_source_status_history_entries: usize,
     /// A set of parameters used to tune RocksDB when used with `UPSERT` sources.
     pub upsert_rocksdb_tuning_config: mz_rocksdb::RocksDBTuningParameters,
+    /// Whether or not to allow shard finalization to occur. Note that this will
+    /// only disable the actual finalization of shards, not registering them for
+    /// finalization.
+    pub finalize_shards: bool,
 }
 
 impl StorageParameters {
@@ -42,12 +46,14 @@ impl StorageParameters {
             pg_replication_timeouts,
             keep_n_source_status_history_entries,
             upsert_rocksdb_tuning_config,
+            finalize_shards,
         }: StorageParameters,
     ) {
         self.persist.update(persist);
         self.pg_replication_timeouts = pg_replication_timeouts;
         self.keep_n_source_status_history_entries = keep_n_source_status_history_entries;
         self.upsert_rocksdb_tuning_config = upsert_rocksdb_tuning_config;
+        self.finalize_shards = finalize_shards
     }
 }
 
@@ -60,6 +66,7 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
                 self.keep_n_source_status_history_entries,
             ),
             upsert_rocksdb_tuning_config: Some(self.upsert_rocksdb_tuning_config.into_proto()),
+            finalize_shards: self.finalize_shards,
         }
     }
 
@@ -77,6 +84,7 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             upsert_rocksdb_tuning_config: proto
                 .upsert_rocksdb_tuning_config
                 .into_rust_if_some("ProtoStorageParameters::upsert_rocksdb_tuning_config")?,
+            finalize_shards: proto.finalize_shards,
         })
     }
 }


### PR DESCRIPTION
Allow disabling shard finalization.

### Motivation

This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
