### PR TITLE
Update contributing guidelines to discourage contributions to certain areas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,15 @@ Materialize is written entirely in Rust. Rust API documentation is hosted at
 
 Prospective code contributors might find the [good first issue tag](https://github.com/MaterializeInc/materialize/issues?q=is%3Aopen+is%3Aissue+label%3A%22D-good+first+issue%22) useful.
 
+It's a good idea to comment on any GitHub issue you're planning to pick up to
+let folks know. That way, you can get proactive advice and speedier reviews.
+
+If you start work on the issue before hearing back from a Materialize engineer,
+there is a risk that we may not be able to accept your changes. The team may not
+have bandwidth to review your changes, or the code in question may require
+specialized knowledge to modify without introducing bugs. When in doubt, wait
+for a Materialize engineer to respond before starting work!
+
 Bug reports are welcome, and the most effective way to report a bug is to [file
 an issue](https://github.com/MaterializeInc/materialize/issues/new/choose). As
 Materialize is under rapid development, it is helpful if you report the version
@@ -35,3 +44,12 @@ When landing large or substantial changes, we want to make sure users are aware 
 - All new features
 - All API changes
 - Large bug fixes
+
+### Where to contribute
+Some areas that are well suited for external contributions are:
+- Adding SQL functions
+- Adding pg_catalog tables to support more [tools and integrations](https://materialize.com/docs/integrations/)
+
+Areas that are not well suited for external contributions:
+- The [coordinator](https://github.com/MaterializeInc/materialize/tree/main/src/adapter/src/coord)
+- [Persist](https://github.com/MaterializeInc/materialize/tree/main/src/persist)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ our development process is available in the [doc/developer](doc/developer) folde
 Materialize is written entirely in Rust. Rust API documentation is hosted at
 <https://dev.materialize.com/api/rust/>.
 
-Prospective code contributors might find the [good first issue tag](https://github.com/MaterializeInc/materialize/issues?q=is%3Aopen+is%3Aissue+label%3A%22D-good+first+issue%22) useful.
+Prospective code contributors might find the [good for external contributors tag](https://github.com/MaterializeInc/materialize/issues?q=is%3Aopen+is%3Aissue+label%3A%22D-good+for+external+contributors%22+) useful.
 
 It's a good idea to comment on any GitHub issue you're planning to pick up to
 let folks know. That way, you can get proactive advice and speedier reviews.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,3 +53,4 @@ Some areas that are well suited for external contributions are:
 Areas that are not well suited for external contributions:
 - The [coordinator](https://github.com/MaterializeInc/materialize/tree/main/src/adapter/src/coord)
 - [Persist](https://github.com/MaterializeInc/materialize/tree/main/src/persist)
+- [Compute](https://github.com/MaterializeInc/materialize/tree/main/src/compute)


### PR DESCRIPTION
As a follow up to https://github.com/MaterializeInc/materialize/issues/19743, we want to be more prescriptive about what types of external contributions we'll encourage, and more explicit guidelines for picking up an issue.

Surfaces has decided to disallow external contributions to the coordinator for two reasons:
* The cost of educating and performing extra-thorough reviews is not worth the benefit-cost/risk tradeoff, given the complexity and importance of this code
* Major coordinator changes should only be done as part of a more focused, planned body of work, again given the nuances. One-off changes picked up at random increase the risk of missed problems.

Questions for reviewer:
* Any other suggestions for both the "areas that are best suited for external contributions" and "ask first" sections? I picked persist there arbitrarily, and can remove if folks disagree.

This is one of a series of follow up items from the above issue.