### PR TITLE
adapter: move internal flags to separate files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@
 /doc/developer/reference/storage    @MaterializeInc/storage
 /misc/dbt-materialize               @MaterializeInc/devex
 /src/adapter                        @MaterializeInc/surfaces
+/src/adapter/src/flags.rs
 /src/alloc                          @benesch
 /src/audit-log                      @MaterializeInc/surfaces
 /src/avro                           @umanwizard
@@ -71,6 +72,7 @@
 /src/segment                        @benesch
 /src/service                        @MaterializeInc/storage @MaterializeInc/compute
 /src/sql                            @MaterializeInc/surfaces
+/src/sql/src/session/vars.rs
 # HirRelationExpr is the boundary between the `sql` crate and the compute
 # layer, and is jointly owned by the two teams.
 /src/sql/src/plan/expr.rs           @MaterializeInc/surfaces @MaterializeInc/compute

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -137,7 +137,7 @@ use crate::metrics::Metrics;
 use crate::session::{EndTransactionAction, Session};
 use crate::subscribe::ActiveSubscribe;
 use crate::util::{ClientTransmitter, CompletedClientTransmitter, ComputeSinkId, ResultExt};
-use crate::AdapterNotice;
+use crate::{flags, AdapterNotice};
 
 pub(crate) mod id_bundle;
 pub(crate) mod peek;
@@ -842,9 +842,9 @@ impl Coordinator {
         info!("coordinator init: beginning bootstrap");
 
         // Inform the controllers about their initial configuration.
-        let compute_config = self.catalog().compute_config();
+        let compute_config = flags::compute_config(self.catalog().system_config());
         self.controller.compute.update_configuration(compute_config);
-        let storage_config = self.catalog().storage_config();
+        let storage_config = flags::storage_config(self.catalog().system_config());
         self.controller.storage.update_configuration(storage_config);
 
         // Capture identifiers that need to have their read holds relaxed once the bootstrap completes.
@@ -1467,7 +1467,7 @@ impl Coordinator {
         });
 
         self.schedule_storage_usage_collection();
