### PR TITLE
adapter: correctly compute dependencies for materialized views

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -165,7 +165,7 @@ impl Coordinator {
             }
             Plan::CreateMaterializedView(plan) => {
                 let result = self
-                    .sequence_create_materialized_view(ctx.session_mut(), plan)
+                    .sequence_create_materialized_view(ctx.session_mut(), plan, depends_on)
                     .await;
                 ctx.retire(result);
             }

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -245,6 +245,100 @@ SELECT count(*) FROM mz_materialized_views WHERE name = 'mv'
 ----
 0
 
+# mz_scheduling_elapsed_raw, a log source, is optimized away, but should still count as a dependency
+query error db error: ERROR: materialized view objects cannot depend on log sources
+CREATE MATERIALIZED VIEW mv AS SELECT (SELECT 1 FROM mz_internal.mz_scheduling_elapsed_raw WHERE FALSE);
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_table_keys = true
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE t1 (f1 INTEGER NOT NULL PRIMARY KEY);
+
+statement ok
+CREATE TABLE t2 (f1 INTEGER NOT NULL PRIMARY KEY);
+
+# Folds to Constant, t1 is optimized away but must still be counted as a dependency
+statement ok
+CREATE MATERIALIZED VIEW mv AS SELECT * FROM t1 WHERE FALSE;
+
+statement error db error: ERROR: cannot drop table t1: still depended upon by materialized view mv
+DROP TABLE t1
+
+statement ok
+DROP MATERIALIZED VIEW mv
+
+# In the cases below, t2 is optimized away but should still be present as a dependency
+statement ok
+CREATE MATERIALIZED VIEW mv AS SELECT t1.* FROM t1 LEFT JOIN t2 ON (t1.f1 = t2.f1);
+
+statement error db error: ERROR: cannot drop table t2: still depended upon by materialized view mv
+DROP TABLE t2
+
+statement ok
+DROP MATERIALIZED VIEW mv
+
+statement ok
+CREATE MATERIALIZED VIEW mv AS SELECT * FROM t1 WHERE FALSE AND EXISTS (SELECT * FROM t2);
+
+statement error db error: ERROR: cannot drop table t2: still depended upon by materialized view mv
+DROP TABLE t2
+
+statement ok
+DROP MATERIALIZED VIEW mv
+
+statement ok
+CREATE MATERIALIZED VIEW mv AS SELECT * FROM t1 WHERE TRUE OR EXISTS (SELECT * FROM t2);
+
+statement error db error: ERROR: cannot drop table t2: still depended upon by materialized view mv
+DROP TABLE t2
+
+statement ok
+DROP MATERIALIZED VIEW mv
+
+statement ok
+CREATE MATERIALIZED VIEW mv AS SELECT (SELECT f1 FROM t2 WHERE FALSE) FROM t1;
+
+statement error db error: ERROR: cannot drop table t2: still depended upon by materialized view mv
+DROP TABLE t2
+
+statement ok
+DROP MATERIALIZED VIEW mv
+
+# No need to evaluate second argument of COALESCE if first is non-null
+statement ok
+CREATE MATERIALIZED VIEW mv AS SELECT COALESCE(1, (SELECT * FROM t2 LIMIT 1)) FROM t1;
+
+statement error db error: ERROR: cannot drop table t2: still depended upon by materialized view mv
+DROP TABLE t2
+
+statement ok
+DROP MATERIALIZED VIEW mv
+
+statement ok
+CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
+
+# Mention of int4_list is optimized away
+statement ok
+CREATE MATERIALIZED VIEW mv AS SELECT * FROM t1 WHERE NULL::int4_list IS NOT NULL;
+
+statement error db error: ERROR: cannot drop type int4_list: still depended upon by materialized view mv
+DROP TYPE int4_list
+
+statement ok
+DROP MATERIALIZED VIEW mv
+
+statement ok
+DROP TYPE int4_list
+
+statement ok
+DROP TABLE t1
+
+statement ok
+DROP TABLE t2
+
 
 # Test: Materialized view prevents dropping its cluster.
 

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -224,6 +224,28 @@ query error unknown catalog item 'v'
 SELECT * FROM v
 
 
+# Test: a view on a materialized view that optimizes to the empty set
+# still prevents the underlying view from being dropped.
+# See: https://github.com/MaterializeInc/materialize/issues/20315
+
+statement ok
+CREATE VIEW v AS SELECT 1 AS c
+
+statement ok
+CREATE MATERIALIZED VIEW mv AS SELECT * FROM v WHERE c IS NULL
+
+statement error cannot drop view v: still depended upon by materialized view mv
+DROP VIEW v
+
+statement ok
+DROP VIEW v CASCADE
+
+query I
+SELECT count(*) FROM mz_materialized_views WHERE name = 'mv'
+----
+0
+
+
 # Test: Materialized view prevents dropping its cluster.
 
 statement ok


### PR DESCRIPTION
This commit fixes a bug introduced by #19648, in which we stopped tracking the dependencies of a materialized view correctly.

The root cause was that there are two notions of dependencies tracked by the system:

  1. An object required while planning an `mz_sql_parser::ast::Statement`.
  2. An object required to determine the timestamp of a `MirRelationExpr` in a plan.

Pre PR #19648, the code used (1) in a place where (2) was expected. Post PR #19648, the code used (2) in a place where (1) was expected. This commit uses (1) where (1) is expected and (2) where (2) is expected.

A future commit will make this easier to understand.

Fix #20315.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

Future commit coming with clarity-enhancing improvements.

@philip-stoev perhaps you would like to throw some more test cases at this PR?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
