### PR TITLE
environmentd: fix telemetry for managed clusters

### DIFF
--- a/src/environmentd/src/telemetry.rs
+++ b/src/environmentd/src/telemetry.rs
@@ -144,11 +144,11 @@ async fn report_loop(
                             SELECT jsonb_object_agg(base.size, coalesce(count, 0))
                             FROM mz_internal.mz_cluster_replica_sizes base
                             LEFT JOIN (
-                                SELECT size, count(*)::int4
+                                SELECT r.size, count(*)::int4
                                 FROM mz_cluster_replicas r
                                 JOIN mz_clusters c ON c.id = r.cluster_id
                                 WHERE c.id LIKE 'u%'
-                                GROUP BY size
+                                GROUP BY r.size
                             ) extant ON base.size = extant.size
                         ),
                         'active_confluent_schema_registry_connections', (SELECT count(*) FROM mz_connections WHERE id LIKE 'u%' AND type = 'confluent-schema-registry')::int4,


### PR DESCRIPTION
The managed cluster work added a new `size` column to `mz_clusters`, which broke the telemetry query by making an unqualified reference to `size` ambiguous.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug: telemetry is broken in v0.58.0.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
