### PR TITLE
expr: implement try_to_timestamp

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -265,6 +265,7 @@ message ProtoUnaryFunc {
         mz_repr.relation_and_scalar.ProtoScalarType cast_map_to_string = 138;
         google.protobuf.Empty cast_int2_vector_to_string = 139;
         mz_repr.relation_and_scalar.ProtoScalarType cast_range_to_string = 282;
+        google.protobuf.Empty try_to_timestamp_iso_8601_monotone = 298;
         google.protobuf.Empty ceil_float32 = 140;
         google.protobuf.Empty ceil_float64 = 141;
         google.protobuf.Empty ceil_numeric = 142;

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4464,6 +4464,7 @@ derive_unary!(
     CastMapToString,
     CastInt2VectorToString,
     CastRangeToString,
+    TryToTimestampIso8601Monotone,
     CeilFloat32,
     CeilFloat64,
     CeilNumeric,
@@ -5204,6 +5205,7 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
             UnaryFunc::CastMapToString(func) => CastMapToString(func.ty.into_proto()),
             UnaryFunc::CastInt2VectorToString(_) => CastInt2VectorToString(()),
             UnaryFunc::CastRangeToString(func) => CastRangeToString(func.ty.into_proto()),
+            UnaryFunc::TryToTimestampIso8601Monotone(_) => TryToTimestampIso8601Monotone(()),
             UnaryFunc::CeilFloat32(_) => CeilFloat32(()),
             UnaryFunc::CeilFloat64(_) => CeilFloat64(()),
             UnaryFunc::CeilNumeric(_) => CeilNumeric(()),
@@ -5612,6 +5614,7 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                     ty: ty.into_rust()?,
                 }
                 .into()),
+                TryToTimestampIso8601Monotone(_) => Ok(impls::TryToTimestampIso8601Monotone.into()),
                 CeilFloat32(_) => Ok(impls::CeilFloat32.into()),
                 CeilFloat64(_) => Ok(impls::CeilFloat64.into()),
                 CeilNumeric(_) => Ok(impls::CeilNumeric.into()),

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -108,6 +108,23 @@ sqlfunc!(
     }
 );
 
+sqlfunc!(
+    #[sqlname = "try_to_timestamp_iso_8601_monotone"]
+    #[is_monotone = true]
+    fn try_to_timestamp_iso_8601_monotone(a: &'a str) -> Option<CheckedTimestamp<NaiveDateTime>> {
+        if !a.ends_with('Z') {
+            return None;
+        }
+        let a = &a[..a.len()-1];
+        // WIP pretty sure we're gonna have to hand-roll a parser here?
+        // `parse_from_str` doesn't behave the way we want for 3 digit years and
+        // probably other things.
+        let ts = a.parse::<NaiveDateTime>().ok()?;
+        let ts = CheckedTimestamp::from_timestamplike(ts).ok()?;
+        Some(ts)
+    }
+);
+
 pub fn date_part_interval_inner<D>(units: DateTimeUnits, interval: Interval) -> Result<D, EvalError>
 where
     D: DecimalLike,

--- a/test/sqllogictest/try_to_timestamp.slt
+++ b/test/sqllogictest/try_to_timestamp.slt
@@ -1,0 +1,56 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# TODO
+# - upper and lower case T and Z
+# - timestamp out of range
+# - fractional seconds
+# - non Z timezone
+
+mode cockroach
+
+query T
+select try_to_timestamp('2015-09-18T23:56:04', 'YYYY-MM-DDTHH:MI:SSZ');
+----
+NULL
+
+query T
+select try_to_timestamp('2015-09-18T23:56:04Z', 'YYYY-MM-DDTHH:MI:SSZ');
+----
+2015-09-18 23:56:04
+
+query T
+select try_to_timestamp('2015-09-18T23:56:04.001Z', 'YYYY-MM-DDTHH:MI:SSZ');
+----
+2015-09-18 23:56:04.001
+
+# WIP this should parse
+query T
+select try_to_timestamp('20150-09-18T23:56:04Z', 'YYYY-MM-DDTHH:MI:SSZ');
+----
+NULL
+
+query T
+select try_to_timestamp('-2015-09-18T23:56:04Z', 'YYYY-MM-DDTHH:MI:SSZ');
+----
+2016-09-18 23:56:04 BC
+
+query T
+select try_to_timestamp('nope', 'YYYY-MM-DDTHH:MI:SSZ');
+----
+NULL
+
+# WIP this shouldn't parse
+query T
+select try_to_timestamp('215-09-18T23:56:04Z', 'YYYY-MM-DDTHH:MI:SSZ');
+----
+0215-09-18 23:56:04
+
+query error db error: ERROR: unsupported try_to_timestamp format 'nope'
+select try_to_timestamp('2015-09-18T23:56:04Z', 'nope');


### PR DESCRIPTION

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
