### PR TITLE
 compute: mz_dataflow_initial_output_duration_seconds

### DIFF
--- a/doc/developer/design/20230531_compute_metrics.md
+++ b/doc/developer/design/20230531_compute_metrics.md
@@ -261,8 +261,8 @@ All metrics in this list have a `worker_id` label identifying the Timely worker.
     * **Description**: The import frontiers of dataflows.
     * **Export Type**: prometheus-exporter, through the `mz_compute_import_frontiers` introspection source
     * **Notes**: To reduce the cardinality of this metric, we limit it to non-transient dataflows.
-  * [ ] `mz_dataflow_initial_output_duration_seconds`
-    * **Type**: counter
+  * [x] `mz_dataflow_initial_output_duration_seconds`
+    * **Type**: gauge
     * **Labels**: `worker_id`, `collection_id`
     * **Description**: The time from dataflow installation up to when the first output was produced.
     * **Export Type**: direct

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -12,6 +12,7 @@ use std::num::NonZeroUsize;
 use std::ops::DerefMut;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Instant;
 
 use bytesize::ByteSize;
 use differential_dataflow::trace::TraceReader;
@@ -237,12 +238,12 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                 let metrics = self
                     .compute_state
                     .metrics
-                    .for_collection(collection_id, worker_id);
+                    .for_collection(object_id, worker_id);
                 let mut collection = CollectionState::new(metrics);
 
