### PR TITLE
testdrive: Print source of Python-generated testdrive fragments in errors

### DIFF
--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import time
+from inspect import getframeinfo, stack
 from typing import TYPE_CHECKING, Any, Optional
 
 from materialize.checks.executors import Executor
@@ -31,10 +32,11 @@ class Testdrive(Action):
     def __init__(self, input: str) -> None:
         self.input = input
         self.handle: Optional[Any] = None
+        self.caller = getframeinfo(stack()[1][0])
 
     def execute(self, e: Executor) -> None:
         """Pass testdrive actions to be run by an Executor-specific implementation."""
-        self.handle = e.testdrive(self.input)
+        self.handle = e.testdrive(self.input, self.caller)
 
     def join(self, e: Executor) -> None:
         e.join(self.handle)

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import os
+from inspect import Traceback
 from typing import Optional
 
 from kubernetes.client import V1Container, V1EnvVar, V1ObjectMeta, V1Pod, V1PodSpec
@@ -48,6 +49,7 @@ class Testdrive(K8sPod):
         input: Optional[str] = None,
         no_reset: bool = False,
         seed: Optional[int] = None,
+        caller: Optional[Traceback] = None,
     ) -> None:
         wait(condition="condition=Ready", resource="pod/testdrive")
         self.kubectl(
@@ -71,6 +73,7 @@ class Testdrive(K8sPod):
             # "--aws-secret-access-key=minio123",
             *(["--no-reset"] if no_reset else []),
             *([f"--seed={seed}"] if seed else []),
+            *([f"--source={caller.filename}:{caller.lineno}"] if caller else []),
             *args,
             input=input,
         )

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -28,7 +28,7 @@ import time
 import traceback
 from contextlib import contextmanager
 from dataclasses import dataclass
-from inspect import getmembers, isfunction
+from inspect import Traceback, getframeinfo, getmembers, isfunction, stack
 from ssl import SSLContext
 from tempfile import TemporaryFile
 from typing import (
@@ -720,6 +720,7 @@ class Composition:
         service: str = "testdrive",
         persistent: bool = True,
         args: List[str] = [],
+        caller: Optional[Traceback] = None,
     ) -> None:
         """Run a string as a testdrive script.
 
@@ -730,10 +731,14 @@ class Composition:
             persistent: Whether a persistent testdrive container will be used.
         """
 
+        caller = caller or getframeinfo(stack()[1][0])
+
+        args_with_source = args + [f"--source={caller.filename}:{caller.lineno}"]
+
         if persistent:
-            self.exec(service, *args, stdin=input)
+            self.exec(service, *args_with_source, stdin=input)
         else:
-            self.run(service, *args, stdin=input)
+            self.run(service, *args_with_source, stdin=input)
 
 
 class ServiceHealthcheck(TypedDict, total=False):

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -78,6 +78,8 @@ pub struct Config {
     /// If unspecified, testdrive creates a temporary directory with a random
     /// name.
     pub temp_dir: Option<String>,
+    /// Source string to print out on errors.
+    pub source: Option<String>,
     /// The default timeout for cancellable operations.
     pub default_timeout: Duration,
     /// The default number of tries for retriable operations.

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -126,6 +126,9 @@ struct Args {
     /// name.
     #[clap(long, value_name = "PATH")]
     temp_dir: Option<String>,
+    /// Source string to print out on errors.
+    #[clap(long, value_name = "SOURCE")]
+    source: Option<String>,
     /// Default timeout for cancellable operations.
     #[clap(long, parse(try_from_str = humantime::parse_duration), default_value = "30s", value_name = "DURATION")]
     default_timeout: Duration,
@@ -368,6 +371,7 @@ async fn main() {
         seed: args.seed,
         reset: !args.no_reset,
         temp_dir: args.temp_dir,
+        source: args.source,
         default_timeout: args.default_timeout,
         default_max_tries: args.default_max_tries,
         initial_backoff: args.initial_backoff,
@@ -507,7 +511,9 @@ async fn main() {
         eprint!("+++ ");
         eprintln!("!!! Error Report");
         eprintln!("{} errors were encountered during execution", error_count);
-        if !error_files.is_empty() {
+        if config.source.is_some() {
+            eprintln!("source: {}", config.source.unwrap());
+        } else if !error_files.is_empty() {
             eprintln!(
                 "files involved: {}",
                 error_files.iter().map(|p| p.display()).join(" ")


### PR DESCRIPTION
Uses traces to keep track of the caller which generated the td fragment

Fixes: #20297

Example:
```
^^^ +++
19:1: error: unable to parse SQL: SAET cluster=identifiers;: Expected a keyword at the beginning of a statement, found identifier "saet"
     |
  18 |
  19 | > SAET cluster=identifiers;
     | ^
+++ !!! Error Report
1 errors were encountered during execution
source: /home/deen/git/materialize/misc/python/materialize/checks/identifiers.py:233
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
