### PR TITLE
feature-benchmark: Detect memory usage regressions

### DIFF
--- a/doc/developer/feature-benchmark.md
+++ b/doc/developer/feature-benchmark.md
@@ -154,6 +154,12 @@ the retry attempts.
 Reported performance improvements are not retried to establish reprodicibility, so should be considered flukes if seen in the CI
 output until reliably reproduced locally.
 
+# Measuring memory consumption
+
+If started with `--measure-memory`, the feature benchmark will measure memory consumption and report any regressions.
+
+`docker stats` is used to measure the memory consumption of the entire Materialize container, which includes CRDB.
+
 # Troubleshooting
 
 ## Benchmark terminated prematurely

--- a/misc/python/materialize/feature_benchmark/aggregation.py
+++ b/misc/python/materialize/feature_benchmark/aggregation.py
@@ -12,13 +12,15 @@ from typing import Any, Callable, List
 
 import numpy as np
 
+from materialize.feature_benchmark.measurement import Measurement
+
 
 class Aggregation:
     def __init__(self) -> None:
         self._data: List[float] = []
 
-    def append(self, measurement: float) -> None:
-        self._data.append(measurement)
+    def append(self, measurement: Measurement) -> None:
+        self._data.append(measurement.value)
 
     def aggregate(self) -> Any:
         return self.func()([*self._data])

--- a/misc/python/materialize/feature_benchmark/comparator.py
+++ b/misc/python/materialize/feature_benchmark/comparator.py
@@ -9,20 +9,20 @@
 
 from typing import Generic, List, Protocol, TypeVar
 
+from materialize.feature_benchmark.measurement import MeasurementType
+
 T = TypeVar("T")
 
 
 class Comparator(Generic[T]):
-    def __init__(self, name: str, threshold: float) -> None:
-        self._name = name
-        self._threshold = threshold
+    def __init__(self, type: MeasurementType, name: str, threshold: float) -> None:
+        self.name = name
+        self.type = type
+        self.threshold = threshold
         self._points: List[T] = []
 
     def append(self, point: T) -> None:
         self._points.append(point)
-
-    def name(self) -> str:
-        return self._name
 
     def this(self) -> T:
         return self._points[0]
@@ -52,22 +52,22 @@ class RelativeThresholdComparator(Comparator[float]):
     def is_regression(self) -> bool:
         ratio = self.ratio()
         if ratio > 1:
-            return ratio - 1 > self._threshold
+            return ratio - 1 > self.threshold
         else:
             return False
 
     def human_readable(self) -> str:
         ratio = self.ratio()
         if ratio >= 2:
-            return f"{ratio:3.1f} TIMES slower"
+            return f"{ratio:3.1f} TIMES more/slower"
         elif ratio > 1:
-            return f"{-(1-ratio)*100:3.1f} pct   slower"
+            return f"{-(1-ratio)*100:3.1f} pct   more/slower"
         elif ratio == 1:
             return "          same"
         elif ratio > 0.5:
-            return f"{(1-ratio)*100:3.1f} pct   faster"
+            return f"{(1-ratio)*100:3.1f} pct   less/faster"
         else:
-            return f"{(1/ratio):3.1f} times faster"
+            return f"{(1/ratio):3.1f} times less/faster"
 
 
 class Overlappable(Protocol):
@@ -80,4 +80,4 @@ class OverlapComparator(Comparator[Overlappable]):
         return self._points[0].overlap(other=self._points[1])
 
     def is_regression(self) -> bool:
-        return self.ratio() < 1 - self._threshold
+        return self.ratio() < 1 - self.threshold

--- a/misc/python/materialize/feature_benchmark/executor.py
+++ b/misc/python/materialize/feature_benchmark/executor.py
@@ -34,6 +34,9 @@ class Executor:
         self._known_fragments.add(fragment)
         return result
 
