### PR TITLE
ci: Run Miri cargo tests in parallel on two instances

### DIFF
--- a/ci/test/cargo-test-miri.sh
+++ b/ci/test/cargo-test-miri.sh
@@ -18,5 +18,9 @@ set -euo pipefail
 # so keep them away from the `target` directory.
 export CARGO_TARGET_DIR="$PWD/miri-target"
 export MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-strict-provenance"
+
+PARTITION=$((${BUILDKITE_PARALLEL_JOB:-0}+1))
+TOTAL=${BUILDKITE_PARALLEL_JOB_COUNT:-1}
+
 # exclude netwrok based tests, they mostly fail on epoll_wait
-cargo miri nextest run -j"$(nproc)" --no-fail-fast --workspace --exclude 'mz-adapter*' --exclude 'mz-environmentd*' --exclude 'mz-expr*' --exclude 'mz-compute-client*' --exclude 'mz-persist-client*' --exclude 'mz-ssh-util*' --exclude 'mz-rocksdb*' --exclude 'mz-sqllogictest*'
+cargo miri nextest run -j"$(nproc)" --partition "count:$PARTITION/$TOTAL" --no-fail-fast --workspace --exclude 'mz-adapter*' --exclude 'mz-environmentd*' --exclude 'mz-expr*' --exclude 'mz-compute-client*' --exclude 'mz-persist-client*' --exclude 'mz-ssh-util*' --exclude 'mz-rocksdb*' --exclude 'mz-sqllogictest*'

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -154,9 +154,10 @@ steps:
       queue: builder-linux-x86_64
 
   - id: miri-test
-    label: Miri test
+    label: Miri test %n
     command: bin/ci-builder run nightly ci/test/cargo-test-miri.sh
     inputs: [src]
+    parallelism: 2
     timeout_in_minutes: 30
     agents:
       queue: builder-linux-x86_64
@@ -546,7 +547,7 @@ steps:
           args: [--scenario=RestartSourcePostgres, --check=DebeziumPostgres, --check=PgCdc]
 
   - id: cloudtest
-    label: Cloudtest
+    label: Cloudtest %n
     depends_on: build-x86_64
     parallelism: 3
     timeout_in_minutes: 30


### PR DESCRIPTION
to speed up runtime so that Miri is not the slowest part of our CI run. I'm not sure if this is still considered ok or too expensive. If so, we could move Miri to nightly instead. This has to build the tests twice now, duplicating 3 minutes of build time. This changes the time from 26 min -> 15 min.

Part of #20132 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
