### PR TITLE
data-ingest: Get rid of slow copy calls

### DIFF
--- a/misc/python/materialize/data_ingest/field.py
+++ b/misc/python/materialize/data_ingest/field.py
@@ -11,14 +11,21 @@ from typing import Any, Callable, Optional, Type
 
 from pg8000.native import literal
 
-from materialize.data_ingest.data_type import DataType, RecordSize
+from materialize.data_ingest.data_type import DataType
+
+
+def identity(x: Any) -> Any:
+    return identity
+
+
+def formatted_value(value: Any) -> str:
+    return literal(str(value))
 
 
 class Field:
     name: str
     data_type: Type[DataType]
     is_key: bool
-    value: Optional[Any]
     # value_fn can be used to encode a value which is stored in this field, for example:
     # import uuid
     # namespace = uuid.uuid4()
@@ -30,23 +37,12 @@ class Field:
         name: str,
         data_type: Type[DataType],
         is_key: bool,
-        value: Optional[Any] = None,
         value_fn: Optional[Callable[[Any], Any]] = None,
     ):
         self.name = name
         self.data_type = data_type
         self.is_key = is_key
-        self.value = value
-        self.value_fn = value or (lambda x: x)
-
-    def set_random_value(self, record_size: RecordSize) -> None:
-        self.value = self.value_fn(self.data_type.random_value(record_size))
-
-    def set_numeric_value(self, key: int) -> None:
-        self.value = self.value_fn(self.data_type.numeric_value(key))
-
-    def formatted_value(self) -> str:
-        return literal(str(self.value))
+        self.value_fn = value_fn or identity
 
     def __repr__(self) -> str:
-        return f"Field({'key' if self.is_key else 'value'}, {self.name}: {self.data_type.__name__} = {self.value})"
+        return f"Field({'key' if self.is_key else 'value'}, {self.name}: {self.data_type.__name__})"

--- a/misc/python/materialize/data_ingest/row.py
+++ b/misc/python/materialize/data_ingest/row.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 from enum import Enum
-from typing import List
+from typing import Any, List
 
 from materialize.data_ingest.field import Field
 
@@ -21,11 +21,13 @@ class Operation(Enum):
 
 class Row:
     fields: List[Field]
+    values: List[Any]
     operation: Operation
 
-    def __init__(self, fields: List[Field], operation: Operation):
+    def __init__(self, fields: List[Field], values: List[Any], operation: Operation):
         self.fields = fields
+        self.values = values
         self.operation = operation
 
     def __repr__(self) -> str:
-        return f"Row({self.fields}, {self.operation})"
+        return f"Row({self.fields}, {self.values}, {self.operation})"


### PR DESCRIPTION
Put values into separate list instead so we don't have to copy the List[Field]

Locally 5-20% faster in my runs.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
