### PR TITLE
Improve invalid accumulation error reporting in `DistinctBy`

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -441,13 +441,13 @@ where
                     // output.
                     output.push((Row::default(), 1));
                 },
-                move |_key, input: &[(_, Diff)], output| {
-                    for (row, count) in input.iter() {
+                move |key, input: &[(_, Diff)], output| {
+                    for (_, count) in input.iter() {
                         if count.is_positive() {
                             continue;
                         }
                         let message = "Non-positive multiplicity in DistinctBy";
-                        error_logger.log(message, &format!("row={row:?}, count={count}"));
+                        error_logger.log(message, &format!("row={key:?}, count={count}"));
                         output.push((EvalError::Internal(message.to_string()).into(), 1));
                         return;
                     }


### PR DESCRIPTION
This PR improves the error reporting of invalid accumulations in `DistinctBy`. Previously, the error message would output the empty values associated with a key, since in the case of `DistinctBy` the entire row is moved into the key. Now, the error message reported as a `WARN` (and in Sentry breadcrumbs) will actually contain the row for which the invalid accumulation was seen.

Advances #20405.

### Motivation

  * This PR fixes a previously unreported bug.

We failed to recognize that emitting the reduction values in the error reporting for `DistinctBy` was not informative. These values are always the empty row, since `DistinctBy` operates by taking the entire row as the `key`. If we want the information about the row where the invalid accumulation happened to be reported as a warning (and thus put into Sentry breadcrumbs), the error logging should use the `key` instead.

### Tips for reviewer

Given that this change is really small and that a regression test would require `mzcompose` to look into what is written to the logs, I figured that testing it manually would be a reasonable trade-off of effort vs. gain. Just let me know if you think otherwise and I can create a regression test instead.

For the manual testing, I followed a setup similar to `negative-multiplicities.td`:

```sql
CREATE TABLE base (data bigint, diff bigint);
CREATE MATERIALIZED VIEW data AS SELECT data AS data1, data AS data2 FROM base, repeat_row(diff);
INSERT INTO base VALUES (1, 1);
INSERT INTO base VALUES (1, -1), (1, -1);
SELECT DISTINCT data FROM data;
```

Then, the last query produced a clean error, and we could see the following in the logs:
```
cluster-u1-replica-8: 2023-07-10T11:08:43.712058Z  WARN mz_compute::render::errors: [customer-data] Non-positive multiplicity in DistinctBy (row=Row{[List([Int64(1), Int64(1)])]}, count=-1) dataflow="oneshot-select-t16"
cluster-u1-replica-8: 2023-07-10T11:08:43.712090Z ERROR mz_compute::render::errors: Non-positive multiplicity in DistinctBy
```

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR is sufficiently small to not require a design.
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
