### PR TITLE
doc: Reference Terraform modules from AWS Postgres guides

### DIFF
--- a/doc/user/content/ingest-data/postgres-amazon-aurora.md
+++ b/doc/user/content/ingest-data/postgres-amazon-aurora.md
@@ -63,6 +63,10 @@ Select the option that works best for you.
 
 [AWS PrivateLink](https://aws.amazon.com/privatelink/) lets you connect Materialize to your Aurora instance without exposing traffic to the public internet. To use AWS PrivateLink, you create a network load balancer in the same VPC as your Aurora instance and a VPC endpoint service that Materialize connects to. The VPC endpoint service then routes requests from Materialize to Aurora via the network load balancer.
 
+{{< note >}}
+Materialize provides a Terraform module that automates the creation and configuration of AWS resources for a PrivateLink connection. For more details, see the [Terraform module repository](https://github.com/MaterializeInc/terraform-aws-rds-privatelink).
+{{</ note >}}
+
 1. Get the IP address of your Aurora instance.
 
     You'll need this address to register your Aurora instance as the target for the network load balancer in the next step.
@@ -115,6 +119,10 @@ Select the option that works best for you.
 {{< tab "Use an SSH tunnel">}}
 
 To create an SSH tunnel from Materialize to your database, you launch an instance to serve as an SSH bastion host, configure the bastion host to allow traffic only from Materialize, and then configure your database's private network to allow traffic from the bastion host.
+
+{{< note >}}
+Materialize provides a Terraform module that automates the creation and configuration of resources for an SSH tunnel. For more details, see the [Terraform module repository](https://github.com/MaterializeInc/terraform-aws-ec2-ssh-bastion).
+{{</ note >}}
 
 1. [Launch an EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/LaunchingAndUsingInstances.html) to serve as your SSH bastion host.
 

--- a/doc/user/content/ingest-data/postgres-amazon-rds.md
+++ b/doc/user/content/ingest-data/postgres-amazon-rds.md
@@ -116,6 +116,10 @@ Select the option that works best for you.
 
 [AWS PrivateLink](https://aws.amazon.com/privatelink/) lets you connect Materialize to your RDS instance without exposing traffic to the public internet. To use AWS PrivateLink, you create a network load balancer in the same VPC as your RDS instance and a VPC endpoint service that Materialize connects to. The VPC endpoint service then routes requests from Materialize to RDS via the network load balancer.
 
+{{< note >}}
+Materialize provides a Terraform module that automates the creation and configuration of AWS resources for a PrivateLink connection. For more details, see the [Terraform module repository](https://github.com/MaterializeInc/terraform-aws-rds-privatelink).
+{{</ note >}}
+
 1. Get the IP address of your RDS instance. You'll need this address to register your RDS instance as the target for the network load balancer in the next step.
 
     To get the IP address of your RDS instance:
@@ -166,6 +170,10 @@ Select the option that works best for you.
 {{< tab "Use an SSH tunnel">}}
 
 To create an SSH tunnel from Materialize to your database, you launch an instance to serve as an SSH bastion host, configure the bastion host to allow traffic only from Materialize, and then configure your database's private network to allow traffic from the bastion host.
+
+{{< note >}}
+Materialize provides a Terraform module that automates the creation and configuration of resources for an SSH tunnel. For more details, see the [Terraform module repository](https://github.com/MaterializeInc/terraform-aws-ec2-ssh-bastion).
+{{</ note >}}
 
 1. [Launch an EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/LaunchingAndUsingInstances.html) to serve as your SSH bastion host.
 


### PR DESCRIPTION
This PR updates the RDS Postgres and RDS Aurora integration guides to point users at our PrivateLink and SSH tunnel Terraform modules.

I didn't update the other Postgres guides because these modules are AWS-specific.

Fixes: #19764

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
