### PR TITLE
[persist] Filter pushdown flag and docs

### DIFF
--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -68,6 +68,7 @@ Modifier | Description
 **join_impls** | Render details about the implementation strategy of optimized MIR `Join` nodes.
 **keys** | Annotate each subplan with its unique keys.
 **types** | Annotate each subplan with its inferred type.
+**filter_pushdown** | **[Alpha only!]** For each source, include a `pushdown` field that explains which filters [can be pushed down](../../transform-data/patterns/temporal-filters/#temporal-filter-pushdown).
 
 ## Query compilation pipeline
 

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -84,7 +84,7 @@ impl<'a> ExplainSource<'a> {
         op: &'a MapFilterProject,
         context: &ExplainContext<'a>,
     ) -> ExplainSource<'a> {
-        let pushdown_info = if context.config.mfp_pushdown {
+        let pushdown_info = if context.config.filter_pushdown {
             let mfp_mapped = MfpEval::new(&Trace, op.input_arity, &op.expressions);
             let pushdown = op
                 .predicates

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -172,7 +172,7 @@ pub struct ExplainConfig {
     /// Show the `type` attribute in the explanation.
     pub types: bool,
     /// Show MFP pushdown information.
-    pub mfp_pushdown: bool,
+    pub filter_pushdown: bool,
 }
 
 impl Default for ExplainConfig {
@@ -189,7 +189,7 @@ impl Default for ExplainConfig {
             subtree_size: false,
             timing: false,
             types: false,
-            mfp_pushdown: false,
+            filter_pushdown: false,
         }
     }
 }
@@ -221,7 +221,7 @@ impl TryFrom<BTreeSet<String>> for ExplainConfig {
             subtree_size: flags.remove("subtree_size"),
             timing: flags.remove("timing"),
             types: flags.remove("types"),
-            mfp_pushdown: flags.remove("mfp_pushdown"),
+            filter_pushdown: flags.remove("filter_pushdown") || flags.remove("mfp_pushdown"),
         };
         if flags.is_empty() {
             Ok(result)
@@ -620,7 +620,7 @@ mod tests {
             subtree_size: false,
             timing: true,
             types: false,
-            mfp_pushdown: false,
+            filter_pushdown: false,
         };
         let context = ExplainContext {
             env,

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -352,10 +352,10 @@ pub fn plan_explain(
         .collect::<BTreeSet<_>>();
     let mut config = ExplainConfig::try_from(config_flags)?;
 
-    if config.mfp_pushdown {
+    if config.filter_pushdown {
         scx.require_feature_flag(&vars::ENABLE_MFP_PUSHDOWN_EXPLAIN)?;
         // If filtering is disabled, explain plans should not include pushdown info.
-        config.mfp_pushdown = scx.catalog.system_vars().persist_stats_filter_enabled();
+        config.filter_pushdown = scx.catalog.system_vars().persist_stats_filter_enabled();
     }
 
     let format = match format {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1096,7 +1096,7 @@ feature_flags!(
         "monotonic evaluation of one-shot SELECT queries"
     ),
     (enable_primary_key_not_enforced, "PRIMARY KEY NOT ENFORCED"),
-    (enable_mfp_pushdown_explain, "`mfp_pushdown` explain"),
+    (enable_mfp_pushdown_explain, "`filter_pushdown` explain"),
     (
         enable_multi_worker_storage_persist_sink,
         "multi-worker storage persist sink"

--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -31,7 +31,7 @@ CREATE TABLE events (
 );
 
 query T multiline
-EXPLAIN WITH(mfp_pushdown)
+EXPLAIN WITH(filter_pushdown)
 SELECT count(*)
 FROM events
 WHERE mz_now() >= insert_ms
@@ -62,7 +62,7 @@ Source materialize.public.events
 EOF
 
 query T multiline
-EXPLAIN WITH(mfp_pushdown)
+EXPLAIN WITH(filter_pushdown)
 SELECT content, insert_ms
 FROM events
 -- The event should appear in only one interval of duration `10000`.
@@ -85,7 +85,7 @@ Source materialize.public.events
 EOF
 
 query T multiline
-EXPLAIN WITH(mfp_pushdown)
+EXPLAIN WITH(filter_pushdown)
 SELECT content, insert_ms
 FROM events
 -- The event should appear in `6` intervals each of width `10000`.
@@ -108,7 +108,7 @@ Source materialize.public.events
 EOF
 
 query T multiline
-EXPLAIN WITH(mfp_pushdown)
+EXPLAIN WITH(filter_pushdown)
 SELECT content, insert_ms
 FROM events
 -- The event should appear inside the interval that begins at
@@ -130,7 +130,7 @@ Source materialize.public.events
 EOF
 
 query T multiline
-EXPLAIN WITH(mfp_pushdown)
+EXPLAIN WITH(filter_pushdown)
 SELECT content, insert_ms, delete_ms
 FROM events
 WHERE mz_now() >= insert_ms + 60000
@@ -152,7 +152,7 @@ EOF
 # function _does_ report pushdown even when the argument list is long.
 
 query T multiline
-EXPLAIN WITH(mfp_pushdown)
+EXPLAIN WITH(filter_pushdown)
 SELECT content, insert_ms, delete_ms
 FROM events
 WHERE COALESCE(delete_ms, insert_ms) < mz_now();
@@ -168,7 +168,7 @@ Source materialize.public.events
 EOF
 
 query T multiline
-EXPLAIN WITH(mfp_pushdown)
+EXPLAIN WITH(filter_pushdown)
 SELECT content, insert_ms, delete_ms
 FROM events
 WHERE mz_now() < delete_ms + 10000
@@ -199,7 +199,7 @@ CREATE TABLE events_timestamped (
 );
 
 query T multiline
-EXPLAIN WITH(mfp_pushdown)
+EXPLAIN WITH(filter_pushdown)
 SELECT content, inserted_at
 FROM events_timestamped
 WHERE EXTRACT(YEAR FROM inserted_at) = 2021;


### PR DESCRIPTION
Get this feature ready to show to users:
- Section of the docs!
- Rename from `mfp_pushdown`, since MFP is an implementation detail that users are unlikely to be familiar with. (Whereas our docs already discuss filters.)

### Motivation

#18007

### Tips for reviewer

I'm not very attached to my prose: feel free to push up edits to the documentation directly.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
