### PR TITLE
Remove `enable_managed_clusters` flag

### DIFF
--- a/misc/python/materialize/checks/managed_cluster.py
+++ b/misc/python/materialize/checks/managed_cluster.py
@@ -18,16 +18,6 @@ class CreateManagedCluster(Check):
     def _can_run(self) -> bool:
         return self.base_version >= MzVersion.parse("0.58.0-dev")
 
-    def initialize(self) -> Testdrive:
-        return Testdrive(
-            dedent(
-                """
-                $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-                ALTER SYSTEM SET enable_managed_clusters = true
-                """
-            )
-        )
-
     def manipulate(self) -> List[Testdrive]:
         return [
             Testdrive(dedent(s))
@@ -79,16 +69,6 @@ class CreateManagedCluster(Check):
 class DropManagedCluster(Check):
     def _can_run(self) -> bool:
         return self.base_version >= MzVersion.parse("0.58.0-dev")
-
-    def initialize(self) -> Testdrive:
-        return Testdrive(
-            dedent(
-                """
-                $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-                ALTER SYSTEM SET enable_managed_clusters = true
-                """
-            )
-        )
 
     def manipulate(self) -> List[Testdrive]:
         return [

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -64,7 +64,6 @@ def run(
     )
     system_conn.autocommit = True
     with system_conn.cursor() as cur:
-        cur.execute("ALTER SYSTEM SET enable_managed_clusters = true")
         cur.execute("ALTER SYSTEM SET max_schemas_per_database = 105")
         cur.execute("ALTER SYSTEM SET max_tables = 105")
         cur.execute("ALTER SYSTEM SET max_materialized_views = 105")

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2831,8 +2831,6 @@ pub fn plan_create_cluster(
     let managed = managed.unwrap_or_else(|| replicas.is_none());
 
     if managed {
-        scx.require_feature_flag(&vars::ENABLE_MANAGED_CLUSTERS)?;
-
         if replicas.is_some() {
             sql_bail!("REPLICAS not supported for managed clusters");
         }
@@ -4306,8 +4304,6 @@ pub fn plan_alter_cluster(
         if_exists,
     }: AlterClusterStatement<Aug>,
 ) -> Result<Plan, PlanError> {
-    scx.require_feature_flag(&vars::ENABLE_MANAGED_CLUSTERS)?;
-
     let cluster = match resolve_cluster(scx, &name, if_exists)? {
         Some(entry) => entry,
         None => {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1265,7 +1265,6 @@ feature_flags!(
         enable_within_timestamp_order_by_in_subscribe,
         "`WITHIN TIMESTAMP ORDER BY ..`"
     ),
-    (enable_managed_clusters, "managed clusters"),
     (
         enable_cardinality_estimates,
         "join planning with cardinality estimates"

--- a/test/cloudtest/test_managed_cluster.py
+++ b/test/cloudtest/test_managed_cluster.py
@@ -16,12 +16,6 @@ def test_managed_cluster_sizing(mz: MaterializeApplication) -> None:
     """Test that a SIZE N cluster indeed creates N clusterd instances."""
     SIZE = 2
 
-    mz.environmentd.sql(
-        "ALTER SYSTEM SET enable_managed_clusters = true",
-        port="internal",
-        user="mz_system",
-    )
-
     mz.environmentd.sql(f"CREATE CLUSTER sized1 SIZE '{SIZE}-1', REPLICATION FACTOR 2")
     cluster_id = mz.environmentd.sql_query(
         "SELECT id FROM mz_clusters WHERE name = 'sized1'"

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -14,12 +14,6 @@ mode cockroach
 # Start from a pristine state
 reset-server
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_managed_clusters = true;
-----
-COMPLETE 0
-
-
 statement ok
 CREATE CLUSTER foo SIZE '1'
 
@@ -440,23 +434,6 @@ ALTER CLUSTER foo SET (MANAGED, SIZE '1', DISK)
 
 statement ok
 DROP CLUSTER foo
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_managed_clusters = false;
-----
-COMPLETE 0
-
-statement error db error: ERROR: managed clusters is not supported
-CREATE CLUSTER foo MANAGED, SIZE '1'
-
-statement ok
-CREATE CLUSTER foo REPLICAS ()
-
-statement error db error: ERROR: managed clusters is not supported
-ALTER CLUSTER foo RESET (MANAGED)
-
-statement error db error: ERROR: managed clusters is not supported
-ALTER CLUSTER foo SET (MANAGED)
 
 # Restore pristine server state
 reset-server

--- a/test/testdrive/disk-feature-flag.td
+++ b/test/testdrive/disk-feature-flag.td
@@ -12,7 +12,6 @@
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_create_source_denylist_with_options = false
 ALTER SYSTEM SET enable_disk_cluster_replicas = true
-ALTER SYSTEM SET enable_managed_clusters = true
 ALTER SYSTEM SET disk_cluster_replicas_default = false
 
 > DROP CLUSTER IF EXISTS c;

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -109,7 +109,6 @@ def workflow_testdrive(c: Composition, parser: WorkflowArgumentParser) -> None:
         ],
         additional_system_parameter_defaults={
             "disk_cluster_replicas_default": "true",
-            "enable_managed_clusters": "true",
         },
         environment_extra=materialized_environment_extra,
     )
@@ -167,7 +166,6 @@ def workflow_rehydration(c: Composition) -> None:
                 additional_system_parameter_defaults={
                     "disk_cluster_replicas_default": "true",
                     "enable_disk_cluster_replicas": "true",
-                    "enable_managed_clusters": "true",
                     # Force backpressure to be enabled.
                     "storage_dataflow_max_inflight_bytes": "1",
                     "storage_dataflow_max_inflight_bytes_to_cluster_size_percent": "1",
@@ -190,7 +188,6 @@ def workflow_rehydration(c: Composition) -> None:
                     "--orchestrator-process-scratch-directory=/scratch",
                 ],
                 additional_system_parameter_defaults={
-                    "enable_managed_clusters": "true",
                     # Force backpressure to be enabled.
                     "storage_dataflow_max_inflight_bytes": "1",
                     "storage_dataflow_max_inflight_bytes_to_cluster_size_percent": "1",


### PR DESCRIPTION
Remove the `enable_managed_clusters` feature flag and turn on feature unconditionally.

This needs to be sequenced with the flag in LD and should only be merged once we don't plan to disable the feature anymore.

Fixes #20368

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
