### PR TITLE
adapter: Clarify function name

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3233,7 +3233,7 @@ impl Catalog {
                             }),
                             MZ_SYSTEM_ROLE_ID,
                             PrivilegeMap::from_mz_acl_items(vec![
-                                rbac::default_catalog_privilege(
+                                rbac::default_builtin_object_privilege(
                                     mz_sql::catalog::ObjectType::Source,
                                 ),
                                 rbac::owner_privilege(
@@ -3263,7 +3263,9 @@ impl Catalog {
                             }),
                             MZ_SYSTEM_ROLE_ID,
                             PrivilegeMap::from_mz_acl_items(vec![
-                                rbac::default_catalog_privilege(mz_sql::catalog::ObjectType::Table),
+                                rbac::default_builtin_object_privilege(
+                                    mz_sql::catalog::ObjectType::Table,
+                                ),
                                 rbac::owner_privilege(
                                     mz_sql::catalog::ObjectType::Table,
                                     MZ_SYSTEM_ROLE_ID,
@@ -3301,7 +3303,9 @@ impl Catalog {
                             item,
                             MZ_SYSTEM_ROLE_ID,
                             PrivilegeMap::from_mz_acl_items(vec![
-                                rbac::default_catalog_privilege(mz_sql::catalog::ObjectType::View),
+                                rbac::default_builtin_object_privilege(
+                                    mz_sql::catalog::ObjectType::View,
+                                ),
                                 rbac::owner_privilege(
                                     mz_sql::catalog::ObjectType::View,
                                     MZ_SYSTEM_ROLE_ID,
@@ -3348,7 +3352,7 @@ impl Catalog {
                             }),
                             MZ_SYSTEM_ROLE_ID,
                             PrivilegeMap::from_mz_acl_items(vec![
-                                rbac::default_catalog_privilege(
+                                rbac::default_builtin_object_privilege(
                                     mz_sql::catalog::ObjectType::Source,
                                 ),
                                 rbac::owner_privilege(
@@ -3905,7 +3909,7 @@ impl Catalog {
                 }),
                 MZ_SYSTEM_ROLE_ID,
                 PrivilegeMap::from_mz_acl_items(vec![
-                    rbac::default_catalog_privilege(mz_sql::catalog::ObjectType::Type),
+                    rbac::default_builtin_object_privilege(mz_sql::catalog::ObjectType::Type),
                     rbac::owner_privilege(mz_sql::catalog::ObjectType::Type, MZ_SYSTEM_ROLE_ID),
                 ]),
             );

--- a/src/adapter/src/catalog/storage/stash.rs
+++ b/src/adapter/src/catalog/storage/stash.rs
@@ -260,7 +260,7 @@ pub async fn initialize(
     ));
 
     let schema_privileges = vec![
-        rbac::default_catalog_privilege(mz_sql::catalog::ObjectType::Schema).into_proto(),
+        rbac::default_builtin_object_privilege(mz_sql::catalog::ObjectType::Schema).into_proto(),
         rbac::owner_privilege(mz_sql::catalog::ObjectType::Schema, MZ_SYSTEM_ROLE_ID).into_proto(),
     ];
 

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -1482,7 +1482,7 @@ pub(crate) const fn owner_privilege(object_type: ObjectType, owner_id: RoleId) -
     }
 }
 
-pub(crate) const fn default_catalog_privilege(object_type: ObjectType) -> MzAclItem {
+pub(crate) const fn default_builtin_object_privilege(object_type: ObjectType) -> MzAclItem {
     let acl_mode = match object_type {
         ObjectType::Table
         | ObjectType::View


### PR DESCRIPTION
This comment renames a function `default_catalog_privilege` to `default_builtin_object_privilege` to clarify that it's only meant to be applied to builtin objects.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
