### PR TITLE
doc/user: improve Kafka source and sink docs

### DIFF
--- a/ci/deploy_website/website.sh
+++ b/ci/deploy_website/website.sh
@@ -29,6 +29,7 @@ set -euo pipefail
 declare -A shortlinks=(
     [bug]="https://github.com/MaterializeInc/materialize/issues/new?labels=C-bug&template=01-bug.yml"
     [non-materialized-error]="https://materialize.com/docs/sql/create-view/#querying-non-materialized-views"
+    [sink-key-selection]="https://materialize.com/docs/sql/create-sink/#key-selection"
     [chat]="https://join.slack.com/t/materializecommunity/shared_invite/zt-ljdufufo-PTwVPmgzlZtI7RIQLDrAiA"
 )
 

--- a/doc/user/content/releases/v0.27.md
+++ b/doc/user/content/releases/v0.27.md
@@ -108,7 +108,7 @@ substantial breaking changes from [v0.26 LTS].
   This option may be restored in the future, given sufficient demand.
 
 * **Breaking change.** Do not default to the [Debezium
-  envelope](/sql/create-sink#debezium-envelope) in `CREATE SINK`. You
+  envelope](/sql/create-sink/kafka/#debezium-envelope) in `CREATE SINK`. You
   must explicitly specify the envelope to use.
 
 * **Breaking change.** Remove the `CREATE VIEWS` statement, which was used to

--- a/doc/user/content/sql/create-sink/_index.md
+++ b/doc/user/content/sql/create-sink/_index.md
@@ -13,8 +13,7 @@ menu:
 
 A [sink](../../get-started/key-concepts/#sinks) describes an external system you
 want Materialize to write data to, and provides details about how to encode
-that data. To create a sink, you must specify a [connector](#connectors), a
-[format](#formats) and an [envelope](#envelopes).
+that data.
 
 ## Connectors
 
@@ -30,72 +29,6 @@ systems:
 
 For details on the syntax, supported formats and features of each connector,
 check out the dedicated `CREATE SINK` documentation pages.
-
-## Formats
-
-To write to an external data sink, you must specify the format Materialize
-should use to encode ouput data. This is handled by specifying a `FORMAT` in
-the `CREATE SINK` statement.
-
-### Avro
-
-<p style="font-size:14px"><b>Syntax:</b> <code>FORMAT AVRO</code></p>
-
-Materialize can encode output data as Avro messages, and automatically publish a
-schema to a schema registry based on the columns and data types in the source,
-table or materialized view you want to send to the sink.
-
-### JSON
-
-<p style="font-size:14px"><b>Syntax:</b> <code>FORMAT JSON</code></p>
-
-Materialize can encode output data as JSON messages. Publishing schemas to a
-schema registry is not supported yet for JSON-formatted sinks {{% gh 7186 %}}.
-
-## Envelopes
-
-In addition to determining how to encode output data, Materialize also needs to
-understand the desired behaviour of sinked events in the downstream external
-system. Whether a change is simply emitted as an event with a diff structure,
-or actively inserts, updates, or deletes existing data downstream depends on
-the `ENVELOPE` specified in the `CREATE SINK` statement.
-
-### Upsert envelope
-
-<p style="font-size:14px"><b>Syntax:</b> <code>ENVELOPE UPSERT</code></p>
-
-The upsert envelope treats all records as having a **key** and a **value**, and
-supports inserts, updates and deletes in the sink:
-
-- If the key does not match a preexisting record downstream, it inserts the
-  record's key and value.
-
-- If the key matches a preexisting record downstream and the value
-  is _non-null_, Materialize updates the existing record with the new value.
-
-- If the key matches a preexisting record downstream and the value is _null_,
-  Materialize deletes the record.
-
-[//]: # "TODO(morsapaes) Add information about upsert key selection"
-
-### Debezium envelope
-
-<p style="font-size:14px"><b>Syntax:</b> <code>ENVELOPE DEBEZIUM</code></p>
-
-Materialize provides a dedicated envelope that describes the decoded records'
-old and new values with a Debezium-like diff structure, representing inserts,
-updates, or deletes to the underlying source, table or materialized view being
-written to the sink:
-
-- If the `before` field is _null_, the record represents an insert.
-
-- If the `before` and `after` fields are _non-null_, the record represents an
-  update.
-
-- If the `after` field is _null_, the record represents a delete.
-
-[//]: # "TODO(morsapaes) Add more specific information about envelope
-semantics + example output."
 
 ## Best practices
 

--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -46,8 +46,9 @@ _sink&lowbar;name_ | A name for the sink. This name is only used within Material
 _item&lowbar;name_ | The name of the source, table or materialized view you want to send to the sink.
 **CONNECTION** _connection_name_ | The name of the connection to use in the sink. For details on creating connections, check the [`CREATE CONNECTION`](/sql/create-connection) documentation page.
 **KEY (** _key&lowbar;column_ **)** | An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset.
-**ENVELOPE DEBEZIUM** | The generated schemas have a [Debezium-style diff envelope](../#debezium-envelope) to capture changes in the input view or source.
-**ENVELOPE UPSERT** | The sink emits data with upsert semantics: updates and inserts for the given key are expressed as a value, and deletes are expressed as a null value payload in Kafka. For more detail, see [Handling upserts](/sql/create-sink/kafka/#handling-upserts).
+**NOT ENFORCED** | Whether to disable validation of key uniqueness when using the upsert envelope. See [Key selection](#key-selection) for details.
+**ENVELOPE DEBEZIUM** | The generated schemas have a [Debezium-style diff envelope](#debezium-envelope) to capture changes in the input view or source.
+**ENVELOPE UPSERT** | The sink emits data with [upsert semantics](#upsert-envelope).
 
 ### `CONNECTION` options
 
@@ -69,33 +70,256 @@ Field                | Value  | Description
 `SNAPSHOT`           | `bool` | Default: `true`. Whether to emit the consolidated results of the query before the sink was created at the start of the sink. To see only results after the sink is created, specify `WITH (SNAPSHOT = false)`.
 `SIZE`               | `text`    | The [size](#sizing-a-sink) for the sink. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`. Required if the `IN CLUSTER` option is not specified.
 
-## Supported formats
+## Formats
 
-|<div style="width:290px">Format</div> | [Upsert envelope] | [Debezium envelope] |
----------------------------------------|:-----------------:|:-------------------:|
-| [Avro]                               | ✓                 | ✓                   |
-| [JSON]                               | ✓                 | ✓                   |
+The `FORMAT` option controls the encoding of the message key and value that
+Materialize writes to Kafka.
 
-### Avro namespaces
+**Known limitation:** Materialize does not permit specifying the key
+format independently from the value format.
 
-For Avro-formatted sinks, you can specify the [fullnames](https://avro.apache.org/docs/current/specification/#names) for the Avro schemas Materialize generates using the `AVRO KEY FULLNAME` and `AVRO VALUE FULLNAME` [syntax](#syntax).
+### Avro
+
+<p style="font-size:14px"><b>Syntax:</b> <code>FORMAT AVRO</code></p>
+
+When using the Avro format, the value of each Kafka message is an Avro record
+containing a field for each column of the sink's source relation. The names and
+ordering of the fields in the record match the names and ordering of the columns
+in the relation.
+
+If the `KEY` option is specified, the key of each Kafka message is an Avro
+record containing a field for each key column, in the same order and with
+the same names.
+
+If a column name is not a valid Avro name, Materialize adjusts the name
+according to the following rules:
+
+  * Replace all non-alphanumeric characters with underscores.
+  * If the name begins with a number, add an underscore at the start of the
+    name.
+  * If the adjusted name is not unique, add the smallest number possible to
+    the end of the name to make it unique.
+
+For example, consider a table with two columns named `col-a` and `col@a`.
+Materialize will use the names `col_a` and `col_a1`, respectively, in the
+generated Avro schema.
+
+When using a Confluent Schema Registry:
+
+  * Materialize will automatically publish Avro schemas for the key, if present,
+    and the value to the registry.
+
+  * You can specify the
+    [fullnames](https://avro.apache.org/docs/current/specification/#names) for the
+    Avro schemas Materialize generates using the `AVRO KEY FULLNAME` and `AVRO
+    VALUE FULLNAME` [syntax](#syntax).
+
+SQL types are converted to Avro types according to the following conversion
+table:
+
+SQL type                     | Avro type
+-----------------------------|----------
+[`bigint`]                   | `"long"`
+[`boolean`]                  | `"boolean"`
+[`bytea`]                    | `"bytes"`
+[`date`]                     | `{"type": "int", "logicalType": "date"}`
+[`double precision`]         | `"double"`
+[`integer`]                  | `"int"`
+[`interval`]                 | `{"type": "fixed", "size": 16, "name": "com.materialize.sink.interval"}`
+[`jsonb`]                    | `{"type": "string", "connect.name": "io.debezium.data.Json"}`
+[`map`]                      | `{"type": "map", "values": ...}`
+[`list`]                     | `{"type": "array", "items": ...}`
+[`numeric(p,s)`][`numeric`]  | `{"type": "bytes", "logicalType": "decimal", "precision": P, "scale": s}`
+[`oid`]                      | `{"type": "fixed", "size": 4, "name": "com.materialize.sink.uint4"}`
+[`real`]                     | `"float"`
+[`record`]                   | `{"type": "record", "name": ..., "fields": ...}`
+[`smallint`]                 | `"int"`
+[`text`]                     | `"string"`
+[`time`]                     | `{"type": "long", "logicalType": "time-micros"}`
+[`uint2`]                    | `{"type": "fixed", "size": 2, "name": "com.materialize.sink.uint2"}`
+[`uint4`]                    | `{"type": "fixed", "size": 4, "name": "com.materialize.sink.uint4"}`
+[`uint8`]                    | `{"type": "fixed", "size": 8, "name": "com.materialize.sink.uint8"}`
+[`timestamp`]                | `{"type": "long", "logicalType: "timestamp-micros"}`
+[`timestamp with time zone`] | `{"type": "long", "logicalType: "timestamp-micros"}`
+[Arrays]                     | `{"type": "array", "items": ...}`
+
+### JSON
+
+<p style="font-size:14px"><b>Syntax:</b> <code>FORMAT JSON</code></p>
+
+When using the JSON format, the value of each Kafka message is a JSON object
+containing a field for each column of the sink's source relation. The names and
+ordering of the fields in the record match the names and ordering of the columns
+in the relation.
+
+If the `KEY` option is specified, the key of each Kafka message is a JSON
+object containing a field for each key column, in the same order and with the
+same names.
+
+SQL values are converted to JSON values according to the following conversion
+table:
+
+SQL type                     | Conversion
+-----------------------------|-------------------------------------
+[`array`][`arrays`]          | Values are converted to JSON arrays. Multidimensional arrays are flattened into a single dimension following row-major order.
+[`bigint`]                   | Values are converted to JSON numbers.
+[`boolean`]                  | Values are converted to `true` or `false`.
+[`integer`]                  | Values are converted to JSON numbers.
+[`list`]                     | Values are converted to JSON arrays.
+[`numeric`]                  | Values are converted to a JSON string containing the decimal representation of the number.
+[`record`]                   | Records are converted to JSON objects. The names and ordering of the fields in the object match the names and ordering of the fields in the record.
+[`smallint`]                 | values are converted to JSON numbers.
+[`timestamp`][`timestamp with time zone`] | Values are converted to JSON strings containing the number of milliseconds since the Unix epoch.
+[`uint2`]                    | Values are converted to JSON numbers.
+[`uint4`]                    | Values are converted to JSON numbers.
+[`uint8`]                    | Values are converted to JSON numbers.
+Other                        | Values are cast to [`text`] and then converted to JSON strings.
+
+## Envelopes
+
+The sink's envelope determines how inserts, updates, and delete events are
+mapped to Kafka messages.
+
+### Upsert
+
+<p style="font-size:14px"><b>Syntax:</b> <code>ENVELOPE UPSERT</code></p>
+
+The upsert envelope:
+
+  * Emits insertion and update events without additional decoration.
+  * Converts deletion events into messages with a `null` value (i.e.,
+    _tombstones_).
+  * Requires that you specify a unique key for the sink's source
+    relation using the `KEY` option.
+
+Consider using the upsert envelope if:
+
+  * You need to follow standard Kafka conventions for upsert semantics.
+  * You want to enable key-based compaction on the sink's Kafka topic while
+    retaining the most recent value for each key.
+
+#### Key selection
+
+The `KEY` that you specify for an upsert envelope sink must be a unique key of
+the sink's source relation.
+
+Materialize will attempt to validate the uniqueness of the specified key. If
+validation fails, you'll receive an error message like one of the following:
+
+```
+ERROR:  upsert key could not be validated as unique
+DETAIL: Materialize could not prove that the specified upsert envelope key
+("col1") is a unique key of the underlying relation. There are no known
+valid unique keys for the underlying relation.
+
+ERROR:  upsert key could not be validated as unique
+DETAIL: Materialize could not prove that the specified upsert envelope key
+("col1") is a unique key of the underlying relation. The following keys
+are known to be unique for the underlying relation:
+  ("col2")
+  ("col3", "col4")
+```
+
+The first error message indicates that Materialize could not prove the existence
+of any unique keys for the sink's source relation. The second error message
+indicates that Materialize could prove that `col2` and `(col3, col4)` were
+unique keys of the sink's source relation, but could not provide the uniqueness
+of the specified upsert key of `col1`.
+
+There are three ways to resolve this error:
+
+* Change the sink to use one of the keys that Materialize determined to be
+  unique, if such a key exists and has the appropriate semantics for your
+  use case.
+
+* Create a materialized view that deduplicates the input relation by the
+  desired upsert key:
+
+  ```sql
+  -- For each row with the same key `k`, the `ORDER BY` clause ensures we
+  -- keep the row with the largest value of `v`.
+  CREATE MATERIALIZED VIEW deduped AS
+  SELECT DISTINCT ON (k) v
+  FROM original_input
+  ORDER BY k, v DESC;
+
+  -- Materialize can now prove that `k` is a unique key of `deduped`.
+  CREATE SINK s IN CLUSTER my_io_cluster
+  FROM deduped
+  INTO KAFKA CONNECTION kafka_connection (TOPIC 't')
+  KEY (k)
+  FORMAT JSON ENVELOPE UPSERT;
+  ```
+
+  {{< note >}}
+  Maintaining the `deduped` materialized view requires memory proportional to the
+  number of records in `original_input`. Be sure to assign `deduped`
+  to a cluster with adequate resources to handle your data volume.
+  {{< /note >}}
+
+* Use the `NOT ENFORCED` clause to disable Materialize's validation of the key's
+  uniqueness:
+
+  ```sql
+  CREATE SINK s IN CLUSTER my_io_cluster
+  FROM original_input
+  INTO KAFKA CONNECTION kafka_connection (TOPIC 't')
+  -- We have outside knowledge that `k` is a unique key of `original_input`, but
+  -- Materialize cannot prove this, so we disable its key uniqueness check.
+  KEY k NOT ENFORCED
+  FORMAT JSON ENVELOPE UPSERT;
+  ```
+
+  You should only disable this verification if you have outside knowledge of
+  the properties of your data that guarantees the uniqueness of the key you
+  have specified.
+
+  {{< warning >}}
+  If the key is not in fact unique, downstream consumers may not be able to
+  correctly interpret the data in the topic, and Kafka key compaction may
+  incorrectly garbage collect records from the topic.
+  {{< /warning >}}
+
+### Debezium
+
+<p style="font-size:14px"><b>Syntax:</b> <code>ENVELOPE DEBEZIUM</code></p>
+
+The Debezium envelope wraps each event in an object containing a `before` and
+`after` field to indicate whether the event was an insertion, deletion, or
+update:
+
+```json
+// Insertion event.
+{"before": null, "after": {"field1": "val1", ...}}
+
+// Deletion event.
+{"before": {"field1": "val1", ...}, "after": null}
+
+// Update event.
+{"before": {"field1": "oldval1", ...}, "after": {"field1": "newval1", ...}}
+```
+
+Consider using the Debezium envelope if:
+
+  * You have downstream consumers that want update events to contain both the
+    old and new value of the row.
+  * There is no natural [key](#key-selection) for the sink.
 
 ## Features
 
-### Handling upserts
+### Automatic topic creation
 
-To create a sink that uses the standard key-value convention to support inserts, updates, and deletes in the sink topic, you can use `ENVELOPE UPSERT`:
+If the specified Kafka topic does not exist, Materialize will attempt to create
+it while processing the `CREATE SINK` statement. Materialize will configure the
+topic with the broker's default number of partitions and replication factor.
 
-```sql
-CREATE SINK avro_sink
-  FROM <source, table or mview>
-  INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_avro_topic')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
-  ENVELOPE UPSERT
-  WITH (SIZE = '3xsmall');
-```
+To customize the topic configuration, create the sink's topic outside of
+Materialize with the desired configuration (e.g., using the [`kafka-topics.sh`]
+tool) before running `CREATE SINK`.
 
-[//]: # "TODO(morsapaes) Add information about upsert key selection"
+{{< warning >}}
+{{% kafka-sink-drop %}}
+{{</ warning >}}
 
 ### Exactly-once processing
 
@@ -112,6 +336,25 @@ Exactly-once semantics are an end-to-end property of a system, but Materialize o
 - The consumers' processing is idempotent, and offsets are only committed when processing is complete.
 
 For more details, see [the Kafka documentation](https://kafka.apache.org/documentation/).
+
+## Required permissions
+
+The access control lists (ACLs) on the Kafka cluster must allow Materialize
+to perform the following operations on the following resources:
+
+Operation type  | Resource type    | Resource name
+----------------|------------------|--------------
+Read, Write     | Topic            | Consult `mz_kafka_connections.sink_progress_topic` for the sink's connection
+Write           | Topic            | The specified `TOPIC` option
+Write           | Transactional ID | `mz-producer-{SINK ID}-*`
+
+When using [automatic topic creation](#automatic-topic-creation), Materialize
+additionally requires access to the following operations:
+
+Operation type   | Resource type    | Resource name
+-----------------|------------------|--------------
+DescribeConfigs  | Cluster          | n/a
+Create           | Topic            | The specified `TOPIC` option
 
 ## Examples
 
@@ -192,24 +435,19 @@ CREATE CONNECTION csr_basic_http
 
 ### Creating a sink
 
-When sinking into Kafka, Materialize will write all the changes from the
-specified source, table, or materialized view into the sink topic. If the topic
-does not exist, Materialize will attempt to create it.
+#### Upsert envelope
 
-{{< note >}}
-{{% kafka-sink-drop  %}}
-{{</ note >}}
-
-{{< tabs tabID="1" >}}
+{{< tabs >}}
 {{< tab "Avro">}}
 
 ```sql
 CREATE SINK avro_sink
+  IN CLUSTER my_io_cluster
   FROM <source, table or mview>
   INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_avro_topic')
+  KEY (key_col)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
-  ENVELOPE DEBEZIUM
-  WITH (SIZE = '3xsmall');
+  ENVELOPE DEBEZIUM;
 ```
 
 {{< /tab >}}
@@ -217,11 +455,41 @@ CREATE SINK avro_sink
 
 ```sql
 CREATE SINK json_sink
+  IN CLUSTER my_io_cluster
+  FROM <source, table or mview>
+  INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_json_topic')
+  KEY (key_col)
+  FORMAT JSON
+  ENVELOPE DEBEZIUM;
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
+#### Debezium envelope
+
+{{< tabs >}}
+{{< tab "Avro">}}
+
+```sql
+CREATE SINK avro_sink
+  IN CLUSTER my_io_cluster
+  FROM <source, table or mview>
+  INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_avro_topic')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
+  ENVELOPE DEBEZIUM;
+```
+
+{{< /tab >}}
+{{< tab "JSON">}}
+
+```sql
+CREATE SINK json_sink
+  IN CLUSTER my_io_cluster
   FROM <source, table or mview>
   INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_json_topic')
   FORMAT JSON
-  ENVELOPE DEBEZIUM
-  WITH (SIZE = '3xsmall');
+  ENVELOPE DEBEZIUM;
 ```
 
 {{< /tab >}}
@@ -233,11 +501,11 @@ To provision a specific amount of CPU and memory to a sink on creation, use the 
 
 ```sql
 CREATE SINK avro_sink
+  IN CLUSTER my_io_cluster
   FROM <source, table or mview>
   INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_avro_topic')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
-  ENVELOPE DEBEZIUM
-  WITH (SIZE = '3xsmall');
+  ENVELOPE DEBEZIUM;
 ```
 
 To resize the sink after creation:
@@ -252,3 +520,28 @@ The smallest sink size (`3xsmall`) is a resonable default to get started. For mo
 
 - [`SHOW SINKS`](/sql/show-sinks)
 - [`DROP SINK`](/sql/drop-sink)
+
+[`bigint`]: ../../types/integer
+[`boolean`]: ../../types/boolean
+[`bytea`]: ../../types/bytea
+[`date`]: ../../types/date
+[`double precision`]: ../../types/float
+[`integer`]: ../../types/integer
+[`interval`]: ../../types/interval
+[`jsonb`]: ../../types/jsonb
+[`map`]: ../../types/map
+[`list`]: ../../types/list
+[`numeric`]: ../../types/numeric
+[`oid`]: ../../types/oid
+[`real`]: ../../types/float
+[`record`]: ../../types/record
+[`smallint`]: ../../types/integer
+[`text`]: ../../types/text
+[`time`]: ../../types/time
+[`uint2`]: ../../types/uint
+[`uint4`]: ../../types/uint
+[`uint8`]: ../../types/uint
+[`timestamp`]: ../../types/timestamp
+[`timestamp with time zone`]: ../../types/timestamp
+[arrays]: ../../types/array
+[`kafka-topics.sh`]: https://docs.confluent.io/kafka/operations-tools/kafka-tools.html#kafka-topics-sh

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -363,7 +363,7 @@ Field            | Type        | Meaning
 `type`           | [`text`]    | The type of the sink: `kafka`.
 `connection_id`  | [`text`]    | The ID of the connection associated with the sink, if any. Corresponds to [`mz_connections.id`](/sql/system-catalog/mz_catalog/#mz_connections).
 `size`           | [`text`]    | The size of the sink.
-`envelope_type`  | [`text`]    | The [envelope](/sql/create-sink/#envelopes) of the sink: `upsert`, or `debezium`.
+`envelope_type`  | [`text`]    | The [envelope](/sql/create-sink/kafka/#envelopes) of the sink: `upsert`, or `debezium`.
 `cluster_id`     | [`text`]    | The ID of the cluster maintaining the sink. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters).
 `owner_id`       | [`text`]    | The role ID of the owner of the sink. Corresponds to [`mz_roles.id`](/sql/system-catalog/mz_catalog/#mz_roles).
 

--- a/doc/user/layouts/partials/sql-grammar/create-sink-kafka.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-sink-kafka.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="587" height="489">
+<svg xmlns="http://www.w3.org/2000/svg" width="587" height="587">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="114" height="32" rx="10"/>
@@ -50,92 +50,100 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="517" y="119">INTO</text>
-   <rect x="32" y="243" width="168" height="32"/>
-   <rect x="30" y="241" width="168" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="40" y="261">kafka_sink_connection</text>
-   <rect x="240" y="243" width="48" height="32" rx="10"/>
-   <rect x="238"
-         y="241"
+   <rect x="211" y="199" width="168" height="32"/>
+   <rect x="209" y="197" width="168" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="219" y="217">kafka_sink_connection</text>
+   <rect x="51" y="309" width="48" height="32" rx="10"/>
+   <rect x="49"
+         y="307"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="248" y="261">KEY</text>
-   <rect x="308" y="243" width="26" height="32" rx="10"/>
-   <rect x="306"
-         y="241"
+   <text class="terminal" x="59" y="327">KEY</text>
+   <rect x="119" y="309" width="26" height="32" rx="10"/>
+   <rect x="117"
+         y="307"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="316" y="261">(</text>
-   <rect x="374" y="243" width="98" height="32"/>
-   <rect x="372" y="241" width="98" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="382" y="261">key_column</text>
-   <rect x="374" y="199" width="24" height="32" rx="10"/>
-   <rect x="372"
-         y="197"
+   <text class="terminal" x="127" y="327">(</text>
+   <rect x="185" y="309" width="98" height="32"/>
+   <rect x="183" y="307" width="98" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="193" y="327">key_column</text>
+   <rect x="185" y="265" width="24" height="32" rx="10"/>
+   <rect x="183"
+         y="263"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="382" y="217">,</text>
-   <rect x="512" y="243" width="26" height="32" rx="10"/>
-   <rect x="510"
-         y="241"
+   <text class="terminal" x="193" y="283">,</text>
+   <rect x="323" y="309" width="26" height="32" rx="10"/>
+   <rect x="321"
+         y="307"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="520" y="261">)</text>
-   <rect x="45" y="357" width="80" height="32" rx="10"/>
+   <text class="terminal" x="331" y="327">)</text>
+   <rect x="389" y="341" width="130" height="32" rx="10"/>
+   <rect x="387"
+         y="339"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="397" y="359">NOT ENFORCED</text>
+   <rect x="45" y="455" width="80" height="32" rx="10"/>
    <rect x="43"
-         y="355"
+         y="453"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="375">FORMAT</text>
-   <rect x="145" y="357" width="134" height="32"/>
-   <rect x="143" y="355" width="134" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="153" y="375">sink_format_spec</text>
-   <rect x="319" y="325" width="94" height="32" rx="10"/>
+   <text class="terminal" x="53" y="473">FORMAT</text>
+   <rect x="145" y="455" width="134" height="32"/>
+   <rect x="143" y="453" width="134" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="153" y="473">sink_format_spec</text>
+   <rect x="319" y="423" width="94" height="32" rx="10"/>
    <rect x="317"
-         y="323"
+         y="421"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="327" y="343">ENVELOPE</text>
-   <rect x="453" y="325" width="92" height="32" rx="10"/>
+   <text class="terminal" x="327" y="441">ENVELOPE</text>
+   <rect x="453" y="423" width="92" height="32" rx="10"/>
    <rect x="451"
-         y="323"
+         y="421"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="461" y="343">DEBEZIUM</text>
-   <rect x="453" y="369" width="76" height="32" rx="10"/>
+   <text class="terminal" x="461" y="441">DEBEZIUM</text>
+   <rect x="453" y="467" width="76" height="32" rx="10"/>
    <rect x="451"
-         y="367"
+         y="465"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="461" y="387">UPSERT</text>
-   <rect x="359" y="455" width="58" height="32" rx="10"/>
+   <text class="terminal" x="461" y="485">UPSERT</text>
+   <rect x="359" y="553" width="58" height="32" rx="10"/>
    <rect x="357"
-         y="453"
+         y="551"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="367" y="473">WITH</text>
-   <rect x="437" y="455" width="102" height="32"/>
-   <rect x="435" y="453" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="445" y="473">with_options</text>
+   <text class="terminal" x="367" y="571">WITH</text>
+   <rect x="437" y="553" width="102" height="32"/>
+   <rect x="435" y="551" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="445" y="571">with_options</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m114 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m88 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-450 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m54 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-575 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m168 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-577 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h244 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v12 m274 0 v-12 m-274 12 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h10 m134 0 h10 m20 -32 h10 m94 0 h10 m20 0 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-270 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h190 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v12 m220 0 v-12 m-220 12 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m58 0 h10 m0 0 h10 m102 0 h10 m23 -32 h-3"/>
-   <polygon points="577 437 585 433 585 441"/>
-   <polygon points="577 437 569 433 569 441"/>
+         d="m17 17 h2 m0 0 h10 m114 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m88 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-450 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m54 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-396 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m168 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-392 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m20 44 h10 m26 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m-508 -32 h20 m508 0 h20 m-548 0 q10 0 10 10 m528 0 q0 -10 10 -10 m-538 10 v46 m528 0 v-46 m-528 46 q0 10 10 10 m508 0 q10 0 10 -10 m-518 10 h10 m0 0 h498 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-578 114 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h244 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v12 m274 0 v-12 m-274 12 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h10 m134 0 h10 m20 -32 h10 m94 0 h10 m20 0 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-270 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h190 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v12 m220 0 v-12 m-220 12 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m58 0 h10 m0 0 h10 m102 0 h10 m23 -32 h-3"/>
+   <polygon points="577 535 585 531 585 539"/>
+   <polygon points="577 535 569 531 569 539"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -96,7 +96,7 @@ create_sink_kafka ::=
     ('IN CLUSTER' cluster_name)?
     'FROM' item_name
     'INTO' kafka_sink_connection
-    ('KEY' '(' key_column ( ',' key_column )* ')')?
+    ('KEY' '(' key_column ( ',' key_column )* ')' 'NOT ENFORCED'?)?
     ('FORMAT' sink_format_spec)?
     ('ENVELOPE' ('DEBEZIUM'|'UPSERT'))
     ('WITH' with_options)?

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -441,7 +441,7 @@ impl ErrorResponse {
             AdapterNotice::NonApplicablePrivilegeTypes { .. } => SqlState::WARNING,
             AdapterNotice::PlanNotice(plan) => match plan {
                 PlanNotice::ObjectDoesNotExist { .. } => SqlState::UNDEFINED_OBJECT,
-                PlanNotice::KeyNotEnforced { .. } => SqlState::WARNING,
+                PlanNotice::UpsertSinkKeyNotEnforced { .. } => SqlState::WARNING,
             },
         };
         ErrorResponse {
@@ -611,7 +611,7 @@ impl Severity {
             AdapterNotice::NonApplicablePrivilegeTypes { .. } => Severity::Notice,
             AdapterNotice::PlanNotice(notice) => match notice {
                 PlanNotice::ObjectDoesNotExist { .. } => Severity::Notice,
-                PlanNotice::KeyNotEnforced { .. } => Severity::Warning,
+                PlanNotice::UpsertSinkKeyNotEnforced { .. } => Severity::Warning,
             },
         }
     }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -84,6 +84,11 @@ pub enum PlanError {
     StrconvParse(strconv::ParseError),
     Catalog(CatalogError),
     UpsertSinkWithoutKey,
+    UpsertSinkWithInvalidKey {
+        name: String,
+        desired_key: Vec<String>,
+        valid_keys: Vec<Vec<String>>,
+    },
     InvalidWmrRecursionLimit(String),
     InvalidNumericMaxScale(InvalidNumericMaxScaleError),
     InvalidCharLength(InvalidCharLengthError),
@@ -217,6 +222,31 @@ impl PlanError {
             Self::PostgresConnectionErr { cause } => Some(cause.to_string_with_causes()),
             Self::InvalidProtobufSchema { cause } => Some(cause.to_string_with_causes()),
             Self::InvalidOptionValue { err, .. } => err.detail(),
+            Self::UpsertSinkWithInvalidKey {
+                name,
+                desired_key,
+                valid_keys,
+            } => {
+                let valid_keys = if valid_keys.is_empty() {
+                    "There are no known valid unique keys for the underlying relation.".into()
+                } else {
+                    format!(
+                        "The following keys are known to be unique for the underlying relation:\n{}",
+                        valid_keys
+                            .iter()
+                            .map(|k|
+                                format!("  ({})", k.iter().map(|c| c.as_str().quoted()).join(", "))
+                            )
+                            .join("\n"),
+                    )
+                };
+                Some(format!(
+                    "Materialize could not prove that the specified upsert envelope key ({}) \
+                    was a unique key of the underlying relation {}. {valid_keys}",
+                    separated(", ", desired_key.iter().map(|c| c.as_str().quoted())),
+                    name.quoted()
+                ))
+            }
             Self::VarError(e) => e.detail(),
             _ => None,
         }
@@ -292,6 +322,9 @@ impl PlanError {
             }
             Self::InvalidOrderByInSubscribeWithinTimestampOrderBy => {
                 Some("All order bys must be output columns.".into())
+            }
+            Self::UpsertSinkWithInvalidKey { .. } | Self::UpsertSinkWithoutKey => {
+                Some("See: https://materialize.com/s/sink-key-selection".into())
             }
             Self::Catalog(e) => e.hint(),
             Self::VarError(e) => e.hint(),
@@ -383,6 +416,9 @@ impl fmt::Display for PlanError {
             Self::StrconvParse(e) => write!(f, "{}", e),
             Self::Catalog(e) => write!(f, "{}", e),
             Self::UpsertSinkWithoutKey => write!(f, "upsert sinks must specify a key"),
+            Self::UpsertSinkWithInvalidKey { .. } => {
+                write!(f, "upsert key could not be validated as unique")
+            }
             Self::InvalidWmrRecursionLimit(msg) => write!(f, "Invalid WITH MUTUALLY RECURSIVE recursion limit. {}", msg),
             Self::InvalidNumericMaxScale(e) => e.fmt(f),
             Self::InvalidCharLength(e) => e.fmt(f),

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -313,13 +313,13 @@ $ kafka-verify-data headers=materialize-timestamp format=avro topic=not-enforced
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink-${testdrive.seed}') KEY (a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
-contains:Invalid upsert key: (a), there are no valid keys
+contains:upsert key could not be validated as unique
 
 ! CREATE SINK another_invalid_key FROM input_keyed
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink-${testdrive.seed}') KEY (b)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
-contains:Invalid upsert key: (b), valid keys are: (a)
+contains:upsert key could not be validated as unique
 
 > CREATE MATERIALIZED VIEW input_keyed_ab AS SELECT a, b FROM input GROUP BY a, b
 
@@ -327,22 +327,22 @@ contains:Invalid upsert key: (b), valid keys are: (a)
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink-${testdrive.seed}') KEY (a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
-contains:Invalid upsert key: (a), valid keys are: (a, b)
+contains:upsert key could not be validated as unique
 
 ! CREATE SINK another_invalid_sub_key FROM input_keyed_ab
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink-${testdrive.seed}') KEY (b)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
-contains:Invalid upsert key: (b), valid keys are: (a, b)
+contains:upsert key could not be validated as unique
 
 ! CREATE SINK invalid_key_from_upsert_input FROM upsert_input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-sink-${testdrive.seed}')
   KEY (key1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
-contains:Invalid upsert key: (key1), valid keys are: (key1, key2)
+contains:upsert key could not be validated as unique
 
 ! CREATE SINK invalid_key_from_upsert_input FROM upsert_input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-sink-${testdrive.seed}')
   KEY (key2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
-contains:Invalid upsert key: (key2), valid keys are: (key1, key2)
+contains:upsert key could not be validated as unique


### PR DESCRIPTION
This commit tackles several long-desired improvements to the Kafka source and sink documentation:

  * A fuller description of how `FORMAT JSON` and `FORMAT AVRO` actually encode data for sinks.

  * A description of `ENVELOPE DEBEZIUM`, and guidance on when to choose `ENVELOPE UPSERT` vs `ENVELOPE DEBEZIUM`.

  * Guidance on how to deal with common upsert `KEY` errors, including use of the `NOT ENFORCED` escape hatch.

  * An enumeration of what permissions are required on the Kafka broker for both sources and sinks.

Fix #11487.
Fix #13119.
Fix #18848.
Fix #19143.
Fix #20183.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes several recognized bugs.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
