### PR TITLE
doc: Copy anchor links to clipboard on click

### DIFF
--- a/doc/user/layouts/_default/baseof.html
+++ b/doc/user/layouts/_default/baseof.html
@@ -77,9 +77,23 @@ Apache License, Version 2.0. */}}
     <div class="backdrop"></div>
 
     <script>
+      /* Add anchor links to headings */
       anchors.add(
         ".content h2, .content h3, .content h4, .content h5, .content h6"
       );
+
+      /* Copy anchor links to clipboard on click */
+      $('.anchorjs-link').click(function (e) {
+        e.preventDefault();
+        var copyText = $(this).prop('href');
+
+        document.addEventListener('copy', function(e) {
+          e.clipboardData.setData('text/plain', copyText);
+          e.preventDefault();
+        }, true);
+
+        document.execCommand('copy');
+      });
 
       $(".content ol:has(p)").addClass("has-p");
 

--- a/doc/user/layouts/_default/baseof.html
+++ b/doc/user/layouts/_default/baseof.html
@@ -83,16 +83,26 @@ Apache License, Version 2.0. */}}
       );
 
       /* Copy anchor links to clipboard on click */
-      $('.anchorjs-link').click(function (e) {
-        e.preventDefault();
-        var copyText = $(this).prop('href');
-
-        document.addEventListener('copy', function(e) {
-          e.clipboardData.setData('text/plain', copyText);
+      document.addEventListener("click", function (e) {
+        const target = e.target;
+        if (target.classList.contains("anchorjs-link")) {
+          const initialIcon =  e.target.getAttribute("data-anchorjs-icon");
+          e.target.setAttribute("data-anchorjs-icon", "\u2713");
+          setTimeout(() => {
+            e.target.setAttribute("data-anchorjs-icon", initialIcon);
+          }, 1000)
           e.preventDefault();
-        }, true);
+          const copyText = target.href;
 
-        document.execCommand('copy');
+          const copyHandler = function(e) {
+            e.clipboardData.setData('text/plain', copyText);
+            e.preventDefault();
+            document.removeEventListener('copy', copyHandler);
+          }
+
+          document.addEventListener('copy', copyHandler, true);
+          document.execCommand("copy");
+        }
       });
 
       $(".content ol:has(p)").addClass("has-p");


### PR DESCRIPTION
We use Anchor.js to add anchor links to headings so we can link users to specific sections of a page.

This PR adds a bit more JavaScript that copies anchor link URLs to the clipboard when the anchor icon is clicked. This makes it easier to share anchor links.

Adapted from https://dev.to/tqbit/how-to-use-javascript-to-copy-text-to-the-clipboard-2hi2.

Fixes: #16876

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
