### PR TITLE
adapter: Give mz_introspection USAGE on clusters

### DIFF
--- a/misc/python/materialize/checks/default_privileges.py
+++ b/misc/python/materialize/checks/default_privileges.py
@@ -73,6 +73,7 @@ class DefaultPrivileges(Check):
                   LEFT JOIN mz_databases AS databases ON defaults.database_id = databases.id
                   LEFT JOIN mz_schemas AS schemas ON defaults.schema_id = schemas.id
                   ORDER BY role_name, grantee_name;
+                PUBLIC <null> <null> CLUSTER mz_introspection U
                 PUBLIC <null> <null> TYPE PUBLIC U
                 materialize defpriv_db defpriv_schema TABLE defpriv_role1 arwd
                 materialize defpriv_db defpriv_schema TABLE defpriv_role2 arwd

--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -320,6 +320,7 @@ class Owners(Check):
                 contains: column "privileges" does not exist
 
                 > SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name LIKE 'owner_cluster%'
+                owner_cluster1 mz_introspection=U/owner_role_01
                 owner_cluster1 owner_role_01=UC/owner_role_01
 
                 > SELECT name, unnest(privileges)::text FROM mz_connections WHERE name LIKE 'owner_%'

--- a/src/adapter/src/catalog/storage/stash.rs
+++ b/src/adapter/src/catalog/storage/stash.rs
@@ -362,6 +362,11 @@ pub async fn initialize(
             grantor: Some(MZ_SYSTEM_ROLE_ID.into_proto()),
             acl_mode: Some(AclMode::USAGE.into_proto()),
         },
+        proto::MzAclItem {
+            grantee: Some(MZ_INTROSPECTION_ROLE_ID.into_proto()),
+            grantor: Some(MZ_SYSTEM_ROLE_ID.into_proto()),
+            acl_mode: Some(AclMode::USAGE.into_proto()),
+        },
         rbac::owner_privilege(mz_sql::catalog::ObjectType::Cluster, MZ_SYSTEM_ROLE_ID).into_proto(),
     ];
 

--- a/src/adapter/src/catalog/storage/stash.rs
+++ b/src/adapter/src/catalog/storage/stash.rs
@@ -560,18 +560,34 @@ pub async fn initialize(
     DEFAULT_PRIVILEGES_COLLECTION
         .initialize(
             tx,
-            vec![(
-                proto::DefaultPrivilegesKey {
-                    role_id: Some(RoleId::Public.into_proto()),
-                    database_id: None,
-                    schema_id: None,
-                    object_type: mz_sql::catalog::ObjectType::Type.into_proto().into(),
-                    grantee: Some(RoleId::Public.into_proto()),
-                },
-                proto::DefaultPrivilegesValue {
-                    privileges: Some(AclMode::USAGE.into_proto()),
-                },
-            )],
+            vec![
+                // mz_introspection needs USAGE privileges on all clusters for the
+                // prometheus-exporter.
+                (
+                    proto::DefaultPrivilegesKey {
+                        role_id: Some(RoleId::Public.into_proto()),
+                        database_id: None,
+                        schema_id: None,
+                        object_type: mz_sql::catalog::ObjectType::Cluster.into_proto().into(),
+                        grantee: Some(MZ_INTROSPECTION_ROLE_ID.into_proto()),
+                    },
+                    proto::DefaultPrivilegesValue {
+                        privileges: Some(AclMode::USAGE.into_proto()),
+                    },
+                ),
+                (
+                    proto::DefaultPrivilegesKey {
+                        role_id: Some(RoleId::Public.into_proto()),
+                        database_id: None,
+                        schema_id: None,
+                        object_type: mz_sql::catalog::ObjectType::Type.into_proto().into(),
+                        grantee: Some(RoleId::Public.into_proto()),
+                    },
+                    proto::DefaultPrivilegesValue {
+                        privileges: Some(AclMode::USAGE.into_proto()),
+                    },
+                ),
+            ],
         )
         .await?;
     SYSTEM_PRIVILEGES_COLLECTION

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -34,5 +34,9 @@
   {
     "name": "objects_v22.proto",
     "md5": "64a606a4e034cb9ab0e30f8ad02d4d02"
+  },
+  {
+    "name": "objects_v23.proto",
+    "md5": "167bdf10e2e9681049ec4d23352dc15a"
   }
 ]

