### PR TITLE
sql: Add privileges for system privileges

### DIFF
--- a/misc/python/materialize/checks/default_privileges.py
+++ b/misc/python/materialize/checks/default_privileges.py
@@ -28,7 +28,10 @@ class DefaultPrivileges(Check):
             > SET SCHEMA defpriv_schema
             > CREATE ROLE defpriv_role1
             >[version<5900] ALTER ROLE defpriv_role1 CREATEDB CREATECLUSTER
-            >[version>=5900] GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role1
+
+            $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+            GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role1
+
             > CREATE TABLE defpriv_table1 (c int)
             """
             )
@@ -44,7 +47,10 @@ class DefaultPrivileges(Check):
                 > ALTER DEFAULT PRIVILEGES IN SCHEMA defpriv_db.defpriv_schema GRANT ALL PRIVILEGES ON TABLES TO defpriv_role1;
                 > CREATE ROLE defpriv_role2
                 >[version<5900] ALTER ROLE defpriv_role2 CREATEDB CREATECLUSTER
-                >[version>=5900] GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role2
+
+                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role2
+
                 > CREATE TABLE defpriv_table2 (c int)
                 """,
                 """
@@ -53,7 +59,10 @@ class DefaultPrivileges(Check):
                 > ALTER DEFAULT PRIVILEGES IN SCHEMA defpriv_db.defpriv_schema GRANT ALL PRIVILEGES ON TABLES TO defpriv_role2;
                 > CREATE ROLE defpriv_role3
                 >[version<5900] ALTER ROLE defpriv_role3 CREATEDB CREATECLUSTER
-                >[version>=5900] GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role3
+
+                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role3
+
                 > CREATE TABLE defpriv_table3 (c int)
                 """,
             ]

--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -103,7 +103,9 @@ class Owners(Check):
 
                 > CREATE ROLE owner_role_01
                 >[version<5900] ALTER ROLE owner_role_01 CREATEDB CREATECLUSTER
-                >[version>=5900] GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO owner_role_01
+
+                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO owner_role_01
                 """
             )
             + self._create_objects("owner_role_01", 1, expensive=True)
@@ -124,7 +126,9 @@ class Owners(Check):
 
                     > CREATE ROLE owner_role_02
                     >[version<5900] ALTER ROLE owner_role_02 CREATEDB CREATECLUSTER
-                    >[version>=5900] GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO owner_role_02
+
+                    $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO owner_role_02
                     """
                 ),
                 self._create_objects("owner_role_01", 3)
@@ -139,7 +143,9 @@ class Owners(Check):
 
                     > CREATE ROLE owner_role_03
                     >[version<5900] ALTER ROLE owner_role_03 CREATEDB CREATECLUSTER
