### PR TITLE
cloudtests: fix test_upgrade

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -46,6 +46,7 @@ ERROR_RE = re.compile(
     | unsupported\ SQL\ type\ in\ testdrive:
     | environmentd:\ fatal: # startup failure
     | clusterd:\ fatal: # startup failure
+    | error:\ Found\ argument\ '.*'\ which\ wasn't\ expected,\ or\ isn't\ valid\ in\ this\ context
     )
     # Emitted by tests employing explicit mz_panic()
     (?!.*forced\ panic)

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -153,8 +153,6 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             f"--persist-blob-url=s3://minio:minio123@persist/persist?endpoint={s3_endpoint}&region=minio",
             "--orchestrator=kubernetes",
             "--orchestrator-kubernetes-image-pull-policy=if-not-present",
-            # Kind sets up a basic local-file storage class based on Rancher, named `standard`
-            "--orchestrator-kubernetes-ephemeral-volume-class=standard",
             "--persist-consensus-url=postgres://root@cockroach.default:26257?options=--search_path=consensus",
             "--adapter-stash-url=postgres://root@cockroach.default:26257?options=--search_path=adapter",
             "--storage-stash-url=postgres://root@cockroach.default:26257?options=--search_path=storage",
@@ -200,6 +198,11 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             args += [
                 "--internal-persist-pubsub-listen-addr=0.0.0.0:6879",
                 "--persist-pubsub-url=http://persist-pubsub",
+            ]
+        if self._meets_minimum_version("0.60.0-dev"):
+            args += [
+                # Kind sets up a basic local-file storage class based on Rancher, named `standard`
+                "--orchestrator-kubernetes-ephemeral-volume-class=standard"
             ]
         container = V1Container(
             name="environmentd",


### PR DESCRIPTION
This fixes the `test_upgrade` ("Platform checks upgrade in Cloudtest/K8s") (https://buildkite.com/materialize/nightlies/builds/2750#01892f83-542c-42d9-b4a0-e96dfef3e938).

environmentd was failing due to
```
default/environmentd-0[environmentd]: error: Found argument '--orchestrator-kubernetes-ephemeral-volume-class' which wasn't expected, or isn't valid in this context
```

Nightly: https://buildkite.com/materialize/nightlies/builds/2766