### PR TITLE
[skunkworks] burn down dbeaver compatibility

### DIFF
--- a/doc/user/content/sql/system-catalog/pg_catalog.md
+++ b/doc/user/content/sql/system-catalog/pg_catalog.md
@@ -34,6 +34,7 @@ system catalog](https://www.postgresql.org/docs/current/catalogs.html):
   * [`pg_rewrite`](https://www.postgresql.org/docs/current/catalog-pg-rewrite.html)
   * [`pg_roles`](https://www.postgresql.org/docs/current/view-pg-roles.html)
   * [`pg_settings`](https://www.postgresql.org/docs/current/view-pg-settings.html)
+  * [`pg_shdescription`](https://www.postgresql.org/docs/current/catalog-pg-shdescription.html)
   * [`pg_tables`](https://www.postgresql.org/docs/current/view-pg-tables.html)
   * [`pg_tablespace`](https://www.postgresql.org/docs/current/catalog-pg-tablespace.html)
   * [`pg_trigger`](https://www.postgresql.org/docs/current/catalog-pg-trigger.html)

--- a/doc/user/content/sql/system-catalog/pg_catalog.md
+++ b/doc/user/content/sql/system-catalog/pg_catalog.md
@@ -20,6 +20,7 @@ system catalog](https://www.postgresql.org/docs/current/catalogs.html):
   * [`pg_database`](https://www.postgresql.org/docs/current/catalog-pg-database.html)
   * [`pg_description`](https://www.postgresql.org/docs/current/catalog-pg-description.html)
   * [`pg_enum`](https://www.postgresql.org/docs/current/catalog-pg-enum.html)
+  * [`pg_event_trigger`](https://www.postgresql.org/docs/current/catalog-pg-event-trigger.html)
   * [`pg_extension`](https://www.postgresql.org/docs/current/catalog-pg-extension.html)
   * [`pg_index`](https://www.postgresql.org/docs/current/catalog-pg-index.html)
   * [`pg_inherits`](https://www.postgresql.org/docs/current/catalog-pg-inherits.html)

--- a/doc/user/content/sql/system-catalog/pg_catalog.md
+++ b/doc/user/content/sql/system-catalog/pg_catalog.md
@@ -17,6 +17,7 @@ system catalog](https://www.postgresql.org/docs/current/catalogs.html):
   * [`pg_class`](https://www.postgresql.org/docs/current/catalog-pg-class.html)
   * [`pg_collation`](https://www.postgresql.org/docs/current/catalog-pg-collation.html)
   * [`pg_constraint`](https://www.postgresql.org/docs/current/catalog-pg-constraint.html)
+  * [`pg_depend`](https://www.postgresql.org/docs/current/catalog-pg-depend.html)
   * [`pg_database`](https://www.postgresql.org/docs/current/catalog-pg-database.html)
   * [`pg_description`](https://www.postgresql.org/docs/current/catalog-pg-description.html)
   * [`pg_enum`](https://www.postgresql.org/docs/current/catalog-pg-enum.html)

--- a/doc/user/content/sql/system-catalog/pg_catalog.md
+++ b/doc/user/content/sql/system-catalog/pg_catalog.md
@@ -24,6 +24,7 @@ system catalog](https://www.postgresql.org/docs/current/catalogs.html):
   * [`pg_extension`](https://www.postgresql.org/docs/current/catalog-pg-extension.html)
   * [`pg_index`](https://www.postgresql.org/docs/current/catalog-pg-index.html)
   * [`pg_inherits`](https://www.postgresql.org/docs/current/catalog-pg-inherits.html)
+  * [`pg_language`](https://www.postgresql.org/docs/current/catalog-pg-language.html)
   * [`pg_locks`](https://www.postgresql.org/docs/current/view-pg-locks.html)
   * [`pg_matviews`](https://www.postgresql.org/docs/current/view-pg-matviews.html)
   * [`pg_namespace`](https://www.postgresql.org/docs/current/catalog-pg-namespace.html)

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -825,6 +825,18 @@
   - signature: 'pg_postmaster_start_time() -> timestamptz'
     description: Returns the time when the server started.
     unmaterializable: true
+  - signature: 'pg_relation_size(relation: regclass[, fork: text]) -> bigint'
+    description: >-
+      Disk space used by the specified fork ('main', 'fsm', 'vm', or 'init')
+      of the specified table or index. If no fork is specified, it defaults
+      to 'main'. This function always returns -1 because Materialize does
+      not store tables and indexes on local disk.
+  - signature: 'pg_stat_get_numscans(oid: oid) -> bigint'
+    description: >-
+       Number of sequential scans done when argument is a table,
+       or number of index scans done when argument is an index.
+       This function always returns -1 because Materialize does
+       not collect statistics.
   - signature: 'version() -> text'
     description: Returns a PostgreSQL-compatible version string.
     unmaterializable: true

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -794,6 +794,10 @@
       Reconstructs the creating command for an index. (This is a decompiled
       reconstruction, not the original text of the command.) If column is
       supplied and is not zero, only the definition of that column is reconstructed.
+  - signature: 'pg_get_ruledef(rule_oid: oid[, pretty bool]) -> text'
+    description: >-
+      Reconstructs the creating command for a rule. This function
+      always returns NULL because Materialize does not support rules.
   - signature: 'pg_get_userbyid(role: oid) -> text'
     description: >-
       Returns the role (user) name for the given `oid`. If no role matches the

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2653,6 +2653,20 @@ JOIN mz_roles member ON membership.member = member.id
 JOIN mz_roles grantor ON membership.grantor = grantor.id",
 };
 
+pub const PG_EVENT_TRIGGER: BuiltinView = BuiltinView {
+    name: "pg_event_trigger",
+    schema: PG_CATALOG_SCHEMA,
+    sql: "CREATE VIEW pg_catalog.pg_event_trigger AS SELECT
+        NULL::pg_catalog.oid AS oid,
+        NULL::pg_catalog.text AS evtname,
+        NULL::pg_catalog.text AS evtevent,
+        NULL::pg_catalog.oid AS evtowner,
+        NULL::pg_catalog.oid AS evtfoid,
+        NULL::pg_catalog.char AS evtenabled,
+        NULL::pg_catalog.text[] AS evttags
+    WHERE false",
+};
+
 pub const MZ_PEEK_DURATIONS_HISTOGRAM_PER_WORKER: BuiltinView = BuiltinView {
     name: "mz_peek_durations_histogram_per_worker",
     schema: MZ_INTERNAL_SCHEMA,
@@ -3996,6 +4010,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&PG_TRIGGER),
         Builtin::View(&PG_REWRITE),
         Builtin::View(&PG_EXTENSION),
+        Builtin::View(&PG_EVENT_TRIGGER),
         Builtin::View(&INFORMATION_SCHEMA_COLUMNS),
         Builtin::View(&INFORMATION_SCHEMA_TABLES),
         Builtin::Source(&MZ_SINK_STATUS_HISTORY),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2667,6 +2667,22 @@ pub const PG_EVENT_TRIGGER: BuiltinView = BuiltinView {
     WHERE false",
 };
 
+pub const PG_LANGUAGE: BuiltinView = BuiltinView {
+    name: "pg_language",
+    schema: PG_CATALOG_SCHEMA,
+    sql: "CREATE VIEW pg_catalog.pg_language AS SELECT
+        NULL::pg_catalog.oid  AS oid,
+        NULL::pg_catalog.text AS lanname,
+        NULL::pg_catalog.oid  AS lanowner,
+        NULL::pg_catalog.bool AS lanispl,
+        NULL::pg_catalog.bool AS lanpltrusted,
+        NULL::pg_catalog.oid  AS lanplcallfoid,
+        NULL::pg_catalog.oid  AS laninline,
+        NULL::pg_catalog.oid  AS lanvalidator,
+        NULL::pg_catalog.text[] AS lanacl
+    WHERE false",
+};
+
 pub const MZ_PEEK_DURATIONS_HISTOGRAM_PER_WORKER: BuiltinView = BuiltinView {
     name: "mz_peek_durations_histogram_per_worker",
     schema: MZ_INTERNAL_SCHEMA,
@@ -4011,6 +4027,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&PG_REWRITE),
         Builtin::View(&PG_EXTENSION),
         Builtin::View(&PG_EVENT_TRIGGER),
+        Builtin::View(&PG_LANGUAGE),
         Builtin::View(&INFORMATION_SCHEMA_COLUMNS),
         Builtin::View(&INFORMATION_SCHEMA_TABLES),
         Builtin::Source(&MZ_SINK_STATUS_HISTORY),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2683,6 +2683,16 @@ pub const PG_LANGUAGE: BuiltinView = BuiltinView {
     WHERE false",
 };
 
+pub const PG_SHDESCRIPTION: BuiltinView = BuiltinView {
+    name: "pg_shdescription",
+    schema: PG_CATALOG_SCHEMA,
+    sql: "CREATE VIEW pg_catalog.pg_shdescription AS SELECT
+        NULL::pg_catalog.oid AS objoid,
+        NULL::pg_catalog.oid AS classoid,
+        NULL::pg_catalog.text AS description
+    WHERE false",
+};
+
 pub const MZ_PEEK_DURATIONS_HISTOGRAM_PER_WORKER: BuiltinView = BuiltinView {
     name: "mz_peek_durations_histogram_per_worker",
     schema: MZ_INTERNAL_SCHEMA,
@@ -4028,6 +4038,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&PG_EXTENSION),
         Builtin::View(&PG_EVENT_TRIGGER),
         Builtin::View(&PG_LANGUAGE),
+        Builtin::View(&PG_SHDESCRIPTION),
         Builtin::View(&INFORMATION_SCHEMA_COLUMNS),
         Builtin::View(&INFORMATION_SCHEMA_TABLES),
         Builtin::Source(&MZ_SINK_STATUS_HISTORY),

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2007,6 +2007,10 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         "get_byte" => Scalar {
             params!(Bytes, Int32) => BinaryFunc::GetByte => Int32, 721;
         },
+        "pg_get_ruledef" => Scalar {
+            params!(Oid) => sql_impl_func("NULL::pg_catalog.text") => String, 1573;
+            params!(Oid, Bool) => sql_impl_func("NULL::pg_catalog.text") => String, 2504;
+        },
         "has_schema_privilege" => Scalar {
             params!(String, String, String) => sql_impl_func("has_schema_privilege(mz_internal.mz_role_oid($1), mz_internal.mz_schema_oid($2), $3)") => Bool, 2268;
             params!(String, Oid, String) => sql_impl_func("has_schema_privilege(mz_internal.mz_role_oid($1), $2, $3)") => Bool, 2269;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2349,6 +2349,13 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         "pg_postmaster_start_time" => Scalar {
             params!() => UnmaterializableFunc::PgPostmasterStartTime => TimestampTz, 2560;
         },
+        "pg_relation_size" => Scalar {
+            params!(RegClass, String) => sql_impl_func("CASE WHEN $1 IS NULL OR $2 IS NULL THEN NULL ELSE -1::pg_catalog.int8 END") => Int64, 2332;
+            params!(RegClass) => sql_impl_func("CASE WHEN $1 IS NULL THEN NULL ELSE -1::pg_catalog.int8 END") => Int64, 2325;
+        },
+        "pg_stat_get_numscans" => Scalar {
+            params!(Oid) => sql_impl_func("CASE WHEN $1 IS NULL THEN NULL ELSE -1::pg_catalog.int8 END") => Int64, 1928;
+        },
         "pg_table_is_visible" => Scalar {
             params!(Oid) => sql_impl_func(
                 "(SELECT s.name = ANY(pg_catalog.current_schemas(true))

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -287,9 +287,9 @@ static VALID_CASTS: Lazy<BTreeMap<(ScalarBaseType, ScalarBaseType), CastImpl>> =
         (Oid, Int32) => Assignment: CastOidToInt32(func::CastOidToInt32),
         (Oid, Int64) => Assignment: CastOidToInt32(func::CastOidToInt32),
         (Oid, String) => Explicit: CastOidToString(func::CastOidToString),
-        (Oid, RegClass) => Assignment: CastOidToRegClass(func::CastOidToRegClass),
-        (Oid, RegProc) => Assignment: CastOidToRegProc(func::CastOidToRegProc),
-        (Oid, RegType) => Assignment: CastOidToRegType(func::CastOidToRegType),
+        (Oid, RegClass) => Implicit: CastOidToRegClass(func::CastOidToRegClass),
+        (Oid, RegProc) => Implicit: CastOidToRegProc(func::CastOidToRegProc),
+        (Oid, RegType) => Implicit: CastOidToRegType(func::CastOidToRegType),
 
         // REGCLASS
         (RegClass, Oid) => Implicit: CastRegClassToOid(func::CastRegClassToOid),

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1582,3 +1582,8 @@ query B
 SELECT pg_tablespace_location(0) IS NULL
 ----
 true
+
+query B
+SELECT pg_get_ruledef(0) IS NULL
+----
+true

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1587,3 +1587,28 @@ query B
 SELECT pg_get_ruledef(0) IS NULL
 ----
 true
+
+query I
+SELECT pg_relation_size('pg_views'::regclass)
+----
+-1
+
+query I
+SELECT pg_relation_size('pg_views'::regclass::oid)
+----
+-1
+
+query I
+SELECT pg_relation_size('pg_views'::regclass, 'main')
+----
+-1
+
+query I
+SELECT pg_relation_size('pg_views'::regclass::oid, 'main')
+----
+-1
+
+query I
+SELECT pg_stat_get_numscans('pg_views'::regclass::oid)
+----
+-1

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -577,6 +577,10 @@ pg_enum
 VIEW
 materialize
 pg_catalog
+pg_event_trigger
+VIEW
+materialize
+pg_catalog
 pg_extension
 VIEW
 materialize

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -637,6 +637,10 @@ pg_settings
 VIEW
 materialize
 pg_catalog
+pg_shdescription
+VIEW
+materialize
+pg_catalog
 pg_tables
 VIEW
 materialize

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -593,6 +593,10 @@ pg_inherits
 VIEW
 materialize
 pg_catalog
+pg_language
+VIEW
+materialize
+pg_catalog
 pg_locks
 VIEW
 materialize

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -569,6 +569,10 @@ pg_database
 VIEW
 materialize
 pg_catalog
+pg_depend
+VIEW
+materialize
+pg_catalog
 pg_description
 VIEW
 materialize

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -269,3 +269,16 @@ name                nullable    type
  evtfoid            false       oid
  evtenabled         false       char
  evttags            false       text[]
+
+> SHOW COLUMNS FROM pg_language
+name                nullable    type
+------------------------------------------------------------
+ lanname            false       text
+ oid                false       oid
+ lanowner           false       oid
+ lanispl            false       boolean
+ lanpltrusted       false       boolean
+ lanplcallfoid      false       oid
+ laninline          false       oid
+ lanvalidator       false       oid
+ lanacl             false       text[]

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -258,3 +258,14 @@ name                nullable    type
  extversion         false       text
  extconfig          false       oid[]
  extcondition       false       text[]
+
+> SHOW COLUMNS FROM pg_event_trigger
+name                nullable    type
+------------------------------------------------------------
+ oid                false       oid
+ evtname            false       text
+ evtevent           false       text
+ evtowner           false       oid
+ evtfoid            false       oid
+ evtenabled         false       char
+ evttags            false       text[]

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -282,3 +282,10 @@ name                nullable    type
  laninline          false       oid
  lanvalidator       false       oid
  lanacl             false       text[]
+
+> SHOW COLUMNS FROM pg_shdescription
+name                nullable    type
+------------------------------------------------------------
+ objoid             false       oid
+ classoid           false       oid
+ description        false       text

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -289,3 +289,14 @@ name                nullable    type
  objoid             false       oid
  classoid           false       oid
  description        false       text
+
+> SHOW COLUMNS FROM pg_depend
+name                nullable    type
+------------------------------------------------------------
+ classid            true        oid
+ objid              false       oid
+ objsubid           false       integer
+ refclassid         true        oid
+ refobjid           false       oid
+ refobjsubid        false       integer
+ deptype            false       char


### PR DESCRIPTION
### Motivation

This fills out pg_catalog support for [dbeaver](https://dbeaver.io). There is still some missing functionality around showing index columns, but brings support to a place where it is usable and it stops throwing errors. 

Fixes #9204.

### Tips for reviewer

Each commit is structured such that is can be reviewed independently. Please take extra care to look through `pg_depend`, it is the one change with real business logic. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
