### PR TITLE
Output consistency tests: ignore error message deviation on evaluation shortcuts

### DIFF
--- a/misc/python/materialize/output_consistency/expression/expression.py
+++ b/misc/python/materialize/output_consistency/expression/expression.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 from __future__ import annotations
 
-from typing import List, Optional, Set
+from typing import Callable, List, Optional, Set
 
 from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
@@ -86,6 +86,12 @@ class Expression:
         hence false if all leaves of this expression are directly consumed by an aggregation.
         This is relevant because when using non-aggregate functions on multiple rows, different evaluation strategies may yield different error messages due to a different row processing order."""
         raise NotImplementedError
+
+    def matches(self, predicate: Callable[[Expression], bool]) -> bool:
+        return predicate(self)
+
+    def contains(self, predicate: Callable[[Expression], bool]) -> bool:
+        return self.matches(predicate)
 
 
 class LeafExpression(Expression):

--- a/misc/python/materialize/output_consistency/expression/expression_with_args.py
+++ b/misc/python/materialize/output_consistency/expression/expression_with_args.py
@@ -6,7 +6,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-from typing import List, Optional, Set
+from typing import Callable, List, Optional, Set
 
 from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
@@ -121,6 +121,16 @@ class ExpressionWithArgs(Expression):
         return leaves
 
     def is_leaf(self) -> bool:
+        return False
+
+    def contains(self, predicate: Callable[[Expression], bool]) -> bool:
+        if super().contains(predicate):
+            return True
+
+        for arg in self.args:
+            if arg.contains(predicate):
+                return True
+
         return False
 
     def contains_leaf_not_directly_consumed_by_aggregation(self) -> bool:

--- a/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
@@ -166,7 +166,7 @@ class PreExecutionInconsistencyIgnoreFilter:
         all_involved_characteristics: Set[ExpressionCharacteristics],
     ) -> IgnoreVerdict:
         # Note that function names are always provided in lower case.
-        if db_function.function_name in {
+        if db_function.function_name_in_lower_case in {
             "sum",
             "avg",
             "stddev_samp",
@@ -185,7 +185,7 @@ class PreExecutionInconsistencyIgnoreFilter:
                 # tracked with https://github.com/MaterializeInc/materialize/issues/19511
                 return YesIgnore("#19511")
 
-        if db_function.function_name in {"regexp_match"}:
+        if db_function.function_name_in_lower_case in {"regexp_match"}:
             if len(expression.args) == 3 and isinstance(
                 expression.args[2], EnumConstant
             ):
@@ -193,9 +193,10 @@ class PreExecutionInconsistencyIgnoreFilter:
                 # https://github.com/MaterializeInc/materialize/issues/18494
                 return YesIgnore("#18494")
 
-        if db_function.function_name in {"array_agg", "string_agg"} and not isinstance(
-            db_function, DbFunctionWithCustomPattern
-        ):
+        if db_function.function_name_in_lower_case in {
+            "array_agg",
+            "string_agg",
+        } and not isinstance(db_function, DbFunctionWithCustomPattern):
             # The unordered variants are to be ignored.
             # https://github.com/MaterializeInc/materialize/issues/19832
             return YesIgnore("#19832")
@@ -249,7 +250,8 @@ class PostExecutionInconsistencyIgnoreFilter:
                     operation = expression.operation
                     return (
                         isinstance(operation, DbFunction)
-                        and operation.function_name in FUNCTIONS_TAKING_SHORTCUTS
+                        and operation.function_name_in_lower_case
+                        in FUNCTIONS_TAKING_SHORTCUTS
                     )
                 return False
 

--- a/misc/python/materialize/output_consistency/operation/operation.py
+++ b/misc/python/materialize/output_consistency/operation/operation.py
@@ -168,7 +168,7 @@ class DbFunction(DbOperationOrFunction):
             relevance=relevance,
             is_enabled=is_enabled,
         )
-        self.function_name = function_name.lower()
+        self.function_name_in_lower_case = function_name.lower()
 
     def validate_params(self, params: List[OperationParam]) -> None:
         optional_param_seen = False
@@ -190,10 +190,10 @@ class DbFunction(DbOperationOrFunction):
     def to_pattern(self, args_count: int) -> str:
         self.validate_args_count_in_range(args_count)
         args_pattern = ", ".join(["$"] * args_count)
-        return f"{self.function_name}({args_pattern})"
+        return f"{self.function_name_in_lower_case}({args_pattern})"
 
     def __str__(self) -> str:
-        return f"DbFunction: {self.function_name}"
+        return f"DbFunction: {self.function_name_in_lower_case}"
 
 
 class DbFunctionWithCustomPattern(DbFunction):
@@ -224,7 +224,7 @@ class DbFunctionWithCustomPattern(DbFunction):
 
         if args_count not in self.pattern_per_param_count:
             raise RuntimeError(
-                f"No pattern specified for {self.function_name} with {args_count} params"
+                f"No pattern specified for {self.function_name_in_lower_case} with {args_count} params"
             )
 
         return self.pattern_per_param_count[args_count]

--- a/misc/python/materialize/output_consistency/runner/test_runner.py
+++ b/misc/python/materialize/output_consistency/runner/test_runner.py
@@ -81,6 +81,11 @@ class ConsistencyTestRunner:
                     f" (last executed query #{self.execution_manager.query_counter})"
                 )
 
+            if expression_count % 5000 == 0:
+                self.output_printer.print_status(
+                    f"Random state verification: {self.expression_generator.randomized_picker.random_number(0, 10000)}"
+                )
+
             operation = self.expression_generator.pick_random_operation(True)
 
             shall_abort_after_iteration = self._shall_abort(expression_count, end_time)


### PR DESCRIPTION
### Motivation

This resolves https://github.com/MaterializeInc/materialize/issues/20237.
