### PR TITLE
rbac: Add item usage privileges to CREATE SINK

### DIFF
--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -653,6 +653,11 @@ fn generate_required_privileges(
                 AclMode::CREATE,
                 role_id,
             )];
+            privileges.extend(generate_item_usage_privileges(
+                catalog,
+                resolved_ids,
+                role_id,
+            ));
             privileges.extend_from_slice(&generate_read_privileges(
                 catalog,
                 iter::once(sink.from),

--- a/test/testdrive/privilege_checks.td
+++ b/test/testdrive/privilege_checks.td
@@ -28,6 +28,10 @@ REVOKE ALL PRIVILEGES ON DATABASE materialize FROM materialize;
 REVOKE ALL PRIVILEGES ON CLUSTER default FROM materialize;
 REVOKE ALL PRIVILEGES ON SYSTEM FROM materialize;
 
+# CREATE SINK
+
+## WITH SIZE
+
 ! CREATE SINK s FROM t
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
@@ -37,6 +41,26 @@ contains:permission denied for SCHEMA "materialize.public"
 
 $ postgres-execute connection=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO materialize;
+
+! CREATE SINK s FROM t
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+  WITH (SIZE '1')
+contains:permission denied for CONNECTION "materialize.public.kafka_conn"
+
+$ postgres-execute connection=mz_system
+GRANT USAGE ON CONNECTION kafka_conn TO materialize;
+
+! CREATE SINK s FROM t
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+  WITH (SIZE '1')
+contains:permission denied for CONNECTION "materialize.public.csr_conn"
+
+$ postgres-execute connection=mz_system
+GRANT USAGE ON CONNECTION csr_conn TO materialize;
 
 ! CREATE SINK s FROM t
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
@@ -87,6 +111,8 @@ contains:permission denied for SCHEMA "materialize.public"
 $ postgres-execute connection=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO materialize;
 
+## IN CLUSTER
+
 $ postgres-execute connection=mz_system
 CREATE CLUSTER sink_cluster REPLICAS (r1 (SIZE '1'));
 
@@ -106,14 +132,155 @@ GRANT CREATE ON CLUSTER sink_cluster TO materialize;
 
 $ postgres-execute connection=mz_system
 REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM materialize;
+REVOKE USAGE ON CONNECTION kafka_conn, csr_conn FROM materialize;
 REVOKE SELECT ON TABLE t FROM materialize;
 REVOKE CREATECLUSTER ON SYSTEM FROM materialize;
 REVOKE CREATE ON CLUSTER sink_cluster FROM materialize;
 DROP SINK s;
 DROP SINK s1;
 DROP TABLE t;
+DROP CLUSTER sink_cluster;
+
+# CREATE CONNECTION
+
+$ postgres-execute connection=mz_system
+CREATE SECRET confluent_username AS 'materialize';
+CREATE SECRET confluent_password AS 'password';
+
+! CREATE CONNECTION conn TO KAFKA (
+      BROKER '${testdrive.kafka-addr}',
+      SASL MECHANISMS = 'PLAIN',
+      SASL USERNAME = SECRET confluent_username,
+      SASL PASSWORD = SECRET confluent_password
+  ) WITH (VALIDATE = false);
+contains:permission denied for SCHEMA "materialize.public"
+
+$ postgres-execute connection=mz_system
+GRANT CREATE ON SCHEMA materialize.public TO materialize;
+
+! CREATE CONNECTION conn TO KAFKA (
+      BROKER '${testdrive.kafka-addr}',
+      SASL MECHANISMS = 'PLAIN',
+      SASL USERNAME = SECRET confluent_username,
+      SASL PASSWORD = SECRET confluent_password
+  ) WITH (VALIDATE = false);
+contains:permission denied for SECRET "materialize.public.confluent_username"
+
+$ postgres-execute connection=mz_system
+GRANT USAGE ON SECRET confluent_username TO materialize;
+
+! CREATE CONNECTION conn TO KAFKA (
+      BROKER '${testdrive.kafka-addr}',
+      SASL MECHANISMS = 'PLAIN',
+      SASL USERNAME = SECRET confluent_username,
+      SASL PASSWORD = SECRET confluent_password
+  ) WITH (VALIDATE = false);
+contains:permission denied for SECRET "materialize.public.confluent_password"
+
+$ postgres-execute connection=mz_system
+GRANT USAGE ON SECRET confluent_password TO materialize;
+
+> CREATE CONNECTION conn TO KAFKA (
+      BROKER '${testdrive.kafka-addr}',
+      SASL MECHANISMS = 'PLAIN',
+      SASL USERNAME = SECRET confluent_username,
+      SASL PASSWORD = SECRET confluent_password
+  ) WITH (VALIDATE = false);
+
+$ postgres-execute connection=mz_system
+REVOKE CREATE ON SCHEMA materialize.public FROM materialize;
+REVOKE USAGE ON SECRET confluent_username, confluent_password FROM materialize;
+DROP CONNECTION conn;
+DROP SECRET confluent_username;
+DROP SECRET confluent_password;
+
+## CREATE SOURCE
+
+$ kafka-create-topic topic=rbac partitions=1
+
+$ set int-schema={"type": "record", "name": "schema_int", "fields": [ {"name": "f1", "type": "int"} ] }
+
+$ kafka-ingest format=avro topic=rbac schema=${int-schema} timestamp=1
+{"f1": 123}
+
+## WITH SIZE
+
+! CREATE SOURCE s
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rbac-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+  WITH (SIZE '1')
+contains:permission denied for SCHEMA "materialize.public"
+
+$ postgres-execute connection=mz_system
+GRANT CREATE ON SCHEMA materialize.public TO materialize;
+
+! CREATE SOURCE s
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rbac-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+  WITH (SIZE '1')
+contains:permission denied for SYSTEM
+
+$ postgres-execute connection=mz_system
+GRANT CREATECLUSTER ON SYSTEM TO materialize;
+
+! CREATE SOURCE s
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rbac-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+  WITH (SIZE '1')
+contains:permission denied for CONNECTION "materialize.public.kafka_conn"
+
+$ postgres-execute connection=mz_system
+GRANT USAGE ON CONNECTION kafka_conn TO materialize;
+
+! CREATE SOURCE s
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rbac-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+  WITH (SIZE '1')
+contains:permission denied for CONNECTION "materialize.public.csr_conn"
+
+$ postgres-execute connection=mz_system
+GRANT USAGE ON CONNECTION csr_conn TO materialize;
+
+> CREATE SOURCE s
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rbac-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+  WITH (SIZE '1')
+
+## IN CLUSTER
+
+$ postgres-execute connection=mz_system
+CREATE CLUSTER source_cluster REPLICAS (r1 (SIZE '1'));
+
+! CREATE SOURCE s1 IN CLUSTER source_cluster
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rbac-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+contains:permission denied for CLUSTER "source_cluster"
+
+$ postgres-execute connection=mz_system
+GRANT CREATE ON CLUSTER source_cluster TO materialize;
+
+> CREATE SOURCE s1 IN CLUSTER source_cluster
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rbac-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+
+$ postgres-execute connection=mz_system
+REVOKE CREATE ON SCHEMA materialize.public FROM materialize;
+REVOKE USAGE ON CONNECTION kafka_conn, csr_conn FROM materialize;
+REVOKE CREATECLUSTER ON SYSTEM FROM materialize;
+REVOKE CREATE ON CLUSTER source_cluster FROM materialize;
+DROP SOURCE s;
+DROP SOURCE s1;
+DROP CLUSTER source_cluster;
+
+$ postgres-execute connection=mz_system
 DROP CONNECTION csr_conn;
 DROP CONNECTION kafka_conn;
-DROP CLUSTER sink_cluster;
 ALTER SYSTEM SET enable_rbac_checks TO false;
 ALTER SYSTEM SET enable_ld_rbac_checks TO false;


### PR DESCRIPTION
This commit adds required item usage privileges to CREATE SINK.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add required connection, secret, and type USAGE privileges to `CREATE SINK`.
