### PR TITLE
[persist] Restore Blob state based on the contents of Consensus

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -529,6 +529,17 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: source-sink-errors
 
+  - id: backup-restore
+    label: "CRDB / Persist backup and restore"
+    artifact_paths: junit_*.xml
+    depends_on: build-x86_64
+    timeout_in_minutes: 10
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: backup-restore
+
   - id: feature-benchmark-kafka-only
     label: "Feature benchmark (Kafka only)"
     depends_on: build-x86_64

--- a/misc/images/jobs/.gitignore
+++ b/misc/images/jobs/.gitignore
@@ -1,1 +1,2 @@
 /persistcli
+/mz-stash-debug

--- a/misc/python/materialize/mzcompose/services/minio.py
+++ b/misc/python/materialize/mzcompose/services/minio.py
@@ -47,3 +47,19 @@ class Minio(Service):
                 },
             },
         )
+
+
+class Mc(Service):
+    def __init__(
+        self,
+        name: str = "mc",
+        image: str = "minio/mc:RELEASE.2023-07-07T05-25-51Z",
+    ) -> None:
+        super().__init__(
+            name=name,
+            config={
+                "image": image,
+                "volumes": ["../../mzdata/mc:/root/.mc"],
+                "depends_on": {"minio": {"condition": "service_started"}},
+            },
+        )

--- a/misc/python/materialize/mzcompose/services/minio.py
+++ b/misc/python/materialize/mzcompose/services/minio.py
@@ -59,7 +59,5 @@ class Mc(Service):
             name=name,
             config={
                 "image": image,
-                "volumes": ["../../mzdata/mc:/root/.mc"],
-                "depends_on": {"minio": {"condition": "service_started"}},
             },
         )

