### PR TITLE
sql: remove `enable_format_json` feature flag

### DIFF
--- a/misc/python/materialize/checks/json_source.py
+++ b/misc/python/materialize/checks/json_source.py
@@ -18,15 +18,12 @@ class JsonSource(Check):
     """Test CREATE SOURCE ... FORMAT JSON"""
 
     def _can_run(self) -> bool:
-        return self.base_version >= MzVersion.parse("0.53.0-dev")
+        return self.base_version >= MzVersion.parse("0.60.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(
             dedent(
                 """
-                $[version>=5300] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-                ALTER SYSTEM SET enable_format_json = true
-
                 $ kafka-create-topic topic=format-json partitions=1
 
                 $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-json

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1631,10 +1631,7 @@ fn get_encoding_inner(
                     .map_err(|_| sql_err!("CSV delimiter must be an ASCII character"))?,
             })
         }
-        Format::Json => {
-            scx.require_feature_flag(&crate::session::vars::ENABLE_FORMAT_JSON)?;
-            DataEncodingInner::Json
-        }
+        Format::Json => DataEncodingInner::Json,
         Format::Text => DataEncodingInner::Text,
     }))
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1078,7 +1078,6 @@ feature_flags!(
         enable_envelope_upsert_in_subscribe,
         "`ENVELOPE UPSERT` can be used in `SUBSCRIBE`"
     ),
-    (enable_format_json, "FORMAT JSON"),
     (enable_index_options, "INDEX OPTIONS"),
     (
         enable_kafka_config_denylist_options,

--- a/test/sql-feature-flags/mzcompose.py
+++ b/test/sql-feature-flags/mzcompose.py
@@ -251,41 +251,6 @@ class WithMutuallyRecursive(FeatureTestScenario):
         return f"SELECT * FROM wmr_{ordinal:02d}"
 
 
-class FormatJson(FeatureTestScenario):
-    @classmethod
-    def feature_name(cls) -> str:
-        return "enable_format_json"
-
-    @classmethod
-    def feature_error(cls) -> str:
-        return "FORMAT JSON is not supported"
-
-    @classmethod
-    def initialize(cls) -> str:
-        return "> CREATE CONNECTION IF NOT EXISTS kafka_conn_for_format_json TO KAFKA (BROKER '${testdrive.kafka-addr}')"
-
-    @classmethod
-    def create_item(cls, ordinal: int) -> str:
-        return dedent(
-            f"""
-            CREATE SOURCE kafka_source_{ordinal:02d}
-                FROM KAFKA CONNECTION kafka_conn_for_format_json (TOPIC 'bar')
-                FORMAT JSON
-                WITH (SIZE '1');
-            """
-        )
-
-    @classmethod
-    def drop_item(cls, ordinal: int) -> str:
-        return f"DROP SOURCE kafka_source_{ordinal:02d};"
-
-    @classmethod
-    def query_item(cls, ordinal: int) -> str:
-        # Test cannot spin up infra for this feature to be tested, but we just want to verify it
-        # plans successfully.
-        return "SELECT true;"
-
-
 def run_test(c: Composition, args: argparse.Namespace) -> None:
     c.up("redpanda", "materialized")
     c.up("testdrive", persistent=True)

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -7,11 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_format_json = true
-
-
-
 > CREATE MATERIALIZED VIEW simple_view AS SELECT 1 AS a, 2 AS b, 3 AS c;
 
 > CREATE CONNECTION kafka_conn

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_format_json = true
 ALTER SYSTEM SET enable_kafka_config_denylist_options = true
 
 #

--- a/test/testdrive/kafka-sink-statistics.td
+++ b/test/testdrive/kafka-sink-statistics.td
@@ -7,10 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_format_json = true
-
-
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}');
 

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_format_json = true
-
 # This testdrive file is exactly the same as upsert-kafka.td, but using the new syntax.
 
 $ set keyschema={

--- a/test/testdrive/linked-clusters.td
+++ b/test/testdrive/linked-clusters.td
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_format_json = true
-
 # The expected number of rows in system tables depends on the number of replicas
 $ skip-if
 SELECT ${arg.replicas} > 1;

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_format_json = true
-
 > CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
 
 > SHOW SOURCES

--- a/test/testdrive/source-format-json.td
+++ b/test/testdrive/source-format-json.td
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_format_json = true
-
 # Verify behavior of FORMAT JSON
 
 $ kafka-create-topic topic=data partitions=1

--- a/test/testdrive/statistics-deletion.td
+++ b/test/testdrive/statistics-deletion.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_format_json = true
 ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
 
 # Clean up cluster manually, since testdrive does not automatically clean up

--- a/test/testdrive/storage-clusters.td
+++ b/test/testdrive/storage-clusters.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_format_json = true
 ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
 
 # Clean up cluster manually, since testdrive does not automatically clean up


### PR DESCRIPTION
It's enabled for everyone in production, so we no longer need this feature flag.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR removes a stale feature flag.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support `FORMAT JSON` for Kafka sources. (Technically shipped today via a feature flag, but I suppose we should mention it in the release notes at some point, and this release is as good as any.)
