### PR TITLE
Point out #eng-design-docs in the design doc README

### DIFF
--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -109,7 +109,10 @@ short.
    small set of people who have a vested interest in the area the design
    touches. If it's not clear who that is, ask your TL, EM, or in #eng-general.
 4. Announce that the design doc is ready for review in #eng-announce, if you
-   think it's helpful to surface the design to a larger set of people.
+   think it's helpful to surface the design to a larger set of people. This
+   step is optional. We have an automation that posts new ready-for-review
+   design docs to #eng-design-docs and in many cases that will be sufficient
+   to inform any interested parties.
 
 ### Iteration
 


### PR DESCRIPTION
The intent is to make people aware of #eng-design-docs and the automatic notification that can replace a separate posting to #eng-announce.

### Motivation

  * This PR updates a README.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