-                collection.reported_frontier = ReportedFrontier::NotReported {
-                    lower: dataflow.as_of.clone().unwrap(),
-                };
+                let as_of = dataflow.as_of.clone().unwrap();
+                collection.as_of = as_of.clone();
+                collection.set_reported_frontier(ReportedFrontier::NotReported { lower: as_of });
 
                 let existing = self.compute_state.collections.insert(object_id, collection);
                 if existing.is_some() {
@@ -354,7 +355,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         // Remove frontier logging.
         if let Some(logger) = self.compute_state.compute_logger.as_mut() {
             logger.log(ComputeEvent::ExportDropped { id });
-            if let Some(time) = collection.reported_frontier.logging_time() {
+            if let Some(time) = collection.reported_frontier().logging_time() {
                 logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
             }
         }
@@ -366,7 +367,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         //  * The collection has already advanced to the empty frontier, in which case
         //    the final `FrontierUppers` response already serves the purpose of reporting
         //    the end of the dataflow.
-        if !collection.is_subscribe() && !collection.reported_frontier.is_empty() {
+        if !collection.is_subscribe() && !collection.reported_frontier().is_empty() {
             self.compute_state.dropped_collections.push(id);
         }
     }
@@ -449,7 +450,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                 continue;
             }
 
-            match &collection.reported_frontier {
+            match collection.reported_frontier() {
                 ReportedFrontier::Reported(old_frontier) => {
                     // In steady state it is not expected for `old_frontier` to be beyond
                     // `new_frontier`. However, during reconcilation this can happen as we
@@ -469,7 +470,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
             let new_reported_frontier = ReportedFrontier::Reported(new_frontier.clone());
 
             if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-                if let Some(time) = collection.reported_frontier.logging_time() {
+                if let Some(time) = collection.reported_frontier().logging_time() {
                     logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
                 }
                 if let Some(time) = new_reported_frontier.logging_time() {
@@ -478,7 +479,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
             }
 
             new_uppers.push((id, new_frontier));
-            collection.reported_frontier = new_reported_frontier;
+            collection.set_reported_frontier(new_reported_frontier);
         }
 
         if !new_uppers.is_empty() {
@@ -556,7 +557,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                     SubscribeResponse::DroppedAt(_) => Antichain::new(),
                 };
 
-                match &collection.reported_frontier {
+                match collection.reported_frontier() {
                     ReportedFrontier::Reported(old_frontier) => {
                         assert!(
                             PartialOrder::less_than(old_frontier, &new_frontier),
@@ -575,7 +576,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                 let new_reported_frontier = ReportedFrontier::Reported(new_frontier);
 
                 if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-                    if let Some(time) = collection.reported_frontier.logging_time() {
+                    if let Some(time) = collection.reported_frontier().logging_time() {
                         logger.log(ComputeEvent::Frontier {
                             id: sink_id,
                             time,
@@ -591,7 +592,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                     }
                 }
 
-                collection.reported_frontier = new_reported_frontier;
+                collection.set_reported_frontier(new_reported_frontier);
             } else {
                 // Presumably tracking state for this subscribe was already dropped by
                 // `drop_collection`. There is nothing left to do for logging.
@@ -914,7 +915,10 @@ impl ReportedFrontier {
 /// State maintained for a compute collection.
 pub struct CollectionState {
     /// Tracks the frontier that has been reported to the controller.
-    pub reported_frontier: ReportedFrontier,
+    ///
+    // TODO(#20766): Now that we explicitly track the collection's `as_of`, we might be able to
+    // simplify this to an `Antichain<Timestamp>` again.
+    reported_frontier: ReportedFrontier,
     /// A token that should be dropped when this collection is dropped to clean up associated
     /// sink state.
     ///
@@ -936,6 +940,10 @@ pub struct CollectionState {
     ///
     /// If this is `None`, no metrics are collected.
     pub metrics: Option<CollectionMetrics>,
+    /// Time at which this collection was installed.
+    created_at: Instant,
+    /// Original as_of of this collection.
+    as_of: Antichain<Timestamp>,
 }
 
 impl CollectionState {
@@ -946,10 +954,42 @@ impl CollectionState {
             sink_write_frontier: None,
             index_flow_control_probes: Default::default(),
             metrics,
+            created_at: Instant::now(),
+            as_of: Antichain::from_elem(Timestamp::MIN),
         }
+    }
+
+    /// Return the frontier that has been reported to the controller.
+    pub fn reported_frontier(&self) -> &ReportedFrontier {
+        &self.reported_frontier
+    }
+
+    /// Set the frontier that has been reported to the controller.
+    pub fn set_reported_frontier(&mut self, new_frontier: ReportedFrontier) {
+        self.reported_frontier = new_frontier;
+        self.observe_snapshot_produced();
     }
 
     fn is_subscribe(&self) -> bool {
         self.sink_token.is_some() && self.sink_write_frontier.is_none()
+    }
+
+    /// If the collection has produced its snapshot recently, update the collection metrics to
+    /// reflect this.
+    fn observe_snapshot_produced(&mut self) {
+        let Some(metrics) = &self.metrics else { return };
+        let ReportedFrontier::Reported(frontier) = &self.reported_frontier else { return };
+
+        // If the metric value is greater than 0, that means we have already observed the snapshot
+        // and have nothing else to do.
+        let initial_output_duration = metrics.initial_output_duration_seconds.get();
+        if initial_output_duration > 0. {
+            return;
+        }
+
+        if PartialOrder::less_than(&self.as_of, frontier) {
+            let duration = self.created_at.elapsed().as_secs_f64();
+            metrics.initial_output_duration_seconds.set(duration);
+        }
     }
 }

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -11,6 +11,7 @@ use mz_compute_client::metrics::{CommandMetrics, HistoryMetrics};
 use mz_ore::metric;
 use mz_ore::metrics::raw::{IntCounterVec, UIntGaugeVec};
 use mz_ore::metrics::{IntCounter, MetricsRegistry, UIntGauge};
+use mz_repr::GlobalId;
 
 #[derive(Clone, Debug)]
 pub struct ComputeMetrics {
@@ -58,6 +59,22 @@ impl ComputeMetrics {
         }
     }
 
+    pub fn for_collection(
+        &self,
+        collection_id: GlobalId,
+        _worker_id: usize,
+    ) -> Option<CollectionMetrics> {
+        // In an effort to reduce the cardinality of timeseries created, we collect metrics only
+        // for non-transient dataflows. This is roughly equivalent to "long-lived" dataflows,
+        // with the exception of subscribes which may or may not be long-lived. We might want to
+        // change this policy in the future to track subscribes as well.
+        if collection_id.is_transient() {
+            return None;
+        }
+
+        Some(CollectionMetrics {})
+    }
+
     /// Record the reconciliation result for a single dataflow.
     ///
     /// Reconciliation is recorded as successful if the given properties all hold. Otherwise it is
@@ -85,3 +102,6 @@ impl ComputeMetrics {
         }
     }
 }
+
+/// Metrics maintained per compute collection.
+pub struct CollectionMetrics {}

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -9,16 +9,24 @@
 
 use mz_compute_client::metrics::{CommandMetrics, HistoryMetrics};
 use mz_ore::metric;
-use mz_ore::metrics::raw::{IntCounterVec, UIntGaugeVec};
-use mz_ore::metrics::{IntCounter, MetricsRegistry, UIntGauge};
+use mz_ore::metrics::{
+    raw, DeleteOnDropGauge, GaugeVec, GaugeVecExt, IntCounter, MetricsRegistry, UIntGauge,
+};
 use mz_repr::GlobalId;
+use prometheus::core::AtomicF64;
 
 #[derive(Clone, Debug)]
 pub struct ComputeMetrics {
-    pub history_command_count: UIntGaugeVec,
+    // command history
+    pub history_command_count: raw::UIntGaugeVec,
     pub history_dataflow_count: UIntGauge,
+
+    // reconciliation
     pub reconciliation_reused_dataflows: IntCounter,
-    pub reconciliation_replaced_dataflows: IntCounterVec,
+    pub reconciliation_replaced_dataflows: raw::IntCounterVec,
+
+    // dataflow state
+    pub dataflow_initial_output_duration_seconds: GaugeVec,
 }
 
 impl ComputeMetrics {
@@ -42,6 +50,11 @@ impl ComputeMetrics {
                 help: "The number of dataflows that were replaced during compute reconciliation.",
                 var_labels: ["reason"],
             )),
+            dataflow_initial_output_duration_seconds: registry.register(metric!(
+                name: "mz_dataflow_initial_output_duration_seconds",
+                help: "The time from dataflow installation up to when the first output was produced.",
+                var_labels: ["worker_id", "collection_id"],
+            )),
         }
     }
 
@@ -62,7 +75,7 @@ impl ComputeMetrics {
     pub fn for_collection(
         &self,
         collection_id: GlobalId,
-        _worker_id: usize,
+        worker_id: usize,
     ) -> Option<CollectionMetrics> {
         // In an effort to reduce the cardinality of timeseries created, we collect metrics only
         // for non-transient dataflows. This is roughly equivalent to "long-lived" dataflows,
@@ -72,7 +85,14 @@ impl ComputeMetrics {
             return None;
         }
 
-        Some(CollectionMetrics {})
+        let labels = vec![worker_id.to_string(), collection_id.to_string()];
+        let initial_output_duration_seconds = self
+            .dataflow_initial_output_duration_seconds
+            .get_delete_on_drop_gauge(labels);
+
+        Some(CollectionMetrics {
+            initial_output_duration_seconds,
+        })
     }
 
     /// Record the reconciliation result for a single dataflow.
@@ -104,4 +124,6 @@ impl ComputeMetrics {
 }
 
 /// Metrics maintained per compute collection.
-pub struct CollectionMetrics {}
+pub struct CollectionMetrics {
+    pub initial_output_duration_seconds: DeleteOnDropGauge<'static, AtomicF64, Vec<String>>,
+}

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -655,7 +655,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
 
                 // Compensate what already was sent to logging sources.
                 if let Some(logger) = &compute_state.compute_logger {
-                    if let Some(time) = collection.reported_frontier.logging_time() {
+                    if let Some(time) = collection.reported_frontier().logging_time() {
                         logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
                     }
                     if let Some(time) = new_reported_frontier.logging_time() {
@@ -663,7 +663,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     }
                 }
 
-                collection.reported_frontier = new_reported_frontier;
+                collection.set_reported_frontier(new_reported_frontier);
 
                 // Sink tokens should be retained for retained dataflows, and dropped for dropped
                 // dataflows.


### PR DESCRIPTION
This PR introduces a new replica metric, `mz_dataflow_initial_output_duration_seconds`, that tracks the time from the installation of a compute collection until it first produced any outputs. This is not necessarily the time until a dataflow has been fully hydrated (depending on your definition of 'hydration'), but might be a good stand-in.

From the design doc (#19717):

>   * [ ] `mz_dataflow_initial_output_duration_seconds`
>        * **Type**: gauge
>        * **Labels**: `worker_id`, `collection_id`
>        * **Description**: The time from dataflow installation up to when the first output was produced.
>        * **Export Type**: direct
>        * **Notes**: To reduce the cardinality of this metric, we limit it to non-transient dataflows.

### Demo

You can try the metric out by running these commands in psql:

```sql
materialize=> create table t (a int);
CREATE TABLE
materialize=> insert into t select generate_series(1, 2000);
INSERT 0 2000
materialize=> create view v as select t1.a as x, t2.a as y from t t1, t t2;
CREATE VIEW
materialize=> \timing
Timing is on.
materialize=> create default index on v; select * from v limit 1;
CREATE INDEX
Time: 173.885 ms
  x  |  y
-----+-----
 256 | 256
(1 row)

Time: 15370.698 ms (00:15.371)
```

Then check the metrics endpoint and you should see an entry with a time close to the duration of that final SELECT:
```
mz_dataflow_initial_output_duration_seconds{collection_id="u2",worker_id="0"} 15.362563792
```

When you drop the index, the metrics entry will go away too.

### Motivation

  * This PR adds a known-desirable feature.

Part of #18745.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
