### PR TITLE
adapter: correct initial timestamp determination in transactions

### DIFF
--- a/src/adapter/src/coord/id_bundle.rs
+++ b/src/adapter/src/coord/id_bundle.rs
@@ -84,7 +84,7 @@ impl Coordinator {
         session: &Session,
         id_bundle: &CollectionIdBundle,
     ) -> Vec<String> {
-        id_bundle
+        let mut names: Vec<_> = id_bundle
             .iter()
             // This could filter out an entry that has been replaced in another transaction.
             .filter_map(|id| self.catalog().try_get_entry(&id))
@@ -93,6 +93,8 @@ impl Coordinator {
                     .resolve_full_name(item.name(), Some(session.conn_id()))
                     .to_string()
             })
-            .collect()
+            .collect();
+        names.sort();
+        names
     }
 }


### PR DESCRIPTION
In #19026 various timestamp functions were refactored to allow `EXPLAIN TIMESTAMP` to reflect (and effect) the current transaction. This is tricky code and the refactor incorrectly changed the behavior of transactions. In a transaction our intention is to find a timestamp during the first statement that will be valid for any other object a user might query later in the transaction, then aquire read holds on all those referenced objects. In that change, the first statement only used the referenced IDs when determining a timestamp, not all nearby (objects in the same schema) IDs. Read holds were still correctly aquired on all nearby objects.

This could cause the transaction's timestamp to not be in advance of the since of other nearby objects. For example, take two objects in the table. At the first query, object A has a since of 10, object B has a since of 20. A first query in the transaction `SELECT * FROM A` would choose 10 as its timestamp, then aquire read holds on A and B at 10. A later query in the transaction `SELECT * FROM B` would choose 10 as its timestamp (which it fetched from the in-progress transaction state), and panic because B's since is in advance of 10.

One of the reasons this happened is the transaction metadata only held on to the TimestampContext. `EXPLAIN TIMESTAMP` needs a larger struct, a TimestampDetermination. Teach the session metadata to track this outer struct so EXPLAIN can use it. This allows us to now only call determine_timestamp once during transaction start, instead of during each query in a transaction. Refactor some of the other read handling code to look more like it did pre-19026.

After this code, the test repro from 19743 no longer causes crashes.

Fixes #19743
Fixes #19897
Fixes #19398

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

* Looking at the code right before 19026 is useful: https://github.com/MaterializeInc/materialize/blob/0e5efd4f537b9a78ba71a76b2e15e0c3191b6c67/src/adapter/src/coord/sequencer/inner.rs#L2242

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix timestamp generation for transactions with multiple statements that could lead to crashes.