### PR TITLE
doc: Improve role documentation

### DIFF
--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -26,7 +26,8 @@ attributes for a role during authentication, every time that role tries
 to connect to Materialize. Therefore, you cannot specify either
 attribute when altering an existing role.
 
-Unlike PostgreSQL, materialize does not currently support `NOINHERIT`.
+Unlike PostgreSQL, materialize does not currently support the `NOINHERIT` attribute and the `SET
+ROLE` command.
 
 You may not specify redundant or conflicting sets of options. For example,
 Materialize will reject the statement `ALTER ROLE ... INHERIT INHERIT`.

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -39,8 +39,7 @@ Unlike PostgreSQL, Materialize does not use role attributes to determine a roles
 top level objects such as databases and other roles. Instead, Materialize uses system level
 privileges. See [GRANT PRIVILEGE](../grant-privilege) for more details.
 
-When RBAC is enabled a role must have the `CREATEROLE` system privilege attribute to create another
-role.
+When RBAC is enabled a role must have the `CREATEROLE` system privilege to create another role.
 
 ## Examples
 

--- a/doc/user/content/sql/grant-role.md
+++ b/doc/user/content/sql/grant-role.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 `GRANT` grants membership of one role to another role. Roles can be members of
-other roles, as well as inherit all the attributes and privileges of those roles.
+other roles, as well as inherit all the privileges of those roles.
 
 {{< alpha />}}
 

--- a/doc/user/content/sql/revoke-role.md
+++ b/doc/user/content/sql/revoke-role.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 `REVOKE` revokes membership of one role from another role. Roles can be members
-of other roles, as well as inherit all the attributes and privileges of those
+of other roles, as well as inherit all the privileges of those
 roles. This membership can also be revoked.
 
 {{< alpha />}}


### PR DESCRIPTION
### Motivation
Improve docs

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
