### PR TITLE
webhooks: Fix nightly

### DIFF
--- a/misc/python/materialize/checks/webhook.py
+++ b/misc/python/materialize/checks/webhook.py
@@ -21,7 +21,7 @@ def schemas() -> str:
 
 class Webhook(Check):
     def _can_run(self) -> bool:
-        return self.base_version >= MzVersion.parse("0.59.0-dev")
+        return self.base_version >= MzVersion.parse("0.61.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(


### PR DESCRIPTION
### Motivation

A test for the new webhook sources was marked as being able to run with any version `>= 0.59`, but the changes actually landed in `v0.61`. This PR bumps that version requirement to fix our nightly builds

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
