### PR TITLE
ci: Fail run on unknown errors

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -84,8 +84,7 @@ associated open Github issues in Materialize repository.""",
     parser.add_argument("log_files", nargs="+", help="log files to search in")
     args = parser.parse_args()
 
-    annotate_logged_errors(args.log_files)
-    return 0
+    return annotate_logged_errors(args.log_files)
 
 
 def annotate_errors(errors: List[str], title: str, style: str) -> None:
@@ -117,11 +116,12 @@ def annotate_errors(errors: List[str], title: str, style: str) -> None:
     )
 
 
-def annotate_logged_errors(log_files: List[str]) -> None:
+def annotate_logged_errors(log_files: List[str]) -> int:
+    """Returns the number of unknown errors"""
     error_logs = get_error_logs(log_files)
 
     if not error_logs:
-        return
+        return 0
 
     step_key: str = os.getenv("BUILDKITE_STEP_KEY", "")
     buildkite_label: str = os.getenv("BUILDKITE_LABEL", "")
@@ -190,6 +190,10 @@ def annotate_logged_errors(log_files: List[str]) -> None:
         "error",
     )
     annotate_errors(known_errors, "Known errors in logs, ignoring", "info")
+
+    if unknown_errors:
+        print("Unknown errors found in logs, marking run as failed")
+    return len(unknown_errors)
 
 
 def get_error_logs(log_files: List[str]) -> List[ErrorLog]:


### PR DESCRIPTION
### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
