### PR TITLE
tests: Fix "Full testdrive in cloudtest" by exposing port

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -38,6 +38,7 @@ from materialize.cloudtest.k8s import K8sService, K8sStatefulSet
 class EnvironmentdService(K8sService):
     def __init__(self) -> None:
         service_port = V1ServicePort(name="sql", port=6875)
+        http_port = V1ServicePort(name="http", port=6876)
         internal_port = V1ServicePort(name="internal", port=6877)
         self.service = V1Service(
             api_version="v1",
@@ -45,7 +46,7 @@ class EnvironmentdService(K8sService):
             metadata=V1ObjectMeta(name="environmentd", labels={"app": "environmentd"}),
             spec=V1ServiceSpec(
                 type="NodePort",
-                ports=[service_port, internal_port],
+                ports=[service_port, internal_port, http_port],
                 selector={"app": "environmentd"},
             ),
         )


### PR DESCRIPTION
### Motivation

This fixes "Full Testdrive in Cloudtest (K8s)" of https://buildkite.com/materialize/nightlies/builds/2791#0189474c-9769-4576-aeb0-1bcfc3775cd5

### Nightly

https://buildkite.com/materialize/nightlies/builds/2795#01894957-f4d6-45c3-80d4-03ac0cabc4e6 🟢  🎉 