### PR TITLE
repr: mark type/Datum conversions inline

### DIFF
--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -339,6 +339,8 @@ pub trait TimestampLike:
 
 impl TryFrom<Datum<'_>> for NaiveDateTime {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Timestamp(dt) => Ok(dt.t),
@@ -349,6 +351,8 @@ impl TryFrom<Datum<'_>> for NaiveDateTime {
 
 impl TryFrom<Datum<'_>> for DateTime<Utc> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::TimestampTz(dt_tz) => Ok(dt_tz.t),

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1006,6 +1006,7 @@ impl<'a> Datum<'a> {
 }
 
 impl<'a> From<bool> for Datum<'a> {
+    #[inline]
     fn from(b: bool) -> Datum<'a> {
         if b {
             Datum::True
@@ -1016,96 +1017,112 @@ impl<'a> From<bool> for Datum<'a> {
 }
 
 impl<'a> From<i16> for Datum<'a> {
+    #[inline]
     fn from(i: i16) -> Datum<'a> {
         Datum::Int16(i)
     }
 }
 
 impl<'a> From<i32> for Datum<'a> {
+    #[inline]
     fn from(i: i32) -> Datum<'a> {
         Datum::Int32(i)
     }
 }
 
 impl<'a> From<i64> for Datum<'a> {
+    #[inline]
     fn from(i: i64) -> Datum<'a> {
         Datum::Int64(i)
     }
 }
 
 impl<'a> From<u8> for Datum<'a> {
+    #[inline]
     fn from(u: u8) -> Datum<'a> {
         Datum::UInt8(u)
     }
 }
 
 impl<'a> From<u16> for Datum<'a> {
+    #[inline]
     fn from(u: u16) -> Datum<'a> {
         Datum::UInt16(u)
     }
 }
 
 impl<'a> From<u32> for Datum<'a> {
+    #[inline]
     fn from(u: u32) -> Datum<'a> {
         Datum::UInt32(u)
     }
 }
 
 impl<'a> From<u64> for Datum<'a> {
+    #[inline]
     fn from(u: u64) -> Datum<'a> {
         Datum::UInt64(u)
     }
 }
 
 impl<'a> From<OrderedFloat<f32>> for Datum<'a> {
+    #[inline]
     fn from(f: OrderedFloat<f32>) -> Datum<'a> {
         Datum::Float32(f)
     }
 }
 
 impl<'a> From<OrderedFloat<f64>> for Datum<'a> {
+    #[inline]
     fn from(f: OrderedFloat<f64>) -> Datum<'a> {
         Datum::Float64(f)
     }
 }
 
 impl<'a> From<f32> for Datum<'a> {
+    #[inline]
     fn from(f: f32) -> Datum<'a> {
         Datum::Float32(OrderedFloat(f))
     }
 }
 
 impl<'a> From<f64> for Datum<'a> {
+    #[inline]
     fn from(f: f64) -> Datum<'a> {
         Datum::Float64(OrderedFloat(f))
     }
 }
 
 impl<'a> From<i128> for Datum<'a> {
+    #[inline]
     fn from(d: i128) -> Datum<'a> {
         Datum::Numeric(OrderedDecimal(Numeric::try_from(d).unwrap()))
     }
 }
 
 impl<'a> From<u128> for Datum<'a> {
+    #[inline]
     fn from(d: u128) -> Datum<'a> {
         Datum::Numeric(OrderedDecimal(Numeric::try_from(d).unwrap()))
     }
 }
 
 impl<'a> From<Numeric> for Datum<'a> {
+    #[inline]
     fn from(n: Numeric) -> Datum<'a> {
         Datum::Numeric(OrderedDecimal(n))
     }
 }
 
 impl<'a> From<OrderedDecimal<Numeric>> for Datum<'a> {
+    #[inline]
     fn from(n: OrderedDecimal<Numeric>) -> Datum<'a> {
         Datum::Numeric(n)
     }
 }
 
 impl<'a> From<chrono::Duration> for Datum<'a> {
+    #[inline]
     fn from(duration: chrono::Duration) -> Datum<'a> {
         let micros = duration.num_microseconds().unwrap_or(0);
         Datum::Interval(Interval::new(0, 0, micros))
@@ -1113,42 +1130,49 @@ impl<'a> From<chrono::Duration> for Datum<'a> {
 }
 
 impl<'a> From<Interval> for Datum<'a> {
+    #[inline]
     fn from(other: Interval) -> Datum<'a> {
         Datum::Interval(other)
     }
 }
 
 impl<'a> From<&'a str> for Datum<'a> {
+    #[inline]
     fn from(s: &'a str) -> Datum<'a> {
         Datum::String(s)
     }
 }
 
 impl<'a> From<&'a [u8]> for Datum<'a> {
