### PR TITLE
sql: Remove the ability to set role attributes

### DIFF
--- a/doc/user/content/manage/access-control/_index.md
+++ b/doc/user/content/manage/access-control/_index.md
@@ -58,7 +58,7 @@ user more elevated privileges in the Materialize administrator console.
 
 ## RBAC structure
 
-RBAC in practice is a group of roles with assigned privileges and attributes.
+RBAC in practice is a group of roles with assigned privileges.
 You can assign specific users to roles or assign privileges to users to inherit
 from other roles.
 
@@ -77,13 +77,10 @@ organization. You can edit these actions when you create the role:
 
 | Name              | Description                                                                 |
 |-------------------|-----------------------------------------------------------------------------|
-| `CREATEDB`        | Can create a database.                                                      |
-| `CREATEROLE`      | Can create, alter, delete roles and can grant and revoke role membership.   |
 | `INHERIT`         | **Read-only.** Can inherit privileges of other roles.                       |
-| `CREATECLUSTER`   | Can create a cluster.                                                       |
-| `NOCREATEDB`      | Denies the role the ability to create databases.                            |
-| `NOCREATEROLE`    | Denies the role the ability to create, alter, delete roles or grant/revoke. |
-| `NOCREATECLUSTER` | Denies the role the ability to create clusters.                             |
+
+PostgreSQL uses role attributes to determine if a role is allowed to execute certain statements. In
+Materialize these have all been replaced by system privileges.
 
 ### Privileges
 
@@ -91,32 +88,37 @@ Privileges are the actions or operations a role is allowed to perform on a
 specific object. After you create a role, you can grant it the following
 object-specific privileges in Materialize:
 
-| Privilege | Description                                                | `psql` |
-| --------- | ---------------------------------------------------------- | ------ |
-| `SELECT`  | Allows selecting rows from an object.                      | `r`    |
-| `INSERT`  | Allows inserting into an object.                           | `a`    |
-| `UPDATE`  | Allows updating an object (requires `SELECT`).             | `w`    |
-| `DELETE`  | Allows deleting from an object (requires `SELECT`).        | `d`    |
-| `CREATE`  | Allows creating a new object within another object.        | `C`    |
-| `USAGE`   | Allows using an object or looking up members of an object. | `U`    |
+| Privilege       | Description                                                                                    | `psql` |
+|-----------------|------------------------------------------------------------------------------------------------|--------|
+| `SELECT`        | Allows selecting rows from an object.                                                          | `r`    |
+| `INSERT`        | Allows inserting into an object.                                                               | `a`    |
+| `UPDATE`        | Allows updating an object (requires `SELECT`).                                                 | `w`    |
+| `DELETE`        | Allows deleting from an object (requires `SELECT`).                                            | `d`    |
+| `CREATE`        | Allows creating a new object within another object.                                            | `C`    |
+| `USAGE`         | Allows using an object or looking up members of an object.                                     | `U`    |
+| `CREATEROLE`    | Allows creating, altering, deleting roles and the ability to grant and revoke role membership. | `R`    |
+| `CREATEDB`      | Allows creating databases.                                                                     | `B`    |
+| `CREATECLUSTER` | Allows creating clusters.                                                                      | `N`    |
+
 
 Note that the system catalog uses the abbreviation of the privilege name.
 
 Objects in Materialize have different levels of privileges available to them.
 Materialize supports the following object type privileges:
 
-| Object Type          | Privileges                             |
-|----------------------|----------------------------------------|
-| `DATABASE`           | `USAGE`, `CREATE`                      |
-| `SCHEMA`             | `USAGE`, `CREATE`                      |
-| `TABLE`              | `INSERT`, `SELECT`, `UPDATE`, `DELETE` |
-| `VIEW`               | `SELECT`                               |
-| `MATERIALIZED  VIEW` | `SELECT`                               |
-| `TYPE`               | `USAGE`                                |
-| `SOURCE`             | `SELECT`                               |
-| `CONNECTION`         | `USAGE`                                |
-| `SECRET`             | `USAGE`                                |
-| `CLUSTER`            | `USAGE`, `CREATE`                      |
+| Object Type          | Privileges                                |
+|----------------------|-------------------------------------------|
+| `SYSTEM`             | `CREATEROLE`, `CREATEDB`, `CREATECLUSTER` |
+| `DATABASE`           | `USAGE`, `CREATE`                         |
+| `SCHEMA`             | `USAGE`, `CREATE`                         |
+| `TABLE`              | `INSERT`, `SELECT`, `UPDATE`, `DELETE`    |
+| `VIEW`               | `SELECT`                                  |
+| `MATERIALIZED  VIEW` | `SELECT`                                  |
+| `TYPE`               | `USAGE`                                   |
+| `SOURCE`             | `SELECT`                                  |
+| `CONNECTION`         | `USAGE`                                   |
+| `SECRET`             | `USAGE`                                   |
+| `CLUSTER`            | `USAGE`, `CREATE`                         |
 
 ### Inheritance
 

