### PR TITLE
repr: parse multi-dimensional arrays

### DIFF
--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -254,7 +254,7 @@ impl LazyUnaryFunc for CastStringToArray {
         if a.is_null() {
             return Ok(Datum::Null);
         }
-        let datums = strconv::parse_array(
+        let (datums, dims) = strconv::parse_array(
             a.unwrap_str(),
             || Datum::Null,
             |elem_text| {
@@ -266,7 +266,8 @@ impl LazyUnaryFunc for CastStringToArray {
                     .eval(&[Datum::String(elem_text)], temp_storage)
             },
         )?;
-        array_create_scalar(&datums, temp_storage)
+
+        Ok(temp_storage.try_make_datum(|packer| packer.push_array(&dims, datums))?)
     }
 
     /// The output ColumnType of this function

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -546,21 +546,11 @@ impl Value {
         let s = str::from_utf8(raw)?;
         Ok(match ty {
             Type::Array(elem_type) => {
-                let elements = strconv::parse_array(
+                let (elements, dims) = strconv::parse_array(
                     s,
                     || None,
                     |elem_text| Value::decode_text(elem_type, elem_text.as_bytes()).map(Some),
                 )?;
-                // At the moment, we only support one dimensional arrays. Note
-                // that empty arrays are represented as zero dimensional arrays,
-                // per PostgreSQL.
-                let mut dims = vec![];
-                if !elements.is_empty() {
-                    dims.push(ArrayDimension {
-                        lower_bound: 1,
-                        length: elements.len(),
-                    })
-                }
                 Value::Array { dims, elements }
             }
             Type::Int2Vector { .. } => {
@@ -736,7 +726,7 @@ mod tests {
 
         assert_eq!(
             decoded_int_array.map_err(|e| e.to_string()).unwrap_err(),
-            "invalid input syntax for type array: specifying array lower bounds is not supported: \"[0:0]={t}\"".to_string()
+            "invalid input syntax for type array: Specifying array lower bounds is not supported: \"[0:0]={t}\"".to_string()
         );
     }
 }

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -742,11 +742,37 @@ where
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+enum ArrayParsingError {
+    #[error("Array value must start with \"{{\"")]
+    OpeningBraceMissing,
+    #[error("Specifying array lower bounds is not supported")]
+    DimsUnsupported,
+    #[error("{0}")]
+    Generic(String),
+    #[error("Unexpected \"{0}\" character.")]
+    UnexpectedChar(char),
+    #[error("Multidimensional arrays must have sub-arrays with matching dimensions.")]
+    NonRectilinearDims,
+    #[error("Unexpected array element.")]
+    UnexpectedElement,
+    #[error("Junk after closing right brace.")]
+    Junk,
+    #[error("Unexpected end of input.")]
+    EarlyTerm,
+}
+
+impl From<String> for ArrayParsingError {
+    fn from(value: String) -> Self {
+        ArrayParsingError::Generic(value)
+    }
+}
+
 pub fn parse_array<'a, T, E>(
     s: &'a str,
     make_null: impl FnMut() -> T,
     gen_elem: impl FnMut(Cow<'a, str>) -> Result<T, E>,
-) -> Result<Vec<T>, ParseError>
+) -> Result<(Vec<T>, Vec<ArrayDimension>), ParseError>
 where
     E: ToString,
 {
@@ -758,55 +784,256 @@ fn parse_array_inner<'a, T, E>(
     s: &'a str,
     mut make_null: impl FnMut() -> T,
     mut gen_elem: impl FnMut(Cow<'a, str>) -> Result<T, E>,
-) -> Result<Vec<T>, String>
+) -> Result<(Vec<T>, Vec<ArrayDimension>), ArrayParsingError>
 where
     E: ToString,
 {
-    let mut elems = vec![];
-    let buf = &mut LexBuf::new(s);
+    use ArrayParsingError::*;
 
-    if buf.consume('[') {
-        bail!("specifying array lower bounds is not supported");
+    #[derive(Clone, Debug, Default)]
+    struct Dimension {
+        // If None, still discovering this dimension's permitted width;
+        // otherwise only permits `length` elements per dimension.
+        length: Option<usize>,
+        // Whether this dimension has a staged element that can be committed.
+        // This prevents us from accepting "empty" elements, e.g. `{1,}` or
+        // `{1,,2}`.
+        staged_element: bool,
+        // The total number of elements committed in this dimension since it was
+        // last entered. Zeroed out when exited.
+        committed_element_count: usize,
     }
 
-    if !buf.consume('{') {
-        bail!("malformed array literal: missing opening left brace");
+    #[derive(Clone, Debug, Default)]
+    struct ArrayBuilder<'a> {
+        // The current character we're operating from.
+        current_command_char: char,
+        // The dimension information, which will get turned into
+        // `ArrayDimensions`.
+        dimensions: Vec<Dimension>,
+        // THe current dimension we're operating on.
+        current_dim: usize,
+        // Whether or not this array may be modified any further.
+        sealed: bool,
+        // The elements extracted from the input str. This is on the array
+        // builder to necessitate using `insert_element` so we understand when
+        // elements are staged.
+        elements: Vec<Option<Cow<'a, str>>>,
     }
+
+    impl<'a> ArrayBuilder<'a> {
+        fn build(
+            s: &'a str,
+        ) -> Result<(Vec<Option<Cow<'a, str>>>, Vec<ArrayDimension>), ArrayParsingError> {
+            let buf = &mut LexBuf::new(s);
+
+            // TODO: support parsing array dimensions
+            if buf.consume('[') {
+                Err(DimsUnsupported)?;
+            }
+
+            buf.take_while(|ch| ch.is_ascii_whitespace());
+
+            if !buf.consume('{') {
+                Err(OpeningBraceMissing)?;
+            }
+
+            let mut dimensions = 1;
+
+            loop {
+                buf.take_while(|ch| ch.is_ascii_whitespace());
+                if buf.consume('{') {
+                    dimensions += 1;
+                } else {
+                    break;
+                }
+            }
+
+            let mut builder = ArrayBuilder {
+                current_command_char: '{',
+                dimensions: vec![Dimension::default(); dimensions],
+                // We enter the builder at the element-bearing dimension, which is the last
+                // dimension.
+                current_dim: dimensions - 1,
+                sealed: false,
+                elements: vec![],
+            };
+
+            let is_special_char = |c| matches!(c, '{' | '}' | ',' | '\\' | '"');
+            let is_end_of_literal = |c| matches!(c, ',' | '}');
+
+            loop {
+                buf.take_while(|ch| ch.is_ascii_whitespace());
+
+                // Filter command state from terminal states.
+                match buf.next() {
+                    None if builder.sealed => {
+                        break;
+                    }
+                    None => Err(EarlyTerm)?,
+                    Some(_) if builder.sealed => Err(Junk)?,
+                    Some(c) => builder.current_command_char = c,
+                }
+
+                // Run command char
+                match builder.current_command_char {
+                    '{' => builder.enter_dim()?,
+                    '}' => builder.exit_dim()?,
+                    ',' => builder.commit_element(true)?,
+                    c => {
+                        buf.prev();
+                        let s = match c {
+                            '"' => Some(lex_quoted_element(buf)?),
+                            _ => lex_unquoted_element(buf, is_special_char, is_end_of_literal)?,
+                        };
+                        builder.insert_element(s)?;
+                    }
+                }
+            }
+
+            if builder.elements.is_empty() {
+                // Per PG, empty arrays are represented by empty dimensions
+                // rather than one dimension with 0 length.
+                return Ok((vec![], vec![]));
+            }
+
+            let dims = builder
+                .dimensions
+                .into_iter()
+                .map(|dim| ArrayDimension {
+                    length: dim
+                        .length
+                        .expect("every dimension must have its length discovered"),
+                    lower_bound: 1,
+                })
+                .collect();
+
+            Ok((builder.elements, dims))
+        }
+
+        /// Descend into another dimension of the array.
+        fn enter_dim(&mut self) -> Result<(), ArrayParsingError> {
+            let d = &mut self.dimensions[self.current_dim];
+            // Cannot enter a new dimension with an uncommitted element.
+            if d.staged_element {
+                return Err(UnexpectedChar(self.current_command_char));
+            }
+
+            self.current_dim += 1;
+
+            // You have exceeded the maximum dimensions.
+            if self.current_dim >= self.dimensions.len() {
+                return Err(NonRectilinearDims);
+            }
+
+            Ok(())
+        }
+
+        /// Insert a new element into the array, ensuring it is in the proper dimension.
+        fn insert_element(&mut self, s: Option<Cow<'a, str>>) -> Result<(), ArrayParsingError> {
+            // Can only insert elements into data-bearing dimension, which is
+            // the last one.
+            if self.current_dim != self.dimensions.len() - 1 {
+                return Err(UnexpectedElement);
+            }
+
+            self.stage_element()?;
+
+            self.elements.push(s);
+
+            Ok(())
+        }
+
+        /// Stage an element to be committed. Only one element can be staged at
+        /// a time and staged elements must be committed before moving onto the
+        /// next element or leaving the dimension.
+        fn stage_element(&mut self) -> Result<(), ArrayParsingError> {
+            let d = &mut self.dimensions[self.current_dim];
+            // Cannot stage two elements at once, i.e. previous element wasn't
+            // followed by committing token (`,` or `}`).
+            if d.staged_element {
+                return Err(UnexpectedElement);
+            }
+            d.staged_element = true;
+            Ok(())
+        }
+
+        /// Commit the currently staged element, which can be made optional.
+        /// This ensures that each element has an appropriate terminal character
+        /// after it.
+        fn commit_element(&mut self, require_staged: bool) -> Result<(), ArrayParsingError> {
+            let d = &mut self.dimensions[self.current_dim];
+            if !d.staged_element {
+                // - , requires a preceding staged element
+                // - } does not require a preceding staged element only when
+                //   it's the close of an empty dimension.
+                return if require_staged || d.committed_element_count > 0 {
+                    Err(UnexpectedChar(self.current_command_char))
+                } else {
+                    // This indicates that we have an empty value in this
+                    // dimension and want to exit before incrementing the
+                    // committed element count.
+                    Ok(())
+                };
+            }
+            d.staged_element = false;
+            d.committed_element_count += 1;
+
+            Ok(())
+        }
+
+        /// Exit the current dimension, committing any currently staged element
+        /// in this dimension, and marking the interior array that this is part
+        /// of as staged itself. If this is the 0th dimension, i.e. the closed
+        /// brace matching the first open brace, seal the builder from further
+        /// modification.
+        fn exit_dim(&mut self) -> Result<(), ArrayParsingError> {
+            // Commit an element of this dimension
+            self.commit_element(false)?;
+
+            let d = &mut self.dimensions[self.current_dim];
+
+            // Ensure that the elements in this dimension conform to the expected shape.
+            match d.length {
+                None => d.length = Some(d.committed_element_count),
+                Some(l) => {
+                    if l != d.committed_element_count {
+                        return Err(NonRectilinearDims);
+                    }
+                }
+            }
+
+            // Reset this dimension's counter in case it's re-entered.
+            d.committed_element_count = 0;
+
+            // If we closed the last dimension, this array may not be modified
+            // any longer.
+            if self.current_dim == 0 {
+                self.sealed = true;
+            } else {
+                self.current_dim -= 1;
+                // This object is an element of a higher dimension.
+                self.stage_element()?;
+            }
+
+            Ok(())
+        }
+    }
+
+    let (raw_elems, dims) = ArrayBuilder::build(s)?;
+
+    let mut elems = Vec::with_capacity(raw_elems.len());
 
     let mut gen = |elem| gen_elem(elem).map_err(|e| e.to_string());
-    let is_special_char = |c| matches!(c, '{' | '}' | ',' | '\\' | '"');
-    let is_end_of_literal = |c| matches!(c, ',' | '}');
 
-    loop {
-        buf.take_while(|ch| ch.is_ascii_whitespace());
-        match buf.next() {
-            Some('}') => break,
-            _ if elems.len() == 0 => {
-                buf.prev();
-            }
-            Some(',') => {}
-            Some(c) => bail!("expected ',' or '}}', got '{}'", c),
-            None => bail!("unexpected end of input"),
-        }
-        buf.take_while(|ch| ch.is_ascii_whitespace());
-
-        let elem = match buf.peek() {
-            Some('"') => gen(lex_quoted_element(buf)?)?,
-            Some('{') => bail!("parsing multi-dimensional arrays is not supported"),
-            Some(_) => match lex_unquoted_element(buf, is_special_char, is_end_of_literal)? {
-                Some(elem) => gen(elem)?,
-                None => make_null(),
-            },
-            None => bail!("unexpected end of input"),
-        };
-        elems.push(elem);
+    for elem in raw_elems.into_iter() {
+        elems.push(match elem {
+            Some(elem) => gen(elem)?,
+            None => make_null(),
+        });
     }
 
-    if buf.next().is_some() {
-        bail!("malformed array literal: junk after closing right brace");
-    }
-
-    Ok(elems)
+    Ok((elems, dims))
 }
 
 pub fn parse_list<'a, T, E>(

--- a/test/pg-cdc/types-array.td
+++ b/test/pg-cdc/types-array.td
@@ -282,5 +282,10 @@ INSERT INTO t_integer_array VALUES ('{{1},{2}}');
 
 INSERT INTO t_integer_array SELECT * FROM t_integer_array;
 
-! SELECT * FROM t_integer_array;
-contains:invalid input syntax for type array
+> SELECT * FROM t_integer_array;
+ {1,2}
+ {1,2}
+ {1,2}
+ {1,2}
+ {{1},{2}}
+ {{1},{2}}

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -434,7 +434,7 @@ def unsupported_pg_table(c: Composition) -> None:
         dedent(
             """
                  $ postgres-execute connection=postgres://postgres:postgres@postgres
-                 INSERT INTO source1 VALUES (3, '{{1},{2}}')
+                 INSERT INTO source1 VALUES (3, '[2:3]={2,2}')
                  """
         )
     )

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -26,17 +26,18 @@ SELECT '{  1,   2  , 3 }'::int[]
 ----
 {1,2,3}
 
-query error invalid input syntax for type array: malformed array literal: missing opening left brace
+query error db error: ERROR: invalid input syntax for type array: Array value must start with "\{": ""
 SELECT ''::int[]
 
-query error invalid input syntax for type array: malformed array literal: junk after closing right brace
+query error db error: ERROR: invalid input syntax for type array: Junk after closing right brace\.: "\{1, 2, 3\} 4"
 SELECT '{1, 2, 3} 4'::int[]
 
-# This ought to be supported one day, but it is a lot of work.
-query error parsing multi-dimensional arrays is not supported
+query T
 SELECT '{{1}, {2}}'::int[]
+----
+{{1},{2}}
 
-query error specifying array lower bounds is not supported
+query error db error: ERROR: invalid input syntax for type array: Specifying array lower bounds is not supported: "\[1:2\]=\{1,2\}"
 SELECT '[1:2]={1,2}'::int[]
 
 # Test coercion behavior of multidimensional arrays.
@@ -1033,3 +1034,275 @@ SELECT array_position(ARRAY[['mon']]::text[], null, 1)
 
 query error searching for elements in multidimensional arrays is not supported
 SELECT array_position(ARRAY[['mon']]::text[], 'mon', null)
+
+# multi-dimensional arrays
+# how else can we handle whitespace terminals in strings?
+query T
+SELECT
+    concat_ws(
+        E'\t',
+        v,
+        array_length(v, 1),
+        array_length(v, 2),
+        array_length(v, 3),
+        array_length(v, 4),
+        v[1],
+        v[1][1],
+        v[1][1][1],
+        v[1][1][1][1],
+        'end'
+    )
+FROM (
+    SELECT a::text[] AS v FROM (
+        VALUES (null),
+        ('{a}'),
+        ('{""}'),
+        ('{''}'),
+        ('{" "}'),
+        ('{" 🌍 "}'),
+        ('{\\}'),
+        ('{"{",\\}'),
+        ('{\"\", \"\\\"\"}'),
+        ('{null}'),
+        ('{b,b}'),
+        ('{{c},{c},{c}}'),
+        ('{{a}}'),
+        ('{{a},{a}}'),
+        ('{{a,b,c},{a,b,c}}'),
+        ('{{{b},{b}},{{b},{b}}}'),
+        ('{{{c},{c},{c}}}'),
+        ('{{"c", d},{"c", d},{"c", d}}'),
+        ('{{c, null},{null, d},{"null", null}}'),
+        ('{{{{b},{b}}},{{{b},{b}}},{{{b},{b}}}}'),
+        ('{{{a}}}'),
+        ('{{{a}},{{a}}}'),
+        ('{{{a}},{{null}}}'),
+        ('{}'),
+        ('{{},{}}'),
+        ('{{{}},{{}}}'),
+        ('{{{null}},{{null}}}'),
+        -- Can exceed max dims with empty array which consolidates down
+        ('{{{{{{{},{}}}}}}}')
+    ) AS x (a)
+) AS x (v);
+----
+end
+{}	end
+{}	end
+{}	end
+{}	end
+{""}	1		end
+{'}	1	'	end
+{a}	1	a	end
+{NULL}	1	end
+{" "}	1	 	end
+{b,b}	2	b	end
+{"\\"}	1	\	end
+{{a}}	1	1	a	end
+{"{","\\"}	2	{	end
+{{a},{a}}	2	1	a	end
+{{{a}}}	1	1	1	a	end
+{" 🌍 "}	1	 🌍 	end
+{{c},{c},{c}}	3	1	c	end
+{{{a}},{{a}}}	2	1	1	a	end
+{{a,b,c},{a,b,c}}	2	3	a	end
+{{{c},{c},{c}}}	1	3	1	c	end
+{"\"\"","\"\\\"\""}	2	""	end
+{{{a}},{{NULL}}}	2	1	1	a	end
+{{c,d},{c,d},{c,d}}	3	2	c	end
+{{{NULL}},{{NULL}}}	2	1	1	end
+{{{b},{b}},{{b},{b}}}	2	2	1	b	end
+{{c,NULL},{NULL,d},{null,NULL}}	3	2	c	end
+{{{{b},{b}}},{{{b},{b}}},{{{b},{b}}}}	3	1	2	1	b	end
+
+# Test that whitespace produces same results
+query T
+SELECT
+    concat_ws(
+        E'\t',
+        v,
+        array_length(v, 1),
+        array_length(v, 2),
+        array_length(v, 3),
+        array_length(v, 4),
+        v[1],
+        v[1][1],
+        v[1][1][1],
+        v[1][1][1][1]
+    )
+FROM (
+    SELECT a::text[] AS v FROM (
+        VALUES (null),
+        ('       {a}'),
+        ('{null}        '),
+        ('{      b,b}'),
+        ('{{c      },{c},{c}}'),
+        ('{{a       }}'),
+        ('{{a},        {a}}'),
+        ('{{a,b,c},{    a,b,c}}'),
+        ('{{{b},{b}},{{b},{b}}      }'),
+        ('{{{c},{c},{c}}}         '),
+        ('{  {  c  ,  d  }  ,  {  c  ,  d  }  ,  {  c  ,  d  }  }  ')
+    ) AS x (a)
+) AS x (v);
+----
+(empty)
+{a}	1	a
+{NULL}	1
+{b,b}	2	b
+{{a}}	1	1	a
+{{a},{a}}	2	1	a
+{{c},{c},{c}}	3	1	c
+{{a,b,c},{a,b,c}}	2	3	a
+{{{c},{c},{c}}}	1	3	1	c
+{{c,d},{c,d},{c,d}}	3	2	c
+{{{b},{b}},{{b},{b}}}	2	2	1	b
+
+#
+# Empty
+query error db error: ERROR: invalid input syntax for type array: Array value must start with "\{": ""
+SELECT ''::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Array value must start with "\{": "          "
+SELECT '          '::int[];
+
+#
+# Missing elems
+query error db error: ERROR: invalid input syntax for type array: Unexpected "\}" character\.: "\{1,\}"
+SELECT '{1,}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected "," character\.: "\{,1\}"
+SELECT '{,1}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected "," character\.: "\{,\}"
+SELECT '{,}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected "\}" character\.: "\{\\" \\",\}"
+SELECT '{" ",}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected "," character\.: "\{,\\" \\"\}"
+SELECT '{," "}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected "\}" character\.: "\{',\}"
+SELECT '{'',}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected "," character\.: "\{,'\}"
+SELECT '{,''}'::int[];
+
+#
+# Escapes
+query error db error: ERROR: invalid input syntax for type array: unterminated element: "\{\\\}"
+SELECT '{\}'::text[];
+
+#
+# Single chars
+query error db error: ERROR: invalid input syntax for type array: Unexpected end of input\.: "\{"
+SELECT '{'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Array value must start with "\{": "\}"
+SELECT '}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Array value must start with "\{": ","
+SELECT ','::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Array value must start with "\{": "a"
+SELECT 'a'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Array value must start with "\{": "'"
+SELECT ''''::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Array value must start with "\{": "\\""
+SELECT '"'::int[];
+
+#
+# Lopsided brackets
+query error db error: ERROR: invalid input syntax for type array: Unexpected end of input\.: "\{\{a\}"
+SELECT '{{a}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Junk after closing right brace\.: "\{a\}\}"
+SELECT '{a}}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected end of input\.: "\{\{\}"
+SELECT '{{}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Junk after closing right brace\.: "\{\}\}"
+SELECT '{}}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected end of input\.: "\{  \{a\}"
+SELECT '{  {a}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Junk after closing right brace\.: "\{  a\}\}"
+SELECT '{  a}}'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected end of input\.: "\{\{  \}"
+SELECT '{{  }'::int[];
+
+query error db error: ERROR: invalid input syntax for type array: Junk after closing right brace\.: "\{\}  \}"
+SELECT '{}  }'::int[];
+
+#
+# Missing commas++
+query error db error: ERROR: invalid input syntax for type array: Junk after closing right brace\.: "\{1\}\{1\}"
+SELECT '{1}{1}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected "\{" character\.: "\{\{1\}\{1\}\}"
+SELECT '{{1}{1}}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Junk after closing right brace\.: "\{\}\{\}"
+SELECT '{}{}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected "\{" character\.: "\{\{\}\{\}\}"
+SELECT '{{}{}}'::text[];
+
+#
+# Manged seps
+query error db error: ERROR: invalid input syntax for type array: Unexpected array element\.: "\{\{1,2\},\\\{2,3\}\}"
+SELECT E'{{1,2},\\{2,3}}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected array element\.: "\{\{\\"1 2\\" x\},\{3\}\}"
+SELECT '{{"1 2" x},{3}}'::text[];
+
+#
+# Non-rectilinear
+query error db error: ERROR: invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{1,\{2\}\},\{2,3\}\}"
+SELECT '{{1,{2}},{2,3}}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{1\},\{\{2\}\}\}"
+SELECT '{{1},{{2}}}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected array element\.: "\{\{\{1\}\},\{2\}\}"
+SELECT '{{{1}},{2}}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{\},\{\{\}\}\}"
+SELECT '{{},{{}}}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{\{\}\},\{\}\}"
+SELECT '{{{}},{}}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{1\},\{\}\}"
+SELECT '{{1},{}}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{\},\{1\}\}"
+SELECT '{{},{1}}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{1,2\},\{1\}\}"
+SELECT '{{1,2},{1}}'::text[];
+
+#
+# Non-rectilinear w/ null
+query error db error: ERROR: invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{null, \{1\}\}"
+SELECT '{null, {1}}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Unexpected array element\.: "\{\{1\}, null\}"
+SELECT '{{1}, null}'::text[];
+
+query error db error: ERROR: invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{\{null\}\},\{\{\}\}\}"
+SELECT '{{{null}},{{}}}'::text[];
+
+# Exceeded dimensions
+query error db error: ERROR: number of array dimensions \(7\) exceeds the maximum allowed \(6\)
+SELECT '{{{{{{{7}}}}}}}'::int[];
+
+# We check max depth only after successfully parsing
+query error db error: ERROR: invalid input syntax for type array: Unexpected end of input\.: "\{\{\{\{\{\{\{7\}\}\}\}\}\}"
+SELECT '{{{{{{{7}}}}}}'::int[];

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -2567,7 +2567,7 @@ SELECT pg_typeof(NULL::int[]::int list);
 ----
 integer list
 
-query error invalid input syntax for type array: parsing multi-dimensional arrays is not supported
+query error casting multi-dimensional array to list; got array with 2 dimensions not yet supported
 SELECT '{{1},{2},{3}}'::int[]::int list::text;
 
 # Verify nested lists

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -186,7 +186,7 @@ query error db error: ERROR: operator is not unique: unknown \? unknown
 SELECT NULL ? 'a'
 
 ## ?&
-query error malformed array literal: missing opening left brace
+query error db error: ERROR: invalid input syntax for type array: Array value must start with "\{": "a"
 SELECT '{a=>1, b=>2}'::map[text=>int] ?& 'a'
 
 query error db error: ERROR: operator does not exist: map\[text=>integer\] \?\& integer\[\]
@@ -252,7 +252,7 @@ SELECT '{hello=>{world=>1293}}'::map[text=>map[text=>smallint]] -> 'hello'::text
 false
 
 ## ?|
-query error malformed array literal: missing opening left brace
+query error db error: ERROR: invalid input syntax for type array: Array value must start with "\{": "a"
 SELECT '{a=>1, b=>2}'::map[text=>int] ?| 'a'
 
 query error db error: ERROR: operator does not exist: map\[text=>integer\] \?\| integer\[\]

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1310,8 +1310,19 @@ query I
 SELECT generate_subscripts('{1,2,3,4}'::int[], 12345) AS s;
 ----
 
-query error parsing multi-dimensional arrays is not supported
+query T
 SELECT generate_subscripts('{{1,2,3,4}, {5,6,7,8}}'::int[], 1) AS s;
+----
+1
+2
+
+query T
+SELECT generate_subscripts('{{1,2,3,4}, {5,6,7,8}}'::int[], 2) AS s;
+----
+1
+2
+3
+4
 
 query error table functions are not allowed in other table functions
 SELECT generate_subscripts('{1,2,3,4}'::int[], 1), repeat_row(generate_series(1, 1)) AS s


### PR DESCRIPTION
Implements support for parsing multi-dimensional arrays w/o explicit bounds.

### Motivation

This PR adds a known-desirable feature.

### Tips for reviewer

This PR differs from the current version of PG in that it supports parsing multi-dimensional empty arrays. However, that feature is likely to be supported in an upcoming version of PG ([link](https://www.postgresql.org/message-id/flat/2794005.1683042087@sss.pgh.pa.us))––and Tom Lane also questioned its prohibition in the first place, so really doesn't seem breaking to diverge from PG in this way.

Additionally, if someone has a better or more structured approach for generating these test cases, I'm all ears. I tried writing something to generate them but it either output far too many cases or didn't comprehensively capture all the little corners we should test.

@MaterializeInc/qa The above comment is maybe most directed at you all. Also glad to help w/ this testing, but what we have is already more thorough than what got PG by for 20 years 😂 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support parsing multi-dimensional arrays, e.g. `'{{1},{2}}`::int[]`.
