### PR TITLE
compute: introduce a `CollectionState`

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -47,31 +47,19 @@ use crate::render::LinearJoinImpl;
 /// This state is restricted to the COMPUTE state, the deterministic, idempotent work
 /// done between data ingress and egress.
 pub struct ComputeState {
+    /// State kept for each installed compute collection.
+    pub collections: BTreeMap<GlobalId, CollectionState>,
+    /// Collections that were recently dropped and whose removal needs to be reported.
+    pub dropped_collections: Vec<GlobalId>,
     /// The traces available for sharing across dataflows.
     pub traces: TraceManager,
-    /// Tokens that should be dropped when a dataflow is dropped to clean up
-    /// associated state.
-    pub sink_tokens: BTreeMap<GlobalId, SinkToken>,
     /// Shared buffer with SUBSCRIBE operator instances by which they can respond.
     ///
     /// The entries are pairs of sink identifier (to identify the subscribe instance)
     /// and the response itself.
     pub subscribe_response_buffer: Rc<RefCell<Vec<(GlobalId, SubscribeResponse)>>>,
-    /// Frontier of sink writes (all subsequent writes will be at times at or
-    /// equal to this frontier)
-    pub sink_write_frontiers: BTreeMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
-    /// Probe handles for regulating the output of dataflow sources.
-    ///
-    /// Keys are IDs of indexes that are (transitively) fed by a flow-controlled source. New
-    /// dataflows that depend on these indexes are expected to report their output frontiers
-    /// through the corresponding probe handles.
-    pub flow_control_probes: BTreeMap<GlobalId, Vec<probe::Handle<Timestamp>>>,
     /// Peek commands that are awaiting fulfillment.
     pub pending_peeks: BTreeMap<Uuid, PendingPeek>,
-    /// Tracks the frontier information that has been sent over `response_tx`.
-    pub reported_frontiers: BTreeMap<GlobalId, ReportedFrontier>,
-    /// Collections that were recently dropped and whose removal needs to be reported.
-    pub dropped_collections: Vec<GlobalId>,
     /// The logger, from Timely's logging framework, if logs are enabled.
     pub compute_logger: Option<logging::compute::Logger>,
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
@@ -102,14 +90,11 @@ impl ComputeState {
         let command_history = ComputeCommandHistory::new(metrics.for_history());
 
         Self {
-            traces,
-            sink_tokens: Default::default(),
-            subscribe_response_buffer: Default::default(),
-            sink_write_frontiers: Default::default(),
-            flow_control_probes: Default::default(),
-            pending_peeks: Default::default(),
-            reported_frontiers: Default::default(),
+            collections: Default::default(),
             dropped_collections: Default::default(),
+            traces,
+            subscribe_response_buffer: Default::default(),
+            pending_peeks: Default::default(),
             compute_logger: None,
             persist_clients,
             command_history,
@@ -123,7 +108,23 @@ impl ComputeState {
 
     /// Return whether a collection with the given ID exists.
     pub fn collection_exists(&self, id: GlobalId) -> bool {
-        self.traces.get(&id).is_some() || self.sink_tokens.contains_key(&id)
+        self.collections.contains_key(&id)
+    }
+
+    /// Return a reference to the identified collection.
+    ///
+    /// Panics if the collection doesn't exist.
+    pub fn expect_collection(&self, id: GlobalId) -> &CollectionState {
+        self.collections.get(&id).expect("collection must exist")
+    }
+
+    /// Return a mutable reference to the identified collection.
+    ///
+    /// Panics if the collection doesn't exist.
+    pub fn expect_collection_mut(&mut self, id: GlobalId) -> &mut CollectionState {
+        self.collections
+            .get_mut(&id)
+            .expect("collection must exist")
     }
 }
 
@@ -223,18 +224,19 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
 
             let dataflow_index = self.timely_worker.next_dataflow_index();
 
-            // Initialize frontiers for each object, and optionally log their construction.
+            // Initialize compute and logging state for each object.
             for (object_id, collection_id) in exported_ids {
-                let reported_frontier = ReportedFrontier::NotReported {
+                let mut collection = CollectionState::new();
+
+                collection.reported_frontier = ReportedFrontier::NotReported {
                     lower: dataflow.as_of.clone().unwrap(),
                 };
-                if let Some(frontier) = self
-                    .compute_state
-                    .reported_frontiers
-                    .insert(object_id, reported_frontier)
-                {
+
+                let existing = self.compute_state.collections.insert(object_id, collection);
+                if existing.is_some() {
                     error!(
-                        "existing frontier {frontier:?} for newly created dataflow id {object_id}"
+                        id = ?object_id,
+                        "existing collection for newly created dataflow",
                     );
                 }
 
@@ -328,27 +330,19 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
     }
 
     fn drop_collection(&mut self, id: GlobalId) {
-        let is_subscribe = self.compute_state.sink_tokens.contains_key(&id)
-            && !self.compute_state.sink_write_frontiers.contains_key(&id);
-
-        // Sink-specific work:
-        self.compute_state.sink_write_frontiers.remove(&id);
-        self.compute_state.sink_tokens.remove(&id);
-        // Index-specific work:
-        self.compute_state.traces.del_trace(&id);
-        self.compute_state.flow_control_probes.remove(&id);
-
-        // Work common to sinks and indexes:
-
-        // Remove removing frontier tracking and logging.
-        let prev_frontier = self
+        let collection = self
             .compute_state
-            .reported_frontiers
+            .collections
             .remove(&id)
-            .expect("Dropped compute collection with no frontier");
+            .expect("dropped untracked collection");
+
+        // If this collection is an index, remove its trace.
+        self.compute_state.traces.del_trace(&id);
+
+        // Remove frontier logging.
         if let Some(logger) = self.compute_state.compute_logger.as_mut() {
             logger.log(ComputeEvent::ExportDropped { id });
-            if let Some(time) = prev_frontier.logging_time() {
+            if let Some(time) = collection.reported_frontier.logging_time() {
                 logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
             }
         }
@@ -360,7 +354,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         //  * The collection has already advanced to the empty frontier, in which case
         //    the final `FrontierUppers` response already serves the purpose of reporting
         //    the end of the dataflow.
-        if !is_subscribe && !prev_frontier.is_empty() {
+        if !collection.is_subscribe() && !collection.reported_frontier.is_empty() {
             self.compute_state.dropped_collections.push(id);
         }
     }
@@ -379,18 +373,19 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
             self.compute_state.traces.set(id, trace);
         }
 
-        // Initialize frontier reporting for all logging indexes.
+        // Initialize compute and logging state for each logging index.
         let index_ids = config.index_logs.values().copied();
         for id in index_ids {
-            if let Some(frontier) = self
-                .compute_state
-                .reported_frontiers
-                .insert(id, ReportedFrontier::new())
-            {
+            let collection = CollectionState::new();
+
+            let existing = self.compute_state.collections.insert(id, collection);
+            if existing.is_some() {
                 error!(
-                    "existing frontier {frontier:?} for newly initialized logging export id {id}"
+                    id = ?id,
+                    "existing collection for newly initialized logging export",
                 );
             }
+
             logger.log(ComputeEvent::Frontier {
                 id,
                 time: timely::progress::Timestamp::minimum(),
@@ -422,26 +417,33 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
     pub fn report_compute_frontiers(&mut self) {
         let mut new_uppers = Vec::new();
 
-        let mut update_frontier = |id, new_frontier: &Antichain<Timestamp>| {
-            let reported_frontier = self
-                .compute_state
-                .reported_frontiers
-                .get_mut(&id)
-                .unwrap_or_else(|| panic!("Frontier update for untracked identifier: {id}"));
+        for (&id, collection) in self.compute_state.collections.iter_mut() {
+            let mut new_frontier = Antichain::new();
+            if let Some(traces) = self.compute_state.traces.get_mut(&id) {
+                traces.oks_mut().read_upper(&mut new_frontier);
+            } else if let Some(frontier) = &collection.sink_write_frontier {
+                new_frontier.clone_from(&frontier.borrow());
+            } else {
+                // Subscribe frontiers are reported in `process_subscribes` instead.
+                if !collection.is_subscribe() {
+                    error!(id = ?id, "collection without frontier");
+                }
+                continue;
+            }
 
-            match reported_frontier {
+            match &collection.reported_frontier {
                 ReportedFrontier::Reported(old_frontier) => {
                     // In steady state it is not expected for `old_frontier` to be beyond
                     // `new_frontier`. However, during reconcilation this can happen as we
                     // artificially advance the frontiers of to-be-dropped collections to disable
                     // frontier reporting for them.
-                    if !PartialOrder::less_than(old_frontier, new_frontier) {
-                        return; // nothing new to report
+                    if !PartialOrder::less_than(old_frontier, &new_frontier) {
+                        continue; // nothing new to report
                     }
                 }
                 ReportedFrontier::NotReported { lower } => {
-                    if !PartialOrder::less_equal(lower, new_frontier) {
-                        return; // lower bound for reporting not yet reached
+                    if !PartialOrder::less_equal(lower, &new_frontier) {
+                        continue; // lower bound for reporting not yet reached
                     }
                 }
             }
@@ -449,7 +451,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
             let new_reported_frontier = ReportedFrontier::Reported(new_frontier.clone());
 
             if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-                if let Some(time) = reported_frontier.logging_time() {
+                if let Some(time) = collection.reported_frontier.logging_time() {
                     logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
                 }
                 if let Some(time) = new_reported_frontier.logging_time() {
@@ -457,18 +459,8 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                 }
             }
 
-            new_uppers.push((id, new_frontier.clone()));
-            *reported_frontier = new_reported_frontier;
-        };
-
-        let mut new_frontier = Antichain::new();
-        for (id, traces) in self.compute_state.traces.traces.iter_mut() {
-            traces.oks_mut().read_upper(&mut new_frontier);
-            update_frontier(*id, &new_frontier);
-        }
-        for (id, frontier) in self.compute_state.sink_write_frontiers.iter() {
-            new_frontier.clone_from(&frontier.borrow());
-            update_frontier(*id, &new_frontier);
+            new_uppers.push((id, new_frontier));
+            collection.reported_frontier = new_reported_frontier;
         }
 
         if !new_uppers.is_empty() {
@@ -540,14 +532,13 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         let mut subscribe_responses = self.compute_state.subscribe_response_buffer.borrow_mut();
         for (sink_id, mut response) in subscribe_responses.drain(..) {
             // Update frontier logging for this subscribe.
-            if let Some(reported_frontier) = self.compute_state.reported_frontiers.get_mut(&sink_id)
-            {
+            if let Some(collection) = self.compute_state.collections.get_mut(&sink_id) {
                 let new_frontier = match &response {
                     SubscribeResponse::Batch(b) => b.upper.clone(),
                     SubscribeResponse::DroppedAt(_) => Antichain::new(),
                 };
 
-                match reported_frontier {
+                match &collection.reported_frontier {
                     ReportedFrontier::Reported(old_frontier) => {
                         assert!(
                             PartialOrder::less_than(old_frontier, &new_frontier),
@@ -566,7 +557,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                 let new_reported_frontier = ReportedFrontier::Reported(new_frontier);
 
                 if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-                    if let Some(time) = reported_frontier.logging_time() {
+                    if let Some(time) = collection.reported_frontier.logging_time() {
                         logger.log(ComputeEvent::Frontier {
                             id: sink_id,
                             time,
@@ -582,10 +573,10 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                     }
                 }
 
-                *reported_frontier = new_reported_frontier;
+                collection.reported_frontier = new_reported_frontier;
             } else {
-                // Presumably tracking state for this frontier was already dropped by
-                // `handle_allow_compaction`. There is nothing left to do for logging.
+                // Presumably tracking state for this subscribe was already dropped by
+                // `drop_collection`. There is nothing left to do for logging.
             }
 
             response
@@ -899,5 +890,43 @@ impl ReportedFrontier {
             Self::Reported(frontier) => frontier.get(0).copied(),
             Self::NotReported { .. } => Some(timely::progress::Timestamp::minimum()),
         }
+    }
+}
+
+/// State maintained for a compute collection.
+pub struct CollectionState {
+    /// Tracks the frontier that has been reported to the controller.
+    pub reported_frontier: ReportedFrontier,
+    /// A token that should be dropped when this collection is dropped to clean up associated
+    /// sink state.
+    ///
+    /// Only `Some` if the collection is a sink.
+    pub sink_token: Option<SinkToken>,
+    /// Frontier of sink writes.
+    ///
+    /// Only `Some` if the collection is a sink and *not* a subscribe.
+    pub sink_write_frontier: Option<Rc<RefCell<Antichain<Timestamp>>>>,
+    /// Probe handles for regulating the output of dataflow sources that (transitively) feed this
+    /// collection.
+    ///
+    /// Only populated if the collection is an index.
+    ///
+    /// New dataflows that depend on this index are expected to report their output frontiers
+    /// through these probe handles.
+    pub index_flow_control_probes: Vec<probe::Handle<Timestamp>>,
+}
+
+impl CollectionState {
+    fn new() -> Self {
+        Self {
+            reported_frontier: ReportedFrontier::new(),
+            sink_token: None,
+            sink_write_frontier: None,
+            index_flow_control_probes: Default::default(),
+        }
+    }
+
+    fn is_subscribe(&self) -> bool {
+        self.sink_token.is_some() && self.sink_write_frontier.is_none()
     }
 }

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -264,8 +264,10 @@ pub fn build_compute_dataflow<A: Allocate>(
         // Collect flow control probes for this dataflow.
         let index_ids = dataflow.index_imports.keys();
         let output_probes: Vec<_> = index_ids
-            .flat_map(|id| compute_state.flow_control_probes.get(id))
-            .flatten()
+            .flat_map(|id| {
+                let collection = compute_state.expect_collection(*id);
+                &collection.index_flow_control_probes
+            })
             .cloned()
             .chain(flow_control_probe)
             .collect();
@@ -491,9 +493,8 @@ where
             )
         });
 
-        compute_state
-            .flow_control_probes
-            .insert(idx_id, probes.clone());
+        let collection = compute_state.expect_collection_mut(idx_id);
+        collection.index_flow_control_probes = probes.clone();
 
         match bundle.arrangement(&idx.key) {
             Some(ArrangementFlavor::Local(oks, errs)) => {
@@ -556,9 +557,8 @@ where
             )
         });
 
-        compute_state
-            .flow_control_probes
-            .insert(idx_id, probes.clone());
+        let collection = compute_state.expect_collection_mut(idx_id);
+        collection.index_flow_control_probes = probes.clone();
 
         match bundle.arrangement(&idx.key) {
             Some(ArrangementFlavor::Local(oks, errs)) => {

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -100,9 +100,8 @@ where
                     needed_tokens.push(sink_token);
                 }
 
-                compute_state
-                    .sink_tokens
-                    .insert(sink_id, SinkToken::new(Box::new(needed_tokens)));
+                let collection = compute_state.expect_collection_mut(sink_id);
+                collection.sink_token = Some(SinkToken::new(Box::new(needed_tokens)));
             });
     }
 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -391,30 +391,14 @@ impl<'w, A: Allocate> Worker<'w, A> {
     fn handle_command(&mut self, response_tx: &mut ResponseSender, cmd: ComputeCommand) {
         match &cmd {
             ComputeCommand::CreateInstance(_) => {
-                let command_history =
-                    ComputeCommandHistory::new(self.compute_metrics.for_history());
-
-                self.compute_state = Some(ComputeState {
-                    traces: TraceManager::new(
-                        self.trace_metrics.clone(),
-                        self.timely_worker.index(),
-                    ),
-                    sink_tokens: BTreeMap::new(),
-                    subscribe_response_buffer: Rc::new(RefCell::new(Vec::new())),
-                    sink_write_frontiers: BTreeMap::new(),
-                    flow_control_probes: BTreeMap::new(),
-                    pending_peeks: BTreeMap::new(),
-                    reported_frontiers: BTreeMap::new(),
-                    dropped_collections: Vec::new(),
-                    compute_logger: None,
-                    persist_clients: Arc::clone(&self.persist_clients),
-                    command_history,
-                    max_result_size: u32::MAX,
-                    dataflow_max_inflight_bytes: usize::MAX,
-                    linear_join_impl: Default::default(),
-                    metrics: self.compute_metrics.clone(),
-                    tracing_handle: Arc::clone(&self.tracing_handle),
-                });
+                let traces =
+                    TraceManager::new(self.trace_metrics.clone(), self.timely_worker.index());
+                self.compute_state = Some(ComputeState::new(
+                    traces,
+                    Arc::clone(&self.persist_clients),
+                    self.compute_metrics.clone(),
+                    Arc::clone(&self.tracing_handle),
+                ));
             }
             _ => (),
         }

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -283,9 +283,8 @@ where
         Antichain::new()
     }));
 
-    compute_state
-        .sink_write_frontiers
-        .insert(sink_id, Rc::clone(&shared_frontier));
+    let collection = compute_state.expect_collection_mut(sink_id);
+    collection.sink_write_frontier = Some(Rc::clone(&shared_frontier));
 
     let mut mint_op =
         AsyncOperatorBuilder::new(format!("{} mint_batch_descriptions", operator_name), scope);


### PR DESCRIPTION
Prior to this PR, the per-collection state tracked by compute was spread over several `BTreeMap`s in `ComputeState`:
     * `sink_tokens`
     * `sink_write_frontiers`
     * `flow_control_probes`
     * `reported_frontiers`

This made it hard to keep track of the collection state as a whole and invited bugs caused by inconsistencies (e.g. we might forget to drop all of the state for a collection).

This PR refactors the `ComputeState` by replacing the four per-collection fields mentioned above with a single `collections` map. Values in this map are `CollectionState` objects that each contain the entire state specific to a single collection. An exception is trace state, which is kept in the `TraceManager` and pulling that apart seemed too much of a hassle.

### Motivation

   * This PR refactors existing code.

As part of implementing the proposed `mz_dataflow_initial_output_duration_seconds` compute metric (draft PR: https://github.com/MaterializeInc/materialize/pull/20126), I noticed that with the current code that would mean adding two new per-collection `ComputeState` fields, one for keeping the the delete-on-drop collection metrics and one for remembering the time at which the collection was installed. I figured it was worth to invest some time to clean up our collection tracking. 

### Tips for reviewer

This PR includes a minor cleanup commit that I already added in #18442. It would be nice if we could finally land that too.

Most of the changes are pretty mechanical, replacing a direct field access on `ComputeState` with an access to `collections` and then one of its fields. A notable exception if `report_compute_frontiers` where I replaced the previous logic of iterating over trace frontiers then sink frontiers by a single iteration over all collections. I then inlined the frontier update closure which was only needed to deduplicate code. I suggest you look at both implementations side-by-side to convince yourself that they do the same thing, rather than trying to decipher the diff.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
