### PR TITLE
canary environment: Simple integration between dbt and mzcompose

### DIFF
--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -11,24 +11,12 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from materialize.mzcompose import Composition, WorkflowArgumentParser
-from materialize.mzcompose.services import Materialized, Redpanda, Service
+from materialize.mzcompose.services import Dbt, Materialized, Redpanda
 
 SERVICES = [
     Materialized(),
     Redpanda(),
-    Service(
-        "dbt-test",
-        {
-            "mzbuild": "dbt-materialize",
-            "environment": [
-                "TMPDIR=/share/tmp",
-            ],
-            "volumes": [
-                "secrets:/secrets",
-                "tmp:/share/tmp",
-            ],
-        },
-    ),
+    Dbt(),
 ]
 
 
@@ -83,7 +71,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     c.up("redpanda")
                     c.up("materialized")
                     c.run(
-                        "dbt-test",
+                        "dbt",
                         "pytest",
                         *test_args,
                         env_extra={

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -538,6 +538,7 @@ class Composition:
         capture_stderr: bool = False,
         stdin: Optional[str] = None,
         check: bool = True,
+        workdir: Optional[str] = None,
     ) -> subprocess.CompletedProcess:
         """Execute a one-off command in a service's running container
 
@@ -554,6 +555,7 @@ class Composition:
         return self.invoke(
             "exec",
             *(["--detach"] if detach else []),
+            *(["--workdir", workdir] if workdir else []),
             "-T",
             service,
             *(

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -1081,3 +1081,21 @@ class Grafana(Service):
                 ],
             },
         )
+
+
+class Dbt(Service):
+    def __init__(self, name: str = "dbt") -> None:
+        super().__init__(
+            name=name,
+            config={
+                "mzbuild": "dbt-materialize",
+                "environment": [
+                    "TMPDIR=/share/tmp",
+                ],
+                "volumes": [
+                    ".:/workdir",
+                    "secrets:/secrets",
+                    "tmp:/share/tmp",
+                ],
+            },
+        )

--- a/test/canary-environment/.gitignore
+++ b/test/canary-environment/.gitignore
@@ -1,0 +1,4 @@
+logs/*
+target/*
+.user.yml
+dbt_packages

--- a/test/canary-environment/dbt_project.yml
+++ b/test/canary-environment/dbt_project.yml
@@ -1,0 +1,22 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: 'canary_environment'
+version: '1.0.0'
+config-version: 2
+
+profile: 'canary_environment'
+
+model-paths: ["models"]
+test-paths: ["tests"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+  - "target"
+  - "dbt_packages"

--- a/test/canary-environment/models/schema.yml
+++ b/test/canary-environment/models/schema.yml
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: 2
+
+sources:
+  - name: tpch
+    schema: "{{ target.schema }}"
+    tables:
+      - name: customer
+      - name: lineitem
+      - name: nation
+      - name: orders
+        tests:
+          - makes_progress
+      - name: part
+      - name: partsupp
+      - name: region
+      - name: supplier
+
+models:
+    - name: tpch_q01
+      tests:
+        - makes_progress
+    - name: tpch_q18
+      tests:
+        - makes_progress

--- a/test/canary-environment/models/tpch.sql
+++ b/test/canary-environment/models/tpch.sql
@@ -1,0 +1,16 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+{{ config(materialized='source') }}
+
+CREATE SOURCE {{ this }}
+  FROM LOAD GENERATOR
+  TPCH (SCALE FACTOR 1, TICK INTERVAL '0.001s')
+  FOR ALL TABLES
+  WITH (SIZE = '1');

--- a/test/canary-environment/models/tpch_q01.sql
+++ b/test/canary-environment/models/tpch_q01.sql
@@ -1,0 +1,35 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+-- TPC-H Query #Q18, chosen for the workload for its GROUP BY clause
+
+-- depends_on: {{ ref('tpch') }}
+{{ config(materialized='materializedview', indexes=[{'default': True}]) }}
+
+SELECT
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) AS sum_qty,
+    sum(l_extendedprice) AS sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+    avg(l_quantity) AS avg_qty,
+    avg(l_extendedprice) AS avg_price,
+    avg(l_discount) AS avg_disc,
+    count(*) AS count_order
+FROM
+    {{ source('tpch','lineitem') }}
+WHERE
+    l_shipdate <= DATE '1998-12-01' - INTERVAL '60' day
+GROUP BY
+    l_returnflag,
+    l_linestatus
+ORDER BY
+    l_returnflag,
+    l_linestatus

--- a/test/canary-environment/models/tpch_q18.sql
+++ b/test/canary-environment/models/tpch_q18.sql
@@ -1,0 +1,48 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+-- TPC-H Query #Q18, chosen for the workload for its GROUP BY clause
+-- We have modified the predicate to sum(l_quantity) > 250
+-- to ensure the result updates frequently
+
+-- depends_on: {{ ref('tpch') }}
+{{ config(materialized='materializedview', indexes=[{'default': True}]) }}
+
+SELECT
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice,
+    sum(l_quantity)
+FROM
+    {{ source('tpch','customer') }} ,
+    {{ source('tpch','orders') }} ,
+    {{ source('tpch','lineitem') }}
+WHERE
+    o_orderkey IN (
+        SELECT
+            l_orderkey
+        FROM
+            lineitem
+        GROUP BY
+            l_orderkey having
+                sum(l_quantity) > 250
+    )
+    AND c_custkey = o_custkey
+    AND o_orderkey = l_orderkey
+GROUP BY
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice
+ORDER BY
+    o_totalprice DESC,
+    o_orderdate

--- a/test/canary-environment/mzcompose
+++ b/test/canary-environment/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/canary-environment/mzcompose.py
+++ b/test/canary-environment/mzcompose.py
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.mzcompose import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services import Dbt, Materialized
+
+SERVICES = [
+    Materialized(),
+    Dbt(),
+]
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    c.down()
+    c.up("materialized")
+    c.up("dbt", persistent=True)
+    c.exec("dbt", "dbt", "run", workdir="/workdir")
+    workflow_test(c, parser)
+
+
+def workflow_test(c: Composition, parser: WorkflowArgumentParser) -> None:
+    c.exec("dbt", "dbt", "test", "--threads", "8", workdir="/workdir")

--- a/test/canary-environment/profiles.yml
+++ b/test/canary-environment/profiles.yml
@@ -1,0 +1,24 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+canary_environment:
+  outputs:
+
+    dev:
+      type: materialize
+      threads: 1
+      host: materialized
+      port: 6875
+      user: materialize
+      pass: materialize
+      dbname: materialize
+      schema: public
+      autocommit: True
+
+  target: dev

--- a/test/canary-environment/tests/all_replicas_ready.sql
+++ b/test/canary-environment/tests/all_replicas_ready.sql
@@ -1,0 +1,12 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+select *
+from mz_internal.mz_cluster_replica_statuses
+where status != 'ready'

--- a/test/canary-environment/tests/all_sources_running.sql
+++ b/test/canary-environment/tests/all_sources_running.sql
@@ -1,0 +1,15 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+select *
+from mz_internal.mz_source_statuses
+where not (
+  status = 'running' or
+  (type = 'progress' and status = 'created')
+)

--- a/test/canary-environment/tests/generic/makes_progress.sql
+++ b/test/canary-environment/tests/generic/makes_progress.sql
@@ -1,0 +1,29 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+{% test makes_progress(model) %}
+-- {{ model }} must be mentioned somewhere in the query or dbt will croak */
+
+{% set query %}
+   BEGIN;
+   DECLARE c1 CURSOR FOR SUBSCRIBE ( SELECT * FROM {{ model }} )  WITH (SNAPSHOT = FALSE);
+   FETCH 1 c1 WITH (timeout='60s');
+{% endset %}
+
+{% set result = run_query(query) %}
+
+{% if execute %}
+SELECT 1 WHERE {{ result.rows | length }} = 0
+{% endif %}
+
+-- we need to explicitly reset the current transaction
+-- so that a new one is opened for the next SUBSCRIBE
+{% do run_query("ROLLBACK") %}
+
+{% endtest %}


### PR DESCRIPTION
- Allow mzcompose to invoke dbt
- create a simple dbt project for the canary environment
- instantiate the TPC-H generator and two TPC-H queries as materialized indexed views
- define various dbt tests to be used to validate the health of the environment

Relates to #20365

### Motivation

See https://www.notion.so/materialize/Comprehensive-Canary-Environment-2f7306cd683a4d1a9152b020adb77e77

As per @uce's direction dbt will be used to hold the configuration of the future comprehensive canary environment. I have gone a bit further and have tried to implement at least some of the validation that will be performed against that environment as the so-called dbt tests, which are basically user-defined queries that are supposed to return an empty set if a test is to be considered passed.

### Tips for reviewer

@morsapaes if you can critique my dbt style that would be much appreciated.

