### PR TITLE
adapter: Refactor object name error messages

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -8219,39 +8219,12 @@ impl SessionCatalog for ConnCatalog<'_> {
         }
     }
 
-    fn get_object_name(&self, object_id: &ObjectId) -> String {
-        match object_id {
-            ObjectId::Cluster(cluster_id) => self.get_cluster(*cluster_id).name().to_string(),
-            ObjectId::ClusterReplica((cluster_id, replica_id)) => self
-                .get_cluster_replica(*cluster_id, *replica_id)
-                .name()
-                .to_string(),
-            ObjectId::Database(database_id) => self.get_database(database_id).name().to_string(),
-            ObjectId::Schema((database_spec, schema_spec)) => {
-                let name = self.get_schema(database_spec, schema_spec).name();
-                self.resolve_full_schema_name(name).to_string()
-            }
-            ObjectId::Role(role_id) => self.get_role(role_id).name().to_string(),
-            ObjectId::Item(id) => {
-                let name = self.get_item(id).name();
-                self.resolve_full_name(name).to_string()
-            }
-        }
-    }
-
     fn get_system_object_type(&self, id: &SystemObjectId) -> mz_sql::catalog::SystemObjectType {
         match id {
             SystemObjectId::Object(object_id) => {
                 SystemObjectType::Object(self.get_object_type(object_id))
             }
             SystemObjectId::System => SystemObjectType::System,
-        }
-    }
-
-    fn get_system_object_name(&self, id: &SystemObjectId) -> String {
-        match id {
-            SystemObjectId::Object(object_id) => self.get_object_name(object_id),
-            SystemObjectId::System => "SYSTEM".to_string(),
         }
     }
 

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -16,7 +16,7 @@ use mz_ore::str::StrExt;
 use mz_repr::adt::mz_acl_item::AclMode;
 use mz_repr::strconv;
 use mz_sql::ast::NoticeSeverity;
-use mz_sql::catalog::SystemObjectType;
+use mz_sql::catalog::ErrorMessageObjectDescription;
 use mz_sql::plan::PlanNotice;
 use mz_sql::session::vars::IsolationLevel;
 
@@ -99,12 +99,11 @@ pub enum AdapterNotice {
         name: String,
     },
     CannotRevoke {
-        name: String,
+        object_description: ErrorMessageObjectDescription,
     },
     NonApplicablePrivilegeTypes {
         non_applicable_privileges: AclMode,
-        object_type: SystemObjectType,
-        object_name: String,
+        object_description: ErrorMessageObjectDescription,
     },
     PlanNotice(PlanNotice),
 }
