### PR TITLE
adapter: Make item error messages human readable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4813,6 +4813,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "static_assertions",
  "thiserror",
  "tokio",
  "tokio-postgres",

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -419,7 +419,10 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
             .expect("can only create indexes on items with a valid description")
             .typ()
             .clone();
-        let name = index_entry.name().to_string();
+        let name = self
+            .catalog
+            .resolve_full_name(index_entry.name(), index_entry.conn_id())
+            .to_string();
         let mut dataflow = DataflowDesc::new(name);
         self.import_into_dataflow(&index.on, &mut dataflow)?;
         for BuildDesc { plan, .. } in &mut dataflow.objects_to_build {
@@ -495,7 +498,10 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
             ),
         };
 
-        let name = mview_entry.name().to_string();
+        let name = self
+            .catalog
+            .resolve_full_name(mview_entry.name(), mview_entry.conn_id())
+            .to_string();
         let mut dataflow = DataflowDesc::new(name);
 
         self.import_view_into_dataflow(&internal_view_id, &mview.optimized_expr, &mut dataflow)?;

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -48,6 +48,7 @@ regex = "1.7.0"
 reqwest = "0.11.13"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
+static_assertions = "1.1"
 thiserror = "1.0.37"
 tokio = { version = "1.24.2", features = ["fs"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -86,14 +86,9 @@ pub struct QualifiedItemName {
     pub item: String,
 }
 
-impl fmt::Display for QualifiedItemName {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let ResolvedDatabaseSpecifier::Id(id) = &self.qualifiers.database_spec {
-            write!(f, "{}.", id)?;
-        }
-        write!(f, "{}.{}", self.qualifiers.schema_spec, self.item)
-    }
-}
+// Do not implement [`Display`] for [`QualifiedItemName`]. [`FullItemName`] should always be
+// displayed instead.
+static_assertions::assert_not_impl_any!(QualifiedItemName: fmt::Display);
 
 /// An optionally-qualified human-readable name of an item in the catalog.
 ///

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -203,7 +203,10 @@ pub async fn purify_create_source(
                 // Get Kafka connection
                 match item.connection()? {
                     Connection::Kafka(connection) => connection.clone(),
-                    _ => sql_bail!("{} is not a kafka connection", item.name()),
+                    _ => sql_bail!(
+                        "{} is not a kafka connection",
+                        scx.catalog.resolve_full_name(item.name())
+                    ),
                 }
             };
 
@@ -273,7 +276,10 @@ pub async fn purify_create_source(
                 let item = scx.get_item_by_resolved_name(connection)?;
                 match item.connection()? {
                     Connection::Postgres(connection) => connection.clone(),
-                    _ => sql_bail!("{} is not a postgres connection", item.name()),
+                    _ => sql_bail!(
+                        "{} is not a postgres connection",
+                        scx.catalog.resolve_full_name(item.name())
+                    ),
                 }
             };
             let crate::plan::statement::PgConfigOptionExtracted {


### PR DESCRIPTION
This commit updates various error messages to make item names more human readable. Previously, many error messages printed the names in the format "database_id.schema_id.item_name". Now they are printed in the format "database_name.schema_name.item_name".

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improve error messages containing item names.
