### PR TITLE
sql: support ALTER SOURCE...ADD SUBSOURCE

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -526,6 +526,7 @@ impl ExecuteResponse {
             | AlterSecret
             | AlterSink
             | AlterSource
+            | PurifiedAlterSource
             | RotateKeys => {
                 vec![AlteredObject]
             }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -100,7 +100,7 @@ use mz_repr::explain::ExplainFormat;
 use mz_repr::role_id::RoleId;
 use mz_repr::{Datum, GlobalId, RelationType, Row, Timestamp};
 use mz_secrets::SecretsController;
-use mz_sql::ast::{CreateSourceStatement, CreateSubsourceStatement, Raw, Statement};
+use mz_sql::ast::{CreateSubsourceStatement, Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
 use mz_sql::names::{Aug, ResolvedIds};
 use mz_sql::plan::{CopyFormat, CreateConnectionPlan, Params, QueryWhen};
@@ -183,7 +183,7 @@ pub const DUMMY_AVAILABILITY_ZONE: &str = "";
 pub enum Message<T = mz_repr::Timestamp> {
     Command(Command),
     ControllerReady,
-    CreateSourceStatementReady(CreateSourceStatementReady),
+    PurifiedStatementReady(PurifiedStatementReady),
     CreateConnectionValidationReady(CreateConnectionValidationReady),
     SinkConnectionReady(SinkConnectionReady),
     WriteLockGrant(tokio::sync::OwnedMutexGuard<()>),
@@ -238,9 +238,9 @@ pub struct BackgroundWorkResult<T> {
     pub otel_ctx: OpenTelemetryContext,
 }
 
-pub type CreateSourceStatementReady = BackgroundWorkResult<(
+pub type PurifiedStatementReady = BackgroundWorkResult<(
     Vec<(GlobalId, CreateSubsourceStatement<Aug>)>,
-    CreateSourceStatement<Aug>,
+    Statement<Aug>,
 )>;
 
 #[derive(Derivative)]

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -94,6 +94,7 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
         | Plan::AlterIndexResetOptions(_)
         | Plan::AlterSink(_)
         | Plan::AlterSource(_)
+        | Plan::PurifiedAlterSource { .. }
         | Plan::AlterItemRename(_)
         | Plan::AlterSecret(_)
         | Plan::AlterSystemSet(_)
@@ -296,6 +297,7 @@ pub fn user_privilege_hack(
         | Plan::AlterRole(_)
         | Plan::AlterSink(_)
         | Plan::AlterSource(_)
+        | Plan::PurifiedAlterSource { .. }
         | Plan::AlterItemRename(_)
         | Plan::AlterSecret(_)
         | Plan::AlterSystemSet(_)

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -30,8 +30,9 @@ use crate::client::ConnectionId;
 use crate::command::{Command, ExecuteResponse};
 use crate::coord::appends::Deferred;
 use crate::coord::{
-    Coordinator, CreateConnectionValidationReady, CreateSourceStatementReady, Message, PeekStage,
-    PeekStageFinish, PendingReadTxn, PlanValidity, RealTimeRecencyContext, SinkConnectionReady,
+    Coordinator, CreateConnectionValidationReady, Message, PeekStage, PeekStageFinish,
+    PendingReadTxn, PlanValidity, PurifiedStatementReady, RealTimeRecencyContext,
+    SinkConnectionReady,
 };
 use crate::util::ResultExt;
 use crate::{catalog, AdapterNotice, TimestampContext};
@@ -50,8 +51,8 @@ impl Coordinator {
                     self.message_controller(m).await
                 }
             }
-            Message::CreateSourceStatementReady(ready) => {
-                self.message_create_source_statement_ready(ready).await
+            Message::PurifiedStatementReady(ready) => {
+                self.message_purified_statement_ready(ready).await
             }
             Message::CreateConnectionValidationReady(ready) => {
                 self.message_create_connection_validation_ready(ready).await
@@ -358,16 +359,16 @@ impl Coordinator {
     }
 
     #[tracing::instrument(level = "debug", skip(self, ctx))]
-    async fn message_create_source_statement_ready(
+    async fn message_purified_statement_ready(
         &mut self,
-        CreateSourceStatementReady {
+        PurifiedStatementReady {
             mut ctx,
             result,
             params,
             resolved_ids,
             original_stmt,
             otel_ctx,
-        }: CreateSourceStatementReady,
+        }: PurifiedStatementReady,
     ) {
         otel_ctx.attach_as_parent();
 
@@ -428,32 +429,38 @@ impl Coordinator {
             Ok(ok) => ok,
             Err(e) => return ctx.retire(Err(e.into())),
         };
-        let resolved_ids = mz_sql::names::visit_dependencies(&stmt);
-        let source_id = match self.catalog_mut().allocate_user_id().await {
-            Ok(id) => id,
-            Err(e) => return ctx.retire(Err(e.into())),
-        };
-        let plan =
-            match self.plan_statement(ctx.session_mut(), Statement::CreateSource(stmt), &params) {
-                Ok(Plan::CreateSource(plan)) => plan,
-                Ok(_) => {
-                    unreachable!("planning CREATE SOURCE must result in a Plan::CreateSource")
-                }
-                Err(e) => return ctx.retire(Err(e)),
-            };
-        plans.push(CreateSourcePlans {
-            source_id,
-            plan,
-            resolved_ids,
-        });
 
-        // Finally, sequence all plans in one go
-        self.sequence_plan(
-            ctx,
-            Plan::CreateSources(plans),
-            ResolvedIds(BTreeSet::new()),
-        )
-        .await;
+        let resolved_ids = mz_sql::names::visit_dependencies(&stmt);
+
+        match self.plan_statement(ctx.session_mut(), stmt, &params) {
+            Ok(Plan::CreateSource(plan)) => {
+                let source_id = match self.catalog_mut().allocate_user_id().await {
+                    Ok(id) => id,
+                    Err(e) => return ctx.retire(Err(e.into())),
+                };
+
+                plans.push(CreateSourcePlans {
+                    source_id,
+                    plan,
+                    resolved_ids,
+                });
+
+                // Finally, sequence all plans in one go
+                self.sequence_plan(
+                    ctx,
+                    Plan::CreateSources(plans),
+                    ResolvedIds(BTreeSet::new()),
+                )
+                .await;
+            }
+            Ok(Plan::AlterSource(_)) => {
+                todo!()
+            }
+            Ok(p) => {
+                unreachable!("{:?} is not purified", p)
+            }
+            Err(e) => ctx.retire(Err(e)),
+        };
     }
 
     #[tracing::instrument(level = "debug", skip(self, ctx))]

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -453,8 +453,16 @@ impl Coordinator {
                 )
                 .await;
             }
-            Ok(Plan::AlterSource(_)) => {
-                todo!()
+            Ok(Plan::AlterSource(alter_source)) => {
+                self.sequence_plan(
+                    ctx,
+                    Plan::PurifiedAlterSource {
+                        alter_source,
+                        subsources: plans,
+                    },
+                    ResolvedIds(BTreeSet::new()),
+                )
+                .await;
             }
             Ok(p) => {
                 unreachable!("{:?} is not purified", p)

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -464,6 +464,10 @@ impl Coordinator {
                 )
                 .await;
             }
+            Ok(plan @ Plan::AlterNoop(..)) => {
+                self.sequence_plan(ctx, plan, ResolvedIds(BTreeSet::new()))
+                    .await
+            }
             Ok(p) => {
                 unreachable!("{:?} is not purified", p)
             }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -352,9 +352,17 @@ impl Coordinator {
                 let result = self.sequence_alter_sink(ctx.session(), plan).await;
                 ctx.retire(result);
             }
-            Plan::AlterSource(plan) => {
-                let result = self.sequence_alter_source(ctx.session_mut(), plan).await;
+            Plan::PurifiedAlterSource {
+                alter_source,
+                subsources,
+            } => {
+                let result = self
+                    .sequence_alter_source(ctx.session_mut(), alter_source, subsources)
+                    .await;
                 ctx.retire(result);
+            }
+            Plan::AlterSource(_) => {
+                unreachable!("ALTER SOURCE must be purified")
             }
             Plan::AlterSystemSet(plan) => {
                 let result = self.sequence_alter_system_set(ctx.session(), plan).await;

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3761,7 +3761,10 @@ impl Coordinator {
         &mut self,
         session: &mut Session,
         AlterSourcePlan { id, action }: AlterSourcePlan,
+        subsources: Vec<CreateSourcePlans>,
     ) -> Result<ExecuteResponse, AdapterError> {
+        assert!(subsources.is_empty());
+
         let cur_entry = self.catalog().get_entry(&id);
         let cur_source = cur_entry.source().expect("known to be source");
 

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -25,6 +25,7 @@
 
 Access
 Acks
+Add
 Addresses
 All
 Alter

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1669,6 +1669,39 @@ impl<T: AstInfo> AstDisplay for AlterSinkStatement<T> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AlterSourceAddSubsourceOptionName {
+    /// Columns whose types you want to unconditionally format as text
+    TextColumns,
+}
+
+impl AstDisplay for AlterSourceAddSubsourceOptionName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str(match self {
+            AlterSourceAddSubsourceOptionName::TextColumns => "TEXT COLUMNS",
+        })
+    }
+}
+impl_display!(AlterSourceAddSubsourceOptionName);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// An option in an `ALTER SOURCE...ADD SUBSOURCE` statement.
+pub struct AlterSourceAddSubsourceOption<T: AstInfo> {
+    pub name: AlterSourceAddSubsourceOptionName,
+    pub value: Option<WithOptionValue<T>>,
+}
+
+impl<T: AstInfo> AstDisplay for AlterSourceAddSubsourceOption<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        if let Some(v) = &self.value {
+            f.write_str(" = ");
+            f.write_node(v);
+        }
+    }
+}
+impl_display_t!(AlterSourceAddSubsourceOption);
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AlterSourceAction<T: AstInfo> {
     SetOptions(Vec<CreateSourceOption<T>>),
@@ -1676,6 +1709,7 @@ pub enum AlterSourceAction<T: AstInfo> {
     AddSubsources {
         subsources: Vec<CreateSourceSubsource<T>>,
         details: Option<WithOptionValue<T>>,
+        options: Vec<AlterSourceAddSubsourceOption<T>>,
     },
     DropSubsources {
         if_exists: bool,
@@ -1727,7 +1761,21 @@ impl<T: AstInfo> AstDisplay for AlterSourceStatement<T> {
                     f.write_str(" CASCADE");
                 }
             }
-            _ => todo!(),
+            AlterSourceAction::AddSubsources {
+                subsources,
+                details: _,
+                options,
+            } => {
+                f.write_str("ADD SUBSOURCE ");
+
+                f.write_node(&display::comma_separated(subsources));
+
+                if !options.is_empty() {
+                    f.write_str(" WITH (");
+                    f.write_node(&display::comma_separated(options));
+                    f.write_str(")");
+                }
+            }
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1675,7 +1675,7 @@ pub enum AlterSourceAction<T: AstInfo> {
     ResetOptions(Vec<CreateSourceOptionName>),
     AddSubsources {
         subsources: Vec<CreateSourceSubsource<T>>,
-        details: Option<String>,
+        details: Option<WithOptionValue<T>>,
     },
     DropSubsources {
         if_exists: bool,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1673,6 +1673,10 @@ impl<T: AstInfo> AstDisplay for AlterSinkStatement<T> {
 pub enum AlterSourceAction<T: AstInfo> {
     SetOptions(Vec<CreateSourceOption<T>>),
     ResetOptions(Vec<CreateSourceOptionName>),
+    AddSubsources {
+        subsources: Vec<CreateSourceSubsource<T>>,
+        details: Option<String>,
+    },
     DropSubsources {
         if_exists: bool,
         cascade: bool,
@@ -1723,6 +1727,7 @@ impl<T: AstInfo> AstDisplay for AlterSourceStatement<T> {
                     f.write_str(" CASCADE");
                 }
             }
+            _ => todo!(),
         }
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1093,6 +1093,134 @@ ALTER SOURCE IF EXISTS n DROP SUBSOURCE IF EXISTS x, y, z CASCADE
 =>
 AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: true, action: DropSubsources { if_exists: true, cascade: true, names: [UnresolvedItemName([Ident("x")]), UnresolvedItemName([Ident("y")]), UnresolvedItemName([Ident("z")])] } })
 
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d
+----
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }], details: None, options: [] } })
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g
+----
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }], details: None, options: [] } })
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g
+----
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(Deferred(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")]))) }], details: None, options: [] } })
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c
+----
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], details: None, options: [] } })
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g, a.b.c
+----
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g, a.b.c
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(Deferred(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], details: None, options: [] } })
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c, a.b.c.d AS e.f.g
+----
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c, a.b.c.d AS e.f.g
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }], details: None, options: [] } })
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a, b.c, c, d.e
+----
+ALTER SOURCE n ADD SUBSOURCE a, b.c, c, d.e
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("d"), Ident("e")]), subsource: None }], details: None, options: [] } })
+
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d WITH (TEXT COLUMNS [a.b, c.d])
+----
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d WITH (TEXT COLUMNS = (a.b, c.d))
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }], details: None, options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g WITH (TEXT COLUMNS [a.b, c.d])
+----
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g WITH (TEXT COLUMNS = (a.b, c.d))
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }], details: None, options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g WITH (TEXT COLUMNS [a.b, c.d])
+----
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g WITH (TEXT COLUMNS = (a.b, c.d))
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(Deferred(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")]))) }], details: None, options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c WITH (TEXT COLUMNS [a.b, c.d])
+----
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c WITH (TEXT COLUMNS = (a.b, c.d))
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], details: None, options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g, a.b.c WITH (TEXT COLUMNS [a.b, c.d])
+----
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g, a.b.c WITH (TEXT COLUMNS = (a.b, c.d))
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(Deferred(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], details: None, options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c, a.b.c.d AS e.f.g WITH (TEXT COLUMNS [a.b, c.d])
+----
+ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c, a.b.c.d AS e.f.g WITH (TEXT COLUMNS = (a.b, c.d))
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }], details: None, options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+
+parse-statement
+ALTER SOURCE n ADD SUBSOURCE a, b.c, c, d.e WITH (TEXT COLUMNS [a.b, c.d])
+----
+ALTER SOURCE n ADD SUBSOURCE a, b.c, c, d.e WITH (TEXT COLUMNS = (a.b, c.d))
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("d"), Ident("e")]), subsource: None }], details: None, options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+
+parse-statement
+ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c, c, d.e WITH (TEXT COLUMNS [a.b, c.d])
+----
+ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c, c, d.e WITH (TEXT COLUMNS = (a.b, c.d))
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: true, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("d"), Ident("e")]), subsource: None }], details: None, options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+
+parse-statement
+ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c, c, d.e WITH ()
+----
+error: Expected one of TEXT, found right parenthesis
+ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c, c, d.e WITH ()
+                                                            ^
+
+parse-statement
+ALTER SOURCE IF EXISTS n ADD TABLE a, b.c AS d
+----
+ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c AS d
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: true, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("b"), Ident("c")]), subsource: Some(Deferred(UnresolvedItemName([Ident("d")]))) }], details: None, options: [] } })
+
+parse-statement
+ALTER SOURCE IF EXISTS n ADD SOURCE a, b.c AS d
+----
+error: Expected one of SUBSOURCE or TABLE, found SOURCE
+ALTER SOURCE IF EXISTS n ADD SOURCE a, b.c AS d
+                             ^
+
 parse-statement
 ALTER VIEW name SET (property = true)
 ----

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -45,8 +45,8 @@ use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::role_id::RoleId;
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
 use mz_sql_parser::ast::{
-    CreateSourceSubsource, QualifiedReplica, TransactionIsolationLevel, TransactionMode,
-    WithOptionValue,
+    AlterSourceAddSubsourceOption, CreateSourceSubsource, QualifiedReplica,
+    TransactionIsolationLevel, TransactionMode, WithOptionValue,
 };
 use mz_storage_client::types::sinks::{SinkEnvelope, StorageSinkConnectionBuilder};
 use mz_storage_client::types::sources::{SourceDesc, Timeline};
