### PR TITLE
parser: Improve error for cursor with hold

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -6545,6 +6545,14 @@ impl<'a> Parser<'a> {
             .map_parser_err(StatementKind::Declare)?;
         self.expect_keyword(CURSOR)
             .map_parser_err(StatementKind::Declare)?;
+        if self.peek_keywords(&[WITH, HOLD]) {
+            return parser_err!(
+                self,
+                self.peek_pos(),
+                format!("WITH HOLD is unsupported for cursors")
+            )
+            .map_parser_err(StatementKind::Declare);
+        }
         // WITHOUT HOLD is optional and the default behavior so we can ignore it.
         let _ = self.parse_keywords(&[WITHOUT, HOLD]);
         self.expect_keyword(FOR)

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -6546,13 +6546,15 @@ impl<'a> Parser<'a> {
         self.expect_keyword(CURSOR)
             .map_parser_err(StatementKind::Declare)?;
         if self.parse_keyword(WITH) {
-            self.expect_keyword(HOLD)?;
-            return parser_err!(
+            let err = parser_err!(
                 self,
-                self.peek_pos(),
+                self.peek_prev_pos(),
                 format!("WITH HOLD is unsupported for cursors")
             )
             .map_parser_err(StatementKind::Declare);
+            self.expect_keyword(HOLD)
+                .map_parser_err(StatementKind::Declare)?;
+            return err;
         }
         // WITHOUT HOLD is optional and the default behavior so we can ignore it.
         let _ = self.parse_keywords(&[WITHOUT, HOLD]);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -6545,7 +6545,8 @@ impl<'a> Parser<'a> {
             .map_parser_err(StatementKind::Declare)?;
         self.expect_keyword(CURSOR)
             .map_parser_err(StatementKind::Declare)?;
-        if self.peek_keywords(&[WITH, HOLD]) {
+        if self.parse_keyword(WITH) {
+            self.expect_keyword(HOLD)?;
             return parser_err!(
                 self,
                 self.peek_pos(),

--- a/src/sql-parser/tests/testdata/cursor
+++ b/src/sql-parser/tests/testdata/cursor
@@ -28,6 +28,13 @@ DECLARE c CURSOR FOR SUBSCRIBE t
 Declare(DeclareStatement { name: Ident("c"), stmt: Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("t")]))), options: [], as_of: None, up_to: None, output: Diffs }) })
 
 parse-statement
+DECLARE c CURSOR WITH HOLD FOR SELECT * FROM t;
+----
+error: WITH HOLD is unsupported for cursors
+DECLARE c CURSOR WITH HOLD FOR SELECT * FROM t;
+                 ^
+
+parse-statement
 CLOSE c
 ----
 CLOSE c


### PR DESCRIPTION
This commit improves the error message returned when a user tries to declare a cursor with hold, which is unsupported in Materialize.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
