### PR TITLE
doc/user: take another pass at sink envelope documentation

### DIFF
--- a/ci/deploy_website/website.sh
+++ b/ci/deploy_website/website.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 declare -A shortlinks=(
     [bug]="https://github.com/MaterializeInc/materialize/issues/new?labels=C-bug&template=01-bug.yml"
     [non-materialized-error]="https://materialize.com/docs/sql/create-view/#querying-non-materialized-views"
-    [sink-key-selection]="https://materialize.com/docs/sql/create-sink/#key-selection"
+    [sink-key-selection]="https://materialize.com/docs/sql/create-sink/#upsert-key-selection"
     [chat]="https://join.slack.com/t/materializecommunity/shared_invite/zt-ljdufufo-PTwVPmgzlZtI7RIQLDrAiA"
 )
 


### PR DESCRIPTION
* Attempt a better explanation of how update events are formed from insertion and deletion events.

* Consistently use the term "underlying relation" rather than "sink's source relation".

* Move the key selection guidance to a "troubleshooting" section to start to separate reference docs from guidance.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR improves documentation, based on some unresolved feedback in #20196.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
