### PR TITLE
storage/pg: move invariant comparing snapshot and resume_lsn

### DIFF
--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -197,8 +197,8 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                     let cap = cap.retain_for_output(0);
                     for req in data.drain(..) {
                         assert!(
-                            resume_lsn <= req.snapshot_lsn,
-                            "slot compacted past snapshot point. snapshot_lsn={} resume_lsn={resume_lsn}", req.snapshot_lsn
+                            resume_lsn <= req.snapshot_lsn + 1,
+                            "slot compacted past snapshot point. snapshot consistent point={} resume_lsn={resume_lsn}", req.snapshot_lsn + 1
                         );
                         rewinds.insert(req.oid, (cap.clone(), req));
                     }


### PR DESCRIPTION
Prior to #20329, RewindRequests' snapshot_lsn was the the
consistent_point returned from CREATE_REPLICATION_SLOT. We then
asserted that the resume_lsn was less than or equal to this value.

However, in #20329, we started subtracting 1 from the
consistent_point but did not change the assertion's equality.

In a [CI][1] run using #20329, I observed a case where the consistent
point was equal to the resume LSN, and our subtraction of one
caused the assertion to fail.

That this means is that the temporary replication slot used for
snapshotting had a consistent point equal to the
`confirmed_flush_lsn`; often times starting a new replication slot
advances the WAL, meaning that its consistent point will be
beyond the `confirmed_flush_lsn`, but nothing I have found
necessitates that to be the case. It also seems like this check
simply moves us back to the state we were in before #20329, so
should be somewhat uncontroversial.

[1]: https://buildkite.com/materialize/tests/builds/58992#01892d0c-15f3-470d-807f-1fbe8e3d254a

### Motivation

This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
