### PR TITLE
webhooks: Drop persist shard when dropping webhook source

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2114,7 +2114,10 @@ fn webhook_concurrent_actions() {
         if status.is_success() {
             saw_atleast_one_success_after_close = true;
         }
-        assert!(status.is_success() || status == http::StatusCode::NOT_FOUND)
+        assert!(
+            status.is_success() || status == http::StatusCode::NOT_FOUND,
+            "found bad status {status:?}"
+        );
     }
     assert!(saw_atleast_one_success_after_close);
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -79,6 +79,7 @@ use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Write;
 use std::net::Ipv4Addr;
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std::{iter, thread};
@@ -1987,4 +1988,133 @@ fn test_http_metrics() {
     assert_eq!(failure_metric.get_counter().get_value(), 1.0);
     assert_eq!(failure_metric.get_label()[0].get_value(), "/api/sql");
     assert_eq!(failure_metric.get_label()[1].get_value(), "400");
+}
+
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // too slow
+fn webhook_concurrent_actions() {
+    let server = util::start_server(util::Config::default()).unwrap();
+    server.enable_feature_flags(&["enable_webhook_sources"]);
+
+    let mut client = server.connect(postgres::NoTls).unwrap();
+
+    #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
+    struct WebhookEvent {
+        ts: u128,
+        name: String,
+        thread: usize,
+    }
+
+    // Create a webhook source.
+    client
+        .execute(
+            "CREATE CLUSTER webhook_cluster REPLICAS (r1 (SIZE '1'));",
+            &[],
+        )
+        .expect("failed to create cluster");
+    client
+        .execute(
+            "CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON",
+            &[],
+        )
+        .expect("failed to create source");
+
+    let now = || {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos()
+    };
+
+    // Flag that lets us shutdown our threads.
+    let keep_sending = Arc::new(AtomicBool::new(true));
+    let success_count = Arc::new(AtomicUsize::new(0));
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    // Spin up a few threads that push a bunch of data to the webhook.
+    let posters: Vec<_> = (0..4)
+        .map(|thread_idx| {
+            let keep_sending_ = Arc::clone(&keep_sending);
+            let success_count_ = Arc::clone(&success_count);
+            let addr = server.inner.http_local_addr().clone();
+            let tx_ = tx.clone();
+
+            std::thread::spawn(move || {
+                let mut i = 0;
+
+                // Keep sending events until we're told to stop.
+                while keep_sending_.load(std::sync::atomic::Ordering::Relaxed) {
+                    let http_client = Client::new();
+                    let webhook_url = format!(
+                        "http://{}/api/webhook/materialize/public/webhook_json",
+                        addr,
+                    );
+
+                    // Create an event.
+                    let event = WebhookEvent {
+                        ts: now(),
+                        name: format!("event_{i}"),
+                        thread: thread_idx,
+                    };
+
+                    // Send all of our events to our webhook source.
+                    let resp = http_client
+                        .post(&webhook_url)
+                        .json(&event)
+                        .send()
+                        .expect("failed to POST event");
+                    tx_.send(resp.status()).expect("channel closed?");
+
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+
+                    // Incrament the count of how many successes we should see.
+                    success_count_.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    i += 1;
+                }
+            })
+        })
+        .collect();
+
+    // Let the posting threads run for a bit.
+    std::thread::sleep(std::time::Duration::from_secs(4));
+
+    // We should see at least this many successes.
+    let expected_success = success_count.load(std::sync::atomic::Ordering::Relaxed);
+    // Drop the source
+    client
+        .execute("DROP SOURCE webhook_json;", &[])
+        .expect("failed to drop source");
+
+    // Keep sending for a bit.
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    // Stop the threads.
+    keep_sending.store(false, std::sync::atomic::Ordering::Relaxed);
+    for handle in posters {
+        handle.join().expect("thread panicked!");
+    }
+    // Drop our sender, otherwise the channel will never complete?
+    drop(tx);
+
+    // Inspect the results.
+    let mut results = rx.into_iter();
+
+    // We should see at least "expected_success" number of successes, because this was the total
+    // count before we dropped the source.
+    for _ in 0..expected_success {
+        let status = results.next().expect("status to exist");
+        assert!(status.is_success())
+    }
+    // We should have seen at least 100 successes.
+    assert!(expected_success > 100);
+
+    // After we drop the source though, we should see a few successes followed by a bunch of
+    // NOT_FOUND.
+    let mut saw_atleast_one_success_after_close = false;
+    while let Some(status) = results.next() {
+        if status.is_success() {
+            saw_atleast_one_success_after_close = true;
+        }
+        assert!(status.is_success() || status == http::StatusCode::NOT_FOUND)
+    }
+    assert!(saw_atleast_one_success_after_close);
 }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -847,6 +847,8 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     /// The state for the storage controller.
     /// TODO(benesch): why is this a separate struct?
     state: StorageControllerState<T>,
+    /// Mechanism for finalizing shards of Webhook sources.
+    internal_response_sender: tokio::sync::mpsc::UnboundedSender<StorageResponse<T>>,
     /// Mechanism for returning frontier advancement for tables.
     internal_response_queue: tokio::sync::mpsc::UnboundedReceiver<StorageResponse<T>>,
     /// The persist location where all storage collections are being written to
@@ -1489,7 +1491,7 @@ where
                         "cannot have multiple IDs for introspection type"
                     );
 
-                    self.state.collection_manager.register_collection(id).await;
+                    self.state.collection_manager.register_collection(id);
 
                     match i {
                         IntrospectionType::ShardMapping => {
@@ -1541,7 +1543,7 @@ where
                 }
                 DataSource::Webhook => {
                     // Register the collection so our manager knows about it.
-                    self.state.collection_manager.register_collection(id).await;
+                    self.state.collection_manager.register_collection(id);
                 }
                 DataSource::Progress | DataSource::Other => {}
             }
