### PR TITLE
deps: dont depend on rocksdb crate in adapter/sql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3418,7 +3418,7 @@ dependencies = [
  "mz-postgres-util",
  "mz-proto",
  "mz-repr",
- "mz-rocksdb",
+ "mz-rocksdb-types",
  "mz-secrets",
  "mz-segment",
  "mz-sql",
@@ -4670,6 +4670,7 @@ dependencies = [
  "itertools",
  "mz-ore",
  "mz-proto",
+ "mz-rocksdb-types",
  "num_cpus",
  "once_cell",
  "prometheus",
@@ -4686,6 +4687,25 @@ dependencies = [
  "tokio",
  "tonic-build",
  "tracing",
+ "uncased",
+ "workspace-hack",
+]
+
+[[package]]
+name = "mz-rocksdb-types"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "mz-ore",
+ "mz-proto",
+ "num_cpus",
+ "proptest",
+ "proptest-derive",
+ "prost",
+ "prost-build",
+ "protobuf-src",
+ "serde",
+ "tonic-build",
  "uncased",
  "workspace-hack",
 ]
@@ -4797,7 +4817,7 @@ dependencies = [
  "mz-postgres-util",
  "mz-proto",
  "mz-repr",
- "mz-rocksdb",
+ "mz-rocksdb-types",
  "mz-secrets",
  "mz-sql-parser",
  "mz-stash",
@@ -5080,7 +5100,7 @@ dependencies = [
  "mz-postgres-util",
  "mz-proto",
  "mz-repr",
- "mz-rocksdb",
+ "mz-rocksdb-types",
  "mz-secrets",
  "mz-service",
  "mz-ssh-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "src/repr",
     "src/repr-test-util",
     "src/rocksdb",
+    "src/rocksdb-types",
     "src/s3-datagen",
     "src/secrets",
     "src/segment",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -38,7 +38,7 @@ mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr", features = ["tracing_"] }
-mz-rocksdb = { path = "../rocksdb" }
+mz-rocksdb-types = { path = "../rocksdb-types" }
 mz-secrets = { path = "../secrets" }
 mz-segment = { path = "../segment" }
 mz-sql = { path = "../sql" }

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -7514,7 +7514,7 @@ impl Catalog {
                 .system_config()
                 .keep_n_source_status_history_entries(),
             upsert_rocksdb_tuning_config: {
-                match mz_rocksdb::RocksDBTuningParameters::from_parameters(
+                match mz_rocksdb_types::RocksDBTuningParameters::from_parameters(
                     self.system_config().upsert_rocksdb_compaction_style(),
                     self.system_config()
                         .upsert_rocksdb_optimize_compaction_memtable_budget(),
@@ -7537,7 +7537,7 @@ impl Catalog {
                             failing back to reasonable defaults: {}",
                             e.display_with_causes()
                         );
-                        mz_rocksdb::RocksDBTuningParameters::default()
+                        mz_rocksdb_types::RocksDBTuningParameters::default()
                     }
                 }
             },

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -30,7 +30,7 @@ mz-timely-util = { path = "../timely-util" }
 once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
 regex = "1.7.0"
-rocksdb = { version = "0.21.0", default-features = false, features = ["snappy"] }
+rocksdb = { version = "0.21.0", default-features = false, features = ["snappy", "zstd", "lz4"] }
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }

--- a/src/rocksdb-types/Cargo.toml
+++ b/src/rocksdb-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "mz-rocksdb"
-description = "A wrapper for RocksDB."
+name = "mz-rocksdb-types"
+description = "Shared types for the `mz-rocksdb` crate"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
@@ -8,26 +8,13 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.66"
-bincode = { version = "1.3.3" }
-itertools = { version = "0.10.5" }
-once_cell = "1.16.0"
 mz-ore = { path = "../ore", features = ["async", "metrics", "test"] }
 mz-proto = { path = "../proto" }
-mz-rocksdb-types = { path = "../rocksdb-types" }
 num_cpus = "1.14.0"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
-tokio = { version = "1.24.2", features = ["macros", "sync", "rt"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.89" }
-thiserror = "1.0.37"
-tracing = "0.1.37"
-# These features use compression code that are licensed with:
-# https://github.com/google/snappy/blob/main/COPYING
-# https://github.com/lz4/lz4/blob/dev/LICENSE
-# https://github.com/facebook/zstd
-rocksdb = { version = "0.21.0", default-features = false, features = ["snappy", "zstd", "lz4"] }
 uncased = "0.9.7"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
@@ -35,10 +22,6 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
 tonic-build = "0.8.2"
-
-[dev-dependencies]
-tempfile = "3.2.0"
-prometheus = { version = "0.13.3", default-features = false }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/rocksdb-types/build.rs
+++ b/src/rocksdb-types/build.rs
@@ -89,6 +89,6 @@ fn main() {
         // broad, but it's better.
         .emit_rerun_if_changed(false)
         .extern_path(".mz_proto", "::mz_proto")
-        .compile_with_config(config, &["rocksdb/src/config.proto"], &[".."])
+        .compile_with_config(config, &["rocksdb-types/src/config.proto"], &[".."])
         .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/rocksdb-types/src/config.proto
+++ b/src/rocksdb-types/src/config.proto
@@ -12,7 +12,7 @@ syntax = "proto3";
 import "google/protobuf/empty.proto";
 import "proto/src/proto.proto";
 
-package mz_rocksdb.config;
+package mz_rocksdb_types.config;
 
 // The lowercase `b` is because prost lowercases it anyways
 // if its capitalized :(

--- a/src/rocksdb-types/src/config.rs
+++ b/src/rocksdb-types/src/config.rs
@@ -1,0 +1,539 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// This module is mostly boilerplate, with all relevant
+// documentation on `RocksDBTuningParameters`.
+#![allow(missing_docs)]
+
+//! This module offers a protobuf implementation (to be used
+//! with LaunchDarkly) `RocksDBTuningParameters` that can be used
+//! to tune a RocksDB instance. The supported options are carefully
+//! considered to be a minimal set required to tune RocksDB to perform
+//! well for the `UPSERT` usecase. This usecase is slightly odd:
+//! - Very high write rate (1:1 with reads)
+//! - No durability requirements
+//! - Minimal space amplification
+//! - Relatively relaxed read and write latency requirements
+//!     - (note that `UPSERT` RocksDB instances are NOT in the
+//!     critical path for any sort of query.
+//!
+//! The defaults (so, the values resulting from derserializing `{}`
+//! into a `RocksDBTuningParameters`) should be reasonable defaults.
+//!
+//! The documentation on each field in `RocksDBTuningParameters` has more
+//! information
+//!
+//! Note that the following documents are required reading to deeply understand
+//! this module:
+//! - <https://github.com/EighteenZi/rocksdb_wiki/blob/master/RocksDB-Tuning-Guide.md>
+//! - <https://github.com/EighteenZi/rocksdb_wiki/blob/master/Compression.md>
+//! - <https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning>
+//! - <https://www.eecg.toronto.edu/~stumm/Papers/Dong-CIDR-16.pdf>
+//! - <http://smalldatum.blogspot.com/2015/11/read-write-space-amplification-pick-2_23.html>
+
+use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use mz_ore::cast::CastFrom;
+use mz_proto::{IntoRustIfSome, RustType, TryFromProtoError};
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+use uncased::UncasedStr;
+
+include!(concat!(env!("OUT_DIR"), "/mz_rocksdb_types.config.rs"));
+
+/// A set of parameters to tune RocksDB. This struct is plain-old-data, and is
+/// used to update `RocksDBConfig`, which contains some dynamic value for some
+/// parameters.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, Arbitrary)]
+pub struct RocksDBTuningParameters {
+    /// RocksDB has 2 primary styles of compaction:
+    /// - The default, usually referred to as "level" compaction
+    /// - "universal"
+    ///
+    /// Universal is simpler and for some workloads could be
+    /// better. Also, you can directly configure its space-amplification ratio
+    /// (using `universal_compaction_target_ratio`). However, its unclear
+    /// if the `UPSERT` workload is a good workload for universal compaction,
+    /// and its also might be the case that universal compaction uses significantly
+    /// more space temporarily while performing compaction.
+    ///
+    /// For these reasons, the default is `CompactionStyle::Level`.
+    pub compaction_style: CompactionStyle,
+    /// The `RocksDB` api offers a single configuration method that sets some
+    /// reasonable defaults for heavy-write workloads, either
+    /// <https://docs.rs/rocksdb/latest/rocksdb/struct.Options.html#method.optimize_level_style_compaction>
+    /// or
+    /// <https://docs.rs/rocksdb/latest/rocksdb/struct.Options.html#method.optimize_universal_style_compaction>
+    /// depending on `compaction_style`. We ALSO enable this configuration, which is tuned
+    /// by the size of the memtable (basically the in-memory buffer used to avoid IO). The default
+    /// here is ~512MB, which is the default from here: <https://github.com/facebook/rocksdb/blob/main/include/rocksdb/options.h#L102>,
+    /// and about twice the global RocksDB default.
+    pub optimize_compaction_memtable_budget: usize,
+
+    /// This option, when enabled, dynamically tunes
+    /// the size of the various LSM levels to put a bound on space-amplification.
+    /// With the default level-ratio of `10`, this means space-amplification is
+    /// O(1.11 * the size of data). Note this is big-O notation, and the actual
+    /// amplification factor depends on the workload.
+    ///
+    /// See <https://www.eecg.toronto.edu/~stumm/Papers/Dong-CIDR-16.pdf> for more details.
+    ///
+    /// This option defaults to true, as its basically free saved-space, and only applies to
+    /// `CompactionStyle::Level`.
+    pub level_compaction_dynamic_level_bytes: bool,
+
+    /// The additional space-amplification used with universal compaction.
+    /// Only applies to `CompactionStyle::Universal`.
+    ///
+    /// See `compaction_style` for more information.
+    pub universal_compaction_target_ratio: i32,
+
+    /// By default, RocksDB uses only 1 thread to perform compaction and other background tasks.
+    ///
+    /// The default here is the number of cores, as mentioned by
+    /// <https://docs.rs/rocksdb/latest/rocksdb/struct.Options.html#method.increase_parallelism>.
+    ///
+    /// Note that this option is shared across all RocksDB instances that share a `rocksdb::Env`.
+    pub parallelism: Option<i32>,
+
+    /// The most important way to reduce space amplification in RocksDB is compression.
+    ///
+    /// In RocksDB, data on disk is stored in an LSM tree. Because the higher layers (which are
+    /// smaller) will need to be read during reads that aren't cached, we want a relatively
+    /// lightweight compression scheme, choosing `Lz4` as the default, which is considered almost
+    /// always better than `Snappy`.
+    ///
+    /// The meat of the data is stored in the largest, bottom layer, which can be configured
+    /// (using `bottommost_compression_type`) to use a more expensive compression scheme to save
+    /// more space. The default is `Zstd`, which many think has the best compression ratio. Note
+    /// that tuning the bottommost layer separately only makes sense when you have free cpu,
+    /// which we have in the case of the `UPSERT` usecase.
+    pub compression_type: CompressionType,
+
+    /// See `compression_type` for more information.
+    pub bottommost_compression_type: CompressionType,
+
+    /// The size of the `multi_get` and `multi_put` batches sent to RocksDB. The default is 1024.
+    pub batch_size: usize,
+
+    /// The maximum duration for the retries when performing rocksdb actions in case of retry-able errors.
+    pub retry_max_duration: Duration,
+}
+
+impl Default for RocksDBTuningParameters {
+    fn default() -> Self {
+        Self {
+            compaction_style: defaults::DEFAULT_COMPACTION_STYLE,
+            optimize_compaction_memtable_budget:
+                defaults::DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET,
+            level_compaction_dynamic_level_bytes:
+                defaults::DEFAULT_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES,
+            universal_compaction_target_ratio: defaults::DEFAULT_UNIVERSAL_COMPACTION_RATIO,
+            parallelism: defaults::DEFAULT_PARALLELISM,
+            compression_type: defaults::DEFAULT_COMPRESSION_TYPE,
+            bottommost_compression_type: defaults::DEFAULT_BOTTOMMOST_COMPRESSION_TYPE,
+            batch_size: defaults::DEFAULT_BATCH_SIZE,
+            retry_max_duration: defaults::DEFAULT_RETRY_DURATION,
+        }
+    }
+}
+
+impl RocksDBTuningParameters {
+    /// Build a `RocksDBTuningParameters` from strings and values from LD parameters.
+    pub fn from_parameters(
+        compaction_style: CompactionStyle,
+        optimize_compaction_memtable_budget: usize,
+        level_compaction_dynamic_level_bytes: bool,
+        universal_compaction_target_ratio: i32,
+        parallelism: Option<i32>,
+        compression_type: CompressionType,
+        bottommost_compression_type: CompressionType,
+        batch_size: usize,
+        retry_max_duration: Duration,
+    ) -> Result<Self, anyhow::Error> {
+        Ok(Self {
+            compaction_style,
+            optimize_compaction_memtable_budget,
+            level_compaction_dynamic_level_bytes,
+            universal_compaction_target_ratio: if universal_compaction_target_ratio > 100 {
+                universal_compaction_target_ratio
+            } else {
+                return Err(anyhow::anyhow!(
+                    "universal_compaction_target_ratio ({}) must be > 100",
+                    universal_compaction_target_ratio
+                ));
+            },
+            parallelism: match parallelism {
+                Some(parallelism) => {
+                    if parallelism < 1 {
+                        return Err(anyhow::anyhow!(
+                            "parallelism({}) must be > 1, or not specified",
+                            universal_compaction_target_ratio
+                        ));
+                    }
+                    Some(parallelism)
+                }
+                None => None,
+            },
+            compression_type,
+            bottommost_compression_type,
+            batch_size,
+            retry_max_duration,
+        })
+    }
+}
+
+/// The 2 primary compaction styles in RocksDB`. See `RocksDBTuningParameters::compaction_style`
+/// for more information.
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug, Arbitrary)]
+pub enum CompactionStyle {
+    Level,
+    Universal,
+}
+
+impl FromStr for CompactionStyle {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = UncasedStr::new(s);
+        if s == "level" {
+            Ok(Self::Level)
+        } else if s == "universal" {
+            Ok(Self::Universal)
+        } else {
+            Err(anyhow::anyhow!("{} is not a supported compaction style", s))
+        }
+    }
+}
+
+impl std::fmt::Display for CompactionStyle {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            CompactionStyle::Level => write!(f, "level"),
+            CompactionStyle::Universal => write!(f, "universal"),
+        }
+    }
+}
+
+/// Mz-supported compression types in RocksDB`. See `RocksDBTuningParameters::compression_type`
+/// for more information.
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug, Arbitrary)]
+pub enum CompressionType {
+    Zstd,
+    Snappy,
+    Lz4,
+    None,
+}
+
+impl FromStr for CompressionType {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = UncasedStr::new(s);
+        if s == "zstd" {
+            Ok(Self::Zstd)
+        } else if s == "snappy" {
+            Ok(Self::Snappy)
+        } else if s == "lz4" {
+            Ok(Self::Lz4)
+        } else if s == "none" {
+            Ok(Self::None)
+        } else {
+            Err(anyhow::anyhow!("{} is not a supported compression type", s))
+        }
+    }
+}
+
+impl std::fmt::Display for CompressionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            CompressionType::Zstd => write!(f, "zstd"),
+            CompressionType::Snappy => write!(f, "snappy"),
+            CompressionType::Lz4 => write!(f, "lz4"),
+            CompressionType::None => write!(f, "none"),
+        }
+    }
+}
+
+impl RustType<ProtoRocksDbTuningParameters> for RocksDBTuningParameters {
+    fn into_proto(&self) -> ProtoRocksDbTuningParameters {
+        use proto_rocks_db_tuning_parameters::{
+            proto_compaction_style, proto_compression_type, ProtoCompactionStyle,
+            ProtoCompressionType,
+        };
+
+        fn compression_into_proto(compression_type: &CompressionType) -> ProtoCompressionType {
+            ProtoCompressionType {
+                kind: Some(match compression_type {
+                    CompressionType::Zstd => proto_compression_type::Kind::Zstd(()),
+                    CompressionType::Snappy => proto_compression_type::Kind::Snappy(()),
+                    CompressionType::Lz4 => proto_compression_type::Kind::Lz4(()),
+                    CompressionType::None => proto_compression_type::Kind::None(()),
+                }),
+            }
+        }
+        ProtoRocksDbTuningParameters {
+            compaction_style: Some(ProtoCompactionStyle {
+                kind: Some(match self.compaction_style {
+                    CompactionStyle::Level => proto_compaction_style::Kind::Level(()),
+                    CompactionStyle::Universal => proto_compaction_style::Kind::Universal(()),
+                }),
+            }),
+            optimize_compaction_memtable_budget: u64::cast_from(
+                self.optimize_compaction_memtable_budget,
+            ),
+            level_compaction_dynamic_level_bytes: self.level_compaction_dynamic_level_bytes,
+            universal_compaction_target_ratio: self.universal_compaction_target_ratio,
+            parallelism: self.parallelism,
+            compression_type: Some(compression_into_proto(&self.compression_type)),
+            bottommost_compression_type: Some(compression_into_proto(
+                &self.bottommost_compression_type,
+            )),
+            batch_size: u64::cast_from(self.batch_size),
+            retry_max_duration: Some(self.retry_max_duration.into_proto()),
+        }
+    }
+
+    fn from_proto(proto: ProtoRocksDbTuningParameters) -> Result<Self, TryFromProtoError> {
+        use proto_rocks_db_tuning_parameters::{
+            proto_compaction_style, proto_compression_type, ProtoCompactionStyle,
+            ProtoCompressionType,
+        };
+
+        fn compression_from_proto(
+            compression_type: Option<ProtoCompressionType>,
+        ) -> Result<CompressionType, TryFromProtoError> {
+            match compression_type {
+                Some(ProtoCompressionType {
+                    kind: Some(proto_compression_type::Kind::Zstd(())),
+                }) => Ok(CompressionType::Zstd),
+                Some(ProtoCompressionType {
+                    kind: Some(proto_compression_type::Kind::Snappy(())),
+                }) => Ok(CompressionType::Snappy),
+                Some(ProtoCompressionType {
+                    kind: Some(proto_compression_type::Kind::Lz4(())),
+                }) => Ok(CompressionType::Lz4),
+                Some(ProtoCompressionType {
+                    kind: Some(proto_compression_type::Kind::None(())),
+                }) => Ok(CompressionType::None),
+                Some(ProtoCompressionType { kind: None }) => Err(TryFromProtoError::MissingField(
+                    "ProtoRocksDbTuningParameters::compression_type::kind".into(),
+                )),
+                None => Err(TryFromProtoError::MissingField(
+                    "ProtoRocksDbTuningParameters::compression_type".into(),
+                )),
+            }
+        }
+        Ok(Self {
+            compaction_style: match proto.compaction_style {
+                Some(ProtoCompactionStyle {
+                    kind: Some(proto_compaction_style::Kind::Level(())),
+                }) => CompactionStyle::Level,
+                Some(ProtoCompactionStyle {
+                    kind: Some(proto_compaction_style::Kind::Universal(())),
+                }) => CompactionStyle::Universal,
+                Some(ProtoCompactionStyle { kind: None }) => {
+                    return Err(TryFromProtoError::MissingField(
+                        "ProtoRocksDbTuningParameters::compaction_style::kind".into(),
+                    ))
+                }
+                None => {
+                    return Err(TryFromProtoError::MissingField(
+                        "ProtoRocksDbTuningParameters::compaction_style".into(),
+                    ))
+                }
+            },
+            optimize_compaction_memtable_budget: usize::cast_from(
+                proto.optimize_compaction_memtable_budget,
+            ),
+            level_compaction_dynamic_level_bytes: proto.level_compaction_dynamic_level_bytes,
+            universal_compaction_target_ratio: proto.universal_compaction_target_ratio,
+            parallelism: proto.parallelism,
+            compression_type: compression_from_proto(proto.compression_type)?,
+            bottommost_compression_type: compression_from_proto(proto.bottommost_compression_type)?,
+            batch_size: usize::cast_from(proto.batch_size),
+            retry_max_duration: proto
+                .retry_max_duration
+                .into_rust_if_some("ProtoRocksDbTuningParameters::retry_max_duration")?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RocksDBDynamicConfig {
+    batch_size: Arc<AtomicUsize>,
+}
+
+impl RocksDBDynamicConfig {
+    pub fn batch_size(&self) -> usize {
+        // SeqCst is probably not required here, but its the easiest to reason about
+        self.batch_size.load(Ordering::SeqCst)
+    }
+}
+
+/// Configurable options for a `RocksDBInstance`. Some can be updated
+/// dynamically, as cloned instances of this object will shared dynamic values.
+#[derive(Debug, Clone)]
+pub struct RocksDBConfig {
+    pub compaction_style: CompactionStyle,
+    pub optimize_compaction_memtable_budget: usize,
+    pub level_compaction_dynamic_level_bytes: bool,
+    pub universal_compaction_target_ratio: i32,
+    pub parallelism: Option<i32>,
+    pub compression_type: CompressionType,
+    pub bottommost_compression_type: CompressionType,
+    pub retry_max_duration: Duration,
+    pub dynamic: RocksDBDynamicConfig,
+}
+
+impl Default for RocksDBConfig {
+    fn default() -> Self {
+        RocksDBConfig::new(RocksDBTuningParameters::default())
+    }
+}
+
+impl RocksDBConfig {
+    fn new(params: RocksDBTuningParameters) -> Self {
+        let RocksDBTuningParameters {
+            compaction_style,
+            optimize_compaction_memtable_budget,
+            level_compaction_dynamic_level_bytes,
+            universal_compaction_target_ratio,
+            parallelism,
+            compression_type,
+            bottommost_compression_type,
+            batch_size,
+            retry_max_duration,
+        } = params;
+
+        Self {
+            compaction_style,
+            optimize_compaction_memtable_budget,
+            level_compaction_dynamic_level_bytes,
+            universal_compaction_target_ratio,
+            parallelism,
+            compression_type,
+            bottommost_compression_type,
+            retry_max_duration,
+            dynamic: RocksDBDynamicConfig {
+                batch_size: Arc::new(AtomicUsize::new(batch_size)),
+            },
+        }
+    }
+
+    /// Apply the new parameters to the config. Dynamic parameters
+    /// are updated in place.
+    pub fn apply(&mut self, params: RocksDBTuningParameters) {
+        let RocksDBTuningParameters {
+            compaction_style,
+            optimize_compaction_memtable_budget,
+            level_compaction_dynamic_level_bytes,
+            universal_compaction_target_ratio,
+            parallelism,
+            compression_type,
+            bottommost_compression_type,
+            batch_size,
+            retry_max_duration,
+        } = params;
+
+        self.compaction_style = compaction_style;
+        self.optimize_compaction_memtable_budget = optimize_compaction_memtable_budget;
+        self.level_compaction_dynamic_level_bytes = level_compaction_dynamic_level_bytes;
+        self.universal_compaction_target_ratio = universal_compaction_target_ratio;
+        self.parallelism = parallelism;
+        self.compression_type = compression_type;
+        self.bottommost_compression_type = bottommost_compression_type;
+        self.retry_max_duration = retry_max_duration;
+
+        // SeqCst is probably not required here, but its the easiest to reason about
+        self.dynamic.batch_size.store(batch_size, Ordering::SeqCst);
+    }
+}
+
+/// The following are defaults (and default strings for LD parameters)
+/// for `RocksDBTuningParameters`.
+pub mod defaults {
+    use std::time::Duration;
+
+    use super::*;
+
+    pub const DEFAULT_COMPACTION_STYLE: CompactionStyle = CompactionStyle::Level;
+
+    /// From here: <https://github.com/facebook/rocksdb/blob/main/include/rocksdb/options.h#L102>
+    pub const DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET: usize = 512 * 1024 * 1024;
+
+    pub const DEFAULT_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES: bool = true;
+
+    /// From here: <https://docs.rs/rocksdb/latest/rocksdb/struct.UniversalCompactOptions.html>
+    pub const DEFAULT_UNIVERSAL_COMPACTION_RATIO: i32 = 200;
+
+    pub const DEFAULT_PARALLELISM: Option<i32> = None;
+
+    pub const DEFAULT_COMPRESSION_TYPE: CompressionType = CompressionType::Lz4;
+
+    pub const DEFAULT_BOTTOMMOST_COMPRESSION_TYPE: CompressionType = CompressionType::Zstd;
+
+    /// A reasonable default batch size for gets and puts in RocksDB. Based
+    /// on advice here: <https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ>.
+    pub const DEFAULT_BATCH_SIZE: usize = 1024;
+
+    /// The default max duration for retrying the retry-able errors in rocksdb.
+    pub const DEFAULT_RETRY_DURATION: Duration = Duration::from_secs(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_proto::protobuf_roundtrip;
+    use proptest::prelude::*;
+
+    use super::*;
+
+    #[mz_ore::test]
+    fn defaults_equality() {
+        let r = RocksDBTuningParameters::from_parameters(
+            defaults::DEFAULT_COMPACTION_STYLE,
+            defaults::DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET,
+            defaults::DEFAULT_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES,
+            defaults::DEFAULT_UNIVERSAL_COMPACTION_RATIO,
+            defaults::DEFAULT_PARALLELISM,
+            defaults::DEFAULT_COMPRESSION_TYPE,
+            defaults::DEFAULT_BOTTOMMOST_COMPRESSION_TYPE,
+            defaults::DEFAULT_BATCH_SIZE,
+            defaults::DEFAULT_RETRY_DURATION,
+        )
+        .unwrap();
+
+        assert_eq!(r, RocksDBTuningParameters::default());
+    }
+
+    #[mz_ore::test]
+    fn dynamic_defaults() {
+        assert_eq!(
+            RocksDBConfig::default()
+                .dynamic
+                .batch_size
+                .load(Ordering::SeqCst),
+            defaults::DEFAULT_BATCH_SIZE
+        )
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // too slow
+    fn rocksdb_tuning_roundtrip() {
+        proptest!(|(expect in any::<RocksDBTuningParameters>())| {
+            let actual = protobuf_roundtrip::<_, ProtoRocksDbTuningParameters>(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+
+        });
+    }
+}

--- a/src/rocksdb-types/src/lib.rs
+++ b/src/rocksdb-types/src/lib.rs
@@ -73,54 +73,14 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
-use std::env;
+//! An async wrapper around RocksDB, that does IO on a separate thread.
+//!
+//! This crate offers a limited API to communicate with RocksDB, to get
+//! the best performance possible (most importantly, by batching operations).
+//! Currently this API is only `upsert`, which replaces (or deletes) values for
+//! a set of keys, and returns the previous values.
 
-fn main() {
-    env::set_var("PROTOC", protobuf_src::protoc());
+#![warn(missing_docs)]
 
-    let mut config = prost_build::Config::new();
-    config.btree_map(["."]);
-
-    tonic_build::configure()
-        // Enabling `emit_rerun_if_changed` will rerun the build script when
-        // anything in the include directory (..) changes. This causes quite a
-        // bit of spurious recompilation, so we disable it. The default behavior
-        // is to re-run if any file in the crate changes; that's still a bit too
-        // broad, but it's better.
-        .emit_rerun_if_changed(false)
-        .extern_path(".mz_ccsr.config", "::mz_ccsr")
-        .extern_path(".mz_expr.id", "::mz_expr")
-        .extern_path(".mz_expr.linear", "::mz_expr")
-        .extern_path(".mz_expr.relation", "::mz_expr")
-        .extern_path(".mz_expr.scalar", "::mz_expr")
-        .extern_path(".mz_kafka_util.addr", "::mz_kafka_util")
-        .extern_path(".mz_postgres_util.desc", "::mz_postgres_util::desc")
-        .extern_path(".mz_repr.adt.regex", "::mz_repr::adt::regex")
-        .extern_path(".mz_repr.chrono", "::mz_repr::chrono")
-        .extern_path(".mz_repr.antichain", "::mz_repr::antichain")
-        .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
-        .extern_path(".mz_orchestrator", "::mz_orchestrator")
-        .extern_path(".mz_persist_client", "::mz_persist_client")
-        .extern_path(".mz_proto", "::mz_proto")
-        .extern_path(".mz_repr.relation_and_scalar", "::mz_repr")
-        .extern_path(".mz_repr.row", "::mz_repr")
-        .extern_path(".mz_repr.url", "::mz_repr::url")
-        .extern_path(".mz_rocksdb_types", "::mz_rocksdb_types")
-        .extern_path(".mz_cluster_client", "::mz_cluster_client")
-        .compile_with_config(
-            config,
-            &[
-                "storage-client/src/controller.proto",
-                "storage-client/src/client.proto",
-                "storage-client/src/types/errors.proto",
-                "storage-client/src/types/connections/aws.proto",
-                "storage-client/src/types/instances.proto",
-                "storage-client/src/types/parameters.proto",
-                "storage-client/src/types/sinks.proto",
-                "storage-client/src/types/sources.proto",
-                "storage-client/src/types/sources/encoding.proto",
-            ],
-            &[".."],
-        )
-        .unwrap_or_else(|e| panic!("{e}"))
-}
+pub mod config;
+pub use config::{defaults, RocksDBConfig, RocksDBTuningParameters};

--- a/src/rocksdb/src/config.rs
+++ b/src/rocksdb/src/config.rs
@@ -11,274 +11,35 @@
 // documentation on `RocksDBTuningParameters`.
 #![allow(missing_docs)]
 
-//! This module offers a `serde::Deserialize` implementation (to be used
-//! with LaunchDarkly) `RocksDBTuningParameters` that can be used
-//! to tune a RocksDB instance. The supported options are carefully
-//! considered to be a minimal set required to tune RocksDB to perform
-//! well for the `UPSERT` usecase. This usecase is slightly odd:
-//! - Very high write rate (1:1 with reads)
-//! - No durability requirements
-//! - Minimal space amplification
-//! - Relatively relaxed read and write latency requirements
-//!     - (note that `UPSERT` RocksDB instances are NOT in the
-//!     critical path for any sort of query.
-//!
-//! The defaults (so, the values resulting from derserializing `{}`
-//! into a `RocksDBTuningParameters`) should be reasonable defaults.
-//!
-//! The documentation on each field in `RocksDBTuningParameters` has more
-//! information
-//!
-//! Note that the following documents are required reading to deeply understand
-//! this module:
-//! - <https://github.com/EighteenZi/rocksdb_wiki/blob/master/RocksDB-Tuning-Guide.md>
-//! - <https://github.com/EighteenZi/rocksdb_wiki/blob/master/Compression.md>
-//! - <https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning>
-//! - <https://www.eecg.toronto.edu/~stumm/Papers/Dong-CIDR-16.pdf>
-//! - <http://smalldatum.blogspot.com/2015/11/read-write-space-amplification-pick-2_23.html>
+//! This module handles converting `mz_rocksdb_types` into `rocksdb` types.
 
-use std::str::FromStr;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
-
-use mz_ore::cast::CastFrom;
-use mz_proto::{IntoRustIfSome, RustType, TryFromProtoError};
-use proptest_derive::Arbitrary;
 use rocksdb::{DBCompactionStyle, DBCompressionType};
-use serde::{Deserialize, Serialize};
-use uncased::UncasedStr;
 
-include!(concat!(env!("OUT_DIR"), "/mz_rocksdb.config.rs"));
+pub use mz_rocksdb_types::config::defaults;
+pub use mz_rocksdb_types::config::*;
 
-/// A set of parameters to tune RocksDB. This struct is plain-old-data, and is
-/// used to update `RocksDBConfig`, which contains some dynamic value for some
-/// parameters.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, Arbitrary)]
-pub struct RocksDBTuningParameters {
-    /// RocksDB has 2 primary styles of compaction:
-    /// - The default, usually referred to as "level" compaction
-    /// - "universal"
-    ///
-    /// Universal is simpler and for some workloads could be
-    /// better. Also, you can directly configure its space-amplification ratio
-    /// (using `universal_compaction_target_ratio`). However, its unclear
-    /// if the `UPSERT` workload is a good workload for universal compaction,
-    /// and its also might be the case that universal compaction uses significantly
-    /// more space temporarily while performing compaction.
-    ///
-    /// For these reasons, the default is `CompactionStyle::Level`.
-    pub compaction_style: CompactionStyle,
-    /// The `RocksDB` api offers a single configuration method that sets some
-    /// reasonable defaults for heavy-write workloads, either
-    /// <https://docs.rs/rocksdb/latest/rocksdb/struct.Options.html#method.optimize_level_style_compaction>
-    /// or
-    /// <https://docs.rs/rocksdb/latest/rocksdb/struct.Options.html#method.optimize_universal_style_compaction>
-    /// depending on `compaction_style`. We ALSO enable this configuration, which is tuned
-    /// by the size of the memtable (basically the in-memory buffer used to avoid IO). The default
-    /// here is ~512MB, which is the default from here: <https://github.com/facebook/rocksdb/blob/main/include/rocksdb/options.h#L102>,
-    /// and about twice the global RocksDB default.
-    pub optimize_compaction_memtable_budget: usize,
-
-    /// This option, when enabled, dynamically tunes
-    /// the size of the various LSM levels to put a bound on space-amplification.
-    /// With the default level-ratio of `10`, this means space-amplification is
-    /// O(1.11 * the size of data). Note this is big-O notation, and the actual
-    /// amplification factor depends on the workload.
-    ///
-    /// See <https://www.eecg.toronto.edu/~stumm/Papers/Dong-CIDR-16.pdf> for more details.
-    ///
-    /// This option defaults to true, as its basically free saved-space, and only applies to
-    /// `CompactionStyle::Level`.
-    pub level_compaction_dynamic_level_bytes: bool,
-
-    /// The additional space-amplification used with universal compaction.
-    /// Only applies to `CompactionStyle::Universal`.
-    ///
-    /// See `compaction_style` for more information.
-    pub universal_compaction_target_ratio: i32,
-
-    /// By default, RocksDB uses only 1 thread to perform compaction and other background tasks.
-    ///
-    /// The default here is the number of cores, as mentioned by
-    /// <https://docs.rs/rocksdb/latest/rocksdb/struct.Options.html#method.increase_parallelism>.
-    ///
-    /// Note that this option is shared across all RocksDB instances that share a `rocksdb::Env`.
-    pub parallelism: Option<i32>,
-
-    /// The most important way to reduce space amplification in RocksDB is compression.
-    ///
-    /// In RocksDB, data on disk is stored in an LSM tree. Because the higher layers (which are
-    /// smaller) will need to be read during reads that aren't cached, we want a relatively
-    /// lightweight compression scheme, choosing `Lz4` as the default, which is considered almost
-    /// always better than `Snappy`.
-    ///
-    /// The meat of the data is stored in the largest, bottom layer, which can be configured
-    /// (using `bottommost_compression_type`) to use a more expensive compression scheme to save
-    /// more space. The default is `Zstd`, which many think has the best compression ratio. Note
-    /// that tuning the bottommost layer separately only makes sense when you have free cpu,
-    /// which we have in the case of the `UPSERT` usecase.
-    pub compression_type: CompressionType,
-
-    /// See `compression_type` for more information.
-    pub bottommost_compression_type: CompressionType,
-
-    /// The size of the `multi_get` and `multi_put` batches sent to RocksDB. The default is 1024.
-    pub batch_size: usize,
-
-    /// The maximum duration for the retries when performing rocksdb actions in case of retry-able errors.
-    pub retry_max_duration: Duration,
+/// An `Into` we can implement on foreign types
+trait IntoRocksDBType {
+    type Type;
+    fn into_rocksdb(self) -> Self::Type;
 }
 
-impl Default for RocksDBTuningParameters {
-    fn default() -> Self {
-        Self {
-            compaction_style: defaults::DEFAULT_COMPACTION_STYLE,
-            optimize_compaction_memtable_budget:
-                defaults::DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET,
-            level_compaction_dynamic_level_bytes:
-                defaults::DEFAULT_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES,
-            universal_compaction_target_ratio: defaults::DEFAULT_UNIVERSAL_COMPACTION_RATIO,
-            parallelism: defaults::DEFAULT_PARALLELISM,
-            compression_type: defaults::DEFAULT_COMPRESSION_TYPE,
-            bottommost_compression_type: defaults::DEFAULT_BOTTOMMOST_COMPRESSION_TYPE,
-            batch_size: defaults::DEFAULT_BATCH_SIZE,
-            retry_max_duration: defaults::DEFAULT_RETRY_DURATION,
-        }
-    }
-}
-
-impl RocksDBTuningParameters {
-    /// Build a `RocksDBTuningParameters` from strings and values from LD parameters.
-    pub fn from_parameters(
-        compaction_style: CompactionStyle,
-        optimize_compaction_memtable_budget: usize,
-        level_compaction_dynamic_level_bytes: bool,
-        universal_compaction_target_ratio: i32,
-        parallelism: Option<i32>,
-        compression_type: CompressionType,
-        bottommost_compression_type: CompressionType,
-        batch_size: usize,
-        retry_max_duration: Duration,
-    ) -> Result<Self, anyhow::Error> {
-        Ok(Self {
-            compaction_style,
-            optimize_compaction_memtable_budget,
-            level_compaction_dynamic_level_bytes,
-            universal_compaction_target_ratio: if universal_compaction_target_ratio > 100 {
-                universal_compaction_target_ratio
-            } else {
-                return Err(anyhow::anyhow!(
-                    "universal_compaction_target_ratio ({}) must be > 100",
-                    universal_compaction_target_ratio
-                ));
-            },
-            parallelism: match parallelism {
-                Some(parallelism) => {
-                    if parallelism < 1 {
-                        return Err(anyhow::anyhow!(
-                            "parallelism({}) must be > 1, or not specified",
-                            universal_compaction_target_ratio
-                        ));
-                    }
-                    Some(parallelism)
-                }
-                None => None,
-            },
-            compression_type,
-            bottommost_compression_type,
-            batch_size,
-            retry_max_duration,
-        })
-    }
-}
-
-/// The 2 primary compaction styles in RocksDB`. See `RocksDBTuningParameters::compaction_style`
-/// for more information.
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug, Arbitrary)]
-pub enum CompactionStyle {
-    Level,
-    Universal,
-}
-
-impl FromStr for CompactionStyle {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = UncasedStr::new(s);
-        if s == "level" {
-            Ok(Self::Level)
-        } else if s == "universal" {
-            Ok(Self::Universal)
-        } else {
-            Err(anyhow::anyhow!("{} is not a supported compaction style", s))
-        }
-    }
-}
-
-impl std::fmt::Display for CompactionStyle {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            CompactionStyle::Level => write!(f, "level"),
-            CompactionStyle::Universal => write!(f, "universal"),
-        }
-    }
-}
-
-impl From<CompactionStyle> for DBCompactionStyle {
-    fn from(cs: CompactionStyle) -> DBCompactionStyle {
+impl IntoRocksDBType for CompactionStyle {
+    type Type = DBCompactionStyle;
+    fn into_rocksdb(self) -> Self::Type {
         use CompactionStyle::*;
-        match cs {
+        match self {
             Level => DBCompactionStyle::Level,
             Universal => DBCompactionStyle::Universal,
         }
     }
 }
 
-/// Mz-supported compression types in RocksDB`. See `RocksDBTuningParameters::compression_type`
-/// for more information.
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug, Arbitrary)]
-pub enum CompressionType {
-    Zstd,
-    Snappy,
-    Lz4,
-    None,
-}
-
-impl FromStr for CompressionType {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = UncasedStr::new(s);
-        if s == "zstd" {
-            Ok(Self::Zstd)
-        } else if s == "snappy" {
-            Ok(Self::Snappy)
-        } else if s == "lz4" {
-            Ok(Self::Lz4)
-        } else if s == "none" {
-            Ok(Self::None)
-        } else {
-            Err(anyhow::anyhow!("{} is not a supported compression type", s))
-        }
-    }
-}
-
-impl std::fmt::Display for CompressionType {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            CompressionType::Zstd => write!(f, "zstd"),
-            CompressionType::Snappy => write!(f, "snappy"),
-            CompressionType::Lz4 => write!(f, "lz4"),
-            CompressionType::None => write!(f, "none"),
-        }
-    }
-}
-
-impl From<CompressionType> for DBCompressionType {
-    fn from(ct: CompressionType) -> DBCompressionType {
+impl IntoRocksDBType for CompressionType {
+    type Type = DBCompressionType;
+    fn into_rocksdb(self) -> Self::Type {
         use CompressionType::*;
-        match ct {
+        match self {
             Zstd => DBCompressionType::Zstd,
             Snappy => DBCompressionType::Snappy,
             Lz4 => DBCompressionType::Lz4,
@@ -286,332 +47,53 @@ impl From<CompressionType> for DBCompressionType {
         }
     }
 }
+/// Apply these tuning parameters to a `rocksdb::Options`. Some may
+/// be applied to a shared `Env` underlying the `Options`.
+pub fn apply_to_options(config: &RocksDBConfig, options: &mut rocksdb::Options) {
+    let RocksDBConfig {
+        compaction_style,
+        optimize_compaction_memtable_budget,
+        level_compaction_dynamic_level_bytes,
+        universal_compaction_target_ratio,
+        parallelism,
+        compression_type,
+        bottommost_compression_type,
+        retry_max_duration: _,
+        dynamic: _,
+    } = config;
 
-impl RustType<ProtoRocksDbTuningParameters> for RocksDBTuningParameters {
-    fn into_proto(&self) -> ProtoRocksDbTuningParameters {
-        use proto_rocks_db_tuning_parameters::{
-            proto_compaction_style, proto_compression_type, ProtoCompactionStyle,
-            ProtoCompressionType,
-        };
+    options.set_compression_type((*compression_type).into_rocksdb());
 
-        fn compression_into_proto(compression_type: &CompressionType) -> ProtoCompressionType {
-            ProtoCompressionType {
-                kind: Some(match compression_type {
-                    CompressionType::Zstd => proto_compression_type::Kind::Zstd(()),
-                    CompressionType::Snappy => proto_compression_type::Kind::Snappy(()),
-                    CompressionType::Lz4 => proto_compression_type::Kind::Lz4(()),
-                    CompressionType::None => proto_compression_type::Kind::None(()),
-                }),
-            }
+    if *bottommost_compression_type != CompressionType::None {
+        options.set_bottommost_compression_type((*bottommost_compression_type).into_rocksdb())
+    }
+
+    options.set_compaction_style((*compaction_style).into_rocksdb());
+    match compaction_style {
+        CompactionStyle::Level => {
+            options.optimize_level_style_compaction(*optimize_compaction_memtable_budget);
+            options.set_level_compaction_dynamic_level_bytes(*level_compaction_dynamic_level_bytes);
         }
-        ProtoRocksDbTuningParameters {
-            compaction_style: Some(ProtoCompactionStyle {
-                kind: Some(match self.compaction_style {
-                    CompactionStyle::Level => proto_compaction_style::Kind::Level(()),
-                    CompactionStyle::Universal => proto_compaction_style::Kind::Universal(()),
-                }),
-            }),
-            optimize_compaction_memtable_budget: u64::cast_from(
-                self.optimize_compaction_memtable_budget,
-            ),
-            level_compaction_dynamic_level_bytes: self.level_compaction_dynamic_level_bytes,
-            universal_compaction_target_ratio: self.universal_compaction_target_ratio,
-            parallelism: self.parallelism,
-            compression_type: Some(compression_into_proto(&self.compression_type)),
-            bottommost_compression_type: Some(compression_into_proto(
-                &self.bottommost_compression_type,
-            )),
-            batch_size: u64::cast_from(self.batch_size),
-            retry_max_duration: Some(self.retry_max_duration.into_proto()),
-        }
-    }
+        CompactionStyle::Universal => {
+            options.optimize_universal_style_compaction(*optimize_compaction_memtable_budget);
+            options.set_level_compaction_dynamic_level_bytes(*level_compaction_dynamic_level_bytes);
 
-    fn from_proto(proto: ProtoRocksDbTuningParameters) -> Result<Self, TryFromProtoError> {
-        use proto_rocks_db_tuning_parameters::{
-            proto_compaction_style, proto_compression_type, ProtoCompactionStyle,
-            ProtoCompressionType,
-        };
+            let mut universal_options = rocksdb::UniversalCompactOptions::default();
+            universal_options
+                .set_max_size_amplification_percent(*universal_compaction_target_ratio);
 
-        fn compression_from_proto(
-            compression_type: Option<ProtoCompressionType>,
-        ) -> Result<CompressionType, TryFromProtoError> {
-            match compression_type {
-                Some(ProtoCompressionType {
-                    kind: Some(proto_compression_type::Kind::Zstd(())),
-                }) => Ok(CompressionType::Zstd),
-                Some(ProtoCompressionType {
-                    kind: Some(proto_compression_type::Kind::Snappy(())),
-                }) => Ok(CompressionType::Snappy),
-                Some(ProtoCompressionType {
-                    kind: Some(proto_compression_type::Kind::Lz4(())),
-                }) => Ok(CompressionType::Lz4),
-                Some(ProtoCompressionType {
-                    kind: Some(proto_compression_type::Kind::None(())),
-                }) => Ok(CompressionType::None),
-                Some(ProtoCompressionType { kind: None }) => Err(TryFromProtoError::MissingField(
-                    "ProtoRocksDbTuningParameters::compression_type::kind".into(),
-                )),
-                None => Err(TryFromProtoError::MissingField(
-                    "ProtoRocksDbTuningParameters::compression_type".into(),
-                )),
-            }
-        }
-        Ok(Self {
-            compaction_style: match proto.compaction_style {
-                Some(ProtoCompactionStyle {
-                    kind: Some(proto_compaction_style::Kind::Level(())),
-                }) => CompactionStyle::Level,
-                Some(ProtoCompactionStyle {
-                    kind: Some(proto_compaction_style::Kind::Universal(())),
-                }) => CompactionStyle::Universal,
-                Some(ProtoCompactionStyle { kind: None }) => {
-                    return Err(TryFromProtoError::MissingField(
-                        "ProtoRocksDbTuningParameters::compaction_style::kind".into(),
-                    ))
-                }
-                None => {
-                    return Err(TryFromProtoError::MissingField(
-                        "ProtoRocksDbTuningParameters::compaction_style".into(),
-                    ))
-                }
-            },
-            optimize_compaction_memtable_budget: usize::cast_from(
-                proto.optimize_compaction_memtable_budget,
-            ),
-            level_compaction_dynamic_level_bytes: proto.level_compaction_dynamic_level_bytes,
-            universal_compaction_target_ratio: proto.universal_compaction_target_ratio,
-            parallelism: proto.parallelism,
-            compression_type: compression_from_proto(proto.compression_type)?,
-            bottommost_compression_type: compression_from_proto(proto.bottommost_compression_type)?,
-            batch_size: usize::cast_from(proto.batch_size),
-            retry_max_duration: proto
-                .retry_max_duration
-                .into_rust_if_some("ProtoRocksDbTuningParameters::retry_max_duration")?,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct RocksDBDynamicConfig {
-    batch_size: Arc<AtomicUsize>,
-}
-
-impl RocksDBDynamicConfig {
-    pub(crate) fn batch_size(&self) -> usize {
-        // SeqCst is probably not required here, but its the easiest to reason about
-        self.batch_size.load(Ordering::SeqCst)
-    }
-}
-
-/// Configurable options for a `RocksDBInstance`. Some can be updated
-/// dynamically, as cloned instances of this object will shared dynamic values.
-#[derive(Debug, Clone)]
-pub struct RocksDBConfig {
-    compaction_style: CompactionStyle,
-    optimize_compaction_memtable_budget: usize,
-    level_compaction_dynamic_level_bytes: bool,
-    universal_compaction_target_ratio: i32,
-    parallelism: Option<i32>,
-    compression_type: CompressionType,
-    bottommost_compression_type: CompressionType,
-    pub(crate) retry_max_duration: Duration,
-    pub(crate) dynamic: RocksDBDynamicConfig,
-}
-
-impl Default for RocksDBConfig {
-    fn default() -> Self {
-        RocksDBConfig::new(RocksDBTuningParameters::default())
-    }
-}
-
-impl RocksDBConfig {
-    fn new(params: RocksDBTuningParameters) -> Self {
-        let RocksDBTuningParameters {
-            compaction_style,
-            optimize_compaction_memtable_budget,
-            level_compaction_dynamic_level_bytes,
-            universal_compaction_target_ratio,
-            parallelism,
-            compression_type,
-            bottommost_compression_type,
-            batch_size,
-            retry_max_duration,
-        } = params;
-
-        Self {
-            compaction_style,
-            optimize_compaction_memtable_budget,
-            level_compaction_dynamic_level_bytes,
-            universal_compaction_target_ratio,
-            parallelism,
-            compression_type,
-            bottommost_compression_type,
-            retry_max_duration,
-            dynamic: RocksDBDynamicConfig {
-                batch_size: Arc::new(AtomicUsize::new(batch_size)),
-            },
+            options.set_universal_compaction_options(&universal_options);
         }
     }
 
-    /// Apply the new parameters to the config. Dynamic parameters
-    /// are updated in place.
-    pub fn apply(&mut self, params: RocksDBTuningParameters) {
-        let RocksDBTuningParameters {
-            compaction_style,
-            optimize_compaction_memtable_budget,
-            level_compaction_dynamic_level_bytes,
-            universal_compaction_target_ratio,
-            parallelism,
-            compression_type,
-            bottommost_compression_type,
-            batch_size,
-            retry_max_duration,
-        } = params;
-
-        self.compaction_style = compaction_style;
-        self.optimize_compaction_memtable_budget = optimize_compaction_memtable_budget;
-        self.level_compaction_dynamic_level_bytes = level_compaction_dynamic_level_bytes;
-        self.universal_compaction_target_ratio = universal_compaction_target_ratio;
-        self.parallelism = parallelism;
-        self.compression_type = compression_type;
-        self.bottommost_compression_type = bottommost_compression_type;
-        self.retry_max_duration = retry_max_duration;
-
-        // SeqCst is probably not required here, but its the easiest to reason about
-        self.dynamic.batch_size.store(batch_size, Ordering::SeqCst);
-    }
-
-    /// Apply these tuning parameters to a `rocksdb::Options`. Some may
-    /// be applied to a shared `Env` underlying the `Options`.
-    pub fn apply_to_options(&self, options: &mut rocksdb::Options) {
-        let RocksDBConfig {
-            compaction_style,
-            optimize_compaction_memtable_budget,
-            level_compaction_dynamic_level_bytes,
-            universal_compaction_target_ratio,
-            parallelism,
-            compression_type,
-            bottommost_compression_type,
-            retry_max_duration: _,
-            dynamic: _,
-        } = self;
-
-        options.set_compression_type((*compression_type).into());
-
-        if *bottommost_compression_type != CompressionType::None {
-            options.set_bottommost_compression_type((*bottommost_compression_type).into())
-        }
-
-        options.set_compaction_style((*compaction_style).into());
-        match compaction_style {
-            CompactionStyle::Level => {
-                options.optimize_level_style_compaction(*optimize_compaction_memtable_budget);
-                options.set_level_compaction_dynamic_level_bytes(
-                    *level_compaction_dynamic_level_bytes,
-                );
-            }
-            CompactionStyle::Universal => {
-                options.optimize_universal_style_compaction(*optimize_compaction_memtable_budget);
-                options.set_level_compaction_dynamic_level_bytes(
-                    *level_compaction_dynamic_level_bytes,
-                );
-
-                let mut universal_options = rocksdb::UniversalCompactOptions::default();
-                universal_options
-                    .set_max_size_amplification_percent(*universal_compaction_target_ratio);
-
-                options.set_universal_compaction_options(&universal_options);
-            }
-        }
-
-        let parallelism = if let Some(parallelism) = parallelism {
-            *parallelism
-        } else {
-            // TODO(guswynn): it's unclear if this should be `get_physical`. The
-            // RocksDB docs do not make it clear.
-            num_cpus::get()
-                .try_into()
-                .expect("More than 3 billion cores")
-        };
-        options.increase_parallelism(parallelism);
-    }
-}
-
-/// The following are defaults (and default strings for LD parameters)
-/// for `RocksDBTuningParameters`.
-pub mod defaults {
-    use std::time::Duration;
-
-    use super::*;
-
-    pub const DEFAULT_COMPACTION_STYLE: CompactionStyle = CompactionStyle::Level;
-
-    /// From here: <https://github.com/facebook/rocksdb/blob/main/include/rocksdb/options.h#L102>
-    pub const DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET: usize = 512 * 1024 * 1024;
-
-    pub const DEFAULT_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES: bool = true;
-
-    /// From here: <https://docs.rs/rocksdb/latest/rocksdb/struct.UniversalCompactOptions.html>
-    pub const DEFAULT_UNIVERSAL_COMPACTION_RATIO: i32 = 200;
-
-    pub const DEFAULT_PARALLELISM: Option<i32> = None;
-
-    pub const DEFAULT_COMPRESSION_TYPE: CompressionType = CompressionType::Lz4;
-
-    pub const DEFAULT_BOTTOMMOST_COMPRESSION_TYPE: CompressionType = CompressionType::Zstd;
-
-    /// A reasonable default batch size for gets and puts in RocksDB. Based
-    /// on advice here: <https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ>.
-    pub const DEFAULT_BATCH_SIZE: usize = 1024;
-
-    /// The default max duration for retrying the retry-able errors in rocksdb.
-    pub const DEFAULT_RETRY_DURATION: Duration = Duration::from_secs(1);
-}
-
-#[cfg(test)]
-mod tests {
-    use mz_proto::protobuf_roundtrip;
-    use proptest::prelude::*;
-
-    use super::*;
-
-    #[mz_ore::test]
-    fn defaults_equality() {
-        let r = RocksDBTuningParameters::from_parameters(
-            defaults::DEFAULT_COMPACTION_STYLE,
-            defaults::DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET,
-            defaults::DEFAULT_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES,
-            defaults::DEFAULT_UNIVERSAL_COMPACTION_RATIO,
-            defaults::DEFAULT_PARALLELISM,
-            defaults::DEFAULT_COMPRESSION_TYPE,
-            defaults::DEFAULT_BOTTOMMOST_COMPRESSION_TYPE,
-            defaults::DEFAULT_BATCH_SIZE,
-            defaults::DEFAULT_RETRY_DURATION,
-        )
-        .unwrap();
-
-        assert_eq!(r, RocksDBTuningParameters::default());
-    }
-
-    #[mz_ore::test]
-    fn dynamic_defaults() {
-        assert_eq!(
-            RocksDBConfig::default()
-                .dynamic
-                .batch_size
-                .load(Ordering::SeqCst),
-            defaults::DEFAULT_BATCH_SIZE
-        )
-    }
-
-    #[mz_ore::test]
-    #[cfg_attr(miri, ignore)] // too slow
-    fn rocksdb_tuning_roundtrip() {
-        proptest!(|(expect in any::<RocksDBTuningParameters>())| {
-            let actual = protobuf_roundtrip::<_, ProtoRocksDbTuningParameters>(&expect);
-            assert!(actual.is_ok());
-            assert_eq!(actual.unwrap(), expect);
-
-        });
-    }
+    let parallelism = if let Some(parallelism) = parallelism {
+        *parallelism
+    } else {
+        // TODO(guswynn): it's unclear if this should be `get_physical`. The
+        // RocksDB docs do not make it clear.
+        num_cpus::get()
+            .try_into()
+            .expect("More than 3 billion cores")
+    };
+    options.increase_parallelism(parallelism);
 }

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -155,7 +155,7 @@ impl InstanceOptions {
         // Set the env first so tuning applies to the shared `Env`.
         options.set_env(&self.env);
 
-        tuning_config.apply_to_options(&mut options);
+        config::apply_to_options(tuning_config, &mut options);
 
         options
     }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -33,7 +33,7 @@ mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util", features = ["privileges"] }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr", features = ["tracing_"] }
-mz-rocksdb = { path = "../rocksdb" }
+mz-rocksdb-types = { path = "../rocksdb-types" }
 mz-secrets = { path = "../secrets" }
 mz-sql-parser = { path = "../sql-parser" }
 mz-stash = { path = "../stash" }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -588,7 +588,7 @@ const UPSERT_SOURCE_DISK_DEFAULT: ServerVar<bool> = ServerVar {
 mod upsert_rocksdb {
     use std::str::FromStr;
 
-    use mz_rocksdb::config::{CompactionStyle, CompressionType};
+    use mz_rocksdb_types::config::{CompactionStyle, CompressionType};
 
     use super::*;
 
@@ -630,75 +630,75 @@ mod upsert_rocksdb {
 
     pub static UPSERT_ROCKSDB_COMPACTION_STYLE: ServerVar<CompactionStyle> = ServerVar {
         name: UncasedStr::new("upsert_rocksdb_compaction_style"),
-        value: &mz_rocksdb::defaults::DEFAULT_COMPACTION_STYLE,
+        value: &mz_rocksdb_types::defaults::DEFAULT_COMPACTION_STYLE,
         description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb::config` module. \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
                   Only takes effect on source restart (Materialize).",
         internal: true,
     };
     pub const UPSERT_ROCKSDB_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET: ServerVar<usize> = ServerVar {
         name: UncasedStr::new("upsert_rocksdb_optimize_compaction_memtable_budget"),
-        value: &mz_rocksdb::defaults::DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET,
+        value: &mz_rocksdb_types::defaults::DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET,
         description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb::config` module. \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
                   Only takes effect on source restart (Materialize).",
         internal: true,
     };
     pub const UPSERT_ROCKSDB_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES: ServerVar<bool> = ServerVar {
         name: UncasedStr::new("upsert_rocksdb_level_compaction_dynamic_level_bytes"),
-        value: &mz_rocksdb::defaults::DEFAULT_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES,
+        value: &mz_rocksdb_types::defaults::DEFAULT_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES,
         description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb::config` module. \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
                   Only takes effect on source restart (Materialize).",
         internal: true,
     };
     pub const UPSERT_ROCKSDB_UNIVERSAL_COMPACTION_RATIO: ServerVar<i32> = ServerVar {
         name: UncasedStr::new("upsert_rocksdb_universal_compaction_ratio"),
-        value: &mz_rocksdb::defaults::DEFAULT_UNIVERSAL_COMPACTION_RATIO,
+        value: &mz_rocksdb_types::defaults::DEFAULT_UNIVERSAL_COMPACTION_RATIO,
         description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb::config` module. \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
                   Only takes effect on source restart (Materialize).",
         internal: true,
     };
     pub const UPSERT_ROCKSDB_PARALLELISM: ServerVar<Option<i32>> = ServerVar {
         name: UncasedStr::new("upsert_rocksdb_parallelism"),
-        value: &mz_rocksdb::defaults::DEFAULT_PARALLELISM,
+        value: &mz_rocksdb_types::defaults::DEFAULT_PARALLELISM,
         description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb::config` module. \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
                   Only takes effect on source restart (Materialize).",
         internal: true,
     };
     pub static UPSERT_ROCKSDB_COMPRESSION_TYPE: ServerVar<CompressionType> = ServerVar {
         name: UncasedStr::new("upsert_rocksdb_compression_type"),
-        value: &mz_rocksdb::defaults::DEFAULT_COMPRESSION_TYPE,
+        value: &mz_rocksdb_types::defaults::DEFAULT_COMPRESSION_TYPE,
         description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb::config` module. \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
                   Only takes effect on source restart (Materialize).",
         internal: true,
     };
     pub static UPSERT_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE: ServerVar<CompressionType> = ServerVar {
         name: UncasedStr::new("upsert_rocksdb_bottommost_compression_type"),
-        value: &mz_rocksdb::defaults::DEFAULT_BOTTOMMOST_COMPRESSION_TYPE,
+        value: &mz_rocksdb_types::defaults::DEFAULT_BOTTOMMOST_COMPRESSION_TYPE,
         description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb::config` module. \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
                   Only takes effect on source restart (Materialize).",
         internal: true,
     };
 
     pub static UPSERT_ROCKSDB_BATCH_SIZE: ServerVar<usize> = ServerVar {
         name: UncasedStr::new("upsert_rocksdb_batch_size"),
-        value: &mz_rocksdb::defaults::DEFAULT_BATCH_SIZE,
+        value: &mz_rocksdb_types::defaults::DEFAULT_BATCH_SIZE,
         description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb::config` module. \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
                   Can be changed dynamically (Materialize).",
         internal: true,
     };
 
     pub static UPSERT_ROCKSDB_RETRY_DURATION: ServerVar<Duration> = ServerVar {
         name: UncasedStr::new("upsert_rocksdb_retry_duration"),
-        value: &mz_rocksdb::defaults::DEFAULT_RETRY_DURATION,
+        value: &mz_rocksdb_types::defaults::DEFAULT_RETRY_DURATION,
         description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb::config` module. \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
                   Only takes effect on source restart (Materialize).",
         internal: true,
     };
@@ -2053,7 +2053,7 @@ impl SystemVars {
         *self.expect_value(&UPSERT_SOURCE_DISK_DEFAULT)
     }
 
-    pub fn upsert_rocksdb_compaction_style(&self) -> mz_rocksdb::config::CompactionStyle {
+    pub fn upsert_rocksdb_compaction_style(&self) -> mz_rocksdb_types::config::CompactionStyle {
         *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_COMPACTION_STYLE)
     }
 
@@ -2073,13 +2073,13 @@ impl SystemVars {
         *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_PARALLELISM)
     }
 
-    pub fn upsert_rocksdb_compression_type(&self) -> mz_rocksdb::config::CompressionType {
+    pub fn upsert_rocksdb_compression_type(&self) -> mz_rocksdb_types::config::CompressionType {
         *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_COMPRESSION_TYPE)
     }
 
     pub fn upsert_rocksdb_bottommost_compression_type(
         &self,
-    ) -> mz_rocksdb::config::CompressionType {
+    ) -> mz_rocksdb_types::config::CompressionType {
         *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE)
     }
 

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -36,7 +36,7 @@ mz-persist-types = { path = "../persist-types" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-proto = { path = "../proto", features = ["tokio-postgres"] }
 mz-repr = { path = "../repr" }
-mz-rocksdb = { path = "../rocksdb" }
+mz-rocksdb-types = { path = "../rocksdb-types" }
 mz-secrets = { path = "../secrets" }
 mz-service = { path = "../service" }
 mz-ssh-util = { path = "../ssh-util" }

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -11,7 +11,7 @@ syntax = "proto3";
 
 import "proto/src/proto.proto";
 import "persist-client/src/cfg.proto";
-import "rocksdb/src/config.proto";
+import "rocksdb-types/src/config.proto";
 
 package mz_storage_client.types.parameters;
 
@@ -20,7 +20,7 @@ message ProtoStorageParameters {
     mz_persist_client.cfg.ProtoPersistParameters persist = 1;
     ProtoPgReplicationTimeouts pg_replication_timeouts = 3;
     uint64 keep_n_source_status_history_entries = 4;
-    mz_rocksdb.config.ProtoRocksDbTuningParameters upsert_rocksdb_tuning_config = 5;
+    mz_rocksdb_types.config.ProtoRocksDbTuningParameters upsert_rocksdb_tuning_config = 5;
     bool finalize_shards = 6;
     uint64 keep_n_sink_status_history_entries = 7;
 }

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -31,7 +31,7 @@ pub struct StorageParameters {
     pub keep_n_source_status_history_entries: usize,
     pub keep_n_sink_status_history_entries: usize,
     /// A set of parameters used to tune RocksDB when used with `UPSERT` sources.
-    pub upsert_rocksdb_tuning_config: mz_rocksdb::RocksDBTuningParameters,
+    pub upsert_rocksdb_tuning_config: mz_rocksdb_types::RocksDBTuningParameters,
     /// Whether or not to allow shard finalization to occur. Note that this will
     /// only disable the actual finalization of shards, not registering them for
     /// finalization.

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -61,7 +61,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = { version = "1.7.0" }
-rocksdb = { version = "0.21.0", default-features = false, features = ["snappy"] }
+rocksdb = { version = "0.21.0", default-features = false, features = ["snappy", "zstd", "lz4"] }
 seahash = "4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }


### PR DESCRIPTION
Closes https://github.com/MaterializeInc/materialize/issues/19911

### Motivation
   * This PR refactors existing code.
 
### Tips for reviewer


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

