### PR TITLE
slt: Exclude system_privileges.slt from auto views

### DIFF
--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -93,6 +93,7 @@ tests_without_views=(
     test/sqllogictest/role_membership.slt
     test/sqllogictest/schemas.slt
     test/sqllogictest/subquery.slt
+    test/sqllogictest/system_privileges.slt
     test/sqllogictest/table_func.slt
     test/sqllogictest/temporal.slt
     test/sqllogictest/timedomain.slt

--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -155,6 +155,7 @@ tests_without_views=(
     test/sqllogictest/subscribe_outputs.slt
     test/sqllogictest/subsource.slt
     test/sqllogictest/system-cluster.slt
+    test/sqllogictest/system_privileges.slt
     test/sqllogictest/table_func.slt
     test/sqllogictest/temporal.slt
     test/sqllogictest/timedomain.slt


### PR DESCRIPTION
Was newly added while the auto view PR was open. Via https://buildkite.com/materialize/sql-logic-tests/builds/5586#0188f779-7e8e-4790-aa78-67c0e9578d8a
```
SELECT * FROM mz_system_privileges
InconsistentViewOutcome:test/sqllogictest/system_privileges.slt:28
        expected from query: Success
        actually from indexed view: PlanFailure { error: db error: ERROR: cannot use wildcard expansions or NATURAL JOINs in a view that depends on system objects
DETAIL: This is a limitation in Materialize that will be lifted in a future release. See https://github.com/MaterializeInc/materialize/issues/16650 for details. HINT: Rewrite the view to refer to all columns by name. Expand all wildcards and convert all NATURAL JOINs to USING joins.
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
