### PR TITLE
[cloud-api] update default cloud endpoint

### DIFF
--- a/src/cloud-api/src/config.rs
+++ b/src/cloud-api/src/config.rs
@@ -25,7 +25,7 @@ use crate::client::Client;
 
 /// The default endpoint the client will use to issue the requests.
 pub static DEFAULT_ENDPOINT: Lazy<Url> =
-    Lazy::new(|| "https://cloud.materialize.com".parse().unwrap());
+    Lazy::new(|| "https://console.materialize.com".parse().unwrap());
 
 /// Configures the required parameters of a [`Client`].
 pub struct ClientConfig {


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug.

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->