### PR TITLE
pg sources: drop text column references

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3694,6 +3694,8 @@ impl Coordinator {
                     },
                 );
 
+                referenced_subsources.sort();
+
                 // Remove dropped references from text columns.
                 match &mut create_source_stmt.connection {
                     CreateSourceConnection::Postgres { options, .. } => {
@@ -3723,7 +3725,9 @@ impl Coordinator {
                                             }
                                         }
                                         _ => true,
-                                    })
+                                    });
+
+                                    names.sort();
                                 }
                                 _ => {}
                             }

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -165,7 +165,7 @@ impl_display!(UnresolvedDatabaseName);
 
 // The name of an item not yet created during name resolution, which should be
 // resolveable as an item name later.
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
 pub enum DeferredItemName<T: AstInfo> {
     Named(T::ItemName),
     Deferred(UnresolvedItemName),

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -635,7 +635,7 @@ impl<T: AstInfo> AstDisplay for CreateSourceStatement<T> {
 impl_display_t!(CreateSourceStatement);
 
 /// A selected subsource in a FOR TABLES (..) statement
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct CreateSourceSubsource<T: AstInfo> {
     pub reference: UnresolvedItemName,
     pub subsource: Option<DeferredItemName<T>>,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -616,6 +616,8 @@ pub async fn purify_create_source(
                 });
             }
 
+            targeted_subsources.sort();
+
             *referenced_subsources = Some(ReferencedSubsources::SubsetTables(targeted_subsources));
 
             // Remove any old detail references

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -55,19 +55,22 @@ INSERT INTO table_e VALUES (1, 'one');
 ALTER TABLE table_e REPLICA IDENTITY FULL;
 INSERT INTO table_e VALUES (2, 'two');
 
-CREATE TABLE table_f (pk INTEGER PRIMARY KEY, f2 TEXT);
-INSERT INTO table_f VALUES (1, 'one');
+CREATE TYPE an_enum AS ENUM ('var0', 'var1');
+CREATE TABLE table_f (pk INTEGER PRIMARY KEY, f2 an_enum);
+INSERT INTO table_f VALUES (1, 'var0');
 ALTER TABLE table_f REPLICA IDENTITY FULL;
-INSERT INTO table_f VALUES (2, 'two');
+INSERT INTO table_f VALUES (2, 'var1');
 
 CREATE TABLE table_g (pk INTEGER PRIMARY KEY, f2 TEXT);
 INSERT INTO table_g VALUES (1, 'one');
 ALTER TABLE table_g REPLICA IDENTITY FULL;
 INSERT INTO table_g VALUES (2, 'two');
 
-
 > CREATE SOURCE "mz_source"
-  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS (table_f.f2)
+  )
   FOR SCHEMAS (public);
 
 > SHOW SUBSOURCES ON mz_source
@@ -82,7 +85,10 @@ table_g               subsource
 
 # Show all tablestodo this should be splittable
 > SELECT regexp_match(create_sql, 'FOR TABLES \((.+?)\) EXPOSE')[1] FROM (SHOW CREATE SOURCE mz_source);
-"\"postgres\".\"public\".\"table_a\" AS \"materialize\".\"public\".\"table_a\", \"postgres\".\"public\".\"table_b\" AS \"materialize\".\"public\".\"table_b\", \"postgres\".\"public\".\"table_g\" AS \"materialize\".\"public\".\"table_g\", \"postgres\".\"public\".\"table_c\" AS \"materialize\".\"public\".\"table_c\", \"postgres\".\"public\".\"table_d\" AS \"materialize\".\"public\".\"table_d\", \"postgres\".\"public\".\"table_e\" AS \"materialize\".\"public\".\"table_e\", \"postgres\".\"public\".\"table_f\" AS \"materialize\".\"public\".\"table_f\""
+"\"postgres\".\"public\".\"table_a\" AS \"materialize\".\"public\".\"table_a\", \"postgres\".\"public\".\"table_b\" AS \"materialize\".\"public\".\"table_b\", \"postgres\".\"public\".\"table_c\" AS \"materialize\".\"public\".\"table_c\", \"postgres\".\"public\".\"table_d\" AS \"materialize\".\"public\".\"table_d\", \"postgres\".\"public\".\"table_e\" AS \"materialize\".\"public\".\"table_e\", \"postgres\".\"public\".\"table_f\" AS \"materialize\".\"public\".\"table_f\", \"postgres\".\"public\".\"table_g\" AS \"materialize\".\"public\".\"table_g\""
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+"\"postgres\".\"public\".\"table_f\".\"f2\""
 
 #
 # Error checking
@@ -191,6 +197,10 @@ contains:cannot drop source table_e: still depended upon by materialized view mv
 
 # IF NOT EXISTS + CASCADE works
 > ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e, table_f CASCADE;
+
+# TEXT COLUMNS removed from table_f
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+""
 
 > SHOW SUBSOURCES ON mz_source
 mz_source_progress    progress


### PR DESCRIPTION
I overlooked dropping references to dropped subsources from the text columns clause. This matters only in as much as it makes it that the output of `CREATE SOURCE` is non-roundtrippable, but we can fix it so we should.

### Motivation

This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
