### PR TITLE
adapter: eagerly validate max replicas limit for managed clusters

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -327,7 +327,7 @@ impl AdapterError {
                     .into(),
             ),
             AdapterError::ResourceExhaustion { resource_type, .. } => Some(format!(
-                "Drop an existing {resource_type} or contact sales to request a limit increase."
+                "Drop an existing {resource_type} or contact support to request a limit increase."
             )),
             AdapterError::StatementTimeout => Some(
                 "Consider increasing the maximum allowed statement duration for this session by \

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -405,6 +405,10 @@ DROP CLUSTER foo CASCADE
 statement error db error: ERROR: unknown cluster replica size invalid_size
 CREATE CLUSTER foo SIZE invalid_size, REPLICATION FACTOR 0
 
+# Test for #20195 . Without the fix, this query will hang indefinitely
+statement error db error: ERROR: creating cluster replica would violate max_replicas_per_cluster limit \(desired: 9999999, limit: 5, current: 0\)
+CREATE CLUSTER foo SIZE '1', replication factor 9999999;
+
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_managed_clusters = false;
 ----


### PR DESCRIPTION
Otherwise we'll attempt to allocate replica IDs for as many replicas as the user requested before checking whether that number of replicas is acceptable. This allows users to place unbounded load on CockroachDB.

Fix #20195.

@philip-stoev is there a good way to test this? 

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
