### PR TITLE
sql: Implement grant/revoke for system privileges

### DIFF
--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -16,7 +16,7 @@ use mz_ore::str::StrExt;
 use mz_repr::adt::mz_acl_item::AclMode;
 use mz_repr::strconv;
 use mz_sql::ast::NoticeSeverity;
-use mz_sql::catalog::ObjectType;
+use mz_sql::catalog::SystemObjectType;
 use mz_sql::plan::PlanNotice;
 use mz_sql::session::vars::IsolationLevel;
 
@@ -103,7 +103,7 @@ pub enum AdapterNotice {
     },
     NonApplicablePrivilegeTypes {
         non_applicable_privileges: AclMode,
-        object_type: ObjectType,
+        object_type: SystemObjectType,
         object_name: String,
     },
     PlanNotice(PlanNotice),

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1087,6 +1087,27 @@ impl From<&GlobalId> for ObjectId {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum SystemObjectId {
+    Object(ObjectId),
+    System,
+}
+
+impl SystemObjectId {
+    pub fn object_id(&self) -> Option<&ObjectId> {
+        match self {
+            SystemObjectId::Object(object_id) => Some(object_id),
+            SystemObjectId::System => None,
+        }
+    }
+}
+
+impl From<ObjectId> for SystemObjectId {
+    fn from(id: ObjectId) -> Self {
+        SystemObjectId::Object(id)
+    }
+}
+
 #[derive(Debug)]
 pub struct NameResolver<'a> {
     catalog: &'a dyn SessionCatalog,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -57,7 +57,9 @@ use crate::catalog::{
     CatalogType, DefaultPrivilegeAclItem, DefaultPrivilegeObject, IdReference, ObjectType,
     RoleAttributes,
 };
-use crate::names::{Aug, FullItemName, ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier};
+use crate::names::{
+    Aug, FullItemName, ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier, SystemObjectId,
+};
 
 pub(crate) mod error;
 pub(crate) mod explain;
@@ -642,7 +644,7 @@ pub struct DropOwnedPlan {
     /// All object IDs to drop.
     pub drop_ids: Vec<ObjectId>,
     /// The privileges to revoke.
-    pub privilege_revokes: Vec<(ObjectId, MzAclItem)>,
+    pub privilege_revokes: Vec<(SystemObjectId, MzAclItem)>,
     /// The default privileges to revoke.
     pub default_privilege_revokes: Vec<(DefaultPrivilegeObject, DefaultPrivilegeAclItem)>,
 }
