### PR TITLE
Fix definitions of "reachability" recursive queries

### DIFF
--- a/doc/user/content/sql/recursive-ctes.md
+++ b/doc/user/content/sql/recursive-ctes.md
@@ -110,11 +110,11 @@ INSERT INTO users VALUES
   ('C', 2, 'Carol'),
   ('D', 5, 'Dan');
 INSERT INTO transfers VALUES
-  ('B', 'C', 20.0 , now() + '10 seconds'),
-  ('A', 'D', 15.0 , now() + '20 seconds'),
-  ('C', 'D', 25.0 , now() + '30 seconds'),
-  ('A', 'B', 10.0 , now() + '40 seconds'),
-  ('C', 'A', 35.0 , now() + '50 seconds');
+  ('B', 'C', 20.0 , now()),
+  ('A', 'D', 15.0 , now() + '05 seconds'),
+  ('C', 'D', 25.0 , now() + '10 seconds'),
+  ('A', 'B', 10.0 , now() + '15 seconds'),
+  ('C', 'A', 35.0 , now() + '20 seconds');
 ```
 
 ### Transitive closure
@@ -128,8 +128,6 @@ CREATE MATERIALIZED VIEW connected AS
 WITH MUTUALLY RECURSIVE
   connected(src_id char(1), dst_id char(1)) AS (
     SELECT DISTINCT src_id, tgt_id FROM transfers WHERE mz_now() <= ts + interval '10s'
-    UNION
-    SELECT src_id, dst_id FROM connected
     UNION
     SELECT c1.src_id, c2.dst_id FROM connected c1 JOIN connected c2 ON c1.dst_id = c2.src_id
   )

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -167,9 +167,9 @@ all database objects in the system.
 
 ### `mz_object_transitive_dependencies`
 
-The `mz_object_transitive_dependencies` table describes the transitive dependency structure between
+The `mz_object_transitive_dependencies` view describes the transitive dependency structure between
 all database objects in the system.
-This table is the transitive closure of [`mz_object_dependencies`](#mz_object_dependencies).
+The view is defined as the transitive closure of [`mz_object_dependencies`](#mz_object_dependencies).
 
 | Field                   | Type         | Meaning                                                                                                               |
 | ----------------------- | ------------ | --------                                                                                                              |

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2129,17 +2129,12 @@ pub const MZ_OBJECT_TRANSITIVE_DEPENDENCIES: BuiltinView = BuiltinView {
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE VIEW mz_internal.mz_object_transitive_dependencies AS
 WITH MUTUALLY RECURSIVE
-  base(id text, referenced_object_id text) AS (
+  reach(object_id text, referenced_object_id text) AS (
     SELECT object_id, referenced_object_id FROM mz_internal.mz_object_dependencies
-  ),
-  reach(id text, referenced_object_id text) AS (
-    SELECT id, referenced_object_id FROM base
-    UNION ALL -- (TODO use UNION once #19817 is fixed)
-    SELECT id, referenced_object_id FROM reach
     UNION
-    SELECT r1.id, r2.referenced_object_id FROM reach r1 JOIN reach r2 ON r1.referenced_object_id = r2.id
+    SELECT x, z FROM reach r1(x, y) JOIN reach r2(y, z) USING(y)
   )
-SELECT id, referenced_object_id FROM reach;",
+SELECT object_id, referenced_object_id FROM reach;",
 };
 
 pub const MZ_COMPUTE_EXPORTS: BuiltinView = BuiltinView {


### PR DESCRIPTION
As highlighted by @frankmcsherry, the reachability definition that we use in the WMR reference docs and in the `mz_object_transitive_dependencies` is a bit too complicated (one of the `UNION` branches is not needed).

### Motivation

  * This PR adds a feature that has not yet been specified.

The reachability definition that we use in the WMR reference doc examples and in `mz_object_transitive_dependencies` can be simplified. In addition, tweak the docs a bit to make them simpler / more accurate.

### Tips for reviewer

* The first commit can be reviewed by @RobinClowers (these are the changes requested by you).
* For the removal of the `UNION` branch I'm tagging @umanwizard.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
