### PR TITLE
environmentd: add errors codes to http/ws endpoints

### DIFF
--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -371,8 +371,7 @@ impl From<AdapterError> for SqlError {
     fn from(err: AdapterError) -> Self {
         SqlError {
             message: err.to_string(),
-            // TODO: Move codes out of pgwire so they can be shared here.
-            code: SqlState::INTERNAL_ERROR.code().to_string(),
+            code: err.code().code().to_string(),
             detail: err.detail(),
             hint: err.hint(),
         }

--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -54,7 +54,7 @@ http
 {"query":"create view v1 as select 1; create view v2 as select 1"}
 ----
 200 OK
-{"results":[{"error":{"message":"CREATE VIEW v1 AS SELECT 1 cannot be run inside a transaction block","code":"XX000"},"notices":[]}]}
+{"results":[{"error":{"message":"CREATE VIEW v1 AS SELECT 1 cannot be run inside a transaction block","code":"25001"},"notices":[]}]}
 
 # Syntax errors fail the request.
 http
@@ -425,4 +425,4 @@ http
 {"query":"CREATE MATERIALIZED VIEW _now AS SELECT now()"}
 ----
 200 OK
-{"results":[{"error":{"message":"cannot materialize call to current_timestamp","code":"XX000","detail":"See: https://materialize.com/docs/sql/functions/now_and_mz_now/","hint":"Try using `mz_now()` here instead."},"notices":[]}]}
+{"results":[{"error":{"message":"cannot materialize call to current_timestamp","code":"0A000","detail":"See: https://materialize.com/docs/sql/functions/now_and_mz_now/","hint":"Try using `mz_now()` here instead."},"notices":[]}]}

--- a/src/environmentd/tests/testdata/http/ws
+++ b/src/environmentd/tests/testdata/http/ws
@@ -174,7 +174,7 @@ ws-text
 {"query": "CREATE VIEW v AS SELECT 1"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":false,"is_streaming":false}}
-{"type":"Error","payload":{"message":"CREATE VIEW v AS SELECT 1 cannot be run inside a transaction block","code":"XX000"}}
+{"type":"Error","payload":{"message":"CREATE VIEW v AS SELECT 1 cannot be run inside a transaction block","code":"25001"}}
 {"type":"ReadyForQuery","payload":"E"}
 
 ws-text
@@ -276,7 +276,7 @@ ws-text
 {"type":"Row","payload":["18446744073709551615",1,1]}
 {"type":"CommandComplete","payload":"SUBSCRIBE"}
 {"type":"CommandStarting","payload":{"has_rows":false,"is_streaming":false}}
-{"type":"Error","payload":{"message":"SUBSCRIBE in transactions must be the only read statement","code":"XX000"}}
+{"type":"Error","payload":{"message":"SUBSCRIBE in transactions must be the only read statement","code":"25000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text rows=2 fixtimestamp=true

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -12,11 +12,10 @@ use std::collections::BTreeMap;
 use itertools::Itertools;
 use mz_adapter::session::TransactionCode;
 use mz_adapter::{AdapterError, AdapterNotice, StartupMessage};
-use mz_expr::EvalError;
-use mz_repr::{ColumnName, NotNullViolation, RelationDesc};
+use mz_repr::{ColumnName, RelationDesc};
 use mz_sql::ast::NoticeSeverity;
-use mz_sql::plan::{PlanError, PlanNotice};
-use mz_sql::session::vars::{ClientSeverity as AdapterClientSeverity, VarError};
+use mz_sql::plan::PlanNotice;
+use mz_sql::session::vars::ClientSeverity as AdapterClientSeverity;
 use postgres::error::SqlState;
 
 // Pgwire protocol versions are represented as 32-bit integers, where the
@@ -303,104 +302,9 @@ impl ErrorResponse {
     }
 
     pub fn from_adapter_error(severity: Severity, e: AdapterError) -> ErrorResponse {
-        // TODO(benesch): we should only use `SqlState::INTERNAL_ERROR` for
-        // those errors that are truly internal errors. At the moment we have
-        // a various classes of uncategorized errors that use this error code
-        // inappropriately.
-        let code = match &e {
-            // DATA_EXCEPTION to match what Postgres returns for degenerate
-            // range bounds
-            AdapterError::AbsurdSubscribeBounds { .. } => SqlState::DATA_EXCEPTION,
-            AdapterError::AmbiguousSystemColumnReference => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::BadItemInStorageCluster { .. } => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::Catalog(_) => SqlState::INTERNAL_ERROR,
-            AdapterError::ChangedPlan => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::DuplicateCursor(_) => SqlState::DUPLICATE_CURSOR,
-            AdapterError::Eval(EvalError::CharacterNotValidForEncoding(_)) => {
-                SqlState::PROGRAM_LIMIT_EXCEEDED
-            }
-            AdapterError::Eval(EvalError::CharacterTooLargeForEncoding(_)) => {
-                SqlState::PROGRAM_LIMIT_EXCEEDED
-            }
-            AdapterError::Eval(EvalError::LengthTooLarge) => SqlState::PROGRAM_LIMIT_EXCEEDED,
-            AdapterError::Eval(EvalError::NullCharacterNotPermitted) => {
-                SqlState::PROGRAM_LIMIT_EXCEEDED
-            }
-            AdapterError::Eval(_) => SqlState::INTERNAL_ERROR,
-            AdapterError::Explain(_) => SqlState::INTERNAL_ERROR,
-            AdapterError::IdExhaustionError => SqlState::INTERNAL_ERROR,
-            AdapterError::Internal(_) => SqlState::INTERNAL_ERROR,
-            AdapterError::IntrospectionDisabled { .. } => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::InvalidLogDependency { .. } => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::InvalidClusterReplicaAz { .. } => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::InvalidClusterReplicaSize { .. } => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::InvalidSetIsolationLevel => SqlState::ACTIVE_SQL_TRANSACTION,
-            AdapterError::InvalidStorageClusterSize { .. } => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::SourceOrSinkSizeRequired { .. } => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::InvalidTableMutationSelection => SqlState::INVALID_TRANSACTION_STATE,
-            AdapterError::ConstraintViolation(NotNullViolation(_)) => SqlState::NOT_NULL_VIOLATION,
-            AdapterError::NoClusterReplicasAvailable(_) => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::OperationProhibitsTransaction(_) => SqlState::ACTIVE_SQL_TRANSACTION,
-            AdapterError::OperationRequiresTransaction(_) => SqlState::NO_ACTIVE_SQL_TRANSACTION,
-            AdapterError::ParseError(_) => SqlState::SYNTAX_ERROR,
-            AdapterError::PlanError(PlanError::InvalidSchemaName) => SqlState::INVALID_SCHEMA_NAME,
-            AdapterError::PlanError(_) => SqlState::INTERNAL_ERROR,
-            AdapterError::PreparedStatementExists(_) => SqlState::DUPLICATE_PSTATEMENT,
-            AdapterError::ReadOnlyTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,
-            AdapterError::ReadWriteUnavailable => SqlState::INVALID_TRANSACTION_STATE,
-            AdapterError::StatementTimeout => SqlState::QUERY_CANCELED,
-            AdapterError::Canceled => SqlState::QUERY_CANCELED,
-            AdapterError::IdleInTransactionSessionTimeout => {
-                SqlState::IDLE_IN_TRANSACTION_SESSION_TIMEOUT
-            }
-            AdapterError::RecursionLimit(_) => SqlState::INTERNAL_ERROR,
-            AdapterError::RelationOutsideTimeDomain { .. } => SqlState::INVALID_TRANSACTION_STATE,
-            AdapterError::ResourceExhaustion { .. } => SqlState::INSUFFICIENT_RESOURCES,
-            AdapterError::ResultSize(_) => SqlState::OUT_OF_MEMORY,
-            AdapterError::SafeModeViolation(_) => SqlState::INTERNAL_ERROR,
-            AdapterError::SqlCatalog(_) => SqlState::INTERNAL_ERROR,
-            AdapterError::SubscribeOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
-            AdapterError::Transform(_) => SqlState::INTERNAL_ERROR,
-            AdapterError::UnallowedOnCluster { .. } => {
-                SqlState::S_R_E_PROHIBITED_SQL_STATEMENT_ATTEMPTED
-            }
-            AdapterError::Unauthorized(_) => SqlState::INSUFFICIENT_PRIVILEGE,
-            AdapterError::UncallableFunction { .. } => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::UnknownCursor(_) => SqlState::INVALID_CURSOR_NAME,
-            AdapterError::UnknownPreparedStatement(_) => SqlState::UNDEFINED_PSTATEMENT,
-            AdapterError::UnknownLoginRole(_) => SqlState::INVALID_AUTHORIZATION_SPECIFICATION,
-            AdapterError::UnknownClusterReplica { .. } => SqlState::UNDEFINED_OBJECT,
-            AdapterError::UnmaterializableFunction(_) => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::UnrecognizedConfigurationParam(_) => SqlState::UNDEFINED_OBJECT,
-            AdapterError::UnstableDependency { .. } => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::Unsupported(..) => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::Unstructured(_) => SqlState::INTERNAL_ERROR,
-            AdapterError::UntargetedLogRead { .. } => SqlState::FEATURE_NOT_SUPPORTED,
-            // It's not immediately clear which error code to use here because a
-            // "write-only transaction" and "single table write transaction" are
-            // not things in Postgres. This error code is the generic "bad txn thing"
-            // code, so it's probably the best choice.
-            AdapterError::WriteOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
-            AdapterError::MultiTableWriteTransaction => SqlState::INVALID_TRANSACTION_STATE,
-            AdapterError::Storage(_) | AdapterError::Compute(_) | AdapterError::Orchestrator(_) => {
-                SqlState::INTERNAL_ERROR
-            }
-            AdapterError::ConcurrentRoleDrop(_) => SqlState::UNDEFINED_OBJECT,
-            AdapterError::DependentObject(_) => SqlState::DEPENDENT_OBJECTS_STILL_EXIST,
-            AdapterError::VarError(e) => match e {
-                VarError::ConstrainedParameter { .. } => SqlState::INVALID_PARAMETER_VALUE,
-                VarError::FixedValueParameter(_) => SqlState::INVALID_PARAMETER_VALUE,
-                VarError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,
-                VarError::InvalidParameterValue { .. } => SqlState::INVALID_PARAMETER_VALUE,
-                VarError::ReadOnlyParameter(_) => SqlState::CANT_CHANGE_RUNTIME_PARAM,
-                VarError::UnknownParameter(_) => SqlState::UNDEFINED_OBJECT,
-                VarError::RequiresUnsafeMode { .. } => SqlState::CANT_CHANGE_RUNTIME_PARAM,
-                VarError::RequiresFeatureFlag { .. } => SqlState::CANT_CHANGE_RUNTIME_PARAM,
-            },
-        };
         ErrorResponse {
             severity,
-            code,
+            code: e.code(),
             message: e.to_string(),
             detail: e.detail(),
             hint: e.hint(),
@@ -409,44 +313,9 @@ impl ErrorResponse {
     }
 
     pub fn from_adapter_notice(notice: AdapterNotice) -> ErrorResponse {
-        let code = match &notice {
-            AdapterNotice::DatabaseAlreadyExists { .. } => SqlState::DUPLICATE_DATABASE,
-            AdapterNotice::SchemaAlreadyExists { .. } => SqlState::DUPLICATE_SCHEMA,
-            AdapterNotice::TableAlreadyExists { .. } => SqlState::DUPLICATE_TABLE,
-            AdapterNotice::ObjectAlreadyExists { .. } => SqlState::DUPLICATE_OBJECT,
-            AdapterNotice::DatabaseDoesNotExist { .. } => SqlState::WARNING,
-            AdapterNotice::ClusterDoesNotExist { .. } => SqlState::WARNING,
-            AdapterNotice::NoResolvableSearchPathSchema { .. } => SqlState::WARNING,
-            AdapterNotice::ExistingTransactionInProgress => SqlState::ACTIVE_SQL_TRANSACTION,
-            AdapterNotice::ExplicitTransactionControlInImplicitTransaction => {
-                SqlState::NO_ACTIVE_SQL_TRANSACTION
-            }
-            AdapterNotice::UserRequested { .. } => SqlState::WARNING,
-            AdapterNotice::ClusterReplicaStatusChanged { .. } => SqlState::WARNING,
-            AdapterNotice::DroppedActiveDatabase { .. } => SqlState::WARNING,
-            AdapterNotice::DroppedActiveCluster { .. } => SqlState::WARNING,
-            AdapterNotice::QueryTimestamp { .. } => SqlState::WARNING,
-            AdapterNotice::EqualSubscribeBounds { .. } => SqlState::WARNING,
-            AdapterNotice::QueryTrace { .. } => SqlState::WARNING,
-            AdapterNotice::UnimplementedIsolationLevel { .. } => SqlState::WARNING,
-            AdapterNotice::DroppedSubscribe { .. } => SqlState::WARNING,
-            AdapterNotice::BadStartupSetting { .. } => SqlState::WARNING,
-            AdapterNotice::RbacSystemDisabled => SqlState::WARNING,
-            AdapterNotice::RbacUserDisabled => SqlState::WARNING,
-            AdapterNotice::RoleMembershipAlreadyExists { .. } => SqlState::WARNING,
-            AdapterNotice::RoleMembershipDoesNotExists { .. } => SqlState::WARNING,
-            AdapterNotice::AutoRunOnIntrospectionCluster => SqlState::WARNING,
-            AdapterNotice::AlterIndexOwner { .. } => SqlState::WARNING,
-            AdapterNotice::CannotRevoke { .. } => SqlState::WARNING,
-            AdapterNotice::NonApplicablePrivilegeTypes { .. } => SqlState::WARNING,
-            AdapterNotice::PlanNotice(plan) => match plan {
-                PlanNotice::ObjectDoesNotExist { .. } => SqlState::UNDEFINED_OBJECT,
-                PlanNotice::UpsertSinkKeyNotEnforced { .. } => SqlState::WARNING,
-            },
-        };
         ErrorResponse {
             severity: Severity::for_adapter_notice(&notice),
-            code,
+            code: notice.code(),
             message: notice.to_string(),
             detail: notice.detail(),
             hint: notice.hint(),


### PR DESCRIPTION
Move them out of pgwire and into their common adapter objects.

Fixes #20284

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a