--- a/doc/user/content/manage/access-control/manage-privileges.md
+++ b/doc/user/content/manage/access-control/manage-privileges.md
@@ -22,18 +22,19 @@ GRANT USAGE ON <OBJECT_TYPE> <object_name> TO <role_name>;
 
 Materialize objects allow for the following privileges:
 
-| Object Type         | Privileges                             |
-|---------------------|----------------------------------------|
-| `DATABASE`          | `USAGE`, `CREATE`                      |
-| `SCHEMA`            | `USAGE`, `CREATE`                      |
-| `TABLE`             | `INSERT`, `SELECT`, `UPDATE`, `DELETE` |
-| `VIEW`              | `SELECT`                               |
-| `MATERIALIZED VIEW` | `SELECT`                               |
-| `TYPE`              | `USAGE`                                |
-| `SOURCE`            | `SELECT`                               |
-| `CONNECTION`        | `USAGE`                                |
-| `SECRET`            | `USAGE`                                |
-| `CLUSTER`           | `USAGE`, `CREATE`                      |
+| Object Type         | Privileges                                |
+|---------------------|-------------------------------------------|
+| `SYSTEM`            | `CREATEROLE`, `CREATEDB`, `CREATECLUSTER` |
+| `DATABASE`          | `USAGE`, `CREATE`                         |
+| `SCHEMA`            | `USAGE`, `CREATE`                         |
+| `TABLE`             | `INSERT`, `SELECT`, `UPDATE`, `DELETE`    |
+| `VIEW`              | `SELECT`                                  |
+| `MATERIALIZED VIEW` | `SELECT`                                  |
+| `TYPE`              | `USAGE`                                   |
+| `SOURCE`            | `SELECT`                                  |
+| `CONNECTION`        | `USAGE`                                   |
+| `SECRET`            | `USAGE`                                   |
+| `CLUSTER`           | `USAGE`, `CREATE`                         |
 
 Materialize object access is also dependent on cluster privileges.
 Roles that need access to an object that use compute resources must also have

--- a/doc/user/content/manage/access-control/manage-roles.md
+++ b/doc/user/content/manage/access-control/manage-roles.md
@@ -23,13 +23,7 @@ Materialize roles have the following available attributes:
 
 | Name              | Description                                                                 |
 |-------------------|-----------------------------------------------------------------------------|
-| `CREATEDB`        | Can create a database.                                                      |
-| `CREATEROLE`      | Can create, alter, delete roles and can grant and revoke role membership.   |
 | `INHERIT`         | **Read-only.** Can inherit privileges of other roles.                       |
-| `CREATECLUSTER`   | Can create a cluster.                                                       |
-| `NOCREATEDB`      | Denies the role the ability to create databases.                            |
-| `NOCREATEROLE`    | Denies the role the ability to create, alter, delete roles or grant/revoke. |
-| `NOCREATECLUSTER` | Denies the role the ability to create clusters.                             |
 
 ## Alter a role's attributes
 

--- a/doc/user/content/manage/access-control/rbac-tutorial.md
+++ b/doc/user/content/manage/access-control/rbac-tutorial.md
@@ -75,20 +75,16 @@ example.
     ```
     Your `id` and `oid` values will look different.
 
-  The `inherit`, `create_role`, `create_db`, and `create_cluster` are the
-  role attributes assigned to a role when it is created. These attributes
-  determine the system-level privileges of a role and do not impact object-level privileges.
+  The `inherit` is the role attribute assigned to a role when it is created.
 
   * `INHERIT` is set to true by default and allows roles to inherit the
-    privileges of roles it is a member of.
+    privileges of roles it is a member of. It is not possible to set this to false.
 
-  * `CREATEROLE` allows the role to create, change, or delete other roles or
-    assign role membership.
+  * `CREATEROLE` is deprecated and will be removed soon. It has no effect.
 
-  * `CREATEDB` allows the role to create new databases.
+  * `CREATEDB` is deprecated and will be removed soon. It has no effect.
 
-  * `CREATECLUSTER` allows the role to create Materialize clusters. This
-    attribute is unique to the Materialize concept of clusters.
+  * `CREATECLUSTER` is deprecated and will be removed soon. It has no effect.
 
 ## Step 3. Create example objects
 
@@ -208,18 +204,24 @@ privileges as needed.
 1. Create a second role your Materialize account:
 
    ```sql
-   CREATE ROLE qa_role WITH CREATEDB;
+   CREATE ROLE qa_role;
+   ```
+
+2. Apply `CREATEDB` privileges to the `qa_role`
+
+   ```sql
+   GRANT CREATEDB ON SYSTEM TO qa_role;
    ```
 
    This role has permission to create a new database in the Materialize account.
 
-2. Create a new `qa_db` database:
+3. Create a new `qa_db` database:
 
    ```sql
    CREATE DATABASE qa_db;
    ```
 
-3. Apply `USAGE` and `CREATE` privileges to the `qa_role` role for the new database:
+4. Apply `USAGE` and `CREATE` privileges to the `qa_role` role for the new database:
 
    ```sql
    GRANT USAGE, CREATE ON DATABASE qa_db TO qa_role;
