### PR TITLE
bin/mz: allow running from any folder

### DIFF
--- a/bin/mz
+++ b/bin/mz
@@ -11,4 +11,8 @@
 #
 # mz -- build and run the Materialize CLI.
 
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
 exec cargo run --bin mz -- "$@"


### PR DESCRIPTION
The [`letrec-bench`](https://github.com/MaterializeInc/letrec-bench) README.md has some code that might benefit from pointing and running `bin/mz` as an absolute or relative path from another current working directory.

### Motivation

  * This PR adds a feature that has not yet been specified.

Do a `cd $parent` before `exec` in order to allow for things like:

```bash
export MZ="$HOME/workspace/materialize/bin/mz"
$MZ --profile=staging region enable aws/eu-west-1
```

### Tips for reviewer

I'm not sure if the `cd ...` on top of the `exec` is the recommended way to go, but it does the job.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
