### PR TITLE
test: Fix nightly default privilege tests

### DIFF
--- a/misc/python/materialize/checks/default_privileges.py
+++ b/misc/python/materialize/checks/default_privileges.py
@@ -27,7 +27,8 @@ class DefaultPrivileges(Check):
             > CREATE SCHEMA defpriv_schema
             > SET SCHEMA defpriv_schema
             > CREATE ROLE defpriv_role1
-            > GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role1
+            >[version<5900] ALTER ROLE defpriv_role1 CREATEDB CREATECLUSTER
+            >[version>=5900] GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role1
             > CREATE TABLE defpriv_table1 (c int)
             """
             )
@@ -42,7 +43,8 @@ class DefaultPrivileges(Check):
                 > SET SCHEMA defpriv_schema
                 > ALTER DEFAULT PRIVILEGES IN SCHEMA defpriv_db.defpriv_schema GRANT ALL PRIVILEGES ON TABLES TO defpriv_role1;
                 > CREATE ROLE defpriv_role2
-                > GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role2
+                >[version<5900] ALTER ROLE defpriv_role2 CREATEDB CREATECLUSTER
+                >[version>=5900] GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role2
                 > CREATE TABLE defpriv_table2 (c int)
                 """,
                 """
@@ -50,7 +52,8 @@ class DefaultPrivileges(Check):
                 > SET SCHEMA defpriv_schema
                 > ALTER DEFAULT PRIVILEGES IN SCHEMA defpriv_db.defpriv_schema GRANT ALL PRIVILEGES ON TABLES TO defpriv_role2;
                 > CREATE ROLE defpriv_role3
-                > GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role3
+                >[version<5900] ALTER ROLE defpriv_role3 CREATEDB CREATECLUSTER
+                >[version>=5900] GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role3
                 > CREATE TABLE defpriv_table3 (c int)
                 """,
             ]


### PR DESCRIPTION
This commit fixes the nightly default privilege tests so that they use either role attributes or system privileges depending on the version.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
