### PR TITLE
Change Kafka doc to show how to decode uft8 encoded byte arrays

### DIFF
--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -171,7 +171,7 @@ SELECT
     seller,
     item,
     (
-        SELECT convert_from((h).value, 'utf8')::bigint AS client_id
+        SELECT convert_from((h).value, 'utf8') AS client_id
         FROM unnest(headers) AS h
         WHERE (h).key = 'client_id'
     )


### PR DESCRIPTION
### Motivation

It's not straight forward how to decode Kafka headers. [In the foreseeable future](https://materializeinc.slack.com/archives/C02CB7L4TCG/p1687780275458039?thread_ts=1687768965.316149&cid=C02CB7L4TCG), we will only be able to decode utf8 encoded `bytea`. This PR changes the example to use `convert_from` to show how the utf8 conversion works until more elaborate encodings (AVRO, protobuf) become available.
