### PR TITLE
tests: Deflake test with CockroachDB issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4295,6 +4295,7 @@ dependencies = [
  "pin-project",
  "prometheus",
  "proptest",
+ "rand",
  "scopeguard",
  "sentry",
  "sentry-tracing",

--- a/misc/scratch/ci.json
+++ b/misc/scratch/ci.json
@@ -1,7 +1,7 @@
 {
-    "name": "c5.2xlarge as used by the CI",
+    "name": "c6a.8xlarge as used by the CI",
     "launch_script": "true",
-    "instance_type": "c5.2xlarge",
+    "instance_type": "c6a.8xlarge",
     "ami": "ami-09d56f8956ab235b3",
     "size_gb": 50,
     "tags": {}

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -29,6 +29,7 @@ openssl = { version = "0.10.48", features = ["vendored"], optional = true }
 paste = "1.0.11"
 pin-project = "1.0.12"
 prometheus = { version = "0.13.3", default-features = false, optional = true }
+rand = { version = "0.8.5", optional = true }
 smallvec = { version = "1.10.0", optional = true }
 stacker = { version = "0.1.15", optional = true }
 sentry = { version = "0.29.1", optional = true, features = ["debug-images"] }

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -18,7 +18,7 @@ differential-dataflow = "0.12.0"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 itertools = "0.10.5"
-mz-ore = { path = "../ore", features = ["metrics", "network", "async", "test"] }
+mz-ore = { path = "../ore", features = ["metrics", "network", "async", "rand", "test"] }
 mz-postgres-util = { path = "../postgres-util" }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -345,8 +345,10 @@ impl StashFactory {
         // url is bad. We also need to allow for a down server, though, so retry for a while before
         // bailing. These numbers are made up.
         let retry = Retry::default()
-            .clamp_backoff(Duration::from_secs(1))
-            .max_duration(Duration::from_secs(30))
+            .initial_backoff(Duration::from_secs(1))
+            .max_duration(Duration::from_secs(60))
+            .factor(1.5)
+            .jitter(Duration::from_millis(150))
             .into_retry_stream();
         let mut retry = Box::pin(retry);
         loop {


### PR DESCRIPTION
### Motivation

Fixes: #19931 

We're seeing tests occasionally flake in CI because of an error like:
```
TransactionRetryWithProtoRefreshError: TransactionRetryError: retry txn (RETRY_SERIALIZABLE - failed preemptive refresh due to a conflict: committed value on key /Table/3/1/100/2/1)
```

CockroachDB indicates this error is retryable, but we already have retry logic in place and the issue was still occurring.

Some investigation revealed that this appears to be an error on a CRDB internal table that has to do with schemas. In our Stash tests we create and drop schemas for each test, so when testing in parallel you could imagine us creating and dropping schemas quite quickly. Initially we thought this was a CRDB issue, possibly some live lock scenario, but I couldn't get a minimum repro to reliably occur. I could definitely get this error to be thrown, but it would always resolve itself after a couple of retries. Running our CI flow locally (i.e. `ci/test/cargo-test`) also didn't repro the issue.

What I ended up doing was creating an AWS scratch instance using the same kind of machine we do for CI, and re-running the flow there. Once I did that I could easily observe the test failures after running our flow a couple of times. To me this indicates it's a test only issue, and what's different about CI than my local machine, is CI has 32 threads and thus as we have it configured, runs 64 tests in parallel. At this point I started adjusting our retry strategy because I figured running so many tests in parallel was resulting in some contention.

After adding some jitter to our retry helpers I was able to run the "Cargo test" CI workflow 10 times in a row and they all passed. Whereas previously I observed it to fail at least 2 times in 10 runs.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
