### PR TITLE
sql: prevent misuse of resolved IDs via newtype

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -376,7 +376,7 @@ impl CatalogState {
 
         if !entry.item().is_temporary() {
             // Populate or clean up the `mz_object_dependencies` table.
-            for dependee in entry.item().uses() {
+            for dependee in &entry.item().uses().0 {
                 updates.push(self.pack_depends_update(id, *dependee, diff))
             }
         }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -102,7 +102,7 @@ use mz_repr::{Datum, GlobalId, RelationType, Row, Timestamp};
 use mz_secrets::SecretsController;
 use mz_sql::ast::{CreateSourceStatement, CreateSubsourceStatement, Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
-use mz_sql::names::Aug;
+use mz_sql::names::{Aug, ResolvedIds};
 use mz_sql::plan::{CopyFormat, CreateConnectionPlan, Params, QueryWhen};
 use mz_sql::session::vars::ConnectionCounter;
 use mz_storage_client::controller::{
@@ -233,7 +233,7 @@ pub struct BackgroundWorkResult<T> {
     pub ctx: ExecuteContext,
     pub result: Result<T, AdapterError>,
     pub params: Params,
-    pub depends_on: Vec<GlobalId>,
+    pub resolved_ids: ResolvedIds,
     pub original_stmt: Statement<Raw>,
     pub otel_ctx: OpenTelemetryContext,
 }
@@ -913,7 +913,7 @@ impl Coordinator {
             .entries()
             .cloned()
             .map(|entry| {
-                let remaining_deps = entry.uses().to_vec();
+                let remaining_deps = entry.uses().0.iter().copied().collect::<Vec<_>>();
                 (entry, remaining_deps)
             })
             .collect();

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -10,7 +10,7 @@
 use std::collections::BTreeSet;
 
 use mz_compute_client::controller::{ComputeInstanceId, ComputeInstanceRef};
-use mz_expr::MirScalarExpr;
+use mz_expr::{CollectionPlan, MirScalarExpr};
 use mz_repr::{GlobalId, TimestampManipulation};
 use mz_transform::IndexOracle;
 
@@ -79,8 +79,8 @@ impl<T: TimestampManipulation> ComputeInstanceIndexOracle<'_, T> {
             } else {
                 match self.catalog.get_entry(&id).item() {
                     // Unmaterialized view. Search its dependencies.
-                    view @ CatalogItem::View(_) => {
-                        todo.extend(view.uses());
+                    CatalogItem::View(view) => {
+                        todo.extend(view.optimized_expr.0.depends_on());
                     }
                     CatalogItem::Source(_)
                     | CatalogItem::Table(_)

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -21,7 +21,7 @@
 use mz_expr::CollectionPlan;
 use mz_repr::GlobalId;
 use mz_sql::catalog::{ErrorMessageObjectDescription, SessionCatalog};
-use mz_sql::names::SystemObjectId;
+use mz_sql::names::{ResolvedIds, SystemObjectId};
 use mz_sql::plan::{Plan, SubscribeFrom};
 use smallvec::SmallVec;
 
@@ -213,7 +213,7 @@ pub fn user_privilege_hack(
     catalog: &impl SessionCatalog,
     session: &Session,
     plan: &Plan,
-    depends_on: &Vec<GlobalId>,
+    resolved_ids: &ResolvedIds,
 ) -> Result<(), AdapterError> {
     if session.user().name != MZ_INTROSPECTION_ROLE.name {
         return Ok(());
@@ -309,7 +309,7 @@ pub fn user_privilege_hack(
         }
     }
 
-    for id in depends_on {
+    for id in &resolved_ids.0 {
         let item = catalog.get_item(id);
         let full_name = catalog.resolve_full_name(item.name());
         if !catalog.is_system_schema(&full_name.schema) {

--- a/src/adapter/src/subscribe.rs
+++ b/src/adapter/src/subscribe.rs
@@ -47,7 +47,7 @@ pub struct ActiveSubscribe {
     pub arity: usize,
     /// The cluster that the subscribe is running on.
     pub cluster_id: ClusterId,
-    /// All `GlobalId`s that the subscribe depend on.
+    /// All `GlobalId`s that the subscribe's expression depends on.
     pub depends_on: BTreeSet<GlobalId>,
     /// The time when the subscribe was started.
     pub start_time: EpochMillis,

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -84,6 +84,7 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use mz_adapter::catalog::storage::MZ_SYSTEM_ROLE_ID;
@@ -93,7 +94,9 @@ use mz_ore::now::NOW_ZERO;
 use mz_repr::RelationDesc;
 use mz_sql::ast::{Expr, Statement};
 use mz_sql::catalog::CatalogDatabase;
-use mz_sql::names::{self, ItemQualifiers, QualifiedItemName, ResolvedDatabaseSpecifier};
+use mz_sql::names::{
+    self, ItemQualifiers, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds,
+};
 use mz_sql::plan::{PlanContext, QueryContext, QueryLifetime, StatementContext};
 use mz_sql::DEFAULT_SCHEMA;
 use tokio::sync::Mutex;
@@ -155,7 +158,7 @@ async fn datadriven() {
                                             desc: RelationDesc::empty(),
                                             defaults: vec![Expr::null(); 0],
                                             conn_id: None,
-                                            depends_on: vec![],
+                                            resolved_ids: ResolvedIds(BTreeSet::new()),
                                             custom_logical_compaction_window: None,
                                             is_retained_metrics_object: false,
                                         }),

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -43,7 +43,8 @@ use uuid::Uuid;
 use crate::func::Func;
 use crate::names::{
     Aug, DatabaseId, FullItemName, FullSchemaName, ObjectId, PartialItemName, QualifiedItemName,
-    QualifiedSchemaName, ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier, SystemObjectId,
+    QualifiedSchemaName, ResolvedDatabaseSpecifier, ResolvedIds, SchemaId, SchemaSpecifier,
+    SystemObjectId,
 };
 use crate::normalize;
 use crate::plan::statement::ddl::PlannedRoleAttributes;
@@ -584,7 +585,7 @@ pub trait CatalogItem {
 
     /// Returns the IDs of the catalog items upon which this catalog item
     /// depends.
-    fn uses(&self) -> &[GlobalId];
+    fn uses(&self) -> &ResolvedIds;
 
     /// Returns the IDs of the catalog items that depend upon this catalog item.
     fn used_by(&self) -> &[GlobalId];

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -59,7 +59,8 @@ use crate::catalog::{
     RoleAttributes,
 };
 use crate::names::{
-    Aug, FullItemName, ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier, SystemObjectId,
+    Aug, FullItemName, ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds,
+    SystemObjectId,
 };
 
 pub(crate) mod error;
@@ -508,17 +509,7 @@ pub struct CreateSourcePlan {
 pub struct CreateSourcePlans {
     pub source_id: GlobalId,
     pub plan: CreateSourcePlan,
-    pub depends_on: Vec<GlobalId>,
-}
-
-impl From<(GlobalId, CreateSourcePlan, Vec<GlobalId>)> for CreateSourcePlans {
-    fn from(plan: (GlobalId, CreateSourcePlan, Vec<GlobalId>)) -> Self {
-        CreateSourcePlans {
-            source_id: plan.0,
-            plan: plan.1,
-            depends_on: plan.2,
-        }
-    }
+    pub resolved_ids: ResolvedIds,
 }
 
 /// Specifies the cluster for a source or a sink.


### PR DESCRIPTION
Use a newtype to prevent confusing the set of IDs returned by name
resolution with the set of IDs returned by
`MirRelationExpr::depends_on`.

Fix https://github.com/MaterializeInc/materialize/issues/19080.

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

Builds on #20318. Look at just the last commit in this PR.

There were more than a few places throughout where I found we were using the wrong kind of `depends_on`. @jkosh44 please scrutinize the RBAC changes. I did those files very mechanically and wasn't giving them the same level of thought as all the other changes. 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
