### PR TITLE
Fix error message in timezone.slt

### DIFF
--- a/test/sqllogictest/timezone.slt
+++ b/test/sqllogictest/timezone.slt
@@ -122,5 +122,5 @@ SELECT TIMESTAMPTZ '2020-11-01 01:00:00 America/New_York'
 2020-11-01 06:00:00+00
 
 # Regression for 20324
-query error db error: ERROR: timestamp out of range
+query error timestamp out of range
 SELECT pg_catalog.timezone(-INTERVAL '1' MINUTE, TIMESTAMP '95143-12-31 23:59:59' + INTERVAL '167 MILLENNIUM')


### PR DESCRIPTION
Considering it's running with --auto-index-selects

Seen in https://buildkite.com/materialize/sql-logic-tests/builds/5599#01893f92-845a-4684-935a-61dfe89cef7a

Verified locally: `bin/sqllogictest -- --auto-index-selects test/sqllogictest/timezone.slt`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
