### PR TITLE
Enable monotonic oneshot SELECTs in selected SLTs

### DIFF
--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -14,6 +14,11 @@ ALTER SYSTEM SET enable_table_keys = true
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE t (a int, b int)
 

--- a/test/sqllogictest/array_subquery.slt
+++ b/test/sqllogictest/array_subquery.slt
@@ -9,6 +9,11 @@
 
 mode cockroach
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE xs (x int not null)
 

--- a/test/sqllogictest/cockroach/distinct_on.slt
+++ b/test/sqllogictest/cockroach/distinct_on.slt
@@ -24,6 +24,11 @@ ALTER SYSTEM SET enable_table_keys = true
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE xyz (
   x INT,

--- a/test/sqllogictest/cockroach/subquery_correlated.slt
+++ b/test/sqllogictest/cockroach/subquery_correlated.slt
@@ -29,6 +29,11 @@ ALTER SYSTEM SET enable_table_foreign_key = true
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 # ------------------------------------------------------------------------------
 # Create a simple schema that models customers and orders. Each customer has an
 # id (c_id), and has zero or more orders that are related via a foreign key of

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -10,6 +10,11 @@
 # Test requires stable object IDs
 reset-server
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE t (
   a int,
@@ -40,6 +45,46 @@ CREATE VIEW ov AS SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
 statement ok
 CREATE MATERIALIZED VIEW mv AS
 SELECT * FROM t WHERE a IS NOT NULL
+
+statement ok
+CREATE VIEW hierarchical_group_by AS
+SELECT
+  a,
+  MIN(b),
+  MAX(DISTINCT b)
+FROM t
+GROUP BY a
+
+statement ok
+CREATE VIEW hierarchical_global AS
+SELECT
+  MIN(b),
+  MAX(DISTINCT b)
+FROM t
+
+statement ok
+CREATE VIEW collated_group_by AS
+SELECT
+  a,
+  COUNT(DISTINCT b),
+  STRING_AGG(b::text || '1',  ',') AS b1,
+  MIN(b),
+  MAX(DISTINCT b),
+  SUM(b),
+  STRING_AGG(b::text || '2',  ',') AS b2
+FROM t
+GROUP BY a
+
+statement ok
+CREATE VIEW collated_global AS
+SELECT
+  COUNT(DISTINCT b),
+  STRING_AGG(b::text || '1',  ',') as b1,
+  MIN(b),
+  MAX(DISTINCT b),
+  SUM(b),
+  STRING_AGG(b::text || '2',  ',') as b2
+FROM t
 
 mode cockroach
 
@@ -379,12 +424,12 @@ EOF
 # TopKBasic plan.
 query T multiline
 EXPLAIN PHYSICAL PLAN WITH(no_fast_path) AS JSON FOR
-SELECT * FROM ov
+VIEW ov
 ----
 {
   "plans": [
     {
-      "id": "Explained Query",
+      "id": "materialize.public.ov",
       "plan": {
         "TopK": {
           "input": {
@@ -465,6 +510,96 @@ SELECT * FROM ov
                 256,
                 16
               ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# MonotonicTopK plan (one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(no_fast_path) AS JSON FOR
+SELECT * FROM ov
+----
+{
+  "plans": [
+    {
+      "id": "Explained Query",
+      "plan": {
+        "TopK": {
+          "input": {
+            "ArrangeBy": {
+              "input": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
+                  },
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        {
+                          "0": 0,
+                          "1": 1
+                        },
+                        [
+                          1
+                        ]
+                      ]
+                    ]
+                  },
+                  "plan": "PassArrangements"
+                }
+              },
+              "forms": {
+                "raw": true,
+                "arranged": []
+              },
+              "input_key": [
+                {
+                  "Column": 0
+                }
+              ],
+              "input_mfp": {
+                "expressions": [],
+                "predicates": [],
+                "projection": [
+                  0,
+                  1
+                ],
+                "input_arity": 2
+              }
+            }
+          },
+          "top_k_plan": {
+            "MonotonicTopK": {
+              "group_key": [],
+              "order_key": [
+                {
+                  "column": 1,
+                  "desc": false,
+                  "nulls_last": true
+                },
+                {
+                  "column": 0,
+                  "desc": true,
+                  "nulls_last": false
+                }
+              ],
+              "limit": 5,
+              "arity": 2,
+              "must_consolidate": true
             }
           }
         }
@@ -1933,17 +2068,12 @@ EOF
 # Test Reduce::Hierarchical (with GROUP BY).
 query T multiline
 EXPLAIN PHYSICAL PLAN AS JSON FOR
-SELECT
-  a,
-  MIN(b),
-  MAX(DISTINCT b)
-FROM t
-GROUP BY a
+VIEW hierarchical_group_by
 ----
 {
   "plans": [
     {
-      "id": "Explained Query",
+      "id": "materialize.public.hierarchical_group_by",
       "plan": {
         "Reduce": {
           "input": {
@@ -2034,18 +2164,106 @@ GROUP BY a
 }
 EOF
 
-# Test Reduce::Hierarchical (global aggregate).
+# Test Reduce::Hierarchical (with GROUP BY, one-shot).
 query T multiline
 EXPLAIN PHYSICAL PLAN AS JSON FOR
-SELECT
-  MIN(b),
-  MAX(DISTINCT b)
-FROM t
+SELECT * FROM hierarchical_group_by
 ----
 {
   "plans": [
     {
       "id": "Explained Query",
+      "plan": {
+        "Reduce": {
+          "input": {
+            "Get": {
+              "id": {
+                "Global": {
+                  "User": 1
+                }
+              },
+              "keys": {
+                "raw": false,
+                "arranged": [
+                  [
+                    [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    {
+                      "0": 0,
+                      "1": 1
+                    },
+                    [
+                      1
+                    ]
+                  ]
+                ]
+              },
+              "plan": "PassArrangements"
+            }
+          },
+          "key_val_plan": {
+            "key_plan": {
+              "mfp": {
+                "expressions": [],
+                "predicates": [],
+                "projection": [
+                  0
+                ],
+                "input_arity": 2
+              }
+            },
+            "val_plan": {
+              "mfp": {
+                "expressions": [],
+                "predicates": [],
+                "projection": [
+                  1,
+                  1
+                ],
+                "input_arity": 2
+              }
+            }
+          },
+          "plan": {
+            "Hierarchical": {
+              "Monotonic": {
+                "aggr_funcs": [
+                  "MinInt32",
+                  "MaxInt32"
+                ],
+                "skips": [
+                  0,
+                  0
+                ],
+                "must_consolidate": true
+              }
+            }
+          },
+          "input_key": [
+            {
+              "Column": 0
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# Test Reduce::Hierarchical (global aggregate).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS JSON FOR
+VIEW hierarchical_global
+----
+{
+  "plans": [
+    {
+      "id": "materialize.public.hierarchical_global",
       "plan": {
         "Let": {
           "id": 0,
@@ -2138,6 +2356,266 @@ FROM t
                       256,
                       16
                     ]
+                  }
+                }
+              },
+              "input_key": null
+            }
+          },
+          "body": {
+            "Union": {
+              "inputs": [
+                {
+                  "ArrangeBy": {
+                    "input": {
+                      "Get": {
+                        "id": {
+                          "Local": 0
+                        },
+                        "keys": {
+                          "raw": false,
+                          "arranged": [
+                            [
+                              [],
+                              {
+                                "0": 0,
+                                "1": 1
+                              },
+                              [
+                                0,
+                                1
+                              ]
+                            ]
+                          ]
+                        },
+                        "plan": "PassArrangements"
+                      }
+                    },
+                    "forms": {
+                      "raw": true,
+                      "arranged": []
+                    },
+                    "input_key": [],
+                    "input_mfp": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
+                    }
+                  }
+                },
+                {
+                  "Mfp": {
+                    "input": {
+                      "Union": {
+                        "inputs": [
+                          {
+                            "Negate": {
+                              "input": {
+                                "Get": {
+                                  "id": {
+                                    "Local": 0
+                                  },
+                                  "keys": {
+                                    "raw": false,
+                                    "arranged": [
+                                      [
+                                        [],
+                                        {
+                                          "0": 0,
+                                          "1": 1
+                                        },
+                                        [
+                                          0,
+                                          1
+                                        ]
+                                      ]
+                                    ]
+                                  },
+                                  "plan": {
+                                    "Arrangement": [
+                                      [],
+                                      null,
+                                      {
+                                        "expressions": [],
+                                        "predicates": [],
+                                        "projection": [],
+                                        "input_arity": 2
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "Constant": {
+                              "rows": {
+                                "Ok": [
+                                  [
+                                    {
+                                      "data": []
+                                    },
+                                    0,
+                                    1
+                                  ]
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "mfp": {
+                      "expressions": [
+                        {
+                          "Literal": [
+                            {
+                              "Ok": {
+                                "data": [
+                                  0
+                                ]
+                              }
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        {
+                          "Literal": [
+                            {
+                              "Ok": {
+                                "data": [
+                                  0
+                                ]
+                              }
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ]
+                        }
+                      ],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 0
+                    },
+                    "input_key_val": null
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# Test Reduce::Hierarchical (global aggregate, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS JSON FOR
+SELECT * FROM hierarchical_global
+----
+{
+  "plans": [
+    {
+      "id": "Explained Query",
+      "plan": {
+        "Let": {
+          "id": 0,
+          "value": {
+            "Reduce": {
+              "input": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
+                  },
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        {
+                          "0": 0,
+                          "1": 1
+                        },
+                        [
+                          1
+                        ]
+                      ]
+                    ]
+                  },
+                  "plan": {
+                    "Arrangement": [
+                      [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      null,
+                      {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [
+                          1
+                        ],
+                        "input_arity": 2
+                      }
+                    ]
+                  }
+                }
+              },
+              "key_val_plan": {
+                "key_plan": {
+                  "mfp": {
+                    "expressions": [],
+                    "predicates": [],
+                    "projection": [],
+                    "input_arity": 1
+                  }
+                },
+                "val_plan": {
+                  "mfp": {
+                    "expressions": [],
+                    "predicates": [],
+                    "projection": [
+                      0,
+                      0
+                    ],
+                    "input_arity": 1
+                  }
+                }
+              },
+              "plan": {
+                "Hierarchical": {
+                  "Monotonic": {
+                    "aggr_funcs": [
+                      "MinInt32",
+                      "MaxInt32"
+                    ],
+                    "skips": [
+                      0,
+                      0
+                    ],
+                    "must_consolidate": true
                   }
                 }
               },
@@ -3295,21 +3773,12 @@ EOF
 # Test Reduce::Collated (with GROUP BY).
 query T multiline
 EXPLAIN PHYSICAL PLAN AS JSON FOR
-SELECT
-  a,
-  COUNT(DISTINCT b),
-  STRING_AGG(b::text || '1',  ','),
-  MIN(b),
-  MAX(DISTINCT b),
-  SUM(b),
-  STRING_AGG(b::text || '2',  ',')
-FROM t
-GROUP BY a
+VIEW collated_group_by
 ----
 {
   "plans": [
     {
-      "id": "Explained Query",
+      "id": "materialize.public.collated_group_by",
       "plan": {
         "Reduce": {
           "input": {
@@ -3785,22 +4254,491 @@ GROUP BY a
 }
 EOF
 
-# Test Reduce::Collated (global aggregate).
+# Test Reduce::Collated (with GROUP BY, one-shot).
 query T multiline
 EXPLAIN PHYSICAL PLAN AS JSON FOR
-SELECT
-  COUNT(DISTINCT b),
-  STRING_AGG(b::text || '1',  ','),
-  MIN(b),
-  MAX(DISTINCT b),
-  SUM(b),
-  STRING_AGG(b::text || '2',  ',')
-FROM t
+SELECT * FROM collated_group_by
 ----
 {
   "plans": [
     {
       "id": "Explained Query",
+      "plan": {
+        "Reduce": {
+          "input": {
+            "Get": {
+              "id": {
+                "Global": {
+                  "User": 1
+                }
+              },
+              "keys": {
+                "raw": false,
+                "arranged": [
+                  [
+                    [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    {
+                      "0": 0,
+                      "1": 1
+                    },
+                    [
+                      1
+                    ]
+                  ]
+                ]
+              },
+              "plan": "PassArrangements"
+            }
+          },
+          "key_val_plan": {
+            "key_plan": {
+              "mfp": {
+                "expressions": [],
+                "predicates": [],
+                "projection": [
+                  0
+                ],
+                "input_arity": 2
+              }
+            },
+            "val_plan": {
+              "mfp": {
+                "expressions": [
+                  {
+                    "CallUnary": {
+                      "func": {
+                        "CastInt32ToString": null
+                      },
+                      "expr": {
+                        "Column": 1
+                      }
+                    }
+                  },
+                  {
+                    "CallVariadic": {
+                      "func": {
+                        "RecordCreate": {
+                          "field_names": [
+                            ""
+                          ]
+                        }
+                      },
+                      "exprs": [
+                        {
+                          "CallVariadic": {
+                            "func": {
+                              "RecordCreate": {
+                                "field_names": [
+                                  "value",
+                                  "sep"
+                                ]
+                              }
+                            },
+                            "exprs": [
+                              {
+                                "CallBinary": {
+                                  "func": "TextConcat",
+                                  "expr1": {
+                                    "Column": 2
+                                  },
+                                  "expr2": {
+                                    "Literal": [
+                                      {
+                                        "Ok": {
+                                          "data": [
+                                            19,
+                                            1,
+                                            49
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "scalar_type": "String",
+                                        "nullable": false
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        19,
+                                        1,
+                                        44
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "String",
+                                    "nullable": false
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "CallVariadic": {
+                      "func": {
+                        "RecordCreate": {
+                          "field_names": [
+                            ""
+                          ]
+                        }
+                      },
+                      "exprs": [
+                        {
+                          "CallVariadic": {
+                            "func": {
+                              "RecordCreate": {
+                                "field_names": [
+                                  "value",
+                                  "sep"
+                                ]
+                              }
+                            },
+                            "exprs": [
+                              {
+                                "CallBinary": {
+                                  "func": "TextConcat",
+                                  "expr1": {
+                                    "Column": 2
+                                  },
+                                  "expr2": {
+                                    "Literal": [
+                                      {
+                                        "Ok": {
+                                          "data": [
+                                            19,
+                                            1,
+                                            50
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "scalar_type": "String",
+                                        "nullable": false
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        19,
+                                        1,
+                                        44
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "String",
+                                    "nullable": false
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "predicates": [],
+                "projection": [
+                  1,
+                  3,
+                  1,
+                  1,
+                  1,
+                  4
+                ],
+                "input_arity": 2
+              }
+            }
+          },
+          "plan": {
+            "Collation": {
+              "accumulable": {
+                "full_aggrs": [
+                  {
+                    "func": "Count",
+                    "expr": {
+                      "Column": 1
+                    },
+                    "distinct": true
+                  },
+                  {
+                    "func": "SumInt32",
+                    "expr": {
+                      "Column": 1
+                    },
+                    "distinct": false
+                  }
+                ],
+                "simple_aggrs": [
+                  [
+                    1,
+                    4,
+                    {
+                      "func": "SumInt32",
+                      "expr": {
+                        "Column": 1
+                      },
+                      "distinct": false
+                    }
+                  ]
+                ],
+                "distinct_aggrs": [
+                  [
+                    0,
+                    0,
+                    {
+                      "func": "Count",
+                      "expr": {
+                        "Column": 1
+                      },
+                      "distinct": true
+                    }
+                  ]
+                ]
+              },
+              "hierarchical": {
+                "Monotonic": {
+                  "aggr_funcs": [
+                    "MinInt32",
+                    "MaxInt32"
+                  ],
+                  "skips": [
+                    2,
+                    0
+                  ],
+                  "must_consolidate": true
+                }
+              },
+              "basic": {
+                "Multiple": [
+                  [
+                    1,
+                    {
+                      "func": {
+                        "StringAgg": {
+                          "order_by": []
+                        }
+                      },
+                      "expr": {
+                        "CallVariadic": {
+                          "func": {
+                            "RecordCreate": {
+                              "field_names": [
+                                ""
+                              ]
+                            }
+                          },
+                          "exprs": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      "value",
+                                      "sep"
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallBinary": {
+                                      "func": "TextConcat",
+                                      "expr1": {
+                                        "CallUnary": {
+                                          "func": {
+                                            "CastInt32ToString": null
+                                          },
+                                          "expr": {
+                                            "Column": 1
+                                          }
+                                        }
+                                      },
+                                      "expr2": {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                19,
+                                                1,
+                                                49
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "String",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Literal": [
+                                      {
+                                        "Ok": {
+                                          "data": [
+                                            19,
+                                            1,
+                                            44
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "scalar_type": "String",
+                                        "nullable": false
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "distinct": false
+                    }
+                  ],
+                  [
+                    5,
+                    {
+                      "func": {
+                        "StringAgg": {
+                          "order_by": []
+                        }
+                      },
+                      "expr": {
+                        "CallVariadic": {
+                          "func": {
+                            "RecordCreate": {
+                              "field_names": [
+                                ""
+                              ]
+                            }
+                          },
+                          "exprs": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      "value",
+                                      "sep"
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallBinary": {
+                                      "func": "TextConcat",
+                                      "expr1": {
+                                        "CallUnary": {
+                                          "func": {
+                                            "CastInt32ToString": null
+                                          },
+                                          "expr": {
+                                            "Column": 1
+                                          }
+                                        }
+                                      },
+                                      "expr2": {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                19,
+                                                1,
+                                                50
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "String",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Literal": [
+                                      {
+                                        "Ok": {
+                                          "data": [
+                                            19,
+                                            1,
+                                            44
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "scalar_type": "String",
+                                        "nullable": false
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "distinct": false
+                    }
+                  ]
+                ]
+              },
+              "aggregate_types": [
+                "Accumulable",
+                "Basic",
+                "Hierarchical",
+                "Hierarchical",
+                "Accumulable",
+                "Basic"
+              ]
+            }
+          },
+          "input_key": [
+            {
+              "Column": 0
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# Test Reduce::Collated (global aggregate).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS JSON FOR
+VIEW collated_global
+----
+{
+  "plans": [
+    {
+      "id": "materialize.public.collated_global",
       "plan": {
         "Let": {
           "id": 0,
@@ -4091,6 +5029,743 @@ FROM t
                         256,
                         16
                       ]
+                    }
+                  },
+                  "basic": {
+                    "Multiple": [
+                      [
+                        1,
+                        {
+                          "func": {
+                            "StringAgg": {
+                              "order_by": []
+                            }
+                          },
+                          "expr": {
+                            "CallVariadic": {
+                              "func": {
+                                "RecordCreate": {
+                                  "field_names": [
+                                    ""
+                                  ]
+                                }
+                              },
+                              "exprs": [
+                                {
+                                  "CallVariadic": {
+                                    "func": {
+                                      "RecordCreate": {
+                                        "field_names": [
+                                          "value",
+                                          "sep"
+                                        ]
+                                      }
+                                    },
+                                    "exprs": [
+                                      {
+                                        "CallBinary": {
+                                          "func": "TextConcat",
+                                          "expr1": {
+                                            "CallUnary": {
+                                              "func": {
+                                                "CastInt32ToString": null
+                                              },
+                                              "expr": {
+                                                "Column": 0
+                                              }
+                                            }
+                                          },
+                                          "expr2": {
+                                            "Literal": [
+                                              {
+                                                "Ok": {
+                                                  "data": [
+                                                    19,
+                                                    1,
+                                                    49
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "scalar_type": "String",
+                                                "nullable": false
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                19,
+                                                1,
+                                                44
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "String",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "distinct": false
+                        }
+                      ],
+                      [
+                        5,
+                        {
+                          "func": {
+                            "StringAgg": {
+                              "order_by": []
+                            }
+                          },
+                          "expr": {
+                            "CallVariadic": {
+                              "func": {
+                                "RecordCreate": {
+                                  "field_names": [
+                                    ""
+                                  ]
+                                }
+                              },
+                              "exprs": [
+                                {
+                                  "CallVariadic": {
+                                    "func": {
+                                      "RecordCreate": {
+                                        "field_names": [
+                                          "value",
+                                          "sep"
+                                        ]
+                                      }
+                                    },
+                                    "exprs": [
+                                      {
+                                        "CallBinary": {
+                                          "func": "TextConcat",
+                                          "expr1": {
+                                            "CallUnary": {
+                                              "func": {
+                                                "CastInt32ToString": null
+                                              },
+                                              "expr": {
+                                                "Column": 0
+                                              }
+                                            }
+                                          },
+                                          "expr2": {
+                                            "Literal": [
+                                              {
+                                                "Ok": {
+                                                  "data": [
+                                                    19,
+                                                    1,
+                                                    50
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "scalar_type": "String",
+                                                "nullable": false
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                19,
+                                                1,
+                                                44
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "String",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "distinct": false
+                        }
+                      ]
+                    ]
+                  },
+                  "aggregate_types": [
+                    "Accumulable",
+                    "Basic",
+                    "Hierarchical",
+                    "Hierarchical",
+                    "Accumulable",
+                    "Basic"
+                  ]
+                }
+              },
+              "input_key": null
+            }
+          },
+          "body": {
+            "Union": {
+              "inputs": [
+                {
+                  "ArrangeBy": {
+                    "input": {
+                      "Get": {
+                        "id": {
+                          "Local": 0
+                        },
+                        "keys": {
+                          "raw": false,
+                          "arranged": [
+                            [
+                              [],
+                              {
+                                "0": 0,
+                                "1": 1,
+                                "2": 2,
+                                "3": 3,
+                                "4": 4,
+                                "5": 5
+                              },
+                              [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5
+                              ]
+                            ]
+                          ]
+                        },
+                        "plan": "PassArrangements"
+                      }
+                    },
+                    "forms": {
+                      "raw": true,
+                      "arranged": []
+                    },
+                    "input_key": [],
+                    "input_mfp": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5
+                      ],
+                      "input_arity": 6
+                    }
+                  }
+                },
+                {
+                  "Mfp": {
+                    "input": {
+                      "Union": {
+                        "inputs": [
+                          {
+                            "Negate": {
+                              "input": {
+                                "Get": {
+                                  "id": {
+                                    "Local": 0
+                                  },
+                                  "keys": {
+                                    "raw": false,
+                                    "arranged": [
+                                      [
+                                        [],
+                                        {
+                                          "0": 0,
+                                          "1": 1,
+                                          "2": 2,
+                                          "3": 3,
+                                          "4": 4,
+                                          "5": 5
+                                        },
+                                        [
+                                          0,
+                                          1,
+                                          2,
+                                          3,
+                                          4,
+                                          5
+                                        ]
+                                      ]
+                                    ]
+                                  },
+                                  "plan": {
+                                    "Arrangement": [
+                                      [],
+                                      null,
+                                      {
+                                        "expressions": [],
+                                        "predicates": [],
+                                        "projection": [],
+                                        "input_arity": 6
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "Constant": {
+                              "rows": {
+                                "Ok": [
+                                  [
+                                    {
+                                      "data": []
+                                    },
+                                    0,
+                                    1
+                                  ]
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "mfp": {
+                      "expressions": [
+                        {
+                          "Literal": [
+                            {
+                              "Ok": {
+                                "data": [
+                                  5,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0
+                                ]
+                              }
+                            },
+                            {
+                              "scalar_type": "Int64",
+                              "nullable": false
+                            }
+                          ]
+                        },
+                        {
+                          "Literal": [
+                            {
+                              "Ok": {
+                                "data": [
+                                  0
+                                ]
+                              }
+                            },
+                            {
+                              "scalar_type": "String",
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        {
+                          "Literal": [
+                            {
+                              "Ok": {
+                                "data": [
+                                  0
+                                ]
+                              }
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        {
+                          "Literal": [
+                            {
+                              "Ok": {
+                                "data": [
+                                  0
+                                ]
+                              }
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        {
+                          "Literal": [
+                            {
+                              "Ok": {
+                                "data": [
+                                  0
+                                ]
+                              }
+                            },
+                            {
+                              "scalar_type": "Int64",
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        {
+                          "Literal": [
+                            {
+                              "Ok": {
+                                "data": [
+                                  0
+                                ]
+                              }
+                            },
+                            {
+                              "scalar_type": "String",
+                              "nullable": true
+                            }
+                          ]
+                        }
+                      ],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5
+                      ],
+                      "input_arity": 0
+                    },
+                    "input_key_val": null
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# Test Reduce::Collated (global aggregate, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS JSON FOR
+SELECT * FROM collated_global
+----
+{
+  "plans": [
+    {
+      "id": "Explained Query",
+      "plan": {
+        "Let": {
+          "id": 0,
+          "value": {
+            "Reduce": {
+              "input": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
+                  },
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        {
+                          "0": 0,
+                          "1": 1
+                        },
+                        [
+                          1
+                        ]
+                      ]
+                    ]
+                  },
+                  "plan": {
+                    "Arrangement": [
+                      [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      null,
+                      {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [
+                          1
+                        ],
+                        "input_arity": 2
+                      }
+                    ]
+                  }
+                }
+              },
+              "key_val_plan": {
+                "key_plan": {
+                  "mfp": {
+                    "expressions": [],
+                    "predicates": [],
+                    "projection": [],
+                    "input_arity": 1
+                  }
+                },
+                "val_plan": {
+                  "mfp": {
+                    "expressions": [
+                      {
+                        "CallUnary": {
+                          "func": {
+                            "CastInt32ToString": null
+                          },
+                          "expr": {
+                            "Column": 0
+                          }
+                        }
+                      },
+                      {
+                        "CallVariadic": {
+                          "func": {
+                            "RecordCreate": {
+                              "field_names": [
+                                ""
+                              ]
+                            }
+                          },
+                          "exprs": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      "value",
+                                      "sep"
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallBinary": {
+                                      "func": "TextConcat",
+                                      "expr1": {
+                                        "Column": 1
+                                      },
+                                      "expr2": {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                19,
+                                                1,
+                                                49
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "String",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Literal": [
+                                      {
+                                        "Ok": {
+                                          "data": [
+                                            19,
+                                            1,
+                                            44
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "scalar_type": "String",
+                                        "nullable": false
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "CallVariadic": {
+                          "func": {
+                            "RecordCreate": {
+                              "field_names": [
+                                ""
+                              ]
+                            }
+                          },
+                          "exprs": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      "value",
+                                      "sep"
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallBinary": {
+                                      "func": "TextConcat",
+                                      "expr1": {
+                                        "Column": 1
+                                      },
+                                      "expr2": {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                19,
+                                                1,
+                                                50
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "String",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Literal": [
+                                      {
+                                        "Ok": {
+                                          "data": [
+                                            19,
+                                            1,
+                                            44
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "scalar_type": "String",
+                                        "nullable": false
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "predicates": [],
+                    "projection": [
+                      0,
+                      2,
+                      0,
+                      0,
+                      0,
+                      3
+                    ],
+                    "input_arity": 1
+                  }
+                }
+              },
+              "plan": {
+                "Collation": {
+                  "accumulable": {
+                    "full_aggrs": [
+                      {
+                        "func": "Count",
+                        "expr": {
+                          "Column": 0
+                        },
+                        "distinct": true
+                      },
+                      {
+                        "func": "SumInt32",
+                        "expr": {
+                          "Column": 0
+                        },
+                        "distinct": false
+                      }
+                    ],
+                    "simple_aggrs": [
+                      [
+                        1,
+                        4,
+                        {
+                          "func": "SumInt32",
+                          "expr": {
+                            "Column": 0
+                          },
+                          "distinct": false
+                        }
+                      ]
+                    ],
+                    "distinct_aggrs": [
+                      [
+                        0,
+                        0,
+                        {
+                          "func": "Count",
+                          "expr": {
+                            "Column": 0
+                          },
+                          "distinct": true
+                        }
+                      ]
+                    ]
+                  },
+                  "hierarchical": {
+                    "Monotonic": {
+                      "aggr_funcs": [
+                        "MinInt32",
+                        "MaxInt32"
+                      ],
+                      "skips": [
+                        2,
+                        0
+                      ],
+                      "must_consolidate": true
                     }
                   },
                   "basic": {

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -12,6 +12,10 @@ ALTER SYSTEM SET enable_with_mutually_recursive = true
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
 
 statement ok
 CREATE TABLE t (
@@ -43,6 +47,46 @@ CREATE VIEW ov AS SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
 statement ok
 CREATE MATERIALIZED VIEW mv AS
 SELECT * FROM t WHERE a IS NOT NULL
+
+statement ok
+CREATE VIEW hierarchical_group_by AS
+SELECT
+  a,
+  MIN(b),
+  MAX(DISTINCT b)
+FROM t
+GROUP BY a
+
+statement ok
+CREATE VIEW hierarchical_global AS
+SELECT
+  MIN(b),
+  MAX(DISTINCT b)
+FROM t
+
+statement ok
+CREATE VIEW collated_group_by AS
+SELECT
+  a,
+  COUNT(DISTINCT b),
+  STRING_AGG(b::text || '1',  ',') AS b1,
+  MIN(b),
+  MAX(DISTINCT b),
+  SUM(b),
+  STRING_AGG(b::text || '2',  ',') AS b2
+FROM t
+GROUP BY a
+
+statement ok
+CREATE VIEW collated_global AS
+SELECT
+  COUNT(DISTINCT b),
+  STRING_AGG(b::text || '1',  ',') AS b1,
+  MIN(b),
+  MAX(DISTINCT b),
+  SUM(b),
+  STRING_AGG(b::text || '2',  ',') AS b2
+FROM t
 
 mode cockroach
 
@@ -133,10 +177,29 @@ EOF
 # TopKBasic plan.
 query T multiline
 EXPLAIN PHYSICAL PLAN WITH(no_fast_path) AS TEXT FOR
+VIEW ov
+----
+materialize.public.ov:
+  TopK::Basic order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
+    ArrangeBy
+      input_key=[#0]
+      raw=true
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# MonotonicTopK plan.
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(no_fast_path) AS TEXT FOR
 SELECT * FROM ov
 ----
 Explained Query:
-  TopK::Basic order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
+  TopK::MonotonicTopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 must_consolidate
     ArrangeBy
       input_key=[#0]
       raw=true
@@ -384,14 +447,9 @@ EOF
 # Test Reduce::Hierarchical (with GROUP BY).
 query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR
-SELECT
-  a,
-  MIN(b),
-  MAX(DISTINCT b)
-FROM t
-GROUP BY a
+VIEW hierarchical_group_by
 ----
-Explained Query:
+materialize.public.hierarchical_group_by:
   Reduce::Hierarchical
     aggr_funcs=[min, max]
     skips=[0, 0]
@@ -410,13 +468,82 @@ Used Indexes:
 
 EOF
 
+# Test Reduce::Hierarchical (with GROUP BY, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+SELECT * FROM hierarchical_group_by
+----
+Explained Query:
+  Reduce::Hierarchical
+    aggr_funcs=[min, max]
+    skips=[0, 0]
+    monotonic
+    must_consolidate
+    val_plan
+      project=(#1, #1)
+    key_plan
+      project=(#0)
+    input_key=#0
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
 # Test Reduce::Hierarchical (global aggregate).
 query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR
-SELECT
-  MIN(b),
-  MAX(DISTINCT b)
-FROM t
+VIEW hierarchical_global
+----
+materialize.public.hierarchical_global:
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+      Mfp
+        project=(#0, #1)
+        map=(null, null)
+        Union
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+          Constant
+            - ()
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[min, max]
+        skips=[0, 0]
+        buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
+        val_plan
+          project=(#0, #0)
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test Reduce::Hierarchical (global aggregate, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+SELECT * FROM hierarchical_global
 ----
 Explained Query:
   Return
@@ -444,7 +571,8 @@ Explained Query:
       Reduce::Hierarchical
         aggr_funcs=[min, max]
         skips=[0, 0]
-        buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
+        monotonic
+        must_consolidate
         val_plan
           project=(#0, #0)
         key_plan
@@ -542,18 +670,9 @@ EOF
 # Test Reduce::Collated (with GROUP BY).
 query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR
-SELECT
-  a,
-  COUNT(DISTINCT b),
-  STRING_AGG(b::text || '1',  ','),
-  MIN(b),
-  MAX(DISTINCT b),
-  SUM(b),
-  STRING_AGG(b::text || '2',  ',')
-FROM t
-GROUP BY a
+VIEW collated_group_by
 ----
-Explained Query:
+materialize.public.collated_group_by:
   Reduce::Collation
     aggregate_types=[a, b, h, h, a, b]
     accumulable
@@ -581,17 +700,100 @@ Used Indexes:
 
 EOF
 
+# Test Reduce::Collated (with GROUP BY, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+SELECT * FROM collated_group_by
+----
+Explained Query:
+  Reduce::Collation
+    aggregate_types=[a, b, h, h, a, b]
+    accumulable
+      simple_aggrs[0]=(1, 4, sum(#1))
+      distinct_aggrs[0]=(0, 0, count(distinct #1))
+    hierarchical
+      aggr_funcs=[min, max]
+      skips=[2, 0]
+      monotonic
+      must_consolidate
+    basic
+      aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
+      aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
+    val_plan
+      project=(#1, #3, #1, #1, #1, #4)
+      map=(integer_to_text(#1), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
+    key_plan
+      project=(#0)
+    input_key=#0
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
 # Test Reduce::Collated (global aggregate).
 query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR
-SELECT
-  COUNT(DISTINCT b),
-  STRING_AGG(b::text || '1',  ','),
-  MIN(b),
-  MAX(DISTINCT b),
-  SUM(b),
-  STRING_AGG(b::text || '2',  ',')
-FROM t
+VIEW collated_global
+----
+materialize.public.collated_global:
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+      Mfp
+        project=(#0..=#5)
+        map=(0, null, null, null, null, null)
+        Union
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+          Constant
+            - ()
+  With
+    cte l0 =
+      Reduce::Collation
+        aggregate_types=[a, b, h, h, a, b]
+        accumulable
+          simple_aggrs[0]=(1, 4, sum(#0))
+          distinct_aggrs[0]=(0, 0, count(distinct #0))
+        hierarchical
+          aggr_funcs=[min, max]
+          skips=[2, 0]
+          buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
+        basic
+          aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
+          aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
+        val_plan
+          project=(#0, #2, #0, #0, #0, #3)
+          map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test Reduce::Collated (global aggregate, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+SELECT * FROM collated_global
 ----
 Explained Query:
   Return
@@ -624,7 +826,8 @@ Explained Query:
         hierarchical
           aggr_funcs=[min, max]
           skips=[2, 0]
-          buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
+          monotonic
+          must_consolidate
         basic
           aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
           aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))

--- a/test/sqllogictest/github-16036.slt
+++ b/test/sqllogictest/github-16036.slt
@@ -10,6 +10,11 @@
 # Regression test for https://github.com/MaterializeInc/materialize/issues/16036
 mode cockroach
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE t1 (v1 TEXT, k1 INTEGER, k2 INTEGER);
 

--- a/test/sqllogictest/github-9027.slt
+++ b/test/sqllogictest/github-9027.slt
@@ -10,6 +10,11 @@
 # Regression test for https://github.com/MaterializeInc/materialize/issues/9027
 mode cockroach
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE orders ( o_orderkey integer, o_custkey integer NOT NULL, o_orderstatus text NOT NULL, o_totalprice decimal(15, 2) NOT NULL, o_orderdate DATE NOT NULL, o_orderpriority text NOT NULL, o_clerk text NOT NULL, o_shippriority integer NOT NULL, o_comment text NOT NULL);
 

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -9,6 +9,11 @@
 
 mode cockroach
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE foo (
     a int,

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -9,6 +9,11 @@
 
 mode cockroach
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE cities (
     name text NOT NULL,

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -19,6 +19,11 @@ ALTER SYSTEM SET enable_with_mutually_recursive = true
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE t1 (a int, b text)
 

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -16,6 +16,11 @@ ALTER SYSTEM SET enable_with_mutually_recursive = true
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE x (a int not null, u int, b bool)
 

--- a/test/sqllogictest/unsigned_int.slt
+++ b/test/sqllogictest/unsigned_int.slt
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 query I
 SELECT 42::uint2
 ----

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -14,6 +14,11 @@ ALTER SYSTEM SET enable_with_mutually_recursive = true
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+----
+COMPLETE 0
+
 ## Test correct (intended) behavior:
 
 ## Test a plausibly correct recursive query.


### PR DESCRIPTION
This  PR turns on the feature flag `enable_monotonic_oneshot_selects` in a selected set of SLTs. The set comprises:
1. _The fast SLTs that are _currently_ run with `--auto-index-selects`_: Since these SLTs may be expanded in the future, we can also think of a complementary strategy for a follow-up PR wherein the feature is activated whenever `--auto-index-selects` is provided. This PR, however, has value in that a manually validated set of tests will now be subsequently be run with the feature turned on in CI.
2. _All SLTs that include EXPLAIN PHYSICAL PLAN commands_: We only need to touch SLTs with `EXPLAIN PHYSICAL PLAN` commands, as only physical plans can be changed by one-shot refinements. Even in this subset, some of the tests do not have their output affected, since they do not use LIR operators that can be replaced by monotonic variants. In the tests where output is changed, we now include two physical plan outputs. The first corresponds to creating a view with the `SELECT` command and then issuing `EXPLAIN PHYSICAL PLAN FOR VIEW <view>` (non-monotonic operators, equivalent to what would be planned if the view were indexed), and the second to issuing `EXPLAIN PHYSICAL PLAN FOR SELECT * FROM <view>` (monotonic operators, equivalent to a one-shot `SELECT` on the unindexed view). 

Advances #18734. 

### Motivation

  * This PR adds a known-desirable feature. https://github.com/MaterializeInc/materialize/issues/18734

### Tips for reviewer

The commits can be looked at individually. The diff for `test/sqllogictest/explain/physical_plan_as_json.slt` came out pretty hard to check (sorry!). Perhaps this can be improved if instead of using `EXPLAIN PHYSICAL PLAN FOR SELECT * FROM <view>`, we would just repeat the entire query. But I thought that changing the SLT in this way would be a shame, since the pattern of either `EXPLAIN PHYSICAL PLAN FOR VIEW <view>` vs. `EXPLAIN PHYSICAL PLAN FOR SELECT * FROM <view>` is conceptually much simpler to understand (for me at least).

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20230421_stabilize_monotonic_select.md).
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
