### PR TITLE
storage: make sink_status_history truncatable

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -7306,6 +7306,9 @@ impl Catalog {
             keep_n_source_status_history_entries: self
                 .system_config()
                 .keep_n_source_status_history_entries(),
+            keep_n_sink_status_history_entries: self
+                .system_config()
+                .keep_n_source_status_history_entries(),
             upsert_rocksdb_tuning_config: {
                 match mz_rocksdb::RocksDBTuningParameters::from_parameters(
                     self.system_config().upsert_rocksdb_compaction_style(),

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -959,6 +959,14 @@ const KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
     internal: true
 };
 
+/// Controls [`mz_storage_client::types::parameters::StorageParameters::keep_n_sink_status_history_entries`].
+const KEEP_N_SINK_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("keep_n_sink_status_history_entries"),
+    value: &5,
+    description: "On reboot, truncate all but the last n entries per ID in the sink_status_history collection (Materialize).",
+    internal: true
+};
+
 const ENABLE_STORAGE_SHARD_FINALIZATION: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("enable_storage_shard_finalization"),
     value: &true,
@@ -1728,6 +1736,7 @@ impl SystemVars {
             .with_var(&ENABLE_LAUNCHDARKLY)
             .with_var(&MAX_CONNECTIONS)
             .with_var(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
+            .with_var(&KEEP_N_SINK_STATUS_HISTORY_ENTRIES)
             .with_var(&ENABLE_MZ_JOIN_CORE)
             .with_var(&ENABLE_STORAGE_SHARD_FINALIZATION);
         vars.refresh_internal_state();
@@ -2205,6 +2214,10 @@ impl SystemVars {
 
     pub fn keep_n_source_status_history_entries(&self) -> usize {
         *self.expect_value(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
+    }
+
+    pub fn keep_n_sink_status_history_entries(&self) -> usize {
+        *self.expect_value(&KEEP_N_SINK_STATUS_HISTORY_ENTRIES)
     }
 
     /// Returns the `enable_mz_join_core` configuration parameter.

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -22,6 +22,7 @@ message ProtoStorageParameters {
     uint64 keep_n_source_status_history_entries = 4;
     mz_rocksdb.config.ProtoRocksDbTuningParameters upsert_rocksdb_tuning_config = 5;
     bool finalize_shards = 6;
+    uint64 keep_n_sink_status_history_entries = 7;
 }
 
 

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -29,6 +29,7 @@ pub struct StorageParameters {
     pub persist: PersistParameters,
     pub pg_replication_timeouts: mz_postgres_util::ReplicationTimeouts,
     pub keep_n_source_status_history_entries: usize,
+    pub keep_n_sink_status_history_entries: usize,
     /// A set of parameters used to tune RocksDB when used with `UPSERT` sources.
     pub upsert_rocksdb_tuning_config: mz_rocksdb::RocksDBTuningParameters,
     /// Whether or not to allow shard finalization to occur. Note that this will
@@ -45,6 +46,7 @@ impl StorageParameters {
             persist,
             pg_replication_timeouts,
             keep_n_source_status_history_entries,
+            keep_n_sink_status_history_entries,
             upsert_rocksdb_tuning_config,
             finalize_shards,
         }: StorageParameters,
@@ -52,6 +54,7 @@ impl StorageParameters {
         self.persist.update(persist);
         self.pg_replication_timeouts = pg_replication_timeouts;
         self.keep_n_source_status_history_entries = keep_n_source_status_history_entries;
+        self.keep_n_sink_status_history_entries = keep_n_sink_status_history_entries;
         self.upsert_rocksdb_tuning_config = upsert_rocksdb_tuning_config;
         self.finalize_shards = finalize_shards
     }
@@ -64,6 +67,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             pg_replication_timeouts: Some(self.pg_replication_timeouts.into_proto()),
             keep_n_source_status_history_entries: u64::cast_from(
                 self.keep_n_source_status_history_entries,
+            ),
+            keep_n_sink_status_history_entries: u64::cast_from(
+                self.keep_n_sink_status_history_entries,
             ),
             upsert_rocksdb_tuning_config: Some(self.upsert_rocksdb_tuning_config.into_proto()),
             finalize_shards: self.finalize_shards,
@@ -80,6 +86,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
                 .into_rust_if_some("ProtoStorageParameters::pg_replication_timeouts")?,
             keep_n_source_status_history_entries: usize::cast_from(
                 proto.keep_n_source_status_history_entries,
+            ),
+            keep_n_sink_status_history_entries: usize::cast_from(
+                proto.keep_n_sink_status_history_entries,
             ),
             upsert_rocksdb_tuning_config: proto
                 .upsert_rocksdb_tuning_config

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -281,6 +281,12 @@ def workflow_allowed_cluster_replica_sizes(c: Composition) -> None:
             """
             > SHOW allowed_cluster_replica_sizes
             "\\"1\\", \\"2\\""
+
+            $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+
+            # Reset for following tests
+            $ postgres-execute connection=mz_system
+            ALTER SYSTEM RESET allowed_cluster_replica_sizes
             """
         ),
     )
@@ -303,6 +309,93 @@ def workflow_drop_materialize_database(c: Composition) -> None:
     # Verify that materialize hasn't blown up
     c.sql("SELECT 1")
 
+    # Restore for next tests
+    c.sql(
+        "CREATE DATABASE materialize",
+        port=6877,
+        user="mz_system",
+    )
+    c.sql(
+        "GRANT ALL PRIVILEGES ON SCHEMA materialize.public TO materialize",
+        port=6877,
+        user="mz_system",
+    )
+
+
+def workflow_bound_size_mz_status_history(c: Composition) -> None:
+    c.up("zookeeper", "kafka", "schema-registry", "materialized")
+    c.up("testdrive_no_reset", persistent=True)
+
+    c.testdrive(
+        service="testdrive_no_reset",
+        input=dedent(
+            """
+            $ kafka-create-topic topic=status-history
+
+            > CREATE CONNECTION kafka_conn
+              TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+            > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+                URL '${testdrive.schema-registry-url}'
+              );
+
+            > CREATE SOURCE kafka_source
+              FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-status-history-${testdrive.seed}')
+              FORMAT TEXT
+
+            > CREATE SINK kafka_sink FROM kafka_source
+              INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-${testdrive.seed}')
+              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+              ENVELOPE DEBEZIUM
+            """
+        ),
+    )
+
+    # Fill mz_source_status_history and mz_sink_status_history up with enough events
+    for i in range(10):
+        c.testdrive(
+            service="testdrive_no_reset",
+            input=dedent(
+                """
+                > ALTER SOURCE kafka_source SET (SIZE = '1')
+
+                > ALTER SINK kafka_sink SET (SIZE = '1')
+                """
+            ),
+        )
+
+    # Verify that we have enough events so that they can be truncated
+    c.testdrive(
+        service="testdrive_no_reset",
+        input=dedent(
+            """
+            > SELECT COUNT(*) > 7 FROM mz_internal.mz_source_status_history
+            true
+
+            > SELECT COUNT(*) > 7 FROM mz_internal.mz_sink_status_history
+            true
+            """
+        ),
+    )
+
+    # Restart mz.
+    c.kill("materialized")
+    c.up("materialized")
+
+    # Verify that we have fewer events now
+    c.testdrive(
+        service="testdrive_no_reset",
+        input=dedent(
+            """
+            > SELECT COUNT(*) FROM mz_internal.mz_source_status_history
+            7
+
+            > SELECT COUNT(*) FROM mz_internal.mz_sink_status_history
+            7
+            """
+        ),
+    )
+
 
 def workflow_default(c: Composition) -> None:
     c.workflow("github-17578")
@@ -312,3 +405,4 @@ def workflow_default(c: Composition) -> None:
     c.workflow("stash")
     c.workflow("allowed-cluster-replica-sizes")
     c.workflow("drop-materialize-database")
+    c.workflow("bound-size-mz-status-history")


### PR DESCRIPTION
@def- This should be good to test with #20056

### Motivation

This PR adds a known-desirable feature. Closes #17548

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
