### PR TITLE
test: Fix cloudtest upgrade test version gating

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -95,7 +95,7 @@ class ConfigureMz(MzcomposeAction):
             system_settings.add(
                 "ALTER ROLE materialize CREATEROLE CREATEDB CREATECLUSTER;"
             )
-        elif e.current_mz_version >= MzVersion.parse("0.59.0-dev"):
+        elif e.current_mz_version >= MzVersion.parse("0.59.0"):
             system_settings.add("GRANT ALL PRIVILEGES ON SYSTEM TO materialize;")
 
         if e.current_mz_version >= MzVersion(0, 47, 0):

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -339,7 +339,7 @@ impl State {
             }
         }
 
-        // Alter materialize user with all attributes.
+        // Alter materialize user with all system privileges.
         inner_client
             .batch_execute(&format!(
                 "GRANT ALL PRIVILEGES ON SYSTEM TO {}",


### PR DESCRIPTION
Fixes #20246

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