@@ -259,35 +261,11 @@ permissions as the `qa_role`.
    the next section, you will edit role attributes for these roles and drop
    privileges.
 
-## Step 8. Revoke privileges and alter role attributes
+## Step 8. Revoke privileges
 
-Your `dev_role` and `qa_role` have the same role attributes. You can alter or
-revoke certain attributes and privileges for each role, even if they are
-inherited from another role.
+You can revoke certain privileges for each role, even if they are inherited from another role.
 
-1. Update the `CREATEROLE` attribute for the `dev_role`:
-
-   ```sql
-   ALTER ROLE dev_role WITH CREATEROLE;
-   ```
-
-   The `qa_role` will not have the `CREATEROLE` attribute enabled because attributes are not inherited.
-
-2. Compare the attributes of the `qa_role` and `dev_role`:
-
-   ```sql
-   SELECT * FROM mz_roles;
-   ```
-
-   Your output should contain the role names and the updated attributes:
-
-   ```nofmt
-   id|oid|name|inherit|create_role|create_db|create_cluster
-   u9|22444|qa_role|t|f|f|f
-   u8|20016|dev_role|t|t|f|f
-   ```
-
-3. Let's say you decide `dev_role` no longer needs `CREATE` privileges on the
+1. Let's say you decide `dev_role` no longer needs `CREATE` privileges on the
    `dev_table` object. You can revoke that privilege for the role:
 
    ```sql

--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -18,12 +18,6 @@ Field               | Use
 --------------------|-------------------------------------------------------------------------
 _role_name_         | A name for the role.
 **INHERIT**         | Grants the role the ability to inheritance of privileges of other roles.
-**CREATEROLE**      | Grants the role the ability to create, alter, delete roles and the ability to grant and revoke role membership. This attribute is very powerful. It allows roles to grant and revoke membership in other roles, even if it doesn't have explicit membership in those roles. As a consequence, any role with this attribute can obtain the privileges of any other role in the system.
-**NOCREATEROLE**    | Denies the role the ability to create, alter, delete roles or grant and revoke role membership.
-**CREATEDB**        | Grants the role the ability to create databases.
-**NOCREATEDB**      | Denies the role the ability to create databases.
-**CREATECLUSTER**   | Grants the role the ability to create clusters.
-**NOCREATECLUSTER** | Denies the role the ability to create clusters.
 
 ## Details
 
@@ -35,23 +29,24 @@ attribute when altering an existing role.
 Unlike PostgreSQL, materialize does not currently support `NOINHERIT`.
 
 You may not specify redundant or conflicting sets of options. For example,
-Materialize will reject the statement `ALTER ROLE ... CREATEDB NOCREATEDB` because
-the `CREATEDB` and `NOCREATEDB` options conflict.
+Materialize will reject the statement `ALTER ROLE ... INHERIT INHERIT`.
 
-When RBAC is enabled a role must have the `CREATEROLE` attribute to alter another role.
-Additionally, no role can grant another role an attribute that the altering role doesn't
-have itself.
+Unlike PostgreSQL, Materialize does not use role attributes to determine a roles ability to create
+top level objects such as databases and other roles. Instead, Materialize uses system level
+privileges. See [GRANT PRIVILEGE](../grant-privilege) for more details.
+
+When RBAC is enabled a role must have the `CREATEROLE` system privilege to alter another role.
 
 ## Examples
 
 ```sql
-ALTER ROLE rj CREATEDB NOCREATECLUSTER;
+ALTER ROLE rj INHERIT;
 ```
 ```sql
-SELECT name, create_db, create_cluster FROM mz_roles WHERE name = 'rj';
+SELECT name, inherit FROM mz_roles WHERE name = 'rj';
 ```
 ```nofmt
