### PR TITLE
k8s-orchestrator: set fsGroup for clusterd pods

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -337,6 +337,9 @@ pub struct Args {
     /// services that request disk.
     #[clap(long, env = "ORCHESTRATOR_KUBERNETES_EPHEMERAL_VOLUME_CLASS")]
     orchestrator_kubernetes_ephemeral_volume_class: Option<String>,
+    /// The optional fs group for service's pods' `securityContext`.
+    #[clap(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_FS_GROUP")]
+    orchestrator_kubernetes_service_fs_group: Option<i64>,
     #[clap(long, env = "ORCHESTRATOR_PROCESS_WRAPPER")]
     orchestrator_process_wrapper: Option<String>,
     /// Where the process orchestrator should store secrets.
@@ -718,6 +721,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                         ephemeral_volume_storage_class: args
                             .orchestrator_kubernetes_ephemeral_volume_class
                             .clone(),
+                        service_fs_group: args.orchestrator_kubernetes_service_fs_group.clone(),
                     }))
                     .context("creating kubernetes orchestrator")?,
             );


### PR DESCRIPTION
This is required for clusterd to access `/scratch` in staging/prod. Its unclear why its not necessary in kind.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
