### PR TITLE
ci: Don't use v0.55.5 for upgrade tests

### DIFF
--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -22,6 +22,11 @@ ROOT = Path(os.environ["MZ_ROOT"])
 # not released on Docker
 INVALID_VERSIONS = {
     MzVersion.parse_mz("v0.52.1"),
+    MzVersion.parse_mz("v0.55.1"),
+    MzVersion.parse_mz("v0.55.2"),
+    MzVersion.parse_mz("v0.55.3"),
+    MzVersion.parse_mz("v0.55.4"),
+    MzVersion.parse_mz("v0.55.5"),
     MzVersion.parse_mz("v0.55.6"),
     MzVersion.parse_mz("v0.56.0"),
     MzVersion.parse_mz("v0.57.1"),


### PR DESCRIPTION
Not released on Dockerhub

https://buildkite.com/materialize/nightlies/builds/2642#0188e573-6e38-4643-a7d7-7a9a7cd64314

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
