### PR TITLE
adapter: Route simple queries to mz_introspection

### DIFF
--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -18,7 +18,7 @@
 //!
 //! [`mz_introspection`]: https://materialize.com/docs/sql/show-clusters/#mz_introspection-system-cluster
 
-use mz_expr::CollectionPlan;
+use mz_expr::{CollectionPlan, MirRelationExpr};
 use mz_repr::GlobalId;
 use mz_sql::catalog::{ErrorMessageObjectDescription, SessionCatalog};
 use mz_sql::names::{ResolvedIds, SystemObjectId};
@@ -31,6 +31,30 @@ use crate::coord::TargetCluster;
 use crate::notice::AdapterNotice;
 use crate::session::Session;
 use crate::{rbac, AdapterError};
+
+fn constant_or_unmaterializable(expr: &MirRelationExpr) -> bool {
+    match expr {
+        MirRelationExpr::ArrangeBy { input, .. } => constant_or_unmaterializable(input),
+        MirRelationExpr::Constant { .. } | MirRelationExpr::Get { .. } => true,
+        MirRelationExpr::Map { input, scalars } => {
+            constant_or_unmaterializable(input)
+                && scalars.iter().all(|e| match e {
+                    mz_expr::MirScalarExpr::Column(_)
+                    | mz_expr::MirScalarExpr::Literal(_, _)
+                    | mz_expr::MirScalarExpr::CallUnmaterializable(_) => true,
+                    mz_expr::MirScalarExpr::CallUnary { .. }
+                    | mz_expr::MirScalarExpr::CallBinary { .. }
+                    | mz_expr::MirScalarExpr::CallVariadic { .. }
+                    | mz_expr::MirScalarExpr::If { .. } => false,
+                })
+        }
+        MirRelationExpr::Let { value, body, .. } => {
+            constant_or_unmaterializable(value) && constant_or_unmaterializable(body)
+        }
+        MirRelationExpr::Project { input, .. } => constant_or_unmaterializable(input),
+        _ => false,
+    }
+}
 
 /// Checks whether or not we should automatically run a query on the `mz_introspection`
 /// cluster, as opposed to whatever the current default cluster is.
@@ -137,7 +161,13 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
         system_only && non_replica
     });
 
-    if non_empty && valid_dependencies {
+    let needs_no_active_cluster = match plan {
+        Plan::Select(plan) if constant_or_unmaterializable(&plan.source) => true,
+        _ => false,
+    };
+    tracing::info!("needs_no_active_cluster: {needs_no_active_cluster}; plan: {plan:?}");
+
+    if (non_empty && valid_dependencies) || needs_no_active_cluster {
         let intros_cluster = catalog.resolve_builtin_cluster(&MZ_INTROSPECTION_CLUSTER);
         tracing::debug!("Running on '{}' cluster", MZ_INTROSPECTION_CLUSTER.name);
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -77,6 +77,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-compute-reconciliation-no-errors",
         "test-mz-subscriptions",
         "test-mv-source-sink",
+        "test-query-without-default-cluster",
     ]:
         with c.test_case(name):
             c.workflow(name)
@@ -1781,3 +1782,17 @@ def workflow_test_mv_source_sink(c: Composition) -> None:
     assert (
         mv_since >= t_since
     ), f'"since" timestamp of mv ({mv_since}) is less than "since" timestamp of its source table ({t_since})'
+
+def workflow_test_query_without_default_cluster(c: Composition) -> None:
+    """Test queries without a default cluster in Materialize."""
+
+    c.down(destroy_volumes=True)
+
+    with c.override(
+        Testdrive(),
+        Postgres(),
+        Materialized(),
+    ):
+        c.up("materialized", "postgres")
+
+        c.run("testdrive", "query-without-default-cluster.td")

--- a/test/cluster/query-without-default-cluster.td
+++ b/test/cluster/query-without-default-cluster.td
@@ -21,7 +21,7 @@ DROP CLUSTER default CASCADE
 > SELECT 1 from (select mz_now(), now())
 1
 
-# filtering isn't supported today
+# filtering isn't supported as a simple query today
 ! SELECT * FROM (VALUES (1), (2)) where column1 > 1
 contains:unknown cluster 'default'
 

--- a/test/cluster/query-without-default-cluster.td
+++ b/test/cluster/query-without-default-cluster.td
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+
+$ postgres-execute connection=mz_system
+DROP CLUSTER default CASCADE
+
+> SELECT 0
+0
+
+> SELECT 1 as id
+1
+
+> SELECT 1 from (select mz_now(), now())
+1
+
+# filtering isn't supported today
+! SELECT * FROM (VALUES (1), (2)) where column1 > 1
+contains:unknown cluster 'default'
+
+# to make it easier to run the test again, let's recreate the default cluster
+$ postgres-execute connection=mz_system
+CREATE CLUSTER default REPLICAS ()


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Fixes #20247. Simple queries don't need a cluster to run on and it would help some dbt use cases if we just handled them. The scope of "simple" queries can increase over time, this PR handles the examples from the ticket and unmaterializable functions which aren't evaluated on a cluster anyway.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
