### PR TITLE
sql: allow raise codes, hints, details

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -437,9 +437,18 @@ impl Coordinator {
                     ctx.retire(Ok(ExecuteResponse::Deallocate { all: true }));
                 }
             },
-            Plan::Raise(RaisePlan { severity }) => {
-                ctx.session()
-                    .add_notice(AdapterNotice::UserRequested { severity });
+            Plan::Raise(RaisePlan {
+                severity,
+                code,
+                detail,
+                hint,
+            }) => {
+                ctx.session().add_notice(AdapterNotice::UserRequested {
+                    severity,
+                    code,
+                    detail,
+                    hint,
+                });
                 ctx.retire(Ok(ExecuteResponse::Raised));
             }
             Plan::RotateKeys(RotateKeysPlan { id }) => {

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -112,7 +112,10 @@ pub enum AdapterNotice {
 impl AdapterNotice {
     /// Reports additional details about the notice, if any are available.
     pub fn detail(&self) -> Option<String> {
-        None
+        match self {
+            AdapterNotice::PlanNotice(notice) => notice.detail(),
+            _ => None,
+        }
     }
 
     /// Reports a hint for the user about how the notice could be addressed.
@@ -133,7 +136,6 @@ impl AdapterNotice {
             AdapterNotice::RbacSystemDisabled => Some("To enable RBAC please reach out to support with a request to turn RBAC on.".into()),
             AdapterNotice::RbacUserDisabled => Some("To enable RBAC globally run `ALTER SYSTEM SET enable_rbac_checks TO TRUE` as a superuser. TO enable RBAC for just this session run `SET enable_session_rbac_checks TO TRUE`.".into()),
             AdapterNotice::AlterIndexOwner {name: _} => Some("Change the ownership of the index's relation, instead.".into()),
-            AdapterNotice::PlanNotice(notice) => notice.detail(),
             _ => None
         }
     }

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -52,6 +52,9 @@ pub enum AdapterNotice {
     ExplicitTransactionControlInImplicitTransaction,
     UserRequested {
         severity: NoticeSeverity,
+        code: Option<String>,
+        detail: Option<String>,
+        hint: Option<String>,
     },
     ClusterReplicaStatusChanged {
         cluster: String,
@@ -114,6 +117,7 @@ impl AdapterNotice {
     pub fn detail(&self) -> Option<String> {
         match self {
             AdapterNotice::PlanNotice(notice) => notice.detail(),
+            AdapterNotice::UserRequested { detail, .. } => detail.clone(),
             _ => None,
         }
     }
@@ -136,6 +140,7 @@ impl AdapterNotice {
             AdapterNotice::RbacSystemDisabled => Some("To enable RBAC please reach out to support with a request to turn RBAC on.".into()),
             AdapterNotice::RbacUserDisabled => Some("To enable RBAC globally run `ALTER SYSTEM SET enable_rbac_checks TO TRUE` as a superuser. TO enable RBAC for just this session run `SET enable_session_rbac_checks TO TRUE`.".into()),
             AdapterNotice::AlterIndexOwner {name: _} => Some("Change the ownership of the index's relation, instead.".into()),
+            AdapterNotice::UserRequested { hint, .. } => hint.clone(),
             _ => None
         }
     }
@@ -175,7 +180,7 @@ impl fmt::Display for AdapterNotice {
             AdapterNotice::ExplicitTransactionControlInImplicitTransaction => {
                 write!(f, "there is no transaction in progress")
             }
-            AdapterNotice::UserRequested { severity } => {
+            AdapterNotice::UserRequested { severity, .. } => {
                 write!(f, "raised a test {}", severity.to_string().to_lowercase())
             }
             AdapterNotice::ClusterReplicaStatusChanged {

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -1240,7 +1240,12 @@ fn generate_required_privileges(
         })
         | Plan::Execute(ExecutePlan { name: _, params: _ })
         | Plan::Deallocate(DeallocatePlan { name: _ })
-        | Plan::Raise(RaisePlan { severity: _ })
+        | Plan::Raise(RaisePlan {
+            severity: _,
+            code: _,
+            detail: _,
+            hint: _,
+        })
         | Plan::GrantRole(GrantRolePlan {
             role_ids: _,
             member_ids: _,

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -420,7 +420,10 @@ impl ErrorResponse {
             AdapterNotice::ExplicitTransactionControlInImplicitTransaction => {
                 SqlState::NO_ACTIVE_SQL_TRANSACTION
             }
-            AdapterNotice::UserRequested { .. } => SqlState::WARNING,
+            AdapterNotice::UserRequested { code, .. } => match code {
+                Some(code) => SqlState::from_code(code),
+                None => SqlState::WARNING,
+            },
             AdapterNotice::ClusterReplicaStatusChanged { .. } => SqlState::WARNING,
             AdapterNotice::DroppedActiveDatabase { .. } => SqlState::WARNING,
             AdapterNotice::DroppedActiveCluster { .. } => SqlState::WARNING,
@@ -584,7 +587,7 @@ impl Severity {
             AdapterNotice::NoResolvableSearchPathSchema { .. } => Severity::Notice,
             AdapterNotice::ExistingTransactionInProgress => Severity::Warning,
             AdapterNotice::ExplicitTransactionControlInImplicitTransaction => Severity::Warning,
-            AdapterNotice::UserRequested { severity } => match severity {
+            AdapterNotice::UserRequested { severity, .. } => match severity {
                 NoticeSeverity::Debug => Severity::Debug,
                 NoticeSeverity::Info => Severity::Info,
                 NoticeSeverity::Log => Severity::Log,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2810,12 +2810,30 @@ impl_display!(DeallocateStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RaiseStatement {
     pub severity: NoticeSeverity,
+    pub code: Option<String>,
+    pub detail: Option<String>,
+    pub hint: Option<String>,
 }
 
 impl AstDisplay for RaiseStatement {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("RAISE ");
         f.write_node(&self.severity);
+        if let Some(code) = &self.code {
+            f.write_str(" CODE '");
+            f.write_node(&display::escape_single_quote_string(code));
+            f.write_str("'");
+        }
+        if let Some(detail) = &self.detail {
+            f.write_str(" DETAIL '");
+            f.write_node(&display::escape_single_quote_string(detail));
+            f.write_str("'");
+        }
+        if let Some(hint) = &self.hint {
+            f.write_str(" HINT '");
+            f.write_node(&display::escape_single_quote_string(hint));
+            f.write_str("'");
+        }
     }
 }
 impl_display!(RaiseStatement);

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -67,6 +67,7 @@ Close
 Cluster
 Clusters
 Coalesce
+Code
 Collate
 Columns
 Commit
@@ -107,6 +108,7 @@ Delete
 Delimited
 Delimiter
 Desc
+Detail
 Details
 Discard
 Disk
@@ -155,6 +157,7 @@ Groups
 Having
 Header
 Headers
+Hint
 Hold
 Host
 Hour

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -6229,8 +6229,25 @@ impl<'a> Parser<'a> {
             Some(_) => unreachable!(),
             None => self.expected(self.peek_pos(), "severity level", self.peek_token())?,
         };
+        let code = self
+            .parse_keyword(CODE)
+            .then(|| self.parse_literal_string())
+            .transpose()?;
+        let detail = self
+            .parse_keyword(DETAIL)
+            .then(|| self.parse_literal_string())
+            .transpose()?;
+        let hint = self
+            .parse_keyword(HINT)
+            .then(|| self.parse_literal_string())
+            .transpose()?;
 
-        Ok(Statement::Raise(RaiseStatement { severity }))
+        Ok(Statement::Raise(RaiseStatement {
+            severity,
+            code,
+            detail,
+            hint,
+        }))
     }
 
     /// Parse a `GRANT` statement, assuming that the `GRANT` token

--- a/src/sql-parser/tests/testdata/raise
+++ b/src/sql-parser/tests/testdata/raise
@@ -1,0 +1,33 @@
+# Copyright 2020 sqlparser-rs contributors. All rights reserved.
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# This file is derived from the sqlparser-rs project, available at
+# https://github.com/andygrove/sqlparser-rs. It was incorporated
+# directly into Materialize on December 21, 2019.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+parse-statement
+RAISE NOTICE
+----
+RAISE NOTICE
+=>
+Raise(RaiseStatement { severity: Notice, code: None, detail: None, hint: None })
+
+parse-statement
+RAISE NOTICE CODE '01234' DETAIL 'detail' HINT 'hint'
+----
+RAISE NOTICE CODE '01234' DETAIL 'detail' HINT 'hint'
+=>
+Raise(RaiseStatement { severity: Notice, code: Some("01234"), detail: Some("detail"), hint: Some("hint") })

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -926,6 +926,9 @@ pub struct DeallocatePlan {
 #[derive(Debug)]
 pub struct RaisePlan {
     pub severity: NoticeSeverity,
+    pub code: Option<String>,
+    pub detail: Option<String>,
+    pub hint: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement/raise.rs
+++ b/src/sql/src/plan/statement/raise.rs
@@ -24,5 +24,8 @@ pub fn plan_raise(scx: &StatementContext, r: RaiseStatement) -> Result<Plan, Pla
     scx.require_feature_flag(&crate::session::vars::ENABLE_RAISE_STATEMENT)?;
     Ok(Plan::Raise(RaisePlan {
         severity: r.severity,
+        code: r.code,
+        detail: r.detail,
+        hint: r.hint,
     }))
 }

--- a/test/pgtest-mz/raise.pt
+++ b/test/pgtest-mz/raise.pt
@@ -11,16 +11,15 @@ ReadyForQuery
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
 
-
 send
 Query {"query": "RAISE DEBUG"}
 ----
 
-until err_field_typs=S
+until
 CommandComplete
 ReadyForQuery
 ----
-NoticeResponse {"fields":[{"typ":"S","value":"DEBUG"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"DEBUG"},{"typ":"C","value":"01000"},{"typ":"M","value":"raised a test debug"}]}
 CommandComplete {"tag":"RAISE"}
 ReadyForQuery {"status":"I"}
 
@@ -28,10 +27,10 @@ send
 Query {"query": "RAISE INFO"}
 ----
 
-until err_field_typs=S
+until
 ReadyForQuery
 ----
-NoticeResponse {"fields":[{"typ":"S","value":"INFO"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"INFO"},{"typ":"C","value":"01000"},{"typ":"M","value":"raised a test info"}]}
 CommandComplete {"tag":"RAISE"}
 ReadyForQuery {"status":"I"}
 
@@ -39,10 +38,10 @@ send
 Query {"query": "RAISE LOG"}
 ----
 
-until err_field_typs=S
+until
 ReadyForQuery
 ----
-NoticeResponse {"fields":[{"typ":"S","value":"LOG"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"LOG"},{"typ":"C","value":"01000"},{"typ":"M","value":"raised a test log"}]}
 CommandComplete {"tag":"RAISE"}
 ReadyForQuery {"status":"I"}
 
@@ -50,10 +49,10 @@ send
 Query {"query": "RAISE NOTICE"}
 ----
 
-until err_field_typs=S
+until
 ReadyForQuery
 ----
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"raised a test notice"}]}
 CommandComplete {"tag":"RAISE"}
 ReadyForQuery {"status":"I"}
 
@@ -61,9 +60,21 @@ send
 Query {"query": "RAISE WARNING"}
 ----
 
-until err_field_typs=S
+until
 ReadyForQuery
 ----
-NoticeResponse {"fields":[{"typ":"S","value":"WARNING"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"01000"},{"typ":"M","value":"raised a test warning"}]}
+CommandComplete {"tag":"RAISE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "RAISE NOTICE CODE '01234' DETAIL 'details here' HINT 'hints here'"}
+----
+
+until err_field_typs=CMSDH
+CommandComplete
+ReadyForQuery
+----
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01234"},{"typ":"M","value":"raised a test notice"},{"typ":"D","value":"details here"},{"typ":"H","value":"hints here"}]}
 CommandComplete {"tag":"RAISE"}
 ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Allows console to more easily test these.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a