### PR TITLE
persist: fix bug with stats on shards with all no-stats columns

### DIFF
--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -267,6 +267,7 @@ pub trait Schema<T>: Debug + Send + Sync {
 pub fn validate_roundtrip<T: Codec + Default + PartialEq + Debug>(
     schema: &T::Schema,
     val: &T,
+    skip_decode: bool,
 ) -> Result<(), String> {
     let mut part = PartBuilder::new(schema, &UnitSchema);
     {
@@ -279,6 +280,10 @@ pub fn validate_roundtrip<T: Codec + Default + PartialEq + Debug>(
 
     // Sanity check that we can compute stats.
     let _stats = part.key_stats().expect("stats should be compute-able");
+
+    if skip_decode {
+        return Ok(());
+    }
 
     let mut actual = T::default();
     assert_eq!(part.len(), 1);

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -2698,6 +2698,7 @@ impl Codec for SourceData {
 /// an Err column.
 #[derive(Debug)]
 pub struct SourceDataEncoder<'a> {
+    len: &'a mut usize,
     ok_validity: ValidityMut<'a>,
     ok: RowEncoder<'a>,
     err: &'a mut <Option<Vec<u8>> as Data>::Mut,
@@ -2705,9 +2706,11 @@ pub struct SourceDataEncoder<'a> {
 
 impl<'a> PartEncoder<'a, SourceData> for SourceDataEncoder<'a> {
     fn encode(&mut self, val: &SourceData) {
+        *self.len += 1;
         match val.as_ref() {
             Ok(row) => {
                 self.ok_validity.push(true);
+                self.ok.inc_len();
                 for (encoder, datum) in self.ok.col_encoders().iter_mut().zip(row.iter()) {
                     encoder.encode(datum);
                 }
@@ -2715,6 +2718,7 @@ impl<'a> PartEncoder<'a, SourceData> for SourceDataEncoder<'a> {
             }
             Err(err) => {
                 self.ok_validity.push(false);
+                self.ok.inc_len();
                 for encoder in self.ok.col_encoders() {
                     encoder.encode_default();
                 }
@@ -2815,9 +2819,10 @@ impl Schema<SourceData> for RelationDesc {
     ) -> Result<Self::Encoder<'a>, String> {
         let ok = cols.col::<Option<DynStruct>>("ok")?;
         let err = cols.col::<Option<Vec<u8>>>("err")?;
-        let () = cols.finish()?;
+        let (len, ()) = cols.finish()?;
         let (ok_validity, ok) = RelationDesc::encoder(self, ok.as_opt_mut())?;
         Ok(SourceDataEncoder {
+            len,
             ok_validity,
             ok,
             err,
@@ -2848,10 +2853,7 @@ mod tests {
     }
 
     fn scalar_type_columnar_roundtrip(scalar_type: ScalarType) {
-        // Skip types that we don't keep stats for (yet).
-        if is_no_stats_type(&scalar_type) {
-            return;
-        }
+        let skip_decode = is_no_stats_type(&scalar_type);
 
         use mz_persist_types::columnar::validate_roundtrip;
         let mut rows = Vec::new();
@@ -2865,14 +2867,14 @@ mod tests {
         // Non-nullable version of the column.
         let schema = RelationDesc::empty().with_column("col", scalar_type.clone().nullable(false));
         for row in rows.iter() {
-            assert_eq!(validate_roundtrip(&schema, row), Ok(()));
+            assert_eq!(validate_roundtrip(&schema, row, skip_decode), Ok(()));
         }
 
         // Nullable version of the column.
         let schema = RelationDesc::empty().with_column("col", scalar_type.nullable(true));
         rows.push(SourceData(Ok(Row::pack(std::iter::once(Datum::Null)))));
         for row in rows.iter() {
-            assert_eq!(validate_roundtrip(&schema, row), Ok(()));
+            assert_eq!(validate_roundtrip(&schema, row, skip_decode), Ok(()));
         }
     }
 


### PR DESCRIPTION
We skip stats on certain ScalarTypes, including MzAclItem. If every column in a struct is skipped, we end up with an empty struct. This resulted in a len-mismatch error at validate time because we were defaulting empty structs to len 0. Instead, manually maintain the length of columnar structs during construction.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
