### PR TITLE
cloudtest: Support --dev and --log_filter in upgrade tests

### DIFF
--- a/test/cloudtest/conftest.py
+++ b/test/cloudtest/conftest.py
@@ -34,6 +34,16 @@ def mz(pytestconfig: pytest.Config) -> MaterializeApplication:
 
 
 @pytest.fixture(scope="session")
+def log_filter(pytestconfig: pytest.Config) -> Any:
+    return pytestconfig.getoption("log_filter")
+
+
+@pytest.fixture(scope="session")
+def dev(pytestconfig: pytest.Config) -> Any:
+    return pytestconfig.getoption("dev")
+
+
+@pytest.fixture(scope="session")
 def aws_region(pytestconfig: pytest.Config) -> Any:
     return pytestconfig.getoption("aws_region")
 

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -42,10 +42,17 @@ class CloudtestUpgrade(Scenario):
 
 
 @pytest.mark.long
-def test_upgrade(aws_region: Optional[str]) -> None:
+def test_upgrade(
+    aws_region: Optional[str], log_filter: Optional[str], dev: bool
+) -> None:
     """Test upgrade from the last released verison to the current source by running all the Platform Checks"""
 
-    mz = MaterializeApplication(tag=str(LAST_RELEASED_VERSION), aws_region=aws_region)
+    mz = MaterializeApplication(
+        tag=str(LAST_RELEASED_VERSION),
+        aws_region=aws_region,
+        log_filter=log_filter,
+        release_mode=(not dev),
+    )
     wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
 
     executor = CloudtestExecutor(application=mz)


### PR DESCRIPTION
Fixes: #20252

Worked for me locally.

The `--dev` flag originally came from https://github.com/MaterializeInc/materialize/pull/15075

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