--- a/src/stash/protos/objects_v23.proto
+++ b/src/stash/protos/objects_v23.proto
@@ -1,0 +1,552 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// This protobuf file defines the types we store in the Stash.
+//
+// Before and after modifying this file, make sure you have a snapshot of the before version,
+// e.g. a copy of this file named 'objects_v{STASH_VERSION}.proto', and a snapshot of the file
+// after your modifications, e.g. 'objects_v{STASH_VERSION + 1}.proto'. Then you can write a
+// migration using these two files, and no matter how they types change in the future, we'll always
+// have these snapshots to facilitate the migration.
+
+
+syntax = "proto3";
+
+package objects_v23;
+
+message ConfigKey {
+    string key = 1;
+}
+
+message ConfigValue {
+    uint64 value = 1;
+}
+
+message SettingKey {
+    string name = 1;
+}
+
+message SettingValue {
+    string value = 1;
+}
+
+message IdAllocKey {
+    string name = 1;
+}
+
+message IdAllocValue {
+    uint64 next_id = 1;
+}
+
+message GidMappingKey {
+    string schema_name = 1;
+    CatalogItemType object_type = 2;
+    string object_name = 3;
+}
+
+message GidMappingValue {
+    uint64 id = 1;
+    string fingerprint = 2;
+}
+
+message ClusterKey {
+    ClusterId id = 1;
+}
+
+message ClusterValue {
+    string name = 1;
+    GlobalId linked_object_id = 2;
+    RoleId owner_id = 3;
+    repeated MzAclItem privileges = 4;
+    ClusterConfig config = 5;
+}
+
+message ClusterIntrospectionSourceIndexKey {
+    ClusterId cluster_id = 1;
+    string name = 2;
+}
+
+message ClusterIntrospectionSourceIndexValue {
+    uint64 index_id = 1;
+}
+
+message ClusterReplicaKey {
+    ReplicaId id = 1;
+}
+
+message ClusterReplicaValue {
+    ClusterId cluster_id = 1;
+    string name = 2;
+    ReplicaConfig config = 3;
+    RoleId owner_id = 4;
+}
+
+message DatabaseKey {
+    DatabaseId id = 1;
+}
+
+message DatabaseValue {
+    string name = 1;
+    RoleId owner_id = 2;
+    repeated MzAclItem privileges = 3;
+}
+
+message SchemaKey {
+    SchemaId id = 1;
+}
+
+message SchemaValue {
+    DatabaseId database_id = 1;
+    string name = 2;
+    RoleId owner_id = 3;
+    repeated MzAclItem privileges = 4;
+}
+
+message ItemKey {
+    GlobalId gid = 1;
+}
+
+message ItemValue {
+    SchemaId schema_id = 1;
+    string name = 2;
+    CatalogItem definition = 3;
+    RoleId owner_id = 4;
+    repeated MzAclItem privileges = 5;
+}
+
+message RoleKey {
+    RoleId id = 1;
+}
+
+message RoleValue {
+    string name = 1;
+    RoleAttributes attributes = 2;
+    RoleMembership membership = 3;
+}
+
+message TimestampKey {
+    string id = 1;
+}
+
+message TimestampValue {
+    Timestamp ts = 1;
+}
+
+message ServerConfigurationKey {
+    string name = 1;
+}
+
+message ServerConfigurationValue {
+    string value = 1;
+}
+
+message AuditLogKey {
+    oneof event {
+        AuditLogEventV1 v1 = 1;
+    }
+}
+
+message StorageUsageKey {
+    message StorageUsageV1 {
+        uint64 id = 1;
+        StringWrapper shard_id = 2;
+        uint64 size_bytes = 3;
+        EpochMillis collection_timestamp = 4;
+    }
+
+    oneof usage {
+        StorageUsageV1 v1 = 1;
+    }
+}
+
+message SinkAsOf {
+    TimestampAntichain frontier = 1;
+    bool strict = 2;
+}
+
+message DurableCollectionMetadata {
+    reserved 1;
+    reserved "remap_shard";
+
+    // StringWrapper remap_shard = 1;
+    string data_shard = 2;
+}
+
+message DurableExportMetadata {
+    SinkAsOf initial_as_of = 1;
+}
+
+// ---- Common Types
+//
+// Note: Normally types like this would go in some sort of `common.proto` file, but we want to keep
+// our proto definitions in a single file to make snapshotting easier, hence them living here.
+
+message Empty { /* purposefully empty */ }
+
+// In protobuf a "None" string is the same thing as an empty string. To get the same semantics of
+// an `Option<String>` from Rust, we need to wrap a string in a message.
+message StringWrapper {
+    string inner = 1;
+}
+
+message Duration {
+    uint64 secs = 1;
+    uint32 nanos = 2;
+}
+
+message EpochMillis {
+    uint64 millis = 1;
+}
+
+// Opaque timestamp type that is specific to Materialize.
+message Timestamp {
+    uint64 internal = 1;
+}
+
+enum CatalogItemType {
+    CATALOG_ITEM_TYPE_UNKNOWN = 0;
+    CATALOG_ITEM_TYPE_TABLE = 1;
+    CATALOG_ITEM_TYPE_SOURCE = 2;
+    CATALOG_ITEM_TYPE_SINK = 3;
+    CATALOG_ITEM_TYPE_VIEW = 4;
+    CATALOG_ITEM_TYPE_MATERIALIZED_VIEW = 5;
+    CATALOG_ITEM_TYPE_INDEX = 6;
+    CATALOG_ITEM_TYPE_TYPE = 7;
+    CATALOG_ITEM_TYPE_FUNC = 8;
+    CATALOG_ITEM_TYPE_SECRET = 9;
+    CATALOG_ITEM_TYPE_CONNECTION = 10;
+}
+
+message CatalogItem {
+    message V1 {
+        string create_sql = 1;
+    }
+
+    oneof value {
+        V1 v1 = 1;
+    }
+}
+
+message GlobalId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        uint64 transient = 3;
+        Empty explain = 4;
+    }
+}
+
+message ClusterId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message DatabaseId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message SchemaId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message ReplicaId {
+    uint64 value = 1;
+}
+
+message ReplicaLogging {
+    bool log_logging = 1;
+    Duration interval = 2;
+}
+
+message ReplicaMergeEffort {
+    uint32 effort = 1;
+}
+
+message ClusterConfig {
+    message ManagedCluster {
+        string size = 1;
+        uint32 replication_factor = 2;
+        repeated string availability_zones = 3;
+        ReplicaLogging logging = 4;
+        ReplicaMergeEffort idle_arrangement_merge_effort = 5;
+    }
+
+    oneof variant {
+        Empty unmanaged = 1;
+        ManagedCluster managed = 2;
+    }
+}
+
+message ReplicaConfig {
+    message UnmanagedLocation {
+        repeated string storagectl_addrs = 1;
+        repeated string storage_addrs = 2;
+        repeated string computectl_addrs = 3;
+        repeated string compute_addrs = 4;
+        uint64 workers = 5;
+    }
+
+    message ManagedLocation {
+        string size = 1;
+        string availability_zone = 2;
+        bool az_user_specified = 3;
+    }
+
+    oneof location {
+        UnmanagedLocation unmanaged = 1;
+        ManagedLocation managed = 2;
+    }
+    ReplicaLogging logging = 3;
+    ReplicaMergeEffort idle_arrangement_merge_effort = 4;
+}
+
+message RoleId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        Empty public = 3;
+    }
+}
+
+message RoleAttributes {
+    bool inherit = 1;
+    bool create_role = 2;
+    bool create_db = 3;
+    bool create_cluster = 4;
+}
+
+message RoleMembership {
+    message Entry {
+        RoleId key = 1;
+        RoleId value = 2;
+    }
+
+    repeated Entry map = 1;
+}
+
+message AclMode {
+    // A bit flag representing all the privileges that can be granted to a role.
+    uint64 bitflags = 1;
+}
+
+message MzAclItem {
+    RoleId grantee = 1;
+    RoleId grantor = 2;
+    AclMode acl_mode = 3;
+}
+
+message TimestampAntichain {
+    repeated Timestamp elements = 1;
+}
+
+enum ObjectType {
+    OBJECT_TYPE_UNKNOWN = 0;
+    OBJECT_TYPE_TABLE = 1;
+    OBJECT_TYPE_VIEW = 2;
+    OBJECT_TYPE_MATERIALIZED_VIEW = 3;
+    OBJECT_TYPE_SOURCE = 4;
+    OBJECT_TYPE_SINK = 5;
+    OBJECT_TYPE_INDEX = 6;
+    OBJECT_TYPE_TYPE = 7;
+    OBJECT_TYPE_ROLE = 8;
+    OBJECT_TYPE_CLUSTER = 9;
+    OBJECT_TYPE_CLUSTER_REPLICA = 10;
+    OBJECT_TYPE_SECRET = 11;
+    OBJECT_TYPE_CONNECTION = 12;
+    OBJECT_TYPE_DATABASE = 13;
+    OBJECT_TYPE_SCHEMA = 14;
+    OBJECT_TYPE_FUNC = 15;
+}
+
+message DefaultPrivilegesKey {
+    RoleId role_id = 1;
+    DatabaseId database_id = 2;
+    SchemaId schema_id = 3;
+    ObjectType object_type = 4;
+    RoleId grantee = 5;
+}
+
+message DefaultPrivilegesValue {
+    AclMode privileges = 1;
+}
+
+message SystemPrivilegesKey {
+    MzAclItem privileges = 1;
+}
+
+message AuditLogEventV1 {
+    enum EventType {
+        EVENT_TYPE_UNKNOWN = 0;
+        EVENT_TYPE_CREATE = 1;
+        EVENT_TYPE_DROP = 2;
+        EVENT_TYPE_ALTER = 3;
+        EVENT_TYPE_GRANT = 4;
+        EVENT_TYPE_REVOKE = 5;
+    }
+
+    enum ObjectType {
+        OBJECT_TYPE_UNKNOWN = 0;
+        OBJECT_TYPE_CLUSTER = 1;
+        OBJECT_TYPE_CLUSTER_REPLICA = 2;
+        OBJECT_TYPE_CONNECTION = 3;
+        OBJECT_TYPE_DATABASE = 4;
+        OBJECT_TYPE_FUNC = 5;
+        OBJECT_TYPE_INDEX = 6;
+        OBJECT_TYPE_MATERIALIZED_VIEW = 7;
+        OBJECT_TYPE_ROLE = 8;
+        OBJECT_TYPE_SECRET = 9;
+        OBJECT_TYPE_SCHEMA = 10;
+        OBJECT_TYPE_SINK = 11;
+        OBJECT_TYPE_SOURCE = 12;
+        OBJECT_TYPE_TABLE = 13;
+        OBJECT_TYPE_TYPE = 14;
+        OBJECT_TYPE_VIEW = 15;
+    }
+
+    message IdFullNameV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+    }
+
+    message FullNameV1 {
+        string database = 1;
+        string schema = 2;
+        string item = 3;
+    }
+
+    message IdNameV1 {
+        string id = 1;
+        string name = 2;
+    }
+
+    message RenameClusterV1 {
+        string id = 1;
+        string old_name = 2;
+        string new_name = 3;
+    }
+
+    message RenameClusterReplicaV1 {
+        string cluster_id = 1;
+        string replica_id = 2;
+        string old_name = 3;
+        string new_name = 4;
+    }
+
+    message RenameItemV1 {
+        string id = 1;
+        FullNameV1 old_name = 2;
+        FullNameV1 new_name = 3;
+    }
+
+    message CreateClusterReplicaV1 {
+        string cluster_id = 1;
+        string cluser_name = 2;
+        StringWrapper replica_id = 3;
+        string replica_name = 4;
+        string logical_size = 5;
+    }
+
+    message DropClusterReplicaV1 {
+        string cluster_id = 1;
+        string cluster_name = 2;
+        StringWrapper replica_id = 3;
+        string replica_name = 4;
+    }
+
+    message CreateSourceSinkV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper size = 3;
+    }
+
+    message CreateSourceSinkV2 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper size = 3;
+        string external_type = 4;
+    }
+
+    message AlterSourceSinkV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper old_size = 3;
+        StringWrapper new_size = 4;
+    }
+
+    message GrantRoleV1 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+    }
+
+    message GrantRoleV2 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+        string executed_by = 4;
+    }
+
+    message RevokeRoleV1 {
+        string role_id = 1;
+        string member_id = 2;
+    }
+
+    message RevokeRoleV2 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+        string executed_by = 4;
+    }
+
+    message SchemaV1 {
+        string id = 1;
+        string name = 2;
+        string database_name = 3;
+    }
+
+    message SchemaV2 {
+        string id = 1;
+        string name = 2;
+        StringWrapper database_name = 3;
+    }
+
+    uint64 id = 1;
+    EventType event_type = 2;
+    ObjectType object_type = 3;
+    StringWrapper user = 4;
+    EpochMillis occurred_at = 5;
+
+    // next-id: 22
+    oneof details {
+        CreateClusterReplicaV1 create_cluster_replica_v1 = 6;
+        DropClusterReplicaV1 drop_cluster_replica_v1 = 7;
+        CreateSourceSinkV1 create_source_sink_v1 = 8;
+        CreateSourceSinkV2 create_source_sink_v2 = 9;
+        AlterSourceSinkV1 alter_source_sink_v1 = 10;
+        GrantRoleV1 grant_role_v1 = 11;
+        GrantRoleV2 grant_role_v2 = 12;
+        RevokeRoleV1 revoke_role_v1 = 13;
+        RevokeRoleV2 revoke_role_v2 = 14;
+        IdFullNameV1 id_full_name_v1 = 15;
+        RenameClusterV1 rename_cluster_v1 = 20;
+        RenameClusterReplicaV1 rename_cluster_replica_v1 = 21;
+        RenameItemV1 rename_item_v1 = 16;
+        IdNameV1 id_name_v1 = 17;
+        SchemaV1 schema_v1 = 18;
+        SchemaV2 schema_v2 = 19;
+    }
+}

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -102,7 +102,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 22;
+pub const STASH_VERSION: u64 = 23;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -951,6 +951,7 @@ impl Stash {
                             19 => upgrade::v19_to_v20::upgrade(&mut tx).await?,
                             20 => upgrade::v20_to_v21::upgrade(&mut tx).await?,
                             21 => upgrade::v21_to_v22::upgrade(&mut tx).await?,
+                            22 => upgrade::v22_to_v23::upgrade(&mut tx).await?,
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -57,6 +57,7 @@ pub mod v18_to_v19;
 pub mod v19_to_v20;
 pub mod v20_to_v21;
 pub mod v21_to_v22;
+pub mod v22_to_v23;
 
 pub use json_to_proto::migrate_json_to_proto;
 

--- a/src/stash/src/upgrade/v22_to_v23.rs
+++ b/src/stash/src/upgrade/v22_to_v23.rs
@@ -1,0 +1,457 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::upgrade::MigrationAction;
+use crate::{StashError, Transaction, TypedCollection};
+
+pub mod objects_v22 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v22.rs"));
+}
+pub mod objects_v23 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v23.rs"));
+}
+
+const MZ_SYSTEM_ROLE_ID: objects_v23::RoleId = objects_v23::RoleId {
+    value: Some(objects_v23::role_id::Value::System(1)),
+};
+const MZ_INTROSPECTION_ROLE_ID: objects_v23::RoleId = objects_v23::RoleId {
+    value: Some(objects_v23::role_id::Value::System(2)),
+};
+const PUBLIC_ROLE_ID: objects_v23::RoleId = objects_v23::RoleId {
+    value: Some(objects_v23::role_id::Value::Public(objects_v23::Empty {})),
+};
+const ACL_MODE_USAGE: objects_v23::AclMode = objects_v23::AclMode { bitflags: 1 << 8 };
+
+/// Give mz_introspection USAGE privileges on all clusters.
+pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {
+    const DEFAULT_PRIVILEGES_COLLECTION: TypedCollection<
+        objects_v22::DefaultPrivilegesKey,
+        objects_v22::DefaultPrivilegesValue,
+    > = TypedCollection::new("default_privileges");
+    const CLUSTER_COLLECTION: TypedCollection<objects_v22::ClusterKey, objects_v22::ClusterValue> =
+        TypedCollection::new("compute_instance");
+
+    DEFAULT_PRIVILEGES_COLLECTION
+        .migrate_to(tx, |entries| {
+            let mut updates = vec![MigrationAction::Insert(
+                objects_v23::DefaultPrivilegesKey {
+                    role_id: Some(PUBLIC_ROLE_ID),
+                    database_id: None,
+                    schema_id: None,
+                    object_type: objects_v23::ObjectType::Cluster.into(),
+                    grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                },
+                objects_v23::DefaultPrivilegesValue {
+                    privileges: Some(ACL_MODE_USAGE),
+                },
+            )];
+
+            for (key, value) in entries {
+                let new_key = key.clone().into();
+                let new_value = value.clone().into();
+                updates.push(MigrationAction::Update(key.clone(), (new_key, new_value)));
+            }
+
+            updates
+        })
+        .await?;
+
+    CLUSTER_COLLECTION
+        .migrate_to(tx, |entries| {
+            let mut updates = Vec::new();
+
+            for (key, value) in entries {
+                let new_key: objects_v23::ClusterKey = key.clone().into();
+                let mut new_value: objects_v23::ClusterValue = value.clone().into();
+                new_value.privileges.push(objects_v23::MzAclItem {
+                    grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                    grantor: Some(MZ_SYSTEM_ROLE_ID),
+                    acl_mode: Some(ACL_MODE_USAGE),
+                });
+                updates.push(MigrationAction::Update(key.clone(), (new_key, new_value)));
+            }
+
+            updates
+        })
+        .await?;
+
+    Ok(())
+}
+
+impl From<objects_v22::RoleId> for objects_v23::RoleId {
+    fn from(id: objects_v22::RoleId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v22::role_id::Value::User(id)) => {
+                Some(objects_v23::role_id::Value::User(id))
+            }
+            Some(objects_v22::role_id::Value::System(id)) => {
+                Some(objects_v23::role_id::Value::System(id))
+            }
+            Some(objects_v22::role_id::Value::Public(_)) => {
+                Some(objects_v23::role_id::Value::Public(Default::default()))
+            }
+        };
+        objects_v23::RoleId { value }
+    }
+}
+
+impl From<objects_v22::DatabaseId> for objects_v23::DatabaseId {
+    fn from(id: objects_v22::DatabaseId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v22::database_id::Value::User(id)) => {
+                Some(objects_v23::database_id::Value::User(id))
+            }
+            Some(objects_v22::database_id::Value::System(id)) => {
+                Some(objects_v23::database_id::Value::System(id))
+            }
+        };
+        objects_v23::DatabaseId { value }
+    }
+}
+
+impl From<objects_v22::SchemaId> for objects_v23::SchemaId {
+    fn from(id: objects_v22::SchemaId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v22::schema_id::Value::User(id)) => {
+                Some(objects_v23::schema_id::Value::User(id))
+            }
+            Some(objects_v22::schema_id::Value::System(id)) => {
+                Some(objects_v23::schema_id::Value::System(id))
+            }
+        };
+        objects_v23::SchemaId { value }
+    }
+}
+
+impl From<objects_v22::ObjectType> for objects_v23::ObjectType {
+    fn from(object_type: objects_v22::ObjectType) -> Self {
+        match object_type {
+            objects_v22::ObjectType::Unknown => objects_v23::ObjectType::Unknown,
+            objects_v22::ObjectType::Table => objects_v23::ObjectType::Table,
+            objects_v22::ObjectType::View => objects_v23::ObjectType::View,
+            objects_v22::ObjectType::MaterializedView => objects_v23::ObjectType::MaterializedView,
+            objects_v22::ObjectType::Source => objects_v23::ObjectType::Source,
+            objects_v22::ObjectType::Sink => objects_v23::ObjectType::Sink,
+            objects_v22::ObjectType::Index => objects_v23::ObjectType::Index,
+            objects_v22::ObjectType::Type => objects_v23::ObjectType::Type,
+            objects_v22::ObjectType::Role => objects_v23::ObjectType::Role,
+            objects_v22::ObjectType::Cluster => objects_v23::ObjectType::Cluster,
+            objects_v22::ObjectType::ClusterReplica => objects_v23::ObjectType::ClusterReplica,
+            objects_v22::ObjectType::Secret => objects_v23::ObjectType::Secret,
+            objects_v22::ObjectType::Connection => objects_v23::ObjectType::Connection,
+            objects_v22::ObjectType::Database => objects_v23::ObjectType::Database,
+            objects_v22::ObjectType::Schema => objects_v23::ObjectType::Schema,
+            objects_v22::ObjectType::Func => objects_v23::ObjectType::Func,
+        }
+    }
+}
+
+impl From<objects_v22::DefaultPrivilegesKey> for objects_v23::DefaultPrivilegesKey {
+    fn from(key: objects_v22::DefaultPrivilegesKey) -> Self {
+        objects_v23::DefaultPrivilegesKey {
+            role_id: key.role_id.map(Into::into),
+            database_id: key.database_id.map(Into::into),
+            schema_id: key.schema_id.map(Into::into),
+            object_type: key.object_type,
+            grantee: key.grantee.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v22::AclMode> for objects_v23::AclMode {
+    fn from(acl_mode: objects_v22::AclMode) -> Self {
+        objects_v23::AclMode {
+            bitflags: acl_mode.bitflags,
+        }
+    }
+}
+
+impl From<objects_v22::DefaultPrivilegesValue> for objects_v23::DefaultPrivilegesValue {
+    fn from(value: objects_v22::DefaultPrivilegesValue) -> Self {
+        objects_v23::DefaultPrivilegesValue {
+            privileges: value.privileges.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v22::ClusterId> for objects_v23::ClusterId {
+    fn from(cluster_id: objects_v22::ClusterId) -> Self {
+        let value = match cluster_id.value {
+            None => None,
+            Some(objects_v22::cluster_id::Value::System(id)) => {
+                Some(objects_v23::cluster_id::Value::System(id))
+            }
+            Some(objects_v22::cluster_id::Value::User(id)) => {
+                Some(objects_v23::cluster_id::Value::User(id))
+            }
+        };
+        Self { value }
+    }
+}
+
+impl From<objects_v22::MzAclItem> for objects_v23::MzAclItem {
+    fn from(item: objects_v22::MzAclItem) -> Self {
+        Self {
+            grantee: item.grantee.map(Into::into),
+            grantor: item.grantor.map(Into::into),
+            acl_mode: item.acl_mode.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v22::ClusterKey> for objects_v23::ClusterKey {
+    fn from(key: objects_v22::ClusterKey) -> Self {
+        Self {
+            id: key.id.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v22::Duration> for objects_v23::Duration {
+    fn from(duration: objects_v22::Duration) -> Self {
+        Self {
+            secs: duration.secs,
+            nanos: duration.nanos,
+        }
+    }
+}
+
+impl From<objects_v22::ReplicaLogging> for objects_v23::ReplicaLogging {
+    fn from(logging: objects_v22::ReplicaLogging) -> Self {
+        Self {
+            log_logging: logging.log_logging,
+            interval: logging.interval.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v22::ReplicaMergeEffort> for objects_v23::ReplicaMergeEffort {
+    fn from(merge_effort: objects_v22::ReplicaMergeEffort) -> Self {
+        Self {
+            effort: merge_effort.effort,
+        }
+    }
+}
+
+impl From<objects_v22::cluster_config::ManagedCluster>
+    for objects_v23::cluster_config::ManagedCluster
+{
+    fn from(managed_cluster: objects_v22::cluster_config::ManagedCluster) -> Self {
+        Self {
+            size: managed_cluster.size,
+            replication_factor: managed_cluster.replication_factor,
+            availability_zones: managed_cluster.availability_zones,
+            logging: managed_cluster.logging.map(Into::into),
+            idle_arrangement_merge_effort: managed_cluster
+                .idle_arrangement_merge_effort
+                .map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v22::cluster_config::Variant> for objects_v23::cluster_config::Variant {
+    fn from(variant: objects_v22::cluster_config::Variant) -> Self {
+        match variant {
+            objects_v22::cluster_config::Variant::Unmanaged(_) => {
+                Self::Unmanaged(Default::default())
+            }
+            objects_v22::cluster_config::Variant::Managed(managed_cluster) => {
+                Self::Managed(managed_cluster.into())
+            }
+        }
+    }
+}
+
+impl From<objects_v22::ClusterConfig> for objects_v23::ClusterConfig {
+    fn from(config: objects_v22::ClusterConfig) -> Self {
+        Self {
+            variant: config.variant.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v22::GlobalId> for objects_v23::GlobalId {
+    fn from(id: objects_v22::GlobalId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v22::global_id::Value::User(id)) => {
+                Some(objects_v23::global_id::Value::User(id))
+            }
+            Some(objects_v22::global_id::Value::System(id)) => {
+                Some(objects_v23::global_id::Value::System(id))
+            }
+            Some(objects_v22::global_id::Value::Transient(id)) => {
+                Some(objects_v23::global_id::Value::Transient(id))
+            }
+            Some(objects_v22::global_id::Value::Explain(_)) => {
+                Some(objects_v23::global_id::Value::Explain(Default::default()))
+            }
+        };
+        Self { value }
+    }
+}
+
+impl From<objects_v22::ClusterValue> for objects_v23::ClusterValue {
+    fn from(cluster: objects_v22::ClusterValue) -> Self {
+        Self {
+            name: cluster.name,
+            owner_id: cluster.owner_id.map(Into::into),
+            privileges: cluster.privileges.into_iter().map(Into::into).collect(),
+            linked_object_id: cluster.linked_object_id.map(Into::into),
+            config: cluster.config.map(Into::into),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::upgrade;
+
+    use crate::upgrade::v22_to_v23::{
+        objects_v22, objects_v23, ACL_MODE_USAGE, MZ_INTROSPECTION_ROLE_ID, MZ_SYSTEM_ROLE_ID,
+        PUBLIC_ROLE_ID,
+    };
+    use crate::{DebugStashFactory, TypedCollection};
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn smoke_test() {
+        const ACL_MODE_USAGE_V22: objects_v22::AclMode = objects_v22::AclMode { bitflags: 1 << 8 };
+        const MZ_SYSTEM_ROLE_ID_V22: objects_v22::RoleId = objects_v22::RoleId {
+            value: Some(objects_v22::role_id::Value::System(1)),
+        };
+
+        // Connect to the Stash.
+        let factory = DebugStashFactory::new().await;
+        let mut stash = factory.open_debug().await;
+
+        // Insert a cluster.
+        let clusters_v22: TypedCollection<objects_v22::ClusterKey, objects_v22::ClusterValue> =
+            TypedCollection::new("compute_instance");
+        clusters_v22
+            .insert_without_overwrite(
+                &mut stash,
+                vec![(
+                    objects_v22::ClusterKey {
+                        id: Some(objects_v22::ClusterId {
+                            value: Some(objects_v22::cluster_id::Value::User(42)),
+                        }),
+                    },
+                    objects_v22::ClusterValue {
+                        name: "dev".into(),
+                        owner_id: Some(objects_v22::RoleId {
+                            value: Some(objects_v22::role_id::Value::User(1)),
+                        }),
+                        privileges: vec![objects_v22::MzAclItem {
+                            grantee: Some(objects_v22::RoleId {
+                                value: Some(objects_v22::role_id::Value::User(2)),
+                            }),
+                            grantor: Some(MZ_SYSTEM_ROLE_ID_V22),
+                            acl_mode: Some(ACL_MODE_USAGE_V22),
+                        }],
+                        linked_object_id: None,
+                        config: Some(objects_v22::ClusterConfig {
+                            variant: Some(objects_v22::cluster_config::Variant::Unmanaged(
+                                Default::default(),
+                            )),
+                        }),
+                    },
+                )],
+            )
+            .await
+            .unwrap();
+
+        // Run our migration.
+        stash
+            .with_transaction(|mut tx| {
+                Box::pin(async move {
+                    upgrade(&mut tx).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .expect("migration failed");
+
+        // Read back the default privileges.
+        let default_privileges: TypedCollection<
+            objects_v23::DefaultPrivilegesKey,
+            objects_v23::DefaultPrivilegesValue,
+        > = TypedCollection::new("default_privileges");
+        let privileges = default_privileges.iter(&mut stash).await.unwrap();
+        // Filter down to just the keys and values to make comparisons easier.
+        let privileges: Vec<_> = privileges
+            .into_iter()
+            .map(|((key, value), _timestamp, _diff)| (key, value))
+            .collect();
+
+        assert!(privileges.contains(&(
+            objects_v23::DefaultPrivilegesKey {
+                role_id: Some(PUBLIC_ROLE_ID),
+                database_id: None,
+                schema_id: None,
+                object_type: objects_v23::ObjectType::Cluster.into(),
+                grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+            },
+            objects_v23::DefaultPrivilegesValue {
+                privileges: Some(ACL_MODE_USAGE),
+            }
+        )));
+
+        // Read back the cluster.
+        let clusters_v23: TypedCollection<objects_v23::ClusterKey, objects_v23::ClusterValue> =
+            TypedCollection::new("compute_instance");
+        let clusters = clusters_v23.iter(&mut stash).await.unwrap();
+        // Filter down to just the keys and values to make comparisons easier.
+        let mut clusters_v23: Vec<_> = clusters
+            .into_iter()
+            .map(|((key, value), _timestamp, _diff)| (key, value))
+            .collect();
+        clusters_v23.sort();
+
+        assert_eq!(
+            clusters_v23,
+            vec![(
+                objects_v23::ClusterKey {
+                    id: Some(objects_v23::ClusterId {
+                        value: Some(objects_v23::cluster_id::Value::User(42)),
+                    }),
+                },
+                objects_v23::ClusterValue {
+                    name: "dev".into(),
+                    owner_id: Some(objects_v23::RoleId {
+                        value: Some(objects_v23::role_id::Value::User(1)),
+                    }),
+                    privileges: vec![
+                        objects_v23::MzAclItem {
+                            grantee: Some(objects_v23::RoleId {
+                                value: Some(objects_v23::role_id::Value::User(2)),
+                            }),
+                            grantor: Some(MZ_SYSTEM_ROLE_ID),
+                            acl_mode: Some(ACL_MODE_USAGE),
+                        },
+                        objects_v23::MzAclItem {
+                            grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                            grantor: Some(MZ_SYSTEM_ROLE_ID),
+                            acl_mode: Some(ACL_MODE_USAGE),
+                        }
+                    ],
+                    linked_object_id: None,
+                    config: Some(objects_v23::ClusterConfig {
+                        variant: Some(objects_v23::cluster_config::Variant::Unmanaged(
+                            Default::default(),
+                        )),
+                    }),
+                },
+            )],
+        );
+    }
+}

--- a/test/sqllogictest/default_privileges.slt
+++ b/test/sqllogictest/default_privileges.slt
@@ -27,7 +27,8 @@ COMPLETE 0
 query TTTTTT
 SELECT * FROM mz_default_privileges
 ----
-p  NULL  NULL  TYPE  p  U
+p  NULL  NULL  TYPE     p   U
+p  NULL  NULL  CLUSTER  s2  U
 
 statement ok
 CREATE TYPE ty AS LIST (ELEMENT TYPE = int4);
@@ -56,6 +57,7 @@ LEFT JOIN mz_roles AS roles ON defaults.role_id = roles.id
 LEFT JOIN mz_roles AS grantees ON defaults.grantee = grantees.id
 LEFT JOIN mz_databases AS databases ON defaults.database_id = databases.id
 LEFT JOIN mz_schemas AS schemas ON defaults.schema_id = schemas.id
+WHERE grantees.name IS NULL OR grantees.name <> 'mz_introspection'
 ORDER BY role_name, grantee_name
 
 # Test altering default privileges
@@ -4539,6 +4541,7 @@ c  r2=U/materialize
 c  r1=UC/materialize
 c  r3=UC/materialize
 c  materialize=UC/materialize
+c  mz_introspection=U/materialize
 
 statement ok
 DROP CLUSTER c
@@ -4553,6 +4556,7 @@ SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
 ----
 c  r8=C/r6
 c  r6=UC/r6
+c  mz_introspection=U/r6
 
 simple conn=r6,user=r6
 DROP CLUSTER c
@@ -4569,6 +4573,7 @@ SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
 ----
 c  r8=C/r7
 c  r7=UC/r7
+c  mz_introspection=U/r7
 
 simple conn=r7,user=r7
 DROP CLUSTER c
@@ -4584,6 +4589,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
 ----
 c  r9=UC/r9
+c  mz_introspection=U/r9
 
 simple conn=r9,user=r9
 DROP CLUSTER c
@@ -4651,6 +4657,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
 ----
 c  materialize=UC/materialize
+c  mz_introspection=U/materialize
 
 statement ok
 DROP CLUSTER c
@@ -4664,6 +4671,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
 ----
 c  r6=UC/r6
+c  mz_introspection=U/r6
 
 simple conn=r6,user=r6
 DROP CLUSTER c
@@ -4679,6 +4687,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
 ----
 c  r7=UC/r7
+c  mz_introspection=U/r7
 
 simple conn=r7,user=r7
 DROP CLUSTER c
@@ -4694,6 +4703,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name = 'c'
 ----
 c  r9=UC/r9
+c  mz_introspection=U/r9
 
 simple conn=r9,user=r9
 DROP CLUSTER c
@@ -5033,6 +5043,9 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA mz_catalog GRANT INSERT ON TABLES TO PUBLIC
 
 statement error role name "mz_system" is reserved
 ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO mz_system
+
+statement error role name "mz_introspection" is reserved
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON CLUSTERS FROM mz_introspection
 
 # Disable rbac checks.
 simple conn=mz_system,user=mz_system

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -1187,6 +1187,7 @@ owner: privileges on database materialize granted by mz_system
 owner: privileges on schema public granted by mz_system
 owner: privileges on cluster default granted by mz_system
 owner: owner of cluster materialize_public_s
+owner: privileges granted on cluster materialize_public_s to mz_introspection
 owner: privileges on cluster materialize_public_s granted by owner
 owner: privileges granted on cluster materialize_public_s to owner
 owner: owner of cluster replica linked
@@ -1729,6 +1730,7 @@ DETAIL: owner: privileges on database materialize granted by mz_system
 owner: privileges on schema public granted by mz_system
 owner: privileges on cluster default granted by mz_system
 owner: owner of cluster clus
+owner: privileges granted on cluster clus to mz_introspection
 owner: privileges on cluster clus granted by owner
 owner: privileges granted on cluster clus to owner
 owner: owner of cluster replica r1

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -316,6 +316,7 @@ query TT
 SELECT * FROM cluster_privileges WHERE name = 'c'
 ----
 c  materialize=UC/materialize
+c  mz_introspection=U/materialize
 
 statement ok
 CREATE DATABASE d;
@@ -430,6 +431,7 @@ query TT
 SELECT * FROM cluster_privileges WHERE name = 'c'
 ----
 c  joe=UC/joe
+c  mz_introspection=U/joe
 
 simple conn=mz_system,user=mz_system
 ALTER DATABASE d OWNER TO joe
@@ -1477,6 +1479,7 @@ SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
 ----
 c  joe=U/materialize
 c  materialize=UC/materialize
+c  mz_introspection=U/materialize
 
 query B
 SELECT has_cluster_privilege('joe', 'c', 'USAGE')
@@ -1497,6 +1500,7 @@ SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
 ----
 c  joe=U/materialize
 c  materialize=UC/materialize
+c  mz_introspection=U/materialize
 
 statement ok
 GRANT USAGE, CREATE on CLUSTER c TO PUBLIC
@@ -1507,6 +1511,7 @@ SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
 c  =UC/materialize
 c  joe=U/materialize
 c  materialize=UC/materialize
+c  mz_introspection=U/materialize
 
 simple conn=joe8,user=joe
 GRANT USAGE on CLUSTER c TO other
@@ -1524,6 +1529,7 @@ SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
 ----
 c  =UC/materialize
 c  materialize=UC/materialize
+c  mz_introspection=U/materialize
 
 query B
 SELECT has_cluster_privilege('joe', 'c', 'USAGE')
@@ -1544,6 +1550,7 @@ SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
 ----
 c  =UC/materialize
 c  materialize=UC/materialize
+c  mz_introspection=U/materialize
 
 statement ok
 DROP ROLE joe
@@ -1558,6 +1565,7 @@ query TT
 SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
 ----
 c  materialize=UC/materialize
+c  mz_introspection=U/materialize
 
 statement error invalid privilege types SELECT, INSERT, UPDATE, DELETE for CLUSTER
 GRANT INSERT, SELECT, UPDATE, DELETE ON CLUSTER c TO joe

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -224,7 +224,7 @@ SELECT * FROM cluster_privileges ORDER BY name
 default           =U/mz_system
 default           mz_system=UC/mz_system
 default           materialize=UC/mz_system
-default           mz_introspection=UC/mz_system
+default           mz_introspection=U/mz_system
 mz_introspection  =U/mz_system
 mz_introspection  mz_system=UC/mz_system
 mz_introspection  mz_introspection=UC/mz_system

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -224,6 +224,7 @@ SELECT * FROM cluster_privileges ORDER BY name
 default           =U/mz_system
 default           mz_system=UC/mz_system
 default           materialize=UC/mz_system
+default           mz_introspection=UC/mz_system
 mz_introspection  =U/mz_system
 mz_introspection  mz_system=UC/mz_system
 mz_introspection  mz_introspection=UC/mz_system


### PR DESCRIPTION
This commit gives the mz_introspection role USAGE privileges on all clusters. This is required so that the prometheus-exporter can get information on cluster replicas by executing replica targeted queries.

Fixes https://github.com/MaterializeInc/cloud/issues/6709

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
