### PR TITLE
sqlsmith: Another type out of range

### DIFF
--- a/test/sqlsmith/Dockerfile
+++ b/test/sqlsmith/Dockerfile
@@ -28,7 +28,7 @@ ADD https://api.github.com/repos/def-/sqlsmith/git/refs/heads/materialize versio
 # Build SQLsmith
 RUN git clone --depth=1 --single-branch --branch=materialize https://github.com/def-/sqlsmith \
     && cd sqlsmith \
-    && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_COMPILER=c++ . \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ . \
     && cmake --build . -j `nproc`
 
 ENTRYPOINT ["sqlsmith/sqlsmith"]

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -128,6 +128,7 @@ known_errors = [
     "pg_cancel_backend in this position not yet supported",
     "unrecognized configuration parameter",
     "numeric field overflow",
+    "bigint out of range",
     "uint8 out of range",
     "interval out of range",
     "timezone interval must not contain months or years",


### PR DESCRIPTION
```
Error XX000: ERROR:  Evaluation error: "-9223372036854775808" bigint out of range
```
Via https://buildkite.com/materialize/nightlies/builds/2659

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
