### PR TITLE
sql: improve and document SHOW SUBSOURCES

### DIFF
--- a/doc/user/content/sql/show-indexes.md
+++ b/doc/user/content/sql/show-indexes.md
@@ -14,8 +14,8 @@ menu:
 
 Field | Use
 ------|-----
-_on&lowbar;name_ | The name of the object whose indexes you want to show. If omitted, all indexes in the cluster are shown.
 _schema&lowbar;name_ | The schema to show objects from. Defaults to first resolvable schema in the search path if neither `on_name` nor `cluster_name` are specified. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
+_on&lowbar;name_ | The name of the object whose indexes you want to show. If omitted, all indexes in the schema are shown.
 _cluster&lowbar;name_ | The cluster to show indexes from. If omitted, indexes from all clusters are shown.
 
 ## Details

--- a/doc/user/content/sql/show-subsources.md
+++ b/doc/user/content/sql/show-subsources.md
@@ -1,0 +1,82 @@
+---
+title: "SHOW SUBSOURCES"
+description: "`SHOW SUBSOURCES` returns the subsources in the current schema."
+menu:
+  main:
+    parent: commands
+---
+
+`SHOW SUBSOURCES` returns the subsources in the current schema.
+
+## Syntax
+
+{{< diagram "show-subsources.svg" >}}
+
+Field | Use
+------|-----
+_schema&lowbar;name_ | The schema to show subsources from. Defaults to first resolvable schema in the search path if `on_name` is not shown.
+_on&lowbar;name_     | The name of the source whose associated subsources you want to show. If omitted, all subsources in the schema are shown.
+
+## Details
+
+A subsource is a relation associated with a source. There are two types of
+subsources:
+
+  * Subsources of type `progress` describe Materialize's ingestion progress for
+    the parent source. Every source has exactly one subsource of type
+    `progress`.
+
+  * Subsources of type `subsource` are used by sources that need to ingest data
+    into multiple tables, like PostgreSQL sources. For each upstream table that
+    is selected for ingestion, Materialize creates a subsource of type
+    `subsource`.
+
+### Output format for `SHOW SUBSOURCES`
+
+`SHOW SUBSOURCES`'s output is a table, with this structure:
+
+```nofmt
+ name  | type
+-------+-----
+ ...   | ...
+```
+
+Field    | Meaning
+---------|--------
+**name** | The name of the subsource.
+**type** | The type of the subsource: `subsource` or `progress`.
+
+## Examples
+
+```sql
+SHOW SOURCES;
+```
+```nofmt
+    name
+----------
+ postgres
+ kafka
+```
+```sql
+SHOW SUBSOURCES ON pg;
+```
+```nofmt
+        name        | type
+--------------------+-----------
+ postgres_progress  | progress
+ table1_in_postgres | subsource
+ table2_in_postgres | subsource
+```
+```sql
+SHOW SUBSOURCES ON kafka;
+```
+```nofmt
+            name    | typef
+--------------------+----------
+ kafka_progress     | progress
+```
+
+## Related pages
+
+- [`SHOW CREATE SOURCE`](../show-create-source)
+- [`CREATE SOURCE`](../create-source)

--- a/doc/user/layouts/partials/sql-grammar/show-indexes.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-indexes.svg
@@ -17,28 +17,28 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="125" y="21">INDEXES</text>
-   <rect x="237" y="35" width="40" height="32" rx="10"/>
+   <rect x="237" y="35" width="60" height="32" rx="10"/>
    <rect x="235"
          y="33"
-         width="40"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="245" y="53">ON</text>
-   <rect x="297" y="35" width="78" height="32"/>
-   <rect x="295" y="33" width="78" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="305" y="53">on_name</text>
-   <rect x="237" y="79" width="60" height="32" rx="10"/>
-   <rect x="235"
-         y="77"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="245" y="97">FROM</text>
-   <rect x="317" y="79" width="114" height="32"/>
-   <rect x="315" y="77" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="325" y="97">schema_name</text>
+   <text class="terminal" x="245" y="53">FROM</text>
+   <rect x="317" y="35" width="114" height="32"/>
+   <rect x="315" y="33" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="325" y="53">schema_name</text>
+   <rect x="237" y="79" width="40" height="32" rx="10"/>
+   <rect x="235"
+         y="77"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="245" y="97">ON</text>
+   <rect x="297" y="79" width="78" height="32"/>
+   <rect x="295" y="77" width="78" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="305" y="97">on_name</text>
    <rect x="45" y="177" width="104" height="32" rx="10"/>
    <rect x="43"
          y="175"
@@ -78,7 +78,7 @@
    <rect x="425" y="187" width="48" height="32" class="nonterminal"/>
    <text class="nonterminal" x="435" y="207">expr</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m40 0 h10 m0 0 h10 m78 0 h10 m0 0 h56 m-224 -10 v20 m234 0 v-20 m-234 20 v24 m234 0 v-24 m-234 24 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-470 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m40 -32 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -44 h-3"/>
