### PR TITLE
Adjust command history leak test to avoid flakiness

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -376,14 +376,12 @@ def workflow_test_github_15531(c: Composition) -> None:
         controller_command_count < 100
     ), "controller history grew more than expected after peeks"
     assert (
-        controller_dataflow_count == 1
+        controller_dataflow_count < 5
     ), "more dataflows than expected in controller history"
     assert (
         replica_command_count < 100
     ), "replica history grew more than expected after peeks"
-    assert (
-        replica_dataflow_count == 1
-    ), "more dataflows than expected in replica history"
+    assert replica_dataflow_count < 5, "more dataflows than expected in replica history"
 
 
 def workflow_test_github_15535(c: Composition) -> None:


### PR DESCRIPTION
This PR adjusts the bounds for acceptable dataflow counts in the compute command histories of the controller and replica in the cluster test for issue #15531, which ensures that we resolved a peek leak in the command history. The bounds are relaxed from 1 to account for a maximum of 2 live dataflows after history reduction plus a fudge factor to account for when reduction actually takes place.

Fixes #20242.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/20242

### Tips for reviewer

This test is carefully constructed to rely on our history reduction being triggered every time the size of the compute history doubles. The issue with it being flaky arises from asserting an exact number for the dataflow count expected to be found in the history. The metric on dataflow count shows dataflows in the history that are either live or not, so some vestigial `CreateDataflows` commands (with corresponding `AllowCompaction` ones) can still linger in the history if it has not been just reduced.

Asserting an exact number is fragile; on the other hand, not asserting a specific bound defeats the purpose of the test. So a proposed improvement to the test is to assert a more comfortable, but still as low as possible number for the dataflow count. We argue as follows: Creating an index at the setup introduces one long-lived dataflow in the history. Subsequently, we loop 20 times issuing sequences of 10 `Peek` commands to this index (`SELECT * FROM t`) interspersed with 10 of each of `CreateDataflows`, `Peek`, and `AllowCompaction` for slow-path, one-shot `SELECT`s (`SELECT * FROM  t2`). Since these commands are performed sequentially, we know that either 1 or 2 dataflows can be alive in the history at any given reduction. However, more dataflows can be included (though not live) due to the history growing in size due to other unrelated commands. We have a heuristic bound on the history size of 100. Given that the history needs to include a minimum of 6 commands and that we include another dataflow every 4 commands generated by the test, we must find less or equal to 26 dataflows (live or not) in the history.

In a local run of the loop proposed by Dennis, I only ever saw dataflow counts of 1 or 2, aligning more closely to the potentially live dataflows upon reductions. We could set the number at the lower bound of 2, if we are willing to revisit in case of further flakiness, or leave it the bound a bit more relaxed closer to the upper estimate of 26. I'd suggest heuristically setting it to less than 5 and iterating if we need to.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has is sufficiently small to not require a design.
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
