### PR TITLE
doc: Remove out-dated details from DROP INDEX doc

### DIFF
--- a/doc/user/content/sql/drop-index.md
+++ b/doc/user/content/sql/drop-index.md
@@ -21,33 +21,6 @@ _index&lowbar;name_ | The name of the index you want to remove.
 
 **Note:** Since indexes cannot currently have dependent objects, `DROP INDEX`, `DROP INDEX RESTRICT`, and `DROP INDEX CASCADE` all do the same thing.
 
-## Details
-
-### Indexes and materialized views
-
-### Primary indexes
-
-By default, materialized views only have one index, which we call the "primary
-index", and which stores the result set of the materialized view's embedded `SELECT`
-statement. You can identify the primary index by its name, which follows the
-format `<view name>_primary_idx`.
-
-This primary index doesn't follow the constraints for typical for primary indexes in traditional databases; it is simply the first index created on a view. Please keep in mind the following constraints:
-
-* If you remove the primary index, you will not be able to query any columns that are not included in another index for the view.
-* If the primary index is the **only** index on the view, you will not be able to query any columns at all and the materialized view will become a non-materialized view. For more details on non-materialized views, see [`CREATE
-VIEW`](../create-view).
-
-If you remove the primary index and want to recreate it:
-
-1. Retrieve the view's embedded `SELECT` statement with [`SHOW CREATE
-   VIEW`](../show-create-view).
-1. Re-create the view as a materialized view with [`CREATE OR REPLACE
-   MATERIALIZED VIEW`](../create-materialized-view).
-
-Alternatively, you can also [`CREATE INDEX`](../create-index) to materialize any
-view.
-
 ## Examples
 
 ### Remove an index


### PR DESCRIPTION
The Details section of the DROP INDEX page references how materialized views worked in the past, as a view with a default index. Mat views haven't worked that woy for some time, so this PR removes the Details section entirely.

Fixes: #18399

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