@@ -869,6 +869,7 @@ pub enum AlterSourceAction {
     AddSubsourceExports {
         subsources: Vec<CreateSourceSubsource<Aug>>,
         details: Option<WithOptionValue<Aug>>,
+        options: Vec<AlterSourceAddSubsourceOption<Aug>>,
     },
 }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -44,8 +44,10 @@ use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::role_id::RoleId;
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
-
-use mz_sql_parser::ast::{QualifiedReplica, TransactionIsolationLevel, TransactionMode};
+use mz_sql_parser::ast::{
+    CreateSourceSubsource, QualifiedReplica, TransactionIsolationLevel, TransactionMode,
+    WithOptionValue,
+};
 use mz_storage_client::types::sinks::{SinkEnvelope, StorageSinkConnectionBuilder};
 use mz_storage_client::types::sources::{SourceDesc, Timeline};
 use serde::{Deserialize, Serialize};
@@ -861,7 +863,13 @@ pub struct AlterSinkPlan {
 #[derive(Debug)]
 pub enum AlterSourceAction {
     Resize(AlterOptionParameter),
-    DropSubsourceExports { to_drop: BTreeSet<GlobalId> },
+    DropSubsourceExports {
+        to_drop: BTreeSet<GlobalId>,
+    },
+    AddSubsourceExports {
+        subsources: Vec<CreateSourceSubsource<Aug>>,
+        details: Option<WithOptionValue<Aug>>,
+    },
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -141,6 +141,12 @@ pub enum Plan {
     AlterIndexResetOptions(AlterIndexResetOptionsPlan),
     AlterSink(AlterSinkPlan),
     AlterSource(AlterSourcePlan),
+    PurifiedAlterSource {
+        // The `ALTER SOURCE` plan
+        alter_source: AlterSourcePlan,
+        // The plan to create any subsources added in the `ALTER SOURCE` statement.
+        subsources: Vec<CreateSourcePlans>,
+    },
     AlterClusterRename(AlterClusterRenamePlan),
     AlterClusterReplicaRename(AlterClusterReplicaRenamePlan),
     AlterItemRename(AlterItemRenamePlan),
@@ -339,7 +345,7 @@ impl Plan {
             Plan::AlterIndexSetOptions(_) => "alter index",
             Plan::AlterIndexResetOptions(_) => "alter index",
             Plan::AlterSink(_) => "alter sink",
-            Plan::AlterSource(_) => "alter source",
+            Plan::AlterSource(_) | Plan::PurifiedAlterSource { .. } => "alter source",
             Plan::AlterItemRename(_) => "rename item",
             Plan::AlterSecret(_) => "alter secret",
             Plan::AlterSystemSet(_) => "alter system",

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -230,13 +230,21 @@ pub fn describe(
 /// Produces a [`Plan`] from the purified statement `stmt`.
 ///
 /// Planning is a pure, synchronous function and so requires that the provided
-/// `stmt` does does not depend on any external state. Only `CREATE SOURCE`
-/// statements can depend on external state; remove that state prior to calling
-/// this function via [`crate::pure::purify_create_source`].
+/// `stmt` does does not depend on any external state. Statements that rely on
+/// external state must remove that state prior to calling this function via
+/// [`crate::pure::purify_statement`].
+///
+/// TODO: sinks do not currently obey this rule, which is a bug
+/// <https://github.com/MaterializeInc/materialize/issues/20019>
 ///
 /// The returned plan is tied to the state of the provided catalog. If the state
 /// of the catalog changes after planning, the validity of the plan is not
 /// guaranteed.
+///
+/// Note that if you want to do something else asynchronously (e.g. validating
+/// connections), these might want to take different code paths than
+/// `purify_statement`. Feel free to rationalize this by thinking of those
+/// statements as not necessarily depending on external state.
 #[tracing::instrument(level = "debug", skip_all)]
 pub fn plan(
     pcx: Option<&PlanContext>,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4818,6 +4818,7 @@ pub fn plan_alter_source(
                 crate::plan::AlterSourceAction::DropSubsourceExports { to_drop }
             }
         }
+        _ => todo!(),
     };
 
     Ok(Plan::AlterSource(AlterSourcePlan { id, action }))

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4818,7 +4818,13 @@ pub fn plan_alter_source(
                 crate::plan::AlterSourceAction::DropSubsourceExports { to_drop }
             }
         }
-        _ => todo!(),
+        AlterSourceAction::AddSubsources {
+            subsources,
+            details,
+        } => crate::plan::AlterSourceAction::AddSubsourceExports {
+            subsources,
+            details,
+        },
     };
 
     Ok(Plan::AlterSource(AlterSourcePlan { id, action }))

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -31,7 +31,8 @@ use mz_repr::{strconv, ColumnName, ColumnType, GlobalId, RelationDesc, RelationT
 use mz_sql_parser::ast::display::comma_separated;
 use mz_sql_parser::ast::{
     AlterClusterAction, AlterClusterStatement, AlterRoleStatement, AlterSinkAction,
-    AlterSinkStatement, AlterSourceAction, AlterSourceStatement, AlterSystemResetAllStatement,
+    AlterSinkStatement, AlterSourceAction, AlterSourceAddSubsourceOption,
+    AlterSourceAddSubsourceOptionName, AlterSourceStatement, AlterSystemResetAllStatement,
     AlterSystemResetStatement, AlterSystemSetStatement, CreateConnectionOption,
     CreateConnectionOptionName, CreateTypeListOption, CreateTypeListOptionName,
     CreateTypeMapOption, CreateTypeMapOptionName, DeferredItemName, DropOwnedStatement,
@@ -4702,6 +4703,11 @@ pub fn describe_alter_connection(
     Ok(StatementDesc::new(None))
 }
 
+generate_extracted_config!(
+    AlterSourceAddSubsourceOption,
+    (TextColumns, Vec::<UnresolvedItemName>, Default(vec![]))
+);
+
 pub fn plan_alter_source(
     scx: &mut StatementContext,
     stmt: AlterSourceStatement<Aug>,
@@ -4821,9 +4827,11 @@ pub fn plan_alter_source(
         AlterSourceAction::AddSubsources {
             subsources,
             details,
+            options,
         } => crate::plan::AlterSourceAction::AddSubsourceExports {
             subsources,
             details,
+            options,
         },
     };
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -17,23 +17,24 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::anyhow;
-use itertools::Itertools;
 use mz_ccsr::{Client, GetByIdError, GetBySubjectError, Schema as CcsrSchema};
 use mz_kafka_util::client::MzClientContext;
 use mz_ore::error::ErrorExt;
 use mz_ore::str::StrExt;
 use mz_proto::RustType;
-use mz_repr::adt::system::Oid;
 use mz_repr::{strconv, GlobalId};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
-    ColumnDef, CreateSubsourceOption, CreateSubsourceOptionName, CsrConnection, CsrSeedAvro,
-    CsrSeedProtobuf, CsrSeedProtobufSchema, DbzMode, DeferredItemName, Envelope, Ident,
-    KafkaConfigOption, KafkaConfigOptionName, KafkaConnection, KafkaSourceConnection,
-    PgConfigOption, PgConfigOptionName, ReaderSchemaSelectionStrategy, UnresolvedItemName,
+    AlterSourceAction, AlterSourceStatement, CreateSubsourceOption, CreateSubsourceOptionName,
+    CsrConnection, CsrSeedAvro, CsrSeedProtobuf, CsrSeedProtobufSchema, DbzMode, DeferredItemName,
+    Envelope, KafkaConfigOption, KafkaConfigOptionName, KafkaConnection, KafkaSourceConnection,
+    PgConfigOption, PgConfigOptionName, RawItemName, ReaderSchemaSelectionStrategy,
+    UnresolvedItemName,
 };
 use mz_storage_client::types::connections::{Connection, ConnectionContext};
-use mz_storage_client::types::sources::PostgresSourcePublicationDetails;
+use mz_storage_client::types::sources::{
+    GenericSourceConnection, PostgresSourcePublicationDetails, SourceConnection,
+};
 use prost::Message;
 use protobuf_native::compiler::{SourceTreeDescriptorDatabase, VirtualSourceTree};
 use protobuf_native::MessageLite;
@@ -52,6 +53,8 @@ use crate::plan::error::PlanError;
 use crate::plan::statement::ddl::load_generator_ast_to_generator;
 use crate::plan::StatementContext;
 use crate::{kafka_util, normalize};
+
+mod postgres;
 
 fn subsource_gen<'a, T>(
     selected_subsources: &mut Vec<CreateSourceSubsource<Aug>>,
@@ -96,6 +99,16 @@ fn subsource_gen<'a, T>(
     Ok(validated_requested_subsources)
 }
 
+// Convenience function to ensure subsources are not named.
+fn named_subsource_err(name: &Option<DeferredItemName<Aug>>) -> Result<(), PlanError> {
+    match name {
+        Some(DeferredItemName::Named(_)) => {
+            sql_bail!("Cannot manually ID qualify subsources")
+        }
+        _ => Ok(()),
+    }
+}
+
 /// Generates a subsource name by prepending source schema name if present
 ///
 /// For eg. if source is `a.b`, then `a` will be prepended to the subsource name
@@ -135,15 +148,6 @@ pub async fn purify_create_source(
         progress_subsource,
         ..
     } = &mut stmt;
-
-    fn named_subsource_err(name: &Option<DeferredItemName<Aug>>) -> Result<(), PlanError> {
-        match name {
-            Some(DeferredItemName::Named(_)) => {
-                sql_bail!("Cannot manually ID qualify subsources")
-            }
-            _ => Ok(()),
-        }
-    }
 
     // Disallow manually targetting subsources, this syntax is reserved for purification only
     named_subsource_err(progress_subsource)?;
@@ -303,28 +307,18 @@ pub async fn purify_create_source(
             let config = connection
                 .config(&*connection_context.secrets_reader)
                 .await?;
+
             let publication_tables =
                 mz_postgres_util::publication_info(&config, &publication, None).await?;
 
             if publication_tables.is_empty() {
-                return Err(PlanError::EmptyPublication(publication));
+                return Err(PlanError::EmptyPublication(publication.to_string()));
             }
 
-            // An index from table name -> schema name -> database name -> PostgresTableDesc
-            let mut tables_by_name = BTreeMap::new();
-            for table in &publication_tables {
-                tables_by_name
-                    .entry(table.name.clone())
-                    .or_insert_with(BTreeMap::new)
-                    .entry(table.namespace.clone())
-                    .or_insert_with(BTreeMap::new)
-                    .entry(connection.database.clone())
-                    .or_insert(table);
-            }
-
-            let publication_catalog = ErsatzCatalog(tables_by_name);
-
-            let mut targeted_subsources = vec![];
+            let publication_catalog = postgres::derive_catalog_from_publication_tables(
+                &connection.database,
+                &publication_tables,
+            )?;
 
             let mut validated_requested_subsources = vec![];
             match referenced_subsources {
@@ -377,7 +371,6 @@ pub async fn purify_create_source(
                 Some(ReferencedSubsources::SubsetTables(subsources)) => {
                     // The user manually selected a subset of upstream tables so we need to
                     // validate that the names actually exist and are not ambiguous
-
                     validated_requested_subsources.extend(subsource_gen(
                         subsources,
                         &publication_catalog,
@@ -396,114 +389,14 @@ pub async fn purify_create_source(
                 );
             }
 
-            // This condition would get caught during the catalog transaction, but produces a
-            // vague, non-contextual error. Instead, error here so we can suggest to the user
-            // how to fix the problem.
-            if let Some(name) = validated_requested_subsources
-                .iter()
-                .map(|(_, subsource_name, _)| subsource_name)
-                .duplicates()
-                .next()
-                .cloned()
-            {
-                let mut upstream_references: Vec<_> = validated_requested_subsources
-                    .into_iter()
-                    .filter_map(|(u, t, _)| if t == name { Some(u) } else { None })
-                    .collect();
+            postgres::validate_requested_subsources(&config, &validated_requested_subsources)
+                .await?;
 
-                upstream_references.sort();
-
-                return Err(PlanError::SubsourceNameConflict {
-                    name,
-                    upstream_references,
-                });
-            }
-
-            // We technically could allow multiple subsources to ingest the same upstream table, but
-            // it is almost certainly an error on the user's end.
-            if let Some(name) = validated_requested_subsources
-                .iter()
-                .map(|(referenced_name, _, _)| referenced_name)
-                .duplicates()
-                .next()
-                .cloned()
-            {
-                let mut target_names: Vec<_> = validated_requested_subsources
-                    .into_iter()
-                    .filter_map(|(u, t, _)| if u == name { Some(t) } else { None })
-                    .collect();
-
-                target_names.sort();
-
-                return Err(PlanError::SubsourceDuplicateReference { name, target_names });
-            }
-
-            // Ensure that we have select permissions on all tables; we have to do this before we
-            // start snapshotting because if we discover we cannot `COPY` from a table while
-            // snapshotting, we break the entire source.
-            let tables_to_check_permissions = validated_requested_subsources
-                .iter()
-                .map(|(UnresolvedItemName(inner), _, _)| [inner[1].as_str(), inner[2].as_str()])
-                .collect();
-
-            mz_postgres_util::check_table_privileges(&config, tables_to_check_permissions).await?;
-
-            let mut text_cols_dict: BTreeMap<u32, BTreeSet<String>> = BTreeMap::new();
-
-            for name in text_columns.iter_mut() {
-                let (qual, col) = match name.0.split_last().expect("must have at least one element")
-                {
-                    (col, qual) if qual.is_empty() => {
-                        return Err(PlanError::InvalidOptionValue {
-                            option_name: PgConfigOptionName::TextColumns.to_ast_string(),
-                            err: Box::new(PlanError::UnderqualifiedColumnName(
-                                col.as_str().to_string(),
-                            )),
-                        });
-                    }
-                    (col, qual) => (qual.to_vec(), col.as_str().to_string()),
-                };
-
-                let qual_name = UnresolvedItemName(qual);
-
-                let (mut fully_qualified_name, desc) = publication_catalog
-                    .resolve(qual_name)
-                    .map_err(|e| PlanError::InvalidOptionValue {
-                        option_name: PgConfigOptionName::TextColumns.to_ast_string(),
-                        err: Box::new(e),
-                    })?;
-
-                if !desc.columns.iter().any(|column| column.name == col) {
-                    return Err(PlanError::InvalidOptionValue {
-                        option_name: PgConfigOptionName::TextColumns.to_ast_string(),
-                        err: Box::new(PlanError::UnknownColumn {
-                            table: Some(
-                                normalize::unresolved_item_name(fully_qualified_name)
-                                    .expect("known to be of valid len"),
-                            ),
-                            column: mz_repr::ColumnName::from(col),
-                        }),
-                    });
-                }
-
-                // Rewrite fully qualified name.
-                fully_qualified_name.0.push(col.as_str().to_string().into());
-                *name = fully_qualified_name;
-
-                let new = text_cols_dict
-                    .entry(desc.oid)
-                    .or_default()
-                    .insert(col.as_str().to_string());
-
-                if !new {
-                    return Err(PlanError::InvalidOptionValue {
-                        option_name: PgConfigOptionName::TextColumns.to_ast_string(),
-                        err: Box::new(PlanError::UnexpectedDuplicateReference {
-                            name: name.clone(),
-                        }),
-                    });
-                }
-            }
+            let text_cols_dict = postgres::generate_text_columns(
+                &publication_catalog,
+                &mut text_columns,
+                &PgConfigOptionName::TextColumns.to_ast_string(),
+            )?;
 
             // Normalize options to contain full qualified values.
             if let Some(text_cols_option) = options
@@ -517,123 +410,15 @@ pub async fn purify_create_source(
                 text_cols_option.value = Some(WithOptionValue::Sequence(seq));
             }
 
-            // Aggregate all unrecognized types.
-            let mut unsupported_cols = vec![];
-
-            // Now that we have an explicit list of validated requested subsources we can create them
-            for (upstream_name, subsource_name, table) in validated_requested_subsources.into_iter()
-            {
-                // Figure out the schema of the subsource
-                let mut columns = vec![];
-                for c in table.columns.iter() {
-                    let name = Ident::new(c.name.clone());
-                    let ty = match text_cols_dict.get(&table.oid) {
-                        Some(names) if names.contains(&c.name) => mz_pgrepr::Type::Text,
-                        _ => match mz_pgrepr::Type::from_oid_and_typmod(c.type_oid, c.type_mod) {
-                            Ok(t) => t,
-                            Err(_) => {
-                                let mut full_name = upstream_name.0.clone();
-                                full_name.push(name);
-                                unsupported_cols.push((
-                                    UnresolvedItemName(full_name).to_ast_string(),
-                                    Oid(c.type_oid),
-                                ));
-                                continue;
-                            }
-                        },
-                    };
-
-                    let data_type = scx.resolve_type(ty)?;
-                    let mut options = vec![];
-
-                    if !c.nullable {
-                        options.push(mz_sql_parser::ast::ColumnOptionDef {
-                            name: None,
-                            option: mz_sql_parser::ast::ColumnOption::NotNull,
-                        });
-                    }
-
-                    columns.push(ColumnDef {
-                        name,
-                        data_type,
-                        collation: None,
-                        options,
-                    });
-                }
-
-                let mut constraints = vec![];
-                for key in table.keys.clone() {
-                    let mut key_columns = vec![];
-
-                    for col_num in key.cols {
-                        key_columns.push(Ident::new(
-                            table
-                                .columns
-                                .iter()
-                                .find(|col| col.col_num == Some(col_num))
-                                .expect("key exists as column")
-                                .name
-                                .clone(),
-                        ))
-                    }
-
-                    let constraint = mz_sql_parser::ast::TableConstraint::Unique {
-                        name: Some(Ident::new(key.name)),
-                        columns: key_columns,
-                        is_primary: key.is_primary,
-                        nulls_not_distinct: key.nulls_not_distinct,
-                    };
-
-                    // We take the first constraint available to be the primary key.
-                    if key.is_primary {
-                        constraints.insert(0, constraint);
-                    } else {
-                        constraints.push(constraint);
-                    }
-                }
-
-                // Create the targeted AST node for the original CREATE SOURCE statement
-                let transient_id = GlobalId::Transient(get_transient_subsource_id());
-
-                let subsource =
-                    scx.allocate_resolved_item_name(transient_id, subsource_name.clone())?;
-
-                targeted_subsources.push(CreateSourceSubsource {
-                    reference: upstream_name,
-                    subsource: Some(DeferredItemName::Named(subsource)),
-                });
-
-                // Create the subsource statement
-                let subsource = CreateSubsourceStatement {
-                    name: subsource_name,
-                    columns,
-                    // TODO(petrosagg): nothing stops us from getting the constraints of the
-                    // upstream tables and mirroring them here which will lead to more optimization
-                    // opportunities if for example there is a primary key or an index.
-                    //
-                    // If we ever do that we must triple check that we will get notified *in the
-                    // replication stream*, if our assumptions change. Failure to do that could
-                    // mean that an upstream table that started with an index was then altered to
-                    // one without and now we're producing garbage data.
-                    constraints,
-                    if_not_exists: false,
-                    with_options: vec![CreateSubsourceOption {
-                        name: CreateSubsourceOptionName::References,
-                        value: Some(WithOptionValue::Value(Value::Boolean(true))),
-                    }],
-                };
-                subsources.push((transient_id, subsource));
-            }
-
-            if !unsupported_cols.is_empty() {
-                return Err(PlanError::UnrecognizedTypeInPostgresSource {
-                    cols: unsupported_cols,
-                });
-            }
-
-            targeted_subsources.sort();
+            let (targeted_subsources, new_subsources) = postgres::generate_targeted_subsources(
+                &scx,
+                validated_requested_subsources,
+                text_cols_dict,
+                get_transient_subsource_id,
+            )?;
 
             *referenced_subsources = Some(ReferencedSubsources::SubsetTables(targeted_subsources));
+            subsources.extend(new_subsources);
 
             // Remove any old detail references
             options.retain(|PgConfigOption { name, .. }| name != &PgConfigOptionName::Details);
@@ -814,6 +599,195 @@ pub async fn purify_create_source(
     purify_source_format(&*catalog, format, connection, envelope, &connection_context).await?;
 
     Ok((subsources, stmt))
+}
+
+pub async fn purify_alter_source(
+    catalog: Box<dyn SessionCatalog>,
+    mut stmt: AlterSourceStatement<Aug>,
+    connection_context: ConnectionContext,
+) -> Result<
+    (
+        Vec<(GlobalId, CreateSubsourceStatement<Aug>)>,
+        AlterSourceStatement<Aug>,
+    ),
+    PlanError,
+> {
+    let scx = StatementContext::new(None, &*catalog);
+    let AlterSourceStatement {
+        source_name,
+        action,
+        if_exists,
+    } = &mut stmt;
+
+    // Get name.
+    let item = match scx.resolve_item(RawItemName::Name(source_name.clone())) {
+        Err(_) if !*if_exists => {
+            return Ok((vec![], stmt));
+        }
+        Ok(item) => item,
+        Err(e) => return Err(e.into()),
+    };
+
+    // Ensure it's an ingestion-based and alterable source.
+    let desc = match item.source_desc() {
+        Ok(Some(desc)) => desc,
+        Ok(None) => {
+            sql_bail!(
+                "{} is a {} not a source",
+                scx.catalog.minimal_qualification(item.name()),
+                item.item_type()
+            )
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    // If there's no further work to do here, early return.
+    let (targeted_subsources, details) = match action {
+        AlterSourceAction::AddSubsources {
+            subsources,
+            details,
+        } => (subsources, details),
+        _ => return Ok((vec![], stmt)),
+    };
+
+    assert!(
+        details.is_none(),
+        "details cannot be set before purification"
+    );
+
+    for CreateSourceSubsource {
+        subsource,
+        reference: _,
+    } in targeted_subsources.iter()
+    {
+        named_subsource_err(subsource)?;
+    }
+
+    // Get connection
+    let pg_source_connection = {
+        match &desc.connection {
+            GenericSourceConnection::Postgres(pg_connection) => pg_connection,
+            _ => sql_bail!(
+                "{} is a {} source, which does not support ALTER TABLE...ADD SUBSOURCES",
+                scx.catalog.minimal_qualification(item.name()),
+                desc.connection.name()
+            ),
+        }
+    };
+
+    // Get PostgresConnection for generating subsources.
+    let pg_connection = &pg_source_connection.connection;
+
+    let config = pg_connection
+        .config(&*connection_context.secrets_reader)
+        .await?;
+
+    let mut publication_tables =
+        mz_postgres_util::publication_info(&config, &pg_source_connection.publication, None)
+            .await?;
+
+    if publication_tables.is_empty() {
+        return Err(PlanError::EmptyPublication(
+            pg_source_connection.publication.to_string(),
+        ));
+    }
+
+    let publication_catalog = postgres::derive_catalog_from_publication_tables(
+        &pg_connection.database,
+        &publication_tables,
+    )?;
+
+    let validated_requested_subsources =
+        subsource_gen(targeted_subsources, &publication_catalog, source_name)?;
+
+    // Determine duplicate references to tables by cross-referencing the table
+    // positions in the current publication info to thei
+    let mut current_subsources = BTreeMap::new();
+    for idx in pg_source_connection.table_casts.keys() {
+        // Table casts all have their values increased by to accommodate for the
+        // primary source--this means that to look them up in the publication
+        // tables you must subtract one.
+        let native_idx = *idx - 1;
+        let table_desc = &pg_source_connection.publication_details.tables[native_idx];
+        current_subsources.insert(
+            UnresolvedItemName(vec![
+                pg_connection.database.clone().into(),
+                table_desc.namespace.clone().into(),
+                table_desc.name.clone().into(),
+            ]),
+            native_idx,
+        );
+    }
+
+    for (upstream_name, _, _) in validated_requested_subsources.iter() {
+        if current_subsources.contains_key(upstream_name) {
+            sql_bail!(
+                "cannot create multiple subsources in the same source that refer to upstream table {}",
+                upstream_name
+            );
+        }
+    }
+
+    postgres::validate_requested_subsources(&config, &validated_requested_subsources).await?;
+
+    // TODO: text columns
+
+    let mut subsource_id_counter = 0;
+    let get_transient_subsource_id = move || {
+        subsource_id_counter += 1;
+        subsource_id_counter
+    };
+
+    let (named_subsources, new_subsources) = postgres::generate_targeted_subsources(
+        &scx,
+        validated_requested_subsources,
+        BTreeMap::new(),
+        get_transient_subsource_id,
+    )?;
+
+    *targeted_subsources = named_subsources;
+
+    // An index from table name -> output index.
+    let mut new_name_to_output_map = BTreeMap::new();
+    for (i, table) in publication_tables.iter().enumerate() {
+        new_name_to_output_map.insert(
+            UnresolvedItemName(vec![
+                pg_connection.database.clone().into(),
+                table.namespace.clone().into(),
+                table.name.clone().into(),
+            ]),
+            i,
+        );
+    }
+
+    // Fixup the publication info
+    for (name, idx) in current_subsources {
+        let table = pg_source_connection.publication_details.tables[idx].clone();
+
+        // Determine if this current subsource is in the new publication tables.
+        match new_name_to_output_map.get(&name) {
+            // These are tables that were previously defined; we want to
+            // duplicate their definition to the new `publication_tables`
+            // because this command is meant only to add new tables, not update
+            // the schema of existing tables.
+            Some(cur_idx) => publication_tables[*cur_idx] = table,
+            // These are tables that no longer exist in the publication but the
+            // user has kept around. When the ingestion restarts after adding
+            // the new table, they will error out, but that is not the problem
+            // or scope of this function.
+            None => publication_tables.push(table),
+        }
+    }
+
+    // TODO: Options
+    let new_details = PostgresSourcePublicationDetails {
+        tables: publication_tables,
+        slot: pg_source_connection.publication_details.slot.clone(),
+    };
+
+    *details = Some(hex::encode(new_details.into_proto().encode_to_vec()));
+
+    Ok((new_subsources, stmt))
 }
 
 async fn purify_source_format(

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -815,7 +815,9 @@ async fn purify_alter_source(
         slot: pg_source_connection.publication_details.slot.clone(),
     };
 
-    *details = Some(hex::encode(new_details.into_proto().encode_to_vec()));
+    *details = Some(WithOptionValue::Value(Value::String(hex::encode(
+        new_details.into_proto().encode_to_vec(),
+    ))));
 
     Ok((new_subsources, Statement::AlterSource(stmt)))
 }

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -25,11 +25,11 @@ use mz_proto::RustType;
 use mz_repr::{strconv, GlobalId};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
-    AlterSourceAction, AlterSourceStatement, CreateSubsourceOption, CreateSubsourceOptionName,
-    CsrConnection, CsrSeedAvro, CsrSeedProtobuf, CsrSeedProtobufSchema, DbzMode, DeferredItemName,
-    Envelope, KafkaConfigOption, KafkaConfigOptionName, KafkaConnection, KafkaSourceConnection,
-    PgConfigOption, PgConfigOptionName, RawItemName, ReaderSchemaSelectionStrategy, Statement,
-    UnresolvedItemName,
+    AlterSourceAction, AlterSourceAddSubsourceOptionName, AlterSourceStatement,
+    CreateSubsourceOption, CreateSubsourceOptionName, CsrConnection, CsrSeedAvro, CsrSeedProtobuf,
+    CsrSeedProtobufSchema, DbzMode, DeferredItemName, Envelope, KafkaConfigOption,
+    KafkaConfigOptionName, KafkaConnection, KafkaSourceConnection, PgConfigOption,
+    PgConfigOptionName, RawItemName, ReaderSchemaSelectionStrategy, Statement, UnresolvedItemName,
 };
 use mz_storage_client::types::connections::{Connection, ConnectionContext};
 use mz_storage_client::types::sources::{
@@ -426,10 +426,14 @@ async fn purify_create_source(
                 .iter_mut()
                 .find(|option| option.name == PgConfigOptionName::TextColumns)
             {
-                let seq = text_columns
+                let mut seq: Vec<_> = text_columns
                     .into_iter()
                     .map(WithOptionValue::UnresolvedItemName)
                     .collect();
+
+                seq.sort();
+                seq.dedup();
+
                 text_cols_option.value = Some(WithOptionValue::Sequence(seq));
             }
 
@@ -683,11 +687,13 @@ async fn purify_alter_source(
         }
     };
 
-    let (targeted_subsources, details) = match action {
+    // If there's no further work to do here, early return.
+    let (targeted_subsources, details, options) = match action {
         AlterSourceAction::AddSubsources {
             subsources,
             details,
-        } => (subsources, details),
+            options,
+        } => (subsources, details, options),
         _ => unreachable!(),
     };
 
@@ -695,6 +701,11 @@ async fn purify_alter_source(
         details.is_none(),
         "details cannot be set before purification"
     );
+
+    let crate::plan::statement::ddl::AlterSourceAddSubsourceOptionExtracted {
+        mut text_columns,
+        ..
+    } = options.clone().try_into()?;
 
     for CreateSourceSubsource {
         subsource,
@@ -758,19 +769,38 @@ async fn purify_alter_source(
     }
 
     postgres::validate_requested_subsources(&config, &validated_requested_subsources).await?;
-
-    // TODO: text columns
-
     let mut subsource_id_counter = 0;
     let get_transient_subsource_id = move || {
         subsource_id_counter += 1;
         subsource_id_counter
     };
 
+    let text_cols_dict = postgres::generate_text_columns(
+        &publication_catalog,
+        &mut text_columns,
+        &AlterSourceAddSubsourceOptionName::TextColumns.to_ast_string(),
+    )?;
+
+    // Normalize options to contain full qualified values.
+    if let Some(text_cols_option) = options
+        .iter_mut()
+        .find(|option| option.name == AlterSourceAddSubsourceOptionName::TextColumns)
+    {
+        let mut seq: Vec<_> = text_columns
+            .into_iter()
+            .map(WithOptionValue::UnresolvedItemName)
+            .collect();
+
+        seq.sort();
+        seq.dedup();
+
+        text_cols_option.value = Some(WithOptionValue::Sequence(seq));
+    }
+
     let (named_subsources, new_subsources) = postgres::generate_targeted_subsources(
         &scx,
         validated_requested_subsources,
-        BTreeMap::new(),
+        text_cols_dict,
         get_transient_subsource_id,
         &publication_tables,
     )?;

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -415,6 +415,7 @@ pub async fn purify_create_source(
                 validated_requested_subsources,
                 text_cols_dict,
                 get_transient_subsource_id,
+                &publication_tables,
             )?;
 
             *referenced_subsources = Some(ReferencedSubsources::SubsetTables(targeted_subsources));
@@ -743,6 +744,7 @@ pub async fn purify_alter_source(
         validated_requested_subsources,
         BTreeMap::new(),
         get_transient_subsource_id,
+        &publication_tables,
     )?;
 
     *targeted_subsources = named_subsources;

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -653,10 +653,10 @@ async fn purify_alter_source(
     let pg_source_connection = {
         // Get name.
         let item = match scx.resolve_item(RawItemName::Name(source_name.clone())) {
-            Err(_) if !*if_exists => {
+            Ok(item) => item,
+            Err(_) if *if_exists => {
                 return Ok((vec![], Statement::AlterSource(stmt)));
             }
-            Ok(item) => item,
             Err(e) => return Err(e),
         };
 

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -1,0 +1,309 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Postgres utilities for SQL purification.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use itertools::Itertools;
+use mz_postgres_util::desc::PostgresTableDesc;
+use mz_postgres_util::Config;
+use mz_repr::adt::system::Oid;
+use mz_repr::GlobalId;
+use mz_sql_parser::ast::display::AstDisplay;
+use mz_sql_parser::ast::{
+    ColumnDef, CreateSubsourceOption, CreateSubsourceOptionName, CreateSubsourceStatement,
+    DeferredItemName, Ident, Value, WithOptionValue,
+};
+use mz_sql_parser::ast::{CreateSourceSubsource, UnresolvedItemName};
+
+use crate::catalog::ErsatzCatalog;
+use crate::names::Aug;
+use crate::normalize;
+use crate::plan::{PlanError, StatementContext};
+
+pub(super) fn derive_catalog_from_publication_tables<'a>(
+    database: &'a str,
+    publication_tables: &'a [PostgresTableDesc],
+) -> Result<ErsatzCatalog<'a, PostgresTableDesc>, PlanError> {
+    // An index from table name -> schema name -> database name -> PostgresTableDesc
+    let mut tables_by_name = BTreeMap::new();
+    for table in publication_tables.iter() {
+        tables_by_name
+            .entry(table.name.clone())
+            .or_insert_with(BTreeMap::new)
+            .entry(table.namespace.clone())
+            .or_insert_with(BTreeMap::new)
+            .entry(database.to_string())
+            .or_insert(table);
+    }
+
+    Ok(ErsatzCatalog(tables_by_name))
+}
+
+pub(super) async fn validate_requested_subsources(
+    config: &Config,
+    requested_subsources: &[(UnresolvedItemName, UnresolvedItemName, &PostgresTableDesc)],
+) -> Result<(), PlanError> {
+    // This condition would get caught during the catalog transaction, but produces a
+    // vague, non-contextual error. Instead, error here so we can suggest to the user
+    // how to fix the problem.
+    if let Some(name) = requested_subsources
+        .iter()
+        .map(|(_, subsource_name, _)| subsource_name)
+        .duplicates()
+        .next()
+        .cloned()
+    {
+        let mut upstream_references: Vec<_> = requested_subsources
+            .into_iter()
+            .filter_map(|(u, t, _)| if t == &name { Some(u.clone()) } else { None })
+            .collect();
+
+        upstream_references.sort();
+
+        return Err(PlanError::SubsourceNameConflict {
+            name,
+            upstream_references,
+        });
+    }
+
+    // We technically could allow multiple subsources to ingest the same upstream table, but
+    // it is almost certainly an error on the user's end.
+    if let Some(name) = requested_subsources
+        .iter()
+        .map(|(referenced_name, _, _)| referenced_name)
+        .duplicates()
+        .next()
+        .cloned()
+    {
+        let mut target_names: Vec<_> = requested_subsources
+            .into_iter()
+            .filter_map(|(u, t, _)| if u == &name { Some(t.clone()) } else { None })
+            .collect();
+
+        target_names.sort();
+
+        return Err(PlanError::SubsourceDuplicateReference { name, target_names });
+    }
+
+    // Ensure that we have select permissions on all tables; we have to do this before we
+    // start snapshotting because if we discover we cannot `COPY` from a table while
+    // snapshotting, we break the entire source.
+    let tables_to_check_permissions = requested_subsources
+        .iter()
+        .map(|(UnresolvedItemName(inner), _, _)| [inner[1].as_str(), inner[2].as_str()])
+        .collect();
+
+    mz_postgres_util::check_table_privileges(config, tables_to_check_permissions).await?;
+
+    Ok(())
+}
+
+pub(super) fn generate_text_columns(
+    publication_catalog: &ErsatzCatalog<'_, PostgresTableDesc>,
+    text_columns: &mut [UnresolvedItemName],
+    option_name: &str,
+) -> Result<BTreeMap<u32, BTreeSet<String>>, PlanError> {
+    let mut text_cols_dict: BTreeMap<u32, BTreeSet<String>> = BTreeMap::new();
+
+    for name in text_columns {
+        let (qual, col) = match name.0.split_last().expect("must have at least one element") {
+            (col, qual) if qual.is_empty() => {
+                return Err(PlanError::InvalidOptionValue {
+                    option_name: option_name.to_string(),
+                    err: Box::new(PlanError::UnderqualifiedColumnName(
+                        col.as_str().to_string(),
+                    )),
+                });
+            }
+            (col, qual) => (qual.to_vec(), col.as_str().to_string()),
+        };
+
+        let qual_name = UnresolvedItemName(qual);
+
+        let (mut fully_qualified_name, desc) =
+            publication_catalog
+                .resolve(qual_name)
+                .map_err(|e| PlanError::InvalidOptionValue {
+                    option_name: option_name.to_string(),
+                    err: Box::new(e),
+                })?;
+
+        if !desc.columns.iter().any(|column| column.name == col) {
+            return Err(PlanError::InvalidOptionValue {
+                option_name: option_name.to_string(),
+                err: Box::new(PlanError::UnknownColumn {
+                    table: Some(
+                        normalize::unresolved_item_name(fully_qualified_name)
+                            .expect("known to be of valid len"),
+                    ),
+                    column: mz_repr::ColumnName::from(col),
+                }),
+            });
+        }
+
+        // Rewrite fully qualified name.
+        fully_qualified_name.0.push(col.as_str().to_string().into());
+        *name = fully_qualified_name;
+
+        let new = text_cols_dict
+            .entry(desc.oid)
+            .or_default()
+            .insert(col.as_str().to_string());
+
+        if !new {
+            return Err(PlanError::InvalidOptionValue {
+                option_name: option_name.to_string(),
+                err: Box::new(PlanError::UnexpectedDuplicateReference { name: name.clone() }),
+            });
+        }
+    }
+
+    Ok(text_cols_dict)
+}
+
+pub(crate) fn generate_targeted_subsources<F>(
+    scx: &StatementContext,
+    validated_requested_subsources: Vec<(
+        UnresolvedItemName,
+        UnresolvedItemName,
+        &PostgresTableDesc,
+    )>,
+    text_cols_dict: BTreeMap<u32, BTreeSet<String>>,
+    mut get_transient_subsource_id: F,
+) -> Result<
+    (
+        Vec<CreateSourceSubsource<Aug>>,
+        Vec<(GlobalId, CreateSubsourceStatement<Aug>)>,
+    ),
+    PlanError,
+>
+where
+    F: FnMut() -> u64,
+{
+    let mut targeted_subsources = vec![];
+    let mut subsources = vec![];
+
+    // Aggregate all unrecognized types.
+    let mut unsupported_cols = vec![];
+
+    // Now that we have an explicit list of validated requested subsources we can create them
+    for (upstream_name, subsource_name, table) in validated_requested_subsources.into_iter() {
+        // Figure out the schema of the subsource
+        let mut columns = vec![];
+        for c in table.columns.iter() {
+            let name = Ident::new(c.name.clone());
+            let ty = match text_cols_dict.get(&table.oid) {
+                Some(names) if names.contains(&c.name) => mz_pgrepr::Type::Text,
+                _ => match mz_pgrepr::Type::from_oid_and_typmod(c.type_oid, c.type_mod) {
+                    Ok(t) => t,
+                    Err(_) => {
+                        let mut full_name = upstream_name.0.clone();
+                        full_name.push(name);
+                        unsupported_cols.push((
+                            UnresolvedItemName(full_name).to_ast_string(),
+                            Oid(c.type_oid),
+                        ));
+                        continue;
+                    }
+                },
+            };
+
+            let data_type = scx.resolve_type(ty)?;
+            let mut options = vec![];
+
+            if !c.nullable {
+                options.push(mz_sql_parser::ast::ColumnOptionDef {
+                    name: None,
+                    option: mz_sql_parser::ast::ColumnOption::NotNull,
+                });
+            }
+
+            columns.push(ColumnDef {
+                name,
+                data_type,
+                collation: None,
+                options,
+            });
+        }
+
+        let mut constraints = vec![];
+        for key in table.keys.clone() {
+            let mut key_columns = vec![];
+
+            for col_num in key.cols {
+                key_columns.push(Ident::new(
+                    table
+                        .columns
+                        .iter()
+                        .find(|col| col.col_num == Some(col_num))
+                        .expect("key exists as column")
+                        .name
+                        .clone(),
+                ))
+            }
+
+            let constraint = mz_sql_parser::ast::TableConstraint::Unique {
+                name: Some(Ident::new(key.name)),
+                columns: key_columns,
+                is_primary: key.is_primary,
+                nulls_not_distinct: key.nulls_not_distinct,
+            };
+
+            // We take the first constraint available to be the primary key.
+            if key.is_primary {
+                constraints.insert(0, constraint);
+            } else {
+                constraints.push(constraint);
+            }
+        }
+
+        // Create the targeted AST node for the original CREATE SOURCE statement
+        let transient_id = GlobalId::Transient(get_transient_subsource_id());
+
+        let subsource = scx.allocate_resolved_item_name(transient_id, subsource_name.clone())?;
+
+        targeted_subsources.push(CreateSourceSubsource {
+            reference: upstream_name,
+            subsource: Some(DeferredItemName::Named(subsource)),
+        });
+
+        // Create the subsource statement
+        let subsource = CreateSubsourceStatement {
+            name: subsource_name,
+            columns,
+            // TODO(petrosagg): nothing stops us from getting the constraints of the
+            // upstream tables and mirroring them here which will lead to more optimization
+            // opportunities if for example there is a primary key or an index.
+            //
+            // If we ever do that we must triple check that we will get notified *in the
+            // replication stream*, if our assumptions change. Failure to do that could
+            // mean that an upstream table that started with an index was then altered to
+            // one without and now we're producing garbage data.
+            constraints,
+            if_not_exists: false,
+            with_options: vec![CreateSubsourceOption {
+                name: CreateSubsourceOptionName::References,
+                value: Some(WithOptionValue::Value(Value::Boolean(true))),
+            }],
+        };
+        subsources.push((transient_id, subsource));
+    }
+
+    if !unsupported_cols.is_empty() {
+        return Err(PlanError::UnrecognizedTypeInPostgresSource {
+            cols: unsupported_cols,
+        });
+    }
+
+    targeted_subsources.sort();
+
+    Ok((targeted_subsources, subsources))
+}

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -200,7 +200,7 @@ contains:cannot drop source table_e: still depended upon by materialized view mv
 
 # TEXT COLUMNS removed from table_f
 > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
-""
+<null>
 
 > SHOW SUBSOURCES ON mz_source
 mz_source_progress    progress

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -35,6 +35,52 @@ INSERT INTO table_a VALUES (1, 'one');
 ALTER TABLE table_a REPLICA IDENTITY FULL;
 INSERT INTO table_a VALUES (2, 'two');
 
+# Check empty publication on ALTER
+
+> CREATE SOURCE "mz_source"
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source'
+  )
+  FOR SCHEMAS (public);
+
+> SELECT * FROM table_a;
+1 one
+2 two
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP TABLE table_a CASCADE;
+
+!ALTER SOURCE mz_source ADD SUBSOURCE table_b;
+contains:PostgreSQL PUBLICATION mz_source is empty
+
+# Adding a table with the same name as a running table does not allow you to add
+# the new table, even though its OID is the different.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
+ALTER TABLE table_a REPLICA IDENTITY FULL;
+INSERT INTO table_a VALUES (9, 'nine');
+
+# Current table_a is not new table_a. Note that this only works right now
+# because we are bad at detecting dropped tables.
+> SELECT * FROM table_a;
+1 one
+2 two
+
+# We are not aware that the new table_a is different
+!ALTER SOURCE mz_source ADD SUBSOURCE table_a;
+contains:cannot create multiple subsources in the same source that refer to upstream table postgres.public.table_a
+
+> DROP SOURCE mz_source;
+
+# Re-populate tables for rest of test.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+
+DELETE FROM table_a;
+INSERT INTO table_a VALUES (1, 'one');
+INSERT INTO table_a VALUES (2, 'two');
+
 CREATE TABLE table_b (pk INTEGER PRIMARY KEY, f2 TEXT);
 INSERT INTO table_b VALUES (1, 'one');
 ALTER TABLE table_b REPLICA IDENTITY FULL;
@@ -69,7 +115,7 @@ INSERT INTO table_g VALUES (2, 'two');
 > CREATE SOURCE "mz_source"
   FROM POSTGRES CONNECTION pg (
     PUBLICATION 'mz_source',
-    TEXT COLUMNS (table_f.f2)
+    TEXT COLUMNS [table_f.f2]
   )
   FOR SCHEMAS (public);
 
@@ -132,15 +178,19 @@ contains:unknown catalog item 'dne'
 
 > ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS dne, dne, dne;
 
+> ALTER SOURCE IF EXISTS dne DROP SUBSOURCE IF EXISTS dne;
+
+> ALTER SOURCE IF EXISTS mz_source DROP SUBSOURCE IF EXISTS dne, dne, dne;
+
 #
 # State checking
 #
 
+> ALTER SOURCE mz_source DROP SUBSOURCE table_a
+
 > SELECT * FROM table_b;
 1 one
 2 two
-
-> ALTER SOURCE mz_source DROP SUBSOURCE table_a;
 
 > SHOW SUBSOURCES ON mz_source
 mz_source_progress    progress
@@ -216,3 +266,155 @@ contains:SOURCE "mz_source" must retain at least one non-progress subsource
 # Show that all table definitions have been updated
 > SELECT regexp_match(create_sql, 'FOR TABLES \((.+?)\) EXPOSE') FROM (SHOW CREATE SOURCE mz_source);
 "{\"postgres\".\"public\".\"table_g\" AS \"materialize\".\"public\".\"table_g\"}"
+
+#
+# Add subsources
+
+! ALTER SOURCE mz_source ADD SUBSOURCE table_g;
+contains:cannot create multiple subsources in the same source that refer to upstream table postgres.public.table_g
+
+> ALTER SOURCE mz_source ADD SUBSOURCE table_a, table_b AS tb;
+
+> SELECT * FROM table_a;
+1 one
+2 two
+
+! ALTER SOURCE mz_source ADD SUBSOURCE table_a;
+contains:cannot create multiple subsources in the same source that refer to upstream table postgres.public.table_a
+
+> SELECT * FROM tb;
+1 one
+2 two
+3 three
+
+!SELECT * FROM table_b;
+contains:unknown catalog item
+
+# We can add tables that didn't exist at the time of publication
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE table_h (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO table_h VALUES (1, 'one');
+ALTER TABLE table_h REPLICA IDENTITY FULL;
+INSERT INTO table_h VALUES (2, 'two');
+
+> ALTER SOURCE mz_source ADD SUBSOURCE table_h;
+
+> SELECT * FROM table_h;
+1 one
+2 two
+
+> SHOW SUBSOURCES ON mz_source
+mz_source_progress progress
+table_a            subsource
+table_g            subsource
+table_h            subsource
+tb                 subsource
+
+#
+# Complex subsource operations
+
+# If your schema change breaks the subsource, you can fix it.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE table_a DROP COLUMN f2;
+INSERT INTO table_a VALUES (3);
+
+! SELECT * FROM table_a;
+contains:incompatible schema change
+
+> ALTER SOURCE mz_source DROP SUBSOURCE table_a;
+
+> ALTER SOURCE mz_source ADD SUBSOURCE table_a;
+
+> SELECT * FROM table_a;
+1
+2
+3
+
+# If you add columns you can re-ingest them
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE table_a ADD COLUMN f2 text;
+INSERT INTO table_a VALUES (4, 'four');
+
+> SELECT * FROM table_a;
+1
+2
+3
+
+> ALTER SOURCE mz_source DROP SUBSOURCE table_a;
+> ALTER SOURCE mz_source ADD SUBSOURCE table_a;
+
+> SELECT * FROM table_a;
+1 <null>
+2 <null>
+3 <null>
+4 four
+
+# If you add a NOT NULL constraint, you can propagate it.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE table_a ADD COLUMN f3 int DEFAULT 1 NOT NULL;
+INSERT INTO table_a VALUES (5, 'five', 5);
+
+> ALTER SOURCE mz_source DROP SUBSOURCE table_a;
+> ALTER SOURCE mz_source ADD SUBSOURCE table_a;
+
+> SELECT * FROM table_a;
+1 <null> 1
+2 <null> 1
+3 <null> 1
+4 four 1
+5 five 5
+
+> EXPLAIN SELECT * FROM table_a WHERE f3 IS NULL;
+"Explained Query (fast path):\n  Constant <empty>\n"
+
+# Can add tables with text columns
+! ALTER SOURCE mz_source ADD SUBSOURCE table_f WITH (TEXT COLUMNS [table_f.f2, table_f.f2]);
+contains: invalid TEXT COLUMNS option value: unexpected multiple references to postgres.public.table_f.f2
+
+> ALTER SOURCE mz_source ADD SUBSOURCE table_f WITH (TEXT COLUMNS [table_f.f2]);
+
+> SELECT * FROM table_f
+1 var0
+2 var1
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+"\"postgres\".\"public\".\"table_f\".\"f2\""
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE table_i (pk INTEGER PRIMARY KEY, f2 an_enum);
+INSERT INTO table_i VALUES (1, 'var0');
+ALTER TABLE table_i REPLICA IDENTITY FULL;
+INSERT INTO table_i VALUES (2, 'var1');
+
+> ALTER SOURCE mz_source ADD SUBSOURCE table_i WITH (TEXT COLUMNS [table_i.f2]);
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+"\"postgres\".\"public\".\"table_f\".\"f2\", \"postgres\".\"public\".\"table_i\".\"f2\""
+
+> ALTER SOURCE mz_source DROP SUBSOURCE table_f, table_i;
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+<null>
+
+! ALTER SOURCE mz_source ADD SUBSOURCE table_e WITH (TEXT COLUMNS (table_z.a));
+contains:invalid TEXT COLUMNS option value: table table_z not found in source
+
+! ALTER SOURCE mz_source ADD SUBSOURCE table_e WITH (TEXT COLUMNS [table_f.f2]);
+contains:TEXT COLUMNS can only refer to tables being added to source
+detail:the following tables were referenced but not added: public.table_f
+
+# Test adding text cols w/o original text columns
+
+> CREATE SOURCE "mz_source_wo_init_text_cols"
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source'
+  )
+  FOR TABLES (table_a AS t_a);
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source_wo_init_text_cols);
+<null>
+
+> ALTER SOURCE mz_source_wo_init_text_cols ADD SUBSOURCE table_f AS t_f WITH (TEXT COLUMNS [table_f.f2]);
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source_wo_init_text_cols);
+"\"postgres\".\"public\".\"table_f\".\"f2\""

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -615,13 +615,27 @@ contains: invalid TEXT COLUMNS option value: table utf8_table not found in sourc
 # n.b includes a reference to pk_table, which is not a table that's part of the
 # source, but is part of the publication.
 
-> CREATE SOURCE enum_source
+! CREATE SOURCE enum_source
   FROM POSTGRES CONNECTION pg (
     PUBLICATION 'mz_source',
     TEXT COLUMNS [
       enum_table.a,
       public.another_enum_table."колона",
       pk_table.pk
+    ]
+  )
+  FOR TABLES (
+    "enum_table",
+    public.another_enum_table
+  );
+contains:TEXT COLUMNS can only refer to tables being added to source
+
+> CREATE SOURCE enum_source
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [
+      enum_table.a,
+      public.another_enum_table."колона"
     ]
   )
   FOR TABLES (

--- a/test/testdrive/kafka-alter-source.td
+++ b/test/testdrive/kafka-alter-source.td
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Verify commands do not work on kafka.
+
+$ kafka-create-topic topic=data partitions=1
+$ kafka-ingest format=bytes topic=data
+one
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE SOURCE data
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FORMAT TEXT;
+
+> SELECT * from data
+one
+
+!ALTER SOURCE data ADD SUBSOURCE t;
+contains:data is a kafka source, which does not support ALTER TABLE...ADD SUBSOURCES
+
+!ALTER SOURCE data DROP SUBSOURCE t;
+contains:unknown catalog item 't'

--- a/test/upgrade/create-in-v0.32.4-pg-cdc.td
+++ b/test/upgrade/create-in-v0.32.4-pg-cdc.td
@@ -30,9 +30,16 @@ CREATE TABLE cdc_enum_table (a an_enum);
 INSERT INTO cdc_enum_table VALUES ('var1'), ('var0');
 ALTER TABLE cdc_enum_table REPLICA IDENTITY FULL;
 
+CREATE TABLE another_enum_table (a an_enum);
+INSERT INTO another_enum_table VALUES ('var1'), ('var0');
+ALTER TABLE another_enum_table REPLICA IDENTITY FULL;
+
 DROP TABLE IF EXISTS cdc_empty_on_boot_table;
 CREATE TABLE cdc_empty_on_boot_table (a int);
 ALTER TABLE cdc_empty_on_boot_table REPLICA IDENTITY FULL;
+
+DROP PUBLICATION IF EXISTS upgrade_pg_cdc_text_col_pub;
+CREATE PUBLICATION upgrade_pg_cdc_text_col_pub FOR TABLE cdc_enum_table, another_enum_table;
 
 # Specifying `TEXT COLUMNS` lets us ingest enum data.
 > CREATE SECRET IF NOT EXISTS pgpass AS 'postgres';
@@ -47,7 +54,7 @@ ALTER TABLE cdc_empty_on_boot_table REPLICA IDENTITY FULL;
   CONNECTION pgconn
   (
     PUBLICATION 'upgrade_pg_cdc_publication',
-    TEXT COLUMNS (cdc_enum_table.a)
+    TEXT COLUMNS (cdc_enum_table.a, another_enum_table.a)
   )
   FOR ALL TABLES;
 
@@ -110,3 +117,12 @@ SELECT mz_version_num() >= 5600;
 3
 4
 5
+
+> CREATE SOURCE dangling_text_cols_source
+  FROM POSTGRES
+  CONNECTION pgconn
+  (
+    PUBLICATION 'upgrade_pg_cdc_publication',
+    TEXT COLUMNS (cdc_enum_table.a, another_enum_table.a)
+  )
+  FOR ALL TABLES;

--- a/test/upgrade/create-in-v0.58.0-pg-text-cols.td
+++ b/test/upgrade/create-in-v0.58.0-pg-text-cols.td
@@ -1,0 +1,37 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# IMPORTANT: The Postgres server has a custom pg_hba.conf that only
+# accepts connections from specific users. You will have to update
+# pg_hba.conf if you modify the existing user names or add new ones.
+
+$ skip-if
+SELECT mz_version_num() >= 6000;
+
+> CREATE SECRET IF NOT EXISTS pgpass AS 'postgres'
+> CREATE CONNECTION IF NOT EXISTS pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+# Create a table with a dangling text cols reference, which will be disallowed
+# in newer versions of MZ. All we care is that the later versions boot with it.
+
+> CREATE SOURCE dangling_text_cols_source
+  FROM POSTGRES
+  CONNECTION pgconn
+  (
+    PUBLICATION 'upgrade_pg_cdc_publication',
+    TEXT COLUMNS (cdc_enum_table.a, another_enum_table.a)
+  )
+  FOR TABLES (
+    cdc_enum_table AS cdc_enum_table_dangling_text_cols_source
+  );


### PR DESCRIPTION
### Motivation

This PR adds a known-desirable feature. Closes #15832

### Tips for reviewer

- Reviewing commit by commit is likely best
- There are some semantic changes to `TEXT COLUMNS` baked in here that I have ensured do not interfere with users who've done now-prohibited things previously (e.g. referring to a table that is not being added to the source). These changes _do_ break the ability to put `SHOW CREATE SOURCE` back into `CREATE SOURCE`.  However, this is a weird and fixable edge case––I do not believe we should hold back making this change or add complexity to support it in `CREATE` but not `ALTER`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Let users add new tables to their PG sources using `ALTER SOURCE...ADD SUBSOURCE`.
