### PR TITLE
sql: Fix return type for text || list text

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3917,7 +3917,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
                     &ScalarType::String,
                 )?;
                 Ok(lhs.call_binary(rhs, TextConcat))
-            }) => String, 2779;
+            }) => NonVecAny, 2779;
             params!(NonVecAny, String) => Operation::binary(|ecx, lhs, rhs| {
                 let lhs = typeconv::plan_cast(
                     ecx,
@@ -3926,7 +3926,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
                     &ScalarType::String,
                 )?;
                 Ok(lhs.call_binary(rhs, TextConcat))
-            }) => String, 2780;
+            }) => NonVecAny, 2780;
             params!(String, String) => TextConcat => String, 654;
             params!(Jsonb, Jsonb) => JsonbConcat => Jsonb, 3284;
             params!(ArrayAnyCompatible, ArrayAnyCompatible) => ArrayArrayConcat => ArrayAnyCompatible, 375;


### PR DESCRIPTION
Broken in MaterializeInc#17971

Fixes: #20113

```
materialize=> SELECT
    mz_operators.name AS oprname,
    left_type.name as oprleft,
    right_type.name as oprright,
    ret_type.name AS oprresult
    FROM mz_catalog.mz_operators
    JOIN mz_catalog.mz_types AS ret_type
    ON mz_operators.return_type_id = ret_type.id
    JOIN mz_catalog.mz_types AS left_type
    ON mz_operators.argument_type_ids[1] = left_type.id
    JOIN mz_catalog.mz_types AS right_type
    ON mz_operators.argument_type_ids[2] = right_type.id
    WHERE array_length(mz_operators.argument_type_ids, 1) = 2 and mz_operators.name = '||';
 oprname |      oprleft       |      oprright      |     oprresult
---------+--------------------+--------------------+--------------------
 ||      | text               | text               | text
 ||      | jsonb              | jsonb              | jsonb
 ||      | text               | anynonarray        | anynonarray
 ||      | anynonarray        | text               | anynonarray
 ||      | anycompatible      | anycompatiblelist  | anycompatiblelist
 ||      | anycompatiblelist  | anycompatible      | anycompatiblelist
 ||      | anycompatiblelist  | anycompatiblelist  | anycompatiblelist
 ||      | anycompatiblearray | anycompatiblearray | anycompatiblearray
(8 rows)
```

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
