### PR TITLE
adapter: Validate deferred plan before sequencing

### DIFF
--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -9,7 +9,7 @@
 
 //! Logic and types for all appends executed by the [`Coordinator`].
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -24,7 +24,7 @@ use tracing::warn;
 
 use crate::catalog::BuiltinTableUpdate;
 use crate::coord::timeline::WriteTimestamp;
-use crate::coord::{Coordinator, Message, PendingTxn};
+use crate::coord::{Coordinator, Message, PendingTxn, PlanValidity};
 use crate::session::{Session, WriteOp};
 use crate::util::{CompletedClientTransmitter, ResultExt};
 use crate::ExecuteContext;
@@ -44,7 +44,7 @@ pub(crate) struct DeferredPlan {
     #[derivative(Debug = "ignore")]
     pub ctx: ExecuteContext,
     pub plan: Plan,
-    pub dependencies: BTreeSet<GlobalId>,
+    pub validity: PlanValidity,
 }
 
 /// Describes what action triggered an update to a builtin table.
@@ -117,7 +117,7 @@ impl PendingWriteTxn {
 /// deferring work.
 #[macro_export]
 macro_rules! guard_write_critical_section {
-    ($coord:expr, $ctx:expr, $plan_to_defer:expr, $dependencies:expr) => {
+    ($coord:expr, $ctx:expr, $plan_to_defer:expr, $source_ids:expr) => {
         if !$ctx.session().has_write_lock() {
             if $coord
                 .try_grant_session_write_lock($ctx.session_mut())
@@ -126,7 +126,12 @@ macro_rules! guard_write_critical_section {
                 $coord.defer_write(Deferred::Plan(DeferredPlan {
                     ctx: $ctx,
                     plan: $plan_to_defer,
-                    dependencies: $dependencies,
+                    validity: PlanValidity {
+                        transient_revision: $coord.catalog().transient_revision(),
+                        source_ids: $source_ids,
+                        cluster_id: None,
+                        replica_id: None,
+                    },
                 }));
                 return;
             }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -95,8 +95,8 @@ use crate::coord::timestamp_selection::{
 };
 use crate::coord::{
     peek, Coordinator, ExecuteContext, Message, PeekStage, PeekStageFinish, PeekStageOptimize,
-    PeekStageTimestamp, PeekStageValidate, PeekValidity, PendingReadTxn, PendingTxn,
-    PendingTxnResponse, RealTimeRecencyContext, SinkConnectionReady, TargetCluster,
+    PeekStageTimestamp, PeekStageValidate, PendingReadTxn, PendingTxn, PendingTxnResponse,
+    PlanValidity, RealTimeRecencyContext, SinkConnectionReady, TargetCluster,
     DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
 };
 use crate::error::AdapterError;
@@ -1866,10 +1866,10 @@ impl Coordinator {
 
         check_no_invalid_log_reads(catalog, cluster, &source_ids, &mut target_replica)?;
 
-        let validity = PeekValidity {
+        let validity = PlanValidity {
             transient_revision: catalog.transient_revision(),
             source_ids: source_ids.clone(),
-            cluster_id: cluster.id(),
+            cluster_id: Some(cluster.id()),
             replica_id: target_replica,
         };
 
@@ -2744,10 +2744,10 @@ impl Coordinator {
         );
         match self.recent_timestamp(ctx.session(), source_ids.iter().cloned()) {
             Some(fut) => {
-                let validity = PeekValidity {
+                let validity = PlanValidity {
                     transient_revision: self.catalog().transient_revision(),
                     source_ids,
-                    cluster_id,
+                    cluster_id: Some(cluster_id),
                     replica_id: None,
                 };
                 let internal_cmd_tx = self.internal_cmd_tx.clone();
@@ -3132,9 +3132,9 @@ impl Coordinator {
         mut ctx: ExecuteContext,
         plan: ReadThenWritePlan,
     ) {
-        let mut dependencies = plan.selection.depends_on();
-        dependencies.insert(plan.id);
-        guard_write_critical_section!(self, ctx, Plan::ReadThenWrite(plan), dependencies);
+        let mut source_ids = plan.selection.depends_on();
+        source_ids.insert(plan.id);
+        guard_write_critical_section!(self, ctx, Plan::ReadThenWrite(plan), source_ids);
 
         let ReadThenWritePlan {
             id,


### PR DESCRIPTION
The adapter uses a global write lock to linearize read then write statements. If a read then write statement fails to acquire the write lock then it is pushed into a queue of deferred statements. Once the statement has acquired the write lock, it is popped off the queue and sequenced (i.e. executed).

While the deferred statement is on the queue, we allow DDL statements to execute. After we pop the statement off the queue we were not checking to make sure all the statements dependencies still existed. If a dependency was deleted while the statement was in the queue, then the statement would cause a panic during sequencing because it assumed all of its dependencies were validated during planning.

This commit adds a step after the statement is popped off of the queue to revalidate all dependencies and check that they still exist. If a dependency was deleted while it was waiting, then an error is returned to the user.

There are various points in the Coordinator where either a statement or plan is taken off of the main Coordinator thread for some asynchronous processing/waiting. Roughly each point has its own bespoke code for re-validating the statement or plan. Issues like this probably suggest that we should implement a more general framework for taking statements and plans off of the main Coordinator thread. For now another bespoke validation is probably good enough.

Fixes #20402

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Removes panics from concurrent DDL and `UPDATE`/`DELETE`/`INSERT INTO SELECT` statements.
