### PR TITLE
Fix memory visualizer to handle dataflow IDs correctly

### DIFF
--- a/src/environmentd/src/http/static/js/memory.jsx
+++ b/src/environmentd/src/http/static/js/memory.jsx
@@ -285,23 +285,7 @@ function View(props) {
         FROM
           mz_internal.mz_dataflow_addresses
         WHERE
-          id
-          IN (
-              SELECT
-                id
-              FROM
-                mz_internal.mz_dataflow_addresses
-              WHERE
-                address[1]
-                  = (
-                      SELECT
-                        address[1]
-                      FROM
-                        mz_internal.mz_dataflow_addresses
-                      WHERE
-                        id = ${props.dataflowId}
-                    )
-            );
+          address[1] = ${props.dataflowId};
 
         SELECT
           id, name
@@ -315,15 +299,7 @@ function View(props) {
               FROM
                 mz_internal.mz_dataflow_addresses
               WHERE
-                address[1]
-                  = (
-                      SELECT
-                        address[1]
-                      FROM
-                        mz_internal.mz_dataflow_addresses
-                      WHERE
-                        id = ${props.dataflowId}
-                    )
+                address[1] = ${props.dataflowId}
             );
 
         SELECT
@@ -340,15 +316,7 @@ function View(props) {
               FROM
                 mz_internal.mz_dataflow_addresses
               WHERE
-                address[1]
-                  = (
-                      SELECT
-                        address[1]
-                      FROM
-                        mz_internal.mz_dataflow_addresses
-                      WHERE
-                        id = ${props.dataflowId}
-                    )
+                address[1] = ${props.dataflowId}
             );
 
         SELECT
@@ -363,15 +331,7 @@ function View(props) {
               FROM
                 mz_internal.mz_dataflow_addresses
               WHERE
-                address[1]
-                  = (
-                      SELECT
-                        address[1]
-                      FROM
-                        mz_internal.mz_dataflow_addresses
-                      WHERE
-                        id = ${props.dataflowId}
-                    )
+                address[1] = ${props.dataflowId}
             );
 
         SELECT


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug: The memory visualizer failed to map dataflow IDs to dataflow parts because it wasn't updated when the dataflow ID was unified (#20061).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
