### PR TITLE
Unify dataflow IDs in introspection views

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -374,7 +374,7 @@ The `mz_compute_exports` view describes the objects exported by [dataflows][data
 | Field          | Type         | Meaning                                                                                                                                                                                                                                                                                        |
 | -------------- | ------------ | --------                                                                                                                                                                                                                                                                                       |
 | `export_id`    | [`text`]     | The ID of the index, materialized view, or subscription exported by the dataflow. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), or [`mz_internal.mz_subscriptions`](#mz_subscriptions). |
-| `dataflow_id`  | [`bigint`]   | The ID of the dataflow. Corresponds to [`mz_dataflows.local_id`](#mz_dataflows).                                                                                                                                                                                                               |
+| `dataflow_id`  | [`bigint`]   | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).                                                                                                                                                                                                               |
 
 ### `mz_compute_frontiers`
 
@@ -414,7 +414,6 @@ The `mz_dataflows` view describes the [dataflows][dataflow] in the system.
 | Field       | Type         | Meaning                                |
 | ----------- | ------------ | --------                               |
 | `id`        | [`bigint`]   | The ID of the dataflow.                |
-| `local_id`  | [`bigint`]   | The scope-local index of the dataflow. |
 | `name`      | [`text`]     | The internal name of the dataflow.     |
 
 ### `mz_dataflow_addresses`

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2065,9 +2065,8 @@ pub const MZ_DATAFLOWS_PER_WORKER: BuiltinView = BuiltinView {
     name: "mz_dataflows_per_worker",
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE VIEW mz_internal.mz_dataflows_per_worker AS SELECT
-    ops.id,
+    addrs.address[1] AS id,
     ops.worker_id,
-    addrs.address[1] AS local_id,
     ops.name
 FROM
     mz_internal.mz_dataflow_addresses_per_worker addrs,
@@ -2082,7 +2081,7 @@ pub const MZ_DATAFLOWS: BuiltinView = BuiltinView {
     name: "mz_dataflows",
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE VIEW mz_internal.mz_dataflows AS
-SELECT id, local_id, name
+SELECT id, name
 FROM mz_internal.mz_dataflows_per_worker
 WHERE worker_id = 0",
 };
@@ -2130,7 +2129,7 @@ FROM
 WHERE
     ops.id = addrs.id AND
     ops.worker_id = addrs.worker_id AND
-    dfs.local_id = addrs.address[1] AND
+    dfs.id = addrs.address[1] AND
     dfs.worker_id = addrs.worker_id",
 };
 

--- a/test/sqllogictest/web-console.slt
+++ b/test/sqllogictest/web-console.slt
@@ -252,7 +252,7 @@ CREATE SECRET my_secret AS 'abcd123';
 statement ok
 CREATE TEMPORARY VIEW export_to_dataflow AS
 SELECT export_id, id FROM mz_internal.mz_compute_exports AS mce JOIN mz_internal.mz_dataflows AS md ON
-mce.dataflow_id = md.local_id;
+mce.dataflow_id = md.id;
 
 statement ok
 CREATE TEMPORARY VIEW all_ops AS

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -209,7 +209,7 @@ mv1_primary_idx mv1
   WHERE
     mv.name = 'my_unique_mv_name' AND
     mv.id = exp.export_id AND
-    exp.dataflow_id = df.local_id AND
+    exp.dataflow_id = df.id AND
     df.name LIKE '%my_unique_mv_name%';
 1
 
@@ -227,7 +227,7 @@ mv1_primary_idx mv1
 
 > SELECT DISTINCT count(*)
   FROM mz_internal.mz_dataflows_per_worker
-  GROUP BY id, local_id, name
+  GROUP BY id, name
 16
 
 > SELECT DISTINCT count(*)

--- a/test/testdrive/render-delta-join.td
+++ b/test/testdrive/render-delta-join.td
@@ -58,12 +58,9 @@ count
         (SELECT id
          FROM mz_internal.mz_dataflow_addresses
          WHERE address[1] =
-             (SELECT address[1]
-              FROM mz_internal.mz_dataflow_addresses
-              WHERE id =
-                  (SELECT id
-                   FROM mz_internal.mz_dataflows
-                   WHERE name LIKE '%.delta_join%')))
+             (SELECT id
+              FROM mz_internal.mz_dataflows
+              WHERE name LIKE '%.delta_join%'))
     AND sent > 100
   ORDER BY sent;
 sent


### PR DESCRIPTION
This PR unifies the dataflow IDs exposed by the introspection views by renaming the previous `mz_dataflows.local_id` field to `id` and dropping the previous `id` field. All dataflow foreign keys now reference `mz_dataflows.id`.

The purpose of this PR is to remove the confusion about which of the two exposed IDs is the correct one for joining relations, and what is the difference between the two IDs. For more details see #20058.

**If we decide to merge this, we need to adjust the queries in the prometheus-exporter as well.**

### Motivation

  * This PR adds a known-desirable feature.

Closes #20058.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Remove the `mz_internal.mz_dataflows.local_id` field. All dataflow foreign key fields now reference `mz_internal.mz_dataflows.id`.