@@ -964,8 +966,8 @@ pub struct RevokeRolePlan {
 pub struct UpdatePrivilege {
     /// The privileges being granted/revoked on an object.
     pub acl_mode: AclMode,
-    /// The ID of the object.
-    pub object_id: ObjectId,
+    /// The ID of the object receiving privileges.
+    pub target_id: SystemObjectId,
     /// The role that is granting the privileges.
     pub grantor: RoleId,
 }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -29,7 +29,7 @@ use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::UnresolvedItemName;
 use mz_sql_parser::parser::ParserError;
 
-use crate::catalog::{CatalogError, CatalogItemType, ObjectType};
+use crate::catalog::{CatalogError, CatalogItemType, SystemObjectType};
 use crate::names::{PartialItemName, ResolvedItemName};
 use crate::plan::plan_utils::JoinSide;
 use crate::plan::scope::ScopeItem;
@@ -87,13 +87,13 @@ pub enum PlanError {
     InvalidId(GlobalId),
     InvalidObject(Box<ResolvedItemName>),
     InvalidObjectType {
-        expected_type: ObjectType,
-        actual_type: ObjectType,
+        expected_type: SystemObjectType,
+        actual_type: SystemObjectType,
         object_name: String,
     },
     InvalidPrivilegeTypes {
         invalid_privileges: AclMode,
-        object_type: ObjectType,
+        object_type: SystemObjectType,
         object_name: Option<String>,
     },
     InvalidVarCharMaxLength(InvalidVarCharMaxLengthError),

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -24,12 +24,12 @@ use mz_storage_client::types::connections::{AwsPrivatelink, Connection, SshTunne
 use crate::ast::{Ident, Statement, UnresolvedItemName};
 use crate::catalog::{
     CatalogCluster, CatalogDatabase, CatalogItem, CatalogItemType, CatalogSchema, ObjectType,
-    SessionCatalog,
+    SessionCatalog, SystemObjectType,
 };
 use crate::names::{
     self, Aug, DatabaseId, FullItemName, ItemQualifiers, ObjectId, PartialItemName,
     QualifiedItemName, RawDatabaseSpecifier, ResolvedDataType, ResolvedDatabaseSpecifier,
-    ResolvedItemName, ResolvedSchemaName, SchemaSpecifier,
+    ResolvedItemName, ResolvedSchemaName, SchemaSpecifier, SystemObjectId,
 };
 use crate::normalize;
 use crate::plan::error::PlanError;
@@ -719,6 +719,13 @@ impl<'a> StatementContext<'a> {
 
     pub fn get_object_type(&self, id: &ObjectId) -> ObjectType {
         self.catalog.get_object_type(id)
+    }
+
+    pub fn get_system_object_type(&self, id: &SystemObjectId) -> SystemObjectType {
+        match id {
+            SystemObjectId::Object(id) => SystemObjectType::Object(self.get_object_type(id)),
+            SystemObjectId::System => SystemObjectType::System,
+        }
     }
 
     /// Returns an error if the named `FeatureFlag` is not set to `on`.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -91,7 +91,7 @@ use crate::kafka_util::{self, KafkaConfigOptionExtracted, KafkaStartOffsetType};
 use crate::names::{
     Aug, DatabaseId, ObjectId, PartialItemName, QualifiedItemName, RawDatabaseSpecifier,
     ResolvedClusterName, ResolvedDataType, ResolvedDatabaseSpecifier, ResolvedItemName,
-    SchemaSpecifier,
+    SchemaSpecifier, SystemObjectId,
 };
 use crate::normalize::{self, ident};
 use crate::plan::error::PlanError;
@@ -3845,10 +3845,10 @@ pub fn plan_drop_owned(
     let mut default_privilege_revokes = Vec::new();
 
     fn update_privilege_revokes(
-        object_id: ObjectId,
+        object_id: SystemObjectId,
         privileges: &PrivilegeMap,
         role_ids: &BTreeSet<RoleId>,
-        privilege_revokes: &mut Vec<(ObjectId, MzAclItem)>,
+        privilege_revokes: &mut Vec<(SystemObjectId, MzAclItem)>,
     ) {
         privilege_revokes.extend(iter::zip(
             iter::repeat(object_id),
@@ -3878,7 +3878,7 @@ pub fn plan_drop_owned(
             drop_ids.push(cluster.id().into());
         }
         update_privilege_revokes(
-            cluster.id().into(),
+            SystemObjectId::Object(cluster.id().into()),
             cluster.privileges(),
             &role_ids,
             &mut privilege_revokes,
@@ -3921,7 +3921,7 @@ pub fn plan_drop_owned(
             drop_ids.push(item.id().into());
         }
         update_privilege_revokes(
-            item.id().into(),
+            SystemObjectId::Object(item.id().into()),
             item.privileges(),
             &role_ids,
             &mut privilege_revokes,
@@ -3951,7 +3951,7 @@ pub fn plan_drop_owned(
                 drop_ids.push((*schema.database(), *schema.id()).into())
             }
             update_privilege_revokes(
-                (*schema.database(), *schema.id()).into(),
+                SystemObjectId::Object((*schema.database(), *schema.id()).into()),
                 schema.privileges(),
                 &role_ids,
                 &mut privilege_revokes,
@@ -3978,12 +3978,20 @@ pub fn plan_drop_owned(
             drop_ids.push(database.id().into());
         }
         update_privilege_revokes(
-            database.id().into(),
+            SystemObjectId::Object(database.id().into()),
             database.privileges(),
             &role_ids,
             &mut privilege_revokes,
         );
     }
+
+    // System
+    update_privilege_revokes(
+        SystemObjectId::System,
+        scx.catalog.get_system_privileges(),
+        &role_ids,
+        &mut privilege_revokes,
+    );
 
     for (default_privilege_object, default_privilege_acl_items) in
         scx.catalog.get_default_privileges()

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -2145,11 +2145,22 @@ GRANT SELECT ON v TO materialize;
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+GRANT CREATEDB ON SYSTEM TO materialize;
+----
+COMPLETE 0
+
 query TT
 SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
 ----
 v  mz_system=r/mz_system
 v  materialize=r/mz_system
+
+query T
+SELECT privileges::text FROM mz_system_privileges
+----
+materialize=B/mz_system
+mz_system=RBN/mz_system
 
 simple conn=mz_system,user=mz_system
 DROP OWNED BY materialize;
@@ -2180,6 +2191,11 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_views WHERE name = 'v'
 ----
 v  mz_system=r/mz_system
+
+query T
+SELECT privileges::text FROM mz_system_privileges
+----
+mz_system=RBN/mz_system
 
 simple conn=mz_system,user=mz_system
 DROP VIEW v;

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -1837,21 +1837,99 @@ sch  materialize=UC/materialize
 ## System
 
 query B
-SELECT has_system_privilege('mz_system', 'CREATEROLE')
+SELECT has_system_privilege('joe', 'CREATEDB')
+----
+false
+
+query B
+SELECT has_system_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'CREATEDB')
+----
+false
+
+statement ok
+GRANT CREATEDB ON SYSTEM TO joe
+
+query T
+SELECT privileges::text FROM mz_system_privileges
+----
+joe=B/mz_system
+mz_system=RBN/mz_system
+
+query B
+SELECT has_system_privilege('joe', 'CREATEDB')
 ----
 true
 
 query B
-SELECT has_system_privilege('mz_system', 'CREATEDB')
+SELECT has_system_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'CREATEDB')
 ----
 true
+
+### Duplicate grants have no effect
+statement ok
+GRANT CREATEDB ON SYSTEM TO joe
+
+query T
+SELECT privileges::text FROM mz_system_privileges
+----
+joe=B/mz_system
+mz_system=RBN/mz_system
+
+statement ok
+GRANT CREATEROLE, CREATECLUSTER ON SYSTEM TO PUBLIC
+
+query T
+SELECT privileges::text FROM mz_system_privileges
+----
+=RN/mz_system
+joe=B/mz_system
+mz_system=RBN/mz_system
+
+statement error role "joe" cannot be dropped because some objects depend on it
+DROP ROLE joe
+
+statement ok
+REVOKE CREATEDB ON SYSTEM FROM joe
+
+query T
+SELECT privileges::text FROM mz_system_privileges
+----
+=RN/mz_system
+mz_system=RBN/mz_system
 
 query B
-SELECT has_system_privilege('mz_system', 'CREATECLUSTER')
+SELECT has_system_privilege('joe', 'CREATEDB')
 ----
-true
+false
 
-# TODO(jkosh44) Add tests when GRANT is implemented for system privileges
+query B
+SELECT has_system_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'CREATEDB')
+----
+false
+
+### Duplicate revokes have no effect
+statement ok
+REVOKE CREATEDB ON SYSTEM FROM joe
+
+query T
+SELECT privileges::text FROM mz_system_privileges
+----
+=RN/mz_system
+mz_system=RBN/mz_system
+
+statement ok
+DROP ROLE joe
+
+statement ok
+CREATE ROLE joe
+
+statement ok
+REVOKE CREATEROLE, CREATECLUSTER ON SYSTEM FROM PUBLIC
+
+query T
+SELECT privileges::text FROM mz_system_privileges
+----
+mz_system=RBN/mz_system
 
 ## Test misc error scenarios
 
@@ -2055,13 +2133,26 @@ SELECT name, privilege FROM item_privileges WHERE name = 'v1'
 ----
 v1  mz_system=r/mz_system
 
-## System
+simple conn=mz_system,user=mz_system
+GRANT ALL ON SYSTEM TO joe
+----
+COMPLETE 0
 
-statement error SYSTEM PRIVILEGES not yet supported
-GRANT CREATECLUSTER ON SYSTEM TO test_role
+query T
+SELECT privileges::text FROM mz_system_privileges
+----
+joe=RBN/mz_system
+mz_system=RBN/mz_system
 
-statement error SYSTEM PRIVILEGES not yet supported
-REVOKE CREATEROLE ON SYSTEM FROM test_role
+simple conn=mz_system,user=mz_system
+REVOKE ALL ON SYSTEM FROM joe
+----
+COMPLETE 0
+
+query T
+SELECT privileges::text FROM mz_system_privileges
+----
+mz_system=RBN/mz_system
 
 ## Test system objects
 
@@ -2411,7 +2502,20 @@ NULL
 
 ### System
 
-# TODO(jkosh44) Add tests when GRANT is implemented for system privileges
+simple conn=mz_system,user=mz_system
+REVOKE ALL PRIVILEGES ON SYSTEM FROM joe;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT CREATECLUSTER ON SYSTEM TO joe
+----
+COMPLETE 0
+
+query B
+SELECT has_system_privilege('joe', 'CREATEROLE, CREATECLUSTER')
+----
+true
 
 ### Cluster
 
@@ -2536,6 +2640,11 @@ true
 
 ### System
 
+simple conn=mz_system,user=mz_system
+REVOKE CREATEDB ON SYSTEM FROM materialize
+----
+COMPLETE 0
+
 query B
 SELECT has_system_privilege('materialize', 'CREATEDB')
 ----
@@ -2546,7 +2655,20 @@ SELECT has_system_privilege('CREATEDB')
 ----
 false
 
-# TODO(jkosh44) Add tests when GRANT is implemented for system privileges
+simple conn=mz_system,user=mz_system
+GRANT CREATEDB ON SYSTEM TO materialize
+----
+COMPLETE 0
+
+query B
+SELECT has_system_privilege('materialize', 'CREATEDB')
+----
+true
+
+query B
+SELECT has_system_privilege('CREATEDB')
+----
+true
 
 ### Cluster
 


### PR DESCRIPTION
This commit implements GRANT and REVOKE for system privileges. GRANT will add system privileges to the catalog while REVOKE will remove them. System privileges are not checked when executing a statement. That is saved for a later commit.

Part of #19997

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Implement GRANT and REVOKE for system privileges. GRANT will add system privileges to the catalog while REVOKE will remove them. System privileges are not checked when executing a statement. That is saved for a later commit.
