### PR TITLE
catalog: Emit audit log events for RBAC

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1611,6 +1611,43 @@ impl CatalogState {
         tx.insert_storage_usage_event(details);
         Ok(())
     }
+
+    fn get_owner_id(&self, id: &ObjectId, conn_id: &ConnectionId) -> Option<RoleId> {
+        match id {
+            ObjectId::Cluster(id) => Some(self.get_cluster(*id).owner_id()),
+            ObjectId::ClusterReplica((cluster_id, replica_id)) => Some(
+                self.get_cluster_replica(*cluster_id, *replica_id)
+                    .owner_id(),
+            ),
+            ObjectId::Database(id) => Some(self.get_database(id).owner_id()),
+            ObjectId::Schema((database_spec, schema_spec)) => Some(
+                self.get_schema(database_spec, schema_spec, conn_id)
+                    .owner_id(),
+            ),
+            ObjectId::Item(id) => Some(*self.get_entry(id).owner_id()),
+            ObjectId::Role(_) => None,
+        }
+    }
+
+    fn get_object_type(&self, object_id: &ObjectId) -> mz_sql::catalog::ObjectType {
+        match object_id {
+            ObjectId::Cluster(_) => mz_sql::catalog::ObjectType::Cluster,
+            ObjectId::ClusterReplica(_) => mz_sql::catalog::ObjectType::ClusterReplica,
+            ObjectId::Database(_) => mz_sql::catalog::ObjectType::Database,
+            ObjectId::Schema(_) => mz_sql::catalog::ObjectType::Schema,
+            ObjectId::Role(_) => mz_sql::catalog::ObjectType::Role,
+            ObjectId::Item(id) => self.get_entry(id).item_type().into(),
+        }
+    }
+
+    fn get_system_object_type(&self, id: &SystemObjectId) -> mz_sql::catalog::SystemObjectType {
+        match id {
+            SystemObjectId::Object(object_id) => {
+                SystemObjectType::Object(self.get_object_type(object_id))
+            }
+            SystemObjectId::System => SystemObjectType::System,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -5306,21 +5343,6 @@ impl Catalog {
         // stronger invariants about when we change items' dependencies.
         drop_ids: BTreeSet<GlobalId>,
     ) -> Result<(), AdapterError> {
-        fn sql_type_to_object_type(sql_type: SqlCatalogItemType) -> ObjectType {
-            match sql_type {
-                SqlCatalogItemType::Connection => ObjectType::Connection,
-                SqlCatalogItemType::Func => ObjectType::Func,
-                SqlCatalogItemType::Index => ObjectType::Index,
-                SqlCatalogItemType::MaterializedView => ObjectType::MaterializedView,
-                SqlCatalogItemType::Secret => ObjectType::Secret,
-                SqlCatalogItemType::Sink => ObjectType::Sink,
-                SqlCatalogItemType::Source => ObjectType::Source,
-                SqlCatalogItemType::Table => ObjectType::Table,
-                SqlCatalogItemType::Type => ObjectType::Type,
-                SqlCatalogItemType::View => ObjectType::View,
-            }
-        }
-
         // NOTE(benesch): to support altering legacy sized sources and sinks
         // (those with linked clusters), we need to generate retractions for
         // `mz_sources` and `mz_sinks` in a separate pass over the operations.
@@ -6053,7 +6075,7 @@ impl Catalog {
                             builtin_table_updates,
                             audit_events,
                             EventType::Create,
-                            sql_type_to_object_type(item.typ()),
+                            catalog_type_to_audit_object_type(item.typ()),
                             details,
                         )?;
                     }
@@ -6319,7 +6341,7 @@ impl Catalog {
                                 builtin_table_updates,
                                 audit_events,
                                 EventType::Drop,
-                                sql_type_to_object_type(entry.item().typ()),
+                                catalog_type_to_audit_object_type(entry.item().typ()),
                                 EventDetails::IdFullNameV1(IdFullNameV1 {
                                     id: id.to_string(),
                                     name: Self::full_name_detail(&state.resolve_full_name(
@@ -6422,38 +6444,38 @@ impl Catalog {
                             privileges.revoke(&privilege);
                         }
                     };
-                    match target_id {
+                    match &target_id {
                         SystemObjectId::Object(object_id) => match object_id {
                             ObjectId::Cluster(id) => {
-                                let cluster_name = state.get_cluster(id).name().to_string();
+                                let cluster_name = state.get_cluster(*id).name().to_string();
                                 builtin_table_updates
                                     .push(state.pack_cluster_update(&cluster_name, -1));
-                                let cluster = state.get_cluster_mut(id);
+                                let cluster = state.get_cluster_mut(*id);
                                 update_privilege_fn(&mut cluster.privileges);
-                                tx.update_cluster(id, cluster)?;
+                                tx.update_cluster(*id, cluster)?;
                                 builtin_table_updates
                                     .push(state.pack_cluster_update(&cluster_name, 1));
                             }
                             ObjectId::Database(id) => {
-                                let database = state.get_database(&id);
+                                let database = state.get_database(id);
                                 builtin_table_updates
                                     .push(state.pack_database_update(database, -1));
-                                let database = state.get_database_mut(&id);
+                                let database = state.get_database_mut(id);
                                 update_privilege_fn(&mut database.privileges);
-                                let database = state.get_database(&id);
-                                tx.update_database(id, database)?;
+                                let database = state.get_database(id);
+                                tx.update_database(*id, database)?;
                                 builtin_table_updates.push(state.pack_database_update(database, 1));
                             }
                             ObjectId::Schema((database_spec, schema_spec)) => {
                                 let schema_id = schema_spec.clone().into();
                                 builtin_table_updates.push(state.pack_schema_update(
-                                    &database_spec,
+                                    database_spec,
                                     &schema_id,
                                     -1,
                                 ));
                                 let schema = state.get_schema_mut(
-                                    &database_spec,
-                                    &schema_spec,
+                                    database_spec,
+                                    schema_spec,
                                     session
                                         .map(|session| session.conn_id())
                                         .unwrap_or(&SYSTEM_CONN_ID),
@@ -6465,23 +6487,23 @@ impl Catalog {
                                 };
                                 tx.update_schema(database_id, schema_id, schema)?;
                                 builtin_table_updates.push(state.pack_schema_update(
-                                    &database_spec,
-                                    &schema_spec.into(),
+                                    database_spec,
+                                    &schema_id,
                                     1,
                                 ));
                             }
                             ObjectId::Item(id) => {
-                                builtin_table_updates.extend(state.pack_item_update(id, -1));
-                                let entry = state.get_entry_mut(&id);
+                                builtin_table_updates.extend(state.pack_item_update(*id, -1));
+                                let entry = state.get_entry_mut(id);
                                 update_privilege_fn(&mut entry.privileges);
                                 if !entry.item().is_temporary() {
                                     tx.update_item(
-                                        id,
+                                        *id,
                                         &entry.name().item,
                                         &Self::serialize_item(entry.item()),
                                     )?;
                                 }
-                                builtin_table_updates.extend(state.pack_item_update(id, 1));
+                                builtin_table_updates.extend(state.pack_item_update(*id, 1));
                             }
                             ObjectId::Role(_) | ObjectId::ClusterReplica(_) => {}
                         },
@@ -6513,6 +6535,26 @@ impl Catalog {
                             }
                         }
                     }
+                    let object_type = state.get_system_object_type(&target_id);
+                    let object_id_str = match &target_id {
+                        SystemObjectId::System => "SYSTEM".to_string(),
+                        SystemObjectId::Object(id) => id.to_string(),
+                    };
+                    state.add_to_audit_log(
+                        oracle_write_ts,
+                        session,
+                        tx,
+                        builtin_table_updates,
+                        audit_events,
+                        variant.into(),
+                        system_object_type_to_audit_object_type(&object_type),
+                        EventDetails::UpdatePrivilegeV1(mz_audit_log::UpdatePrivilegeV1 {
+                            object_id: object_id_str,
+                            grantee_id: privilege.grantee.to_string(),
+                            grantor_id: privilege.grantor.to_string(),
+                            privileges: privilege.acl_mode.to_string(),
+                        }),
+                    )?;
                 }
                 Op::UpdateDefaultPrivilege {
                     privilege_object,
@@ -6557,6 +6599,24 @@ impl Catalog {
                             1,
                         ));
                     }
+                    state.add_to_audit_log(
+                        oracle_write_ts,
+                        session,
+                        tx,
+                        builtin_table_updates,
+                        audit_events,
+                        variant.into(),
+                        object_type_to_audit_object_type(privilege_object.object_type),
+                        EventDetails::AlterDefaultPrivilegeV1(
+                            mz_audit_log::AlterDefaultPrivilegeV1 {
+                                role_id: privilege_object.role_id.to_string(),
+                                database_id: privilege_object.database_id.map(|id| id.to_string()),
+                                schema_id: privilege_object.schema_id.map(|id| id.to_string()),
+                                grantee_id: privilege_acl_item.grantee.to_string(),
+                                privileges: privilege_acl_item.acl_mode.to_string(),
+                            },
+                        ),
+                    )?;
                 }
                 Op::RenameCluster { id, name, to_name } => {
                     if id.is_system() {
@@ -6678,7 +6738,7 @@ impl Catalog {
                             builtin_table_updates,
                             audit_events,
                             EventType::Alter,
-                            sql_type_to_object_type(entry.item().typ()),
+                            catalog_type_to_audit_object_type(entry.item().typ()),
                             details,
                         )?;
                     }
@@ -6752,136 +6812,154 @@ impl Catalog {
                         )?;
                     }
                 }
-                Op::UpdateOwner { id, new_owner } => match id {
-                    ObjectId::Cluster(id) => {
-                        let cluster_name = state.get_cluster(id).name().to_string();
-                        if id.is_system() {
-                            return Err(AdapterError::Catalog(Error::new(
-                                ErrorKind::ReadOnlyCluster(cluster_name),
-                            )));
-                        }
-                        builtin_table_updates.push(state.pack_cluster_update(&cluster_name, -1));
-                        let cluster = state.get_cluster_mut(id);
-                        Self::update_privilege_owners(
-                            &mut cluster.privileges,
-                            cluster.owner_id,
-                            new_owner,
-                        );
-                        cluster.owner_id = new_owner;
-                        tx.update_cluster(id, cluster)?;
-                        builtin_table_updates.push(state.pack_cluster_update(&cluster_name, 1));
-                    }
-                    ObjectId::ClusterReplica((cluster_id, replica_id)) => {
-                        let cluster = state.get_cluster(cluster_id);
-                        if cluster_id.is_system() {
-                            return Err(AdapterError::Catalog(Error::new(
-                                ErrorKind::ReadOnlyCluster(cluster.name().to_string()),
-                            )));
-                        }
-                        let replica_name = cluster
-                            .replicas_by_id
-                            .get(&replica_id)
-                            .expect("catalog out of sync")
-                            .name
-                            .clone();
-                        if is_reserved_name(&replica_name) {
-                            return Err(AdapterError::Catalog(Error::new(
-                                ErrorKind::ReservedReplicaName(replica_name),
-                            )));
-                        }
-                        builtin_table_updates.push(state.pack_cluster_replica_update(
-                            cluster_id,
-                            &replica_name,
-                            -1,
-                        ));
-                        let cluster = state.get_cluster_mut(cluster_id);
-                        let replica = cluster
-                            .replicas_by_id
-                            .get_mut(&replica_id)
-                            .expect("catalog out of sync");
-                        replica.owner_id = new_owner;
-                        tx.update_cluster_replica(cluster_id, replica_id, replica)?;
-                        builtin_table_updates.push(state.pack_cluster_replica_update(
-                            cluster_id,
-                            &replica_name,
-                            1,
-                        ));
-                    }
-                    ObjectId::Database(id) => {
-                        let database = state.get_database(&id);
-                        builtin_table_updates.push(state.pack_database_update(database, -1));
-                        let database = state.get_database_mut(&id);
-                        Self::update_privilege_owners(
-                            &mut database.privileges,
-                            database.owner_id,
-                            new_owner,
-                        );
-                        database.owner_id = new_owner;
-                        let database = state.get_database(&id);
-                        tx.update_database(id, database)?;
-                        builtin_table_updates.push(state.pack_database_update(database, 1));
-                    }
-                    ObjectId::Schema((database_spec, schema_spec)) => {
-                        let schema_id = schema_spec.clone().into();
-                        builtin_table_updates.push(state.pack_schema_update(
-                            &database_spec,
-                            &schema_id,
-                            -1,
-                        ));
-                        let schema = state.get_schema_mut(
-                            &database_spec,
-                            &schema_spec,
-                            session
-                                .map(|session| session.conn_id())
-                                .unwrap_or(&SYSTEM_CONN_ID),
-                        );
-                        Self::update_privilege_owners(
-                            &mut schema.privileges,
-                            schema.owner_id,
-                            new_owner,
-                        );
-                        schema.owner_id = new_owner;
-                        let database_id = match database_spec {
-                            ResolvedDatabaseSpecifier::Ambient => None,
-                            ResolvedDatabaseSpecifier::Id(id) => Some(id),
-                        };
-                        tx.update_schema(database_id, schema_id, schema)?;
-                        builtin_table_updates.push(state.pack_schema_update(
-                            &database_spec,
-                            &schema_id,
-                            1,
-                        ));
-                    }
-                    ObjectId::Item(id) => {
-                        if id.is_system() {
-                            let entry = state.get_entry(&id);
-                            let full_name = state.resolve_full_name(
-                                entry.name(),
-                                session.map(|session| session.conn_id()),
+                Op::UpdateOwner { id, new_owner } => {
+                    let conn_id = session
+                        .map(|session| session.conn_id())
+                        .unwrap_or(&SYSTEM_CONN_ID);
+                    let old_owner = state
+                        .get_owner_id(&id, conn_id)
+                        .expect("cannot update the owner of an object without an owner");
+                    match &id {
+                        ObjectId::Cluster(id) => {
+                            let cluster_name = state.get_cluster(*id).name().to_string();
+                            if id.is_system() {
+                                return Err(AdapterError::Catalog(Error::new(
+                                    ErrorKind::ReadOnlyCluster(cluster_name),
+                                )));
+                            }
+                            builtin_table_updates
+                                .push(state.pack_cluster_update(&cluster_name, -1));
+                            let cluster = state.get_cluster_mut(*id);
+                            Self::update_privilege_owners(
+                                &mut cluster.privileges,
+                                cluster.owner_id,
+                                new_owner,
                             );
-                            return Err(AdapterError::Catalog(Error::new(
-                                ErrorKind::ReadOnlyItem(full_name.to_string()),
-                            )));
+                            cluster.owner_id = new_owner;
+                            tx.update_cluster(*id, cluster)?;
+                            builtin_table_updates.push(state.pack_cluster_update(&cluster_name, 1));
                         }
-                        builtin_table_updates.extend(state.pack_item_update(id, -1));
-                        let entry = state.get_entry_mut(&id);
-                        Self::update_privilege_owners(
-                            &mut entry.privileges,
-                            entry.owner_id,
-                            new_owner,
-                        );
-                        entry.owner_id = new_owner;
-                        if !entry.item().is_temporary() {
-                            tx.update_item(
-                                id,
-                                &entry.name().item,
-                                &Self::serialize_item(entry.item()),
-                            )?;
+                        ObjectId::ClusterReplica((cluster_id, replica_id)) => {
+                            let cluster = state.get_cluster(*cluster_id);
+                            if cluster_id.is_system() {
+                                return Err(AdapterError::Catalog(Error::new(
+                                    ErrorKind::ReadOnlyCluster(cluster.name().to_string()),
+                                )));
+                            }
+                            let replica_name = cluster
+                                .replicas_by_id
+                                .get(replica_id)
+                                .expect("catalog out of sync")
+                                .name
+                                .clone();
+                            if is_reserved_name(&replica_name) {
+                                return Err(AdapterError::Catalog(Error::new(
+                                    ErrorKind::ReservedReplicaName(replica_name),
+                                )));
+                            }
+                            builtin_table_updates.push(state.pack_cluster_replica_update(
+                                *cluster_id,
+                                &replica_name,
+                                -1,
+                            ));
+                            let cluster = state.get_cluster_mut(*cluster_id);
+                            let replica = cluster
+                                .replicas_by_id
+                                .get_mut(replica_id)
+                                .expect("catalog out of sync");
+                            replica.owner_id = new_owner;
+                            tx.update_cluster_replica(*cluster_id, *replica_id, replica)?;
+                            builtin_table_updates.push(state.pack_cluster_replica_update(
+                                *cluster_id,
+                                &replica_name,
+                                1,
+                            ));
                         }
-                        builtin_table_updates.extend(state.pack_item_update(id, 1));
+                        ObjectId::Database(id) => {
+                            let database = state.get_database(id);
+                            builtin_table_updates.push(state.pack_database_update(database, -1));
+                            let database = state.get_database_mut(id);
+                            Self::update_privilege_owners(
+                                &mut database.privileges,
+                                database.owner_id,
+                                new_owner,
+                            );
+                            database.owner_id = new_owner;
+                            let database = state.get_database(id);
+                            tx.update_database(*id, database)?;
+                            builtin_table_updates.push(state.pack_database_update(database, 1));
+                        }
+                        ObjectId::Schema((database_spec, schema_spec)) => {
+                            let schema_id = schema_spec.clone().into();
+                            builtin_table_updates.push(state.pack_schema_update(
+                                database_spec,
+                                &schema_id,
+                                -1,
+                            ));
+                            let schema = state.get_schema_mut(database_spec, schema_spec, conn_id);
+                            Self::update_privilege_owners(
+                                &mut schema.privileges,
+                                schema.owner_id,
+                                new_owner,
+                            );
+                            schema.owner_id = new_owner;
+                            let database_id = match database_spec {
+                                ResolvedDatabaseSpecifier::Ambient => None,
+                                ResolvedDatabaseSpecifier::Id(id) => Some(id),
+                            };
+                            tx.update_schema(database_id.cloned(), schema_id, schema)?;
+                            builtin_table_updates.push(state.pack_schema_update(
+                                database_spec,
+                                &schema_id,
+                                1,
+                            ));
+                        }
+                        ObjectId::Item(id) => {
+                            if id.is_system() {
+                                let entry = state.get_entry(id);
+                                let full_name = state.resolve_full_name(
+                                    entry.name(),
+                                    session.map(|session| session.conn_id()),
+                                );
+                                return Err(AdapterError::Catalog(Error::new(
+                                    ErrorKind::ReadOnlyItem(full_name.to_string()),
+                                )));
+                            }
+                            builtin_table_updates.extend(state.pack_item_update(*id, -1));
+                            let entry = state.get_entry_mut(id);
+                            Self::update_privilege_owners(
+                                &mut entry.privileges,
+                                entry.owner_id,
+                                new_owner,
+                            );
+                            entry.owner_id = new_owner;
+                            if !entry.item().is_temporary() {
+                                tx.update_item(
+                                    *id,
+                                    &entry.name().item,
+                                    &Self::serialize_item(entry.item()),
+                                )?;
+                            }
+                            builtin_table_updates.extend(state.pack_item_update(*id, 1));
+                        }
+                        ObjectId::Role(_) => unreachable!("roles have no owner"),
                     }
-                    ObjectId::Role(_) => unreachable!("roles have no owner"),
-                },
+                    let object_type = state.get_object_type(&id);
+                    state.add_to_audit_log(
+                        oracle_write_ts,
+                        session,
+                        tx,
+                        builtin_table_updates,
+                        audit_events,
+                        EventType::Alter,
+                        object_type_to_audit_object_type(object_type),
+                        EventDetails::UpdateOwnerV1(mz_audit_log::UpdateOwnerV1 {
+                            object_id: id.to_string(),
+                            old_owner_id: old_owner.to_string(),
+                            new_owner_id: new_owner.to_string(),
+                        }),
+                    )?;
+                }
                 Op::UpdateClusterConfig { id, name, config } => {
                     builtin_table_updates.push(state.pack_cluster_update(&name, -1));
                     let cluster = state.get_cluster_mut(id);
@@ -7648,6 +7726,41 @@ pub fn is_public_role(name: &str) -> bool {
     name == &*PUBLIC_ROLE_NAME
 }
 
+pub(crate) fn catalog_type_to_audit_object_type(sql_type: SqlCatalogItemType) -> ObjectType {
+    object_type_to_audit_object_type(sql_type.into())
+}
+
+pub(crate) fn object_type_to_audit_object_type(
+    object_type: mz_sql::catalog::ObjectType,
+) -> ObjectType {
+    system_object_type_to_audit_object_type(&SystemObjectType::Object(object_type))
+}
+
+pub(crate) fn system_object_type_to_audit_object_type(
+    system_type: &SystemObjectType,
+) -> ObjectType {
+    match system_type {
+        SystemObjectType::Object(object_type) => match object_type {
+            mz_sql::catalog::ObjectType::Table => ObjectType::Table,
+            mz_sql::catalog::ObjectType::View => ObjectType::View,
+            mz_sql::catalog::ObjectType::MaterializedView => ObjectType::MaterializedView,
+            mz_sql::catalog::ObjectType::Source => ObjectType::Source,
+            mz_sql::catalog::ObjectType::Sink => ObjectType::Sink,
+            mz_sql::catalog::ObjectType::Index => ObjectType::Index,
+            mz_sql::catalog::ObjectType::Type => ObjectType::Type,
+            mz_sql::catalog::ObjectType::Role => ObjectType::Role,
+            mz_sql::catalog::ObjectType::Cluster => ObjectType::Cluster,
+            mz_sql::catalog::ObjectType::ClusterReplica => ObjectType::ClusterReplica,
+            mz_sql::catalog::ObjectType::Secret => ObjectType::Secret,
+            mz_sql::catalog::ObjectType::Connection => ObjectType::Connection,
+            mz_sql::catalog::ObjectType::Database => ObjectType::Database,
+            mz_sql::catalog::ObjectType::Schema => ObjectType::Schema,
+            mz_sql::catalog::ObjectType::Func => ObjectType::Func,
+        },
+        SystemObjectType::System => ObjectType::System,
+    }
+}
+
 #[derive(Debug, Copy, Clone)]
 pub enum UpdatePrivilegeVariant {
     Grant,
@@ -7659,6 +7772,15 @@ impl From<UpdatePrivilegeVariant> for ExecuteResponse {
         match variant {
             UpdatePrivilegeVariant::Grant => ExecuteResponse::GrantedPrivilege,
             UpdatePrivilegeVariant::Revoke => ExecuteResponse::RevokedPrivilege,
+        }
+    }
+}
+
+impl From<UpdatePrivilegeVariant> for EventType {
+    fn from(variant: UpdatePrivilegeVariant) -> Self {
+        match variant {
+            UpdatePrivilegeVariant::Grant => EventType::Grant,
+            UpdatePrivilegeVariant::Revoke => EventType::Revoke,
         }
     }
 }
@@ -8340,19 +8462,7 @@ impl SessionCatalog for ConnCatalog<'_> {
     }
 
     fn get_owner_id(&self, id: &ObjectId) -> Option<RoleId> {
-        match id {
-            ObjectId::Cluster(id) => Some(self.get_cluster(*id).owner_id()),
-            ObjectId::ClusterReplica((cluster_id, replica_id)) => Some(
-                self.get_cluster_replica(*cluster_id, *replica_id)
-                    .owner_id(),
-            ),
-            ObjectId::Database(id) => Some(self.get_database(id).owner_id()),
-            ObjectId::Schema((database_spec, schema_spec)) => {
-                Some(self.get_schema(database_spec, schema_spec).owner_id())
-            }
-            ObjectId::Item(id) => Some(self.get_item(id).owner_id()),
-            ObjectId::Role(_) => None,
-        }
+        self.state().get_owner_id(id, self.conn_id())
     }
 
     fn get_privileges(&self, id: &SystemObjectId) -> Option<&PrivilegeMap> {
@@ -8388,23 +8498,11 @@ impl SessionCatalog for ConnCatalog<'_> {
     }
 
     fn get_object_type(&self, object_id: &ObjectId) -> mz_sql::catalog::ObjectType {
-        match object_id {
-            ObjectId::Cluster(_) => mz_sql::catalog::ObjectType::Cluster,
-            ObjectId::ClusterReplica(_) => mz_sql::catalog::ObjectType::ClusterReplica,
-            ObjectId::Database(_) => mz_sql::catalog::ObjectType::Database,
-            ObjectId::Schema(_) => mz_sql::catalog::ObjectType::Schema,
-            ObjectId::Role(_) => mz_sql::catalog::ObjectType::Role,
-            ObjectId::Item(item_id) => self.get_item(item_id).item_type().into(),
-        }
+        self.state.get_object_type(object_id)
     }
 
     fn get_system_object_type(&self, id: &SystemObjectId) -> mz_sql::catalog::SystemObjectType {
-        match id {
-            SystemObjectId::Object(object_id) => {
-                SystemObjectType::Object(self.get_object_type(object_id))
-            }
-            SystemObjectId::System => SystemObjectType::System,
-        }
+        self.state.get_system_object_type(id)
     }
 
     /// Returns a [`PartialItemName`] with the minimum amount of qualifiers to unambiguously resolve

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -222,6 +222,7 @@ pub enum ObjectType {
     Schema,
     Sink,
     Source,
+    System,
     Table,
     Type,
     View,
@@ -242,6 +243,7 @@ impl ObjectType {
             ObjectType::Secret => "Secret",
             ObjectType::Sink => "Sink",
             ObjectType::Source => "Source",
+            ObjectType::System => "System",
             ObjectType::Table => "Table",
             ObjectType::Type => "Type",
             ObjectType::View => "View",
@@ -264,6 +266,7 @@ impl RustType<proto::audit_log_event_v1::ObjectType> for ObjectType {
             ObjectType::Schema => proto::audit_log_event_v1::ObjectType::Schema,
             ObjectType::Sink => proto::audit_log_event_v1::ObjectType::Sink,
             ObjectType::Source => proto::audit_log_event_v1::ObjectType::Source,
+            ObjectType::System => proto::audit_log_event_v1::ObjectType::System,
             ObjectType::Table => proto::audit_log_event_v1::ObjectType::Table,
             ObjectType::Type => proto::audit_log_event_v1::ObjectType::Type,
             ObjectType::View => proto::audit_log_event_v1::ObjectType::View,
@@ -286,6 +289,7 @@ impl RustType<proto::audit_log_event_v1::ObjectType> for ObjectType {
             proto::audit_log_event_v1::ObjectType::Schema => Ok(ObjectType::Schema),
             proto::audit_log_event_v1::ObjectType::Sink => Ok(ObjectType::Sink),
             proto::audit_log_event_v1::ObjectType::Source => Ok(ObjectType::Source),
+            proto::audit_log_event_v1::ObjectType::System => Ok(ObjectType::System),
             proto::audit_log_event_v1::ObjectType::Table => Ok(ObjectType::Table),
             proto::audit_log_event_v1::ObjectType::Type => Ok(ObjectType::Type),
             proto::audit_log_event_v1::ObjectType::View => Ok(ObjectType::View),
@@ -311,6 +315,9 @@ pub enum EventDetails {
     GrantRoleV2(GrantRoleV2),
     RevokeRoleV1(RevokeRoleV1),
     RevokeRoleV2(RevokeRoleV2),
+    UpdatePrivilegeV1(UpdatePrivilegeV1),
+    AlterDefaultPrivilegeV1(AlterDefaultPrivilegeV1),
+    UpdateOwnerV1(UpdateOwnerV1),
     IdFullNameV1(IdFullNameV1),
     RenameClusterV1(RenameClusterV1),
     RenameClusterReplicaV1(RenameClusterReplicaV1),
@@ -761,6 +768,100 @@ impl RustType<proto::audit_log_event_v1::RevokeRoleV2> for RevokeRoleV2 {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash, Arbitrary)]
+pub struct UpdatePrivilegeV1 {
+    pub object_id: String,
+    pub grantee_id: String,
+    pub grantor_id: String,
+    pub privileges: String,
+}
+
+impl RustType<proto::audit_log_event_v1::UpdatePrivilegeV1> for UpdatePrivilegeV1 {
+    fn into_proto(&self) -> proto::audit_log_event_v1::UpdatePrivilegeV1 {
+        proto::audit_log_event_v1::UpdatePrivilegeV1 {
+            object_id: self.object_id.to_string(),
+            grantee_id: self.grantee_id.to_string(),
+            grantor_id: self.grantor_id.to_string(),
+            privileges: self.privileges.to_string(),
+        }
+    }
+
+    fn from_proto(
+        proto: proto::audit_log_event_v1::UpdatePrivilegeV1,
+    ) -> Result<Self, TryFromProtoError> {
+        Ok(UpdatePrivilegeV1 {
+            object_id: proto.object_id,
+            grantee_id: proto.grantee_id,
+            grantor_id: proto.grantor_id,
+            privileges: proto.privileges,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash, Arbitrary)]
+pub struct AlterDefaultPrivilegeV1 {
+    pub role_id: String,
+    pub database_id: Option<String>,
+    pub schema_id: Option<String>,
+    pub grantee_id: String,
+    pub privileges: String,
+}
+
+impl RustType<proto::audit_log_event_v1::AlterDefaultPrivilegeV1> for AlterDefaultPrivilegeV1 {
+    fn into_proto(&self) -> proto::audit_log_event_v1::AlterDefaultPrivilegeV1 {
+        proto::audit_log_event_v1::AlterDefaultPrivilegeV1 {
+            role_id: self.role_id.to_string(),
+            database_id: self.database_id.as_ref().map(|id| proto::StringWrapper {
+                inner: id.to_string(),
+            }),
+            schema_id: self.schema_id.as_ref().map(|id| proto::StringWrapper {
+                inner: id.to_string(),
+            }),
+            grantee_id: self.grantee_id.to_string(),
+            privileges: self.privileges.to_string(),
+        }
+    }
+
+    fn from_proto(
+        proto: proto::audit_log_event_v1::AlterDefaultPrivilegeV1,
+    ) -> Result<Self, TryFromProtoError> {
+        Ok(AlterDefaultPrivilegeV1 {
+            role_id: proto.role_id,
+            database_id: proto.database_id.map(|id| id.inner),
+            schema_id: proto.schema_id.map(|id| id.inner),
+            grantee_id: proto.grantee_id,
+            privileges: proto.privileges,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash, Arbitrary)]
+pub struct UpdateOwnerV1 {
+    pub object_id: String,
+    pub old_owner_id: String,
+    pub new_owner_id: String,
+}
+
+impl RustType<proto::audit_log_event_v1::UpdateOwnerV1> for UpdateOwnerV1 {
+    fn into_proto(&self) -> proto::audit_log_event_v1::UpdateOwnerV1 {
+        proto::audit_log_event_v1::UpdateOwnerV1 {
+            object_id: self.object_id.to_string(),
+            old_owner_id: self.old_owner_id.to_string(),
+            new_owner_id: self.new_owner_id.to_string(),
+        }
+    }
+
+    fn from_proto(
+        proto: proto::audit_log_event_v1::UpdateOwnerV1,
+    ) -> Result<Self, TryFromProtoError> {
+        Ok(UpdateOwnerV1 {
+            object_id: proto.object_id,
+            old_owner_id: proto.old_owner_id,
+            new_owner_id: proto.new_owner_id,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash, Arbitrary)]
 pub struct SchemaV1 {
     pub id: String,
     pub name: String,
@@ -837,6 +938,11 @@ impl EventDetails {
             EventDetails::GrantRoleV2(v) => serde_json::to_value(v).expect("must serialize"),
             EventDetails::RevokeRoleV1(v) => serde_json::to_value(v).expect("must serialize"),
             EventDetails::RevokeRoleV2(v) => serde_json::to_value(v).expect("must serialize"),
+            EventDetails::UpdatePrivilegeV1(v) => serde_json::to_value(v).expect("must serialize"),
+            EventDetails::AlterDefaultPrivilegeV1(v) => {
+                serde_json::to_value(v).expect("must serialize")
+            }
+            EventDetails::UpdateOwnerV1(v) => serde_json::to_value(v).expect("must serialize"),
         }
     }
 }
@@ -859,6 +965,11 @@ impl RustType<proto::audit_log_event_v1::Details> for EventDetails {
             EventDetails::GrantRoleV2(details) => GrantRoleV2(details.into_proto()),
             EventDetails::RevokeRoleV1(details) => RevokeRoleV1(details.into_proto()),
             EventDetails::RevokeRoleV2(details) => RevokeRoleV2(details.into_proto()),
+            EventDetails::UpdatePrivilegeV1(details) => UpdatePrivilegeV1(details.into_proto()),
+            EventDetails::AlterDefaultPrivilegeV1(details) => {
+                AlterDefaultPrivilegeV1(details.into_proto())
+            }
+            EventDetails::UpdateOwnerV1(details) => UpdateOwnerV1(details.into_proto()),
             EventDetails::IdFullNameV1(details) => IdFullNameV1(details.into_proto()),
             EventDetails::RenameClusterV1(details) => RenameClusterV1(details.into_proto()),
             EventDetails::RenameClusterReplicaV1(details) => {
@@ -892,6 +1003,11 @@ impl RustType<proto::audit_log_event_v1::Details> for EventDetails {
             GrantRoleV2(details) => Ok(EventDetails::GrantRoleV2(details.into_rust()?)),
             RevokeRoleV1(details) => Ok(EventDetails::RevokeRoleV1(details.into_rust()?)),
             RevokeRoleV2(details) => Ok(EventDetails::RevokeRoleV2(details.into_rust()?)),
+            UpdatePrivilegeV1(details) => Ok(EventDetails::UpdatePrivilegeV1(details.into_rust()?)),
+            AlterDefaultPrivilegeV1(details) => {
+                Ok(EventDetails::AlterDefaultPrivilegeV1(details.into_rust()?))
+            }
+            UpdateOwnerV1(details) => Ok(EventDetails::UpdateOwnerV1(details.into_rust()?)),
             IdFullNameV1(details) => Ok(EventDetails::IdFullNameV1(details.into_rust()?)),
             RenameClusterV1(details) => Ok(EventDetails::RenameClusterV1(details.into_rust()?)),
             RenameClusterReplicaV1(details) => {

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -970,6 +970,27 @@ impl ObjectId {
     }
 }
 
+impl fmt::Display for ObjectId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ObjectId::Cluster(cluster_id) => write!(f, "C{cluster_id}"),
+            ObjectId::ClusterReplica((cluster_id, replica_id)) => {
+                write!(f, "CR{cluster_id}.{replica_id}")
+            }
+            ObjectId::Database(database_id) => write!(f, "D{database_id}"),
+            ObjectId::Schema((database_spec, schema_spec)) => {
+                let database_id = match database_spec {
+                    ResolvedDatabaseSpecifier::Ambient => "".to_string(),
+                    ResolvedDatabaseSpecifier::Id(database_id) => format!("{database_id}."),
+                };
+                write!(f, "S{database_id}{schema_spec}")
+            }
+            ObjectId::Role(role_id) => write!(f, "R{role_id}"),
+            ObjectId::Item(item_id) => write!(f, "I{item_id}"),
+        }
+    }
+}
+
 impl TryFrom<ResolvedObjectName> for ObjectId {
     type Error = anyhow::Error;
 

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "20b96b75360de55bf3233548b6e3c649"
+    "md5": "57275dc806e67834d5ebcfb04001c50d"
   },
   {
     "name": "objects_v15.proto",
@@ -50,5 +50,9 @@
   {
     "name": "objects_v26.proto",
     "md5": "bffd4936bea8f4f894662fcea12e4a5d"
+  },
+  {
+    "name": "objects_v27.proto",
+    "md5": "7ccd2c67b302d72cc4c94be892c7cfc1"
   }
 ]

--- a/src/stash/protos/objects_v27.proto
+++ b/src/stash/protos/objects_v27.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto3";
 
-package objects;
+package objects_v27;
 
 message ConfigKey {
     string key = 1;

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -102,7 +102,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 26;
+pub const STASH_VERSION: u64 = 27;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -955,6 +955,7 @@ impl Stash {
                             23 => upgrade::v23_to_v24::upgrade(&mut tx).await?,
                             24 => upgrade::v24_to_v25::upgrade(&mut tx).await?,
                             25 => upgrade::v25_to_v26::upgrade(),
+                            26 => upgrade::v26_to_v27::upgrade(),
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -61,6 +61,7 @@ pub mod v22_to_v23;
 pub mod v23_to_v24;
 pub mod v24_to_v25;
 pub mod v25_to_v26;
+pub mod v26_to_v27;
 
 pub use json_to_proto::migrate_json_to_proto;
 

--- a/src/stash/src/upgrade/v26_to_v27.rs
+++ b/src/stash/src/upgrade/v26_to_v27.rs
@@ -1,0 +1,11 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// No-op migration for adding RBAC related audit events.
+pub fn upgrade() {}

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -90,56 +90,65 @@ query ITTTT
 SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id
 ----
 1  create  role  {"id":"u1","name":"materialize"}  NULL
-2  create  database  {"id":"u1","name":"materialize"}  NULL
-3  create  schema  {"database_name":"materialize","id":"3","name":"public"}  NULL
-4  create  cluster  {"id":"u1","name":"default"}  NULL
-5  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","disk":false,"logical_size":"1","replica_id":"1","replica_name":"r1"}  NULL
-6  create  database  {"id":"u2","name":"test"}  materialize
-7  create  schema  {"database_name":"test","id":"u6","name":"public"}  materialize
-8  create  schema  {"database_name":"test","id":"u7","name":"sc1"}  materialize
-9  create  schema  {"database_name":"test","id":"u8","name":"sc2"}  materialize
-10  drop  schema  {"database_name":"test","id":"u7","name":"sc1"}  materialize
-11  drop  schema  {"database_name":"test","id":"u6","name":"public"}  materialize
-12  drop  schema  {"database_name":"test","id":"u8","name":"sc2"}  materialize
-13  drop  database  {"id":"u2","name":"test"}  materialize
-14  create  role  {"id":"u2","name":"foo"}  materialize
-15  drop  role  {"id":"u2","name":"foo"}  materialize
-16  create  cluster  {"id":"u2","name":"foo"}  materialize
-17  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","disk":false,"logical_size":"1","replica_id":"4","replica_name":"r"}  materialize
-18  create  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
-19  create  view  {"database":"materialize","id":"u2","item":"unmat","schema":"public"}  materialize
-20  create  table  {"database":"materialize","id":"u3","item":"t","schema":"public"}  materialize
-21  create  index  {"database":"materialize","id":"u4","item":"t_primary_idx","schema":"public"}  materialize
-22  alter  view  {"id":"u2","new_name":{"database":"materialize","item":"renamed","schema":"public"},"old_name":{"database":"materialize","item":"unmat","schema":"public"}}  materialize
-23  drop  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
-24  create  materialized-view  {"database":"materialize","id":"u5","item":"v2","schema":"public"}  materialize
-25  create  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
-26  drop  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
-27  drop  view  {"database":"materialize","id":"u2","item":"renamed","schema":"public"}  materialize
-28  create  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public","size":null,"type":"progress"}  materialize
-29  create  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
-30  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"1","replica_id":"5","replica_name":"linked"}  materialize
-31  create  source  {"database":"materialize","id":"u8","item":"s","schema":"public","size":"1","type":"load-generator"}  materialize
-32  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"5","replica_name":"linked"}  materialize
-33  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"2","replica_id":"6","replica_name":"linked"}  materialize
-34  alter  source  {"database":"materialize","id":"u8","item":"s","new_size":"2","old_size":"1","schema":"public"}  materialize
-35  drop  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public"}  materialize
-36  drop  source  {"database":"materialize","id":"u8","item":"s","schema":"public"}  materialize
-37  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"6","replica_name":"linked"}  materialize
-38  drop  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
-39  create  source  {"database":"materialize","id":"u9","item":"accounts","schema":"public","size":null,"type":"subsource"}  materialize
-40  create  source  {"database":"materialize","id":"u10","item":"auctions","schema":"public","size":null,"type":"subsource"}  materialize
-41  create  source  {"database":"materialize","id":"u11","item":"bids","schema":"public","size":null,"type":"subsource"}  materialize
-42  create  source  {"database":"materialize","id":"u12","item":"organizations","schema":"public","size":null,"type":"subsource"}  materialize
-43  create  source  {"database":"materialize","id":"u13","item":"users","schema":"public","size":null,"type":"subsource"}  materialize
-44  create  source  {"database":"materialize","id":"u14","item":"multiplex_progress","schema":"public","size":null,"type":"progress"}  materialize
-45  create  cluster  {"id":"u4","name":"materialize_public_multiplex"}  materialize
-46  create  cluster-replica  {"cluster_id":"u4","cluster_name":"materialize_public_multiplex","disk":false,"logical_size":"1","replica_id":"7","replica_name":"linked"}  materialize
-47  create  source  {"database":"materialize","id":"u15","item":"multiplex","schema":"public","size":"1","type":"load-generator"}  materialize
-48  alter  cluster-replica  {"cluster_id":"u2","new_name":"s","old_name":"r","replica_id":"4"}  materialize
-49  alter  cluster  {"id":"u2","new_name":"bar","old_name":"foo"}  materialize
-50  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"bar","replica_id":"4","replica_name":"s"}  materialize
-51  drop  cluster  {"id":"u2","name":"bar"}  materialize
+2  grant  cluster  {"database_id":null,"grantee_id":"s2","privileges":"U","role_id":"p","schema_id":null}  NULL
+3  grant  type  {"database_id":null,"grantee_id":"p","privileges":"U","role_id":"p","schema_id":null}  NULL
+4  create  database  {"id":"u1","name":"materialize"}  NULL
+5  grant  database  {"grantee_id":"p","grantor_id":"s1","object_id":"Du1","privileges":"U"}  NULL
+6  grant  database  {"grantee_id":"u1","grantor_id":"s1","object_id":"Du1","privileges":"UC"}  NULL
+7  create  schema  {"database_name":"materialize","id":"3","name":"public"}  NULL
+8  grant  schema  {"grantee_id":"u1","grantor_id":"s1","object_id":"Su1.u3","privileges":"UC"}  NULL
+9  create  cluster  {"id":"u1","name":"default"}  NULL
+10  grant  cluster  {"grantee_id":"p","grantor_id":"s1","object_id":"Cu1","privileges":"U"}  NULL
+11  grant  cluster  {"grantee_id":"u1","grantor_id":"s1","object_id":"Cu1","privileges":"UC"}  NULL
+12  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","disk":false,"logical_size":"1","replica_id":"1","replica_name":"r1"}  NULL
+13  grant  system  {"grantee_id":"s1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
+14  grant  system  {"grantee_id":"u1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
+15  create  database  {"id":"u2","name":"test"}  materialize
+16  create  schema  {"database_name":"test","id":"u6","name":"public"}  materialize
+17  create  schema  {"database_name":"test","id":"u7","name":"sc1"}  materialize
+18  create  schema  {"database_name":"test","id":"u8","name":"sc2"}  materialize
+19  drop  schema  {"database_name":"test","id":"u7","name":"sc1"}  materialize
+20  drop  schema  {"database_name":"test","id":"u6","name":"public"}  materialize
+21  drop  schema  {"database_name":"test","id":"u8","name":"sc2"}  materialize
+22  drop  database  {"id":"u2","name":"test"}  materialize
+23  create  role  {"id":"u2","name":"foo"}  materialize
+24  drop  role  {"id":"u2","name":"foo"}  materialize
+25  create  cluster  {"id":"u2","name":"foo"}  materialize
+26  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","disk":false,"logical_size":"1","replica_id":"4","replica_name":"r"}  materialize
+27  create  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
+28  create  view  {"database":"materialize","id":"u2","item":"unmat","schema":"public"}  materialize
+29  create  table  {"database":"materialize","id":"u3","item":"t","schema":"public"}  materialize
+30  create  index  {"database":"materialize","id":"u4","item":"t_primary_idx","schema":"public"}  materialize
+31  alter  view  {"id":"u2","new_name":{"database":"materialize","item":"renamed","schema":"public"},"old_name":{"database":"materialize","item":"unmat","schema":"public"}}  materialize
+32  drop  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
+33  create  materialized-view  {"database":"materialize","id":"u5","item":"v2","schema":"public"}  materialize
+34  create  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
+35  drop  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
+36  drop  view  {"database":"materialize","id":"u2","item":"renamed","schema":"public"}  materialize
+37  create  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public","size":null,"type":"progress"}  materialize
+38  create  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
+39  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"1","replica_id":"5","replica_name":"linked"}  materialize
+40  create  source  {"database":"materialize","id":"u8","item":"s","schema":"public","size":"1","type":"load-generator"}  materialize
+41  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"5","replica_name":"linked"}  materialize
+42  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"2","replica_id":"6","replica_name":"linked"}  materialize
+43  alter  source  {"database":"materialize","id":"u8","item":"s","new_size":"2","old_size":"1","schema":"public"}  materialize
+44  drop  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public"}  materialize
+45  drop  source  {"database":"materialize","id":"u8","item":"s","schema":"public"}  materialize
+46  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"6","replica_name":"linked"}  materialize
+47  drop  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
+48  create  source  {"database":"materialize","id":"u9","item":"accounts","schema":"public","size":null,"type":"subsource"}  materialize
+49  create  source  {"database":"materialize","id":"u10","item":"auctions","schema":"public","size":null,"type":"subsource"}  materialize
+50  create  source  {"database":"materialize","id":"u11","item":"bids","schema":"public","size":null,"type":"subsource"}  materialize
+51  create  source  {"database":"materialize","id":"u12","item":"organizations","schema":"public","size":null,"type":"subsource"}  materialize
+52  create  source  {"database":"materialize","id":"u13","item":"users","schema":"public","size":null,"type":"subsource"}  materialize
+53  create  source  {"database":"materialize","id":"u14","item":"multiplex_progress","schema":"public","size":null,"type":"progress"}  materialize
+54  create  cluster  {"id":"u4","name":"materialize_public_multiplex"}  materialize
+55  create  cluster-replica  {"cluster_id":"u4","cluster_name":"materialize_public_multiplex","disk":false,"logical_size":"1","replica_id":"7","replica_name":"linked"}  materialize
+56  create  source  {"database":"materialize","id":"u15","item":"multiplex","schema":"public","size":"1","type":"load-generator"}  materialize
+57  alter  cluster-replica  {"cluster_id":"u2","new_name":"s","old_name":"r","replica_id":"4"}  materialize
+58  alter  cluster  {"id":"u2","new_name":"bar","old_name":"foo"}  materialize
+59  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"bar","replica_id":"4","replica_name":"s"}  materialize
+60  drop  cluster  {"id":"u2","name":"bar"}  materialize
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET unsafe_mock_audit_event_timestamp = 666
@@ -152,7 +161,7 @@ CREATE TABLE tt ()
 query ITTTTT
 SELECT id, event_type, object_type, details, user, occurred_at FROM mz_audit_events ORDER BY id DESC LIMIT 1
 ----
-52  create  table  {"database":"materialize","id":"u16","item":"tt","schema":"public"}  materialize  1970-01-01␠00:00:00.666+00
+61  create  table  {"database":"materialize","id":"u16","item":"tt","schema":"public"}  materialize  1970-01-01␠00:00:00.666+00
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM RESET unsafe_mock_audit_event_timestamp
@@ -175,3 +184,61 @@ SELECT internal_replica_id, cluster_name, replica_name, size, created_at IS NOT 
 5  materialize_public_s  linked  1  true  true  true  1
 6  materialize_public_s  linked  2  true  true  true  1
 7  materialize_public_multiplex  linked  1  true  false  NULL  1
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE r1;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON t TO r1;
+----
+COMPLETE 0
+
+query ITTTT
+SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id DESC LIMIT 1
+----
+64  grant  table  {"grantee_id":"u3","grantor_id":"u1","object_id":"Iu3","privileges":"r"}  mz_system
+
+simple conn=mz_system,user=mz_system
+REVOKE SELECT ON t FROM r1;
+----
+COMPLETE 0
+
+query ITTTT
+SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id DESC LIMIT 1
+----
+65  revoke  table  {"grantee_id":"u3","grantor_id":"u1","object_id":"Iu3","privileges":"r"}  mz_system
+
+simple conn=mz_system,user=mz_system
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 IN SCHEMA public GRANT SELECT ON TABLES to PUBLIC;
+----
+COMPLETE 0
+
+query ITTTT
+SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id DESC LIMIT 1
+----
+66  grant  table  {"database_id":"u1","grantee_id":"p","privileges":"r","role_id":"u3","schema_id":"u3"}  mz_system
+
+simple conn=mz_system,user=mz_system
+ALTER DEFAULT PRIVILEGES FOR ROLE r1 IN SCHEMA public REVOKE SELECT ON TABLES FROM PUBLIC;
+----
+COMPLETE 0
+
+query ITTTT
+SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id DESC LIMIT 1
+----
+67  revoke  table  {"database_id":"u1","grantee_id":"p","privileges":"r","role_id":"u3","schema_id":"u3"}  mz_system
+
+statement ok
+CREATE TABLE t1 (a INT);
+
+simple conn=mz_system,user=mz_system
+ALTER TABLE t1 OWNER to r1;
+----
+COMPLETE 0
+
+query ITTTT
+SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id DESC LIMIT 1
+----
+69  alter  table  {"new_owner_id":"u3","object_id":"Iu17","old_owner_id":"u1"}  mz_system


### PR DESCRIPTION
This commit will emit audit log events for GRANT, REVOKE, ALTER DEFAULT PRIVILEGES, and ALTER OWNER.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Emit audit log events for GRANT, REVOKE, ALTER DEFAULT PRIVILEGES, and ALTER OWNER.
