### PR TITLE
cloud-canary: Add scratch directory

### DIFF
--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -41,7 +41,10 @@ SERVICES = [
         image=f"materialize/environmentd:{VERSION}",
         external_cockroach=True,
         persist_blob_url="file:///mzdata/persist/blob",
-        options=["--orchestrator-process-secrets-directory=/mzdata/secrets"],
+        options=[
+            "--orchestrator-process-secrets-directory=/mzdata/secrets",
+            "--orchestrator-process-scratch-directory=/scratch",
+        ],
     ),
     Testdrive(),  # Overriden below
     Mz(


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/20106

It runs further now but still fails: https://buildkite.com/materialize/nightlies/builds/2761#01893469-552f-4c76-866a-3f657ed18055

```
[2023-07-08T07:54:26Z] mzcompose: test case workflow-default failed: never got correct result for dbname=materialize host=[...].us-east-1.aws.staging.materialize.cloud port=6875 user=infra+nightly-canary@materialize.com password='[...]': Can't create a connection to host [...].us-east-1.aws.staging.materialize.cloud and port 6875 (timeout is 1 and source_address is None).
```

Fixes: https://github.com/MaterializeInc/materialize/issues/20401

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
