### PR TITLE
adapter: Remove role attributes

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -8518,18 +8518,6 @@ impl mz_sql::catalog::CatalogRole for Role {
         self.attributes.inherit
     }
 
-    fn create_role(&self) -> bool {
-        self.attributes.create_role
-    }
-
-    fn create_db(&self) -> bool {
-        self.attributes.create_db
-    }
-
-    fn create_cluster(&self) -> bool {
-        self.attributes.create_cluster
-    }
-
     fn membership(&self) -> &BTreeMap<RoleId, RoleId> {
         &self.membership.map
     }

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1619,10 +1619,7 @@ pub static MZ_ROLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column("inherit", ScalarType::Bool.nullable(false))
-        .with_column("create_role", ScalarType::Bool.nullable(false))
-        .with_column("create_db", ScalarType::Bool.nullable(false))
-        .with_column("create_cluster", ScalarType::Bool.nullable(false)),
+        .with_column("inherit", ScalarType::Bool.nullable(false)),
     is_retained_metrics_object: false,
 });
 pub static MZ_ROLE_MEMBERS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -3244,8 +3241,8 @@ AS SELECT
         ELSE NULL::pg_catalog.bool
     END AS rolsuper,
     inherit AS rolinherit,
-    create_role AS rolcreaterole,
-    create_db AS rolcreatedb,
+    mz_catalog.has_system_privilege(r.oid, 'CREATEROLE') AS rolcreaterole,
+    mz_catalog.has_system_privilege(r.oid, 'CREATEDB') AS rolcreatedb,
     -- We determine login status each time a role logs in, so there's no way to accurately depict
     -- this in the catalog. Instead we just hardcode NULL.
     NULL::pg_catalog.bool AS rolcanlogin,

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -147,9 +147,6 @@ impl CatalogState {
                         Datum::UInt32(role.oid),
                         Datum::String(&role.name),
                         Datum::from(role.attributes.inherit),
-                        Datum::from(role.attributes.create_role),
-                        Datum::from(role.attributes.create_db),
-                        Datum::from(role.attributes.create_cluster),
                     ]),
                     diff,
                 })

--- a/src/adapter/src/catalog/storage/stash.rs
+++ b/src/adapter/src/catalog/storage/stash.rs
@@ -136,20 +136,14 @@ pub async fn initialize(
         )
         .await?;
 
