### PR TITLE
`canonicalize_equivalences` only on the first run of JoinImplementation

### DIFF
--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -1216,3 +1216,20 @@ INSERT INTO error_test VALUES (0)
 
 query error division by zero
 SELECT t1.a / t2.a FROM error_test t1, error_test t2
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/20060
+query
+select
+  from
+    (select
+          ref_4."schema_id" as c0
+        from
+          mz_catalog.mz_default_privileges as ref_4
+        where current_schemas(
+            CAST((select max(atthasdef) from pg_attribute)
+               as bool)) = mz_internal.mz_normalize_object_name(
+            CAST(ref_4."schema_id" as text))
+               ) as subq_7
+  where (select "child_id" from mz_internal.mz_view_foreign_keys limit 1)
+       = subq_7."c0";
+----


### PR DESCRIPTION
This fixes https://github.com/MaterializeInc/database-issues/issues/5998. The problem was that `canonicalize_equivalences` can invalidate a join plan when `JoinImplementation` is run for the second time, because in a second run we might discard the new join plan (see at the `match old_implementation` at the end) and just go with the old plan instead, but the old plan might not be compatible with the new equivalences that resulted from the `canonicalize_equivalences` call. (The added code comment also explains this.)

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/5998

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
