### PR TITLE
cloudtest: Fix initial current_version during upgrade tests

### DIFF
--- a/misc/python/materialize/checks/executors.py
+++ b/misc/python/materialize/checks/executors.py
@@ -76,10 +76,10 @@ class MzcomposeExecutorParallel(MzcomposeExecutor):
 
 
 class CloudtestExecutor(Executor):
-    def __init__(self, application: MaterializeApplication) -> None:
+    def __init__(self, application: MaterializeApplication, version: MzVersion) -> None:
         self.application = application
         self.seed = random.getrandbits(32)
-        self.current_mz_version = MzVersion.parse_cargo()
+        self.current_mz_version = version
 
     def cloudtest_application(self) -> MaterializeApplication:
         return self.application

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -55,6 +55,6 @@ def test_upgrade(
     )
     wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
 
-    executor = CloudtestExecutor(application=mz)
+    executor = CloudtestExecutor(application=mz, version=LAST_RELEASED_VERSION)
     scenario = CloudtestUpgrade(checks=Check.__subclasses__(), executor=executor)
     scenario.run()


### PR DESCRIPTION
For upgrade tests the current version was used as the base version, which is wrong. Nightly green: https://buildkite.com/materialize/nightlies/builds/2708

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
