### PR TITLE
[kafka] use connect with confluent client id when connecting to confuent cloud

### DIFF
--- a/src/kafka-util/src/lib.rs
+++ b/src/kafka-util/src/lib.rs
@@ -79,3 +79,7 @@
 
 pub mod admin;
 pub mod client;
+
+/// Client id used when connecting to Confluent brokers
+/// as part of Materializes Connect with Confluent partnership agreement.
+pub const CONNECT_WITH_CONFLUENT_CLIENT_ID: &str = "cwc|0014U00002w9losQAA|materialize|";

--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -438,6 +438,16 @@ impl KafkaConnection {
     fn validate_by_default(&self) -> bool {
         true
     }
+
+    /// Best effort determination if this connection
+    /// is pointed towards Confluent brokers. This method
+    /// may return false negatives but should not return
+    /// any false positives
+    pub fn is_confluent(&self) -> bool {
+        self.brokers
+            .iter()
+            .any(|b| b.address.contains("confluent.cloud"))
+    }
 }
 
 impl RustType<ProtoKafkaConnectionTlsConfig> for KafkaTlsConfig {

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -135,6 +135,8 @@ impl SourceRender for KafkaSourceConnection {
             assert!(capabilities.is_empty());
 
             let group_id = self.group_id(config.id);
+            let client_id = self.client_id(config.id);
+
             let KafkaSourceConnection {
                 connection, topic, ..
             } = self;
@@ -183,10 +185,9 @@ impl SourceRender for KafkaSourceConnection {
                         // ensure that librdkafka does not try to perform its own
                         // consumer group balancing, which would wreak havoc with
                         // our careful partition assignment strategy.
-                        "group.id" => group_id.clone(),
-                        // We just use the `group.id` as the `client.id`, for simplicity,
-                        // as we present to kafka as a single consumer.
-                        "client.id" => group_id,
+                        "group.id" => group_id,
+                        // Client id we present to kafka.
+                        "client.id" => client_id,
                     },
                 )
                 .await;


### PR DESCRIPTION
### Motivation

Materialize is joining the connect with confluent partners program, and they have asked we use a specific client id when connecting to Confluent brokers.

Fixes #20443 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