-    // If provided, generate a new Id and attributes for the bootstrap role.
+    // If provided, generate a new Id for the bootstrap role.
     //
     // Note: Make sure we do this _after_ initializing the ID_ALLOCATOR_COLLECTION.
     let bootstrap_role = if let Some(role) = &options.bootstrap_role {
         let role_id = RoleId::User(id_allocator.allocate(USER_ROLE_ID_ALLOC_KEY.to_string()));
         let role_val = proto::RoleValue {
             name: role.to_string(),
-            attributes: Some(
-                RoleAttributes::new()
-                    .with_create_db()
-                    .with_create_cluster()
-                    .with_create_role()
-                    .into_proto(),
-            ),
+            attributes: Some(RoleAttributes::new().into_proto()),
             membership: Some(RoleMembership::new().into_proto()),
         };
 

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -549,20 +549,16 @@ fn generate_required_privileges(
         },
         Plan::CreateRole(CreateRolePlan {
             name: _,
-            attributes,
+            attributes: _,
         }) => {
-            let mut acl_mode = AclMode::CREATE_ROLE;
-            acl_mode |= attributes.into();
-            vec![(SystemObjectId::System, acl_mode, role_id)]
+            vec![(SystemObjectId::System, AclMode::CREATE_ROLE, role_id)]
         }
         Plan::AlterRole(AlterRolePlan {
             id: _,
             name: _,
-            attributes,
+            attributes: _,
         }) => {
-            let mut acl_mode = AclMode::CREATE_ROLE;
-            acl_mode |= attributes.into();
-            vec![(SystemObjectId::System, acl_mode, role_id)]
+            vec![(SystemObjectId::System, AclMode::CREATE_ROLE, role_id)]
         }
         Plan::CreateClusterReplica(CreateClusterReplicaPlan {
             cluster_id,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1076,23 +1076,17 @@ pub enum RoleAttribute {
     Inherit,
     /// The `NOINHERIT` option.
     NoInherit,
-    /// The `CREATECLUSTER` option.
-    CreateCluster,
-    /// The `NOCREATECLUSTER` option.
-    NoCreateCluster,
-    /// The `CREATEDB` option.
-    CreateDB,
-    /// The `NOCREATEDB` option.
-    NoCreateDB,
-    /// The `CREATEROLE` option.
-    CreateRole,
-    /// The `NOCREATEROLE` option.
-    NoCreateRole,
     // The following are not supported, but included to give helpful error messages.
     Login,
     NoLogin,
     SuperUser,
     NoSuperUser,
+    CreateCluster,
+    NoCreateCluster,
+    CreateDB,
+    NoCreateDB,
+    CreateRole,
+    NoCreateRole,
 }
 
 impl AstDisplay for RoleAttribute {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -24,7 +24,7 @@ use mz_ore::cast::{self, CastFrom, TryCastFrom};
 use mz_ore::str::StrExt;
 use mz_proto::RustType;
 use mz_repr::adt::interval::Interval;
-use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap};
+use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
 use mz_repr::adt::system::Oid;
 use mz_repr::role_id::RoleId;
 use mz_repr::{strconv, ColumnName, ColumnType, GlobalId, RelationDesc, RelationType, ScalarType};
@@ -2639,18 +2639,10 @@ generate_extracted_config!(
 #[derive(Debug)]
 pub struct PlannedRoleAttributes {
     pub inherit: Option<bool>,
-    pub create_role: Option<bool>,
-    pub create_db: Option<bool>,
-    pub create_cluster: Option<bool>,
 }
 
 fn plan_role_attributes(options: Vec<RoleAttribute>) -> Result<PlannedRoleAttributes, PlanError> {
-    let mut planned_attributes = PlannedRoleAttributes {
-        inherit: None,
-        create_role: None,
-        create_db: None,
-        create_cluster: None,
-    };
+    let mut planned_attributes = PlannedRoleAttributes { inherit: None };
 
     for option in options {
         match option {
@@ -2696,22 +2688,6 @@ fn plan_role_attributes(options: Vec<RoleAttribute>) -> Result<PlannedRoleAttrib
     }
 
     Ok(planned_attributes)
-}
-
-impl From<&PlannedRoleAttributes> for AclMode {
-    fn from(attributes: &PlannedRoleAttributes) -> Self {
-        let mut acl_mode = AclMode::empty();
-        if let Some(true) = attributes.create_role {
-            acl_mode |= AclMode::CREATE_ROLE;
-        }
-        if let Some(true) = attributes.create_db {
-            acl_mode |= AclMode::CREATE_DB;
-        }
-        if let Some(true) = attributes.create_cluster {
-            acl_mode |= AclMode::CREATE_CLUSTER;
-        }
-        acl_mode
-    }
 }
 
 pub fn describe_create_role(

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "da97685cd2826c8e9c71e7efbd520c74"
+    "md5": "6f150aab3fa095b00753500ab4950af6"
   },
   {
     "name": "objects_v15.proto",
@@ -42,5 +42,9 @@
   {
     "name": "objects_v24.proto",
     "md5": "36393b93b157a0167efaf97f01b70685"
+  },
+  {
+    "name": "objects_v25.proto",
+    "md5": "0a055b56539327ccbb8e23f209843cf2"
   }
 ]

--- a/src/stash/protos/objects_v25.proto
+++ b/src/stash/protos/objects_v25.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto3";
 
-package objects;
+package objects_v25;
 
 message ConfigKey {
     string key = 1;

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -102,7 +102,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 24;
+pub const STASH_VERSION: u64 = 25;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -953,6 +953,7 @@ impl Stash {
                             21 => upgrade::v21_to_v22::upgrade(&mut tx).await?,
                             22 => upgrade::v22_to_v23::upgrade(&mut tx).await?,
                             23 => upgrade::v23_to_v24::upgrade(&mut tx).await?,
+                            24 => upgrade::v24_to_v25::upgrade(&mut tx).await?,
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -59,6 +59,7 @@ pub mod v20_to_v21;
 pub mod v21_to_v22;
 pub mod v22_to_v23;
 pub mod v23_to_v24;
+pub mod v24_to_v25;
 
 pub use json_to_proto::migrate_json_to_proto;
 

--- a/src/stash/src/upgrade/v24_to_v25.rs
+++ b/src/stash/src/upgrade/v24_to_v25.rs
@@ -1,0 +1,194 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::upgrade::MigrationAction;
+use crate::{StashError, Transaction, TypedCollection};
+
+pub mod objects_v24 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v24.rs"));
+}
+
+pub mod objects_v25 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v25.rs"));
+}
+
+/// Remove role attributes.
+///
+/// Author - jkosh44
+pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {
+    const ROLES_COLLECTION: TypedCollection<objects_v24::RoleKey, objects_v24::RoleValue> =
+        TypedCollection::new("role");
+
+    ROLES_COLLECTION
+        .migrate_to::<objects_v25::RoleKey, objects_v25::RoleValue>(tx, |entries| {
+            entries
+                .into_iter()
+                .map(|(key, value)| {
+                    MigrationAction::Update(key.clone(), (key.clone().into(), value.clone().into()))
+                })
+                .collect()
+        })
+        .await
+}
+
+impl From<objects_v24::RoleId> for objects_v25::RoleId {
+    fn from(id: objects_v24::RoleId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v24::role_id::Value::User(id)) => {
+                Some(objects_v25::role_id::Value::User(id))
+            }
+            Some(objects_v24::role_id::Value::System(id)) => {
+                Some(objects_v25::role_id::Value::System(id))
+            }
+            Some(objects_v24::role_id::Value::Public(_)) => {
+                Some(objects_v25::role_id::Value::Public(Default::default()))
+            }
+        };
+        objects_v25::RoleId { value }
+    }
+}
+
+impl From<objects_v24::RoleAttributes> for objects_v25::RoleAttributes {
+    fn from(attributes: objects_v24::RoleAttributes) -> Self {
+        objects_v25::RoleAttributes {
+            inherit: attributes.inherit,
+        }
+    }
+}
+
+impl From<objects_v24::role_membership::Entry> for objects_v25::role_membership::Entry {
+    fn from(entry: objects_v24::role_membership::Entry) -> Self {
+        objects_v25::role_membership::Entry {
+            key: entry.key.map(Into::into),
+            value: entry.value.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v24::RoleMembership> for objects_v25::RoleMembership {
+    fn from(attributes: objects_v24::RoleMembership) -> Self {
+        objects_v25::RoleMembership {
+            map: attributes
+                .map
+                .into_iter()
+                .map(|entry| entry.into())
+                .collect(),
+        }
+    }
+}
+
+impl From<objects_v24::RoleKey> for objects_v25::RoleKey {
+    fn from(key: objects_v24::RoleKey) -> Self {
+        objects_v25::RoleKey {
+            id: key.id.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v24::RoleValue> for objects_v25::RoleValue {
+    fn from(value: objects_v24::RoleValue) -> Self {
+        objects_v25::RoleValue {
+            name: value.name,
+            attributes: value.attributes.map(Into::into),
+            membership: value.membership.map(Into::into),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::upgrade;
+
+    use crate::upgrade::v24_to_v25::{objects_v24, objects_v25};
+    use crate::{DebugStashFactory, TypedCollection};
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn smoke_test() {
+        const ROLE_ID: objects_v24::RoleId = objects_v24::RoleId {
+            value: Some(objects_v24::role_id::Value::User(1)),
+        };
+        const GROUP_ROLE_ID: objects_v24::RoleId = objects_v24::RoleId {
+            value: Some(objects_v24::role_id::Value::User(2)),
+        };
+
+        // Connect to the Stash.
+        let factory = DebugStashFactory::new().await;
+        let mut stash = factory.open_debug().await;
+
+        // Insert a system privilege.
+        let roles_v24: TypedCollection<objects_v24::RoleKey, objects_v24::RoleValue> =
+            TypedCollection::new("role");
+        roles_v24
+            .insert_without_overwrite(
+                &mut stash,
+                vec![(
+                    objects_v24::RoleKey { id: Some(ROLE_ID) },
+                    objects_v24::RoleValue {
+                        name: "Joe".to_string(),
+                        attributes: Some(objects_v24::RoleAttributes {
+                            inherit: true,
+                            create_role: false,
+                            create_db: true,
+                            create_cluster: false,
+                        }),
+                        membership: Some(objects_v24::RoleMembership {
+                            map: vec![objects_v24::role_membership::Entry {
+                                key: Some(ROLE_ID),
+                                value: Some(GROUP_ROLE_ID),
+                            }],
+                        }),
+                    },
+                )],
+            )
+            .await
+            .unwrap();
+
+        // Run our migration.
+        stash
+            .with_transaction(|mut tx| {
+                Box::pin(async move {
+                    upgrade(&mut tx).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .expect("migration failed");
+
+        // Read back the items.
+        let roles: TypedCollection<objects_v25::RoleKey, objects_v25::RoleValue> =
+            TypedCollection::new("role");
+        let roles = roles.iter(&mut stash).await.unwrap();
+        // Filter down to just the key and value to make comparisons easier.
+        let roles: Vec<_> = roles
+            .into_iter()
+            .map(|((key, value), _timestamp, _diff)| (key, value))
+            .collect();
+
+        assert_eq!(
+            roles,
+            vec![(
+                objects_v25::RoleKey {
+                    id: Some(ROLE_ID.into()),
+                },
+                objects_v25::RoleValue {
+                    name: "Joe".to_string(),
+                    attributes: Some(objects_v25::RoleAttributes { inherit: true }),
+                    membership: Some(objects_v25::RoleMembership {
+                        map: vec![objects_v25::role_membership::Entry {
+                            key: Some(ROLE_ID.into()),
+                            value: Some(GROUP_ROLE_ID.into()),
+                        }]
+                    }),
+                }
+            )]
+        );
+    }
+}

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -12,16 +12,16 @@ mode cockroach
 reset-server
 
 # Verify initial roles.
-query TTBBBB
-SELECT id, name, inherit, create_role, create_db, create_cluster FROM mz_roles WHERE id LIKE 's%'
+query TTB
+SELECT id, name, inherit FROM mz_roles WHERE id LIKE 's%'
 ----
-s1 mz_system true true true true
-s2 mz_introspection true false false false
+s1 mz_system true
+s2 mz_introspection true
 
-query TBBBB
-SELECT name, inherit, create_role, create_db, create_cluster FROM mz_roles WHERE id LIKE 'u%'
+query TB
+SELECT name, inherit FROM mz_roles WHERE id LIKE 'u%'
 ----
-materialize  true  true  true  true
+materialize  true
 
 # Give materialize the CREATEROLE attribute.
 simple conn=mz_system,user=mz_system
@@ -57,13 +57,13 @@ CREATE ROLE rj
 statement error CREATE USER is not supported, for more information consult the documentation at
 CREATE USER fms
 
-query TBBBB
-SELECT name, inherit, create_role, create_db, create_cluster FROM mz_roles
+query TB
+SELECT name, inherit FROM mz_roles
 ----
-rj  true  false  false  false
-mz_system  true  true  true  true
-materialize  true  true  true  true
-mz_introspection  true  false  false  false
+rj  true
+mz_system  true
+materialize  true
+mz_introspection  true
 
 # Dropping multiple roles should not have any effect if one of the role names
 # is bad...
@@ -133,10 +133,10 @@ CREATE ROLE mz_foo
 statement ok
 CREATE ROLE foo
 
-query TBBBB
-SELECT name, inherit, create_role, create_db, create_cluster FROM mz_roles WHERE name = 'foo'
+query TB
+SELECT name, inherit FROM mz_roles WHERE name = 'foo'
 ----
-foo true false false false
+foo true
 
 statement error non inherit roles not yet supported
 ALTER ROLE foo NOINHERIT

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -140,8 +140,8 @@ name                nullable    type
  rolname            false       text
  rolsuper           true        boolean
  rolinherit         false       boolean
- rolcreaterole      false       boolean
- rolcreatedb        false       boolean
+ rolcreaterole      true        boolean
+ rolcreatedb        true        boolean
  rolcanlogin        true        boolean
  rolreplication     false       boolean
  rolbypassrls       false       boolean


### PR DESCRIPTION
This commit removes all role attributes completely from Materialize,
except the inherit role attribute. All other role attributes are
removed from the stash and catalog tables.

We could have written a migration to convert all existing role
attributes into system privileges. However, since RBAC is still in
alpha, we decided to just drop and forget any existing role attributes.

This is a breaking change since it removes columns from an existing
stable catalog table.

Resolves #19997

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Remove role attributes.
