### PR TITLE
storage: support `ALTER SOURCE...DROP SUBSOURCE`

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4993,8 +4993,18 @@ impl Catalog {
         object_ids: &Vec<ObjectId>,
         conn_id: &ConnectionId,
     ) -> Vec<ObjectId> {
-        let mut seen = BTreeSet::new();
-        self.state.object_dependents(object_ids, conn_id, &mut seen)
+        let seen = BTreeSet::new();
+        self.object_dependents_except(object_ids, conn_id, seen)
+    }
+
+    pub(crate) fn object_dependents_except(
+        &self,
+        object_ids: &Vec<ObjectId>,
+        conn_id: &ConnectionId,
+        mut except: BTreeSet<ObjectId>,
+    ) -> Vec<ObjectId> {
+        self.state
+            .object_dependents(object_ids, conn_id, &mut except)
     }
 
     pub(crate) fn cluster_replica_dependents(

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1616,6 +1616,16 @@ impl CatalogState {
 #[derive(Debug)]
 pub struct ConnCatalog<'a> {
     state: Cow<'a, CatalogState>,
+    /// Because we don't have any way of removing items from the catalog
+    /// temporarily, we allow the ConnCatalog to pretend that a set of items
+    /// don't exist during resolution.
+    ///
+    /// This feature is necessary to allow re-planning of statements, which is
+    /// either incredibly useful or required when altering item definitions.
+    ///
+    /// Note that uses of this should field should be used by short-lived
+    /// catalogs.
+    unresolvable_ids: BTreeSet<GlobalId>,
     conn_id: ConnectionId,
     cluster: String,
     database: Option<DatabaseId>,
@@ -1634,9 +1644,27 @@ impl ConnCatalog<'_> {
         &*self.state
     }
 
+    /// Prevent planning from resolving item with the provided ID. Instead,
+    /// return an error as if the item did not exist.
+    ///
+    /// This feature is meant exclusively to permit re-planning statements
+    /// during update operations and should not be used otherwise given its
+    /// extremely "powerful" semantics.
+    ///
+    /// # Panics
+    /// If the catalog's role ID is not [`MZ_SYSTEM_ROLE_ID`].
+    pub fn mark_id_unresolvable_for_replanning(&mut self, id: GlobalId) {
+        assert_eq!(
+            self.role_id, MZ_SYSTEM_ROLE_ID,
+            "only the system role can mark IDs unresolvable",
+        );
+        self.unresolvable_ids.insert(id);
+    }
+
     pub fn into_owned(self) -> ConnCatalog<'static> {
         ConnCatalog {
             state: Cow::Owned(self.state.into_owned()),
+            unresolvable_ids: self.unresolvable_ids.clone(),
             conn_id: self.conn_id,
             cluster: self.cluster,
             database: self.database,
@@ -4553,6 +4581,7 @@ impl Catalog {
             .map(|id| id.clone());
         ConnCatalog {
             state: Cow::Borrowed(state),
+            unresolvable_ids: BTreeSet::new(),
             conn_id: session.conn_id().clone(),
             cluster: session.vars().cluster().into(),
             database,
@@ -4571,6 +4600,7 @@ impl Catalog {
         let (notices_tx, _notices_rx) = mpsc::unbounded_channel();
         ConnCatalog {
             state: Cow::Borrowed(state),
+            unresolvable_ids: BTreeSet::new(),
             conn_id: SYSTEM_CONN_ID.clone(),
             cluster: "default".into(),
             database: state
@@ -8148,24 +8178,38 @@ impl SessionCatalog for ConnCatalog<'_> {
         &self,
         name: &PartialItemName,
     ) -> Result<&dyn mz_sql::catalog::CatalogItem, SqlCatalogError> {
-        Ok(self.state.resolve_entry(
+        let r = self.state.resolve_entry(
             self.database.as_ref(),
             &self.effective_search_path(true),
             name,
             &self.conn_id,
-        )?)
+        )?;
+        if self.unresolvable_ids.contains(&r.id()) {
+            Err(SqlCatalogError::UnknownItem(name.to_string()))
+        } else {
+            Ok(r)
+        }
     }
 
     fn resolve_function(
         &self,
         name: &PartialItemName,
     ) -> Result<&dyn mz_sql::catalog::CatalogItem, SqlCatalogError> {
-        Ok(self.state.resolve_function(
+        let r = self.state.resolve_function(
             self.database.as_ref(),
             &self.effective_search_path(false),
             name,
             &self.conn_id,
-        )?)
+        )?;
+
+        if self.unresolvable_ids.contains(&r.id()) {
+            Err(SqlCatalogError::UnknownFunction {
+                name: name.to_string(),
+                alternative: None,
+            })
+        } else {
+            Ok(r)
+        }
     }
 
     fn try_get_item(&self, id: &GlobalId) -> Option<&dyn mz_sql::catalog::CatalogItem> {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -339,7 +339,7 @@ impl Coordinator {
                 ctx.retire(result);
             }
             Plan::AlterSource(plan) => {
-                let result = self.sequence_alter_source(ctx.session(), plan).await;
+                let result = self.sequence_alter_source(ctx.session_mut(), plan).await;
                 ctx.retire(result);
             }
             Plan::AlterSystemSet(plan) => {

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -344,6 +344,10 @@ impl AdapterError {
             _ => None,
         }
     }
+
+    pub fn internal<E: std::fmt::Display>(context: &str, e: E) -> AdapterError {
+        AdapterError::Internal(format!("{context}: {e}"))
+    }
 }
 
 impl fmt::Display for AdapterError {

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -1159,7 +1159,7 @@ fn generate_required_privileges(
         Plan::AlterIndexSetOptions(AlterIndexSetOptionsPlan { id, options: _ })
         | Plan::AlterIndexResetOptions(AlterIndexResetOptionsPlan { id, options: _ })
         | Plan::AlterSink(AlterSinkPlan { id, size: _ })
-        | Plan::AlterSource(AlterSourcePlan { id, size: _ })
+        | Plan::AlterSource(AlterSourcePlan { id, action: _ })
         | Plan::AlterItemRename(AlterItemRenamePlan {
             id,
             current_full_name: _,

--- a/src/postgres-util/src/privileges.rs
+++ b/src/postgres-util/src/privileges.rs
@@ -97,7 +97,7 @@ pub async fn check_table_privileges(
         ],
     );
 
-    let invalid_table_privileges = client
+    let mut invalid_table_privileges = client
         .query(
             "
             WITH
@@ -129,6 +129,8 @@ pub async fn check_table_privileges(
             }
         })
         .collect::<Vec<String>>();
+
+    invalid_table_privileges.sort();
 
     if invalid_table_privileges.is_empty() {
         Ok(())

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1610,6 +1610,11 @@ impl<T: AstInfo> AstDisplay for AlterSinkStatement<T> {
 pub enum AlterSourceAction<T: AstInfo> {
     SetOptions(Vec<CreateSourceOption<T>>),
     ResetOptions(Vec<CreateSourceOptionName>),
+    DropSubsources {
+        if_exists: bool,
+        cascade: bool,
+        names: Vec<UnresolvedItemName>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1639,6 +1644,7 @@ impl<T: AstInfo> AstDisplay for AlterSourceStatement<T> {
                 f.write_node(&display::comma_separated(options));
                 f.write_str(")");
             }
+            _ => todo!(),
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1644,7 +1644,22 @@ impl<T: AstInfo> AstDisplay for AlterSourceStatement<T> {
                 f.write_node(&display::comma_separated(options));
                 f.write_str(")");
             }
-            _ => todo!(),
+            AlterSourceAction::DropSubsources {
+                if_exists,
+                cascade,
+                names,
+            } => {
+                f.write_str("DROP SUBSOURCE ");
+                if *if_exists {
+                    f.write_str("IF EXISTS ");
+                }
+
+                f.write_node(&display::comma_separated(names));
+
+                if *cascade {
+                    f.write_str(" CASCADE");
+                }
+            }
         }
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1023,6 +1023,47 @@ ALTER SOURCE name RESET (SIZE)
 =>
 AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("name")]), if_exists: false, action: ResetOptions([Size]) })
 
+parse-statement
+ALTER SOURCE n DROP SUBSOURCE x, y, z
+----
+ALTER SOURCE n DROP SUBSOURCE x, y, z
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: DropSubsources { if_exists: false, cascade: false, names: [UnresolvedItemName([Ident("x")]), UnresolvedItemName([Ident("y")]), UnresolvedItemName([Ident("z")])] } })
+
+parse-statement
+ALTER SOURCE n DROP TABLE x, y, z
+----
+ALTER SOURCE n DROP SUBSOURCE x, y, z
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: DropSubsources { if_exists: false, cascade: false, names: [UnresolvedItemName([Ident("x")]), UnresolvedItemName([Ident("y")]), UnresolvedItemName([Ident("z")])] } })
+
+parse-statement
+ALTER SOURCE n DROP SUBSOURCE IF EXISTS x, y, z
+----
+ALTER SOURCE n DROP SUBSOURCE IF EXISTS x, y, z
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: DropSubsources { if_exists: true, cascade: false, names: [UnresolvedItemName([Ident("x")]), UnresolvedItemName([Ident("y")]), UnresolvedItemName([Ident("z")])] } })
+
+parse-statement
+ALTER SOURCE n DROP SUBSOURCE x, y, z CASCADE
+----
+ALTER SOURCE n DROP SUBSOURCE x, y, z CASCADE
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: DropSubsources { if_exists: false, cascade: true, names: [UnresolvedItemName([Ident("x")]), UnresolvedItemName([Ident("y")]), UnresolvedItemName([Ident("z")])] } })
+
+parse-statement
+ALTER SOURCE n DROP SUBSOURCE IF EXISTS x, y, z CASCADE
+----
+ALTER SOURCE n DROP SUBSOURCE IF EXISTS x, y, z CASCADE
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: DropSubsources { if_exists: true, cascade: true, names: [UnresolvedItemName([Ident("x")]), UnresolvedItemName([Ident("y")]), UnresolvedItemName([Ident("z")])] } })
+
+parse-statement
+ALTER SOURCE IF EXISTS n DROP SUBSOURCE IF EXISTS x, y, z CASCADE
+----
+ALTER SOURCE IF EXISTS n DROP SUBSOURCE IF EXISTS x, y, z CASCADE
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: true, action: DropSubsources { if_exists: true, cascade: true, names: [UnresolvedItemName([Ident("x")]), UnresolvedItemName([Ident("y")]), UnresolvedItemName([Ident("z")])] } })
 
 parse-statement
 ALTER VIEW name SET (property = true)

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -827,9 +827,14 @@ pub struct AlterSinkPlan {
 }
 
 #[derive(Debug)]
