### PR TITLE
Fix nullability inference for Timestamp-Interval arithmetics

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2554,7 +2554,7 @@ impl BinaryFunc {
             | AddTimestampTzInterval
             | SubTimestampTzInterval
             | AddTimeInterval
-            | SubTimeInterval => input1_type,
+            | SubTimeInterval => input1_type.nullable(in_nullable),
 
             AddDateInterval | SubDateInterval | AddDateTime | DateBinTimestamp
             | DateTruncTimestamp => ScalarType::Timestamp.nullable(true),

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1362,3 +1362,9 @@ query T
 SELECT to_timestamp(-0.1::float8);
 ----
 1969-12-31 23:59:59.9+00
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/20077
+query T
+SELECT now() + null;
+----
+NULL


### PR DESCRIPTION
When adding or subtracting az interval to/from a timestamp, the type inference was not taking into account the nullability of the second argument. This caused us to infer non-nullable for stuff like `now() + null`, see https://github.com/MaterializeInc/materialize/issues/20077

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/20077

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
