### PR TITLE
adapter: Check for system privileges

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -8140,6 +8140,11 @@ impl SessionCatalog for ConnCatalog<'_> {
             ObjectId::ClusterReplica(_) | ObjectId::Role(_) => None,
         }
     }
+    fn get_system_privileges(&self, role_id: &RoleId) -> AclMode {
+        self.state()
+            .system_privileges
+            .get_all_privileges_for_grantee(role_id)
+    }
 
     fn object_dependents(&self, ids: &Vec<ObjectId>) -> Vec<ObjectId> {
         let mut seen = BTreeSet::new();

--- a/src/repr/src/adt/mz_acl_item.rs
+++ b/src/repr/src/adt/mz_acl_item.rs
@@ -407,6 +407,13 @@ impl PrivilegeMap {
         self.all_values().cloned()
     }
 
+    /// Get all privileges that have been granted to `grantee`.
+    pub fn get_all_privileges_for_grantee(&self, grantee: &RoleId) -> AclMode {
+        self.get_acl_items_for_grantee(grantee)
+            .map(|mz_acl_item| mz_acl_item.acl_mode)
+            .fold(AclMode::empty(), |accum, acl_mode| accum.union(acl_mode))
+    }
+
     /// Adds an [`MzAclItem`] to this map.
     pub fn grant(&mut self, privilege: MzAclItem) {
         let grantee_privileges = self.0.entry(privilege.grantee).or_default();

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -281,6 +281,9 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// Returns the [`PrivilegeMap`] of the object.
     fn get_privileges(&self, id: &ObjectId) -> Option<&PrivilegeMap>;
 
+    /// Returns the privileges that `role_id` has on the system.
+    fn get_system_privileges(&self, role_id: &RoleId) -> AclMode;
+
     /// Returns all the IDs of all objects that depend on `ids`, including `ids` themselves.
     ///
     /// The order is guaranteed to be in reverse dependency order, i.e. the leafs will appear

--- a/test/sqllogictest/role_attributes.slt
+++ b/test/sqllogictest/role_attributes.slt
@@ -55,31 +55,31 @@ simple conn=joe,user=joe
 CREATE ROLE bar;
 ----
 db error: ERROR: permission denied to create role
-DETAIL: You must have the CREATEROLE attribute to create role
+DETAIL: You must have the CREATEROLE system privilege to create role
 
 simple conn=joe,user=joe
 ALTER ROLE foo NOCREATECLUSTER;
 ----
 db error: ERROR: permission denied to alter role
-DETAIL: You must have the CREATEROLE attribute to alter role
+DETAIL: You must have the CREATEROLE system privilege to alter role
 
 simple conn=joe,user=joe
 DROP ROLE foo;
 ----
 db error: ERROR: permission denied to drop roles
-DETAIL: You must have the CREATEROLE attribute to drop roles
+DETAIL: You must have the CREATEROLE system privilege to drop roles
 
 simple conn=joe,user=joe
 CREATE DATABASE foo;
 ----
 db error: ERROR: permission denied to create database
-DETAIL: You must have the CREATEDB attribute to create database
+DETAIL: You must have the CREATEDB system privilege to create database
 
 simple conn=joe,user=joe
 CREATE CLUSTER foo REPLICAS (r1 (size '1'));
 ----
 db error: ERROR: permission denied to create cluster
-DETAIL: You must have the CREATECLUSTER attribute to create cluster
+DETAIL: You must have the CREATECLUSTER system privilege to create cluster
 
 # CREATEROLE NOCREATEDB NOCREATECLUSTER
 
@@ -107,13 +107,13 @@ simple conn=joe,user=joe
 CREATE DATABASE foo;
 ----
 db error: ERROR: permission denied to create database
-DETAIL: You must have the CREATEDB attribute to create database
+DETAIL: You must have the CREATEDB system privilege to create database
 
 simple conn=joe,user=joe
 CREATE CLUSTER foo REPLICAS (r1 (size '1'));
 ----
 db error: ERROR: permission denied to create cluster
-DETAIL: You must have the CREATECLUSTER attribute to create cluster
+DETAIL: You must have the CREATECLUSTER system privilege to create cluster
 
 simple conn=mz_system,user=mz_system
 DROP ROLE bar;
@@ -136,19 +136,19 @@ simple conn=joe,user=joe
 CREATE ROLE bar;
 ----
 db error: ERROR: permission denied to create role
-DETAIL: You must have the CREATEROLE attribute to create role
+DETAIL: You must have the CREATEROLE system privilege to create role
 
 simple conn=joe,user=joe
 ALTER ROLE foo NOCREATECLUSTER;
 ----
 db error: ERROR: permission denied to alter role
-DETAIL: You must have the CREATEROLE attribute to alter role
+DETAIL: You must have the CREATEROLE system privilege to alter role
 
 simple conn=joe,user=joe
 DROP ROLE foo;
 ----
 db error: ERROR: permission denied to drop roles
-DETAIL: You must have the CREATEROLE attribute to drop roles
+DETAIL: You must have the CREATEROLE system privilege to drop roles
 
 simple conn=joe,user=joe
 CREATE DATABASE foo;
@@ -159,7 +159,7 @@ simple conn=joe,user=joe
 CREATE CLUSTER foo REPLICAS (r1 (size '1'));
 ----
 db error: ERROR: permission denied to create cluster
-DETAIL: You must have the CREATECLUSTER attribute to create cluster
+DETAIL: You must have the CREATECLUSTER system privilege to create cluster
 
 simple conn=mz_system,user=mz_system
 DROP DATABASE foo;
@@ -177,25 +177,25 @@ simple conn=joe,user=joe
 CREATE ROLE bar;
 ----
 db error: ERROR: permission denied to create role
-DETAIL: You must have the CREATEROLE attribute to create role
+DETAIL: You must have the CREATEROLE system privilege to create role
 
 simple conn=joe,user=joe
 ALTER ROLE foo NOCREATECLUSTER;
 ----
 db error: ERROR: permission denied to alter role
-DETAIL: You must have the CREATEROLE attribute to alter role
+DETAIL: You must have the CREATEROLE system privilege to alter role
 
 simple conn=joe,user=joe
 DROP ROLE foo;
 ----
 db error: ERROR: permission denied to drop roles
-DETAIL: You must have the CREATEROLE attribute to drop roles
+DETAIL: You must have the CREATEROLE system privilege to drop roles
 
 simple conn=joe,user=joe
 CREATE DATABASE foo;
 ----
 db error: ERROR: permission denied to create database
-DETAIL: You must have the CREATEDB attribute to create database
+DETAIL: You must have the CREATEDB system privilege to create database
 
 simple conn=joe,user=joe
 CREATE CLUSTER foo REPLICAS (r1 (size '1'));
@@ -238,7 +238,7 @@ simple conn=joe,user=joe
 CREATE CLUSTER foo REPLICAS (r1 (size '1'));
 ----
 db error: ERROR: permission denied to create cluster
-DETAIL: You must have the CREATECLUSTER attribute to create cluster
+DETAIL: You must have the CREATECLUSTER system privilege to create cluster
 
 simple conn=mz_system,user=mz_system
 DROP ROLE bar;
@@ -281,7 +281,7 @@ simple conn=joe,user=joe
 CREATE DATABASE foo;
 ----
 db error: ERROR: permission denied to create database
-DETAIL: You must have the CREATEDB attribute to create database
+DETAIL: You must have the CREATEDB system privilege to create database
 
 simple conn=joe,user=joe
 CREATE CLUSTER foo REPLICAS (r1 (size '1'));
@@ -314,19 +314,19 @@ simple conn=joe,user=joe
 CREATE ROLE bar;
 ----
 db error: ERROR: permission denied to create role
-DETAIL: You must have the CREATEROLE attribute to create role
+DETAIL: You must have the CREATEROLE system privilege to create role
 
 simple conn=joe,user=joe
 ALTER ROLE foo NOCREATECLUSTER;
 ----
 db error: ERROR: permission denied to alter role
-DETAIL: You must have the CREATEROLE attribute to alter role
+DETAIL: You must have the CREATEROLE system privilege to alter role
 
 simple conn=joe,user=joe
 DROP ROLE foo;
 ----
 db error: ERROR: permission denied to drop roles
-DETAIL: You must have the CREATEROLE attribute to drop roles
+DETAIL: You must have the CREATEROLE system privilege to drop roles
 
 simple conn=joe,user=joe
 CREATE DATABASE foo;
@@ -470,31 +470,31 @@ simple conn=joe,user=joe
 CREATE ROLE bar;
 ----
 db error: ERROR: permission denied to create role
-DETAIL: You must have the CREATEROLE attribute to create role
+DETAIL: You must have the CREATEROLE system privilege to create role
 
 simple conn=joe,user=joe
 ALTER ROLE foo NOCREATECLUSTER;
 ----
 db error: ERROR: permission denied to alter role
-DETAIL: You must have the CREATEROLE attribute to alter role
+DETAIL: You must have the CREATEROLE system privilege to alter role
 
 simple conn=joe,user=joe
 DROP ROLE foo;
 ----
 db error: ERROR: permission denied to drop roles
-DETAIL: You must have the CREATEROLE attribute to drop roles
+DETAIL: You must have the CREATEROLE system privilege to drop roles
 
 simple conn=joe,user=joe
 CREATE DATABASE foo;
 ----
 db error: ERROR: permission denied to create database
-DETAIL: You must have the CREATEDB attribute to create database
+DETAIL: You must have the CREATEDB system privilege to create database
 
 simple conn=joe,user=joe
 CREATE CLUSTER foo REPLICAS (r1 (size '1'));
 ----
 db error: ERROR: permission denied to create cluster
-DETAIL: You must have the CREATECLUSTER attribute to create cluster
+DETAIL: You must have the CREATECLUSTER system privilege to create cluster
 
 ## Grandparent
 
@@ -517,31 +517,31 @@ simple conn=joe,user=joe
 CREATE ROLE bar;
 ----
 db error: ERROR: permission denied to create role
-DETAIL: You must have the CREATEROLE attribute to create role
+DETAIL: You must have the CREATEROLE system privilege to create role
 
 simple conn=joe,user=joe
 ALTER ROLE foo NOCREATECLUSTER;
 ----
 db error: ERROR: permission denied to alter role
-DETAIL: You must have the CREATEROLE attribute to alter role
+DETAIL: You must have the CREATEROLE system privilege to alter role
 
 simple conn=joe,user=joe
 DROP ROLE foo;
 ----
 db error: ERROR: permission denied to drop roles
-DETAIL: You must have the CREATEROLE attribute to drop roles
+DETAIL: You must have the CREATEROLE system privilege to drop roles
 
 simple conn=joe,user=joe
 CREATE DATABASE foo;
 ----
 db error: ERROR: permission denied to create database
-DETAIL: You must have the CREATEDB attribute to create database
+DETAIL: You must have the CREATEDB system privilege to create database
 
 simple conn=joe,user=joe
 CREATE CLUSTER foo REPLICAS (r1 (size '1'));
 ----
 db error: ERROR: permission denied to create cluster
-DETAIL: You must have the CREATECLUSTER attribute to create cluster
+DETAIL: You must have the CREATECLUSTER system privilege to create cluster
 
 # Check if INHERIT works
 
@@ -566,7 +566,7 @@ simple conn=joe,user=joe
 CREATE SOURCE src FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
 ----
 db error: ERROR: permission denied to create source
-DETAIL: You must have the CREATECLUSTER attribute to create source
+DETAIL: You must have the CREATECLUSTER system privilege to create source
 
 simple conn=mz_system,user=mz_system
 ALTER ROLE joe CREATECLUSTER;
@@ -596,37 +596,37 @@ simple conn=joe,user=joe
 CREATE ROLE bar CREATEDB
 ----
 db error: ERROR: permission denied to create role with attribute CREATEDB
-DETAIL: You must have the CREATEDB attribute to create role with attribute CREATEDB
+DETAIL: You must have the CREATEDB system privilege to create role with attribute CREATEDB
 
 simple conn=joe,user=joe
 ALTER ROLE foo CREATEDB
 ----
 db error: ERROR: permission denied to alter role with attribute CREATEDB
-DETAIL: You must have the CREATEDB attribute to alter role with attribute CREATEDB
+DETAIL: You must have the CREATEDB system privilege to alter role with attribute CREATEDB
 
 simple conn=joe,user=joe
 CREATE ROLE bar CREATECLUSTER
 ----
 db error: ERROR: permission denied to create role with attribute CREATECLUSTER
-DETAIL: You must have the CREATECLUSTER attribute to create role with attribute CREATECLUSTER
+DETAIL: You must have the CREATECLUSTER system privilege to create role with attribute CREATECLUSTER
 
 simple conn=joe,user=joe
 ALTER ROLE foo CREATECLUSTER
 ----
 db error: ERROR: permission denied to alter role with attribute CREATECLUSTER
-DETAIL: You must have the CREATECLUSTER attribute to alter role with attribute CREATECLUSTER
+DETAIL: You must have the CREATECLUSTER system privilege to alter role with attribute CREATECLUSTER
 
 simple conn=joe,user=joe
 CREATE ROLE bar CREATEDB CREATECLUSTER
 ----
 db error: ERROR: permission denied to create role with attributes CREATEDB, CREATECLUSTER
-DETAIL: You must have the CREATEDB, CREATECLUSTER attributes to create role with attributes CREATEDB, CREATECLUSTER
+DETAIL: You must have the CREATEDB, CREATECLUSTER system privileges to create role with attributes CREATEDB, CREATECLUSTER
 
 simple conn=joe,user=joe
 ALTER ROLE foo CREATEDB CREATECLUSTER
 ----
 db error: ERROR: permission denied to alter role with attributes CREATEDB, CREATECLUSTER
-DETAIL: You must have the CREATEDB, CREATECLUSTER attributes to alter role with attributes CREATEDB, CREATECLUSTER
+DETAIL: You must have the CREATEDB, CREATECLUSTER system privileges to alter role with attributes CREATEDB, CREATECLUSTER
 
 ## CREATEDB NOCREATECLUSTER
 
@@ -654,25 +654,25 @@ simple conn=joe,user=joe
 CREATE ROLE bar CREATECLUSTER
 ----
 db error: ERROR: permission denied to create role with attribute CREATECLUSTER
-DETAIL: You must have the CREATECLUSTER attribute to create role with attribute CREATECLUSTER
+DETAIL: You must have the CREATECLUSTER system privilege to create role with attribute CREATECLUSTER
 
 simple conn=joe,user=joe
 ALTER ROLE foo CREATECLUSTER
 ----
 db error: ERROR: permission denied to alter role with attribute CREATECLUSTER
-DETAIL: You must have the CREATECLUSTER attribute to alter role with attribute CREATECLUSTER
+DETAIL: You must have the CREATECLUSTER system privilege to alter role with attribute CREATECLUSTER
 
 simple conn=joe,user=joe
 CREATE ROLE bar CREATEDB CREATECLUSTER
 ----
 db error: ERROR: permission denied to create role with attribute CREATECLUSTER
-DETAIL: You must have the CREATECLUSTER attribute to create role with attribute CREATECLUSTER
+DETAIL: You must have the CREATECLUSTER system privilege to create role with attribute CREATECLUSTER
 
 simple conn=joe,user=joe
 ALTER ROLE foo CREATEDB CREATECLUSTER
 ----
 db error: ERROR: permission denied to alter role with attribute CREATECLUSTER
-DETAIL: You must have the CREATECLUSTER attribute to alter role with attribute CREATECLUSTER
+DETAIL: You must have the CREATECLUSTER system privilege to alter role with attribute CREATECLUSTER
 
 ## NOCREATEDB CREATECLUSTER
 
@@ -685,13 +685,13 @@ simple conn=joe,user=joe
 CREATE ROLE bar CREATEDB
 ----
 db error: ERROR: permission denied to create role with attribute CREATEDB
-DETAIL: You must have the CREATEDB attribute to create role with attribute CREATEDB
+DETAIL: You must have the CREATEDB system privilege to create role with attribute CREATEDB
 
 simple conn=joe,user=joe
 ALTER ROLE foo CREATEDB
 ----
 db error: ERROR: permission denied to alter role with attribute CREATEDB
-DETAIL: You must have the CREATEDB attribute to alter role with attribute CREATEDB
+DETAIL: You must have the CREATEDB system privilege to alter role with attribute CREATEDB
 
 simple conn=joe,user=joe
 CREATE ROLE bar CREATECLUSTER
@@ -712,13 +712,13 @@ simple conn=joe,user=joe
 CREATE ROLE bar CREATEDB CREATECLUSTER
 ----
 db error: ERROR: permission denied to create role with attribute CREATEDB
-DETAIL: You must have the CREATEDB attribute to create role with attribute CREATEDB
+DETAIL: You must have the CREATEDB system privilege to create role with attribute CREATEDB
 
 simple conn=joe,user=joe
 ALTER ROLE foo CREATEDB CREATECLUSTER
 ----
 db error: ERROR: permission denied to alter role with attribute CREATEDB
-DETAIL: You must have the CREATEDB attribute to alter role with attribute CREATEDB
+DETAIL: You must have the CREATEDB system privilege to alter role with attribute CREATEDB
 
 ## CREATEDB CREATECLUSTER
 

--- a/test/sqllogictest/role_create.slt
+++ b/test/sqllogictest/role_create.slt
@@ -62,13 +62,13 @@ simple conn=regress_role_limited_admin,user=regress_role_limited_admin
 CREATE ROLE regress_nosuch_createdb CREATEDB;
 ----
 db error: ERROR: permission denied to create role with attribute CREATEDB
-DETAIL: You must have the CREATEDB attribute to create role with attribute CREATEDB
+DETAIL: You must have the CREATEDB system privilege to create role with attribute CREATEDB
 
 simple conn=regress_role_limited_admin,user=regress_role_limited_admin
 CREATE ROLE regress_nosuch_createcluster CREATECLUSTER;
 ----
 db error: ERROR: permission denied to create role with attribute CREATECLUSTER
-DETAIL: You must have the CREATECLUSTER attribute to create role with attribute CREATECLUSTER
+DETAIL: You must have the CREATECLUSTER system privilege to create role with attribute CREATECLUSTER
 
 simple conn=regress_role_limited_admin,user=regress_role_limited_admin
 CREATE ROLE regress_role_limited;
@@ -79,13 +79,13 @@ simple conn=regress_role_limited_admin,user=regress_role_limited_admin
 ALTER ROLE regress_role_limited CREATEDB;
 ----
 db error: ERROR: permission denied to alter role with attribute CREATEDB
-DETAIL: You must have the CREATEDB attribute to alter role with attribute CREATEDB
+DETAIL: You must have the CREATEDB system privilege to alter role with attribute CREATEDB
 
 simple conn=regress_role_limited_admin,user=regress_role_limited_admin
 ALTER ROLE regress_role_limited CREATECLUSTER;
 ----
 db error: ERROR: permission denied to alter role with attribute CREATECLUSTER
-DETAIL: You must have the CREATECLUSTER attribute to alter role with attribute CREATECLUSTER
+DETAIL: You must have the CREATECLUSTER system privilege to alter role with attribute CREATECLUSTER
 
 simple conn=regress_role_admin,user=regress_role_admin
 CREATE ROLE regress_createdb CREATEDB;


### PR DESCRIPTION
This commit updates the RBAC logic to check for system privileges and
role attributes when executing a SQL statement. The error messages have
been converted to focus on system privileges over role attributes since
system privileges are preferred over role attributes.

There is still no functionality that allows users to grant or revoke
system privileges. That is saved for a later PR.

Works towards resolving #19997

### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer
This PR builds off of https://github.com/MaterializeInc/materialize/pull/20013, only the most recent commit contains new code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
