### PR TITLE
storage: cleanup exports, ingestions from StorageState on drop

### DIFF
--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1274,10 +1274,16 @@ impl StorageState {
                         // Indicates that we may drop `id`, as there are no more valid times to read.
                         //
                         // This handler removes state that is put in place by
-                        // the handler for `CreateSources`/`CreateSinks`, while
+                        // the handler for `RunIngestions`/`CreateSinks`, while
                         // the handler for the internal command does the same
                         // for the state put in place by its corresponding
                         // creation command.
+
+                        // Cleanup exports and ingestions immediately to ensure
+                        // they are not re-rendered in the case of
+                        // reconciliation.
+                        self.exports.remove(&id);
+                        self.ingestions.remove(&id);
 
                         // This will stop reporting of frontiers.
                         self.reported_frontiers.remove(&id);


### PR DESCRIPTION
For more detail on this change, see:
https://github.com/MaterializeInc/materialize/issues/20084

### Motivation

This PR fixes a recognized bug.

Closes #20084
Closes #20078

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