+pub enum AlterSourceAction {
+    Resize(AlterOptionParameter),
+}
+
+#[derive(Debug)]
 pub struct AlterSourcePlan {
     pub id: GlobalId,
-    pub size: AlterOptionParameter,
+    pub action: AlterSourceAction,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -44,6 +44,7 @@ use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::role_id::RoleId;
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
+
 use mz_sql_parser::ast::{QualifiedReplica, TransactionIsolationLevel, TransactionMode};
 use mz_storage_client::types::sinks::{SinkEnvelope, StorageSinkConnectionBuilder};
 use mz_storage_client::types::sources::{SourceDesc, Timeline};
@@ -829,6 +830,7 @@ pub struct AlterSinkPlan {
 #[derive(Debug)]
 pub enum AlterSourceAction {
     Resize(AlterOptionParameter),
+    DropSubsourceExports { to_drop: BTreeSet<GlobalId> },
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -106,6 +106,10 @@ pub enum PlanError {
         subsource: String,
         source: String,
     },
+    DropProgressCollection {
+        progress_collection: String,
+        source: String,
+    },
     AlterViewOnMaterializedView(String),
     ShowCreateViewOnMaterializedView(String),
     ExplainViewOnMaterializedView(String),
@@ -407,7 +411,8 @@ impl fmt::Display for PlanError {
             Self::InvalidProtobufSchema { .. } => {
                 write!(f, "invalid protobuf schema")
             }
-            Self::DropSubsource{subsource, source: _} => write!(f, "SOURCE {subsource} is a subsource and cannot be dropped independently of its primary source"),
+            Self::DropSubsource { subsource, source: _} => write!(f, "SOURCE {} is a subsource and must be dropped with ALTER SOURCE...DROP SUBSOURCE", subsource.quoted()),
+            Self::DropProgressCollection { progress_collection, source: _} => write!(f, "SOURCE {} is a progress collection and cannot be dropped independently of its primary source", progress_collection.quoted()),
             Self::InvalidOptionValue { option_name, err } => write!(f, "invalid {} option value: {}", option_name, err),
             Self::UnexpectedDuplicateReference { name } => write!(f, "unexpected multiple references to {}", name.to_ast_string()),
             Self::RecursiveTypeMismatch(name, declared, inferred) => {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3738,8 +3738,9 @@ fn plan_drop_item_inner(
         Some(catalog_item) => {
             if catalog_item.id().is_system() {
                 sql_bail!(
-                    "cannot drop item {} because it is required by the database system",
-                    scx.catalog.resolve_full_name(catalog_item.name()),
+                    "cannot drop {} {} because it is required by the database system",
+                    catalog_item.item_type(),
+                    scx.catalog.minimal_qualification(catalog_item.name()),
                 );
             }
             let item_type = catalog_item.item_type();
@@ -3823,8 +3824,10 @@ fn plan_drop_item_inner(
                         if dependency_prevents_drop(object_type, dep) {
                             // TODO: Add a hint to add cascade.
                             sql_bail!(
-                                "cannot drop {}: still depended upon by catalog item '{}'",
+                                "cannot drop {} {}: still depended upon by {} {}",
+                                catalog_item.item_type(),
                                 scx.catalog.minimal_qualification(catalog_item.name()),
+                                dep.item_type(),
                                 scx.catalog.minimal_qualification(dep.name())
                             );
                         }

--- a/test/pg-cdc-resumption/alter-mz.td
+++ b/test/pg-cdc-resumption/alter-mz.td
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> ALTER SOURCE mz_source DROP SUBSOURCE t0;

--- a/test/pg-cdc-resumption/mzcompose.py
+++ b/test/pg-cdc-resumption/mzcompose.py
@@ -76,16 +76,24 @@ def disconnect_pg_during_snapshot(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
+        "alter-mz.td",
     )
 
 
 def restart_pg_during_snapshot(c: Composition) -> None:
     restart_pg(c)
 
-    c.run("testdrive", "delete-rows-t1.td", "delete-rows-t2.td", "alter-table.td")
+    c.run(
+        "testdrive",
+        "delete-rows-t1.td",
+        "delete-rows-t2.td",
+        "alter-table.td",
+        "alter-mz.td",
+    )
 
 
 def restart_mz_during_snapshot(c: Composition) -> None:
+    c.run("testdrive", "alter-mz.td")
     restart_mz(c)
 
     c.run("testdrive", "delete-rows-t1.td", "delete-rows-t2.td", "alter-table.td")
@@ -98,13 +106,20 @@ def disconnect_pg_during_replication(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
+        "alter-mz.td",
         "toxiproxy-close-connection.td",
         "toxiproxy-restore-connection.td",
     )
 
 
 def restart_pg_during_replication(c: Composition) -> None:
-    c.run("testdrive", "wait-for-snapshot.td", "delete-rows-t1.td", "alter-table.td")
+    c.run(
+        "testdrive",
+        "wait-for-snapshot.td",
+        "delete-rows-t1.td",
+        "alter-table.td",
+        "alter-mz.td",
+    )
 
     restart_pg(c)
 
@@ -112,7 +127,13 @@ def restart_pg_during_replication(c: Composition) -> None:
 
 
 def restart_mz_during_replication(c: Composition) -> None:
-    c.run("testdrive", "wait-for-snapshot.td", "delete-rows-t1.td", "alter-table.td")
+    c.run(
+        "testdrive",
+        "wait-for-snapshot.td",
+        "delete-rows-t1.td",
+        "alter-table.td",
+        "alter-mz.td",
+    )
 
     restart_mz(c)
 
@@ -125,6 +146,7 @@ def fix_pg_schema_while_mz_restarts(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
+        "alter-mz.td",
         "verify-data.td",
         "alter-table-fix.td",
     )
@@ -144,4 +166,5 @@ def verify_no_snapshot_reingestion(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
+        "alter-mz.td",
     )

--- a/test/pg-cdc-resumption/verify-data.td
+++ b/test/pg-cdc-resumption/verify-data.td
@@ -25,3 +25,6 @@ contains:has been altered
 # Ensure non-definite errors are cleared.
 > SELECT COUNT(*) = 0 FROM mz_internal.mz_source_statuses WHERE error LIKE '%Connection refused%';
 true
+
+! SELECT * FROM t0
+contains:unknown catalog item 't0'

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -1,0 +1,208 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# IMPORTANT: The Postgres server has a custom pg_hba.conf that only
+# accepts connections from specific users. You will have to update
+# pg_hba.conf if you modify the existing user names or add new ones.
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO table_a VALUES (1, 'one');
+ALTER TABLE table_a REPLICA IDENTITY FULL;
+INSERT INTO table_a VALUES (2, 'two');
+
+CREATE TABLE table_b (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO table_b VALUES (1, 'one');
+ALTER TABLE table_b REPLICA IDENTITY FULL;
+INSERT INTO table_b VALUES (2, 'two');
+
+CREATE TABLE table_c (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO table_c VALUES (1, 'one');
+ALTER TABLE table_c REPLICA IDENTITY FULL;
+INSERT INTO table_c VALUES (2, 'two');
+
+CREATE TABLE table_d (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO table_d VALUES (1, 'one');
+ALTER TABLE table_d REPLICA IDENTITY FULL;
+INSERT INTO table_d VALUES (2, 'two');
+
+CREATE TABLE table_e (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO table_e VALUES (1, 'one');
+ALTER TABLE table_e REPLICA IDENTITY FULL;
+INSERT INTO table_e VALUES (2, 'two');
+
+CREATE TABLE table_f (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO table_f VALUES (1, 'one');
+ALTER TABLE table_f REPLICA IDENTITY FULL;
+INSERT INTO table_f VALUES (2, 'two');
+
+CREATE TABLE table_g (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO table_g VALUES (1, 'one');
+ALTER TABLE table_g REPLICA IDENTITY FULL;
+INSERT INTO table_g VALUES (2, 'two');
+
+
+> CREATE SOURCE "mz_source"
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR SCHEMAS (public);
+
+> SHOW SUBSOURCES ON mz_source
+mz_source_progress    progress
+table_a               subsource
+table_b               subsource
+table_c               subsource
+table_d               subsource
+table_e               subsource
+table_f               subsource
+table_g               subsource
+
+# Show all tablestodo this should be splittable
+> SELECT regexp_match(create_sql, 'FOR TABLES \((.+?)\) EXPOSE')[1] FROM (SHOW CREATE SOURCE mz_source);
+"\"postgres\".\"public\".\"table_a\" AS \"materialize\".\"public\".\"table_a\", \"postgres\".\"public\".\"table_b\" AS \"materialize\".\"public\".\"table_b\", \"postgres\".\"public\".\"table_g\" AS \"materialize\".\"public\".\"table_g\", \"postgres\".\"public\".\"table_c\" AS \"materialize\".\"public\".\"table_c\", \"postgres\".\"public\".\"table_d\" AS \"materialize\".\"public\".\"table_d\", \"postgres\".\"public\".\"table_e\" AS \"materialize\".\"public\".\"table_e\", \"postgres\".\"public\".\"table_f\" AS \"materialize\".\"public\".\"table_f\""
+
+#
+# Error checking
+#
+
+! ALTER SOURCE mz_source DROP SUBSOURCE mz_source_progress
+contains:SOURCE "mz_source_progress" is a progress collection and cannot be dropped independently of its primary source
+
+! ALTER SOURCE mz_source DROP SUBSOURCE table_a, mz_source_progress
+contains:SOURCE "mz_source_progress" is a progress collection and cannot be dropped independently of its primary source
+
+! ALTER SOURCE mz_source DROP SUBSOURCE mz_source_progress, table_a
+contains:SOURCE "mz_source_progress" is a progress collection and cannot be dropped independently of its primary source
+
+! ALTER SOURCE mz_source DROP SUBSOURCE mz_source;
+contains:SOURCE "mz_source" is a not a subsource of "mz_source"
+
+> CREATE TABLE mz_table (a int);
+
+! ALTER SOURCE mz_source DROP SUBSOURCE mz_table;
+contains:"materialize.public.mz_table" is a table not a source
+
+> DROP TABLE mz_table;
+
+> CREATE SOURCE "mz_source_too"
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES (public.table_a AS t_a);
+
+! ALTER SOURCE mz_source DROP SUBSOURCE t_a;
+contains:SOURCE "t_a" is a not a subsource of "mz_source"
+
+! ALTER SOURCE mz_source DROP SUBSOURCE mz_source_too;
+contains:SOURCE "mz_source_too" is a not a subsource of "mz_source"
+
+> DROP SOURCE mz_source_too;
+
+! ALTER SOURCE mz_source DROP SUBSOURCE dne;
+contains:unknown catalog item 'dne'
+
+> ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS dne;
+
+> ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS dne, dne, dne;
+
+#
+# State checking
+#
+
+> SELECT * FROM table_b;
+1 one
+2 two
+
+> ALTER SOURCE mz_source DROP SUBSOURCE table_a;
+
+> SHOW SUBSOURCES ON mz_source
+mz_source_progress    progress
+table_b               subsource
+table_c               subsource
+table_d               subsource
+table_e               subsource
+table_f               subsource
+table_g               subsource
+
+! SELECT * FROM table_a;
+contains: unknown catalog item 'table_a'
+
+# Makes progress after dropping subsources
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO table_b VALUES (3, 'three');
+
+> SELECT * FROM table_b;
+1 one
+2 two
+3 three
+
+# IF EXISTS works
+> ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_a;
+
+# Multiple, repetitive tables work
+> ALTER SOURCE mz_source DROP SUBSOURCE table_b, table_c, table_b, table_c, table_b, table_c;
+
+# IF EXISTS works with multiple tables
+> ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_c, table_d;
+
+> CREATE MATERIALIZED VIEW mv_e AS SELECT pk + 1 FROM table_e;
+> CREATE MATERIALIZED VIEW mv_f AS SELECT pk + 1 FROM table_f;
+
+# Makes progress after dropping subsources
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO table_e VALUES (3, 'three');
+
+> SELECT * FROM mv_e;
+2
+3
+4
+
+> SHOW MATERIALIZED VIEWS
+mv_e default
+mv_f default
+
+# RESTRICT works
+! ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e;
+contains:cannot drop source table_e: still depended upon by materialized view mv_e
+
+# CASCADE works
+> ALTER SOURCE mz_source DROP SUBSOURCE table_e CASCADE;
+
+# IF NOT EXISTS + CASCADE works
+> ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e, table_f CASCADE;
+
+> SHOW SUBSOURCES ON mz_source
+mz_source_progress    progress
+table_g               subsource
+
+> SHOW MATERIALIZED VIEWS
+
+# PG sources must retain at least one subsource, if nothing else than for parsing reasons, i.e.
+# empty input for subsources is invalid.
+! ALTER SOURCE mz_source DROP SUBSOURCE table_g;
+contains:SOURCE "mz_source" must retain at least one non-progress subsource
+
+# Show that all table definitions have been updated
+> SELECT regexp_match(create_sql, 'FOR TABLES \((.+?)\) EXPOSE') FROM (SHOW CREATE SOURCE mz_source);
+"{\"postgres\".\"public\".\"table_g\" AS \"materialize\".\"public\".\"table_g\"}"

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -303,10 +303,10 @@ $ unset-regex
 
 # Cannot drop subsources independent of primary source
 ! DROP SOURCE conflict_table
-contains: SOURCE materialize.public.conflict_table is a subsource and cannot be dropped independently of its primary source
+contains: SOURCE "conflict_table" is a subsource and must be dropped with ALTER SOURCE...DROP SUBSOURCE
 
 ! DROP SOURCE conflict_table CASCADE
-contains: SOURCE materialize.public.conflict_table is a subsource and cannot be dropped independently of its primary source
+contains: SOURCE "conflict_table" is a subsource and must be dropped with ALTER SOURCE...DROP SUBSOURCE
 
 > SELECT * FROM no_replica_identity;
 1

--- a/test/pg-cdc/privileges.td
+++ b/test/pg-cdc/privileges.td
@@ -84,4 +84,4 @@ REVOKE SELECT ON public."""select""" FROM priv;
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR SCHEMAS(public);
 contains:failed to connect to PostgreSQL database
-detail:user priv lacks SELECT privileges for tables public."select", public."""select"""
+detail:user priv lacks SELECT privileges for tables public."""select""", public."select"

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -211,7 +211,7 @@ CREATE MATERIALIZED VIEW mv AS SELECT 1
 statement ok
 CREATE VIEW v AS SELECT * FROM mv
 
-statement error cannot drop materialize.public.mv: still depended upon by catalog item 'materialize.public.v'
+statement error cannot drop materialized view mv: still depended upon by view v
 DROP MATERIALIZED VIEW mv
 
 

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -71,7 +71,7 @@ first second
 
 # Confirm we cannot drop the connection while a source depends upon it
 ! DROP CONNECTION testconn;
-contains:depended upon by catalog item 'materialize.public.connection_source'
+contains:depended upon by source connection_source
 
 # Confirm the drop works if we add cascade
 > DROP CONNECTION testconn CASCADE;
@@ -163,7 +163,7 @@ id creature
 1  lizard
 
 ! DROP CONNECTION csr_conn
-contains:depended upon by catalog item 'materialize.public.csr_source'
+contains:depended upon by source csr_source
 
 > DROP CONNECTION csr_conn CASCADE
 

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -50,23 +50,23 @@ contains:source "materialize.public.s" already exists
 > CREATE VIEW test3b AS SELECT * FROM test2;
 
 ! DROP VIEW test1;
-contains:cannot drop materialize.public.test1: still depended upon by catalog item 'materialize.public.test2'
+contains:cannot drop view test1: still depended upon by view test2
 
 ! DROP VIEW test2;
-contains:cannot drop materialize.public.test2: still depended upon by catalog item 'materialize.public.test3a'
+contains:cannot drop view test2: still depended upon by view test3a
 
 > DROP VIEW test3a;
 
 ! DROP VIEW test1;
-contains:cannot drop materialize.public.test1: still depended upon by catalog item 'materialize.public.test2'
+contains:cannot drop view test1: still depended upon by view test2
 
 ! DROP VIEW test2;
-contains:cannot drop materialize.public.test2: still depended upon by catalog item 'materialize.public.test3b'
+contains:cannot drop view test2: still depended upon by view test3b
 
 > DROP VIEW test3b;
 
 ! DROP VIEW test1;
-contains:cannot drop materialize.public.test1: still depended upon by catalog item 'materialize.public.test2'
+contains:cannot drop view test1: still depended upon by view test2
 
 > DROP VIEW test2;
 
@@ -317,14 +317,14 @@ contains:unknown catalog item 'j2'
 > CREATE VIEW v1 AS SELECT CAST('{2}' AS int4_list)
 
 ! DROP TYPE int4_list
-contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+contains:cannot drop type int4_list: still depended upon by view v1
 
 > DROP VIEW v1
 
 > CREATE TABLE t1 (custom int4_list)
 
 ! DROP TYPE int4_list
-contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.t1'
+contains:cannot drop type int4_list: still depended upon by table t1
 
 > DROP TABLE t1
 
@@ -333,28 +333,28 @@ contains:cannot drop materialize.public.int4_list: still depended upon by catalo
 > CREATE VIEW v1 AS SELECT * FROM ( SELECT CAST('{2}' AS int4_list) )
 
 ! DROP TYPE int4_list
-contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+contains:cannot drop type int4_list: still depended upon by view v1
 
 > DROP VIEW v1
 
 > CREATE VIEW v1 AS SELECT CAST(CAST('{2}' AS int4_list) AS text)
 
 ! DROP TYPE int4_list
-contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+contains:cannot drop type int4_list: still depended upon by view v1
 
 > DROP VIEW v1
 
 > CREATE VIEW v1 AS VALUES (CAST('{2}' AS int4_list))
 
 ! DROP TYPE int4_list
-contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+contains:cannot drop type int4_list: still depended upon by view v1
 
 > DROP VIEW v1
 
 > CREATE VIEW v1 AS SELECT MIN(CAST(CAST('{1}' AS int4_list) AS string))
 
 ! DROP TYPE int4_list
-contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+contains:cannot drop type int4_list: still depended upon by view v1
 
 > DROP VIEW v1
 
@@ -365,7 +365,7 @@ contains:cannot drop materialize.public.int4_list: still depended upon by catalo
 > CREATE TEMPORARY TABLE t1 (f1 int4_list)
 
 ! DROP TYPE int4_list
-contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'mz_temp.t1'
+contains:cannot drop type int4_list: still depended upon by table t1
 
 > DROP TABLE t1
 
@@ -374,14 +374,14 @@ contains:cannot drop materialize.public.int4_list: still depended upon by catalo
 > CREATE INDEX i1 ON t1 (CAST(f1 AS int4_list))
 
 ! DROP TYPE int4_list
-contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.i1'
+contains:cannot drop type int4_list: still depended upon by index i1
 
 > DROP TABLE t1
 
 > CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list)
 
 ! DROP TYPE int4_list
-contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.int4_list_list'
+contains:cannot drop type int4_list: still depended upon by type int4_list_list
 
 > DROP TYPE int4_list_list
 
@@ -407,7 +407,7 @@ contains:cannot drop materialize.public.int4_list: still depended upon by catalo
 2
 
 ! CREATE OR REPLACE VIEW v3 AS SELECT 3
-contains:cannot drop materialize.public.v3: still depended upon by catalog item 'materialize.public.v4'
+contains:cannot drop view v3: still depended upon by view v4
 
 > CREATE OR REPLACE VIEW v4 AS SELECT 3
 > SELECT * FROM v4
@@ -427,7 +427,7 @@ contains:cannot drop materialize.public.v3: still depended upon by catalog item 
 > CREATE VIEW test2 AS SELECT * FROM test1;
 
 ! DROP VIEW test1;
-contains:cannot drop materialize.public.test1: still depended upon by catalog item 'materialize.public.test2'
+contains:cannot drop view test1: still depended upon by view test2
 
 # Succeeds even though it's dependent on.
 > CREATE VIEW IF NOT EXISTS test1 AS SELECT 2 as b;

--- a/test/testdrive/list.td
+++ b/test/testdrive/list.td
@@ -48,10 +48,10 @@ name
 bool
 
 ! DROP TYPE bool
-contains:cannot drop item pg_catalog.bool because it is required by the database system
+contains:cannot drop type bool because it is required by the database system
 
 ! DROP TYPE public.bool
-contains:cannot drop materialize.public.bool: still depended upon by catalog item 'materialize.public.another_custom'
+contains:cannot drop type public.bool: still depended upon by type another_custom
 
 > DROP TYPE another_custom
 

--- a/test/testdrive/logging.td
+++ b/test/testdrive/logging.td
@@ -88,10 +88,10 @@ $ set-regex match=s\d+ replacement=SID
 contains:cannot drop schema mz_internal because it is required by the database system
 
 ! DROP VIEW mz_internal.mz_compute_frontiers
-contains:cannot drop item mz_internal.mz_compute_frontiers because it is required by the database system
+contains:cannot drop view mz_internal.mz_compute_frontiers because it is required by the database system
 
 ! DROP SOURCE mz_internal.mz_compute_delays_histogram_raw
-contains:cannot drop item mz_internal.mz_compute_delays_histogram_raw because it is required by the database system
+contains:cannot drop source mz_internal.mz_compute_delays_histogram_raw because it is required by the database system
 
 > SELECT mz_columns.id, mz_columns.name, position, type
   FROM mz_views JOIN mz_columns USING (id)

--- a/test/testdrive/map.td
+++ b/test/testdrive/map.td
@@ -48,10 +48,10 @@ name
 bool
 
 ! DROP TYPE bool
-contains:cannot drop item pg_catalog.bool because it is required by the database system
+contains:cannot drop type bool because it is required by the database system
 
 ! DROP TYPE public.bool
-contains:cannot drop materialize.public.bool: still depended upon by catalog item 'materialize.public.another_custom'
+contains:cannot drop type public.bool: still depended upon by type another_custom
 
 > DROP TYPE another_custom
 

--- a/test/testdrive/temporary.td
+++ b/test/testdrive/temporary.td
@@ -219,7 +219,7 @@ contains:Expected DATABASE, SCHEMA, ROLE, TYPE, INDEX, SINK, SOURCE, TABLE, SECR
 #####################################################################
 
 ! DROP VIEW temp_v;
-contains:cannot drop mz_temp.temp_v: still depended upon by catalog item 'mz_temp.double_temp_v'
+contains:cannot drop view temp_v: still depended upon by view double_temp_v
 
 > DROP VIEW double_temp_v;
 


### PR DESCRIPTION
Adds the ability to drop subsources from a source.

@MaterializeInc/surfaces Almost all of this code is surfaces/adapter code, so will need someone from your team to review much of it. Glad to set aside time for a walkthrough/discussion.

@MaterializeInc/qa This is a large change, so please provide a full-court press.

@petrosagg Obviously very glad for your review, but not strictly necessary.

### Motivation

Part of #15832

### Tips for reviewer

Lots of commits, many of them introduce code that is only used much later during planning and sequencing. Might be good to have the final commit state open in one window and then review commit-by-commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support removing individual tables from Postgres sources using `ALTER SOURCE...DROP SUBSOURCE...` (the more general term for PG sources' tables is subsources).
