### PR TITLE
bin/pydoc: fix crash

### DIFF
--- a/misc/python/materialize/cloudtest/__init__.py
+++ b/misc/python/materialize/cloudtest/__init__.py
@@ -1,0 +1,8 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.

--- a/misc/python/materialize/setup.py
+++ b/misc/python/materialize/setup.py
@@ -1,4 +1,3 @@
-# Copyright 2020 Josh Wills. All rights reserved.
 # Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,19 +15,20 @@
 
 from setuptools import setup
 
-setup(
-    name="materialize",
-    version="0.2.0",
-    description="Materialize test base.",
-    author="Materialize, Inc.",
-    author_email="support@materialize.com",
-    packages=[
-        "materialize",
-        "materialize.cloudtest",
-        "materialize.cloudtest.app",
-        "materialize.cloudtest.k8s",
-        "materialize.mzcompose",
-    ],
-    package_dir={"materialize": "."},
-    install_requires=["pg8000", "semver", "sqlparse", "kubernetes"],
-)
+if __name__ == "__main__":
+    setup(
+        name="materialize",
+        version="0.2.0",
+        description="Materialize test base.",
+        author="Materialize, Inc.",
+        author_email="support@materialize.com",
+        packages=[
+            "materialize",
+            "materialize.cloudtest",
+            "materialize.cloudtest.app",
+            "materialize.cloudtest.k8s",
+            "materialize.mzcompose",
+        ],
+        package_dir={"materialize": "."},
+        install_requires=["pg8000", "semver", "sqlparse", "kubernetes"],
+    )


### PR DESCRIPTION
Due to a bug in Python [0], pydoc crashes on empty __init__.py files. Fix this by adding a copyright header to the empty cloudtest __init__.py file.

Also put the materialize/setup.py file behind an import guard and remove a copyright header that does not apply to the file.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug: deploy builds were failing.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
