### PR TITLE
sql: Prevent SHOW commands in views

### DIFF
--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -196,6 +196,7 @@ pub enum PlanError {
     FromValueRequiresParen,
     VarError(VarError),
     UnsolvablePolymorphicFunctionInput,
+    ShowCommandInView,
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -490,6 +491,7 @@ impl fmt::Display for PlanError {
             Self::UnsolvablePolymorphicFunctionInput => f.write_str(
                 "could not determine polymorphic type because input has type unknown"
             ),
+            Self::ShowCommandInView => f.write_str("SHOW commands are not allowed in views"),
         }
     }
 }

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -127,6 +127,7 @@ pub async fn run_sql(mut cmd: SqlCommand, state: &mut State) -> Result<ControlFl
         | Statement::CreateSource { .. }
         | Statement::CreateTable { .. }
         | Statement::CreateView { .. }
+        | Statement::CreateMaterializedView { .. }
         | Statement::DropObjects { .. } => {
             let disk_state = state
                 .with_catalog_copy(|catalog| catalog.state().dump())

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -370,52 +370,48 @@ ALTER VIEW mv RENAME TO mv2
 statement error materialize\.public\.mv is not a view\nHINT: Use EXPLAIN \[\.\.\.\] MATERIALIZED VIEW to explain a materialized view\.
 EXPLAIN WITH(arity, join_impls) VIEW mv
 
-# We should be able to create materialized views on top of 'SHOW' commands.
+# We should not be able to create materialized views on top of 'SHOW' commands.
 
-statement ok
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_clusters AS SELECT name FROM (SHOW CLUSTERS);
 
-# Depends on an mz_internal table.
-statement error cannot create materialized view with unstable dependencies
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_cluster_replicas AS SELECT cluster, replica, size, ready FROM (SHOW CLUSTER REPLICAS);
 
-# Note: the only reason we use mat_clusters here, is because we know it should exist.
-statement ok
-CREATE MATERIALIZED VIEW mat_columns AS SELECT name, nullable, type FROM (SHOW COLUMNS FROM mat_clusters);
+statement error SHOW commands are not allowed in views
+CREATE MATERIALIZED VIEW mat_columns AS SELECT name, nullable, type FROM (SHOW COLUMNS FROM mz_tables);
 
-statement ok
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_connections AS SELECT name, type FROM (SHOW CONNECTIONS);
 
-statement ok
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_databases AS SELECT name FROM (SHOW DATABASES);
 
-# Depends on an mz_internal table.
-statement error cannot create materialized view with unstable dependencies
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_indexes AS SELECT name, on, cluster, key FROM (SHOW INDEXES);
 
-# Depends on an mz_internal table.
-statement error cannot create materialized view with unstable dependencies
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_mat_views AS SELECT name, cluster FROM (SHOW MATERIALIZED VIEWS);
 
-statement ok
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_objects AS SELECT name FROM (SHOW OBJECTS);
 
-statement ok
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_schemas AS SELECT name FROM (SHOW SCHEMAS);
 
-statement ok
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_secrets AS SELECT name FROM (SHOW SECRETS);
 
-statement ok
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_sinks AS SELECT name, type, size FROM (SHOW SINKS);
 
-statement ok
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_sources AS SELECT name, type, size FROM (SHOW SOURCES);
 
-statement ok
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_tables AS SELECT name FROM (SHOW TABLES);
 
-statement ok
+statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_views AS SELECT name FROM (SHOW VIEWS);
 
 # Cleanup


### PR DESCRIPTION
When a view is created with a SHOW command, the create SQL definition will have the explicit `SHOW` command in it. Many `SHOW` commands will expand into a sub-query that involves the current schema of the executing user. When Materialize restarts and tries to re-plan these queries, it will only have access to the raw `SHOW` command and have no idea what schema to use. As a result Materialize will fail to boot.

Some `SHOW` commands are ok, like `SHOW CLUSTERS`, and there are probably other ways around this issue. Such as expanding the `SHOW` command in the SQL definition. Or explicitly using an unmaterializable function in the HIR to prevent problematic views. For now, we just disallow any `SHOW` commands in views since the issue exists in prod and can corrupt catalogs.

This is a potentially breaking change since some existing views with
`SHOW` might exist in production.

Fixes #20188

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Prevent creating views and materializable views with `SHOW` commands.