-        self.catalog.tracing_config().apply(&self.tracing_handle);
+        flags::tracing_config(self.catalog.system_config()).apply(&self.tracing_handle);
 
         loop {
             // Before adding a branch to this select loop, please ensure that the branch is

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -49,7 +49,7 @@ use crate::coord::{Coordinator, ReplicaMetadata};
 use crate::session::Session;
 use crate::telemetry::SegmentClientExt;
 use crate::util::{ComputeSinkId, ResultExt};
-use crate::{catalog, AdapterError, AdapterNotice};
+use crate::{catalog, flags, AdapterError, AdapterNotice};
 
 /// State provided to a catalog transaction closure.
 pub struct CatalogTxn<'a, T> {
@@ -662,17 +662,17 @@ impl Coordinator {
     }
 
     fn update_tracing_config(&mut self) {
-        let tracing = self.catalog().tracing_config();
+        let tracing = flags::tracing_config(self.catalog().system_config());
         tracing.apply(&self.tracing_handle);
     }
 
     fn update_compute_config(&mut self) {
-        let config_params = self.catalog().compute_config();
+        let config_params = flags::compute_config(self.catalog().system_config());
         self.controller.compute.update_configuration(config_params);
     }
 
     fn update_storage_config(&mut self) {
-        let config_params = self.catalog().storage_config();
+        let config_params = flags::storage_config(self.catalog().system_config());
         self.controller.storage.update_configuration(config_params);
     }
 

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -1,0 +1,100 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use mz_compute_client::protocol::command::ComputeParameters;
+use mz_ore::error::ErrorExt;
+use mz_persist_client::cfg::{PersistParameters, RetryParameters};
+use mz_sql::session::vars::SystemVars;
+use mz_storage_client::types::parameters::StorageParameters;
+use mz_tracing::params::TracingParameters;
+
+/// Return the current compute configuration, derived from the system configuration.
+pub fn compute_config(config: &SystemVars) -> ComputeParameters {
+    ComputeParameters {
+        max_result_size: Some(config.max_result_size()),
+        dataflow_max_inflight_bytes: Some(config.dataflow_max_inflight_bytes()),
+        enable_mz_join_core: Some(config.enable_mz_join_core()),
+        persist: persist_config(config),
+        tracing: tracing_config(config),
+    }
+}
+
+/// Return the current storage configuration, derived from the system configuration.
+pub fn storage_config(config: &SystemVars) -> StorageParameters {
+    StorageParameters {
+        persist: persist_config(config),
+        pg_replication_timeouts: mz_postgres_util::ReplicationTimeouts {
+            connect_timeout: Some(config.pg_replication_connect_timeout()),
+            keepalives_retries: Some(config.pg_replication_keepalives_retries()),
+            keepalives_idle: Some(config.pg_replication_keepalives_idle()),
+            keepalives_interval: Some(config.pg_replication_keepalives_interval()),
+            tcp_user_timeout: Some(config.pg_replication_tcp_user_timeout()),
+        },
+        keep_n_source_status_history_entries: config.keep_n_source_status_history_entries(),
+        keep_n_sink_status_history_entries: config.keep_n_source_status_history_entries(),
+        upsert_rocksdb_tuning_config: {
+            match mz_rocksdb_types::RocksDBTuningParameters::from_parameters(
+                config.upsert_rocksdb_compaction_style(),
+                config.upsert_rocksdb_optimize_compaction_memtable_budget(),
+                config.upsert_rocksdb_level_compaction_dynamic_level_bytes(),
+                config.upsert_rocksdb_universal_compaction_ratio(),
+                config.upsert_rocksdb_parallelism(),
+                config.upsert_rocksdb_compression_type(),
+                config.upsert_rocksdb_bottommost_compression_type(),
+                config.upsert_rocksdb_batch_size(),
+                config.upsert_rocksdb_retry_duration(),
+            ) {
+                Ok(u) => u,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to deserialize upsert_rocksdb parameters \
+                            into a `RocksDBTuningParameters`, \
+                            failing back to reasonable defaults: {}",
+                        e.display_with_causes()
+                    );
+                    mz_rocksdb_types::RocksDBTuningParameters::default()
+                }
+            }
+        },
+        finalize_shards: config.enable_storage_shard_finalization(),
+        tracing: tracing_config(config),
+    }
+}
+
+pub fn tracing_config(config: &SystemVars) -> TracingParameters {
+    TracingParameters {
+        log_filter: Some(config.logging_filter()),
+        opentelemetry_filter: Some(config.opentelemetry_filter()),
+    }
+}
+
+fn persist_config(config: &SystemVars) -> PersistParameters {
+    PersistParameters {
+        blob_target_size: Some(config.persist_blob_target_size()),
+        blob_cache_mem_limit_bytes: Some(config.persist_blob_cache_mem_limit_bytes()),
+        compaction_minimum_timeout: Some(config.persist_compaction_minimum_timeout()),
+        consensus_connect_timeout: Some(config.crdb_connect_timeout()),
+        consensus_tcp_user_timeout: Some(config.crdb_tcp_user_timeout()),
+        sink_minimum_batch_updates: Some(config.persist_sink_minimum_batch_updates()),
+        storage_sink_minimum_batch_updates: Some(
+            config.storage_persist_sink_minimum_batch_updates(),
+        ),
+        next_listen_batch_retryer: Some(RetryParameters {
+            initial_backoff: config.persist_next_listen_batch_retryer_initial_backoff(),
+            multiplier: config.persist_next_listen_batch_retryer_multiplier(),
+            clamp: config.persist_next_listen_batch_retryer_clamp(),
+        }),
+        stats_audit_percent: Some(config.persist_stats_audit_percent()),
+        stats_collection_enabled: Some(config.persist_stats_collection_enabled()),
+        stats_filter_enabled: Some(config.persist_stats_filter_enabled()),
+        pubsub_client_enabled: Some(config.persist_pubsub_client_enabled()),
+        pubsub_push_diff_enabled: Some(config.persist_pubsub_push_diff_enabled()),
+        rollup_threshold: Some(config.persist_rollup_threshold()),
+    }
+}

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -115,6 +115,7 @@ mod util;
 pub mod catalog;
 pub mod client;
 pub mod config;
+pub mod flags;
 pub mod metrics;
 pub mod session;
 pub mod telemetry;


### PR DESCRIPTION
The CODEOWNERS spam of these on the surfaces team has been significant.

### Motivation

  * This PR adds a feature that has not yet been specified.


### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
