### PR TITLE
environmentd: add row desc to http and ws endpoints

### DIFF
--- a/doc/user/content/integrations/http-api.md
+++ b/doc/user/content/integrations/http-api.md
@@ -126,7 +126,7 @@ an array of the following:
 
 Result | JSON value
 ---------------------|------------
-Rows | `{"rows": <2D array of JSON-ified results>, "col_names": <array of text>, "notices": <array of notices>}`
+Rows | `{"rows": <2D array of JSON-ified results>, "desc": <array of column descriptions>, "notices": <array of notices>}`
 Error | `{"error": <Error object from execution>, "notices": <array of notices>}`
 Ok | `{"ok": <tag>, "notices": <array of notices>}`
 
@@ -146,6 +146,8 @@ Note that the returned values include the results of statements which were
 ultimately rolled back because of an error in a later part of the transaction.
 You must parse the results to understand which statements ultimately reflect
 the resultant state.
+
+Column descriptions contain the name, oid, data type size and type modifier of a returned column.
 
 #### TypeScript definition
 
@@ -181,11 +183,22 @@ interface Error {
 	hint?: string;
 }
 
+interface Column {
+    name: string;
+    type_oid: number; // u32
+    type_len: number; // i16
+    type_mod: number; // i32
+}
+
+interface Description {
+	columns: Column[];
+}
+
 type SqlResult =
   | {
 	tag: string;
 	rows: any[][];
-	col_names: string[];
+	desc: Description;
 	notices: Notice[];
 } | {
 	ok: string;
@@ -251,21 +264,38 @@ Response:
 {
   "results": [
     {
-        "tag": "SELECT 4",
-        "rows": [[null],[null],[109],[209]],
-        "col_names": ["cross_add"],
-        "notices": []
+      "desc": {
+        "columns": [
+          {
+            "name": "cross_add",
+            "type_len": 4,
+            "type_mod": -1,
+            "type_oid": 23
+          }
+        ]
+      },
+      "notices": [],
+      "rows": [],
+      "tag": "SELECT 0"
     },
     {
-        "tag": "SELECT 2",
-        "rows":[[100],[200]],
-        "col_names":["a"],
-        "notices": []
+      "desc": {
+        "columns": [
+          {
+            "name": "a",
+            "type_len": 4,
+            "type_mod": -1,
+            "type_oid": 23
+          }
+        ]
+      },
+      "notices": [],
+      "rows": [],
+      "tag": "SELECT 0"
     }
   ]
 }
 ```
-
 
 ## See also
 - [SQL Clients](../sql-clients)

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1119,17 +1119,18 @@ fn test_ws_passes_options() {
         serde_json::from_str(&msg).unwrap()
     };
     let starting = read_msg();
-    let col_name = read_msg();
+    let columns = read_msg();
     let row_val = read_msg();
 
     if !matches!(starting, WebSocketResponse::CommandStarting(_)) {
         panic!("wrong message!, {starting:?}");
     };
 
-    if let WebSocketResponse::Rows(rows) = col_name {
-        assert_eq!(rows, ["application_name"]);
+    if let WebSocketResponse::Rows(rows) = columns {
+        let names: Vec<&str> = rows.columns.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, ["application_name"]);
     } else {
-        panic!("wrong message!, {col_name:?}");
+        panic!("wrong message!, {columns:?}");
     };
 
     if let WebSocketResponse::Row(row) = row_val {
@@ -1175,8 +1176,18 @@ struct HttpResponse<R> {
 #[derive(Debug, Deserialize)]
 struct HttpRows {
     rows: Vec<Vec<serde_json::Value>>,
-    col_names: Vec<String>,
+    desc: HttpResponseDesc,
     notices: Vec<Notice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HttpResponseDesc {
+    columns: Vec<HttpResponseColumn>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HttpResponseColumn {
+    name: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1226,7 +1237,7 @@ fn test_http_options_param() {
     assert!(rows.notices.is_empty());
 
     let row = rows.rows.pop().unwrap().pop().unwrap();
-    let col = rows.col_names.pop().unwrap();
+    let col = rows.desc.columns.pop().unwrap().name;
 
     assert_eq!(col, "application_name");
     assert_eq!(row, "yet_another_client");
@@ -1339,7 +1350,7 @@ fn test_max_connections_on_all_interfaces() {
             );
             assert_eq!(
                 ws.read_message().unwrap(),
-                Message::Text("{\"type\":\"Rows\",\"payload\":[\"?column?\"]}".to_string())
+                Message::Text("{\"type\":\"Rows\",\"payload\":{\"columns\":[{\"name\":\"?column?\",\"type_oid\":23,\"type_len\":4,\"type_mod\":-1}]}}".to_string())
             );
             assert_eq!(
                 ws.read_message().unwrap(),

--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -12,28 +12,28 @@ http
 {"query":"select 1+2 as col"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[3]],"col_names":["col"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[3]],"desc":{"columns":[{"name":"col","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 # Multiple queries are ok.
 http
 {"query":"select 1; select 2"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"tag":"SELECT 1","rows":[[2]],"col_names":["?column?"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[1]],"desc":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]},{"tag":"SELECT 1","rows":[[2]],"desc":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 # Arrays + lists work
 http
 {"query":"select array[1], list[2]"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[[1],[2]]],"col_names":["array","list"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[[1],[2]]],"desc":{"columns":[{"name":"array","type_oid":1007,"type_len":-1,"type_mod":-1},{"name":"list","type_oid":16384,"type_len":-1,"type_mod":-1}]},"notices":[]}]}
 
 # Succeeding and failing queries can mix and match.
 http
 {"query":"select 1; select * from noexist;"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"error":{"message":"unknown catalog item 'noexist'","code":"XX000"},"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[1]],"desc":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]},{"error":{"message":"unknown catalog item 'noexist'","code":"XX000"},"notices":[]}]}
 
 # CREATEs should work when provided alone.
 http
@@ -80,7 +80,7 @@ http
 {"query":"select * from t;"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[1]],"col_names":["a"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[1]],"desc":{"columns":[{"name":"a","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 http
 {"query":"delete from t"}
@@ -99,19 +99,19 @@ http
 {"query":"begin; select 1; commit"}
 ----
 200 OK
-{"results":[{"ok":"BEGIN","notices":[]},{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"COMMIT","notices":[]}]}
+{"results":[{"ok":"BEGIN","notices":[]},{"tag":"SELECT 1","rows":[[1]],"desc":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]},{"ok":"COMMIT","notices":[]}]}
 
 http
 {"query":"begin; select 1; commit; select 2;"}
 ----
 200 OK
-{"results":[{"ok":"BEGIN","notices":[]},{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"COMMIT","notices":[]},{"tag":"SELECT 1","rows":[[2]],"col_names":["?column?"],"notices":[]}]}
+{"results":[{"ok":"BEGIN","notices":[]},{"tag":"SELECT 1","rows":[[1]],"desc":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]},{"ok":"COMMIT","notices":[]},{"tag":"SELECT 1","rows":[[2]],"desc":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 http
 {"query":"select 1; begin; select 2; commit;"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"BEGIN","notices":[]},{"tag":"SELECT 1","rows":[[2]],"col_names":["?column?"],"notices":[]},{"ok":"COMMIT","notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[1]],"desc":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]},{"ok":"BEGIN","notices":[]},{"tag":"SELECT 1","rows":[[2]],"desc":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]},{"ok":"COMMIT","notices":[]}]}
 
 http
 {"query":"begin; select 1/0; commit; select 2;"}
@@ -123,7 +123,7 @@ http
 {"query":"begin; select 1; commit; select 1/0;"}
 ----
 200 OK
-{"results":[{"ok":"BEGIN","notices":[]},{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"COMMIT","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
+{"results":[{"ok":"BEGIN","notices":[]},{"tag":"SELECT 1","rows":[[1]],"desc":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]},{"ok":"COMMIT","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
 http
 {"query":"select 1/0; begin; select 2; commit;"}
@@ -135,7 +135,7 @@ http
 {"query":"select 1; begin; select 1/0; commit;"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"BEGIN","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[1]],"desc":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]},{"ok":"BEGIN","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
 # Txns w/ writes
 
@@ -151,7 +151,7 @@ http
 {"query":"select * from t;"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 0","rows":[],"col_names":["a"],"notices":[]}]}
+{"results":[{"tag":"SELECT 0","rows":[],"desc":{"columns":[{"name":"a","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 # Explicit txn invocation commits values w/in txn, irrespective of results outside txn
 http
@@ -164,7 +164,7 @@ http
 {"query":"select * from t;"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[1]],"col_names":["a"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[1]],"desc":{"columns":[{"name":"a","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 http
 {"query":"delete from t;"}
@@ -188,7 +188,7 @@ http
 {"query":"select * from t;"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 3","rows":[[1],[2],[3]],"col_names":["a"],"notices":[]}]}
+{"results":[{"tag":"SELECT 3","rows":[[1],[2],[3]],"desc":{"columns":[{"name":"a","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 http
 {"query":"delete from t;"}
@@ -207,7 +207,7 @@ http
 {"query":"select * from t;"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 0","rows":[],"col_names":["a"],"notices":[]}]}
+{"results":[{"tag":"SELECT 0","rows":[],"desc":{"columns":[{"name":"a","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 # Empty query OK.
 http
@@ -239,13 +239,13 @@ http
 {"query":"EXPLAIN SELECT 1"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[["Explained Query (fast path):\n  Constant\n    - (1)\n"]],"col_names":["Optimized Plan"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[["Explained Query (fast path):\n  Constant\n    - (1)\n"]],"desc":{"columns":[{"name":"Optimized Plan","type_oid":25,"type_len":-1,"type_mod":-1}]},"notices":[]}]}
 
 http
 {"query":"SHOW VIEWS"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[["v"]],"col_names":["name"],"notices":[{"message":"query was automatically run on the \"mz_introspection\" cluster","severity":"debug"}]}]}
+{"results":[{"tag":"SELECT 1","rows":[["v"]],"desc":{"columns":[{"name":"name","type_oid":25,"type_len":-1,"type_mod":-1}]},"notices":[{"message":"query was automatically run on the \"mz_introspection\" cluster","severity":"debug"}]}]}
 
 http
 {"query":"SET cluster = default"}
@@ -258,47 +258,47 @@ http
 {"queries":[{"query":"select $1+$2::int as col","params":["1","2"]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[3]],"col_names":["col"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[3]],"desc":{"columns":[{"name":"col","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
  # Parameters can be present and empty
 http
 {"queries":[{"query":"select 3 as col","params":[]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[3]],"col_names":["col"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[3]],"desc":{"columns":[{"name":"col","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 # Multiple statements
 http
 {"queries":[{"query":"select 1 as col","params":[]},{"query":"select $1+$2::int as col","params":["1","2"]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[1]],"col_names":["col"],"notices":[]},{"tag":"SELECT 1","rows":[[3]],"col_names":["col"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[1]],"desc":{"columns":[{"name":"col","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]},{"tag":"SELECT 1","rows":[[3]],"desc":{"columns":[{"name":"col","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 http
 {"queries":[{"query":"select $1+$2::int as col","params":["1","2"]},{"query":"select 1 as col","params":[]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[3]],"col_names":["col"],"notices":[]},{"tag":"SELECT 1","rows":[[1]],"col_names":["col"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[3]],"desc":{"columns":[{"name":"col","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]},{"tag":"SELECT 1","rows":[[1]],"desc":{"columns":[{"name":"col","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 http
 {"queries":[{"query":"select $1+$2::int as col","params":["1","2"]},{"query":"select $1*$2::int as col","params":["2","3"]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[3]],"col_names":["col"],"notices":[]},{"tag":"SELECT 1","rows":[[6]],"col_names":["col"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[3]],"desc":{"columns":[{"name":"col","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]},{"tag":"SELECT 1","rows":[[6]],"desc":{"columns":[{"name":"col","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 # Quotes escaped
 http
 {"queries":[{"query":"select length($1), length($2)","params":["abc","'abc'"]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[3,5]],"col_names":["length","length"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[3,5]],"desc":{"columns":[{"name":"length","type_oid":23,"type_len":4,"type_mod":-1},{"name":"length","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 # All parameters values treated as strings
 http
 {"queries":[{"query":"select length($1), length($2)","params":["sum(a)","SELECT * FROM t;"]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[6,16]],"col_names":["length","length"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[6,16]],"desc":{"columns":[{"name":"length","type_oid":23,"type_len":4,"type_mod":-1},{"name":"length","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 # Too many parameters
 http
@@ -319,14 +319,14 @@ http
 {"queries":[{"query":"select $1::decimal+2 as col","params":["nan"]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[["NaN"]],"col_names":["col"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[["NaN"]],"desc":{"columns":[{"name":"col","type_oid":1700,"type_len":-1,"type_mod":2555947}]},"notices":[]}]}
 
 # Null string value parameters
 http
 {"queries":[{"query":"select $1+$2::int as col","params":["1",null]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[[null]],"col_names":["col"],"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[[null]],"desc":{"columns":[{"name":"col","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 # Empty query
 http
@@ -387,7 +387,7 @@ http
 {"queries":[{"query":"select * from t","params":[]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 0","rows":[],"col_names":["a"],"notices":[]}]}
+{"results":[{"tag":"SELECT 0","rows":[],"desc":{"columns":[{"name":"a","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 # Writes
 http
@@ -400,7 +400,7 @@ http
 {"queries":[{"query":"select * from t","params":[]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 3","rows":[[1],[2],[3]],"col_names":["a"],"notices":[]}]}
+{"results":[{"tag":"SELECT 3","rows":[[1],[2],[3]],"desc":{"columns":[{"name":"a","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 http
 {"queries":[{"query":"insert into t values ($1);","params":["4"]},{"query":"begin;","params":[]},{"query":"select 1/0;","params":[]},{"query":"commit;","params":[]}]}
@@ -412,7 +412,7 @@ http
 {"queries":[{"query":"select * from t","params":[]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 3","rows":[[1],[2],[3]],"col_names":["a"],"notices":[]}]}
+{"results":[{"tag":"SELECT 3","rows":[[1],[2],[3]],"desc":{"columns":[{"name":"a","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 http
 {"queries":[{"query":"subscribe (select * from t)","params":[]}]}

--- a/src/environmentd/tests/testdata/http/ws
+++ b/src/environmentd/tests/testdata/http/ws
@@ -23,7 +23,7 @@ ws-text
 {"query": "select NULL"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["?column?"]}
+{"type":"Rows","payload":{"columns":[{"name":"?column?","type_oid":25,"type_len":-1,"type_mod":-1}]}}
 {"type":"Row","payload":[null]}
 {"type":"CommandComplete","payload":"SELECT 1"}
 {"type":"ReadyForQuery","payload":"I"}
@@ -32,7 +32,7 @@ ws-binary
 {"query": "select 'binary'"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["?column?"]}
+{"type":"Rows","payload":{"columns":[{"name":"?column?","type_oid":25,"type_len":-1,"type_mod":-1}]}}
 {"type":"Row","payload":["binary"]}
 {"type":"CommandComplete","payload":"SELECT 1"}
 {"type":"ReadyForQuery","payload":"I"}
@@ -41,11 +41,11 @@ ws-text
 {"query": "select 1,2; values ('a'), ('b')"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["?column?","?column?"]}
+{"type":"Rows","payload":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1},{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]}}
 {"type":"Row","payload":[1,2]}
 {"type":"CommandComplete","payload":"SELECT 1"}
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["column1"]}
+{"type":"Rows","payload":{"columns":[{"name":"column1","type_oid":25,"type_len":-1,"type_mod":-1}]}}
 {"type":"Row","payload":["a"]}
 {"type":"Row","payload":["b"]}
 {"type":"CommandComplete","payload":"SELECT 2"}
@@ -73,7 +73,7 @@ ws-text
 {"query": ";;select 1;"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["?column?"]}
+{"type":"Rows","payload":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]}}
 {"type":"Row","payload":[1]}
 {"type":"CommandComplete","payload":"SELECT 1"}
 {"type":"ReadyForQuery","payload":"I"}
@@ -82,11 +82,11 @@ ws-text
 {"query": ";;select 1;; select 2;;"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["?column?"]}
+{"type":"Rows","payload":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]}}
 {"type":"Row","payload":[1]}
 {"type":"CommandComplete","payload":"SELECT 1"}
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["?column?"]}
+{"type":"Rows","payload":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]}}
 {"type":"Row","payload":[2]}
 {"type":"CommandComplete","payload":"SELECT 1"}
 {"type":"ReadyForQuery","payload":"I"}
@@ -120,7 +120,7 @@ ws-text
 {"queries": [{"query": "select $1::int", "params": ["2"]}]}
 ----
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["int4"]}
+{"type":"Rows","payload":{"columns":[{"name":"int4","type_oid":23,"type_len":4,"type_mod":-1}]}}
 {"type":"Row","payload":[2]}
 {"type":"CommandComplete","payload":"SELECT 1"}
 {"type":"ReadyForQuery","payload":"I"}
@@ -142,7 +142,7 @@ ws-text
 {"queries": [{"query": "select $1::int", "params": [null]}]}
 ----
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["int4"]}
+{"type":"Rows","payload":{"columns":[{"name":"int4","type_oid":23,"type_len":4,"type_mod":-1}]}}
 {"type":"Row","payload":[null]}
 {"type":"CommandComplete","payload":"SELECT 1"}
 {"type":"ReadyForQuery","payload":"I"}
@@ -155,7 +155,7 @@ ws-text
 {"type":"CommandStarting","payload":{"has_rows":false,"is_streaming":false}}
 {"type":"CommandComplete","payload":"BEGIN"}
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["?column?"]}
+{"type":"Rows","payload":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]}}
 {"type":"Row","payload":[1]}
 {"type":"CommandComplete","payload":"SELECT 1"}
 {"type":"ReadyForQuery","payload":"T"}
@@ -199,7 +199,7 @@ ws-text
 {"type":"CommandComplete","payload":"ROLLBACK"}
 {"type":"ParameterStatus","payload":{"name":"application_name","value":"a"}}
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["?column?"]}
+{"type":"Rows","payload":{"columns":[{"name":"?column?","type_oid":23,"type_len":4,"type_mod":-1}]}}
 {"type":"Row","payload":[2]}
 {"type":"CommandComplete","payload":"SELECT 1"}
 {"type":"ReadyForQuery","payload":"I"}
@@ -225,7 +225,7 @@ ws-text
 {"query": "SHOW application_name"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["application_name"]}
+{"type":"Rows","payload":{"columns":[{"name":"application_name","type_oid":25,"type_len":-1,"type_mod":-1}]}}
 {"type":"Row","payload":["c"]}
 {"type":"CommandComplete","payload":"SELECT 1"}
 {"type":"ReadyForQuery","payload":"T"}
@@ -242,7 +242,7 @@ ws-text
 {"query": "SHOW application_name"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
-{"type":"Rows","payload":["application_name"]}
+{"type":"Rows","payload":{"columns":[{"name":"application_name","type_oid":25,"type_len":-1,"type_mod":-1}]}}
 {"type":"Row","payload":["a"]}
 {"type":"CommandComplete","payload":"SELECT 1"}
 {"type":"ReadyForQuery","payload":"I"}
@@ -272,7 +272,7 @@ ws-text
 {"query": "SUBSCRIBE (VALUES (1)); SELECT 1"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":true}}
-{"type":"Rows","payload":["mz_timestamp","mz_diff","column1"]}
+{"type":"Rows","payload":{"columns":[{"name":"mz_timestamp","type_oid":1700,"type_len":-1,"type_mod":2555908},{"name":"mz_diff","type_oid":20,"type_len":8,"type_mod":-1},{"name":"column1","type_oid":23,"type_len":4,"type_mod":-1}]}}
 {"type":"Row","payload":["18446744073709551615",1,1]}
 {"type":"CommandComplete","payload":"SUBSCRIBE"}
 {"type":"CommandStarting","payload":{"has_rows":false,"is_streaming":false}}
@@ -283,6 +283,6 @@ ws-text rows=2 fixtimestamp=true
 {"query": "SUBSCRIBE t"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":true}}
-{"type":"Rows","payload":["mz_timestamp","mz_diff","i"]}
+{"type":"Rows","payload":{"columns":[{"name":"mz_timestamp","type_oid":1700,"type_len":-1,"type_mod":2555908},{"name":"mz_diff","type_oid":20,"type_len":8,"type_mod":-1},{"name":"i","type_oid":23,"type_len":4,"type_mod":-1}]}}
 {"type":"Row","payload":["<TIMESTAMP>",1,1]}
 {"type":"Row","payload":["<TIMESTAMP>",1,2]}


### PR DESCRIPTION
Column names were not sufficient to correctly display datums. Send over the full column description.

See https://github.com/MaterializeInc/console/issues/401

### Motivation

  * This PR adds a known-desirable feature.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - **Breaking change.** Change the `Rows` output format of the WebSocket and HTTP endpoints.