### PR TITLE
[persist] Switch to prefixing parts with the build version

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -39,7 +39,7 @@ use crate::error::InvalidUsage;
 use crate::internal::encoding::{LazyPartStats, Schemas};
 use crate::internal::machine::retry_external;
 use crate::internal::metrics::{BatchWriteMetrics, Metrics, ShardMetrics};
-use crate::internal::paths::{PartId, PartialBatchKey};
+use crate::internal::paths::{PartId, PartialBatchKey, WriterKey};
 use crate::internal::state::{HollowBatch, HollowBatchPart};
 use crate::stats::PartStats;
 use crate::write::WriterEnrichedHollowBatch;
@@ -731,7 +731,8 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         let blob = Arc::clone(&self.blob);
         let cpu_heavy_runtime = Arc::clone(&self.cpu_heavy_runtime);
         let batch_metrics = self.batch_metrics.clone();
-        let partial_key = PartialBatchKey::new(&self.writer_id, &PartId::new());
+        let partial_key =
+            PartialBatchKey::new(&WriterKey::Id(self.writer_id.clone()), &PartId::new());
         let key = partial_key.complete(&self.shard_id);
         let index = u64::cast_from(self.finished_parts.len() + self.writing_parts.len());
         let stats_collection_enabled = self.cfg.stats_collection_enabled;

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -206,8 +206,8 @@ pub struct BatchBuilderConfig {
 
 impl BatchBuilderConfig {
     /// Initialize a batch builder config based on a snapshot of the Persist config.
-    pub fn new(value: &PersistConfig, writer_id: &WriterId) -> Self {
-        let writer_key = WriterKey::Id(writer_id.clone());
+    pub fn new(value: &PersistConfig, _writer_id: &WriterId) -> Self {
+        let writer_key = WriterKey::for_version(&value.build_version);
         BatchBuilderConfig {
             writer_key,
             blob_target_size: value.dynamic.blob_target_size(),

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -230,13 +230,12 @@ pub async fn force_compaction(
             };
             let res =
                 Compactor::<crate::cli::inspect::K, crate::cli::inspect::V, u64, i64>::compact(
-                    CompactConfig::from(&cfg),
+                    CompactConfig::new(&cfg, &writer_id),
                     Arc::clone(&blob),
                     Arc::clone(&metrics),
                     Arc::clone(&machine.applier.shard_metrics),
                     Arc::new(CpuHeavyRuntime::new()),
                     req,
-                    writer_id.clone(),
                     schemas,
                 )
                 .await?;

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -37,7 +37,7 @@ use crate::error::CodecConcreteType;
 use crate::fetch::EncodedPart;
 use crate::internal::encoding::UntypedState;
 use crate::internal::paths::{
-    BlobKey, BlobKeyPrefix, PartialBatchKey, PartialBlobKey, PartialRollupKey,
+    BlobKey, BlobKeyPrefix, PartialBatchKey, PartialBlobKey, PartialRollupKey, WriterKey,
 };
 use crate::internal::state::{ProtoStateDiff, ProtoStateRollup, State};
 use crate::rpc::NoopPubSubSender;
@@ -579,6 +579,10 @@ pub async fn unreferenced_blobs(args: &StateArgs) -> Result<impl serde::Serializ
 
     let mut unreferenced_blobs = UnreferencedBlobs::default();
     for (part, writer) in all_parts {
+        let WriterKey::Id(writer) = writer else {
+            // TODO: even a new-style key might be unreferenced.
+            continue
+        };
         if !known_writers.contains(&writer) && !known_parts.contains(&part) {
             unreferenced_blobs.batch_parts.insert(part);
         }

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -44,8 +44,11 @@ use crate::rpc::NoopPubSubSender;
 use crate::usage::{HumanBytes, StorageUsageClient};
 use crate::{Metrics, PersistClient, PersistConfig, ShardId, StateVersions};
 
+// BuildInfo with a larger version than any version we expect to see in prod,
+// to ensure that any data read is from a smaller version and does not trigger
+// alerts.
 const READ_ALL_BUILD_INFO: BuildInfo = BuildInfo {
-    version: "10000000.0.0+test",
+    version: "99.999.99+test",
     sha: "0000000000000000000000000000000000000000",
     time: "",
 };

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1353,7 +1353,7 @@ pub mod datadriven {
         let consolidate = args.optional("consolidate").unwrap_or(true);
         let updates = args.input.split('\n').flat_map(DirectiveArgs::parse_update);
 
-        let mut cfg = BatchBuilderConfig::from(&datadriven.client.cfg);
+        let mut cfg = BatchBuilderConfig::new(&datadriven.client.cfg, &WriterId::new());
         if let Some(target_size) = target_size {
             cfg.blob_target_size = target_size;
         };
@@ -1372,7 +1372,6 @@ pub mod datadriven {
             Arc::clone(&datadriven.client.cpu_heavy_runtime),
             datadriven.shard_id.clone(),
             datadriven.client.cfg.build_version.clone(),
-            WriterId::new(),
             since,
             Some(upper.clone()),
             consolidate,
@@ -1531,13 +1530,12 @@ pub mod datadriven {
             val: Arc::new(UnitSchema),
         };
         let res = Compactor::<String, (), u64, i64>::compact(
-            CompactConfig::from(&cfg),
+            CompactConfig::new(&cfg, &writer_id),
             Arc::clone(&datadriven.client.blob),
             Arc::clone(&datadriven.client.metrics),
             Arc::clone(&datadriven.machine.applier.shard_metrics),
             Arc::clone(&datadriven.client.cpu_heavy_runtime),
             req,
-            writer_id,
             schemas,
         )
         .await?;

--- a/src/persist-client/src/internal/paths.rs
+++ b/src/persist-client/src/internal/paths.rs
@@ -7,11 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::fmt::{Display, Formatter, Write};
 use std::ops::Deref;
 use std::str::FromStr;
 
 use mz_persist::location::SeqNo;
 use proptest_derive::Arbitrary;
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -49,6 +51,64 @@ impl PartId {
     }
 }
 
+/// A component that provides information about the writer of a blob.
+/// For older blobs, this is a UUID for the specific writer instance;
+/// for newer blobs, this is a string representing the version at which the blob was written.
+/// In either case, it's used to help determine whether a blob may eventually
+/// be linked into state, or whether it's junk that we can clean up.
+/// Note that the ordering is meaningful: all writer-id keys are considered smaller than
+/// all version keys.
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
+pub enum WriterKey {
+    Id(WriterId),
+    Version(String),
+}
+
+impl WriterKey {
+    /// This uses the version numbering scheme specified in [mz_build_info::BuildInfo::version_num].
+    /// (And asserts that the version isn't so large that that scheme is no longer sufficient.)
+    pub fn for_version(version: &Version) -> WriterKey {
+        assert!(version.major <= 99);
+        assert!(version.minor <= 999);
+        assert!(version.patch <= 99);
+        WriterKey::Version(format!(
+            "{:02}{:03}{:02}",
+            version.major, version.minor, version.patch
+        ))
+    }
+}
+
+impl FromStr for WriterKey {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err("empty version string".to_owned());
+        }
+
+        let key = match &s[..1] {
+            "w" => WriterKey::Id(WriterId::from_str(s)?),
+            "n" => WriterKey::Version(s[1..].to_owned()),
+            c => {
+                return Err(format!("unknown prefix for version: {c}"));
+            }
+        };
+        Ok(key)
+    }
+}
+
+impl Display for WriterKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WriterKey::Id(id) => id.fmt(f),
+            WriterKey::Version(s) => {
+                f.write_char('n')?;
+                f.write_str(s)
+            }
+        }
+    }
+}
+
 /// Partially encoded path used in [mz_persist::location::Blob] storage.
 /// Composed of a [WriterId] and [PartId]. Can be completed with a [ShardId] to
 /// form a full [BlobKey].
@@ -60,8 +120,8 @@ impl PartId {
 pub struct PartialBatchKey(pub(crate) String);
 
 impl PartialBatchKey {
-    pub fn new(writer_id: &WriterId, part_id: &PartId) -> Self {
-        PartialBatchKey(format!("{}/{}", writer_id, part_id))
+    pub fn new(version: &WriterKey, part_id: &PartId) -> Self {
+        PartialBatchKey(format!("{}/{}", version, part_id))
     }
 
     pub fn complete(&self, shard_id: &ShardId) -> BlobKey {
@@ -153,7 +213,7 @@ impl Deref for PartialRollupKey {
 #[derive(Debug, PartialEq)]
 pub enum PartialBlobKey {
     /// A parsed [PartialBatchKey].
-    Batch(WriterId, PartId),
+    Batch(WriterKey, PartId),
     /// A parsed [PartialRollupKey].
     Rollup(SeqNo, RollupId),
 }
@@ -186,8 +246,8 @@ impl BlobKey {
         let ids = key.split('/').collect::<Vec<_>>();
 
         match ids[..] {
-            [shard, writer, part] if writer.starts_with('w') => Ok(
-                (ShardId::from_str(shard)?, PartialBlobKey::Batch(WriterId::from_str(writer)?, PartId::from_str(part)?))
+            [shard, writer, part] if writer.starts_with('w') | writer.starts_with('n') => Ok(
+                (ShardId::from_str(shard)?, PartialBlobKey::Batch(WriterKey::from_str(writer)?, PartId::from_str(part)?))
             ),
             [shard, seqno, rollup] if seqno.starts_with('v') => Ok(
                 (ShardId::from_str(shard)?, PartialBlobKey::Rollup(SeqNo::from_str(seqno)?, RollupId::from_str(rollup)?))
@@ -233,7 +293,7 @@ mod tests {
     #[mz_ore::test]
     fn partial_blob_key_completion() {
         let (shard_id, writer_id, part_id) = (ShardId::new(), WriterId::new(), PartId::new());
-        let partial_key = PartialBatchKey::new(&writer_id, &part_id);
+        let partial_key = PartialBatchKey::new(&WriterKey::Id(writer_id.clone()), &part_id);
         assert_eq!(
             partial_key.complete(&shard_id),
             BlobKey(format!("{}/{}/{}", shard_id, writer_id, part_id))
@@ -247,7 +307,10 @@ mod tests {
         // can parse full blob key
         assert_eq!(
             BlobKey::parse_ids(&format!("{}/{}/{}", shard_id, writer_id, part_id)),
-            Ok((shard_id, PartialBlobKey::Batch(writer_id, part_id)))
+            Ok((
+                shard_id,
+                PartialBlobKey::Batch(WriterKey::Id(writer_id), part_id)
+            ))
         );
 
         // fails on invalid blob key formats

--- a/src/persist-client/src/internal/paths.rs
+++ b/src/persist-client/src/internal/paths.rs
@@ -266,7 +266,7 @@ pub enum BlobKeyPrefix<'a> {
     Shard(&'a ShardId),
     /// Scoped to the batch blobs of an individual writer
     #[cfg(test)]
-    Writer(&'a ShardId, &'a WriterId),
+    Writer(&'a ShardId, &'a WriterKey),
     /// Scoped to all state rollup blobs  of an individual shard
     #[cfg(test)]
     Rollups(&'a ShardId),

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -448,7 +448,7 @@ impl StateVersions {
                         .expect("initialized shard should have at least one diff")
                         .seqno;
                     if earliest_before_refetch >= earliest_after_refetch {
-                        warn!("logic error: fetch_current_state refetch expects earliest live diff to advance: {} vs {}", earliest_before_refetch, earliest_after_refetch)
+                        warn!("logic error: fetch_all_live_states refetch expects earliest live diff to advance: {} vs {}", earliest_before_refetch, earliest_after_refetch)
                     }
                     continue;
                 }

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -94,7 +94,7 @@ use crate::{Metrics, PersistConfig, ShardId};
 ///     for other live states to reference rollups that no longer exist.
 #[derive(Debug)]
 pub struct StateVersions {
-    cfg: PersistConfig,
+    pub(crate) cfg: PersistConfig,
     pub(crate) consensus: Arc<dyn Consensus + Send + Sync>,
     pub(crate) blob: Arc<dyn Blob + Send + Sync>,
     metrics: Arc<Metrics>,

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -543,7 +543,7 @@ where
     /// O(MB) come talk to us.
     pub fn builder(&mut self, lower: Antichain<T>) -> BatchBuilder<K, V, T, D> {
         let builder = BatchBuilderInternal::new(
-            BatchBuilderConfig::from(&self.cfg),
+            BatchBuilderConfig::new(&self.cfg, &self.writer_id),
             Arc::clone(&self.metrics),
             Arc::clone(&self.machine.applier.shard_metrics),
             self.schemas.clone(),
@@ -553,7 +553,6 @@ where
             Arc::clone(&self.cpu_heavy_runtime),
             self.machine.shard_id().clone(),
             self.cfg.build_version.clone(),
-            self.writer_id.clone(),
             Antichain::from_elem(T::minimum()),
             None,
             false,


### PR DESCRIPTION
- Replace the `WriterId` component of the path with a new `WriterKey` component that can be either a writer id or a versiony string.
- Update the existing logic that handles writer ids (eg. in usage calculations) to handle both.
- Finally, switch the batch writer to use the new prefix.

### Motivation

Known-desireable: #20254.

### Tips for reviewer

I was a bit on the fence about whether this deserved a flag rollout. I decided not to because most of the complexity is in supporting both paths, and once parts exist with the new path structure we are committed and would need to roll forward if we discover any bugs. However, I've centralized the switch between the two to a single small commit that we can revert if needed, and I'll follow up with the dependent parts in another PR.

I've left a couple comments on bikesheddable decisions inline.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
