### PR TITLE
ignore .debug files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,9 @@ perf.data*
 **/*.orig
 **/*.profraw
 **/*.profdata
+**/*.debug
 
-# This is un-orthodox, but adding it to the repo would "tie" it to each users
+# This is un-orthodox, but adding it to the repo would "tie" it to each user's
 # local version of nixpkgs. This way, we can all use the flake and have a
 # flake.lock that works well with the rest of the package versions on our
 # system.


### PR DESCRIPTION
Recently we started generating split debuginfo files as part of the mzbuild for environmentd/clusterd. This change will prevent them from being taken into account by mzimage fingerprinting.