### PR TITLE
storage: heuristic to detect topic recreation

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -689,6 +689,19 @@ Add partitions to an existing topic
 
 Create a Kafka topic
 
+#### `$ kafka-delete-topic-flaky`
+
+Delete a Kafka topic
+
+Even though `kafka-delete-topic-flaky` ensures that the topic no longer exists
+in the broker metadata there is still work to be done asychnronously before
+it's truly gone that must complete before we attempt to recreate it. There is
+no way to observe this work completing so the only option left is sleeping for
+a while after executing this command. 
+
+For this reason this command must be used with great care or not at all,
+otherwise there is a risk of introducing flakiness in CI.
+
 #### `$ kafka-ingest topic=... schema=... ...`
 
 Sends the data provided to a kafka topic. This action has many arguments:

--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -697,7 +697,7 @@ Even though `kafka-delete-topic-flaky` ensures that the topic no longer exists
 in the broker metadata there is still work to be done asychnronously before
 it's truly gone that must complete before we attempt to recreate it. There is
 no way to observe this work completing so the only option left is sleeping for
-a while after executing this command. 
+a while after executing this command.
 
 For this reason this command must be used with great care or not at all,
 otherwise there is a risk of introducing flakiness in CI.

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -525,6 +525,7 @@ impl Run for PosCommand {
                     "http-request" => http::run_request(builtin, state).await,
                     "kafka-add-partitions" => kafka::run_add_partitions(builtin, state).await,
                     "kafka-create-topic" => kafka::run_create_topic(builtin, state).await,
+                    "kafka-delete-topic-flaky" => kafka::run_delete_topic(builtin, state).await,
                     "kafka-ingest" => kafka::run_ingest(builtin, state).await,
                     "kafka-verify-data" => kafka::run_verify_data(builtin, state).await,
                     "kafka-verify-commit" => kafka::run_verify_commit(builtin, state).await,

--- a/src/testdrive/src/action/kafka.rs
+++ b/src/testdrive/src/action/kafka.rs
@@ -9,12 +9,14 @@
 
 mod add_partitions;
 mod create_topic;
+mod delete_topic;
 mod ingest;
 mod verify_commit;
 mod verify_data;
 
 pub use add_partitions::run_add_partitions;
 pub use create_topic::run_create_topic;
+pub use delete_topic::run_delete_topic;
 pub use ingest::run_ingest;
 pub use verify_commit::run_verify_commit;
 pub use verify_data::run_verify_data;

--- a/src/testdrive/src/action/kafka/delete_topic.rs
+++ b/src/testdrive/src/action/kafka/delete_topic.rs
@@ -1,0 +1,28 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::action::{ControlFlow, State};
+use crate::parser::BuiltinCommand;
+
+pub async fn run_delete_topic(
+    mut cmd: BuiltinCommand,
+    state: &mut State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let topic_prefix = format!("testdrive-{}", cmd.args.string("topic")?);
+    cmd.args.done()?;
+
+    let topic_name = format!("{}-{}", topic_prefix, state.seed);
+
+    println!("Deleting Kafka topic {topic_name}");
+
+    mz_kafka_util::admin::delete_topic(&state.kafka_admin, &state.kafka_admin_opts, &topic_name)
+        .await?;
+    state.kafka_topics.remove(&topic_name);
+    Ok(ControlFlow::Continue)
+}

--- a/test/testdrive/kafka-recreate-topic.td
+++ b/test/testdrive/kafka-recreate-topic.td
@@ -49,3 +49,38 @@ $ kafka-create-topic topic=topic0 partitions=2
 
 ! SELECT * FROM source0
 contains:topic was recreated
+
+# We can also detect that a topic got recreated by observing the high watermark regressing
+
+$ kafka-create-topic topic=topic1 partitions=4
+
+$ kafka-ingest format=avro topic=topic1 schema=${schema} repeat=1
+{"f2": 1}
+
+> CREATE SOURCE source1
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic1-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+
+> SELECT * FROM source1
+f2
+---
+1
+
+# Now recreate the topic with the same number of partitions and observe the error
+
+$ kafka-delete-topic-flaky topic=topic1
+
+# Even though `kafka-delete-topic` ensures that the topic no longer exists in
+# the broker metadata there is still work to be done asychnronously before it's
+# truly gone that must complete before we attempt to recreate it. There is no
+# way to observe this work completing so the only option left is sleeping for a
+# while. This is the sad state of Kafka. If this test ever becomes flaky let's
+# just delete it.
+# See: https://github.com/confluentinc/confluent-kafka-python/issues/541
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
+
+$ kafka-create-topic topic=topic1 partitions=4
+
+! SELECT * FROM source1
+contains:topic was recreated

--- a/test/testdrive/kafka-recreate-topic.td
+++ b/test/testdrive/kafka-recreate-topic.td
@@ -48,11 +48,11 @@ $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
 $ kafka-create-topic topic=topic0 partitions=2
 
 ! SELECT * FROM source0
-contains:topic was recreated
+contains:topic was recreated: partition count regressed from 4 to 2
 
 # We can also detect that a topic got recreated by observing the high watermark regressing
 
-$ kafka-create-topic topic=topic1 partitions=4
+$ kafka-create-topic topic=topic1 partitions=1
 
 $ kafka-ingest format=avro topic=topic1 schema=${schema} repeat=1
 {"f2": 1}
@@ -80,7 +80,7 @@ $ kafka-delete-topic-flaky topic=topic1
 # See: https://github.com/confluentinc/confluent-kafka-python/issues/541
 $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
 
-$ kafka-create-topic topic=topic1 partitions=4
+$ kafka-create-topic topic=topic1 partitions=1
 
 ! SELECT * FROM source1
-contains:topic was recreated
+contains:topic was recreated: high watermark of partition 0 regressed from 1 to 0

--- a/test/testdrive/kafka-recreate-topic.td
+++ b/test/testdrive/kafka-recreate-topic.td
@@ -1,0 +1,51 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+$ set schema={"type" : "record", "name" : "test", "fields": [ { "name": "f2", "type": "long" } ] }
+
+$ kafka-create-topic topic=topic0 partitions=4
+
+$ kafka-ingest format=avro topic=topic0 schema=${schema} repeat=1
+{"f2": 1}
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE SOURCE source0
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic0-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+
+> SELECT * FROM source0
+f2
+---
+1
+
+# Now recreate the topic with fewer partitions and observe the error
+
+$ kafka-delete-topic-flaky topic=topic0
+
+# Even though `kafka-delete-topic` ensures that the topic no longer exists in
+# the broker metadata there is still work to be done asychnronously before it's
+# truly gone that must complete before we attempt to recreate it. There is no
+# way to observe this work completing so the only option left is sleeping for a
+# while. This is the sad state of Kafka. If this test ever becomes flaky let's
+# just delete it.
+# See: https://github.com/confluentinc/confluent-kafka-python/issues/541
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
+
+$ kafka-create-topic topic=topic0 partitions=2
+
+! SELECT * FROM source0
+contains:topic was recreated


### PR DESCRIPTION
### Motivation

Kafka topics are identified by name but it's possible that a user recreates a topic with the same name but different configuration. Ideally we'd want to catch all of these cases and immediately error out the source, since the data is effectively gone. Unfortunately this is not possible without something like KIP-516[1] so we're left with heuristics.

This PR implements one such heuristic that checks if the reported number of partitions went down. If this happens we know that the topic got swapped out.

[1] https://cwiki.apache.org/confluence/display/KAFKA/KIP-516%3A+Topic+Identifiers

Fixes #20062

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
