### PR TITLE
storage: simplify postgres progress tracking

### DIFF
--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -236,10 +236,6 @@ pub enum TransientError {
     UnknownReplicationMessage,
     #[error("unexpected logical replication message")]
     UnknownLogicalReplicationMessage,
-    #[error("malformed logical replication message")]
-    MalformedReplicationMessage(#[source] std::io::Error),
-    #[error("transaction begun without BEGIN")]
-    UnmatchedTransaction,
     #[error("received replication event outside of transaction")]
     BareTransactionEvent,
     #[error("lsn mismatch between BEGIN and COMMIT")]
@@ -318,9 +314,9 @@ async fn fetch_slot_resume_lsn(client: &Client, slot: &str) -> Result<MzOffset, 
 
         match row.get("confirmed_flush_lsn") {
             // For postgres, `confirmed_flush_lsn` means that the slot is able to produce
-            // all transactions that happen at tx_lsn > confirmed_flush_lsn. Therefore the
-            // upper is confirmed_flush_lsn + 1
-            Some(flush_lsn) => return Ok(MzOffset::from(flush_lsn.parse::<PgLsn>().unwrap()) + 1),
+            // all transactions that happen at tx_lsn >= confirmed_flush_lsn. Therefore this value
+            // already has "upper" semantics.
+            Some(flush_lsn) => return Ok(MzOffset::from(flush_lsn.parse::<PgLsn>().unwrap())),
             // It can happen that confirmed_flush_lsn is NULL as the slot initializes
             None => tokio::time::sleep(Duration::from_millis(500)).await,
         };


### PR DESCRIPTION
### Motivation

In the absence of transactions the only available piece of information in the replication stream are keepalive messages. Keepalive messages are documented[1] to contain the current end of WAL on the server. That is a useless number when it comes to progress tracking because there might be pending messages at LSNs between the last received commit_lsn and the current end of WAL.

Fortunatelly for us, the documentation for PrimaryKeepalive messages is wrong and it actually contains the last *sent* LSN[2]. Here "sent" doesn't necessarily mean sent over the wire, but sent to the upstream process that is handling producing the logical stream. Therefore, if we receive a keepalive with a particular LSN we can be certain that there are no other replication messages at previous LSNs, because they would have been already generated and received. We therefore connect the keepalive messages directly to our capability.

[1] https://www.postgresql.org/docs/15/protocol-replication.html#PROTOCOL-REPLICATION-START-REPLICATION
[2] https://www.postgresql.org/message-id/CAFPTHDZS9O9WG02EfayBd6oONzK%2BqfUxS6AbVLJ7W%2BKECza2gg%40mail.gmail.com

Fixes #20295

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