+    #[inline]
     fn from(b: &'a [u8]) -> Datum<'a> {
         Datum::Bytes(b)
     }
 }
 
 impl<'a> From<Date> for Datum<'a> {
+    #[inline]
     fn from(d: Date) -> Datum<'a> {
         Datum::Date(d)
     }
 }
 
 impl<'a> From<NaiveTime> for Datum<'a> {
+    #[inline]
     fn from(t: NaiveTime) -> Datum<'a> {
         Datum::Time(t)
     }
 }
 
 impl<'a> From<CheckedTimestamp<NaiveDateTime>> for Datum<'a> {
+    #[inline]
     fn from(dt: CheckedTimestamp<NaiveDateTime>) -> Datum<'a> {
         Datum::Timestamp(dt)
     }
 }
 
 impl<'a> From<CheckedTimestamp<DateTime<Utc>>> for Datum<'a> {
+    #[inline]
     fn from(dt: CheckedTimestamp<DateTime<Utc>>) -> Datum<'a> {
         Datum::TimestampTz(dt)
     }
@@ -1173,17 +1197,20 @@ impl<'a> TryInto<Datum<'a>> for DateTime<Utc> {
 }
 
 impl<'a> From<Uuid> for Datum<'a> {
+    #[inline]
     fn from(uuid: Uuid) -> Datum<'a> {
         Datum::Uuid(uuid)
     }
 }
 impl<'a> From<crate::Timestamp> for Datum<'a> {
+    #[inline]
     fn from(ts: crate::Timestamp) -> Datum<'a> {
         Datum::MzTimestamp(ts)
     }
 }
 
 impl<'a> From<MzAclItem> for Datum<'a> {
+    #[inline]
     fn from(mz_acl_item: MzAclItem) -> Self {
         Datum::MzAclItem(mz_acl_item)
     }
@@ -3396,6 +3423,7 @@ fn arb_numeric() -> BoxedStrategy<Numeric> {
 }
 
 impl<'a> From<&'a PropDatum> for Datum<'a> {
+    #[inline]
     fn from(pd: &'a PropDatum) -> Self {
         use PropDatum::*;
         match pd {

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1181,6 +1181,7 @@ impl<'a> From<CheckedTimestamp<DateTime<Utc>>> for Datum<'a> {
 impl<'a> TryInto<Datum<'a>> for NaiveDateTime {
     type Error = TimestampError;
 
+    #[inline]
     fn try_into(self) -> Result<Datum<'a>, Self::Error> {
         let t = CheckedTimestamp::from_timestamplike(self)?;
         Ok(t.into())
@@ -1190,6 +1191,7 @@ impl<'a> TryInto<Datum<'a>> for NaiveDateTime {
 impl<'a> TryInto<Datum<'a>> for DateTime<Utc> {
     type Error = TimestampError;
 
+    #[inline]
     fn try_into(self) -> Result<Datum<'a>, Self::Error> {
         let t = CheckedTimestamp::from_timestamplike(self)?;
         Ok(t.into())

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -162,6 +162,8 @@ pub enum Datum<'a> {
 
 impl TryFrom<Datum<'_>> for bool {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::False => Ok(false),
@@ -174,6 +176,7 @@ impl TryFrom<Datum<'_>> for bool {
 impl TryFrom<Datum<'_>> for Option<bool> {
     type Error = ();
 
+    #[inline]
     fn try_from(datum: Datum<'_>) -> Result<Self, Self::Error> {
         match datum {
             Datum::Null => Ok(None),
@@ -186,6 +189,8 @@ impl TryFrom<Datum<'_>> for Option<bool> {
 
 impl TryFrom<Datum<'_>> for f32 {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Float32(f) => Ok(*f),
@@ -196,6 +201,8 @@ impl TryFrom<Datum<'_>> for f32 {
 
 impl TryFrom<Datum<'_>> for Option<f32> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Null => Ok(None),
@@ -207,6 +214,8 @@ impl TryFrom<Datum<'_>> for Option<f32> {
 
 impl TryFrom<Datum<'_>> for OrderedFloat<f32> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Float32(f) => Ok(f),
@@ -217,6 +226,8 @@ impl TryFrom<Datum<'_>> for OrderedFloat<f32> {
 
 impl TryFrom<Datum<'_>> for Option<OrderedFloat<f32>> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Null => Ok(None),
@@ -228,6 +239,8 @@ impl TryFrom<Datum<'_>> for Option<OrderedFloat<f32>> {
 
 impl TryFrom<Datum<'_>> for f64 {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Float64(f) => Ok(*f),
@@ -238,6 +251,8 @@ impl TryFrom<Datum<'_>> for f64 {
 
 impl TryFrom<Datum<'_>> for Option<f64> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Null => Ok(None),
@@ -249,6 +264,8 @@ impl TryFrom<Datum<'_>> for Option<f64> {
 
 impl TryFrom<Datum<'_>> for OrderedFloat<f64> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Float64(f) => Ok(f),
@@ -259,6 +276,8 @@ impl TryFrom<Datum<'_>> for OrderedFloat<f64> {
 
 impl TryFrom<Datum<'_>> for Option<OrderedFloat<f64>> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Null => Ok(None),
@@ -270,6 +289,8 @@ impl TryFrom<Datum<'_>> for Option<OrderedFloat<f64>> {
 
 impl TryFrom<Datum<'_>> for i16 {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Int16(i) => Ok(i),
@@ -280,6 +301,8 @@ impl TryFrom<Datum<'_>> for i16 {
 
 impl TryFrom<Datum<'_>> for Option<i16> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Null => Ok(None),
@@ -291,6 +314,8 @@ impl TryFrom<Datum<'_>> for Option<i16> {
 
 impl TryFrom<Datum<'_>> for i32 {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Int32(i) => Ok(i),
@@ -301,6 +326,8 @@ impl TryFrom<Datum<'_>> for i32 {
 
 impl TryFrom<Datum<'_>> for Option<i32> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Null => Ok(None),
@@ -312,6 +339,8 @@ impl TryFrom<Datum<'_>> for Option<i32> {
 
 impl TryFrom<Datum<'_>> for i64 {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Int64(i) => Ok(i),
@@ -322,6 +351,8 @@ impl TryFrom<Datum<'_>> for i64 {
 
 impl TryFrom<Datum<'_>> for Option<i64> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Null => Ok(None),
@@ -333,6 +364,8 @@ impl TryFrom<Datum<'_>> for Option<i64> {
 
 impl TryFrom<Datum<'_>> for u16 {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::UInt16(u) => Ok(u),
@@ -343,6 +376,8 @@ impl TryFrom<Datum<'_>> for u16 {
 
 impl TryFrom<Datum<'_>> for Option<u16> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Null => Ok(None),
@@ -354,6 +389,8 @@ impl TryFrom<Datum<'_>> for Option<u16> {
 
 impl TryFrom<Datum<'_>> for u32 {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::UInt32(u) => Ok(u),
@@ -364,6 +401,8 @@ impl TryFrom<Datum<'_>> for u32 {
 
 impl TryFrom<Datum<'_>> for Option<u32> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Null => Ok(None),
@@ -375,6 +414,8 @@ impl TryFrom<Datum<'_>> for Option<u32> {
 
 impl TryFrom<Datum<'_>> for u64 {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::UInt64(u) => Ok(u),
@@ -385,6 +426,8 @@ impl TryFrom<Datum<'_>> for u64 {
 
 impl TryFrom<Datum<'_>> for Option<u64> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Null => Ok(None),
@@ -396,6 +439,8 @@ impl TryFrom<Datum<'_>> for Option<u64> {
 
 impl TryFrom<Datum<'_>> for CheckedTimestamp<NaiveDateTime> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Timestamp(dt) => Ok(dt),
@@ -406,6 +451,8 @@ impl TryFrom<Datum<'_>> for CheckedTimestamp<NaiveDateTime> {
 
 impl TryFrom<Datum<'_>> for CheckedTimestamp<DateTime<Utc>> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::TimestampTz(dt_tz) => Ok(dt_tz),
@@ -416,6 +463,8 @@ impl TryFrom<Datum<'_>> for CheckedTimestamp<DateTime<Utc>> {
 
 impl TryFrom<Datum<'_>> for Date {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Date(d) => Ok(d),
@@ -426,6 +475,8 @@ impl TryFrom<Datum<'_>> for Date {
 
 impl TryFrom<Datum<'_>> for OrderedDecimal<Numeric> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Numeric(n) => Ok(n),
@@ -436,6 +487,8 @@ impl TryFrom<Datum<'_>> for OrderedDecimal<Numeric> {
 
 impl TryFrom<Datum<'_>> for Option<OrderedDecimal<Numeric>> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Null => Ok(None),
@@ -447,6 +500,8 @@ impl TryFrom<Datum<'_>> for Option<OrderedDecimal<Numeric>> {
 
 impl TryFrom<Datum<'_>> for crate::Timestamp {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::MzTimestamp(n) => Ok(n),
@@ -457,6 +512,8 @@ impl TryFrom<Datum<'_>> for crate::Timestamp {
 
 impl TryFrom<Datum<'_>> for Option<crate::Timestamp> {
     type Error = ();
+
+    #[inline]
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
             Datum::Null => Ok(None),


### PR DESCRIPTION
Mentioned in #20428

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
