### PR TITLE
Revert "Check for monotonic selects in fast SLTs"

### DIFF
--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -15,10 +15,9 @@ ALTER SYSTEM SET enable_table_keys = true
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-SHOW enable_monotonic_oneshot_selects
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
 ----
-on
-COMPLETE 1
+COMPLETE 0
 
 statement ok
 CREATE TABLE t (a int, b int)

--- a/test/sqllogictest/array_subquery.slt
+++ b/test/sqllogictest/array_subquery.slt
@@ -10,10 +10,9 @@
 mode cockroach
 
 simple conn=mz_system,user=mz_system
-SHOW enable_monotonic_oneshot_selects
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
 ----
-on
-COMPLETE 1
+COMPLETE 0
 
 statement ok
 CREATE TABLE xs (x int not null)

--- a/test/sqllogictest/cockroach/distinct_on.slt
+++ b/test/sqllogictest/cockroach/distinct_on.slt
@@ -25,10 +25,9 @@ ALTER SYSTEM SET enable_table_keys = true
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-SHOW enable_monotonic_oneshot_selects
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
 ----
-on
-COMPLETE 1
+COMPLETE 0
 
 statement ok
 CREATE TABLE xyz (

--- a/test/sqllogictest/cockroach/subquery_correlated.slt
+++ b/test/sqllogictest/cockroach/subquery_correlated.slt
@@ -30,10 +30,9 @@ ALTER SYSTEM SET enable_table_foreign_key = true
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-SHOW enable_monotonic_oneshot_selects
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
 ----
-on
-COMPLETE 1
+COMPLETE 0
 
 # ------------------------------------------------------------------------------
 # Create a simple schema that models customers and orders. Each customer has an

--- a/test/sqllogictest/github-19290.slt
+++ b/test/sqllogictest/github-19290.slt
@@ -10,10 +10,9 @@
 # Regression test for #19290.
 
 simple conn=mz_system,user=mz_system
-SHOW enable_monotonic_oneshot_selects
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
 ----
-on
-COMPLETE 1
+COMPLETE 0
 
 statement ok
 CREATE SOURCE tpch

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -10,10 +10,9 @@
 mode cockroach
 
 simple conn=mz_system,user=mz_system
-SHOW enable_monotonic_oneshot_selects
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
 ----
-on
-COMPLETE 1
+COMPLETE 0
 
 statement ok
 CREATE TABLE foo (

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -10,10 +10,9 @@
 mode cockroach
 
 simple conn=mz_system,user=mz_system
-SHOW enable_monotonic_oneshot_selects
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
 ----
-on
-COMPLETE 1
+COMPLETE 0
 
 statement ok
 CREATE TABLE cities (

--- a/test/sqllogictest/unsigned_int.slt
+++ b/test/sqllogictest/unsigned_int.slt
@@ -8,10 +8,9 @@
 # by the Apache License, Version 2.0.
 
 simple conn=mz_system,user=mz_system
-SHOW enable_monotonic_oneshot_selects
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
 ----
-on
-COMPLETE 1
+COMPLETE 0
 
 query I
 SELECT 42::uint2

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -15,10 +15,9 @@ ALTER SYSTEM SET enable_with_mutually_recursive = true
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-SHOW enable_monotonic_oneshot_selects
+ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
 ----
-on
-COMPLETE 1
+COMPLETE 0
 
 ## Test correct (intended) behavior:
 


### PR DESCRIPTION
This reverts commit 886be0e2ef4c9216c4790446d4b0be9c6ce7f6a7.

Discussion here:
https://materializeinc.slack.com/archives/C01LKF361MZ/p1688732923269929?thread_ts=1688731964.421829&cid=C01LKF361MZ
In short, the problem is that bulk rewrites became harder.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
