### PR TITLE
test: Add test for bound size of mz_*_status_history

### DIFF
--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -281,6 +281,12 @@ def workflow_allowed_cluster_replica_sizes(c: Composition) -> None:
             """
             > SHOW allowed_cluster_replica_sizes
             "\\"1\\", \\"2\\""
+
+            $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+
+            # Reset for following tests
+            $ postgres-execute connection=mz_system
+            ALTER SYSTEM RESET allowed_cluster_replica_sizes
             """
         ),
     )
@@ -303,6 +309,93 @@ def workflow_drop_materialize_database(c: Composition) -> None:
     # Verify that materialize hasn't blown up
     c.sql("SELECT 1")
 
+    # Restore for next tests
+    c.sql(
+        "CREATE DATABASE materialize",
+        port=6877,
+        user="mz_system",
+    )
+    c.sql(
+        "GRANT ALL PRIVILEGES ON SCHEMA materialize.public TO materialize",
+        port=6877,
+        user="mz_system",
+    )
+
+
+def workflow_bound_size_mz_status_history(c: Composition) -> None:
+    c.up("zookeeper", "kafka", "schema-registry", "materialized")
+    c.up("testdrive_no_reset", persistent=True)
+
+    c.testdrive(
+        service="testdrive_no_reset",
+        input=dedent(
+            """
+            $ kafka-create-topic topic=status-history
+
+            > CREATE CONNECTION kafka_conn
+              TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+            > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+                URL '${testdrive.schema-registry-url}'
+              );
+
+            > CREATE SOURCE kafka_source
+              FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-status-history-${testdrive.seed}')
+              FORMAT TEXT
+
+            > CREATE SINK kafka_sink FROM kafka_source
+              INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-${testdrive.seed}')
+              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+              ENVELOPE DEBEZIUM
+            """
+        ),
+    )
+
+    # Fill mz_source_status_history and mz_sink_status_history up with enough events
+    for i in range(10):
+        c.testdrive(
+            service="testdrive_no_reset",
+            input=dedent(
+                """
+                > ALTER SOURCE kafka_source SET (SIZE = '1')
+
+                > ALTER SINK kafka_sink SET (SIZE = '1')
+                """
+            ),
+        )
+
+    # Verify that we have enough events so that they can be truncated
+    c.testdrive(
+        service="testdrive_no_reset",
+        input=dedent(
+            """
+            > SELECT COUNT(*) > 7 FROM mz_internal.mz_source_status_history
+            true
+
+            > SELECT COUNT(*) > 7 FROM mz_internal.mz_sink_status_history
+            true
+            """
+        ),
+    )
+
+    # Restart mz.
+    c.kill("materialized")
+    c.up("materialized")
+
+    # Verify that we have fewer events now
+    c.testdrive(
+        service="testdrive_no_reset",
+        input=dedent(
+            """
+            > SELECT COUNT(*) FROM mz_internal.mz_source_status_history
+            7
+            """
+            # Bound size currently not implemented for mz_sink_status_history
+            # > SELECT COUNT(*) FROM mz_internal.mz_sink_status_history
+            # 7
+        ),
+    )
+
 
 def workflow_default(c: Composition) -> None:
     c.workflow("github-17578")
@@ -312,3 +405,4 @@ def workflow_default(c: Composition) -> None:
     c.workflow("stash")
     c.workflow("allowed-cluster-replica-sizes")
     c.workflow("drop-materialize-database")
+    c.workflow("bound-size-mz-status-history")


### PR DESCRIPTION
Only seems to work for mz_source_status_history, also described that way in https://github.com/MaterializeInc/materialize/pull/19060

Fixes: #17548

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
