### PR TITLE
mz: Retry disable command more often

### DIFF
--- a/src/mz/src/api.rs
+++ b/src/mz/src/api.rs
@@ -153,7 +153,7 @@ pub async fn disable_region_environment(
     valid_profile: &ValidProfile<'_>,
 ) -> Result<(), reqwest::Error> {
     Retry::default()
-        .max_tries(10)
+        .max_tries(100)
         .retry_async(|_| async {
             client
                 .delete(format!("{:}/api/environmentassignment", cloud_provider.api_url).as_str())


### PR DESCRIPTION
Failed again even with 10 retries:
https://buildkite.com/materialize/nightlies/builds/2704#018918f2-bf67-4016-82e0-222483b42519

Nightly succeeded for this: https://buildkite.com/materialize/nightlies/builds/2706

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