+    def DockerMem(self) -> int:
+        raise NotImplementedError
+
 
 class Docker(Executor):
     def __init__(
@@ -66,6 +69,9 @@ class Docker(Executor):
         return self._composition.run(
             "kgen", f"--topic=testdrive-{topic}-{self._seed}", *args
         )
+
+    def DockerMem(self) -> int:
+        return self._composition.mem("materialized")
 
 
 class MzCloud(Executor):

--- a/misc/python/materialize/feature_benchmark/filter.py
+++ b/misc/python/materialize/feature_benchmark/filter.py
@@ -11,23 +11,25 @@ from typing import List
 
 import numpy as np
 
+from materialize.feature_benchmark.measurement import Measurement
+
 
 class Filter:
     def __init__(self) -> None:
         self._data: List[float] = []
 
-    def filter(self, measurement: float) -> bool:
+    def filter(self, measurement: Measurement) -> bool:
         raise NotImplementedError
 
 
 class RemoveOutliers(Filter):
-    def filter(self, measurement: float) -> bool:
-        self._data.append(measurement)
+    def filter(self, measurement: Measurement) -> bool:
+        self._data.append(measurement.value)
 
         if len(self._data) > 3:
             mean = np.mean(self._data)
             stdev = np.std(self._data)
-            if measurement > mean + (1 * stdev):
+            if measurement.value > mean + (1 * stdev):
                 return True
             else:
                 return False
@@ -36,13 +38,13 @@ class RemoveOutliers(Filter):
 
 
 class NoFilter(Filter):
-    def filter(self, measurement: float) -> bool:
+    def filter(self, measurement: Measurement) -> bool:
         return False
 
 
 class FilterFirst(Filter):
-    def filter(self, measurement: float) -> bool:
-        self._data.append(measurement)
+    def filter(self, measurement: Measurement) -> bool:
+        self._data.append(measurement.value)
 
         if len(self._data) == 1:
             print("Discarding first measurement.")

--- a/misc/python/materialize/feature_benchmark/measurement.py
+++ b/misc/python/materialize/feature_benchmark/measurement.py
@@ -1,0 +1,27 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from enum import Enum, auto
+
+
+class MeasurementType(Enum):
+    WALLCLOCK = auto()
+    MEMORY = auto()
+
+    def __str__(self) -> str:
+        return self.name.lower()
+
+
+class Measurement:
+    def __init__(self, type: MeasurementType, value: float) -> None:
+        self.type = type
+        self.value = value
+
+    def __str__(self) -> str:
+        return f"{self.value:>11.3f}({self.type})"

--- a/misc/python/materialize/feature_benchmark/termination.py
+++ b/misc/python/materialize/feature_benchmark/termination.py
@@ -13,13 +13,15 @@ from typing import List, Optional
 import numpy as np
 from scipy import stats  # type: ignore
 
+from materialize.feature_benchmark.measurement import Measurement
+
 
 class TerminationCondition:
     def __init__(self, threshold: float) -> None:
         self._threshold = threshold
         self._data: List[float] = []
 
-    def terminate(self, measurement: float) -> bool:
+    def terminate(self, measurement: Measurement) -> bool:
         assert False
 
 
@@ -30,8 +32,8 @@ class NormalDistributionOverlap(TerminationCondition):
         self._last_fit: Optional[statistics.NormalDist] = None
         super().__init__(threshold=threshold)
 
-    def terminate(self, measurement: float) -> bool:
-        self._data.append(measurement)
+    def terminate(self, measurement: Measurement) -> bool:
+        self._data.append(measurement.value)
 
         if len(self._data) > 10:
             (mu, sigma) = stats.norm.fit(self._data)
@@ -52,8 +54,8 @@ class ProbForMin(TerminationCondition):
     has dropped below the threshold
     """
 
-    def terminate(self, measurement: float) -> bool:
-        self._data.append(measurement)
+    def terminate(self, measurement: Measurement) -> bool:
+        self._data.append(measurement.value)
 
         if len(self._data) > 5:
             mean = np.mean(self._data)
@@ -70,7 +72,7 @@ class ProbForMin(TerminationCondition):
 
 
 class RunAtMost(TerminationCondition):
-    def terminate(self, measurement: float) -> bool:
-        self._data.append(measurement)
+    def terminate(self, measurement: Measurement) -> bool:
+        self._data.append(measurement.value)
 
         return len(self._data) >= self._threshold

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -21,19 +21,20 @@ sys.path.append(os.path.dirname(__file__))
 from scenarios import *  # noqa: F401 F403
 from scenarios import Scenario
 from scenarios_concurrency import *  # noqa: F401 F403
+from scenarios_customer import *  # noqa: F401 F403
 from scenarios_optbench import *  # noqa: F401 F403
 from scenarios_scale import *  # noqa: F401 F403
 from scenarios_subscribe import *  # noqa: F401 F403
 
 from materialize.feature_benchmark.aggregation import Aggregation, MinAggregation
-from materialize.feature_benchmark.benchmark import Benchmark, Report, SingleReport
+from materialize.feature_benchmark.benchmark import Benchmark, Report
 from materialize.feature_benchmark.comparator import (
     Comparator,
     RelativeThresholdComparator,
-    SuccessComparator,
 )
-from materialize.feature_benchmark.executor import Docker, MzCloud
+from materialize.feature_benchmark.executor import Docker
 from materialize.feature_benchmark.filter import Filter, FilterFirst, NoFilter
+from materialize.feature_benchmark.measurement import MeasurementType
 from materialize.feature_benchmark.termination import (
     NormalDistributionOverlap,
     ProbForMin,
@@ -41,10 +42,12 @@ from materialize.feature_benchmark.termination import (
     TerminationCondition,
 )
 from materialize.mzcompose import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services import Cockroach
 from materialize.mzcompose.services import Kafka as KafkaService
 from materialize.mzcompose.services import Kgen as KgenService
 from materialize.mzcompose.services import (
     Materialized,
+    Minio,
     Postgres,
     Redpanda,
     SchemaRegistry,
@@ -74,12 +77,12 @@ def make_termination_conditions(args: argparse.Namespace) -> List[TerminationCon
     ]
 
 
-def make_aggregation() -> Aggregation:
-    return MinAggregation()
+def make_aggregation_class() -> Type[Aggregation]:
+    return MinAggregation
 
 
-def make_comparator(name: str) -> Comparator:
-    return RelativeThresholdComparator(name, threshold=0.10)
+def make_comparator(name: str, type: MeasurementType) -> Comparator:
+    return RelativeThresholdComparator(name=name, type=type, threshold=0.10)
 
 
 default_timeout = "1800s"
@@ -89,6 +92,8 @@ SERVICES = [
     KafkaService(),
     SchemaRegistry(),
     Redpanda(),
+    Cockroach(setup_materialize=True),
+    Minio(setup_materialize=True),
     Materialized(),
     Testdrive(
         default_timeout=default_timeout,
@@ -101,10 +106,15 @@ SERVICES = [
 
 def run_one_scenario(
     c: Composition, scenario: Type[Scenario], args: argparse.Namespace
-) -> Comparator:
+) -> List[Comparator]:
     name = scenario.__name__
     print(f"--- Now benchmarking {name} ...")
-    comparator = make_comparator(name)
+
+    measurement_types = [MeasurementType.WALLCLOCK]
+    if args.measure_memory:
+        measurement_types.append(MeasurementType.MEMORY)
+    comparators = [make_comparator(name=name, type=t) for t in measurement_types]
+
     common_seed = round(time.time())
 
     for mz_id, instance in enumerate(["this", "other"]):
@@ -130,6 +140,8 @@ def run_one_scenario(
             environment_id=f"local-az1-{uuid.uuid4()}-0",
             soft_assertions=False,
             additional_system_parameter_defaults=additional_system_parameter_defaults,
+            external_cockroach=True,
+            external_minio=True,
         )
 
         with c.override(mz):
@@ -142,7 +154,7 @@ def run_one_scenario(
                 rm=True,
             )
 
-            c.up("materialized")
+            c.up("cockroach", "materialized")
 
         executor = Docker(composition=c, seed=common_seed, materialized=mz)
 
@@ -153,16 +165,19 @@ def run_one_scenario(
             executor=executor,
             filter=make_filter(args),
             termination_conditions=make_termination_conditions(args),
-            aggregation=make_aggregation(),
+            aggregation_class=make_aggregation_class(),
+            measure_memory=args.measure_memory,
         )
 
-        outcome, iterations = benchmark.run()
-        comparator.append(outcome)
-        c.kill("materialized", "testdrive")
-        c.rm("materialized", "testdrive")
+        aggregations = benchmark.run()
+        for i, comparator in enumerate(comparators):
+            comparator.append(aggregations[i].aggregate())
+
+        c.kill("cockroach", "materialized", "testdrive")
+        c.rm("cockroach", "materialized", "testdrive")
         c.rm_volumes("mzdata")
 
-    return comparator
+    return comparators
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -174,6 +189,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--redpanda",
         action="store_true",
         help="run against Redpanda instead of the Confluent Platform",
+    )
+
+    parser.add_argument(
+        "--measure-memory",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Measure memory usage",
     )
 
     parser.add_argument(
@@ -303,10 +325,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         report = Report()
 
         for scenario in list(scenarios.keys()):
-            comparison = run_one_scenario(c, scenario, args)
-            report.append(comparison)
+            comparators = run_one_scenario(c, scenario, args)
+            report.extend(comparators)
 
-            if not comparison.is_regression():
+            # Do not retry the scenario if no regressions
+            if all([not c.is_regression() for c in comparators]):
                 del scenarios[scenario]
 
             print(f"+++ Benchmark Report for cycle {cycle+1}:")
@@ -320,144 +343,3 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             f"ERROR: The following scenarios have regressions: {', '.join([scenario.__name__ for scenario in scenarios.keys()])}"
         )
         sys.exit(1)
-
-
-def workflow_mzcloud(c: Composition, parser: WorkflowArgumentParser) -> None:
-    # Make sure Kafka is externally accessible on a predictable port.
-    assert (
-        c.preserve_ports
-    ), "`--preserve-ports` must be specified (BEFORE the `run` command)"
-
-    parser.add_argument(
-        "--mzcloud-url",
-        type=str,
-        help="The postgres connection url to the mzcloud deployment to benchmark.",
-    )
-
-    parser.add_argument(
-        "--external-addr",
-        type=str,
-        help="Kafka and Schema Registry are started by mzcompose and exposed on the public interface. This is the IP address or hostname that is accessible by the mzcloud instance, usually the public IP of your machine.",
-    )
-
-    parser.add_argument(
-        "--root-scenario",
-        "--scenario",
-        metavar="SCENARIO",
-        type=str,
-        default="Scenario",
-        help="Scenario or scenario family to benchmark. See scenarios.py for available scenarios.",
-    )
-
-    parser.add_argument(
-        "--scale",
-        metavar="+N | -N | N",
-        type=str,
-        default=None,
-        help="Absolute or relative scale to apply.",
-    )
-
-    parser.add_argument(
-        "--max-measurements",
-        metavar="N",
-        type=int,
-        default=99,
-        help="Limit the number of measurements to N.",
-    )
-
-    parser.add_argument(
-        "--max-retries",
-        metavar="N",
-        type=int,
-        default=2,
-        help="Retry any potential performance regressions up to N times.",
-    )
-
-    parser.add_argument(
-        "--test-filter",
-        type=str,
-        help="Filter scenario names by this string (case insensitive).",
-    )
-
-    args = parser.parse_args()
-
-    assert args.mzcloud_url
-    assert args.external_addr
-
-    print(
-        f"""
-mzcloud url: {args.mzcloud_url}
-external addr: {args.external_addr}
-
-root_scenario: {args.root_scenario}"""
-    )
-
-    overrides = [
-        KafkaService(
-            environment_extra=[
-                f"KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://{args.external_addr}:9092"
-            ]
-        ),
-    ]
-
-    with c.override(*overrides):
-        c.up("zookeeper", "kafka", "schema-registry")
-        c.up("testdrive", persistent=True)
-
-        # Build the list of scenarios to run
-        root_scenario = globals()[args.root_scenario]
-        initial_scenarios = {}
-
-        if root_scenario.__subclasses__():
-            for scenario in root_scenario.__subclasses__():
-                has_children = False
-                for s in scenario.__subclasses__():
-                    has_children = True
-                    initial_scenarios[s] = 1
-
-                if not has_children:
-                    initial_scenarios[scenario] = 1
-        else:
-            initial_scenarios[root_scenario] = 1
-
-        scenarios = initial_scenarios.copy()
-
-        for cycle in range(0, args.max_retries):
-            print(
-                f"Cycle {cycle+1} with scenarios: {', '.join([scenario.__name__ for scenario in scenarios.keys()])}"
-            )
-
-            report = SingleReport()
-
-            for scenario in list(scenarios.keys()):
-                name = scenario.__name__
-                if args.test_filter and args.test_filter.lower() not in name.lower():
-                    continue
-                print(f"--- Now benchmarking {name} ...")
-                comparator = SuccessComparator(name, threshold=0)
-                common_seed = round(time.time())
-                executor = MzCloud(
-                    composition=c,
-                    mzcloud_url=args.mzcloud_url,
-                    seed=common_seed,
-                    external_addr=args.external_addr,
-                )
-                executor.Reset()
-                mz_id = 0
-
-                benchmark = Benchmark(
-                    mz_id=mz_id,
-                    scenario=scenario,
-                    scale=args.scale,
-                    executor=executor,
-                    filter=make_filter(args),
-                    termination_conditions=make_termination_conditions(args),
-                    aggregation=make_aggregation(),
-                )
-
-                outcome, iterations = benchmark.run()
-                comparator.append(outcome)
-                report.append(comparator)
-
-                print(f"+++ Benchmark Report for cycle {cycle+1}:")
-                report.dump()

--- a/test/feature-benchmark/scenarios_customer.py
+++ b/test/feature-benchmark/scenarios_customer.py
@@ -1,0 +1,47 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+
+from materialize.feature_benchmark.action import Action, TdAction
+from materialize.feature_benchmark.measurement_source import MeasurementSource, Td
+from materialize.feature_benchmark.scenario import Scenario
+
+
+class CustomerWorkload1(Scenario):
+    """Aggregation over a large non-monotonic source."""
+
+    def init(self) -> Action:
+        return TdAction(
+            dedent(
+                f"""
+                > DROP TABLE IF EXISTS t1 CASCADE;
+
+                > CREATE TABLE t1 (f1 INTEGER);
+
+                > INSERT INTO t1 SELECT * FROM generate_series(1, {self.n()});
+                """
+            )
+        )
+
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            dedent(
+                f"""
+                > DROP MATERIALIZED VIEW IF EXISTS v1;
+
+                > CREATE MATERIALIZED VIEW v1 AS SELECT MAX(f1) FROM t1
+                  /* A */;
+
+                > SELECT * FROM v1
+                  /* B */;
+                {self.n()}
+                """
+            )
+        )


### PR DESCRIPTION
Take memory measurements on the workloads and fail if the memory consumption of a particular workload has increased.

Closes #20151

### Motivation

We do not have ways to detect memory consumptions regressions in our CI, unless they raise to the level of failing the bounded-memory test or otherwise cause OOMs.
