### PR TITLE
cloudtest: Add helpful version printing to upgrade tests

### DIFF
--- a/misc/python/materialize/checks/cloudtest_actions.py
+++ b/misc/python/materialize/checks/cloudtest_actions.py
@@ -24,6 +24,14 @@ class ReplaceEnvironmentdStatefulSet(Action):
         self.new_tag = new_tag
 
     def execute(self, e: Executor) -> None:
+        new_version = (
+            MzVersion.parse_mz(self.new_tag)
+            if self.new_tag
+            else MzVersion.parse_cargo()
+        )
+        print(
+            f"Replacing environmentd stateful set from version {e.current_mz_version} to version {new_version}"
+        )
         mz = e.cloudtest_application()
         stateful_set = [
             resource
@@ -35,11 +43,7 @@ class ReplaceEnvironmentdStatefulSet(Action):
 
         stateful_set.tag = self.new_tag
         stateful_set.replace()
-        e.current_mz_version = (
-            MzVersion.parse_mz(self.new_tag)
-            if self.new_tag
-            else MzVersion.parse_cargo()
-        )
+        e.current_mz_version = new_version
 
     def join(self, e: Executor) -> None:
         # execute is blocking already

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -46,6 +46,9 @@ def test_upgrade(
     aws_region: Optional[str], log_filter: Optional[str], dev: bool
 ) -> None:
     """Test upgrade from the last released verison to the current source by running all the Platform Checks"""
+    print(
+        f"Testing upgrade from base version {LAST_RELEASED_VERSION} to current version"
+    )
 
     mz = MaterializeApplication(
         tag=str(LAST_RELEASED_VERSION),


### PR DESCRIPTION
Part of #20297

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
