### PR TITLE
persist: fix bug in StateDiff::validate_roundtrip

### DIFF
--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -238,9 +238,10 @@ impl<T: Timestamp + Lattice + Codec64> StateDiff<T> {
 
         use crate::internal::state::ProtoStateDiff;
 
-        let mut roundtrip_state =
-            from_state.clone(to_state.applier_version.clone(), to_state.hostname.clone());
-        roundtrip_state.walltime_ms = to_state.walltime_ms;
+        let mut roundtrip_state = from_state.clone(
+            from_state.applier_version.clone(),
+            from_state.hostname.clone(),
+        );
         roundtrip_state.apply_diff(metrics, diff.clone())?;
 
         if &roundtrip_state != to_state {


### PR DESCRIPTION
It was using the "to" applier_version, hostname, and walltime_ms, which meant the diff didn't cleanly apply. We weren't noticing it before #19954 because of a bug that meant we weren't applying diffs for these fields. I'm honestly a little confused why we haven't been noticing it since then. This got caught because of a CI failure in #20013 with `test-compute-reconciliation-no-errors`, but I'm honestly baffled how that test is passing right now on main.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
