### PR TITLE
sql: Fix create sink privileges

### DIFF
--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -823,8 +823,6 @@ fn generate_required_privileges(
             ));
             if let Some(id) = cluster_config.cluster_id() {
                 privileges.push((id.into(), AclMode::CREATE, role_id));
-            } else if let Ok(cluster) = catalog.resolve_cluster(None) {
-                privileges.push((cluster.id().into(), AclMode::CREATE, role_id));
             }
             privileges
         }

--- a/test/testdrive/privilege_checks.td
+++ b/test/testdrive/privilege_checks.td
@@ -52,15 +52,6 @@ contains:permission denied for TABLE materialize.public.t
 $ postgres-execute connection=mz_system
 GRANT SELECT ON TABLE t TO materialize;
 
-! CREATE SINK s FROM t
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE DEBEZIUM
-contains:permission denied for CLUSTER default
-
-$ postgres-execute connection=mz_system
-GRANT CREATE ON CLUSTER default TO materialize;
-
 > CREATE SINK s FROM t
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
@@ -78,7 +69,6 @@ contains:permission denied for SCHEMA materialize.public
 $ postgres-execute connection=mz_system
 REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM materialize;
 REVOKE SELECT ON TABLE t FROM materialize;
-REVOKE CREATE ON CLUSTER default FROM materialize;
 DROP SINK s;
 DROP TABLE t;
 DROP CONNECTION csr_conn;


### PR DESCRIPTION
Previously, the privileges for CREATE SINK assumed that if a cluster is omitted, then the sink is created in the active cluster. This is incorrect. If a cluster is omitted, then the sink is created in a new linked cluster. This commit updates the privileges checks to match this.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix privilege checks for CREATE SINK.