+         d="m19 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m-224 -10 v20 m234 0 v-20 m-234 20 v24 m234 0 v-24 m-234 24 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m40 0 h10 m0 0 h10 m78 0 h10 m0 0 h56 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-470 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m40 -32 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -44 h-3"/>
    <polygon points="515 159 523 155 523 163"/>
    <polygon points="515 159 507 155 507 163"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/show-subsources.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-subsources.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="513" height="113">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="115" y="3" width="116" height="32" rx="10"/>
+   <rect x="113"
+         y="1"
+         width="116"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="123" y="21">SUBSOURCES</text>
+   <rect x="271" y="35" width="60" height="32" rx="10"/>
+   <rect x="269"
+         y="33"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="279" y="53">FROM</text>
+   <rect x="351" y="35" width="114" height="32"/>
+   <rect x="349" y="33" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="359" y="53">schema_name</text>
+   <rect x="271" y="79" width="40" height="32" rx="10"/>
+   <rect x="269"
+         y="77"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="279" y="97">ON</text>
+   <rect x="331" y="79" width="78" height="32"/>
+   <rect x="329" y="77" width="78" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="339" y="97">on_name</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m116 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m-224 -10 v20 m234 0 v-20 m-234 20 v24 m234 0 v-24 m-234 24 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m40 0 h10 m0 0 h10 m78 0 h10 m0 0 h56 m23 -76 h-3"/>
+   <polygon points="503 17 511 13 511 21"/>
+   <polygon points="503 17 495 13 495 21"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -358,7 +358,7 @@ show_databases ::=
     'SHOW' 'DATABASES' ('LIKE' 'pattern' | 'WHERE' expr)?
 show_indexes ::=
     'SHOW' 'INDEXES'
-    ((('ON') on_name) | ('FROM' schema_name))?
+    ('FROM' schema_name | 'ON' on_name)?
     ('IN CLUSTER' cluster_name)?
     ('LIKE' 'pattern' | 'WHERE' expr)
 show_materialized_views ::=
@@ -373,6 +373,8 @@ show_sinks ::=
    'SHOW' 'SINKS' ('FROM' schema_name)?
 show_sources ::=
   'SHOW' 'SOURCES' ('FROM' schema_name)?
+show_subsources ::=
+  'SHOW' 'SUBSOURCES' ('FROM' schema_name | 'ON' on_name)?
 show_tables ::=
   'SHOW' 'TABLES' ('FROM' schema_name)?
 show_types ::=

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1949,7 +1949,7 @@ pub enum ShowObjectType<T: AstInfo> {
         from: Option<T::DatabaseName>,
     },
     Subsource {
-        on_source: T::ItemName,
+        on_source: Option<T::ItemName>,
     },
 }
 /// `SHOW <object>S`
@@ -2020,8 +2020,10 @@ impl<T: AstInfo> AstDisplay for ShowObjectsStatement<T> {
         }
 
         if let ShowObjectType::Subsource { on_source } = &self.object_type {
-            f.write_str(" ON ");
-            f.write_node(on_source);
+            if let Some(on_source) = on_source {
+                f.write_str(" ON ");
+                f.write_node(on_source);
+            }
         }
 
         if let Some(filter) = &self.filter {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5725,11 +5725,21 @@ impl<'a> Parser<'a> {
                 ObjectType::View => ShowObjectType::View,
                 ObjectType::Source => ShowObjectType::Source,
                 ObjectType::Subsource => {
-                    self.expect_keyword(ON)?;
+                    let on_source = if self.parse_one_of_keywords(&[ON]).is_some() {
+                        Some(self.parse_raw_name()?)
+                    } else {
+                        None
+                    };
 
-                    ShowObjectType::Subsource {
-                        on_source: self.parse_raw_name()?,
+                    if from.is_some() && on_source.is_some() {
+                        return parser_err!(
+                            self,
+                            self.peek_prev_pos(),
+                            "Cannot specify both FROM and ON"
+                        );
                     }
+
+                    ShowObjectType::Subsource { on_source }
                 }
                 ObjectType::Sink => ShowObjectType::Sink,
                 ObjectType::Type => ShowObjectType::Type,

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -275,33 +275,40 @@ SHOW SUBSOURCES ON c
 ----
 SHOW SUBSOURCES ON c
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Subsource { on_source: Name(UnresolvedItemName([Ident("c")])) }, from: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Subsource { on_source: Some(Name(UnresolvedItemName([Ident("c")]))) }, from: None, filter: None }))
+
+parse-statement
+SHOW SUBSOURCES FROM s
+----
+SHOW SUBSOURCES FROM s
+=>
+Show(ShowObjects(ShowObjectsStatement { object_type: Subsource { on_source: None }, from: Some(UnresolvedSchemaName([Ident("s")])), filter: None }))
 
 parse-statement
 SHOW SUBSOURCES FROM s ON d
 ----
