### PR TITLE
Fix high I/O usage by minio in Zippy, feature-benchmark

### DIFF
--- a/misc/python/materialize/feature_benchmark/scenario.py
+++ b/misc/python/materialize/feature_benchmark/scenario.py
@@ -59,7 +59,16 @@ class RootScenario:
         return TdAction(
             """
 > CREATE TABLE ten (f1 INTEGER);
-> INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+> INSERT INTO ten VALUES (0)
+> INSERT INTO ten VALUES (1)
+> INSERT INTO ten VALUES (2)
+> INSERT INTO ten VALUES (3)
+> INSERT INTO ten VALUES (4)
+> INSERT INTO ten VALUES (5)
+> INSERT INTO ten VALUES (6)
+> INSERT INTO ten VALUES (7)
+> INSERT INTO ten VALUES (8)
+> INSERT INTO ten VALUES (9)
 """
         )
 

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -759,6 +759,7 @@ class Minio(Service):
                 "command": [command],
                 "image": image,
                 "ports": [9000, 9001],
+                "environment": ["MINIO_STORAGE_CLASS_STANDARD=EC:0"],
                 "healthcheck": {
                     "test": [
                         "CMD",

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -743,7 +743,7 @@ class Minio(Service):
     def __init__(
         self,
         name: str = "minio",
-        image: str = "minio/minio:RELEASE.2022-09-25T15-44-53Z.fips",
+        image: str = "minio/minio:RELEASE.2023-07-07T07-13-57Z",
         setup_materialize: bool = False,
     ) -> None:
         # We can pre-create buckets in minio by creating subdirectories in


### PR DESCRIPTION
```
commit b133f9ac28446ab96327be92885449941187fe27 (HEAD -> feature-benchmark-minio, origin/feature-benchmark-minio)
Author: Philip Stoev <pstoev@materialize.com>
Date:   Tue Jul 11 09:21:45 2023 +0200

    mzcompose: Upgrade minio to RELEASE.2023-07-07T07-13-57Z

commit 6b0ff5db282ed096cc25e5d679e7a906e00f9d8a
Author: Philip Stoev <pstoev@materialize.com>
Date:   Mon Jul 10 18:12:02 2023 +0200

    ci: Run minio with no redundancy
    
    minio consumes all available I/O, causing CRDB to be starved out
    and fail. Attempt to reduce the I/O load by running minio with no
    redundancy.
    
    This change will affect Zippy and the feature benchmark.

commit 987de124c97278a7c581beb3148419adb126e57f
Author: Philip Stoev <pstoev@materialize.com>
Date:   Mon Jul 10 18:11:03 2023 +0200

    feature-benchmark: Do not populate the entire table 'ten' at single timestamp
    
    In an attempt to even out the load on some dataflows, do not
    emit all the values in the table 'ten' at the same timestamp
````

### Motivation

When the feature benchmark began tracking memory, a memory leak with file-based persist was detected. This necessitated the conversion of the feature-benchmark to use minio for S3 storage.

Unfortunately minio appears to suffer from some sort of major write amplification that causes many gigabytes of i/o to happen in a very short period, starving CRDB and causing the infamous "FATAL unable to sync for 20 seconds" message.

So the 3 commits taken together seems to resolve the situation for the feature-benchmark, even though the individual contribution of each is difficult to quantify. Two of the commits will also benefit Zippy, so hopefully the CRDB stalls will be gone from there as well.
