### PR TITLE
adapter: teach emit_timestamp_notice to explain

### DIFF
--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -535,7 +535,7 @@ impl<T: TimestampManipulation> TimestampDetermination<T> {
 }
 
 /// Information used when determining the timestamp for a query.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TimestampExplanation<T> {
     /// The chosen timestamp from `determine_timestamp`.
     pub determination: TimestampDetermination<T>,
@@ -543,7 +543,7 @@ pub struct TimestampExplanation<T> {
     pub sources: Vec<TimestampSource<T>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TimestampSource<T> {
     pub name: String,
     pub read_frontier: Vec<T>,

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2402,14 +2402,14 @@ fn test_emit_timestamp_notice() {
         .unwrap();
     client.batch_execute("SELECT * FROM t").unwrap();
 
-    let timestamp_re = Regex::new("query timestamp: (.*)").unwrap();
+    let timestamp_re = Regex::new("query timestamp: *([0-9]+)").unwrap();
 
     // Wait until there's a query timestamp notice.
     let first_timestamp = Retry::default()
         .retry(|_| loop {
             match rx.try_next() {
                 Ok(Some(msg)) => {
-                    if let Some(caps) = timestamp_re.captures(msg.message()) {
+                    if let Some(caps) = timestamp_re.captures(msg.detail().unwrap_or_default()) {
                         let ts: u64 = caps.get(1).unwrap().as_str().parse().unwrap();
                         return Ok(mz_repr::Timestamp::from(ts));
                     }
@@ -2427,7 +2427,8 @@ fn test_emit_timestamp_notice() {
             loop {
                 match rx.try_next() {
                     Ok(Some(msg)) => {
-                        if let Some(caps) = timestamp_re.captures(msg.message()) {
+                        if let Some(caps) = timestamp_re.captures(msg.detail().unwrap_or_default())
+                        {
                             let ts: u64 = caps.get(1).unwrap().as_str().parse().unwrap();
                             let ts = mz_repr::Timestamp::from(ts);
                             if ts > first_timestamp {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -909,7 +909,7 @@ static EMIT_TIMESTAMP_NOTICE: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("emit_timestamp_notice"),
     value: &false,
     description:
-        "Boolean flag indicating whether to send a NOTICE specifying query timestamps (Materialize).",
+        "Boolean flag indicating whether to send a NOTICE with timestamp explanations of queries (Materialize).",
     internal: false
 };
 

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -36,7 +36,7 @@ statement_timeout                   "10 s"                  "Sets the maximum al
 idle_in_transaction_session_timeout "2 min"                 "Sets the maximum allowed duration that a session can sit idle in a transaction before being terminated. If this value is specified without units, it is taken as milliseconds. A value of zero disables the timeout (PostgreSQL)."
 TimeZone                            UTC                     "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
 transaction_isolation               "strict serializable"   "Sets the current transaction's isolation level (PostgreSQL)."
-emit_timestamp_notice               off                     "Boolean flag indicating whether to send a NOTICE specifying query timestamps (Materialize)."
+emit_timestamp_notice               off                     "Boolean flag indicating whether to send a NOTICE with timestamp explanations of queries (Materialize)."
 emit_trace_id_notice                off                     "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize)."
 auto_route_introspection_queries    on                      "Whether to force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize)."
 enable_session_rbac_checks          off                     "User facing session boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."


### PR DESCRIPTION
Enhance our existing timestamp query notice to provide the whole explanation in its detail.

See #19800

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a