### PR TITLE
adapter: Remove invalid comment about system priv

### DIFF
--- a/src/sql/src/plan/statement/acl.rs
+++ b/src/sql/src/plan/statement/acl.rs
@@ -617,7 +617,6 @@ pub fn describe_alter_default_privileges(
     Ok(StatementDesc::new(None))
 }
 
-/// TODO(jkosh44) Handle system privileges.
 pub fn plan_alter_default_privileges(
     scx: &StatementContext,
     AlterDefaultPrivilegesStatement {


### PR DESCRIPTION
This commit removes a TODO comment about adding system privileges to the default privileges framework. Default system privileges make no sense. They would only be applied to new systems whenever a new system is created, but new systems can never be created. System refers to the entire Materialize deployment and there's only ever a single one in the context of a single catalog.

Part of #19997

### Motivation
Removes a comment.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
