### PR TITLE
tests: Use context managers for cursors

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -967,22 +967,22 @@ def _wait_for_pg(
             )
             # The default (autocommit = false) wraps everything in a transaction.
             conn.autocommit = True
-            cur = conn.cursor()
-            cur.execute(query)
-            if expected == "any" and cur.rowcount == -1:
-                ui.progress(" success!", finish=True)
-                return
-            result = list(cur.fetchall())
-            if expected == "any" or result == expected:
-                if print_result:
-                    say(f"query result: {result}")
-                else:
+            with conn.cursor() as cur:
+                cur.execute(query)
+                if expected == "any" and cur.rowcount == -1:
                     ui.progress(" success!", finish=True)
-                return
-            else:
-                say(
-                    f"host={host} port={port} did not return rows matching {expected} got: {result}"
-                )
+                    return
+                result = list(cur.fetchall())
+                if expected == "any" or result == expected:
+                    if print_result:
+                        say(f"query result: {result}")
+                    else:
+                        ui.progress(" success!", finish=True)
+                    return
+                else:
+                    say(
+                        f"host={host} port={port} did not return rows matching {expected} got: {result}"
+                    )
         except Exception as e:
             ui.progress(f"{e if print_result else ''} {int(remaining)}")
             error = e


### PR DESCRIPTION
Cleaner and makes sure cleanup isn't forgotten

Use `?w=1` for reviewing.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
