### PR TITLE
[skunkworks] ore: Add ReceiverExt

### DIFF
--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -33,7 +33,7 @@ smallvec = { version = "1.10.0", optional = true }
 stacker = { version = "0.1.15", optional = true }
 sentry = { version = "0.29.1", optional = true, features = ["debug-images"] }
 serde = { version = "1.0.152", features = ["derive"], optional = true }
-tokio = { version = "1.24.2", features = ["io-util", "net", "rt-multi-thread", "time"], optional = true }
+tokio = { version = "1.24.2", features = ["io-util", "net", "rt-multi-thread", "sync", "time"], optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
 # TODO(guswynn): determine, when, if ever, we can remove `tracing-log`
 # The `tracing-log` feature here is load-bearing: While our busiest-logging dependency (`rdkafka`) is now hooked-up

--- a/src/ore/src/channel.rs
+++ b/src/ore/src/channel.rs
@@ -1,0 +1,253 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Channel utilities and extensions.
+
+use std::collections::VecDeque;
+
+use async_trait::async_trait;
+
+/// Extensions for the receiving end of asynchronous channels.
+#[async_trait(?Send)]
+pub trait ReceiverExt<T> {
+    /// Receives all of the currently buffered elements on the channel, up to some max.
+    ///
+    /// This method returns `None` if the channel has been closed and there are no remaining
+    /// messages in the channel's buffer.
+    ///
+    /// If there are no messages in the channel's buffer, but the channel is not yet closed, this
+    /// method will sleep until a message is sent or the channel is closed. When woken it will
+    /// return up to max currently buffered elements.
+    async fn recv_many(&mut self, max: usize) -> Option<VecDeque<T>>;
+}
+
+#[async_trait(?Send)]
+impl<T> ReceiverExt<T> for tokio::sync::mpsc::Receiver<T> {
+    async fn recv_many(&mut self, max: usize) -> Option<VecDeque<T>> {
+        // Wait for a value to be ready.
+        let first = self.recv().await?;
+        let mut buffer = VecDeque::from([first]);
+
+        // Note(parkmycar): It's very important for cancelation safety that we don't add any more
+        // .await points other than the initial one.
+
+        // Pull all of the remaining values off the channel.
+        while let Ok(v) = self.try_recv() {
+            buffer.push_back(v);
+
+            // Break so we don't loop here continuously.
+            if buffer.len() >= max {
+                break;
+            }
+        }
+
+        Some(buffer)
+    }
+}
+
+#[async_trait(?Send)]
+impl<T> ReceiverExt<T> for tokio::sync::mpsc::UnboundedReceiver<T> {
+    async fn recv_many(&mut self, max: usize) -> Option<VecDeque<T>> {
+        // Wait for a value to be ready.
+        let first = self.recv().await?;
+        let mut buffer = VecDeque::from([first]);
+
+        // Note(parkmycar): It's very important for cancelation safety that we don't add any more
+        // .await points other than the initial one.
+
+        // Pull all of the remaining values off the channel.
+        while let Ok(v) = self.try_recv() {
+            buffer.push_back(v);
+
+            // Break so we don't loop here continuously.
+            if buffer.len() >= max {
+                break;
+            }
+        }
+
+        Some(buffer)
+    }
+}
+
+// allow `futures::block_on` for testing.
+#[allow(clippy::disallowed_methods)]
+#[cfg(test)]
+mod tests {
+    use futures::executor::block_on;
+    use futures::FutureExt;
+    use tokio::sync::mpsc;
+
+    use super::ReceiverExt;
+
+    #[crate::test]
+    fn smoke_test_tokio_mpsc() {
+        let (tx, mut rx) = mpsc::channel(16);
+
+        // Buffer a few elements.
+        tx.try_send(1).expect("enough capacity");
+        tx.try_send(2).expect("enough capacity");
+        tx.try_send(3).expect("enough capacity");
+        tx.try_send(4).expect("enough capacity");
+        tx.try_send(5).expect("enough capacity");
+
+        // Receive a max of three elements at once.
+        let elements = block_on(rx.recv_many(3)).expect("values");
+        assert_eq!(elements, [1, 2, 3]);
+
+        // Receive the remaining elements.
+        let elements = block_on(rx.recv_many(8)).expect("values");
+        assert_eq!(elements, [4, 5]);
+    }
+
+    #[crate::test]
+    fn smoke_test_tokio_unbounded() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        // Buffer a few elements.
+        tx.send(1).expect("enough capacity");
+        tx.send(2).expect("enough capacity");
+        tx.send(3).expect("enough capacity");
+        tx.send(4).expect("enough capacity");
+        tx.send(5).expect("enough capacity");
+
+        // Receive a max of three elements at once.
+        let elements = block_on(rx.recv_many(3)).expect("values");
+        assert_eq!(elements, [1, 2, 3]);
+
+        // Receive the remaining elements.
+        let elements = block_on(rx.recv_many(8)).expect("values");
+        assert_eq!(elements, [4, 5]);
+    }
+
+    #[crate::test]
+    fn test_tokio_mpsc_permit() {
+        let (tx, mut rx) = mpsc::channel(16);
+
+        // Reserve space for a few elements.
+        let permit1 = tx.clone().try_reserve_owned().expect("enough capacity");
+        let permit2 = tx.clone().try_reserve_owned().expect("enough capacity");
+        let permit3 = tx.clone().try_reserve_owned().expect("enough capacity");
+
+        // Close the channel.
+        drop(tx);
+
+        let waker = futures::task::noop_waker();
+        let mut cx = std::task::Context::from_waker(&waker);
+
+        let mut recv_many = rx.recv_many(4);
+
+        // The channel is closed, but there are outstanding permits, so we should return pending.
+        assert!(recv_many.poll_unpin(&mut cx).is_pending());
+
+        // Send data on the channel.
+        permit1.send(1);
+        permit2.send(2);
+        permit3.send(3);
+
+        // We should receive all of the data after a single poll.
+        let elements = match recv_many.poll_unpin(&mut cx) {
+            std::task::Poll::Ready(elements) => elements.expect("elements to be returned"),
+            std::task::Poll::Pending => panic!("future didn't immediately return elements!"),
+        };
+        assert_eq!(elements, [1, 2, 3]);
+        drop(recv_many);
+
+        // Polling the channel one more time should return None since the channel is closed.
+        let elements = match rx.recv_many(4).poll_unpin(&mut cx) {
+            std::task::Poll::Ready(elements) => elements,
+            std::task::Poll::Pending => panic!("future didn't immediately return"),
+        };
+        assert!(elements.is_none());
+    }
+
+    #[crate::test]
+    fn test_empty_channel() {
+        let (tx, mut rx) = mpsc::channel::<usize>(16);
+
+        let recv_many = rx.recv_many(4);
+        drop(tx);
+
+        let elements = block_on(recv_many);
+        assert!(elements.is_none());
+    }
+
+    #[crate::test]
+    fn test_atleast_two_semantics() {
+        let (tx, mut rx) = mpsc::channel(16);
+
+        // Buffer a few elements.
+        tx.try_send(1).expect("enough capacity");
+        tx.try_send(2).expect("enough capacity");
+        tx.try_send(3).expect("enough capacity");
+
+        // Even though we specify a max of one, we'll receive at least 2.
+        let elements = block_on(rx.recv_many(1)).expect("values");
+        assert_eq!(elements, [1, 2]);
+    }
+
+    #[crate::test]
+    fn test_cancelation_safety() {
+        let (tx, mut rx) = mpsc::channel(16);
+
+        // Buffer a few elements.
+        tx.try_send(1).expect("enough capacity");
+        tx.try_send(2).expect("enough capacity");
+        tx.try_send(3).expect("enough capacity");
+
+        let mut immediate_ready = Box::pin(async { 100 }).fuse();
+
+        let mut count = 0;
+        let mut result = vec![];
+
+        loop {
+            count += 1;
+
+            block_on(async {
+                futures::select_biased! {
+                    single = &mut immediate_ready => result.push(single),
+                    many = &mut rx.recv_many(2).fuse() => {
+                        let values = many.expect("stream ended!");
+                        result.extend(values);
+                    },
+                }
+            });
+
+            if count >= 3 {
+                break;
+            }
+        }
+
+        assert_eq!(result, [100, 1, 2, 3]);
+    }
+
+    #[crate::test]
+    fn test_closed_channel() {
+        let (tx, mut rx) = mpsc::channel(16);
+
+        tx.try_send(1).expect("enough capacity");
+        tx.try_send(2).expect("enough capacity");
+        tx.try_send(3).expect("enough capacity");
+
+        // Drop the sender to close it.
+        drop(tx);
+
+        // Make sure the buffer is larger than queued elements.
+        let elements = block_on(rx.recv_many(4)).expect("elements");
+        assert_eq!(elements, [1, 2, 3]);
+
+        // Receiving again should return None.
+        assert!(block_on(rx.recv_many(4)).is_none());
+    }
+}

