### PR TITLE
tracing: ensure we don't apply the otel filter globally

### DIFF
--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -345,7 +345,10 @@ where
             // TODO(parker-timmerman|guswynn): make this configurable with LaunchDarkly
             .max_events_per_span(2048)
             .with_tracer(tracer)
-            .and_then(filter);
+            // WARNING, ENTERING SPOOKY ZONE 2.0
+            //
+            // Notice we use `with_filter` here. `and_then` will apply the filter globally.
+            .with_filter(filter);
         let reloader = Arc::new(move |mut filter: EnvFilter| {
             // Re-apply our defaults on reload.
             for directive in &default_directives {


### PR DESCRIPTION
see https://materializeinc.slack.com/archives/CTESPM7FU/p1687987641720789

Might have been hidden by us by: https://github.com/tokio-rs/tracing/issues/2413

### Motivation

  * This PR fixes a previously unreported bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
