### PR TITLE
environmentd: improve long-lived connection logic for websockets

### DIFF
--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -355,12 +355,26 @@ http
 400 Bad Request
 each query must contain exactly 1 statement, but "select 1; select 2;" contains 2
 
+# Verify t is empty before executing some inserts.
+http
+{"queries":[{"query":"select count(*) from t","params":[]}]}
+----
+200 OK
+{"results":[{"tag":"SELECT 1","rows":[[0]],"desc":{"columns":[{"name":"count","type_oid":20,"type_len":8,"type_mod":-1}]},"notices":[]}]}
+
 # Rolledback
 http
 {"queries":[{"query":"begin;","params":[]},{"query":"insert into t values (1);","params":[]},{"query":"rollback","params":[]}]}
 ----
 200 OK
 {"results":[{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"ROLLBACK","notices":[]}]}
+
+# Rollback prevents insertion.
+http
+{"queries":[{"query":"select count(*) from t","params":[]}]}
+----
+200 OK
+{"results":[{"tag":"SELECT 1","rows":[[0]],"desc":{"columns":[{"name":"count","type_oid":20,"type_len":8,"type_mod":-1}]},"notices":[]}]}
 
 # Implicit txn
 http
@@ -369,12 +383,26 @@ http
 200 OK
 {"results":[{"ok":"INSERT 0 1","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
+# Implicit transactions are each committed, so the INSERT committed before the SELECT error.
+http
+{"queries":[{"query":"select count(*) from t","params":[]},{"query":"delete from t","params":[]}]}
+----
+200 OK
+{"results":[{"tag":"SELECT 1","rows":[[1]],"desc":{"columns":[{"name":"count","type_oid":20,"type_len":8,"type_mod":-1}]},"notices":[]},{"ok":"DELETE 1","notices":[]}]}
+
 # Errors prevent commit + further execution
 http
 {"queries":[{"query":"begin;","params":[]},{"query":"insert into t values (1);","params":[]},{"query":"select 1/0;","params":[]},{"query":"select * from t","params":[]},{"query":"commit","params":[]}]}
 ----
 200 OK
 {"results":[{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
+
+# Because of the explicit transaction, the INSERT did not commit.
+http
+{"queries":[{"query":"select count(*) from t","params":[]}]}
+----
+200 OK
+{"results":[{"tag":"SELECT 1","rows":[[0]],"desc":{"columns":[{"name":"count","type_oid":20,"type_len":8,"type_mod":-1}]},"notices":[]}]}
 
 # Requires explicit commit in explicit txn
 http
@@ -402,17 +430,19 @@ http
 200 OK
 {"results":[{"tag":"SELECT 3","rows":[[1],[2],[3]],"desc":{"columns":[{"name":"a","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
+# The first statement (insert) succeeds and commits because it's an implicit transaction.
 http
 {"queries":[{"query":"insert into t values ($1);","params":["4"]},{"query":"begin;","params":[]},{"query":"select 1/0;","params":[]},{"query":"commit;","params":[]}]}
 ----
 200 OK
 {"results":[{"ok":"INSERT 0 1","notices":[]},{"ok":"BEGIN","notices":[]},{"error":{"message":"division by zero","code":"XX000"},"notices":[]}]}
 
+# We expect to see the INSERT (4) above.
 http
 {"queries":[{"query":"select * from t","params":[]}]}
 ----
 200 OK
-{"results":[{"tag":"SELECT 3","rows":[[1],[2],[3]],"desc":{"columns":[{"name":"a","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
+{"results":[{"tag":"SELECT 4","rows":[[1],[2],[3],[4]],"desc":{"columns":[{"name":"a","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[]}]}
 
 http
 {"queries":[{"query":"subscribe (select * from t)","params":[]}]}


### PR DESCRIPTION
The adapter client handling was initially written only for single-shot HTTP endpoints and so didn't do various things done in the pgwire protocol. But since websockets exist we need this logic but never wrote tests for it.

Teach websockets to correctly close implicit transactions and also reset the client state at the beginning of each message.

Fixes #20262

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a