### PR TITLE
Enable selected SQLite slow SLTs with `--auto-index-selects`

### DIFF
--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -67,8 +67,34 @@ tests=("${temp[@]}")
 sqllogictest -v --auto-index-selects "$@" "${tests[@]}" | tee -a target/slt.log
 sqllogictest -v "$@" "${tests_without_views[@]}" | tee -a target/slt.log
 
+# Due to performance issues (see below), we pick two selected SLTs from
+# the SQLite corpus that we can reasonably run with --auto-index-selects
+# and that include min/max query patterns. Note that none of the SLTs in
+# the corpus we presently use from SQLite contain top-k patterns.
+tests_with_views=(
+     test/sqllogictest/sqlite/test/index/random/1000/slt_good_0.test  \
+     test/sqllogictest/sqlite/test/random/aggregates/slt_good_129.test \
+)
+
+readarray -d '' tests < <(find test/sqllogictest/sqlite/test -type f -print0)
+# Exclude tests_with_views from tests
+for f in "${tests_with_views[@]}"; do
+    tests=("${tests[@]/$f}")
+done
+# Remove empty entries from tests, since
+# sqllogictests emits failures on them.
+temp=()
+for f in "${tests[@]}"; do
+    if [ -n "$f" ]; then
+        temp+=( "$f" )
+    fi
+done
+tests=("${temp[@]}")
+
+# Run selected tests with --auto-index-selects
+sqllogictest -v --auto-index-selects --enable-table-keys "$@" "${tests_with_views[@]}" | tee -a target/slt.log
 # Too slow to run with --auto-index-selects, can't run together with
 # --auto-transactions, no differences seen in previous run. We might want to
 # revisit and see if we can periodically test them, even if it takes 2-3 days
 # for the run to finish.
-find test/sqllogictest/sqlite/test -type f -print0 | xargs -0 sqllogictest -v --auto-transactions --auto-index-tables --enable-table-keys "$@" | tee -a target/slt.log
+sqllogictest -v --auto-transactions --auto-index-tables --enable-table-keys "$@" "${tests[@]}" | tee -a target/slt.log


### PR DESCRIPTION
This PR chooses two SQLite SLTs to be run in CI in the slow SLT pipeline with `--auto-index-selects`. The two SLTs are selected based on including min/max query patterns and being sufficiently small to represent only a small execution time impact on the total test running time. Thus, these tests can be used to increase the corpus used for daily testing of monotonic one-shot `SELECT`s. Other tests in the SQLite corpus that we run were considered. However, they were not included due to the following observations: (a) There seem to be none with top-k patterns; (b) The other tests with min/max patterns were about 10x larger in number of statements, being a poor fit in terms of performance to be run without `--auto-transactions`.

This PR marks the end of a set of changes (e.g., https://github.com/MaterializeInc/materialize/pull/19780, https://github.com/MaterializeInc/materialize/pull/20209, https://github.com/MaterializeInc/materialize/pull/20466) that help us enforce testing of both monotonic and non-monotonic plans in CI.

Fixes #18734.

### Motivation

  * This PR adds a known-desirable feature. https://github.com/MaterializeInc/materialize/issues/18734

### Tips for reviewer

I started a slow SLT build on this change: https://buildkite.com/materialize/sql-logic-tests/builds/5619. AFAICT, with 10-way sharding of the tests, the runtime of the slow SLTs is not affected negatively by this change (compare the first two shards with the remaining ones). Given that this change potentially increases our daily coverage of the output of monotonic vs. non-monotonic plans, I'd argue that it is in general an improvement.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20230421_stabilize_monotonic_select.md).
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