+error: Cannot specify both FROM and ON
 SHOW SUBSOURCES FROM s ON d
-=>
-Show(ShowObjects(ShowObjectsStatement { object_type: Subsource { on_source: Name(UnresolvedItemName([Ident("d")])) }, from: Some(UnresolvedSchemaName([Ident("s")])), filter: None }))
+                          ^
 
 parse-statement
 SHOW SUBSOURCES ON d LIKE 'foo'
 ----
 SHOW SUBSOURCES ON d LIKE 'foo'
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Subsource { on_source: Name(UnresolvedItemName([Ident("d")])) }, from: None, filter: Some(Like("foo")) }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Subsource { on_source: Some(Name(UnresolvedItemName([Ident("d")]))) }, from: None, filter: Some(Like("foo")) }))
 
 parse-statement
-SHOW SUBSOURCES FROM s ON d LIKE 'foo'
+SHOW SUBSOURCES FROM s LIKE 'foo'
 ----
-SHOW SUBSOURCES FROM s ON d LIKE 'foo'
+SHOW SUBSOURCES FROM s LIKE 'foo'
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Subsource { on_source: Name(UnresolvedItemName([Ident("d")])) }, from: Some(UnresolvedSchemaName([Ident("s")])), filter: Some(Like("foo")) }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Subsource { on_source: None }, from: Some(UnresolvedSchemaName([Ident("s")])), filter: Some(Like("foo")) }))
 
 parse-statement
 SHOW SUBSOURCES FROM s IN CLUSTER c
 ----
-error: Expected ON, found IN
+error: Expected end of statement, found IN
 SHOW SUBSOURCES FROM s IN CLUSTER c
                        ^
 

--- a/test/testdrive/show-subsources.td
+++ b/test/testdrive/show-subsources.td
@@ -1,0 +1,79 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Create a load generator source that has several subsources.
+> CREATE SOURCE lga FROM LOAD GENERATOR AUCTION FOR ALL TABLES
+
+# By default, `SHOW SUBSOURCES` should show all sources in the schema.
+> SHOW SUBSOURCES
+name           type
+-------------------------
+accounts       subsource
+auctions       subsource
+bids           subsource
+lga_progress   progress
+organizations  subsource
+users          subsource
+
+# Verify the schema filtering by creating two new sources, one in the current
+# schema and one in another schema. Verify that `SHOW SUBSOURCES` shows the
+# subsources only in the current schema.
+> CREATE SCHEMA other
+> CREATE SOURCE lgc FROM LOAD GENERATOR COUNTER
+> CREATE SOURCE other.lgo FROM LOAD GENERATOR COUNTER
+
+> SHOW SUBSOURCES
+name           type
+-------------------------
+accounts       subsource
+auctions       subsource
+bids           subsource
+lga_progress   progress
+lgc_progress   progress
+organizations  subsource
+users          subsource
+
+> SET SCHEMA = other
+> SHOW SUBSOURCES
+name           type
+-------------------------
+lgo_progress   progress
+
+# Verify that you can override the current schema with `FROM ...`.
+> SHOW SUBSOURCES FROM public
+name           type
+-------------------------
+accounts       subsource
+auctions       subsource
+bids           subsource
+lga_progress   progress
+lgc_progress   progress
+organizations  subsource
+users          subsource
+
+# Verify that `ON ...` filters to the subsources of the named source.
+> SHOW SUBSOURCES ON lgo
+name           type
+-------------------------
+lgo_progress   progress
+
+# Verify again with a cross-schema reference.
+> SHOW SUBSOURCES ON public.lgc
+name           type
+-------------------------
+lgc_progress   progress
+
+# Verify that you cannot combine a schema filter with a source filter.
+! SHOW SUBSOURCES FROM public ON lga
+contains:Cannot specify both FROM and ON
+
+# Verify that `ON` validates that the referenced object is a source.
+> CREATE TABLE t (a int)
+! SHOW SUBSOURCES ON t
+contains:cannot show subsources on materialize.other.t because it is a table


### PR DESCRIPTION
Add documentation for the `SHOW SUBSOURCES` statement that was added in #19936. Also improve the statement in a few ways that I noticed along the way:

  * Properly support the `FROM` clause, which was previously parsed and silently ignored.

  * Disallow `SHOW SUBSOURCES ON <object>` when `<object>` is not a source.

  * Reject specifying `FROM` and `ON` together, to match how `SHOW INDEXES` works.

Fix #20037.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes one recognized and several unrecognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add a new `SHOW SUBSOURCES` statement, which shows the subsources in the current schema.