--- a/src/ore/src/channel.rs
+++ b/src/ore/src/channel.rs
@@ -20,8 +20,8 @@ use std::collections::VecDeque;
 use async_trait::async_trait;
 
 /// Extensions for the receiving end of asynchronous channels.
-#[async_trait(?Send)]
-pub trait ReceiverExt<T> {
+#[async_trait]
+pub trait ReceiverExt<T: Send> {
     /// Receives all of the currently buffered elements on the channel, up to some max.
     ///
     /// This method returns `None` if the channel has been closed and there are no remaining
@@ -30,11 +30,26 @@ pub trait ReceiverExt<T> {
     /// If there are no messages in the channel's buffer, but the channel is not yet closed, this
     /// method will sleep until a message is sent or the channel is closed. When woken it will
     /// return up to max currently buffered elements.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv_many` is used as the event in a `select!` statement
+    /// and some other branch completes first, it is guaranteed that no messages were received on
+    /// this channel.
+    ///
+    /// # Max Buffer Size
+    ///
+    /// The provided max buffer size should always be less than the total capacity of the channel.
+    /// Otherwise a good value is probably a fraction of the total channel size, or however large
+    /// a batch that your receiving component can handle.
+    ///
+    /// TODO(parkmycar): We should refactor this to use `impl Iterator` instead of `VecDeque` when
+    /// "impl trait in trait" is supported.
     async fn recv_many(&mut self, max: usize) -> Option<VecDeque<T>>;
 }
 
-#[async_trait(?Send)]
-impl<T> ReceiverExt<T> for tokio::sync::mpsc::Receiver<T> {
+#[async_trait]
+impl<T: Send> ReceiverExt<T> for tokio::sync::mpsc::Receiver<T> {
     async fn recv_many(&mut self, max: usize) -> Option<VecDeque<T>> {
         // Wait for a value to be ready.
         let first = self.recv().await?;
@@ -57,8 +72,8 @@ impl<T> ReceiverExt<T> for tokio::sync::mpsc::Receiver<T> {
     }
 }
 
-#[async_trait(?Send)]
-impl<T> ReceiverExt<T> for tokio::sync::mpsc::UnboundedReceiver<T> {
+#[async_trait]
+impl<T: Send> ReceiverExt<T> for tokio::sync::mpsc::UnboundedReceiver<T> {
     async fn recv_many(&mut self, max: usize) -> Option<VecDeque<T>> {
         // Wait for a value to be ready.
         let first = self.recv().await?;

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -96,6 +96,9 @@ pub mod bits;
 #[cfg(feature = "bytes_")]
 pub mod bytes;
 pub mod cast;
+#[cfg_attr(nightly_doc_features, doc(cfg(feature = "async")))]
+#[cfg(feature = "async")]
+pub mod channel;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "cli")))]
 #[cfg(feature = "cli")]
 pub mod cli;


### PR DESCRIPTION
### Motivation

This PR adds a new module in `ore` called `channel`, which is available with the `async` feature, and this new module adds a new trait called `ReceiverExt`.

The motivation behind this new extension trait is current channel Receivers ([example](https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.Receiver.html#method.recv)) only allow you to `.await` one message at a time. But it's very possible that since the last time you received a message on a channel multiple have become buffered. 

The new method introduced on the trait is `async fn recv_many(max)`, where we'll wait until at least one message is available on the channel, when woken up, we'll return all of the messages that are immediately available, up to some max. Only yielding up to some max prevents us from yielding messages forever.

Slack context: https://materializeinc.slack.com/archives/CMH6PG4CW/p1687294626794779

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
