### PR TITLE
Adjust error messages in tests

### DIFF
--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -904,7 +904,7 @@ SELECT lpad('str', 5, 'đẹp')
 ----
 đẹstr
 
-query error db error: ERROR: requested length too large
+query error requested length too large
 SELECT lpad('', 2147483647)
 
 
@@ -1360,7 +1360,7 @@ SELECT repeat('a', -1)
 ----
 (empty)
 
-query error db error: ERROR: requested length too large
+query error requested length too large
 SELECT repeat('a', 2147483647)
 
 # Check for char cmp validity, which ignores white space

--- a/test/sqllogictest/timestamptz.slt
+++ b/test/sqllogictest/timestamptz.slt
@@ -193,5 +193,5 @@ true
 1 hour 30 minutes
 true
 
-query error db error: ERROR: timestamp out of range
+query error timestamp out of range
 select timezone('1 day'::interval, '1-12-31'::timestamptz+'262142 years'::interval)


### PR DESCRIPTION
This PR fixes issue #20364 by making adjustments to error messages in the affected tests. The view-based execution displays the error by using the `Display` implementation for `DataflowError` in `storage-client`. This implementation prepends an informative error tag to the message, making it different between one-shot and view-based execution.

Fixes #20364.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/20364

### Tips for reviewer

The relevant code that adds the extra error tag is https://github.com/MaterializeInc/materialize/blob/35b549601d29088867d59b00956b194d9f0426a8/src/storage-client/src/types/errors.rs#L441-L458

The above seems to be very much on purpose so that people can distinguish error categories during incremental view maintenance. So perhaps a feasible strategy for now is to adjust the error messages in the tests instead?

NOTE: To avoid having to run the slow SLTs on this PR, I just tested these files with `--auto-index-selects` locally.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR is sufficiently small to not require a design.
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