@@ -262,20 +261,18 @@ impl fmt::Display for AdapterNotice {
             AdapterNotice::AlterIndexOwner { name } => {
                 write!(f, "cannot change owner of {}", name.quoted())
             }
-            AdapterNotice::CannotRevoke { name } => {
-                write!(f, "no privileges could be revoked for {}", name.quoted())
+            AdapterNotice::CannotRevoke { object_description } => {
+                write!(f, "no privileges could be revoked for {object_description}")
             }
             AdapterNotice::NonApplicablePrivilegeTypes {
                 non_applicable_privileges,
-                object_type,
-                object_name,
+                object_description,
             } => {
                 write!(
                     f,
-                    "non-applicable privilege types {} for {} {}",
+                    "non-applicable privilege types {} for {}",
                     non_applicable_privileges.to_error_string(),
-                    object_type,
-                    object_name.quoted()
+                    object_description,
                 )
             }
             AdapterNotice::PlanNotice(plan) => plan.fmt(f),

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1089,7 +1089,9 @@ impl From<&GlobalId> for ObjectId {
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum SystemObjectId {
+    /// The ID of a specific object.
     Object(ObjectId),
+    /// Identifier for the entire system.
     System,
 }
 

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -1030,12 +1030,12 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: owner of table t
-owner: privileges on table t granted by owner
-owner: privileges granted on table t to owner
-owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: owner of TABLE "materialize.public.t"
+owner: privileges on TABLE "materialize.public.t" granted by owner
+owner: privileges granted on TABLE "materialize.public.t" to owner
+owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=owner1,user=owner
 DROP TABLE t;
@@ -1046,9 +1046,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;
@@ -1102,15 +1102,15 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: owner of table t
-owner: privileges on table t granted by owner
-owner: privileges granted on table t to owner
-owner: owner of index ind
-owner: privileges on index ind granted by owner
-owner: privileges granted on index ind to owner
-owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: owner of TABLE "materialize.public.t"
+owner: privileges on TABLE "materialize.public.t" granted by owner
+owner: privileges granted on TABLE "materialize.public.t" to owner
+owner: owner of INDEX "materialize.public.ind"
+owner: privileges on INDEX "materialize.public.ind" granted by owner
+owner: privileges granted on INDEX "materialize.public.ind" to owner
+owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=owner2,user=owner
 DROP INDEX ind;
@@ -1126,9 +1126,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;
@@ -1177,20 +1177,20 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: owner of source s_progress
-owner: privileges on source s_progress granted by owner
-owner: privileges granted on source s_progress to owner
-owner: owner of source s
-owner: privileges on source s granted by owner
-owner: privileges granted on source s to owner
-owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
-owner: owner of cluster materialize_public_s
-owner: privileges granted on cluster materialize_public_s to mz_introspection
-owner: privileges on cluster materialize_public_s granted by owner
-owner: privileges granted on cluster materialize_public_s to owner
-owner: owner of cluster replica linked
+DETAIL: owner: owner of SOURCE "materialize.public.s_progress"
+owner: privileges on SOURCE "materialize.public.s_progress" granted by owner
+owner: privileges granted on SOURCE "materialize.public.s_progress" to owner
+owner: owner of SOURCE "materialize.public.s"
+owner: privileges on SOURCE "materialize.public.s" granted by owner
+owner: privileges granted on SOURCE "materialize.public.s" to owner
+owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
+owner: owner of CLUSTER "materialize_public_s"
+owner: privileges granted on CLUSTER "materialize_public_s" to mz_introspection
+owner: privileges on CLUSTER "materialize_public_s" granted by owner
+owner: privileges granted on CLUSTER "materialize_public_s" to owner
+owner: owner of CLUSTER REPLICA "linked"
 
 simple conn=owner3,user=owner
 DROP SOURCE s;
@@ -1201,9 +1201,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;
@@ -1252,12 +1252,12 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: owner of view v
-owner: privileges on view v granted by owner
-owner: privileges granted on view v to owner
-owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: owner of VIEW "materialize.public.v"
+owner: privileges on VIEW "materialize.public.v" granted by owner
+owner: privileges granted on VIEW "materialize.public.v" to owner
+owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=owner4,user=owner
 DROP VIEW v;
@@ -1268,9 +1268,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;
@@ -1319,12 +1319,12 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: owner of materialized view mvv
-owner: privileges on materialized view mvv granted by owner
-owner: privileges granted on materialized view mvv to owner
-owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: owner of MATERIALIZED VIEW "materialize.public.mvv"
+owner: privileges on MATERIALIZED VIEW "materialize.public.mvv" granted by owner
+owner: privileges granted on MATERIALIZED VIEW "materialize.public.mvv" to owner
+owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=owner5,user=owner
 DROP MATERIALIZED VIEW mvv;
@@ -1335,9 +1335,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;
@@ -1386,12 +1386,12 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: owner of connection c
-owner: privileges on connection c granted by owner
-owner: privileges granted on connection c to owner
-owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: owner of CONNECTION "materialize.public.c"
+owner: privileges on CONNECTION "materialize.public.c" granted by owner
+owner: privileges granted on CONNECTION "materialize.public.c" to owner
+owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=owner6,user=owner
 DROP CONNECTION c;
@@ -1402,9 +1402,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;
@@ -1453,13 +1453,13 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: owner of type ty
-owner: privileges on type ty granted by owner
-owner: privileges granted on type ty to owner
-owner: privileges granted on type ty to public
-owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: owner of TYPE "materialize.public.ty"
+owner: privileges on TYPE "materialize.public.ty" granted by owner
+owner: privileges granted on TYPE "materialize.public.ty" to owner
+owner: privileges granted on TYPE "materialize.public.ty" to public
+owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=owner7,user=owner
 DROP TYPE ty;
@@ -1470,9 +1470,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;
@@ -1521,12 +1521,12 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: owner of secret se
-owner: privileges on secret se granted by owner
-owner: privileges granted on secret se to owner
-owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: owner of SECRET "materialize.public.se"
+owner: privileges on SECRET "materialize.public.se" granted by owner
+owner: privileges granted on SECRET "materialize.public.se" to owner
+owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=owner8,user=owner
 DROP SECRET se;
@@ -1537,9 +1537,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;
@@ -1588,16 +1588,16 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: owner of database db
-owner: privileges on database db granted by owner
-owner: privileges granted on database db to owner
-owner: owner of schema public
-owner: privileges on schema public granted by owner
-owner: privileges granted on schema public to owner
-owner: privileges granted on schema public to public
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: owner of DATABASE "db"
+owner: privileges on DATABASE "db" granted by owner
+owner: privileges granted on DATABASE "db" to owner
+owner: owner of SCHEMA "db.public"
+owner: privileges on SCHEMA "db.public" granted by owner
+owner: privileges granted on SCHEMA "db.public" to owner
+owner: privileges granted on SCHEMA "db.public" to public
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=owner9,user=owner
 DROP DATABASE db;
@@ -1608,9 +1608,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;
@@ -1659,12 +1659,12 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: owner of schema sc
-owner: privileges on schema sc granted by owner
-owner: privileges granted on schema sc to owner
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: owner of SCHEMA "materialize.sc"
+owner: privileges on SCHEMA "materialize.sc" granted by owner
+owner: privileges granted on SCHEMA "materialize.sc" to owner
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=owner10,user=owner
 DROP SCHEMA sc;
@@ -1675,9 +1675,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;
@@ -1726,14 +1726,14 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
-owner: owner of cluster clus
-owner: privileges granted on cluster clus to mz_introspection
-owner: privileges on cluster clus granted by owner
-owner: privileges granted on cluster clus to owner
-owner: owner of cluster replica r1
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
+owner: owner of CLUSTER "clus"
+owner: privileges granted on CLUSTER "clus" to mz_introspection
+owner: privileges on CLUSTER "clus" granted by owner
+owner: privileges granted on CLUSTER "clus" to owner
+owner: owner of CLUSTER REPLICA "r1"
 
 simple conn=owner11,user=owner
 DROP CLUSTER clus;
@@ -1744,9 +1744,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;
@@ -1795,10 +1795,10 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
-owner: owner of cluster replica r2
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
+owner: owner of CLUSTER REPLICA "r2"
 
 simple conn=owner12,user=owner
 DROP CLUSTER REPLICA default.r2;
@@ -1809,9 +1809,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;
@@ -1865,15 +1865,15 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: owner of table t
-owner: privileges on table t granted by owner
-owner: privileges granted on table t to owner
-owner: owner of view v
-owner: privileges on view v granted by owner
-owner: privileges granted on view v to owner
-owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: owner of TABLE "materialize.public.t"
+owner: privileges on TABLE "materialize.public.t" granted by owner
+owner: privileges granted on TABLE "materialize.public.t" to owner
+owner: owner of VIEW "materialize.public.v"
+owner: privileges on VIEW "materialize.public.v" granted by owner
+owner: privileges granted on VIEW "materialize.public.v" to owner
+owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=owner13,user=owner
 DROP TABLE t
@@ -1884,12 +1884,12 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: owner of view v
-owner: privileges on view v granted by owner
-owner: privileges granted on view v to owner
-owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: owner of VIEW "materialize.public.v"
+owner: privileges on VIEW "materialize.public.v" granted by owner
+owner: privileges granted on VIEW "materialize.public.v" to owner
+owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=owner13,user=owner
 DROP VIEW v
@@ -1900,9 +1900,9 @@ simple conn=materialize,user=materialize
 DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
-DETAIL: owner: privileges on database materialize granted by mz_system
-owner: privileges on schema public granted by mz_system
-owner: privileges on cluster default granted by mz_system
+DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
+owner: privileges on SCHEMA "materialize.public" granted by mz_system
+owner: privileges on CLUSTER "default" granted by mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE CREATE ON DATABASE materialize FROM owner;

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -68,12 +68,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE CONNECTION conn TO KAFKA (BROKER 'localhost:9092');
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 CREATE CONNECTION conn TO KAFKA (BROKER 'localhost:9092');
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO joe;
@@ -100,12 +100,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE SCHEMA sch;
 ----
-db error: ERROR: permission denied for DATABASE materialize
+db error: ERROR: permission denied for DATABASE "materialize"
 
 simple conn=child,user=child
 CREATE SCHEMA sch;
 ----
-db error: ERROR: permission denied for DATABASE materialize
+db error: ERROR: permission denied for DATABASE "materialize"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON DATABASE materialize TO joe;
@@ -132,12 +132,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE SOURCE s1 FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 CREATE SOURCE s1 FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO joe;
@@ -162,12 +162,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE SOURCE s2 IN CLUSTER source_cluster FROM LOAD GENERATOR COUNTER;
 ----
-db error: ERROR: permission denied for CLUSTER source_cluster
+db error: ERROR: permission denied for CLUSTER "source_cluster"
 
 simple conn=child,user=child
 CREATE SOURCE s2 IN CLUSTER source_cluster FROM LOAD GENERATOR COUNTER;
 ----
-db error: ERROR: permission denied for CLUSTER source_cluster
+db error: ERROR: permission denied for CLUSTER "source_cluster"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON CLUSTER source_cluster TO joe;
@@ -199,12 +199,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE SECRET se AS decode('c2VjcmV0Cg==', 'base64');
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 CREATE SECRET se AS decode('c2VjcmV0Cg==', 'base64');
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO joe;
@@ -231,12 +231,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE TYPE ty AS (a text);
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 CREATE TYPE ty AS (a text);
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO joe;
@@ -273,12 +273,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE TABLE t (a ty);
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 CREATE TABLE t (a ty);
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO joe;
@@ -288,12 +288,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE TABLE t (a ty);
 ----
-db error: ERROR: permission denied for TYPE materialize.public.ty
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=child,user=child
 CREATE TABLE t (a ty);
 ----
-db error: ERROR: permission denied for TYPE materialize.public.ty
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON TYPE ty TO PUBLIC;
@@ -335,12 +335,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE VIEW v AS SELECT ROW(1)::ty;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 CREATE VIEW v AS SELECT ROW(1)::ty;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO joe;
@@ -350,12 +350,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE VIEW v AS SELECT ROW(1)::ty;
 ----
-db error: ERROR: permission denied for TYPE materialize.public.ty
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=child,user=child
 CREATE VIEW v AS SELECT ROW(1)::ty;
 ----
-db error: ERROR: permission denied for TYPE materialize.public.ty
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON TYPE ty TO PUBLIC;
@@ -397,12 +397,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE MATERIALIZED VIEW mv AS SELECT ROW(1)::ty;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 CREATE MATERIALIZED VIEW mv AS SELECT ROW(1)::ty;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO joe;
@@ -412,12 +412,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE MATERIALIZED VIEW mv AS SELECT ROW(1)::ty;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=child,user=child
 CREATE MATERIALIZED VIEW mv AS SELECT ROW(1)::ty;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON CLUSTER default TO joe;
@@ -427,12 +427,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE MATERIALIZED VIEW mv AS SELECT ROW(1)::ty;
 ----
-db error: ERROR: permission denied for TYPE materialize.public.ty
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=child,user=child
 CREATE MATERIALIZED VIEW mv AS SELECT ROW(1)::ty;
 ----
-db error: ERROR: permission denied for TYPE materialize.public.ty
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON TYPE ty TO PUBLIC;
@@ -479,12 +479,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE INDEX i ON t (a::ty);
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 CREATE INDEX i ON t (a::ty);
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO joe;
@@ -494,12 +494,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE INDEX i ON t (a::ty);
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=child,user=child
 CREATE INDEX i ON t (a::ty);
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON CLUSTER default TO joe;
@@ -509,12 +509,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE INDEX i ON t (a::ty);
 ----
-db error: ERROR: permission denied for TYPE materialize.public.ty
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=child,user=child
 CREATE INDEX i ON t (a::ty);
 ----
-db error: ERROR: permission denied for TYPE materialize.public.ty
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON TYPE ty TO PUBLIC;
@@ -551,12 +551,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DROP CONNECTION conn;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 DROP CONNECTION conn1;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -583,12 +583,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DROP SCHEMA sch;
 ----
-db error: ERROR: permission denied for DATABASE materialize
+db error: ERROR: permission denied for DATABASE "materialize"
 
 simple conn=child,user=child
 DROP SCHEMA sch1;
 ----
-db error: ERROR: permission denied for DATABASE materialize
+db error: ERROR: permission denied for DATABASE "materialize"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON DATABASE materialize TO joe;
@@ -615,22 +615,22 @@ COMPLETE 0
 simple conn=joe,user=joe
 DROP SOURCE s1;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 DROP SOURCE s3;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=joe,user=joe
 DROP SOURCE s2;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 DROP SOURCE s4;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -667,12 +667,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DROP SECRET se;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 DROP SECRET se1;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -699,12 +699,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DROP INDEX i;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 DROP INDEX i1;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -731,12 +731,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DROP TABLE t;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 DROP TABLE t1;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -763,12 +763,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DROP VIEW v;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 DROP VIEW v1;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -795,12 +795,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DROP MATERIALIZED VIEW mv;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 DROP MATERIALIZED VIEW mv1;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -827,12 +827,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DROP TYPE ty;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 DROP TYPE ty1;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -864,12 +864,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 SHOW CREATE TABLE t;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 SHOW CREATE TABLE t;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -920,12 +920,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -935,12 +935,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for TYPE materialize.public.ty
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=child,user=child
 SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for TYPE materialize.public.ty
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON TYPE ty TO joe;
@@ -950,12 +950,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE t TO joe;
@@ -965,12 +965,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=child,user=child
 SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON CLUSTER default TO joe;
@@ -1042,12 +1042,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 SELECT * FROM v;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 SELECT * FROM v;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -1057,12 +1057,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 SELECT * FROM v;
 ----
-db error: ERROR: permission denied for VIEW materialize.public.v
+db error: ERROR: permission denied for VIEW "materialize.public.v"
 
 simple conn=child,user=child
 SELECT * FROM v;
 ----
-db error: ERROR: permission denied for VIEW materialize.public.v
+db error: ERROR: permission denied for VIEW "materialize.public.v"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE v TO joe;
@@ -1072,12 +1072,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 SELECT * FROM v;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 SELECT * FROM v;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO view_owner;
@@ -1087,12 +1087,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 SELECT * FROM v;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 SELECT * FROM v;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE t TO view_owner;
@@ -1102,12 +1102,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 SELECT * FROM v;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=child,user=child
 SELECT * FROM v;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON CLUSTER default TO joe;
@@ -1198,12 +1198,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 EXPLAIN SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 EXPLAIN SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -1213,12 +1213,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 EXPLAIN SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for TYPE materialize.public.ty
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=child,user=child
 EXPLAIN SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for TYPE materialize.public.ty
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON TYPE ty TO joe;
@@ -1228,12 +1228,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 EXPLAIN SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 EXPLAIN SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE t TO joe;
@@ -1290,12 +1290,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 EXPLAIN SELECT * FROM v;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 EXPLAIN SELECT * FROM v;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -1305,12 +1305,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 EXPLAIN SELECT * FROM v;
 ----
-db error: ERROR: permission denied for VIEW materialize.public.v
+db error: ERROR: permission denied for VIEW "materialize.public.v"
 
 simple conn=child,user=child
 EXPLAIN SELECT * FROM v;
 ----
-db error: ERROR: permission denied for VIEW materialize.public.v
+db error: ERROR: permission denied for VIEW "materialize.public.v"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE v TO joe;
@@ -1320,12 +1320,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 EXPLAIN SELECT * FROM v;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 EXPLAIN SELECT * FROM v;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO view_owner;
@@ -1335,12 +1335,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 EXPLAIN SELECT * FROM v;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 EXPLAIN SELECT * FROM v;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE t TO view_owner;
@@ -1392,12 +1392,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t VALUES (1);
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 INSERT INTO t VALUES (1);
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -1407,12 +1407,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t VALUES (1);
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 INSERT INTO t VALUES (1);
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT INSERT ON TABLE t TO joe;
@@ -1424,12 +1424,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t VALUES (1);
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=child,user=child
 INSERT INTO t VALUES (1);
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON CLUSTER default TO joe;
@@ -1476,12 +1476,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t SELECT * FROM t;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 INSERT INTO t SELECT * FROM t;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -1491,12 +1491,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t SELECT * FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 INSERT INTO t SELECT * FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT INSERT ON TABLE t TO joe;
@@ -1506,12 +1506,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t SELECT * FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 INSERT INTO t SELECT * FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE t TO joe;
@@ -1521,12 +1521,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t SELECT * FROM t;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=child,user=child
 INSERT INTO t SELECT * FROM t;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON CLUSTER default TO joe;
@@ -1551,12 +1551,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t SELECT * FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 INSERT INTO t SELECT * FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 REVOKE SELECT ON TABLE t FROM joe;
@@ -1588,12 +1588,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t VALUES (42) RETURNING a;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 INSERT INTO t VALUES (42) RETURNING a;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -1603,12 +1603,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t VALUES (42) RETURNING a;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 INSERT INTO t VALUES (42) RETURNING a;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT INSERT ON TABLE t TO joe;
@@ -1618,12 +1618,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t VALUES (42) RETURNING a;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 INSERT INTO t VALUES (42) RETURNING a;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE t TO joe;
@@ -1633,12 +1633,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t VALUES (42) RETURNING a;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=child,user=child
 INSERT INTO t VALUES (42) RETURNING a;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON CLUSTER default TO joe;
@@ -1665,12 +1665,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t VALUES (42) RETURNING a;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 INSERT INTO t VALUES (42) RETURNING a;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 REVOKE SELECT ON TABLE t FROM joe;
@@ -1702,12 +1702,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE t SET a = 42;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 UPDATE t SET a = 42;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -1717,12 +1717,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE t SET a = 42;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 UPDATE t SET a = 42;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT UPDATE ON TABLE t TO joe;
@@ -1732,12 +1732,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE T SET a = 42 WHERE a > 6;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 UPDATE T SET a = 42 WHERE a > 6;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE t TO joe;
@@ -1747,12 +1747,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE t SET a = 42;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=child,user=child
 UPDATE t SET a = 42;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON CLUSTER default TO joe;
@@ -1777,12 +1777,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE t SET a = 42;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 UPDATE t SET a = 42;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 REVOKE SELECT ON TABLE t FROM joe;
@@ -1814,12 +1814,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE T SET a = 42 WHERE a > 6;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 UPDATE T SET a = 42 WHERE a > 6;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -1829,12 +1829,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE T SET a = 42 WHERE a > 6;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 UPDATE T SET a = 42 WHERE a > 6;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT UPDATE ON TABLE t TO joe;
@@ -1844,12 +1844,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE T SET a = 42 WHERE a > 6;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 UPDATE T SET a = 42 WHERE a > 6;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE t TO joe;
@@ -1859,12 +1859,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE T SET a = 42 WHERE a > 6;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=child,user=child
 UPDATE T SET a = 42 WHERE a > 6;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON CLUSTER default TO joe;
@@ -1889,12 +1889,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE T SET a = 42 WHERE a > 6;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 UPDATE T SET a = 42 WHERE a > 6;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 REVOKE SELECT ON TABLE t FROM joe;
@@ -1926,12 +1926,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE T SET a = a + 10;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 UPDATE T SET a = a + 10;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -1941,12 +1941,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE T SET a = a + 10;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 UPDATE T SET a = a + 10;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT UPDATE ON TABLE t TO joe;
@@ -1956,12 +1956,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE T SET a = a + 10;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 UPDATE T SET a = a + 10;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE t TO joe;
@@ -1971,12 +1971,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE T SET a = a + 10;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=child,user=child
 UPDATE T SET a = a + 10;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON CLUSTER default TO joe;
@@ -2001,12 +2001,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 UPDATE T SET a = a + 10;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 UPDATE T SET a = a + 10;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 REVOKE SELECT ON TABLE t FROM joe;
@@ -2038,12 +2038,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DELETE FROM t;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 DELETE FROM t;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -2053,12 +2053,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DELETE FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 DELETE FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT DELETE ON TABLE t TO joe;
@@ -2068,12 +2068,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DELETE FROM t WHERE a > 5;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 DELETE FROM t WHERE a > 5;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE t TO joe;
@@ -2083,12 +2083,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DELETE FROM t;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=child,user=child
 DELETE FROM t;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON CLUSTER default TO joe;
@@ -2113,12 +2113,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DELETE FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 DELETE FROM t;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 REVOKE SELECT ON TABLE t FROM joe;
@@ -2150,12 +2150,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DELETE FROM t WHERE a > 5;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 DELETE FROM t WHERE a > 5;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -2165,12 +2165,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DELETE FROM t WHERE a > 5;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 DELETE FROM t WHERE a > 5;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT DELETE ON TABLE t TO joe;
@@ -2180,12 +2180,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DELETE FROM t WHERE a > 5;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 DELETE FROM t WHERE a > 5;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON TABLE t TO joe;
@@ -2195,12 +2195,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DELETE FROM t WHERE a > 5;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=child,user=child
 DELETE FROM t WHERE a > 5;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON CLUSTER default TO joe;
@@ -2225,12 +2225,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 DELETE FROM t WHERE a > 5;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 DELETE FROM t WHERE a > 5;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.t
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 REVOKE SELECT ON TABLE t FROM joe;
@@ -2277,12 +2277,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 ALTER SOURCE s SET (SIZE = '4');
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
 ALTER SOURCE s1 SET (SIZE = '4');
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO joe;
@@ -2353,7 +2353,7 @@ COMPLETE 0
 simple conn=joe,user=joe
 ALTER CLUSTER REPLICA default.r2 OWNER TO other;
 ----
-db error: ERROR: permission denied for CLUSTER default
+db error: ERROR: permission denied for CLUSTER "default"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON CLUSTER default TO joe;
@@ -2412,7 +2412,7 @@ COMPLETE 0
 simple conn=joe,user=joe
 ALTER SCHEMA materialize.sch OWNER TO other;
 ----
-db error: ERROR: permission denied for DATABASE materialize
+db error: ERROR: permission denied for DATABASE "materialize"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON DATABASE materialize TO joe;
@@ -2454,7 +2454,7 @@ COMPLETE 0
 simple conn=joe,user=joe
 ALTER TABLE t OWNER TO other;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO joe;
@@ -2537,7 +2537,7 @@ COMPLETE 0
 simple conn=joe,user=joe
 GRANT CREATE, USAGE ON SCHEMA materialize.sch TO other;
 ----
-db error: ERROR: permission denied for DATABASE materialize
+db error: ERROR: permission denied for DATABASE "materialize"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON DATABASE materialize TO joe;
@@ -2557,7 +2557,7 @@ COMPLETE 0
 simple conn=joe,user=joe
 REVOKE CREATE, USAGE ON SCHEMA materialize.sch FROM other;
 ----
-db error: ERROR: permission denied for DATABASE materialize
+db error: ERROR: permission denied for DATABASE "materialize"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON DATABASE materialize TO joe;
@@ -2594,7 +2594,7 @@ COMPLETE 0
 simple conn=joe,user=joe
 GRANT INSERT, SELECT ON TABLE t TO other;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
@@ -2614,7 +2614,7 @@ COMPLETE 0
 simple conn=joe,user=joe
 REVOKE INSERT, SELECT ON TABLE t FROM other;
 ----
-db error: ERROR: permission denied for SCHEMA materialize.public
+db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;

--- a/test/sqllogictest/privileges_pg.slt
+++ b/test/sqllogictest/privileges_pg.slt
@@ -270,7 +270,7 @@ COMPLETE 1
 simple conn=regress_priv_user2,user=regress_priv_user2
 INSERT INTO atest2 VALUES ('foo', true);
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user2,user=regress_priv_user2
 INSERT INTO atest1 SELECT 1, b FROM atest1;
@@ -285,17 +285,17 @@ COMPLETE 1
 simple conn=regress_priv_user2,user=regress_priv_user2
 UPDATE atest2 SET col2 = NOT col2; -- fail
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user2,user=regress_priv_user2
 DELETE FROM atest2;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user2,user=regress_priv_user2
 COPY atest2 FROM stdin;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user2,user=regress_priv_user2
 GRANT SELECT ON atest1 TO PUBLIC;
@@ -328,58 +328,58 @@ COMPLETE 2
 simple conn=regress_priv_user3,user=regress_priv_user3
 SELECT * FROM atest2;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 INSERT INTO atest1 VALUES (2, 'two');
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest1
+db error: ERROR: permission denied for TABLE "materialize.public.atest1"
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 INSERT INTO atest2 VALUES ('foo', true);
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 INSERT INTO atest1 SELECT 1, b FROM atest1;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest1
+db error: ERROR: permission denied for TABLE "materialize.public.atest1"
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 UPDATE atest1 SET a = 1 WHERE a = 2;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest1
+db error: ERROR: permission denied for TABLE "materialize.public.atest1"
 
 # Intentional (and documented) difference, we require SELECT for UPDATE
 simple conn=regress_priv_user3,user=regress_priv_user3
 UPDATE atest2 SET col2 = NULL;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 UPDATE atest2 SET col2 = NOT col2; -- fails; requires SELECT on atest2
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 DELETE FROM atest2;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 COPY atest2 FROM stdin;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 SELECT * FROM atest1 WHERE ( b IN ( SELECT col1 FROM atest2 ) );
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 SELECT * FROM atest2 WHERE ( col1 IN ( SELECT b FROM atest1 ) );
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 # Can't test COPY with SLT?
 #simple conn=regress_priv_user4,user=regress_priv_user4
@@ -427,7 +427,7 @@ COMPLETE 0
 simple conn=regress_priv_user3,user=regress_priv_user3
 SELECT * FROM atestv2;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 CREATE TABLE atest3 (one int, two int, three int);
@@ -454,7 +454,7 @@ COMPLETE 2
 simple conn=regress_priv_user3,user=regress_priv_user3
 SELECT * FROM atestv2; -- fail
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 GRANT SELECT ON atestv1 TO regress_priv_user4;
@@ -481,7 +481,7 @@ COMPLETE 2
 simple conn=regress_priv_user4,user=regress_priv_user4
 SELECT * FROM atestv2;
 ----
-db error: ERROR: permission denied for VIEW materialize.public.atestv2
+db error: ERROR: permission denied for VIEW "materialize.public.atestv2"
 
 simple conn=regress_priv_user4,user=regress_priv_user4
 SELECT * FROM atestv3;
@@ -491,7 +491,7 @@ COMPLETE 0
 simple conn=regress_priv_user4,user=regress_priv_user4
 SELECT * FROM atestv0;
 ----
-db error: ERROR: permission denied for VIEW materialize.public.atestv0
+db error: ERROR: permission denied for VIEW "materialize.public.atestv0"
 
 simple conn=regress_priv_user4,user=regress_priv_user4
 CREATE VIEW atestv4 AS SELECT * FROM atestv3; -- nested view
@@ -511,7 +511,7 @@ COMPLETE 0
 simple conn=regress_priv_user2,user=regress_priv_user2
 SELECT * FROM atestv3;
 ----
-db error: ERROR: permission denied for VIEW materialize.public.atestv3
+db error: ERROR: permission denied for VIEW "materialize.public.atestv3"
 
 simple conn=regress_priv_user2,user=regress_priv_user2
 SELECT * FROM atestv4;
@@ -526,4 +526,4 @@ COMPLETE 0
 simple conn=regress_priv_user2,user=regress_priv_user2
 SELECT * FROM atestv2;
 ----
-db error: ERROR: permission denied for TABLE materialize.public.atest2
+db error: ERROR: permission denied for TABLE "materialize.public.atest2"

--- a/test/testdrive/privilege_checks.td
+++ b/test/testdrive/privilege_checks.td
@@ -29,7 +29,7 @@ REVOKE CREATE ON CLUSTER default FROM materialize;
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
-contains:permission denied for SCHEMA materialize.public
+contains:permission denied for SCHEMA "materialize.public"
 
 $ postgres-execute connection=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO materialize;
@@ -38,7 +38,7 @@ GRANT CREATE ON SCHEMA materialize.public TO materialize;
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
-contains:permission denied for TABLE materialize.public.t
+contains:permission denied for TABLE "materialize.public.t"
 
 $ postgres-execute connection=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO materialize;
@@ -47,7 +47,7 @@ GRANT USAGE ON SCHEMA materialize.public TO materialize;
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
-contains:permission denied for TABLE materialize.public.t
+contains:permission denied for TABLE "materialize.public.t"
 
 $ postgres-execute connection=mz_system
 GRANT SELECT ON TABLE t TO materialize;
@@ -56,7 +56,7 @@ GRANT SELECT ON TABLE t TO materialize;
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
-contains:permission denied for CLUSTER default
+contains:permission denied for CLUSTER "default"
 
 $ postgres-execute connection=mz_system
 GRANT CREATE ON CLUSTER default TO materialize;
@@ -73,7 +73,7 @@ REVOKE CREATE ON schema materialize.public FROM materialize;
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
-contains:permission denied for SCHEMA materialize.public
+contains:permission denied for SCHEMA "materialize.public"
 
 $ postgres-execute connection=mz_system
 REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM materialize;


### PR DESCRIPTION
This commit refactors error messages that include object names so that they are more consistent. Specifically it does the following:

  - The object name is always fully qualified.
  - The object name is always quoted.
  - Object types are in all caps.
  - The word "SYSTEM", in relation to system privileges, is always formatted the same.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
