### PR TITLE
Include `ahash` with `default_features=false`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8630,6 +8630,7 @@ dependencies = [
 name = "workspace-hack"
 version = "0.0.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "aws-credential-types",
  "aws-sdk-sts",

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -17,7 +17,7 @@ polonius-the-crab = "0.3.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread", "time"] }
 num-traits = "0.2"
-ahash = "0.8.0"
+ahash = { version = "0.8.0", default_features = false }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -563,7 +563,8 @@ where
             // seeds that would be given by `AHash` via ahash::AHasher::default() so as
             // to avoid a different selection due to compile-time features being differently
             // selected in other dependencies using `AHash` vis-à-vis cargo's strategy
-            // of unioning features. This implies that we end up employ the fallback
+            // of unioning features.
+            // NOTE: Depending on target features, we may end up employing the fallback
             // hasher of `AHash`, but it should be sufficient for our needs.
             let random_state = ahash::RandomState::with_seeds(
                 0x243f_6a88_85a3_08d3,

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 
 ### BEGIN HAKARI SECTION
 [dependencies]
+ahash = { version = "0.8.0" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 aws-credential-types = { version = "0.55.1", default-features = false, features = ["hardcoded-credentials"] }
 aws-sdk-sts = { version = "0.26.0", default-features = false, features = ["native-tls", "rt-tokio"] }
@@ -113,6 +114,7 @@ uuid = { version = "1.2.2", features = ["serde", "v4", "v5"] }
 zeroize = { version = "1.5.7", features = ["serde"] }
 
 [build-dependencies]
+ahash = { version = "0.8.0" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 aws-credential-types = { version = "0.55.1", default-features = false, features = ["hardcoded-credentials"] }
 aws-sdk-sts = { version = "0.26.0", default-features = false, features = ["native-tls", "rt-tokio"] }


### PR DESCRIPTION
This PR changes the dependency on `AHash` in `timely-util`'s `Cargo.toml` to be explicit about avoiding default features. This specification was lost as part of the backport in #20124. It is not strictly necessary for the fix related to `AHash` usage in `timely-util`, but it is a good practice so as to steer the build of `AHash` in the right direction (i.e., avoiding runtime random number generation).

The PR also includes some minor improvements to code comments related to `AHash`'s selection of either its primary hasher, which depends on AES instructions, or the fallback hasher. It was observed in the review of #19848 that the target features we get enabled by default do not include AES. Further evaluation of the possibility to do so is the subject of #20028.

### Motivation

   * This PR refactors existing code.

The changes improve our inclusion of `AHash` in `timely-util`, avoiding unnecessary hashing performance degradations if other crates do not require default features either. It also improves some code comments.

### Tips for reviewer

This is just a minor follow-up from the backport in #20124, so nothing should be too controversial here.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR is sufficiently small to not require a design.
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
