### PR TITLE
doc/user: replace stale links to console

### DIFF
--- a/doc/user/layouts/partials/header.html
+++ b/doc/user/layouts/partials/header.html
@@ -50,7 +50,7 @@
       <a role="menuitem" href="https://materialize.com/about">About</a>
     </div>
     <div class="desktop">
-      <a role="menuitem" href="https://cloud.materialize.com/">Login</a>
+      <a role="menuitem" href="https://console.materialize.com/">Sign In</a>
       <a
         class="btn"
         role="menuitem"
@@ -66,7 +66,7 @@
       <a role="menuitem" href="https://materialize.com/pricing">Pricing</a>
       <a role="menuitem" href="https://materialize.com/blog">Blog</a>
       <a role="menuitem" href="https://materialize.com/about">About</a>
-      <a role="menuitem" href="https://cloud.materialize.com/">Login</a>
+      <a role="menuitem" href="https://console.materialize.com/">Sign In</a>
       <div>
         <a
           class="btn"


### PR DESCRIPTION
The headers in the documentation are still pointing to cloud.materialize.com.