--- a/src/persist-cli/src/maelstrom/services.rs
+++ b/src/persist-cli/src/maelstrom/services.rs
@@ -88,6 +88,10 @@ impl MaelstromConsensus {
 
 #[async_trait]
 impl Consensus for MaelstromConsensus {
+    async fn list_keys(&self) -> Result<Vec<String>, ExternalError> {
+        unimplemented!("TODO")
+    }
+
     async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError> {
         let value = match self
             .handle

--- a/src/persist-cli/src/maelstrom/services.rs
+++ b/src/persist-cli/src/maelstrom/services.rs
@@ -17,7 +17,8 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use mz_ore::bytes::SegmentedBytes;
 use mz_persist::location::{
-    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, ExternalError, SeqNo, VersionedData,
+    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, Determinate, ExternalError, SeqNo,
+    VersionedData,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -224,6 +225,20 @@ impl Blob for MaelstromBlob {
         // it's okay if its wrong in Maelstrom.
         Ok(Some(0))
     }
+
+    async fn restore(&self, key: &str) -> Result<(), ExternalError> {
+        let read = self
+            .handle
+            .lin_kv_read(Value::from(format!("blob/{}", key)))
+            .await
+            .map_err(anyhow::Error::new)?;
+        if read.is_none() {
+            return Err(
+                Determinate::new(anyhow!("key {key} not present in the maelstrom store")).into(),
+            );
+        }
+        Ok(())
+    }
 }
 
 /// Implementation of [Blob] that caches get calls.
@@ -288,6 +303,10 @@ impl Blob for CachingBlob {
     async fn delete(&self, key: &str) -> Result<Option<usize>, ExternalError> {
         self.cache.lock().await.remove(key);
         self.blob.delete(key).await
+    }
+
+    async fn restore(&self, key: &str) -> Result<(), ExternalError> {
+        self.blob.restore(key).await
     }
 }
 

--- a/src/persist-cli/src/maelstrom/services.rs
+++ b/src/persist-cli/src/maelstrom/services.rs
@@ -17,8 +17,8 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use mz_ore::bytes::SegmentedBytes;
 use mz_persist::location::{
-    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, Determinate, ExternalError, SeqNo,
-    VersionedData,
+    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, Determinate, ExternalError, ResultStream,
+    SeqNo, VersionedData,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -88,7 +88,7 @@ impl MaelstromConsensus {
 
 #[async_trait]
 impl Consensus for MaelstromConsensus {
-    async fn list_keys(&self) -> Result<Vec<String>, ExternalError> {
+    fn list_keys(&self) -> ResultStream<String> {
         unimplemented!("TODO")
     }
 

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -314,6 +314,11 @@ impl Blob for ReadOnly<Arc<dyn Blob + Sync + Send>> {
         warn!("ignoring delete({key}) in read-only mode");
         Ok(None)
     }
+
+    async fn restore(&self, key: &str) -> Result<(), ExternalError> {
+        warn!("ignoring restore({key}) in read-only mode");
+        Ok(())
+    }
 }
 
 #[async_trait]

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -323,6 +323,10 @@ impl Blob for ReadOnly<Arc<dyn Blob + Sync + Send>> {
 
 #[async_trait]
 impl Consensus for ReadOnly<Arc<dyn Consensus + Sync + Send>> {
+    async fn list_keys(&self) -> Result<Vec<String>, ExternalError> {
+        self.0.list_keys().await
+    }
+
     async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError> {
         self.0.head(key).await
     }

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -185,6 +185,36 @@ pub struct StateRollupArgs {
     pub(crate) rollup_key: Option<String>,
 }
 
+/// Arguments for commands that work over both backing stores.
+/// TODO: squish this into `StateArgs`.
+#[derive(Debug, Clone, clap::Parser)]
+pub struct StoreArgs {
+    /// Consensus to use.
+    ///
+    /// When connecting to a deployed environment's consensus table, the Postgres/CRDB connection
+    /// string must contain the database name and `options=--search_path=consensus`.
+    ///
+    /// When connecting to Cockroach Cloud, use the following format:
+    ///
+    /// ```text
+    /// postgresql://<user>:$COCKROACH_PW@<hostname>:<port>/environment_<environment-id>
+    ///   ?sslmode=verify-full
+    ///   &sslrootcert=/path/to/cockroach-cloud/certs/cluster-ca.crt
+    ///   &options=--search_path=consensus
+    /// ```
+    ///
+    #[clap(long, verbatim_doc_comment, env = "CONSENSUS_URI")]
+    pub(crate) consensus_uri: String,
+
+    /// Blob to use
+    ///
+    /// When connecting to a deployed environment's blob, the necessary connection glue must be in
+    /// place. e.g. for S3, sign into SSO, set AWS_PROFILE and AWS_REGION appropriately, with a blob
+    /// URI scoped to the environment's bucket prefix.
+    #[clap(long, env = "BLOB_URI")]
+    pub(crate) blob_uri: String,
+}
+
 /// Arguments for viewing the current state of a given shard
 #[derive(Debug, Clone, clap::Parser)]
 pub struct StateArgs {

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -199,6 +199,7 @@ mod tests {
                             "blob-scan-batches" => {
                                 machine_dd::blob_scan_batches(&state, args).await
                             }
+                            "clear-blob" => machine_dd::clear_blob(&mut state, args).await,
                             "compact" => machine_dd::compact(&mut state, args).await,
                             "compare-and-append" => {
                                 machine_dd::compare_and_append(&mut state, args).await
@@ -241,6 +242,7 @@ mod tests {
                             "register-leased-reader" => {
                                 machine_dd::register_leased_reader(&mut state, args).await
                             }
+                            "restore-blob" => machine_dd::restore_blob(&mut state, args).await,
                             "set-batch-parts-size" => {
                                 machine_dd::set_batch_parts_size(&mut state, args).await
                             }

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -471,6 +471,7 @@ impl MetricsVecs {
             get: self.external_op_metrics("blob_get", true),
             list_keys: self.external_op_metrics("blob_list_keys", false),
             delete: self.external_op_metrics("blob_delete", false),
+            restore: self.external_op_metrics("restore", false),
             delete_noop: self.external_blob_delete_noop_count.clone(),
             blob_sizes: self.external_blob_sizes.clone(),
             rtt_latency: self.external_rtt_latency.with_label_values(&["blob"]),
@@ -2139,6 +2140,7 @@ pub struct BlobMetrics {
     get: ExternalOpMetrics,
     list_keys: ExternalOpMetrics,
     delete: ExternalOpMetrics,
+    restore: ExternalOpMetrics,
     delete_noop: IntCounter,
     blob_sizes: Histogram,
     pub rtt_latency: Gauge,
@@ -2249,8 +2251,11 @@ impl Blob for MetricsBlob {
     }
 
     async fn restore(&self, key: &str) -> Result<(), ExternalError> {
-        // TODO: metrics!
-        self.blob.restore(key).await
+        self.metrics
+            .blob
+            .restore
+            .run_op(|| self.blob.restore(key), Self::on_err)
+            .await
     }
 }
 

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -2208,6 +2208,11 @@ impl Blob for MetricsBlob {
         }
         Ok(bytes)
     }
+
+    async fn restore(&self, key: &str) -> Result<(), ExternalError> {
+        // TODO: metrics!
+        self.blob.restore(key).await
+    }
 }
 
 #[derive(Debug)]

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -2248,6 +2248,11 @@ impl MetricsConsensus {
 
 #[async_trait]
 impl Consensus for MetricsConsensus {
+    async fn list_keys(&self) -> Result<Vec<String>, ExternalError> {
+        // TODO: metrics!
+        self.consensus.list_keys().await
+    }
+
     #[instrument(name = "consensus::head", skip_all, fields(shard=key))]
     async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError> {
         let res = self

--- a/src/persist-client/src/internal/restore.rs
+++ b/src/persist-client/src/internal/restore.rs
@@ -1,0 +1,98 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! See documentation on [[restore_blob]].
+
+use crate::internal::encoding::UntypedState;
+use crate::internal::paths::BlobKey;
+use crate::internal::state::State;
+use crate::internal::state_diff::{StateDiff, StateFieldValDiff};
+use crate::internal::state_versions::StateVersions;
+use crate::ShardId;
+use anyhow::anyhow;
+use mz_persist::location::Blob;
+use tracing::info;
+
+/// Attempt to restore all the blobs referenced by the current state in consensus.
+/// Returns a list of blobs that were not possible to restore.
+pub(crate) async fn restore_blob(
+    versions: &StateVersions,
+    blob: &(dyn Blob + Send + Sync),
+    build_version: &semver::Version,
+    shard_id: ShardId,
+) -> anyhow::Result<Vec<BlobKey>> {
+    let diffs = versions.fetch_all_live_diffs(&shard_id).await;
+    let Some(first_live_seqno) = diffs.0.first().map(|d| d.seqno) else {
+        info!("No diffs for shard {shard_id}.");
+        return Ok(vec![]);
+    };
+
+    fn after<A>(diff: StateFieldValDiff<A>) -> Option<A> {
+        match diff {
+            StateFieldValDiff::Insert(a) => Some(a),
+            StateFieldValDiff::Update(_, a) => Some(a),
+            StateFieldValDiff::Delete(_) => None,
+        }
+    }
+
+    let mut not_restored = vec![];
+    let mut check_restored = |key: &BlobKey, result: Result<(), _>| {
+        if result.is_err() {
+            not_restored.push(key.clone());
+        }
+    };
+
+    for diff in diffs.0 {
+        let diff: StateDiff<u64> = StateDiff::decode(build_version, diff.data);
+        for rollup in diff.rollups {
+            // We never actually reference rollups from before the first live diff.
+            if rollup.key < first_live_seqno {
+                continue;
+            }
+            if let Some(value) = after(rollup.val) {
+                let key = value.key.complete(&shard_id);
+                check_restored(&key, blob.restore(&key).await);
+                // Elsewhere, we restore any state referenced in live diffs... but we also
+                // need to restore everything referenced in that first rollup.
+                if rollup.key != first_live_seqno {
+                    continue;
+                }
+                let rollup_bytes = blob
+                    .get(&key)
+                    .await?
+                    .ok_or_else(|| anyhow!("fetching just-restored rollup"))?;
+                let rollup_state: State<u64> =
+                    UntypedState::decode(build_version, rollup_bytes).check_ts_codec(&shard_id)?;
+                for (seqno, rollup) in &rollup_state.collections.rollups {
+                    // We never actually reference rollups from before the first live diff.
+                    if *seqno < first_live_seqno {
+                        continue;
+                    }
+                    let key = rollup.key.complete(&shard_id);
+                    check_restored(&key, blob.restore(&key).await);
+                }
+                for batch in rollup_state.collections.trace.batches() {
+                    for part in &batch.parts {
+                        let key = part.key.complete(&shard_id);
+                        check_restored(&key, blob.restore(&key).await);
+                    }
+                }
+            }
+        }
+        for batch in diff.spine {
+            if let Some(_) = after(batch.val) {
+                for part in batch.key.parts {
+                    let key = part.key.complete(&shard_id);
+                    check_restored(&key, blob.restore(&key).await);
+                }
+            }
+        }
+    }
+    Ok(not_restored)
+}

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -157,6 +157,7 @@ mod internal {
     pub mod maintenance;
     pub mod metrics;
     pub mod paths;
+    pub mod restore;
     pub mod service;
     pub mod state;
     pub mod state_diff;

--- a/src/persist-client/tests/machine/restore_blob
+++ b/src/persist-client/tests/machine/restore_blob
@@ -1,0 +1,123 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+# Pre-populate some non-trivial state in our shard.
+
+write-batch output=b0 lower=0 upper=1
+k1 0 1
+----
+parts=1 len=1
+
+write-batch output=b1 lower=1 upper=2
+k2 1 -1
+k3 1 1
+----
+parts=1 len=2
+
+write-batch output=b2 lower=2 upper=3
+k3 2 -1
+k4 2 1
+----
+parts=1 len=2
+
+compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v2 [1]
+
+compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v3 [2]
+
+write-rollup output=v3
+----
+state=v3 diffs=[v2, v4)
+
+compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v4 [3]
+
+write-rollup output=v4
+----
+state=v4 diffs=[v2, v5)
+
+# write a bunch of rollups to verify GC bounds
+add-rollup input=v3
+----
+v5
+
+write-rollup output=v5
+----
+state=v5 diffs=[v4, v6)
+
+add-rollup input=v4
+----
+v6
+
+add-rollup input=v5
+----
+v7
+
+consensus-scan from_seqno=v1
+----
+seqno=v1 batches= rollups=v1
+seqno=v2 batches=b0 rollups=v1
+seqno=v3 batches=b0,b1 rollups=v1
+seqno=v4 batches=b0,b1,b2 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1,v3
+seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
+
+gc to_seqno=v3
+----
+v8 batch_parts=0 rollups=0 truncated=v3 state_rollups=v1
+
+consensus-scan from_seqno=v1
+----
+seqno=v3 batches=b0,b1 rollups=v1
+seqno=v4 batches=b0,b1,b2 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1,v3
+seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
+seqno=v8 batches=b0,b1,b2 rollups=v3,v4,v5
+
+# Delete our state
+clear-blob
+----
+deleted=7
+
+restore-blob
+----
+<empty>
+
+consensus-scan from_seqno=v1
+----
+seqno=v3 batches=b0,b1 rollups=v1
+seqno=v4 batches=b0,b1,b2 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1,v3
+seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
+seqno=v8 batches=b0,b1,b2 rollups=v3,v4,v5
+
+snapshot as_of=2
+----
+<batch [0]-[1]>
+<run 0>
+<part 0>
+k1 2 1
+<batch [1]-[2]>
+<run 0>
+<part 0>
+k2 2 -1
+k3 2 1
+<batch [2]-[3]>
+<run 0>
+<part 0>
+k3 2 -1
+k4 2 1

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -72,7 +72,10 @@ impl BlobConfig {
 
         let config = match url.scheme() {
             "file" => {
-                let config = FileBlobConfig::from(url.path());
+                let mut config = FileBlobConfig::from(url.path());
+                if query_params.remove("tombstone").is_some() {
+                    config.tombstone = true;
+                }
                 Ok(BlobConfig::File(config))
             }
             "s3" => {

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -14,13 +14,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::anyhow;
-use mz_postgres_client::metrics::PostgresClientMetrics;
-use mz_postgres_client::PostgresClientKnobs;
 use tracing::warn;
 use url::Url;
 
+use mz_postgres_client::metrics::PostgresClientMetrics;
+use mz_postgres_client::PostgresClientKnobs;
+
 use crate::file::{FileBlob, FileBlobConfig};
-use crate::location::{Blob, Consensus, ExternalError};
+use crate::location::{Blob, Consensus, Determinate, ExternalError};
 use crate::mem::{MemBlob, MemBlobConfig, MemConsensus};
 use crate::metrics::S3BlobMetrics;
 use crate::postgres::{PostgresConsensus, PostgresConsensusConfig};
@@ -35,7 +36,7 @@ pub enum BlobConfig {
     S3(S3BlobConfig),
     /// Config for [MemBlob], only available in testing to prevent
     /// footguns.
-    Mem,
+    Mem(bool),
 }
 
 /// Configuration knobs for [Blob].
@@ -56,7 +57,9 @@ impl BlobConfig {
         match self {
             BlobConfig::File(config) => Ok(Arc::new(FileBlob::open(config).await?)),
             BlobConfig::S3(config) => Ok(Arc::new(S3Blob::open(config).await?)),
-            BlobConfig::Mem => Ok(Arc::new(MemBlob::open(MemBlobConfig::default()))),
+            BlobConfig::Mem(tombstone) => {
+                Ok(Arc::new(MemBlob::open(MemBlobConfig::new(tombstone))))
+            }
         }
     }
 
@@ -115,8 +118,15 @@ impl BlobConfig {
                 if !cfg!(debug_assertions) {
                     warn!("persist unexpectedly using in-mem blob in a release binary");
                 }
+                let tombstone = match query_params.remove("tombstone").as_deref() {
+                    None | Some("true") => true,
+                    Some("false") => false,
+                    Some(other) => Err(Determinate::new(anyhow!(
+                        "invalid tombstone param value: {other}"
+                    )))?,
+                };
                 query_params.clear();
-                Ok(BlobConfig::Mem)
+                Ok(BlobConfig::Mem(tombstone))
             }
             p => Err(anyhow!(
                 "unknown persist blob scheme {}: {}",

--- a/src/persist/src/intercept.rs
+++ b/src/persist/src/intercept.rs
@@ -107,4 +107,8 @@ impl Blob for InterceptBlob {
             None => ret,
         }
     }
+
+    async fn restore(&self, key: &str) -> Result<(), ExternalError> {
+        self.blob.restore(key).await
+    }
 }

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -153,6 +153,8 @@ impl Blob for MemBlob {
     }
 
     async fn restore(&self, key: &str) -> Result<(), ExternalError> {
+        // Yield to maximize our chances for getting interesting orderings.
+        let () = yield_now().await;
         if !self.core.lock().await.dataz.contains_key(key) {
             return Err(
                 Determinate::new(anyhow!("unable to restore {key} from in-memory state")).into(),

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -199,6 +199,13 @@ impl MemConsensus {
 
 #[async_trait]
 impl Consensus for MemConsensus {
+    async fn list_keys(&self) -> Result<Vec<String>, ExternalError> {
+        // Yield to maximize our chances for getting interesting orderings.
+        let () = yield_now().await;
+        let store = self.data.lock().map_err(Error::from)?;
+        Ok(store.keys().cloned().collect())
+    }
+
     async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError> {
         // Yield to maximize our chances for getting interesting orderings.
         let () = yield_now().await;

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -136,6 +136,18 @@ pub struct MemBlobConfig {
     core: Arc<tokio::sync::Mutex<MemBlobCore>>,
 }
 
+impl MemBlobConfig {
+    /// Create a new instance.
+    pub fn new(tombstone: bool) -> Self {
+        Self {
+            core: Arc::new(tokio::sync::Mutex::new(MemBlobCore {
+                dataz: Default::default(),
+                tombstone,
+            })),
+        }
+    }
+}
+
 /// An in-memory implementation of [Blob].
 #[derive(Debug)]
 pub struct MemBlob {

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -166,6 +166,12 @@ impl Blob for UnreliableBlob {
     async fn delete(&self, key: &str) -> Result<Option<usize>, ExternalError> {
         self.handle.run_op("delete", || self.blob.delete(key)).await
     }
+
+    async fn restore(&self, key: &str) -> Result<(), ExternalError> {
+        self.handle
+            .run_op("restore", || self.blob.restore(key))
+            .await
+    }
 }
 
 /// An unreliable delegate to [Consensus].

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -190,6 +190,12 @@ impl UnreliableConsensus {
 
 #[async_trait]
 impl Consensus for UnreliableConsensus {
+    async fn list_keys(&self) -> Result<Vec<String>, ExternalError> {
+        self.handle
+            .run_op("list_keys", || self.consensus.list_keys())
+            .await
+    }
+
     async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError> {
         self.handle
             .run_op("head", || self.consensus.head(key))

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -22,8 +22,8 @@ use rand::{Rng, SeedableRng};
 use tracing::trace;
 
 use crate::location::{
-    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, Determinate, ExternalError, SeqNo,
-    VersionedData,
+    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, Determinate, ExternalError, ResultStream,
+    SeqNo, VersionedData,
 };
 
 #[derive(Debug)]
@@ -190,10 +190,9 @@ impl UnreliableConsensus {
 
 #[async_trait]
 impl Consensus for UnreliableConsensus {
-    async fn list_keys(&self) -> Result<Vec<String>, ExternalError> {
-        self.handle
-            .run_op("list_keys", || self.consensus.list_keys())
-            .await
+    fn list_keys(&self) -> ResultStream<String> {
+        // TODO: run_op for streams
+        self.consensus.list_keys()
     }
 
     async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError> {

--- a/test/backup-restore/mzcompose
+++ b/test/backup-restore/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/backup-restore/mzcompose.py
+++ b/test/backup-restore/mzcompose.py
@@ -36,7 +36,9 @@ def workflow_default(c: Composition) -> None:
 
     # Enable versioning for the Persist bucket
     c.up("minio")
-    c.run(
+    c.up("mc", persistent=True)
+    c.exec(
+        "mc",
         "mc",
         "alias",
         "set",
@@ -45,12 +47,12 @@ def workflow_default(c: Composition) -> None:
         "minioadmin",
         "minioadmin",
     )
-    c.run("mc", "version", "enable", "persist/persist")
+    c.exec("mc", "mc", "version", "enable", "persist/persist")
     blob_uri = "s3://minioadmin:minioadmin@persist/persist?endpoint=http://minio:9000/&region=minio"
 
     # Set up a backupable connection for CRDB
     c.up("cockroach")
-    c.run("mc", "mb", "persist/crdb-backup")
+    c.exec("mc", "mc", "mb", "persist/crdb-backup")
     c.exec(
         "cockroach",
         "cockroach",

--- a/test/backup-restore/mzcompose.py
+++ b/test/backup-restore/mzcompose.py
@@ -1,0 +1,162 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.service import Service
+from materialize.mzcompose.services.cockroach import Cockroach
+from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.minio import Mc, Minio
+from materialize.mzcompose.services.testdrive import Testdrive
+
+SERVICES = [
+    Cockroach(setup_materialize=True),
+    Minio(setup_materialize=True),
+    Mc(),
+    Materialized(external_minio=True, external_cockroach=True, sanity_restart=False),
+    Testdrive(no_reset=True),
+    Service(
+        name="persistcli",
+        config={
+            # TODO: depends!
+            "mzbuild": "jobs"
+        },
+    ),
+]
+
+
+def workflow_default(c: Composition) -> None:
+    # TODO: extract common substrings
+
+    # Enable versioning for the Persist bucket
+    c.up("minio")
+    c.run(
+        "mc",
+        "alias",
+        "set",
+        "persist",
+        "http://minio:9000/",
+        "minioadmin",
+        "minioadmin",
+    )
+    c.run("mc", "version", "enable", "persist/persist")
+    blob_uri = "s3://minioadmin:minioadmin@persist/persist?endpoint=http://minio:9000/&region=minio"
+
+    # Set up a backupable connection for CRDB
+    c.up("cockroach")
+    c.run("mc", "mb", "persist/crdb-backup")
+    c.exec(
+        "cockroach",
+        "cockroach",
+        "sql",
+        "--insecure",
+        "-e",
+        "CREATE EXTERNAL CONNECTION backup_bucket as "
+        "'s3://persist/crdb-backup?AWS_ENDPOINT=http://minio:9000/&AWS_REGION=minio&"
+        "AWS_ACCESS_KEY_ID=minioadmin&AWS_SECRET_ACCESS_KEY=minioadmin';"
+        "SHOW CREATE ALL EXTERNAL CONNECTIONS;",
+    )
+
+    # Start Materialize, and set up some basic state in it
+    c.up("materialized")
+    c.up("testdrive", persistent=True)
+    c.testdrive(
+        dedent(
+            """
+                > DROP TABLE IF EXISTS numbers;
+                > CREATE TABLE IF NOT EXISTS numbers (id BIGINT);
+                > INSERT INTO numbers SELECT * from generate_series(1, 1);
+                > INSERT INTO numbers SELECT * from generate_series(1, 10);
+                > INSERT INTO numbers SELECT * from generate_series(1, 100);
+                """
+        )
+    )
+
+    # Run a manual CRDB backup
+    c.exec(
+        "cockroach",
+        "cockroach",
+        "sql",
+        "--insecure",
+        "-e",
+        "BACKUP INTO 'external://backup_bucket';",
+    )
+    c.exec(
+        "cockroach",
+        "cockroach",
+        "sql",
+        "--insecure",
+        "-e",
+        "SHOW BACKUPS IN 'external://backup_bucket';",
+    )
+
+    # Make further updates to Materialize's state
+    for i in range(0, 100):
+        # TODO: This seems to be enough to produce interesting shard state;
+        # ie. if we remove the restore-blob step we can see the restore fail.
+        # Is there any cheaper or more obvious way to do that?
+        c.testdrive(
+            dedent(
+                """
+                    > INSERT INTO numbers SELECT * from generate_series(1, 1);
+                    > INSERT INTO numbers SELECT * from generate_series(1, 10);
+                    > INSERT INTO numbers SELECT * from generate_series(1, 100);
+                    """
+            )
+        )
+
+    # Stop the running cluster and execute a restore
+    c.kill(
+        "materialized"
+    )  # Very important that MZ is not running during the restore process!
+    c.exec(
+        "cockroach", "cockroach", "sql", "--insecure", "-e", "DROP DATABASE defaultdb;"
+    )
+    c.exec(
+        "cockroach",
+        "cockroach",
+        "sql",
+        "--insecure",
+        "-e",
+        "RESTORE DATABASE defaultdb FROM LATEST IN 'external://backup_bucket';",
+    )
+
+    # Confirm that the database is readable / has shard data
+    c.exec(
+        "cockroach",
+        "cockroach",
+        "sql",
+        "--insecure",
+        "-e",
+        "SELECT shard, min(sequence_number), max(sequence_number) "
+        "FROM consensus.consensus GROUP BY 1 ORDER BY 2 DESC, 3 DESC, 1 ASC LIMIT 32;",
+    )
+
+    # Bring the persist state back into sync
+    c.run(
+        "persistcli",
+        "admin",
+        "--commit",
+        "restore-blob",
+        f"--blob-uri={blob_uri}",
+        "--consensus-uri=postgres://root@cockroach:26257?options=--search_path=consensus",
+    )
+
+    # Restart Materialize
+    c.up("materialized")
+
+    # Check that the cluster is up and that it answers queries as of the old state
+    c.testdrive(
+        dedent(
+            """
+                > SELECT count(*) FROM numbers;
+                111
+                """
+        )
+    )


### PR DESCRIPTION
Persist state is a mix of stuff in CRDB and stuff in S3. This complicates restoring from backup: if we restore CRDB to an old state, the blobs it references might be deleted.

It's possible to "undelete" deleted blobs in S3 by deleting a delete marker from an unversioned bucket. This PR implements that logic as a CLI tool, and implements a basic test that restores a CRDB state and checks that the database is in the expected state after the CLI runs.

### Motivation

See #18157 for the design.

### Tips for reviewer

One subtlety here is that we can't rely on the usual state iterators, since those rely on the existence of rollups, which may not exist yet. The current draft just iterates over the diffs manually.

I have not yet tested this tool against a real environment. I will probably wait for at least a first pass of code review first!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