-                    >[version>=5900] GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO owner_role_03
+
+                    $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO owner_role_03
                     """
                 ),
             ]

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -209,24 +209,7 @@ pub fn check_plan(
     role_memberships.insert(*current_role_id, role_membership);
     check_object_privileges(catalog, required_privileges, role_memberships)?;
 
-    // Altering the default privileges for the PUBLIC role (aka ALL ROLES) will affect all roles
-    // that currently exist and roles that will exist in the future. It's impossible for an exising
-    // role to be a member of a role that doesn't exist yet, so no current role could possibly have
-    // the privileges required to alter default privileges for the PUBLIC role. Therefore we
-    // only superusers can alter default privileges for the PUBLIC role.
-    if let Plan::AlterDefaultPrivileges(AlterDefaultPrivilegesPlan {
-        privilege_objects, ..
-    }) = &plan
-    {
-        if privilege_objects
-            .iter()
-            .any(|privilege_object| privilege_object.role_id.is_public())
-        {
-            return Err(AdapterError::Unauthorized(UnauthorizedError::Superuser {
-                action: "ALTER DEFAULT PRIVILEGES FOR ALL ROLES".to_string(),
-            }));
-        }
-    }
+    check_superuser_required(plan)?;
 
     Ok(())
 }
@@ -1331,6 +1314,44 @@ fn check_object_privileges(
     }
 
     Ok(())
+}
+
+fn check_superuser_required(plan: &Plan) -> Result<(), UnauthorizedError> {
+    match plan {
+        // Altering the default privileges for the PUBLIC role (aka ALL ROLES) will affect all roles
+        // that currently exist and roles that will exist in the future. It's impossible for an exising
+        // role to be a member of a role that doesn't exist yet, so no current role could possibly have
+        // the privileges required to alter default privileges for the PUBLIC role. Therefore we
+        // only superusers can alter default privileges for the PUBLIC role.
+        Plan::AlterDefaultPrivileges(AlterDefaultPrivilegesPlan {
+            privilege_objects, ..
+        }) if privilege_objects
+            .iter()
+            .any(|privilege_object| privilege_object.role_id.is_public()) =>
+        {
+            Err(UnauthorizedError::Superuser {
+                action: "ALTER DEFAULT PRIVILEGES FOR ALL ROLES".to_string(),
+            })
+        }
+        // To grant/revoke a privilege on some object, generally the grantor/revoker must be the
+        // owner of that object (or have a grant option on that object which isn't implemented in
+        // Materialize yet). There is no owner of the entire system, so it's only reasonable to
+        // restrict granting/revoking system privileges to superusers.
+        Plan::GrantPrivileges(GrantPrivilegesPlan {
+            update_privileges, ..
+        })
+        | Plan::RevokePrivileges(RevokePrivilegesPlan {
+            update_privileges, ..
+        }) if update_privileges
+            .iter()
+            .any(|update_privilege| update_privilege.target_id.is_system()) =>
+        {
+            Err(UnauthorizedError::Superuser {
+                action: "GRANT/REVOKE SYSTEM PRIVILEGES".to_string(),
+            })
+        }
+        _ => Ok(()),
+    }
 }
 
 pub(crate) const fn all_object_privileges(object_type: SystemObjectType) -> AclMode {

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1097,6 +1097,10 @@ impl SystemObjectId {
             SystemObjectId::System => None,
         }
     }
+
+    pub fn is_system(&self) -> bool {
+        matches!(self, SystemObjectId::System)
+    }
 }
 
 impl From<ObjectId> for SystemObjectId {

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -2890,6 +2890,24 @@ REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM joe;
 ----
 COMPLETE 0
 
+## System
+
+statement error You must be a superuser to GRANT/REVOKE SYSTEM PRIVILEGES
+GRANT CREATEDB ON SYSTEM TO joe
+
+simple conn=mz_system,user=mz_system
+GRANT CREATEDB ON SYSTEM TO joe;
+----
+COMPLETE 0
+
+statement error You must be a superuser to GRANT/REVOKE SYSTEM PRIVILEGES
+REVOKE CREATEDB ON SYSTEM FROM joe
+
+simple conn=mz_system,user=mz_system
+REVOKE CREATEDB ON SYSTEM FROM joe
+----
+COMPLETE 0
+
 # GRANT/REVOKE role
 
 simple conn=mz_system,user=mz_system

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -1875,8 +1875,10 @@ SELECT has_system_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'CREA
 ----
 false
 
-statement ok
+simple conn=mz_system,user=mz_system
 GRANT CREATEDB ON SYSTEM TO joe
+----
+COMPLETE 0
 
 query T
 SELECT privileges::text FROM mz_system_privileges
@@ -1895,8 +1897,10 @@ SELECT has_system_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'CREA
 true
 
 ### Duplicate grants have no effect
-statement ok
+simple conn=mz_system,user=mz_system
 GRANT CREATEDB ON SYSTEM TO joe
+----
+COMPLETE 0
 
 query T
 SELECT privileges::text FROM mz_system_privileges
@@ -1904,8 +1908,10 @@ SELECT privileges::text FROM mz_system_privileges
 joe=B/mz_system
 mz_system=RBN/mz_system
 
-statement ok
+simple conn=mz_system,user=mz_system
 GRANT CREATEROLE, CREATECLUSTER ON SYSTEM TO PUBLIC
+----
+COMPLETE 0
 
 query T
 SELECT privileges::text FROM mz_system_privileges
@@ -1917,8 +1923,10 @@ mz_system=RBN/mz_system
 statement error role "joe" cannot be dropped because some objects depend on it
 DROP ROLE joe
 
-statement ok
+simple conn=mz_system,user=mz_system
 REVOKE CREATEDB ON SYSTEM FROM joe
+----
+COMPLETE 0
 
 query T
 SELECT privileges::text FROM mz_system_privileges
@@ -1937,8 +1945,10 @@ SELECT has_system_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'CREA
 false
 
 ### Duplicate revokes have no effect
-statement ok
+simple conn=mz_system,user=mz_system
 REVOKE CREATEDB ON SYSTEM FROM joe
+----
+COMPLETE 0
 
 query T
 SELECT privileges::text FROM mz_system_privileges
@@ -1952,8 +1962,10 @@ DROP ROLE joe
 statement ok
 CREATE ROLE joe
 
-statement ok
+simple conn=mz_system,user=mz_system
 REVOKE CREATEROLE, CREATECLUSTER ON SYSTEM FROM PUBLIC
+----
+COMPLETE 0
 
 query T
 SELECT privileges::text FROM mz_system_privileges


### PR DESCRIPTION
This commit restricts granting and revoking system to superusers only. To grant/revoke a privilege on some object, generally the grantor/revoker must be the owner of that object (or have a grant option on that object which isn't implemented in Materialize yet). There is no owner of the entire system, so it's only reasonable to restrict granting/revoking system privileges to superusers.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add privilege checks to granting/revoking system privileges.
