### PR TITLE
expr: print ErrorIfNull errors without internal error prefix

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -796,5 +796,6 @@ message ProtoEvalError {
         uint64 max_array_size_exceeded = 70;
         string invalid_date_part = 71;
         ProtoDateDiffOverflow date_diff_overflow = 72;
+        string if_null_error = 73;
     }
 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -5793,12 +5793,15 @@ fn error_if_null<'a>(
         .collect::<Result<Vec<_>, _>>()?;
     match datums[0] {
         Datum::Null => {
-            let err_msg = if datums[1].is_null() {
-                "unexpected NULL"
-            } else {
-                datums[1].unwrap_str()
+            let err_msg = match datums[1] {
+                Datum::Null => {
+                    return Err(EvalError::Internal(
+                        "unexpected NULL in error side of error_if_null".to_string(),
+                    ))
+                }
+                o => o.unwrap_str(),
             };
-            Err(EvalError::Internal(err_msg.to_string()))
+            Err(EvalError::IfNullError(err_msg.to_string()))
         }
         _ => Ok(datums[0]),
     }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -2240,6 +2240,9 @@ pub enum EvalError {
         a: String,
         b: String,
     },
+    // The error for ErrorIfNull; this should not be used in other contexts as a generic error
+    // printer.
+    IfNullError(String),
 }
 
 impl fmt::Display for EvalError {
@@ -2424,6 +2427,7 @@ impl fmt::Display for EvalError {
             EvalError::DateDiffOverflow { unit, a, b } => {
                 write!(f, "datediff overflow, {unit} of {a}, {b}")
             }
+            EvalError::IfNullError(s) => f.write_str(s),
         }
     }
 }
@@ -2672,6 +2676,7 @@ impl RustType<ProtoEvalError> for EvalError {
                 a: a.to_owned(),
                 b: b.to_owned(),
             }),
+            EvalError::IfNullError(s) => IfNullError(s.clone()),
         };
         ProtoEvalError { kind: Some(kind) }
     }
@@ -2787,6 +2792,7 @@ impl RustType<ProtoEvalError> for EvalError {
                     a: v.a,
                     b: v.b,
                 }),
+                IfNullError(v) => Ok(EvalError::IfNullError(v)),
             },
             None => Err(TryFromProtoError::missing_field("ProtoEvalError::kind")),
         }

--- a/src/storage-client/src/types/errors.rs
+++ b/src/storage-client/src/types/errors.rs
@@ -462,7 +462,15 @@ impl Display for DataflowError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             DataflowError::DecodeError(e) => write!(f, "Decode error: {}", e),
-            DataflowError::EvalError(e) => write!(f, "Evaluation error: {}", e),
+            DataflowError::EvalError(e) => write!(
+                f,
+                "{}{}",
+                match **e {
+                    EvalError::IfNullError(_) => "",
+                    _ => "Evaluation error: ",
+                },
+                e
+            ),
             DataflowError::SourceError(e) => write!(f, "Source error: {}", e),
             DataflowError::EnvelopeError(e) => write!(f, "Envelope error: {}", e),
         }

--- a/test/sqllogictest/mz-resolve-object-name.slt
+++ b/test/sqllogictest/mz-resolve-object-name.slt
@@ -87,10 +87,10 @@ SELECT mz_internal.mz_global_id_to_name('u3');
 ----
 d.s.t
 
-query error db error: ERROR: internal error: improper relation name \(too many dotted names\): d\.s\.t\.c
+query error db error: ERROR: improper relation name \(too many dotted names\): d\.s\.t\.c
 SELECT mz_internal.mz_resolve_object_name('d.s.t.c');
 
-query error db error: ERROR: internal error: improper relation name \(too many dotted names\): d\.s\.t\.c\.b
+query error db error: ERROR: improper relation name \(too many dotted names\): d\.s\.t\.c\.b
 SELECT mz_internal.mz_resolve_object_name('d.s.t.c.b');
 
 # Respects search path

--- a/test/sqllogictest/parse_ident.slt
+++ b/test/sqllogictest/parse_ident.slt
@@ -260,10 +260,10 @@ SELECT mz_internal.mz_normalize_object_name('"SchemaX"."TableY"')::text;
 ----
 {NULL,SchemaX,TableY}
 
-query error db error: ERROR: internal error: improper relation name \(too many dotted names\): Dbz\.Schemax\.Tabley\.Cola
+query error db error: ERROR: improper relation name \(too many dotted names\): Dbz\.Schemax\.Tabley\.Cola
 SELECT mz_internal.mz_normalize_object_name('Dbz.Schemax.Tabley.Cola')::text;
 
-query error db error: ERROR: internal error: improper relation name \(too many dotted names\): "Dbz"\."SchemaX"\."TableY"\.Cola
+query error db error: ERROR: improper relation name \(too many dotted names\): "Dbz"\."SchemaX"\."TableY"\.Cola
 SELECT mz_internal.mz_normalize_object_name('"Dbz"."SchemaX"."TableY".Cola')::text;
 
 query error db error: ERROR: string is not a valid identifier: ""
@@ -305,7 +305,7 @@ SELECT mz_internal.mz_normalize_object_name('🌍.🌍.🌍');
 ----
 {🌍,🌍,🌍}
 
-query error db error: ERROR: internal error: improper relation name \(too many dotted names\): 🌍\.🌍\.🌍\.🌍
+query error db error: ERROR: improper relation name \(too many dotted names\): 🌍\.🌍\.🌍\.🌍
 SELECT mz_internal.mz_normalize_object_name('🌍.🌍.🌍.🌍');
 
 statement ok


### PR DESCRIPTION
ErrorIfNull is a very valuable construct for generating errors in functions implemented as SQL expressions; its usefulness is hampered, though, by the prefix of "internal error", so remove it.

mentioned recently by both @jkosh44 and @def- 

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
