### PR TITLE
ci: Use mold linker to speed up building

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,17 +87,11 @@ rust-version = "1.68.2"
 # TODO(gusywnn|benesch): remove this when incremental ice's are improved
 incremental = false
 
-[profile.dev.package]
+[profile.dev.build-override]
 # Compile the backtrace crate and its dependencies with all optimizations, even
 # in dev builds, since otherwise backtraces can take 20s+ to symbolize. With
 # optimizations enabled, symbolizing a backtrace takes less than 1s.
-addr2line = { opt-level = 3 }
-adler = { opt-level = 3 }
-backtrace = { opt-level = 3 }
-gimli = { opt-level = 3 }
-miniz_oxide = { opt-level = 3 }
-object = { opt-level = 3 }
-rustc-demangle = { opt-level = 3 }
+opt-level = 3
 
 [profile.release]
 # Emit full debug info, allowing us to easily analyze core dumps from

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -94,7 +94,6 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
     lcov \
     libclang-dev \
     libpq-dev \
-    lld \
     llvm \
     make \
     openssh-client \
@@ -127,7 +126,10 @@ RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.3.0/au
     && curl -fsSL https://github.com/docker/compose/releases/download/v2.15.1/docker-compose-linux-$ARCH_GCC > /usr/local/lib/docker/cli-plugins/docker-compose \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose \
     && curl -fsSL https://github.com/christian-korneck/docker-pushrm/releases/download/v1.9.0/docker-pushrm_linux_$ARCH_GO > /usr/local/lib/docker/cli-plugins/docker-pushrm \
-    && chmod +x /usr/local/lib/docker/cli-plugins/docker-pushrm
+    && chmod +x /usr/local/lib/docker/cli-plugins/docker-pushrm \
+    && curl -fsSL https://github.com/rui314/mold/releases/download/v1.11.0/mold-1.11.0-$ARCH_GCC-linux.tar.gz > mold.tar.gz \
+    && tar -xzf mold.tar.gz \
+    && cp mold-1.11.0-$ARCH_GCC-linux/bin/mold /usr/local/bin/mold
 
 ENTRYPOINT ["autouseradd", "--user", "materialize"]
 
@@ -174,10 +176,10 @@ RUN mkdir rust \
     && cargo install --root /usr/local --version "=0.2.15" --no-default-features --features=s3,openssl/vendored sccache \
     && cargo install --root /usr/local --version "=0.3.6" cargo-binutils
 
-# Link the system lld into the cross-compiling sysroot.
-
-RUN ln -s /usr/bin/lld /opt/x-tools/$ARCH_GCC-unknown-linux-gnu/bin/$ARCH_GCC-unknown-linux-gnu-ld.lld \
-    && ln -s /usr/bin/lld /opt/x-tools/$ARCH_GCC-unknown-linux-gnu/bin/$ARCH_GCC-unknown-linux-gnu-lld
+# Link the system mold into the cross-compiling sysroot.
+# TODO(def-) Use mold endings and switch to -fuse-ld=mold when crosstool-ng is updated
+RUN ln -s /usr/local/bin/mold /opt/x-tools/$ARCH_GCC-unknown-linux-gnu/bin/$ARCH_GCC-unknown-linux-gnu-ld.lld \
+    && ln -s /usr/local/bin/mold /opt/x-tools/$ARCH_GCC-unknown-linux-gnu/bin/$ARCH_GCC-unknown-linux-gnu-lld
 
 # Install the Antithesis stub instrumentation library.
 

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -174,7 +174,8 @@ RUN mkdir rust \
     && `: Until https://github.com/est31/cargo-udeps/pull/147 is released in cargo-udeps` \
     && cargo install --root /usr/local --git https://github.com/est31/cargo-udeps --rev=b84d478ef3efd7264dba8c15c31a50c6399dc5bb --locked cargo-udeps --features=vendored-openssl \
     && cargo install --root /usr/local --version "=0.2.15" --no-default-features --features=s3,openssl/vendored sccache \
-    && cargo install --root /usr/local --version "=0.3.6" cargo-binutils
+    && cargo install --root /usr/local --version "=0.3.6" cargo-binutils \
+    && cargo install --root /usr/local --version "=0.1.61" cargo-chef
 
 # Link the system mold into the cross-compiling sysroot.
 # TODO(def-) Use mold endings and switch to -fuse-ld=mold when crosstool-ng is updated


### PR DESCRIPTION
> mold is available under the AGPL license. Note that this does not mean
> you have to license your program under AGPL if you use mold to link your
> program. The output of the mold linker is a derived work of the object
> files and libraries you pass to the linker, but not a derived work of
> the mold linker itself.

The runtimes of build fluctuate so much that I don't dare to say how much faster this is. Locally I've been using mold on Linux for a while and seen no problems.

Part of #20132 

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
