### PR TITLE
doc/user: restore day of week in maintenance window docs

### DIFF
--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -729,37 +729,6 @@ p+p {
         }
     }
 
-
-    .table-scrollable {
-        box-shadow: inset 0 -4px 3px -3px $medium-grey-v2;
-        margin: 1rem 0 3rem;
-        overflow: auto;
-
-        table {
-            width: 100%;
-        }
-
-        thead th {
-            background: #fff;
-            border: 0;
-            position: sticky;
-            top: 0;
-
-            &:after {
-                border-bottom: 2px $purple-v2 solid;
-                content: "";
-                bottom: -1px;
-                left: 0;
-                right: 0;
-                position: absolute;
-            }
-        }
-
-        &+* {
-            margin-top: 3rem !important;
-        }
-    }
-
     #subscribe_dialog {
         display: none;
         z-index: 10;
@@ -835,6 +804,40 @@ p+p {
         }
     }
 }
+
+.table-scrollable {
+    box-shadow: inset 0 -4px 3px -3px $medium-grey-v2;
+    margin: 1rem 0 3rem;
+    overflow: auto;
+
+    .table-container {
+        overflow: visible;
+    }
+
+    table {
+        width: 100%;
+    }
+
+    thead th {
+        background: #fff;
+        position: sticky;
+        top: 0;
+
+        &:after {
+            border-bottom: 1px var(--highlight) solid;
+            content: "";
+            bottom: -1px;
+            left: 0;
+            right: 0;
+            position: absolute;
+        }
+    }
+
+    &+* {
+        margin-top: 3rem !important;
+    }
+}
+
 
 .level-of-support {
     display: inline-block;
@@ -975,14 +978,6 @@ body.dark .content {
     .alpha {
         .gutter {
             color: #ff8504;
-        }
-    }
-
-    .table-scrollable {
-        thead th {
-            &:after {
-                border-bottom: 2px solid var(--link);
-            }
         }
     }
 

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -23,13 +23,13 @@ and [documentation](https://materialize.com/docs/lts/).
 
 ## Schedule
 
-Each week, Materialize upgrades all regions to the latest version according to
+Materialize upgrades all regions to the latest release each week according to
 the following schedule:
 
-Region        | Upgrade window
---------------|------------------------------
-aws/eu-west-1 | 2100-2300 [Europe/Dublin]
-aws/us-east-1 | 0500-0700 [America/New_York]
+Region        | Day of week | Time
+--------------|-------------|-----------------------------
+aws/eu-west-1 | Wednesday   | 2100-2300 [Europe/Dublin]
+aws/us-east-1 | Thursday    | 0500-0700 [America/New_York]
 
 {{< note >}}
 Upgrade windows follow any daylight saving time or summer time rules

--- a/doc/user/layouts/shortcodes/version-list.html
+++ b/doc/user/layouts/shortcodes/version-list.html
@@ -1,4 +1,4 @@
-<div class="table-scrollable" {{/* style="height: 300px;" */}}>
+<div class="table-scrollable" style="height: 310px;">
   <table>
     <thead>
       <th>Version</th>


### PR DESCRIPTION
I accidentally lost this in the last commit to update this. Also restore the functionality of scrollable tables, which seems to have been lost in the latest docs CSS redesign.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds missing information to our docs.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
