### PR TITLE
storage: restore DISK test in upsert/test_rehydration

### DIFF
--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -161,6 +161,9 @@ def workflow_rehydration(c: Composition) -> None:
             "with DISK",
             Clusterd(
                 name="clusterd1",
+                options=[
+                    "--scratch-directory=/scratch",
+                ],
             ),
         ),
         (


### PR DESCRIPTION
This was lost in the `DISK` replicas pr

### Motivation
  * This PR fixes a previously unreported bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
