### PR TITLE
Add more indexed view scenarios to feature benchmark

### DIFF
--- a/doc/developer/design/20230421_stabilize_monotonic_select.md
+++ b/doc/developer/design/20230421_stabilize_monotonic_select.md
@@ -86,6 +86,8 @@ For (3), it is highly likely that the total time needed to execute these tests b
 
 In addition to `sqllogictests`, we propose that all `mzcompose` workflows be run with the feature flag `enable_monotonic_oneshot_selects` turned on. The reasoning is simple: If we are ever going to turn this feature on in production, then this will be the new way of running one-shot `SELECT`s in Materialize. The optimization will kick in whenever we use min/max/top-k patterns. Thus, there should not be any test that we cannot run with the optimization enabled.
 
+Finally, monitoring of performance regressions performed by the feature benchmark might be impacted by monotonic one-shot `SELECT`s. This is because the execution strategies with monotonic operators often require significantly less memory and query processing time, and the feature benchmark performs measurements with one-shot `SELECT`s in a number of its `Dataflow` scenarios. To address this risk, we propose to add selected redundant scenarios to the feature benchmark where an indexed view is created instead, and both query processing time and memory requirements are evaluated. Note that for these scenarios, we must be careful to supply data from input sources that do not emit the empty frontier, e.g., tables, so that memory requirements can be more accurately assessed.
+
 ### Alternatives
 
 Note that the proposal above changes the semantics of our runner rather than changing the test corpora. Thus, reuse of existing corpora with low effort is achieved. However, the trade-off is reduced visibility of what all the statements actually run by a test are.


### PR DESCRIPTION
This PR adds three additional Dataflow scenarios to the feature benchmark corresponding to indexed-view versions of `MinMax`, `GroupBy`, and `DeltaJoin`. The dataflows created in these new scenarios utilize operators used to maintain indexes or materialized views as opposed to monotonic ones used for one-shot `SELECT`s in the case of `MinMax` and `GroupBy`. As for `DeltaJoin`, the new scenario creates the base data with a table and not a constant view, under the assumption that not emitting the empty frontier implies the need to maintain more memory active. All of the scenarios introduced appear to require more memory to be maintained, and are thus useful to increase variety in support of detecting memory regressions.

Advances #18734.

### Motivation

  * This PR adds a feature that has not yet been specified.

With monotonic one-shot `SELECT`s being enabled by default in `mzcompose` workflows (#20331), there may now be significant performance differences when we compare one-shot `SELECT`s with min/max/top-k patterns with their corresponding indexed view counterparts. As such, it becomes necessary to extend the testing of memory regressions to increase the variety of scenarios, including both one-shot `SELECT`s and indexed views in selected cases.

### Tips for reviewer

The commits can be looked at individually. By testing this locally, I got the following output for the added scenarios compared with their existing one-shot `SELECT` counterparts:

```
NAME                                | TYPE       |    THIS     |    OTHER    |  Regression?  | 'THIS' is:
----------------------------------------------------------------------------------------------------
MinMax                              | wallclock  |       0.568 |       0.575 |      no       | 1.1 pct   less/faster
MinMax                              | memory     |     873.470 |     891.304 |      no       | 2.0 pct   less/faster
MinMaxMaintained                    | wallclock  |       2.004 |       2.052 |      no       | 2.3 pct   less/faster
MinMaxMaintained                    | memory     |    1813.889 |    1815.796 |      no       | 0.1 pct   less/faster
GroupBy                             | wallclock  |       1.089 |       1.087 |      no       | 0.1 pct   more/slower
GroupBy                             | memory     |    1103.401 |    1108.170 |      no       | 0.4 pct   less/faster
GroupByMaintained                   | wallclock  |       5.030 |       5.319 |      no       | 5.4 pct   less/faster
GroupByMaintained                   | memory     |    3057.480 |    2998.352 |      no       | 2.0 pct   more/slower
DeltaJoin                           | wallclock  |       0.554 |       0.565 |      no       | 2.0 pct   less/faster
DeltaJoin                           | memory     |     797.653 |     795.555 |      no       | 0.3 pct   more/slower
DeltaJoinMaintained                 | wallclock  |       0.648 |       0.672 |      no       | 3.5 pct   less/faster
DeltaJoinMaintained                 | memory     |     958.443 |     940.609 |      no       | 1.9 pct   more/slower
```

As we can see above, the differences between `MinMax` vs. `MinMaxMaintained` and `GroupBy` vs. `GroupByMaintained` are substantial, and especially critical wrt. memory.

`DeltaJoin` vs. `DeltaJoinMaintained` illustrates that the technique of initialization based on a constant view followed by a one-shot `SELECT` can lead to an underestimate of the memory requirements. I focused on `DeltaJoin` as this is an important pattern in terms of memory use, but the same might be true of other scenarios (I did not check exhaustively).

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20230421_stabilize_monotonic_select.md).
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
