### PR TITLE
adapter: Fix privileges for Alter

### DIFF
--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -1011,25 +1011,6 @@ fn generate_required_privileges(
             }
             privileges
         }
-        Plan::AlterIndexSetOptions(AlterIndexSetOptionsPlan { id, options: _ })
-        | Plan::AlterIndexResetOptions(AlterIndexResetOptionsPlan { id, options: _ })
-        | Plan::AlterSink(AlterSinkPlan { id, size: _ })
-        | Plan::AlterSource(AlterSourcePlan { id, action: _ })
-        | Plan::AlterItemRename(AlterItemRenamePlan {
-            id,
-            current_full_name: _,
-            to_name: _,
-            object_type: _,
-        })
-        | Plan::AlterSecret(AlterSecretPlan { id, secret_as: _ })
-        | Plan::RotateKeys(RotateKeysPlan { id }) => {
-            let item = catalog.get_item(id);
-            vec![(
-                SystemObjectId::Object(item.name().qualifiers.clone().into()),
-                AclMode::CREATE,
-                role_id,
-            )]
-        }
         Plan::AlterOwner(AlterOwnerPlan {
             id,
             object_type: _,
@@ -1181,6 +1162,21 @@ fn generate_required_privileges(
             rows: _,
         })
         | Plan::AlterNoop(AlterNoopPlan { object_type: _ })
+        | Plan::AlterIndexSetOptions(AlterIndexSetOptionsPlan { id: _, options: _ })
+        | Plan::AlterIndexResetOptions(AlterIndexResetOptionsPlan { id: _, options: _ })
+        | Plan::AlterSink(AlterSinkPlan { id: _, size: _ })
+        | Plan::AlterSource(AlterSourcePlan { id: _, action: _ })
+        | Plan::AlterItemRename(AlterItemRenamePlan {
+            id: _,
+            current_full_name: _,
+            to_name: _,
+            object_type: _,
+        })
+        | Plan::AlterSecret(AlterSecretPlan {
+            id: _,
+            secret_as: _,
+        })
+        | Plan::RotateKeys(RotateKeysPlan { id: _ })
         | Plan::AlterSystemSet(AlterSystemSetPlan { name: _, value: _ })
         | Plan::AlterSystemReset(AlterSystemResetPlan { name: _ })
         | Plan::AlterSystemResetAll(AlterSystemResetAllPlan {})

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -2491,21 +2491,6 @@ COMPLETE 0
 simple conn=joe,user=joe
 ALTER SOURCE s SET (SIZE = '4');
 ----
-db error: ERROR: permission denied for SCHEMA "materialize.public"
-
-simple conn=child,user=child
-ALTER SOURCE s1 SET (SIZE = '4');
-----
-db error: ERROR: permission denied for SCHEMA "materialize.public"
-
-simple conn=mz_system,user=mz_system
-GRANT CREATE ON SCHEMA materialize.public TO joe;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-ALTER SOURCE s SET (SIZE = '4');
-----
 COMPLETE 0
 
 simple conn=child,user=child
@@ -2524,7 +2509,7 @@ DROP SOURCE s1;
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM joe;
+REVOKE USAGE ON SCHEMA materialize.public FROM joe;
 ----
 COMPLETE 0
 


### PR DESCRIPTION
This commit removes the requirement that in order to ALTER an object, the executing role must have `CREATE` privileges in the containing schema. This requirement is only necessary when altering the owner of an object.

This is consistent with how PostgreSQL handles ALTER.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Bring alter privilege requirements in line with PostgreSQL.
