### PR TITLE
ci: Bump timeout for Postgres CDC tests

### DIFF
--- a/ci/test/mkpipeline.py
+++ b/ci/test/mkpipeline.py
@@ -99,7 +99,7 @@ so it is executed.""",
         for step in pipeline["steps"]:
             # Coverage runs are slower
             if "timeout_in_minutes" in step:
-                step["timeout_in_minutes"] *= 2
+                step["timeout_in_minutes"] *= 4
             if step.get("coverage") == "skip":
                 step["skip"] = True
             if step.get("id") == "build-x86_64":


### PR DESCRIPTION
Seen in coverage in https://buildkite.com/materialize/coverage/builds/168#01892500-083b-400e-88c9-1320b6683a3d

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
