### PR TITLE
Enforce `enable_monotonic_oneshot_selects=on` when running `sqllogictest` with `--auto-index-selects`

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -862,6 +862,8 @@ impl<'a> Runner<'a> {
                 .await?;
         }
 
+        inner.ensure_fixed_features().await?;
+
         inner.client = connect(inner.server_addr, None).await;
         inner.system_client = connect(inner.internal_server_addr, Some("mz_system")).await;
         inner.clients = BTreeMap::new();
@@ -1035,7 +1037,7 @@ impl<'a> RunnerInner<'a> {
         let system_client = connect(internal_server_addr, Some("mz_system")).await;
         let client = connect(server_addr, None).await;
 
-        Ok(RunnerInner {
+        let inner = RunnerInner {
             server_addr,
             internal_server_addr,
             _shutdown_trigger: shutdown_trigger,
@@ -1050,7 +1052,26 @@ impl<'a> RunnerInner<'a> {
             enable_table_keys: config.enable_table_keys,
             verbosity: config.verbosity,
             stdout: config.stdout,
-        })
+        };
+        inner.ensure_fixed_features().await?;
+
+        Ok(inner)
+    }
+
+    async fn ensure_fixed_features(&self) -> Result<(), anyhow::Error> {
+        // Here, we set features that should be enabled regardless of whether reset-server was
+        // called. These features may be set conditionally depending on the run configuration.
+        // If auto_index_selects is on, we should turn on enable_monotonic_oneshot_selects.
+        // TODO(vmarcos): Remove this code when we retire the feature flag.
+        if self.auto_index_selects {
+            self.system_client
+                .execute(
+                    "ALTER SYSTEM SET enable_monotonic_oneshot_selects = on",
+                    &[],
+                )
+                .await?;
+        }
+        Ok(())
     }
 
     async fn run_record<'r>(

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1058,9 +1058,9 @@ impl<'a> RunnerInner<'a> {
         Ok(inner)
     }
 
+    /// Set features that should be enabled regardless of whether reset-server was
+    /// called. These features may be set conditionally depending on the run configuration.
     async fn ensure_fixed_features(&self) -> Result<(), anyhow::Error> {
-        // Here, we set features that should be enabled regardless of whether reset-server was
-        // called. These features may be set conditionally depending on the run configuration.
         // If auto_index_selects is on, we should turn on enable_monotonic_oneshot_selects.
         // TODO(vmarcos): Remove this code when we retire the feature flag.
         if self.auto_index_selects {

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -15,9 +15,10 @@ ALTER SYSTEM SET enable_table_keys = true
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+SHOW enable_monotonic_oneshot_selects
 ----
-COMPLETE 0
+on
+COMPLETE 1
 
 statement ok
 CREATE TABLE t (a int, b int)

--- a/test/sqllogictest/array_subquery.slt
+++ b/test/sqllogictest/array_subquery.slt
@@ -10,9 +10,10 @@
 mode cockroach
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+SHOW enable_monotonic_oneshot_selects
 ----
-COMPLETE 0
+on
+COMPLETE 1
 
 statement ok
 CREATE TABLE xs (x int not null)

--- a/test/sqllogictest/cockroach/distinct_on.slt
+++ b/test/sqllogictest/cockroach/distinct_on.slt
@@ -25,9 +25,10 @@ ALTER SYSTEM SET enable_table_keys = true
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+SHOW enable_monotonic_oneshot_selects
 ----
-COMPLETE 0
+on
+COMPLETE 1
 
 statement ok
 CREATE TABLE xyz (

--- a/test/sqllogictest/cockroach/subquery_correlated.slt
+++ b/test/sqllogictest/cockroach/subquery_correlated.slt
@@ -30,9 +30,10 @@ ALTER SYSTEM SET enable_table_foreign_key = true
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+SHOW enable_monotonic_oneshot_selects
 ----
-COMPLETE 0
+on
+COMPLETE 1
 
 # ------------------------------------------------------------------------------
 # Create a simple schema that models customers and orders. Each customer has an

--- a/test/sqllogictest/github-19290.slt
+++ b/test/sqllogictest/github-19290.slt
@@ -10,9 +10,10 @@
 # Regression test for #19290.
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+SHOW enable_monotonic_oneshot_selects
 ----
-COMPLETE 0
+on
+COMPLETE 1
 
 statement ok
 CREATE SOURCE tpch

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -10,9 +10,10 @@
 mode cockroach
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+SHOW enable_monotonic_oneshot_selects
 ----
-COMPLETE 0
+on
+COMPLETE 1
 
 statement ok
 CREATE TABLE foo (

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -10,9 +10,10 @@
 mode cockroach
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+SHOW enable_monotonic_oneshot_selects
 ----
-COMPLETE 0
+on
+COMPLETE 1
 
 statement ok
 CREATE TABLE cities (

--- a/test/sqllogictest/unsigned_int.slt
+++ b/test/sqllogictest/unsigned_int.slt
@@ -8,9 +8,10 @@
 # by the Apache License, Version 2.0.
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+SHOW enable_monotonic_oneshot_selects
 ----
-COMPLETE 0
+on
+COMPLETE 1
 
 query I
 SELECT 42::uint2

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -15,9 +15,10 @@ ALTER SYSTEM SET enable_with_mutually_recursive = true
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
+SHOW enable_monotonic_oneshot_selects
 ----
-COMPLETE 0
+on
+COMPLETE 1
 
 ## Test correct (intended) behavior:
 


### PR DESCRIPTION
This PR enforces that the feature flag `enable_monotonic_oneshot_selects` is turned `on` whenever `--auto-index-selects` is provided to `sqllogictest`. This feature is thus conditionally fixed, regardless of whether the test invokes `reset-server`. To verify that the feature is indeed activated, all fast SLTs that are currently run with `--auto-index-selects`, which previously set the feature explicitly, are changed to only check that the feature is enabled.

Advances #18734.

### Motivation

  * This PR adds a feature that has not yet been specified.

The goal is to run the slow SLTs that we now execute with `--auto-index-selects` also with the feature `enable_monotonic_oneshot_selects` turned on. A few options to achieve this goal were discussed internally ([Slack ref](https://materializeinc.slack.com/archives/C01LKF361MZ/p1688403026506409)). The option selected is the one proposed in this PR.

### Tips for reviewer

The commits can be looked at individually. To avoid issues with tests that `reset-server`, I am introducing the setting even after such a reset. Just let me know if you find this controversial.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20230421_stabilize_monotonic_select.md).
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
