### PR TITLE
resume ingestions using as_of rather than upper

### DIFF
--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -62,9 +62,10 @@ pub enum InternalStorageCommand {
         /// The description of the ingestion/source.
         ingestion_description: IngestionDescription<CollectionMetadata>,
         /// The frontier at which we should (re-)start ingestion.
-        resumption_frontier: Antichain<mz_repr::Timestamp>,
-        /// The frontier at which we should (re-)start ingestion in the source time domain.
-        source_resumption_frontier: BTreeMap<GlobalId, Vec<Row>>,
+        ingestion_as_of: Antichain<mz_repr::Timestamp>,
+        /// The frontier at which we should (re-)start ingestion in the source
+        /// time domain for each export.
+        export_resume_uppers: BTreeMap<GlobalId, Vec<Row>>,
     },
     /// Render a sink dataflow.
     CreateSinkDataflow(

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -227,7 +227,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
     storage_state: &mut StorageState,
     primary_source_id: GlobalId,
     description: IngestionDescription<CollectionMetadata>,
-    resume_upper: Antichain<mz_repr::Timestamp>,
+    as_of: Antichain<mz_repr::Timestamp>,
     source_resume_upper: BTreeMap<GlobalId, Vec<Row>>,
 ) {
     let worker_id = timely_worker.index();
@@ -249,7 +249,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 &debug_name,
                 primary_source_id,
                 description.clone(),
-                resume_upper.clone(),
+                as_of.clone(),
                 source_resume_upper,
                 storage_state,
             );
@@ -292,7 +292,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
             let health_token = crate::source::health_operator(
                 into_time_scope,
                 storage_state,
-                resume_upper,
+                as_of,
                 primary_source_id,
                 &health_stream,
                 health_configs,

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -29,7 +29,7 @@ use prometheus::core::{AtomicI64, GenericCounterVec};
 #[derive(Clone, Debug)]
 pub(super) struct SourceSpecificMetrics {
     pub(super) capability: UIntGaugeVec,
-    pub(super) resume_upper: IntGaugeVec,
+    pub(super) as_of: IntGaugeVec,
     /// A timestamp gauge representing forward progress
     /// in the data shard.
     pub(super) progress: IntGaugeVec,
@@ -51,8 +51,8 @@ impl SourceSpecificMetrics {
                 help: "The current capability for this dataflow. This corresponds to min(mz_partition_closed_ts)",
                 var_labels: ["topic", "source_id", "worker_id"],
             )),
-            resume_upper: registry.register(metric!(
-                name: "mz_resume_upper",
+            as_of: registry.register(metric!(
+                name: "mz_as_of",
                 // TODO(guswynn): should this also track the resumption frontier operator?
                 help: "The timestamp-domain resumption frontier chosen for a source's ingestion",
                 var_labels: ["source_id"],

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -236,7 +236,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             trace!(
                 %id,
                 "timely-{worker_id} initializing table reader with {} and {} tables to snapshot",
-                config.resume_upper.pretty(),
+                config.as_of.pretty(),
                 reader_snapshot_table_info.len()
             );
 

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -1414,8 +1414,8 @@ mod tests {
             partitioned_frontier([(0, MzOffset::from(5))])
         );
 
-        // (rewrite comment) If we compact too far, we get an error. Note we compact
-        // to the previous UPPER we were checking.
+        // If we compact too far and start reading at the since, we get the
+        // minimum timestamp.
         remap_read_handle
             .downgrade_since(&Antichain::from_elem(2001.into()))
             .await;

--- a/src/storage/src/source/resumption.rs
+++ b/src/storage/src/source/resumption.rs
@@ -88,7 +88,7 @@ where
             interval.tick().await;
 
             // Get a new lower bound for the resumption frontier
-            let new_upper = calc.calculate_resumption_frontier().await;
+            let new_upper = calc.calculate_ingestion_as_of().await;
 
             if PartialOrder::less_than(&upper, &new_upper) {
                 tracing::debug!(

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -314,8 +314,8 @@ impl SourcePersistSinkMetrics {
 pub struct SourceMetrics {
     /// Value of the capability associated with this source
     pub(crate) capability: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    /// The resume_upper for a source.
-    pub(crate) resume_upper: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
+    /// The as_of for a source.
+    pub(crate) as_of: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
     /// Per-partition Prometheus metrics.
     pub(crate) partition_metrics: BTreeMap<PartitionId, PartitionMetrics>,
     source_name: String,
@@ -341,9 +341,9 @@ impl SourceMetrics {
                 .source_specific
                 .capability
                 .get_delete_on_drop_gauge(labels.to_vec()),
-            resume_upper: base
+            as_of: base
                 .source_specific
-                .resume_upper
+                .as_of
                 .get_delete_on_drop_gauge(vec![source_id.to_string()]),
             partition_metrics: Default::default(),
             source_name: source_name.to_string(),

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -205,7 +205,7 @@ impl<T: TimestampManipulation + Codec64 + Display> AsyncStorageWorker<T> {
                         }
 
                         // Create a specialized description to be able to call the generic method
-                        let source_resume_upper = match ingestion.desc.connection {
+                        let export_resume_uppers = match ingestion.desc.connection {
                             GenericSourceConnection::Kafka(_) => {
                                 let uppers = reclock_resume_frontier::<KafkaSourceConnection, _>(
                                     &persist_clients,
@@ -252,7 +252,7 @@ impl<T: TimestampManipulation + Codec64 + Display> AsyncStorageWorker<T> {
                                 id,
                                 ingestion,
                                 ingestion_as_of,
-                                source_resume_upper,
+                                export_resume_uppers,
                             ),
                         );
 
@@ -273,7 +273,7 @@ impl<T: TimestampManipulation + Codec64 + Display> AsyncStorageWorker<T> {
     }
 
     /// Calculates a recent resume upper for the given `IngestionDescription`.
-    pub fn calculate_resume_upper(
+    pub fn calculate_as_of(
         &self,
         id: GlobalId,
         ingestion: IngestionDescription<CollectionMetadata>,

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -270,7 +270,7 @@ where
                 let async_storage_worker = Rc::clone(&worker.storage_state.async_worker);
                 let internal_command_fabric = &mut HaltingInternalCommandSender::new();
 
-                let source_resumption_frontier = std::iter::once((
+                let export_resume_uppers = std::iter::once((
                     id,
                     match &desc.connection {
                         GenericSourceConnection::Kafka(c) => minimum_frontier(c),
@@ -308,8 +308,8 @@ where
                                 remap_collection_id: GlobalId::User(99),
                             },
                         // TODO: test resumption as well!
-                        resumption_frontier: Antichain::from_elem(Timestamp::minimum()),
-                        source_resumption_frontier,
+                        ingestion_as_of: Antichain::from_elem(Timestamp::minimum()),
+                        export_resume_uppers,
                     },
                 );
             }


### PR DESCRIPTION
### Motivation

refactors the notion of resumption frontiers to be based on an as_of rather than an upper.

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
