### PR TITLE
ci: Adjust coverage info message

### DIFF
--- a/misc/python/materialize/cli/ci_coverage_pr_report.py
+++ b/misc/python/materialize/cli/ci_coverage_pr_report.py
@@ -247,7 +247,7 @@ ci-coverage-pr-report creates a code coverage report for CI.""",
         )
     else:
         test_case.add_error_info(
-            message="All changed lines are covered outside of unit tests."
+            message="All changed, covered lines are covered outside of unit tests."
         )
     test_cases.append(test_case)
 


### PR DESCRIPTION
"all changes lines" is incorrect and can be confusing when uncovered lines exist.

For example (https://buildkite.com/materialize/coverage/builds/169):
```
# Uncovered Lines in PR in Code Coverage

The following changed lines are uncovered:

diff --git a/src/storage/src/render/upsert/types.rs b/src/storage/src/render/upsert/types.rs
index b851cd4af2..d30aac7437 100644
--- a/src/storage/src/render/upsert/types.rs
+++ b/src/storage/src/render/upsert/types.rs
[...]
!                                tracing::warn!(
!                                    "error spilling to disk {}",
!                                    e.display_with_causes()
[...]

# Lines Covered only in Unit Tests in PR in Code Coverage

All changed lines are covered outside of unit tests.
```