### PR TITLE
build: Use faster EC2 mirror for Ubuntu downloads

### DIFF
--- a/misc/images/ubuntu-base/Dockerfile
+++ b/misc/images/ubuntu-base/Dockerfile
@@ -11,3 +11,7 @@ FROM ubuntu:jammy-20230126
 
 # Ensure any Rust binaries that crash print a backtrace.
 ENV RUST_BACKTRACE=1
+
+RUN sed -i -e 's#http://archive\.ubuntu\.com#http://us-east-1.ec2.archive.ubuntu.com#' \
+           -e 's#http://security\.ubuntu\.com#http://us-east-1.ec2.archive.ubuntu.com#' \
+           -e 's#http://ports\.ubuntu\.com#http://us-east-1.ec2.ports.ubuntu.com#' /etc/apt/sources.list


### PR DESCRIPTION
Slowness seen in https://buildkite.com/materialize/tests/builds/58563#01890590-a721-4fce-900f-a4a383f9331c
Before:
```
[2023-06-29T05:14:29Z] Fetched 25.5 MB in 55s (463 kB/s)
[2023-06-29T05:14:31Z] Fetched 4432 B in 0s (29.3 kB/s)
[2023-06-29T05:23:12Z] Fetched 25.5 MB in 9s (2770 kB/s)
[2023-06-29T05:25:36Z] Fetched 31.1 MB in 2min 23s (218 kB/s)
[2023-06-29T05:33:57Z] Fetched 25.5 MB in 1min 29s (286 kB/s)
[2023-06-29T05:35:36Z] Fetched 33.2 MB in 1min 37s (341 kB/s)
```
After:
```
[2023-06-29T09:14:24Z] Fetched 25.5 MB in 1s (28.9 MB/s)
[2023-06-29T09:14:30Z] Fetched 118 MB in 4s (31.0 MB/s)
[2023-06-29T09:15:15Z] Fetched 25.5 MB in 1s (28.9 MB/s)
[2023-06-29T09:15:16Z] Fetched 2449 kB in 0s (22.6 MB/s)
[2023-06-29T09:15:25Z] Fetched 25.5 MB in 1s (30.7 MB/s)
[2023-06-29T09:15:29Z] Fetched 74.0 MB in 2s (41.1 MB/s)
```

Part of https://github.com/MaterializeInc/materialize/issues/20132

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
