### PR TITLE
SLT: Silence unrecognized config param error in long tests

### DIFF
--- a/test/sqllogictest/cockroach/array.slt
+++ b/test/sqllogictest/cockroach/array.slt
@@ -27,8 +27,9 @@ mode cockroach
 # control characters. In order for the test file to remain valid
 # printable UTF-8, we double-escape the representations below.
 
-statement ok
-SET bytea_output = escape
+# TODO: Support bytea
+#statement ok
+#SET bytea_output = escape
 
 # array construction
 

--- a/test/sqllogictest/cockroach/builtin_function.slt
+++ b/test/sqllogictest/cockroach/builtin_function.slt
@@ -107,16 +107,17 @@ SELECT quote_literal(b'abc'), quote_nullable(b'abc')
 ----
 e'\\x616263'  e'\\x616263'
 
-statement ok
-SET bytea_output = 'escape'
-
-query TT
-SELECT quote_literal(b'abc'), quote_nullable(b'abc')
-----
-'abc'  'abc'
-
-statement ok
-RESET bytea_output
+# TODO: Support bytea
+#statement ok
+#SET bytea_output = 'escape'
+#
+#query TT
+#SELECT quote_literal(b'abc'), quote_nullable(b'abc')
+#----
+#'abc'  'abc'
+#
+#statement ok
+#RESET bytea_output
 
 query T colnames
 SELECT upper('roacH7')


### PR DESCRIPTION
db error: ERROR: unrecognized configuration parameter "bytea_output": ERROR: unrecognized configuration parameter "bytea_output"

Seen in https://buildkite.com/materialize/sql-logic-tests/builds/5604

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