-rj  true  false
+rj  true
 ```
 
 ## Related pages

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -21,12 +21,6 @@ Field               | Use
 --------------------|-------------------------------------------------------------------------
 _role_name_         | A name for the role.
 **INHERIT**         | Grants the role the ability to inheritance of privileges of other roles.
-**CREATEROLE**      | Grants the role the ability to create, alter, delete roles and the ability to grant and revoke role membership. This attribute is very powerful. It allows roles to grant and revoke membership in other roles, even if it doesn't have explicit membership in those roles. As a consequence, any role with this attribute can obtain the privileges of any other role in the system.
-**NOCREATEROLE**    | Denies the role the ability to create, alter, delete roles or grant and revoke role membership.
-**CREATEDB**        | Grants the role the ability to create databases.
-**NOCREATEDB**      | Denies the role the ability to create databases.
-**CREATECLUSTER**   | Grants the role the ability to create clusters.
-**NOCREATECLUSTER** | Denies the role the ability to create clusters.
 
 ## Details
 
@@ -39,12 +33,14 @@ attribute when creating a new role. Additionally, we do not support the
 Unlike PostgreSQL, Materialize does not currently support `NOINHERIT`.
 
 You may not specify redundant or conflicting sets of options. For example,
-Materialize will reject the statement `CREATE ROLE ... CREATEDB NOCREATEDB` because
-the `CREATEDB` and `NOCREATEDB` options conflict.
+Materialize will reject the statement `CREATE ROLE ... INHERIT INHERIT`.
 
-When RBAC is enabled a role must have the `CREATEROLE` attribute to create another role.
-Additionally, no role can create another role with an attribute that the creating role doesn't
-have itself.
+Unlike PostgreSQL, Materialize does not use role attributes to determine a roles ability to create
+top level objects such as databases and other roles. Instead, Materialize uses system level
+privileges. See [GRANT PRIVILEGE](../grant-privilege) for more details.
+
+When RBAC is enabled a role must have the `CREATEROLE` system privilege attribute to create another
+role.
 
 ## Examples
 

--- a/doc/user/layouts/partials/sql-grammar/alter-role.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-role.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="421" height="419">
+<svg xmlns="http://www.w3.org/2000/svg" width="523" height="69">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="66" height="32" rx="10"/>
@@ -28,64 +28,16 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="329" y="53">WITH</text>
-   <rect x="211" y="365" width="76" height="32" rx="10"/>
-   <rect x="209"
-         y="363"
+   <rect x="419" y="3" width="76" height="32" rx="10"/>
+   <rect x="417"
+         y="1"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="219" y="383">INHERIT</text>
-   <rect x="211" y="321" width="114" height="32" rx="10"/>
-   <rect x="209"
-         y="319"
-         width="114"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="219" y="339">CREATEROLE</text>
-   <rect x="211" y="277" width="134" height="32" rx="10"/>
-   <rect x="209"
-         y="275"
-         width="134"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="219" y="295">NOCREATEROLE</text>
-   <rect x="211" y="233" width="96" height="32" rx="10"/>
-   <rect x="209"
-         y="231"
-         width="96"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="219" y="251">CREATEDB</text>
-   <rect x="211" y="189" width="118" height="32" rx="10"/>
-   <rect x="209"
-         y="187"
-         width="118"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="219" y="207">NOCREATEDB</text>
-   <rect x="211" y="145" width="142" height="32" rx="10"/>
-   <rect x="209"
-         y="143"
-         width="142"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="219" y="163">CREATECLUSTER</text>
-   <rect x="211" y="101" width="162" height="32" rx="10"/>
-   <rect x="209"
-         y="99"
-         width="162"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="219" y="119">NOCREATECLUSTER</text>
+   <text class="terminal" x="427" y="21">INHERIT</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-252 396 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h172 m-202 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m182 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-182 0 h10 m76 0 h10 m0 0 h86 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m114 0 h10 m0 0 h48 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m134 0 h10 m0 0 h28 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m96 0 h10 m0 0 h66 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m118 0 h10 m0 0 h44 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m142 0 h10 m0 0 h20 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m162 0 h10 m23 298 h-3"/>
-   <polygon points="411 413 419 409 419 417"/>
-   <polygon points="411 413 403 409 403 417"/>
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m76 0 h10 m3 0 h-3"/>
+   <polygon points="513 17 521 13 521 21"/>
+   <polygon points="513 17 505 13 505 21"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-role.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-role.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="431" height="419">
+<svg xmlns="http://www.w3.org/2000/svg" width="533" height="69">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="76" height="32" rx="10"/>
@@ -28,64 +28,16 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="339" y="53">WITH</text>
-   <rect x="221" y="365" width="76" height="32" rx="10"/>
-   <rect x="219"
-         y="363"
+   <rect x="429" y="3" width="76" height="32" rx="10"/>
+   <rect x="427"
+         y="1"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="229" y="383">INHERIT</text>
-   <rect x="221" y="321" width="114" height="32" rx="10"/>
-   <rect x="219"
-         y="319"
-         width="114"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="229" y="339">CREATEROLE</text>
-   <rect x="221" y="277" width="134" height="32" rx="10"/>
-   <rect x="219"
-         y="275"
-         width="134"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="229" y="295">NOCREATEROLE</text>
-   <rect x="221" y="233" width="96" height="32" rx="10"/>
-   <rect x="219"
-         y="231"
-         width="96"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="229" y="251">CREATEDB</text>
-   <rect x="221" y="189" width="118" height="32" rx="10"/>
-   <rect x="219"
-         y="187"
-         width="118"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="229" y="207">NOCREATEDB</text>
-   <rect x="221" y="145" width="142" height="32" rx="10"/>
-   <rect x="219"
-         y="143"
-         width="142"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="229" y="163">CREATECLUSTER</text>
-   <rect x="221" y="101" width="162" height="32" rx="10"/>
-   <rect x="219"
-         y="99"
-         width="162"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="229" y="119">NOCREATECLUSTER</text>
+   <text class="terminal" x="437" y="21">INHERIT</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-252 396 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h172 m-202 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m182 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-182 0 h10 m76 0 h10 m0 0 h86 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m114 0 h10 m0 0 h48 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m134 0 h10 m0 0 h28 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m96 0 h10 m0 0 h66 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m118 0 h10 m0 0 h44 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m142 0 h10 m0 0 h20 m-192 10 l0 -44 q0 -10 10 -10 m192 54 l0 -44 q0 -10 -10 -10 m-182 0 h10 m162 0 h10 m23 298 h-3"/>
-   <polygon points="421 413 429 409 429 417"/>
-   <polygon points="421 413 413 409 413 417"/>
+         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m76 0 h10 m3 0 h-3"/>
+   <polygon points="523 17 531 13 531 21"/>
+   <polygon points="523 17 515 13 515 21"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -14,7 +14,7 @@ alter_rename ::=
 alter_index ::=
   'ALTER' 'INDEX' name 'SET' 'ENABLED'
 alter_role ::=
-    'ALTER' 'ROLE' role_name 'WITH'? ('INHERIT' | 'CREATEROLE' | 'NOCREATEROLE' | 'CREATEDB' | 'NOCREATEDB' | 'CREATECLUSTER' | 'NOCREATECLUSTER')*
+    'ALTER' 'ROLE' role_name 'WITH'? 'INHERIT'
 alter_secret ::=
   'ALTER' 'SECRET' 'IF EXISTS'? name AS value
 alter_sink ::=
@@ -86,7 +86,7 @@ create_materialized_view ::=
     ('IN CLUSTER' cluster_name)?
     'AS' select_stmt
 create_role ::=
-    'CREATE' 'ROLE' role_name 'WITH'? ('INHERIT' | 'CREATEROLE' | 'NOCREATEROLE' | 'CREATEDB' | 'NOCREATEDB' | 'CREATECLUSTER' | 'NOCREATECLUSTER')*
+    'CREATE' 'ROLE' role_name 'WITH'? 'INHERIT'
 create_secret ::=
     'CREATE' 'SECRET' ('IF NOT EXISTS')? name 'AS' value
 create_schema ::=

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -91,11 +91,11 @@ class ConfigureMz(MzcomposeAction):
 
         # Since we already test with RBAC enabled, we have to give materialize
         # user the relevant attributes so the existing tests keep working.
-        if MzVersion(0, 45, 0) <= e.current_mz_version < MzVersion(0, 59, 0):
+        if MzVersion(0, 45, 0) <= e.current_mz_version < MzVersion.parse("0.59.0-dev"):
             system_settings.add(
                 "ALTER ROLE materialize CREATEROLE CREATEDB CREATECLUSTER;"
             )
-        elif e.current_mz_version >= MzVersion(0, 59, 0):
+        elif e.current_mz_version >= MzVersion.parse("0.59.0-dev"):
             system_settings.add("GRANT ALL PRIVILEGES ON SYSTEM TO materialize;")
 
         if e.current_mz_version >= MzVersion(0, 47, 0):

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -149,10 +149,19 @@ macro_rules! bail_unsupported {
 }
 
 macro_rules! bail_never_supported {
+    ($feature:expr, $docs:expr, $details:expr) => {
+        return Err(crate::plan::error::PlanError::NeverSupported {
+            feature: $feature.to_string(),
+            documentation_link: $docs.to_string(),
+            details: Some($details.to_string()),
+        }
+        .into())
+    };
     ($feature:expr, $docs:expr) => {
         return Err(crate::plan::error::PlanError::NeverSupported {
             feature: $feature.to_string(),
             documentation_link: $docs.to_string(),
+            details: None,
         }
         .into())
     };

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -48,6 +48,7 @@ pub enum PlanError {
     NeverSupported {
         feature: String,
         documentation_link: String,
+        details: Option<String>,
     },
     UnknownColumn {
         table: Option<PartialItemName>,
@@ -209,6 +210,7 @@ impl PlanError {
 
     pub fn detail(&self) -> Option<String> {
         match self {
+            Self::NeverSupported { details, .. } => details.clone(),
             Self::FetchingCsrSchemaFailed { cause, .. } => Some(cause.to_string_with_causes()),
             Self::PostgresConnectionErr { cause } => Some(cause.to_string_with_causes()),
             Self::InvalidProtobufSchema { cause } => Some(cause.to_string_with_causes()),
@@ -306,7 +308,7 @@ impl fmt::Display for PlanError {
                 }
                 Ok(())
             }
-            Self::NeverSupported { feature, documentation_link: documentation_path } => {
+            Self::NeverSupported { feature, documentation_link: documentation_path,.. } => {
                 write!(f, "{feature} is not supported, for more information consult the documentation at https://materialize.com/docs/{documentation_path}",)?;
                 Ok(())
             }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2655,40 +2655,40 @@ fn plan_role_attributes(options: Vec<RoleAttribute>) -> Result<PlannedRoleAttrib
     for option in options {
         match option {
             RoleAttribute::Login | RoleAttribute::NoLogin => {
-                bail_never_supported!("LOGIN attribute", "sql/create-role/#details")
+                bail_never_supported!("LOGIN attribute", "sql/create-role/#details");
             }
             RoleAttribute::SuperUser | RoleAttribute::NoSuperUser => {
-                bail_never_supported!("SUPERUSER attribute", "sql/create-role/#details")
+                bail_never_supported!("SUPERUSER attribute", "sql/create-role/#details");
             }
             RoleAttribute::Inherit | RoleAttribute::NoInherit
                 if planned_attributes.inherit.is_some() =>
             {
                 sql_bail!("conflicting or redundant options");
             }
-            RoleAttribute::CreateCluster | RoleAttribute::NoCreateCluster
-                if planned_attributes.create_cluster.is_some() =>
-            {
-                sql_bail!("conflicting or redundant options");
+            RoleAttribute::CreateCluster | RoleAttribute::NoCreateCluster => {
+                bail_never_supported!(
+                    "CREATECLUSTER attribute",
+                    "sql/create-role/#details",
+                    "Use system privileges instead."
+                );
             }
-            RoleAttribute::CreateDB | RoleAttribute::NoCreateDB
-                if planned_attributes.create_db.is_some() =>
-            {
-                sql_bail!("conflicting or redundant options");
+            RoleAttribute::CreateDB | RoleAttribute::NoCreateDB => {
+                bail_never_supported!(
+                    "CREATEDB attribute",
+                    "sql/create-role/#details",
+                    "Use system privileges instead."
+                );
             }
-            RoleAttribute::CreateRole | RoleAttribute::NoCreateRole
-                if planned_attributes.create_role.is_some() =>
-            {
-                sql_bail!("conflicting or redundant options");
+            RoleAttribute::CreateRole | RoleAttribute::NoCreateRole => {
+                bail_never_supported!(
+                    "CREATEROLE attribute",
+                    "sql/create-role/#details",
+                    "Use system privileges instead."
+                );
             }
 
             RoleAttribute::Inherit => planned_attributes.inherit = Some(true),
             RoleAttribute::NoInherit => planned_attributes.inherit = Some(false),
-            RoleAttribute::CreateCluster => planned_attributes.create_cluster = Some(true),
-            RoleAttribute::NoCreateCluster => planned_attributes.create_cluster = Some(false),
-            RoleAttribute::CreateDB => planned_attributes.create_db = Some(true),
-            RoleAttribute::NoCreateDB => planned_attributes.create_db = Some(false),
-            RoleAttribute::CreateRole => planned_attributes.create_role = Some(true),
-            RoleAttribute::NoCreateRole => planned_attributes.create_role = Some(false),
         }
     }
     if planned_attributes.inherit == Some(false) {

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -218,45 +218,20 @@ CREATE ROLE r1;
 ----
 COMPLETE 0
 
-simple conn=joe,user=joe
-CREATE ROLE rr CREATEDB;
-----
-db error: ERROR: permission denied for SYSTEM
-
-simple conn=child,user=child
-CREATE ROLE rr CREATEDB;
-----
-db error: ERROR: permission denied for SYSTEM
-
 simple conn=mz_system,user=mz_system
-GRANT CREATEDB ON SYSTEM TO joe;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-CREATE ROLE rr CREATEDB;
-----
-COMPLETE 0
-
-simple conn=child,user=child
-CREATE ROLE rr1 CREATEDB;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-REVOKE CREATEROLE, CREATEDB ON SYSTEM FROM joe;
+REVOKE CREATEROLE ON SYSTEM FROM joe;
 ----
 COMPLETE 0
 
 # ALTER ROLE
 
 simple conn=joe,user=joe
-ALTER ROLE r NOCREATEDB;
+ALTER ROLE r INHERIT;
 ----
 db error: ERROR: permission denied for SYSTEM
 
 simple conn=child,user=child
-ALTER ROLE r1 NOCREATEDB;
+ALTER ROLE r1 INHERIT;
 ----
 db error: ERROR: permission denied for SYSTEM
 
@@ -266,42 +241,17 @@ GRANT CREATEROLE ON SYSTEM TO joe;
 COMPLETE 0
 
 simple conn=joe,user=joe
-ALTER ROLE r NOCREATEDB;
+ALTER ROLE r INHERIT;
 ----
 COMPLETE 0
 
 simple conn=child,user=child
-ALTER ROLE r1 NOCREATEDB;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-ALTER ROLE rr CREATECLUSTER;
-----
-db error: ERROR: permission denied for SYSTEM
-
-simple conn=child,user=child
-ALTER ROLE rr1 CREATECLUSTER;
-----
-db error: ERROR: permission denied for SYSTEM
-
-simple conn=mz_system,user=mz_system
-GRANT CREATECLUSTER ON SYSTEM TO joe;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-ALTER ROLE rr CREATECLUSTER;
-----
-COMPLETE 0
-
-simple conn=child,user=child
-ALTER ROLE rr1 CREATECLUSTER;
+ALTER ROLE r1 INHERIT;
 ----
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-REVOKE CREATEROLE, CREATECLUSTER ON SYSTEM FROM joe;
+REVOKE CREATEROLE ON SYSTEM FROM joe;
 ----
 COMPLETE 0
 
@@ -835,12 +785,12 @@ COMPLETE 0
 # DROP ROLE
 
 simple conn=joe,user=joe
-DROP ROLE r, rr;
+DROP ROLE r;
 ----
 db error: ERROR: permission denied for SYSTEM
 
 simple conn=child,user=child
-DROP ROLE r1, rr1;
+DROP ROLE r1;
 ----
 db error: ERROR: permission denied for SYSTEM
 
@@ -850,12 +800,12 @@ GRANT CREATEROLE ON SYSTEM TO joe;
 COMPLETE 0
 
 simple conn=joe,user=joe
-DROP ROLE r, rr;
+DROP ROLE r;
 ----
 COMPLETE 0
 
 simple conn=child,user=child
-DROP ROLE r1, rr1;
+DROP ROLE r1;
 ----
 COMPLETE 0
 

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -25,7 +25,7 @@ materialize  true  true  true  true
 
 # Give materialize the CREATEROLE attribute.
 simple conn=mz_system,user=mz_system
-ALTER ROLE materialize CREATEROLE;
+GRANT CREATEROLE ON SYSTEM TO materialize
 ----
 COMPLETE 0
 
@@ -39,10 +39,16 @@ statement error SUPERUSER attribute is not supported, for more information consu
 CREATE ROLE foo SUPERUSER
 
 statement error conflicting or redundant options
-CREATE ROLE foo CREATEROLE CREATEROLE INHERIT
+CREATE ROLE foo INHERIT INHERIT
 
-statement error conflicting or redundant options
-CREATE ROLE foo CREATEROLE NOCREATEROLE CREATEDB
+statement error CREATEDB attribute is not supported
+CREATE ROLE foo CREATEDB
+
+statement error CREATEROLE attribute is not supported
+CREATE ROLE foo CREATEROLE
+
+statement error CREATECLUSTER attribute is not supported
+CREATE ROLE foo CREATECLUSTER
 
 # Create role and verify its existence.
 statement ok
@@ -123,42 +129,32 @@ CREATE ROLE mz_system
 statement error role name "mz_foo" is reserved
 CREATE ROLE mz_foo
 
-# Create role with attributes
+# Create role
 statement ok
-CREATE ROLE foo CREATEROLE CREATEDB NOCREATECLUSTER
+CREATE ROLE foo
 
 query TBBBB
 SELECT name, inherit, create_role, create_db, create_cluster FROM mz_roles WHERE name = 'foo'
 ----
-foo true true true false
+foo true false false false
 
 statement error non inherit roles not yet supported
 ALTER ROLE foo NOINHERIT
 
 statement error role name "mz_system" is reserved
-ALTER ROLE mz_system NOCREATEDB
+ALTER ROLE mz_system INHERIT
 
 statement error conflicting or redundant options
-ALTER ROLE foo CREATEROLE NOCREATEROLE
+ALTER ROLE foo INHERIT INHERIT
 
-statement error conflicting or redundant options
-ALTER ROLE foo CREATEDB CREATEDB
+statement error CREATEDB attribute is not supported
+ALTER ROLE foo CREATEDB
 
-statement ok
-ALTER ROLE foo NOCREATEDB
+statement error CREATEROLE attribute is not supported
+ALTER ROLE foo CREATEROLE
 
-query TBBBB
-SELECT name, inherit, create_role, create_db, create_cluster FROM mz_roles WHERE name = 'foo'
-----
-foo true true false false
-
-statement ok
+statement error CREATECLUSTER attribute is not supported
 ALTER ROLE foo CREATECLUSTER
-
-query TBBBB
-SELECT name, inherit, create_role, create_db, create_cluster FROM mz_roles WHERE name = 'foo'
-----
-foo true true false true
 
 # Prevent creating, dropping, and altering PUBLIC role
 
@@ -169,7 +165,7 @@ statement error role name "public" is reserved
 DROP ROLE PUBLIC
 
 statement error role name "public" is reserved
-ALTER ROLE public CREATEDB
+ALTER ROLE public INHERIT
 
 statement ok
 BEGIN

--- a/test/sqllogictest/role_create.slt
+++ b/test/sqllogictest/role_create.slt
@@ -9,7 +9,7 @@
 
 # Loosely based on https://github.com/postgres/postgres/blob/master/src/test/regress/expected/create_role.out
 # We have replaced role attributes with system privileges so we had to make a lot of changes to
-# this test to reflect that.
+# this test file to reflect that.
 
 mode cockroach
 
@@ -26,7 +26,7 @@ ALTER SYSTEM SET enable_rbac_checks TO true;
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-CREATE ROLE regress_role_admin CREATEDB CREATECLUSTER CREATEROLE;
+CREATE ROLE regress_role_admin;
 ----
 COMPLETE 0
 
@@ -51,7 +51,7 @@ GRANT CREATE ON DATABASE regression TO regress_role_admin WITH GRANT OPTION;
 db error: ERROR: Expected end of statement, found WITH
 
 simple conn=mz_system,user=mz_system
-CREATE ROLE regress_role_limited_admin CREATEROLE;
+CREATE ROLE regress_role_limited_admin;
 ----
 COMPLETE 0
 
@@ -73,12 +73,14 @@ db error: ERROR: SUPERUSER attribute is not supported, for more information cons
 simple conn=regress_role_limited_admin,user=regress_role_limited_admin
 CREATE ROLE regress_nosuch_createdb CREATEDB;
 ----
-db error: ERROR: permission denied for SYSTEM
+db error: ERROR: CREATEDB attribute is not supported, for more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
+DETAIL: Use system privileges instead.
 
 simple conn=regress_role_limited_admin,user=regress_role_limited_admin
 CREATE ROLE regress_nosuch_createcluster CREATECLUSTER;
 ----
-db error: ERROR: permission denied for SYSTEM
+db error: ERROR: CREATECLUSTER attribute is not supported, for more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
+DETAIL: Use system privileges instead.
 
 simple conn=regress_role_limited_admin,user=regress_role_limited_admin
 CREATE ROLE regress_role_limited;
@@ -88,42 +90,58 @@ COMPLETE 0
 simple conn=regress_role_limited_admin,user=regress_role_limited_admin
 ALTER ROLE regress_role_limited CREATEDB;
 ----
-db error: ERROR: permission denied for SYSTEM
+db error: ERROR: CREATEDB attribute is not supported, for more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
+DETAIL: Use system privileges instead.
 
 simple conn=regress_role_limited_admin,user=regress_role_limited_admin
 ALTER ROLE regress_role_limited CREATECLUSTER;
 ----
-db error: ERROR: permission denied for SYSTEM
+db error: ERROR: CREATECLUSTER attribute is not supported, for more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
+DETAIL: Use system privileges instead.
 
 simple conn=regress_role_admin,user=regress_role_admin
-CREATE ROLE regress_createdb CREATEDB;
+CREATE ROLE regress_createdb;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT CREATEDB ON SYSTEM TO regress_createdb;
 ----
 COMPLETE 0
 
 simple conn=regress_role_admin,user=regress_role_admin
 ALTER ROLE regress_createdb NOCREATEDB;
 ----
-COMPLETE 0
+db error: ERROR: CREATEDB attribute is not supported, for more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
+DETAIL: Use system privileges instead.
 
 simple conn=regress_role_admin,user=regress_role_admin
 ALTER ROLE regress_createdb CREATEDB;
 ----
-COMPLETE 0
+db error: ERROR: CREATEDB attribute is not supported, for more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
+DETAIL: Use system privileges instead.
 
 simple conn=regress_role_admin,user=regress_role_admin
-CREATE ROLE regress_createcluster CREATECLUSTER;
+CREATE ROLE regress_createcluster;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT CREATECLUSTER ON SYSTEM TO regress_createcluster;
 ----
 COMPLETE 0
 
 simple conn=regress_role_admin,user=regress_role_admin
 ALTER ROLE regress_createcluster NOCREATECLUSTER;
 ----
-COMPLETE 0
+db error: ERROR: CREATECLUSTER attribute is not supported, for more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
+DETAIL: Use system privileges instead.
 
 simple conn=regress_role_admin,user=regress_role_admin
 ALTER ROLE regress_createcluster CREATECLUSTER;
 ----
-COMPLETE 0
+db error: ERROR: CREATECLUSTER attribute is not supported, for more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
+DETAIL: Use system privileges instead.
 
 simple conn=regress_role_admin,user=regress_role_admin
 ALTER ROLE regress_createdb SUPERUSER;
@@ -136,7 +154,12 @@ ALTER ROLE regress_createdb NOSUPERUSER;
 db error: ERROR: SUPERUSER attribute is not supported, for more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
 
 simple conn=regress_role_admin,user=regress_role_admin
-CREATE ROLE regress_createrole CREATEROLE;
+CREATE ROLE regress_createrole;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT CREATEROLE ON SYSTEM TO regress_createrole;
 ----
 COMPLETE 0
 


### PR DESCRIPTION
This commit removes the ability for users to set a role's attribute.
Role attributes still exist in the system and catalog tables, but they
cannot be changed, and they have no effect. This commit also updates
the documentation to reflect this.

Works towards resolving #19997

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Remove the ability to set role attributes