@@ -2183,7 +2185,7 @@ where
                 let shards_to_finalize: Vec<_> = ids
                     .iter()
                     .filter_map(|id| {
-                        // Drop all write handles. This is safe to do because there will be nno more
+                        // Drop all write handles. This is safe to do because there will be no more
                         // data passed to the write handle. n.b. we do not need to drop the read
                         // handle because this code is only ever executed in response to dropping a
                         // collection, which downgrades the write handle to the empty anitchain,
@@ -2297,6 +2299,25 @@ where
                     id,
                     frontier.clone(),
                 )]));
+            }
+
+            // Check if the collection is for a Webhook source, unregister if so.
+            let collection = self.state.collections.get(&id);
+            if let Some(CollectionState { description, .. }) = collection {
+                if description.data_source == DataSource::Webhook && frontier.is_empty() {
+                    // Unregister our collection from the manager so writes should no longer occur.
+                    self.state.collection_manager.unregsiter_collection(id);
+                    // Wait for a barrier to assert that no work is in progress for the collection.
+                    self.state.collection_manager.barrier().await;
+
+                    pending_source_drops.push(id);
+                    // Normally `clusterd` will emit this StorageResponse when it knows we can
+                    // drop an ID, but since Webhook sources don't run on a cluster, we manually
+                    // emit this event here.
+                    let _ = self
+                        .internal_response_sender
+                        .send(StorageResponse::DroppedIds([id].into()));
+                }
             }
         }
 
@@ -2430,8 +2451,15 @@ where
 
         Self {
             build_info,
-            state: StorageControllerState::new(postgres_url, tx, now, postgres_factory, envd_epoch)
-                .await,
+            state: StorageControllerState::new(
+                postgres_url,
+                tx.clone(),
+                now,
+                postgres_factory,
+                envd_epoch,
+            )
+            .await,
+            internal_response_sender: tx,
             internal_response_queue: rx,
             persist_location,
             persist: persist_clients,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -847,8 +847,6 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     /// The state for the storage controller.
     /// TODO(benesch): why is this a separate struct?
     state: StorageControllerState<T>,
-    /// Mechanism for finalizing shards of Webhook sources.
-    internal_response_sender: tokio::sync::mpsc::UnboundedSender<StorageResponse<T>>,
     /// Mechanism for returning frontier advancement for tables.
     internal_response_queue: tokio::sync::mpsc::UnboundedReceiver<StorageResponse<T>>,
     /// The persist location where all storage collections are being written to
@@ -857,6 +855,12 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     persist: Arc<PersistClientCache>,
     /// Metrics of the Storage controller
     metrics: StorageControllerMetrics,
+    /// Mechanism for the storage controller to send itself feedback, potentially emulating the
+    /// responses we expect from clusters.
+    ///
+    /// Note: This is used for finalizing shards of webhook sources, once webhook sources are
+    /// installed on a `clusterd` this can likely be refactored away.
+    internal_response_sender: tokio::sync::mpsc::UnboundedSender<StorageResponse<T>>,
 }
 
 #[derive(Debug)]

--- a/src/storage-client/src/controller/collection_mgmt.rs
+++ b/src/storage-client/src/controller/collection_mgmt.rs
@@ -63,6 +63,10 @@ impl CollectionManager {
             oneshot::Sender<Result<(), StorageError>>,
         )>(256);
 
+        // Allows callers to wait until we finish any in-progress work.
+        //
+        // For example, after unregistering a collection a user might wait on a barrier to be sure
+        // any in-progress work with that collection has completed.
         let barrier: Arc<Mutex<Vec<oneshot::Sender<_>>>> = Arc::new(Mutex::new(Vec::new()));
         let barrier_outer = Arc::clone(&barrier);
 
@@ -233,6 +237,10 @@ impl CollectionManager {
     }
 
     /// Unregisters the collection as one that `CollectionManager` will maintain.
+    ///
+    /// Note: After unregistering a collection there could be in-progress work that started before
+    /// the call to unregister. Callers should obtain a `CollectionManager::barrier` and wait for
+    /// its completion before assuming we are no longer interacting with a collection.
     pub(super) fn unregsiter_collection(&self, id: GlobalId) -> bool {
         self.collections
             .lock()

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -194,6 +194,19 @@ ALTER SYSTEM SET enable_unstable_dependencies = true;
 $ webhook-append name=webhook_validation_panic status=503
 abc
 
+# Dropping a webhook source should drop the underlying persist shards.
+
+$ set-from-sql var=webhook-source-id
+SELECT id FROM mz_sources WHERE name = 'webhook_bytes';
+
+> SELECT COUNT(*) FROM mz_internal.mz_storage_shards WHERE object_id = '${webhook-source-id}';
+1
+
+> DROP SOURCE webhook_bytes;
+
+> SELECT COUNT(*) FROM mz_internal.mz_storage_shards WHERE object_id = '${webhook-source-id}';
+0
+
 # Turn off the feature.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_webhook_sources = false


### PR DESCRIPTION
### Motivation

The storage process(?) which runs on `clusterd` is responsible for finalizing(dropping?) shards after a source has been dropped. Because a webhook source is not installed on a cluster, something else in `environmentd` needs to do that work.

This PR updates the `process(...)` function in the storage controller to unregister a collection for a webhook source, when we'd otherwise send a compaction command to storage to compact away all shards. We then send the pre-existing `DroppedIds` command which handles finalizing the underlying shards.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
