### PR TITLE
ci: Reduce number of thread in cargo-test

### DIFF
--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -125,7 +125,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 "run",
                 "--profile=ci",
                 # Most tests don't use 100% of a CPU core, so run two tests per CPU.
-                f"--test-threads={cpu_count * 2}",
+                # TODO(def-): Reenable when #19931 is fixed
+                # f"--test-threads={cpu_count * 2}",
                 *args.args,
             ],
             env=env,


### PR DESCRIPTION
As a workaround for #19931, but doesn't fix the underlying issue, since it also happens in production

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
