### PR TITLE
sql: Grant mz_introspection USAGE on schemas/dbs

### DIFF
--- a/misc/python/materialize/checks/default_privileges.py
+++ b/misc/python/materialize/checks/default_privileges.py
@@ -89,6 +89,8 @@ class DefaultPrivileges(Check):
                   LEFT JOIN mz_schemas AS schemas ON defaults.schema_id = schemas.id
                   ORDER BY role_name, grantee_name;
                 PUBLIC <null> <null> CLUSTER mz_introspection U
+                PUBLIC <null> <null> DATABASE mz_introspection U
+                PUBLIC <null> <null> SCHEMA mz_introspection U
                 PUBLIC <null> <null> TYPE PUBLIC U
                 materialize defpriv_db defpriv_schema TABLE defpriv_role1 arwd
                 materialize defpriv_db defpriv_schema TABLE defpriv_role2 arwd

--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -297,6 +297,13 @@ class Owners(Check):
                 owner_db5 owner_role_01=UC/owner_role_01
                 owner_db6 owner_role_02=UC/owner_role_02
                 owner_db7 owner_role_03=UC/owner_role_03
+                owner_db1 mz_introspection=U/owner_role_01
+                owner_db2 mz_introspection=U/owner_role_01
+                owner_db3 mz_introspection=U/owner_role_01
+                owner_db4 mz_introspection=U/owner_role_02
+                owner_db5 mz_introspection=U/owner_role_01
+                owner_db6 mz_introspection=U/owner_role_02
+                owner_db7 mz_introspection=U/owner_role_03
 
                 > SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name LIKE 'owner_schema%'
                 owner_schema1 owner_role_01=UC/owner_role_01
@@ -306,6 +313,13 @@ class Owners(Check):
                 owner_schema5 owner_role_01=UC/owner_role_01
                 owner_schema6 owner_role_02=UC/owner_role_02
                 owner_schema7 owner_role_03=UC/owner_role_03
+                owner_schema1 mz_introspection=U/owner_role_01
+                owner_schema2 mz_introspection=U/owner_role_01
+                owner_schema3 mz_introspection=U/owner_role_01
+                owner_schema4 mz_introspection=U/owner_role_02
+                owner_schema5 mz_introspection=U/owner_role_01
+                owner_schema6 mz_introspection=U/owner_role_02
+                owner_schema7 mz_introspection=U/owner_role_03
 
                 > SELECT name, unnest(privileges)::text FROM mz_tables WHERE name LIKE 'owner_t%'
                 owner_t1 owner_role_01=arwd/owner_role_01

--- a/src/adapter/src/catalog/storage/stash.rs
+++ b/src/adapter/src/catalog/storage/stash.rs
@@ -214,14 +214,38 @@ pub async fn initialize(
         .await?;
 
     let default_privileges = vec![
-        // mz_introspection needs USAGE privileges on all clusters for the
-        // prometheus-exporter.
+        // mz_introspection needs USAGE privileges on all clusters, databases, and schemas for
+        // debugging.
         (
             DefaultPrivilegesKey {
                 role_id: RoleId::Public,
                 database_id: None,
                 schema_id: None,
                 object_type: mz_sql::catalog::ObjectType::Cluster,
+                grantee: MZ_INTROSPECTION_ROLE_ID,
+            },
+            DefaultPrivilegesValue {
+                privileges: AclMode::USAGE,
+            },
+        ),
+        (
+            DefaultPrivilegesKey {
+                role_id: RoleId::Public,
+                database_id: None,
+                schema_id: None,
+                object_type: mz_sql::catalog::ObjectType::Database,
+                grantee: MZ_INTROSPECTION_ROLE_ID,
+            },
+            DefaultPrivilegesValue {
+                privileges: AclMode::USAGE,
+            },
+        ),
+        (
+            DefaultPrivilegesKey {
+                role_id: RoleId::Public,
+                database_id: None,
+                schema_id: None,
+                object_type: mz_sql::catalog::ObjectType::Schema,
                 grantee: MZ_INTROSPECTION_ROLE_ID,
             },
             DefaultPrivilegesValue {
@@ -274,6 +298,11 @@ pub async fn initialize(
     let mut db_privileges = vec![
         proto::MzAclItem {
             grantee: Some(RoleId::Public.into_proto()),
+            grantor: Some(MZ_SYSTEM_ROLE_ID.into_proto()),
+            acl_mode: Some(AclMode::USAGE.into_proto()),
+        },
+        proto::MzAclItem {
+            grantee: Some(MZ_INTROSPECTION_ROLE_ID.into_proto()),
             grantor: Some(MZ_SYSTEM_ROLE_ID.into_proto()),
             acl_mode: Some(AclMode::USAGE.into_proto()),
         },
@@ -406,6 +435,11 @@ pub async fn initialize(
         privileges: vec![
             proto::MzAclItem {
                 grantee: Some(RoleId::Public.into_proto()),
+                grantor: Some(MZ_SYSTEM_ROLE_ID.into_proto()),
+                acl_mode: Some(AclMode::USAGE.into_proto()),
+            },
+            proto::MzAclItem {
+                grantee: Some(MZ_INTROSPECTION_ROLE_ID.into_proto()),
                 grantor: Some(MZ_SYSTEM_ROLE_ID.into_proto()),
                 acl_mode: Some(AclMode::USAGE.into_proto()),
             },

--- a/src/adapter/src/catalog/storage/stash.rs
+++ b/src/adapter/src/catalog/storage/stash.rs
@@ -382,6 +382,11 @@ pub async fn initialize(
 
     let schema_privileges = vec![
         rbac::default_builtin_object_privilege(mz_sql::catalog::ObjectType::Schema).into_proto(),
+        proto::MzAclItem {
+            grantee: Some(MZ_INTROSPECTION_ROLE_ID.into_proto()),
+            grantor: Some(MZ_SYSTEM_ROLE_ID.into_proto()),
+            acl_mode: Some(AclMode::USAGE.into_proto()),
+        },
         rbac::owner_privilege(mz_sql::catalog::ObjectType::Schema, MZ_SYSTEM_ROLE_ID).into_proto(),
     ];
 

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -54,5 +54,9 @@
   {
     "name": "objects_v27.proto",
     "md5": "7ccd2c67b302d72cc4c94be892c7cfc1"
+  },
+  {
+    "name": "objects_v28.proto",
+    "md5": "891db1de528b10e073463cb8108556e0"
   }
 ]

--- a/src/stash/protos/objects_v28.proto
+++ b/src/stash/protos/objects_v28.proto
@@ -1,0 +1,582 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// This protobuf file defines the types we store in the Stash.
+//
+// Before and after modifying this file, make sure you have a snapshot of the before version,
+// e.g. a copy of this file named 'objects_v{STASH_VERSION}.proto', and a snapshot of the file
+// after your modifications, e.g. 'objects_v{STASH_VERSION + 1}.proto'. Then you can write a
+// migration using these two files, and no matter how they types change in the future, we'll always
+// have these snapshots to facilitate the migration.
+
+
+syntax = "proto3";
+
+package objects_v28;
+
+message ConfigKey {
+    string key = 1;
+}
+
+message ConfigValue {
+    uint64 value = 1;
+}
+
+message SettingKey {
+    string name = 1;
+}
+
+message SettingValue {
+    string value = 1;
+}
+
+message IdAllocKey {
+    string name = 1;
+}
+
+message IdAllocValue {
+    uint64 next_id = 1;
+}
+
+message GidMappingKey {
+    string schema_name = 1;
+    CatalogItemType object_type = 2;
+    string object_name = 3;
+}
+
+message GidMappingValue {
+    uint64 id = 1;
+    string fingerprint = 2;
+}
+
+message ClusterKey {
+    ClusterId id = 1;
+}
+
+message ClusterValue {
+    string name = 1;
+    GlobalId linked_object_id = 2;
+    RoleId owner_id = 3;
+    repeated MzAclItem privileges = 4;
+    ClusterConfig config = 5;
+}
+
+message ClusterIntrospectionSourceIndexKey {
+    ClusterId cluster_id = 1;
+    string name = 2;
+}
+
+message ClusterIntrospectionSourceIndexValue {
+    uint64 index_id = 1;
+}
+
+message ClusterReplicaKey {
+    ReplicaId id = 1;
+}
+
+message ClusterReplicaValue {
+    ClusterId cluster_id = 1;
+    string name = 2;
+    ReplicaConfig config = 3;
+    RoleId owner_id = 4;
+}
+
+message DatabaseKey {
+    DatabaseId id = 1;
+}
+
+message DatabaseValue {
+    string name = 1;
+    RoleId owner_id = 2;
+    repeated MzAclItem privileges = 3;
+}
+
+message SchemaKey {
+    SchemaId id = 1;
+}
+
+message SchemaValue {
+    DatabaseId database_id = 1;
+    string name = 2;
+    RoleId owner_id = 3;
+    repeated MzAclItem privileges = 4;
+}
+
+message ItemKey {
+    GlobalId gid = 1;
+}
+
+message ItemValue {
+    SchemaId schema_id = 1;
+    string name = 2;
+    CatalogItem definition = 3;
+    RoleId owner_id = 4;
+    repeated MzAclItem privileges = 5;
+}
+
+message RoleKey {
+    RoleId id = 1;
+}
+
+message RoleValue {
+    string name = 1;
+    RoleAttributes attributes = 2;
+    RoleMembership membership = 3;
+}
+
+message TimestampKey {
+    string id = 1;
+}
+
+message TimestampValue {
+    Timestamp ts = 1;
+}
+
+message ServerConfigurationKey {
+    string name = 1;
+}
+
+message ServerConfigurationValue {
+    string value = 1;
+}
+
+message AuditLogKey {
+    oneof event {
+        AuditLogEventV1 v1 = 1;
+    }
+}
+
+message StorageUsageKey {
+    message StorageUsageV1 {
+        uint64 id = 1;
+        StringWrapper shard_id = 2;
+        uint64 size_bytes = 3;
+        EpochMillis collection_timestamp = 4;
+    }
+
+    oneof usage {
+        StorageUsageV1 v1 = 1;
+    }
+}
+
+message SinkAsOf {
+    TimestampAntichain frontier = 1;
+    bool strict = 2;
+}
+
+message DurableCollectionMetadata {
+    reserved 1;
+    reserved "remap_shard";
+
+    // StringWrapper remap_shard = 1;
+    string data_shard = 2;
+}
+
+message DurableExportMetadata {
+    SinkAsOf initial_as_of = 1;
+}
+
+// ---- Common Types
+//
+// Note: Normally types like this would go in some sort of `common.proto` file, but we want to keep
+// our proto definitions in a single file to make snapshotting easier, hence them living here.
+
+message Empty { /* purposefully empty */ }
+
+// In protobuf a "None" string is the same thing as an empty string. To get the same semantics of
+// an `Option<String>` from Rust, we need to wrap a string in a message.
+message StringWrapper {
+    string inner = 1;
+}
+
+message Duration {
+    uint64 secs = 1;
+    uint32 nanos = 2;
+}
+
+message EpochMillis {
+    uint64 millis = 1;
+}
+
+// Opaque timestamp type that is specific to Materialize.
+message Timestamp {
+    uint64 internal = 1;
+}
+
+enum CatalogItemType {
+    CATALOG_ITEM_TYPE_UNKNOWN = 0;
+    CATALOG_ITEM_TYPE_TABLE = 1;
+    CATALOG_ITEM_TYPE_SOURCE = 2;
+    CATALOG_ITEM_TYPE_SINK = 3;
+    CATALOG_ITEM_TYPE_VIEW = 4;
+    CATALOG_ITEM_TYPE_MATERIALIZED_VIEW = 5;
+    CATALOG_ITEM_TYPE_INDEX = 6;
+    CATALOG_ITEM_TYPE_TYPE = 7;
+    CATALOG_ITEM_TYPE_FUNC = 8;
+    CATALOG_ITEM_TYPE_SECRET = 9;
+    CATALOG_ITEM_TYPE_CONNECTION = 10;
+}
+
+message CatalogItem {
+    message V1 {
+        string create_sql = 1;
+    }
+
+    oneof value {
+        V1 v1 = 1;
+    }
+}
+
+message GlobalId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        uint64 transient = 3;
+        Empty explain = 4;
+    }
+}
+
+message ClusterId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message DatabaseId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message SchemaId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message ReplicaId {
+    uint64 value = 1;
+}
+
+message ReplicaLogging {
+    bool log_logging = 1;
+    Duration interval = 2;
+}
+
+message ReplicaMergeEffort {
+    uint32 effort = 1;
+}
+
+message ClusterConfig {
+    message ManagedCluster {
+        string size = 1;
+        uint32 replication_factor = 2;
+        repeated string availability_zones = 3;
+        ReplicaLogging logging = 4;
+        ReplicaMergeEffort idle_arrangement_merge_effort = 5;
+        bool disk = 6;
+    }
+
+    oneof variant {
+        Empty unmanaged = 1;
+        ManagedCluster managed = 2;
+    }
+}
+
+message ReplicaConfig {
+    message UnmanagedLocation {
+        repeated string storagectl_addrs = 1;
+        repeated string storage_addrs = 2;
+        repeated string computectl_addrs = 3;
+        repeated string compute_addrs = 4;
+        uint64 workers = 5;
+    }
+
+    message ManagedLocation {
+        string size = 1;
+        string availability_zone = 2;
+        bool az_user_specified = 3;
+        bool disk = 4;
+    }
+
+    oneof location {
+        UnmanagedLocation unmanaged = 1;
+        ManagedLocation managed = 2;
+    }
+    ReplicaLogging logging = 3;
+    ReplicaMergeEffort idle_arrangement_merge_effort = 4;
+}
+
+message RoleId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        Empty public = 3;
+    }
+}
+
+message RoleAttributes {
+    bool inherit = 1;
+}
+
+message RoleMembership {
+    message Entry {
+        RoleId key = 1;
+        RoleId value = 2;
+    }
+
+    repeated Entry map = 1;
+}
+
+message AclMode {
+    // A bit flag representing all the privileges that can be granted to a role.
+    uint64 bitflags = 1;
+}
+
+message MzAclItem {
+    RoleId grantee = 1;
+    RoleId grantor = 2;
+    AclMode acl_mode = 3;
+}
+
+message TimestampAntichain {
+    repeated Timestamp elements = 1;
+}
+
+enum ObjectType {
+    OBJECT_TYPE_UNKNOWN = 0;
+    OBJECT_TYPE_TABLE = 1;
+    OBJECT_TYPE_VIEW = 2;
+    OBJECT_TYPE_MATERIALIZED_VIEW = 3;
+    OBJECT_TYPE_SOURCE = 4;
+    OBJECT_TYPE_SINK = 5;
+    OBJECT_TYPE_INDEX = 6;
+    OBJECT_TYPE_TYPE = 7;
+    OBJECT_TYPE_ROLE = 8;
+    OBJECT_TYPE_CLUSTER = 9;
+    OBJECT_TYPE_CLUSTER_REPLICA = 10;
+    OBJECT_TYPE_SECRET = 11;
+    OBJECT_TYPE_CONNECTION = 12;
+    OBJECT_TYPE_DATABASE = 13;
+    OBJECT_TYPE_SCHEMA = 14;
+    OBJECT_TYPE_FUNC = 15;
+}
+
+message DefaultPrivilegesKey {
+    RoleId role_id = 1;
+    DatabaseId database_id = 2;
+    SchemaId schema_id = 3;
+    ObjectType object_type = 4;
+    RoleId grantee = 5;
+}
+
+message DefaultPrivilegesValue {
+    AclMode privileges = 1;
+}
+
+message SystemPrivilegesKey {
+    RoleId grantee = 1;
+    RoleId grantor = 2;
+}
+
+message SystemPrivilegesValue {
+    AclMode acl_mode = 1;
+}
+
+message AuditLogEventV1 {
+    enum EventType {
+        EVENT_TYPE_UNKNOWN = 0;
+        EVENT_TYPE_CREATE = 1;
+        EVENT_TYPE_DROP = 2;
+        EVENT_TYPE_ALTER = 3;
+        EVENT_TYPE_GRANT = 4;
+        EVENT_TYPE_REVOKE = 5;
+    }
+
+    enum ObjectType {
+        OBJECT_TYPE_UNKNOWN = 0;
+        OBJECT_TYPE_CLUSTER = 1;
+        OBJECT_TYPE_CLUSTER_REPLICA = 2;
+        OBJECT_TYPE_CONNECTION = 3;
+        OBJECT_TYPE_DATABASE = 4;
+        OBJECT_TYPE_FUNC = 5;
+        OBJECT_TYPE_INDEX = 6;
+        OBJECT_TYPE_MATERIALIZED_VIEW = 7;
+        OBJECT_TYPE_ROLE = 8;
+        OBJECT_TYPE_SECRET = 9;
+        OBJECT_TYPE_SCHEMA = 10;
+        OBJECT_TYPE_SINK = 11;
+        OBJECT_TYPE_SOURCE = 12;
+        OBJECT_TYPE_TABLE = 13;
+        OBJECT_TYPE_TYPE = 14;
+        OBJECT_TYPE_VIEW = 15;
+        OBJECT_TYPE_SYSTEM = 16;
+    }
+
+    message IdFullNameV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+    }
+
+    message FullNameV1 {
+        string database = 1;
+        string schema = 2;
+        string item = 3;
+    }
+
+    message IdNameV1 {
+        string id = 1;
+        string name = 2;
+    }
+
+    message RenameClusterV1 {
+        string id = 1;
+        string old_name = 2;
+        string new_name = 3;
+    }
+
+    message RenameClusterReplicaV1 {
+        string cluster_id = 1;
+        string replica_id = 2;
+        string old_name = 3;
+        string new_name = 4;
+    }
+
+    message RenameItemV1 {
+        string id = 1;
+        FullNameV1 old_name = 2;
+        FullNameV1 new_name = 3;
+    }
+
+    message CreateClusterReplicaV1 {
+        string cluster_id = 1;
+        string cluser_name = 2;
+        StringWrapper replica_id = 3;
+        string replica_name = 4;
+        string logical_size = 5;
+        bool disk = 6;
+    }
+
+    message DropClusterReplicaV1 {
+        string cluster_id = 1;
+        string cluster_name = 2;
+        StringWrapper replica_id = 3;
+        string replica_name = 4;
+    }
+
+    message CreateSourceSinkV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper size = 3;
+    }
+
+    message CreateSourceSinkV2 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper size = 3;
+        string external_type = 4;
+    }
+
+    message AlterSourceSinkV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper old_size = 3;
+        StringWrapper new_size = 4;
+    }
+
+    message GrantRoleV1 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+    }
+
+    message GrantRoleV2 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+        string executed_by = 4;
+    }
+
+    message RevokeRoleV1 {
+        string role_id = 1;
+        string member_id = 2;
+    }
+
+    message RevokeRoleV2 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+        string executed_by = 4;
+    }
+
+    message UpdatePrivilegeV1 {
+        string object_id = 1;
+        string grantee_id = 2;
+        string grantor_id = 3;
+        string privileges = 4;
+    }
+
+    message AlterDefaultPrivilegeV1 {
+        string role_id = 1;
+        StringWrapper database_id = 2;
+        StringWrapper schema_id = 3;
+        string grantee_id= 4;
+        string privileges = 5;
+    }
+
+    message UpdateOwnerV1 {
+        string object_id = 1;
+        string old_owner_id = 2;
+        string new_owner_id = 3;
+    }
+
+    message SchemaV1 {
+        string id = 1;
+        string name = 2;
+        string database_name = 3;
+    }
+
+    message SchemaV2 {
+        string id = 1;
+        string name = 2;
+        StringWrapper database_name = 3;
+    }
+
+    uint64 id = 1;
+    EventType event_type = 2;
+    ObjectType object_type = 3;
+    StringWrapper user = 4;
+    EpochMillis occurred_at = 5;
+
+    // next-id: 25
+    oneof details {
+        CreateClusterReplicaV1 create_cluster_replica_v1 = 6;
+        DropClusterReplicaV1 drop_cluster_replica_v1 = 7;
+        CreateSourceSinkV1 create_source_sink_v1 = 8;
+        CreateSourceSinkV2 create_source_sink_v2 = 9;
+        AlterSourceSinkV1 alter_source_sink_v1 = 10;
+        GrantRoleV1 grant_role_v1 = 11;
+        GrantRoleV2 grant_role_v2 = 12;
+        RevokeRoleV1 revoke_role_v1 = 13;
+        RevokeRoleV2 revoke_role_v2 = 14;
+        UpdatePrivilegeV1 update_privilege_v1 = 22;
+        AlterDefaultPrivilegeV1 alter_default_privilege_v1 = 23;
+        UpdateOwnerV1 update_owner_v1 = 24;
+        IdFullNameV1 id_full_name_v1 = 15;
+        RenameClusterV1 rename_cluster_v1 = 20;
+        RenameClusterReplicaV1 rename_cluster_replica_v1 = 21;
+        RenameItemV1 rename_item_v1 = 16;
+        IdNameV1 id_name_v1 = 17;
+        SchemaV1 schema_v1 = 18;
+        SchemaV2 schema_v2 = 19;
+    }
+}

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -103,7 +103,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 27;
+pub const STASH_VERSION: u64 = 28;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -956,6 +956,7 @@ impl Stash {
                             24 => upgrade::v24_to_v25::upgrade(&mut tx).await?,
                             25 => upgrade::v25_to_v26::upgrade(),
                             26 => upgrade::v26_to_v27::upgrade(),
+                            27 => upgrade::v27_to_v28::upgrade(&mut tx).await?,
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -62,6 +62,7 @@ pub mod v23_to_v24;
 pub mod v24_to_v25;
 pub mod v25_to_v26;
 pub mod v26_to_v27;
+pub mod v27_to_v28;
 
 pub use json_to_proto::migrate_json_to_proto;
 

--- a/src/stash/src/upgrade/v27_to_v28.rs
+++ b/src/stash/src/upgrade/v27_to_v28.rs
@@ -1,0 +1,485 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::upgrade::MigrationAction;
+use crate::{StashError, Transaction, TypedCollection};
+
+pub mod objects_v27 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v27.rs"));
+}
+
+pub mod objects_v28 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v28.rs"));
+}
+
+const MZ_INTROSPECTION_ROLE_ID: objects_v28::RoleId = objects_v28::RoleId {
+    value: Some(objects_v28::role_id::Value::System(2)),
+};
+const PUBLIC_ROLE_ID: objects_v28::RoleId = objects_v28::RoleId {
+    value: Some(objects_v28::role_id::Value::Public(objects_v28::Empty {})),
+};
+const ACL_MODE_USAGE: objects_v28::AclMode = objects_v28::AclMode { bitflags: 1 << 8 };
+
+/// Add USAGE privileges on all databases and schemas to the
+/// mz_introspection user.
+///
+/// Author - jkosh44
+pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {
+    const DEFAULT_PRIVILEGES_COLLECTION: TypedCollection<
+        objects_v27::DefaultPrivilegesKey,
+        objects_v27::DefaultPrivilegesValue,
+    > = TypedCollection::new("default_privileges");
+    const DATABASES_COLLECTION: TypedCollection<
+        objects_v27::DatabaseKey,
+        objects_v27::DatabaseValue,
+    > = TypedCollection::new("database");
+    const SCHEMAS_COLLECTION: TypedCollection<objects_v27::SchemaKey, objects_v27::SchemaValue> =
+        TypedCollection::new("schema");
+
+    DEFAULT_PRIVILEGES_COLLECTION
+        .migrate_to(tx, |entries| {
+            let mut updates = vec![
+                MigrationAction::Insert(
+                    objects_v28::DefaultPrivilegesKey {
+                        role_id: Some(PUBLIC_ROLE_ID),
+                        database_id: None,
+                        schema_id: None,
+                        object_type: objects_v27::ObjectType::Database.into(),
+                        grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                    },
+                    objects_v28::DefaultPrivilegesValue {
+                        privileges: Some(ACL_MODE_USAGE),
+                    },
+                ),
+                MigrationAction::Insert(
+                    objects_v28::DefaultPrivilegesKey {
+                        role_id: Some(PUBLIC_ROLE_ID),
+                        database_id: None,
+                        schema_id: None,
+                        object_type: objects_v27::ObjectType::Schema.into(),
+                        grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                    },
+                    objects_v28::DefaultPrivilegesValue {
+                        privileges: Some(ACL_MODE_USAGE),
+                    },
+                ),
+            ];
+
+            for (key, value) in entries {
+                let new_key = key.clone().into();
+                let new_value = value.clone().into();
+                updates.push(MigrationAction::Update(key.clone(), (new_key, new_value)));
+            }
+
+            updates
+        })
+        .await?;
+
+    DATABASES_COLLECTION
+        .migrate_to(tx, |entries| {
+            let mut updates = Vec::with_capacity(entries.len());
+
+            for (key, value) in entries {
+                let new_key: objects_v28::DatabaseKey = key.clone().into();
+                let mut new_value: objects_v28::DatabaseValue = value.clone().into();
+                new_value.privileges.push(objects_v28::MzAclItem {
+                    grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                    grantor: value.owner_id.clone().map(Into::into),
+                    acl_mode: Some(ACL_MODE_USAGE),
+                });
+                updates.push(MigrationAction::Update(key.clone(), (new_key, new_value)));
+            }
+
+            updates
+        })
+        .await?;
+
+    SCHEMAS_COLLECTION
+        .migrate_to(tx, |entries| {
+            let mut updates = Vec::with_capacity(entries.len());
+
+            for (key, value) in entries {
+                let new_key: objects_v28::SchemaKey = key.clone().into();
+                let mut new_value: objects_v28::SchemaValue = value.clone().into();
+                new_value.privileges.push(objects_v28::MzAclItem {
+                    grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                    grantor: value.owner_id.clone().map(Into::into),
+                    acl_mode: Some(ACL_MODE_USAGE),
+                });
+                updates.push(MigrationAction::Update(key.clone(), (new_key, new_value)));
+            }
+
+            updates
+        })
+        .await?;
+
+    Ok(())
+}
+
+impl From<objects_v27::DatabaseId> for objects_v28::DatabaseId {
+    fn from(id: objects_v27::DatabaseId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v27::database_id::Value::User(id)) => {
+                Some(objects_v28::database_id::Value::User(id))
+            }
+            Some(objects_v27::database_id::Value::System(id)) => {
+                Some(objects_v28::database_id::Value::System(id))
+            }
+        };
+        objects_v28::DatabaseId { value }
+    }
+}
+
+impl From<objects_v27::DatabaseKey> for objects_v28::DatabaseKey {
+    fn from(key: objects_v27::DatabaseKey) -> Self {
+        Self {
+            id: key.id.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v27::RoleId> for objects_v28::RoleId {
+    fn from(id: objects_v27::RoleId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v27::role_id::Value::User(id)) => {
+                Some(objects_v28::role_id::Value::User(id))
+            }
+            Some(objects_v27::role_id::Value::System(id)) => {
+                Some(objects_v28::role_id::Value::System(id))
+            }
+            Some(objects_v27::role_id::Value::Public(_)) => {
+                Some(objects_v28::role_id::Value::Public(Default::default()))
+            }
+        };
+        objects_v28::RoleId { value }
+    }
+}
+
+impl From<objects_v27::AclMode> for objects_v28::AclMode {
+    fn from(acl_mode: objects_v27::AclMode) -> Self {
+        objects_v28::AclMode {
+            bitflags: acl_mode.bitflags,
+        }
+    }
+}
+
+impl From<objects_v27::MzAclItem> for objects_v28::MzAclItem {
+    fn from(item: objects_v27::MzAclItem) -> Self {
+        Self {
+            grantee: item.grantee.map(Into::into),
+            grantor: item.grantor.map(Into::into),
+            acl_mode: item.acl_mode.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v27::DatabaseValue> for objects_v28::DatabaseValue {
+    fn from(value: objects_v27::DatabaseValue) -> Self {
+        Self {
+            name: value.name,
+            owner_id: value.owner_id.map(Into::into),
+            privileges: value.privileges.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<objects_v27::SchemaId> for objects_v28::SchemaId {
+    fn from(id: objects_v27::SchemaId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v27::schema_id::Value::User(id)) => {
+                Some(objects_v28::schema_id::Value::User(id))
+            }
+            Some(objects_v27::schema_id::Value::System(id)) => {
+                Some(objects_v28::schema_id::Value::System(id))
+            }
+        };
+        objects_v28::SchemaId { value }
+    }
+}
+
+impl From<objects_v27::SchemaKey> for objects_v28::SchemaKey {
+    fn from(key: objects_v27::SchemaKey) -> Self {
+        Self {
+            id: key.id.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v27::SchemaValue> for objects_v28::SchemaValue {
+    fn from(value: objects_v27::SchemaValue) -> Self {
+        Self {
+            database_id: value.database_id.map(Into::into),
+            name: value.name,
+            owner_id: value.owner_id.map(Into::into),
+            privileges: value.privileges.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<objects_v27::ObjectType> for objects_v28::ObjectType {
+    fn from(object_type: objects_v27::ObjectType) -> Self {
+        match object_type {
+            objects_v27::ObjectType::Unknown => objects_v28::ObjectType::Unknown,
+            objects_v27::ObjectType::Table => objects_v28::ObjectType::Table,
+            objects_v27::ObjectType::View => objects_v28::ObjectType::View,
+            objects_v27::ObjectType::MaterializedView => objects_v28::ObjectType::MaterializedView,
+            objects_v27::ObjectType::Source => objects_v28::ObjectType::Source,
+            objects_v27::ObjectType::Sink => objects_v28::ObjectType::Sink,
+            objects_v27::ObjectType::Index => objects_v28::ObjectType::Index,
+            objects_v27::ObjectType::Type => objects_v28::ObjectType::Type,
+            objects_v27::ObjectType::Role => objects_v28::ObjectType::Role,
+            objects_v27::ObjectType::Cluster => objects_v28::ObjectType::Cluster,
+            objects_v27::ObjectType::ClusterReplica => objects_v28::ObjectType::ClusterReplica,
+            objects_v27::ObjectType::Secret => objects_v28::ObjectType::Secret,
+            objects_v27::ObjectType::Connection => objects_v28::ObjectType::Connection,
+            objects_v27::ObjectType::Database => objects_v28::ObjectType::Database,
+            objects_v27::ObjectType::Schema => objects_v28::ObjectType::Schema,
+            objects_v27::ObjectType::Func => objects_v28::ObjectType::Func,
+        }
+    }
+}
+
+impl From<objects_v27::DefaultPrivilegesKey> for objects_v28::DefaultPrivilegesKey {
+    fn from(key: objects_v27::DefaultPrivilegesKey) -> Self {
+        objects_v28::DefaultPrivilegesKey {
+            role_id: key.role_id.map(Into::into),
+            database_id: key.database_id.map(Into::into),
+            schema_id: key.schema_id.map(Into::into),
+            object_type: key.object_type,
+            grantee: key.grantee.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v27::DefaultPrivilegesValue> for objects_v28::DefaultPrivilegesValue {
+    fn from(value: objects_v27::DefaultPrivilegesValue) -> Self {
+        objects_v28::DefaultPrivilegesValue {
+            privileges: value.privileges.map(Into::into),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::upgrade;
+
+    use crate::upgrade::v27_to_v28::{
+        objects_v27, objects_v28, ACL_MODE_USAGE, MZ_INTROSPECTION_ROLE_ID, PUBLIC_ROLE_ID,
+    };
+    use crate::{DebugStashFactory, TypedCollection};
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn smoke_test() {
+        const ACL_MODE_USAGE_V27: objects_v27::AclMode = objects_v27::AclMode { bitflags: 1 << 8 };
+        const OWNER_ROLE_ID_V27: objects_v27::RoleId = objects_v27::RoleId {
+            value: Some(objects_v27::role_id::Value::User(1)),
+        };
+        const OWNER_ROLE_ID_V28: objects_v28::RoleId = objects_v28::RoleId {
+            value: Some(objects_v28::role_id::Value::User(1)),
+        };
+
+        // Connect to the Stash.
+        let factory = DebugStashFactory::new().await;
+        let mut stash = factory.open_debug().await;
+
+        // Insert a database.
+        let databases_v27: TypedCollection<objects_v27::DatabaseKey, objects_v27::DatabaseValue> =
+            TypedCollection::new("database");
+        databases_v27
+            .insert_without_overwrite(
+                &mut stash,
+                vec![(
+                    objects_v27::DatabaseKey {
+                        id: Some(objects_v27::DatabaseId {
+                            value: Some(objects_v27::database_id::Value::User(42)),
+                        }),
+                    },
+                    objects_v27::DatabaseValue {
+                        name: "db".into(),
+                        owner_id: Some(OWNER_ROLE_ID_V27),
+                        privileges: vec![objects_v27::MzAclItem {
+                            grantee: Some(objects_v27::RoleId {
+                                value: Some(objects_v27::role_id::Value::User(2)),
+                            }),
+                            grantor: Some(OWNER_ROLE_ID_V27),
+                            acl_mode: Some(ACL_MODE_USAGE_V27),
+                        }],
+                    },
+                )],
+            )
+            .await
+            .unwrap();
+
+        // Insert a schema.
+        let schemas_v27: TypedCollection<objects_v27::SchemaKey, objects_v27::SchemaValue> =
+            TypedCollection::new("schema");
+        schemas_v27
+            .insert_without_overwrite(
+                &mut stash,
+                vec![(
+                    objects_v27::SchemaKey {
+                        id: Some(objects_v27::SchemaId {
+                            value: Some(objects_v27::schema_id::Value::User(42)),
+                        }),
+                    },
+                    objects_v27::SchemaValue {
+                        database_id: Some(objects_v27::DatabaseId {
+                            value: Some(objects_v27::database_id::Value::User(42)),
+                        }),
+                        name: "sch".into(),
+                        owner_id: Some(OWNER_ROLE_ID_V27),
+                        privileges: vec![objects_v27::MzAclItem {
+                            grantee: Some(objects_v27::RoleId {
+                                value: Some(objects_v27::role_id::Value::User(2)),
+                            }),
+                            grantor: Some(OWNER_ROLE_ID_V27),
+                            acl_mode: Some(ACL_MODE_USAGE_V27),
+                        }],
+                    },
+                )],
+            )
+            .await
+            .unwrap();
+
+        // Run our migration.
+        stash
+            .with_transaction(|mut tx| {
+                Box::pin(async move {
+                    upgrade(&mut tx).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .expect("migration failed");
+
+        // Read back the default privileges.
+        let default_privileges: TypedCollection<
+            objects_v28::DefaultPrivilegesKey,
+            objects_v28::DefaultPrivilegesValue,
+        > = TypedCollection::new("default_privileges");
+        let privileges = default_privileges.iter(&mut stash).await.unwrap();
+        // Filter down to just the keys and values to make comparisons easier.
+        let privileges: Vec<_> = privileges
+            .into_iter()
+            .map(|((key, value), _timestamp, _diff)| (key, value))
+            .collect();
+
+        assert!(privileges.contains(&(
+            objects_v28::DefaultPrivilegesKey {
+                role_id: Some(PUBLIC_ROLE_ID),
+                database_id: None,
+                schema_id: None,
+                object_type: objects_v28::ObjectType::Database.into(),
+                grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+            },
+            objects_v28::DefaultPrivilegesValue {
+                privileges: Some(ACL_MODE_USAGE),
+            }
+        )));
+        assert!(privileges.contains(&(
+            objects_v28::DefaultPrivilegesKey {
+                role_id: Some(PUBLIC_ROLE_ID),
+                database_id: None,
+                schema_id: None,
+                object_type: objects_v28::ObjectType::Schema.into(),
+                grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+            },
+            objects_v28::DefaultPrivilegesValue {
+                privileges: Some(ACL_MODE_USAGE),
+            }
+        )));
+
+        // Read back the databases.
+        let databases_v28: TypedCollection<objects_v28::DatabaseKey, objects_v28::DatabaseValue> =
+            TypedCollection::new("database");
+        let databases = databases_v28.iter(&mut stash).await.unwrap();
+        // Filter down to just the keys and values to make comparisons easier.
+        let mut databases_v28: Vec<_> = databases
+            .into_iter()
+            .map(|((key, value), _timestamp, _diff)| (key, value))
+            .collect();
+        databases_v28.sort();
+
+        assert_eq!(
+            databases_v28,
+            vec![(
+                objects_v28::DatabaseKey {
+                    id: Some(objects_v28::DatabaseId {
+                        value: Some(objects_v28::database_id::Value::User(42)),
+                    }),
+                },
+                objects_v28::DatabaseValue {
+                    name: "db".into(),
+                    owner_id: Some(OWNER_ROLE_ID_V28),
+                    privileges: vec![
+                        objects_v28::MzAclItem {
+                            grantee: Some(objects_v28::RoleId {
+                                value: Some(objects_v28::role_id::Value::User(2)),
+                            }),
+                            grantor: Some(OWNER_ROLE_ID_V28),
+                            acl_mode: Some(ACL_MODE_USAGE),
+                        },
+                        objects_v28::MzAclItem {
+                            grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                            grantor: Some(OWNER_ROLE_ID_V28),
+                            acl_mode: Some(ACL_MODE_USAGE),
+                        }
+                    ],
+                },
+            )],
+        );
+
+        // Read back the schemas.
+        let schemas_v28: TypedCollection<objects_v28::SchemaKey, objects_v28::SchemaValue> =
+            TypedCollection::new("schema");
+        let schemas = schemas_v28.iter(&mut stash).await.unwrap();
+        // Filter down to just the keys and values to make comparisons easier.
+        let mut schemas_v28: Vec<_> = schemas
+            .into_iter()
+            .map(|((key, value), _timestamp, _diff)| (key, value))
+            .collect();
+        schemas_v28.sort();
+
+        assert_eq!(
+            schemas_v28,
+            vec![(
+                objects_v28::SchemaKey {
+                    id: Some(objects_v28::SchemaId {
+                        value: Some(objects_v28::schema_id::Value::User(42)),
+                    }),
+                },
+                objects_v28::SchemaValue {
+                    database_id: Some(objects_v28::DatabaseId {
+                        value: Some(objects_v28::database_id::Value::User(42)),
+                    }),
+                    name: "sch".into(),
+                    owner_id: Some(OWNER_ROLE_ID_V28),
+                    privileges: vec![
+                        objects_v28::MzAclItem {
+                            grantee: Some(objects_v28::RoleId {
+                                value: Some(objects_v28::role_id::Value::User(2)),
+                            }),
+                            grantor: Some(OWNER_ROLE_ID_V28),
+                            acl_mode: Some(ACL_MODE_USAGE),
+                        },
+                        objects_v28::MzAclItem {
+                            grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                            grantor: Some(OWNER_ROLE_ID_V28),
+                            acl_mode: Some(ACL_MODE_USAGE),
+                        }
+                    ],
+                },
+            )],
+        );
+    }
+}

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -91,64 +91,66 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 ----
 1  create  role  {"id":"u1","name":"materialize"}  NULL
 2  grant  cluster  {"database_id":null,"grantee_id":"s2","privileges":"U","role_id":"p","schema_id":null}  NULL
-3  grant  type  {"database_id":null,"grantee_id":"p","privileges":"U","role_id":"p","schema_id":null}  NULL
-4  create  database  {"id":"u1","name":"materialize"}  NULL
-5  grant  database  {"grantee_id":"p","grantor_id":"s1","object_id":"Du1","privileges":"U"}  NULL
-6  grant  database  {"grantee_id":"u1","grantor_id":"s1","object_id":"Du1","privileges":"UC"}  NULL
-7  create  schema  {"database_name":"materialize","id":"3","name":"public"}  NULL
-8  grant  schema  {"grantee_id":"u1","grantor_id":"s1","object_id":"Su1.u3","privileges":"UC"}  NULL
-9  create  cluster  {"id":"u1","name":"default"}  NULL
-10  grant  cluster  {"grantee_id":"p","grantor_id":"s1","object_id":"Cu1","privileges":"U"}  NULL
-11  grant  cluster  {"grantee_id":"u1","grantor_id":"s1","object_id":"Cu1","privileges":"UC"}  NULL
-12  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","disk":false,"logical_size":"1","replica_id":"1","replica_name":"r1"}  NULL
-13  grant  system  {"grantee_id":"s1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
-14  grant  system  {"grantee_id":"u1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
-15  create  database  {"id":"u2","name":"test"}  materialize
-16  create  schema  {"database_name":"test","id":"u6","name":"public"}  materialize
-17  create  schema  {"database_name":"test","id":"u7","name":"sc1"}  materialize
-18  create  schema  {"database_name":"test","id":"u8","name":"sc2"}  materialize
-19  drop  schema  {"database_name":"test","id":"u7","name":"sc1"}  materialize
-20  drop  schema  {"database_name":"test","id":"u6","name":"public"}  materialize
-21  drop  schema  {"database_name":"test","id":"u8","name":"sc2"}  materialize
-22  drop  database  {"id":"u2","name":"test"}  materialize
-23  create  role  {"id":"u2","name":"foo"}  materialize
-24  drop  role  {"id":"u2","name":"foo"}  materialize
-25  create  cluster  {"id":"u2","name":"foo"}  materialize
-26  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","disk":false,"logical_size":"1","replica_id":"4","replica_name":"r"}  materialize
-27  create  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
-28  create  view  {"database":"materialize","id":"u2","item":"unmat","schema":"public"}  materialize
-29  create  table  {"database":"materialize","id":"u3","item":"t","schema":"public"}  materialize
-30  create  index  {"database":"materialize","id":"u4","item":"t_primary_idx","schema":"public"}  materialize
-31  alter  view  {"id":"u2","new_name":{"database":"materialize","item":"renamed","schema":"public"},"old_name":{"database":"materialize","item":"unmat","schema":"public"}}  materialize
-32  drop  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
-33  create  materialized-view  {"database":"materialize","id":"u5","item":"v2","schema":"public"}  materialize
-34  create  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
-35  drop  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
-36  drop  view  {"database":"materialize","id":"u2","item":"renamed","schema":"public"}  materialize
-37  create  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public","size":null,"type":"progress"}  materialize
-38  create  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
-39  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"1","replica_id":"5","replica_name":"linked"}  materialize
-40  create  source  {"database":"materialize","id":"u8","item":"s","schema":"public","size":"1","type":"load-generator"}  materialize
-41  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"5","replica_name":"linked"}  materialize
-42  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"2","replica_id":"6","replica_name":"linked"}  materialize
-43  alter  source  {"database":"materialize","id":"u8","item":"s","new_size":"2","old_size":"1","schema":"public"}  materialize
-44  drop  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public"}  materialize
-45  drop  source  {"database":"materialize","id":"u8","item":"s","schema":"public"}  materialize
-46  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"6","replica_name":"linked"}  materialize
-47  drop  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
-48  create  source  {"database":"materialize","id":"u9","item":"accounts","schema":"public","size":null,"type":"subsource"}  materialize
-49  create  source  {"database":"materialize","id":"u10","item":"auctions","schema":"public","size":null,"type":"subsource"}  materialize
-50  create  source  {"database":"materialize","id":"u11","item":"bids","schema":"public","size":null,"type":"subsource"}  materialize
-51  create  source  {"database":"materialize","id":"u12","item":"organizations","schema":"public","size":null,"type":"subsource"}  materialize
-52  create  source  {"database":"materialize","id":"u13","item":"users","schema":"public","size":null,"type":"subsource"}  materialize
-53  create  source  {"database":"materialize","id":"u14","item":"multiplex_progress","schema":"public","size":null,"type":"progress"}  materialize
-54  create  cluster  {"id":"u4","name":"materialize_public_multiplex"}  materialize
-55  create  cluster-replica  {"cluster_id":"u4","cluster_name":"materialize_public_multiplex","disk":false,"logical_size":"1","replica_id":"7","replica_name":"linked"}  materialize
-56  create  source  {"database":"materialize","id":"u15","item":"multiplex","schema":"public","size":"1","type":"load-generator"}  materialize
-57  alter  cluster-replica  {"cluster_id":"u2","new_name":"s","old_name":"r","replica_id":"4"}  materialize
-58  alter  cluster  {"id":"u2","new_name":"bar","old_name":"foo"}  materialize
-59  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"bar","replica_id":"4","replica_name":"s"}  materialize
-60  drop  cluster  {"id":"u2","name":"bar"}  materialize
+3 grant  database {"database_id":null,"grantee_id":"s2","privileges":"U","role_id":"p","schema_id":null}  NULL
+4  grant  schema  {"database_id":null,"grantee_id":"s2","privileges":"U","role_id":"p","schema_id":null}  NULL
+5  grant  type  {"database_id":null,"grantee_id":"p","privileges":"U","role_id":"p","schema_id":null}  NULL
+6  create  database  {"id":"u1","name":"materialize"}  NULL
+7  grant  database  {"grantee_id":"p","grantor_id":"s1","object_id":"Du1","privileges":"U"}  NULL
+8  grant  database  {"grantee_id":"u1","grantor_id":"s1","object_id":"Du1","privileges":"UC"}  NULL
+9  create  schema  {"database_name":"materialize","id":"3","name":"public"}  NULL
+10  grant  schema  {"grantee_id":"u1","grantor_id":"s1","object_id":"Su1.u3","privileges":"UC"}  NULL
+11  create  cluster  {"id":"u1","name":"default"}  NULL
+12  grant  cluster  {"grantee_id":"p","grantor_id":"s1","object_id":"Cu1","privileges":"U"}  NULL
+13  grant  cluster  {"grantee_id":"u1","grantor_id":"s1","object_id":"Cu1","privileges":"UC"}  NULL
+14  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","disk":false,"logical_size":"1","replica_id":"1","replica_name":"r1"}  NULL
+15  grant  system  {"grantee_id":"s1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
+16  grant  system  {"grantee_id":"u1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
+17  create  database  {"id":"u2","name":"test"}  materialize
+18  create  schema  {"database_name":"test","id":"u6","name":"public"}  materialize
+19  create  schema  {"database_name":"test","id":"u7","name":"sc1"}  materialize
+20  create  schema  {"database_name":"test","id":"u8","name":"sc2"}  materialize
+21  drop  schema  {"database_name":"test","id":"u7","name":"sc1"}  materialize
+22  drop  schema  {"database_name":"test","id":"u6","name":"public"}  materialize
+23  drop  schema  {"database_name":"test","id":"u8","name":"sc2"}  materialize
+24  drop  database  {"id":"u2","name":"test"}  materialize
+25  create  role  {"id":"u2","name":"foo"}  materialize
+26  drop  role  {"id":"u2","name":"foo"}  materialize
+27  create  cluster  {"id":"u2","name":"foo"}  materialize
+28  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","disk":false,"logical_size":"1","replica_id":"4","replica_name":"r"}  materialize
+29  create  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
+30  create  view  {"database":"materialize","id":"u2","item":"unmat","schema":"public"}  materialize
+31  create  table  {"database":"materialize","id":"u3","item":"t","schema":"public"}  materialize
+32  create  index  {"database":"materialize","id":"u4","item":"t_primary_idx","schema":"public"}  materialize
+33  alter  view  {"id":"u2","new_name":{"database":"materialize","item":"renamed","schema":"public"},"old_name":{"database":"materialize","item":"unmat","schema":"public"}}  materialize
+34  drop  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
+35  create  materialized-view  {"database":"materialize","id":"u5","item":"v2","schema":"public"}  materialize
+36  create  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
+37  drop  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
+38  drop  view  {"database":"materialize","id":"u2","item":"renamed","schema":"public"}  materialize
+39  create  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public","size":null,"type":"progress"}  materialize
+40  create  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
+41  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"1","replica_id":"5","replica_name":"linked"}  materialize
+42  create  source  {"database":"materialize","id":"u8","item":"s","schema":"public","size":"1","type":"load-generator"}  materialize
+43  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"5","replica_name":"linked"}  materialize
+44  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"2","replica_id":"6","replica_name":"linked"}  materialize
+45  alter  source  {"database":"materialize","id":"u8","item":"s","new_size":"2","old_size":"1","schema":"public"}  materialize
+46  drop  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public"}  materialize
+47  drop  source  {"database":"materialize","id":"u8","item":"s","schema":"public"}  materialize
+48  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"6","replica_name":"linked"}  materialize
+49  drop  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
+50  create  source  {"database":"materialize","id":"u9","item":"accounts","schema":"public","size":null,"type":"subsource"}  materialize
+51  create  source  {"database":"materialize","id":"u10","item":"auctions","schema":"public","size":null,"type":"subsource"}  materialize
+52  create  source  {"database":"materialize","id":"u11","item":"bids","schema":"public","size":null,"type":"subsource"}  materialize
+53  create  source  {"database":"materialize","id":"u12","item":"organizations","schema":"public","size":null,"type":"subsource"}  materialize
+54  create  source  {"database":"materialize","id":"u13","item":"users","schema":"public","size":null,"type":"subsource"}  materialize
+55  create  source  {"database":"materialize","id":"u14","item":"multiplex_progress","schema":"public","size":null,"type":"progress"}  materialize
+56  create  cluster  {"id":"u4","name":"materialize_public_multiplex"}  materialize
+57  create  cluster-replica  {"cluster_id":"u4","cluster_name":"materialize_public_multiplex","disk":false,"logical_size":"1","replica_id":"7","replica_name":"linked"}  materialize
+58  create  source  {"database":"materialize","id":"u15","item":"multiplex","schema":"public","size":"1","type":"load-generator"}  materialize
+59  alter  cluster-replica  {"cluster_id":"u2","new_name":"s","old_name":"r","replica_id":"4"}  materialize
+60  alter  cluster  {"id":"u2","new_name":"bar","old_name":"foo"}  materialize
+61  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"bar","replica_id":"4","replica_name":"s"}  materialize
+62  drop  cluster  {"id":"u2","name":"bar"}  materialize
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET unsafe_mock_audit_event_timestamp = 666
@@ -161,7 +163,7 @@ CREATE TABLE tt ()
 query ITTTTT
 SELECT id, event_type, object_type, details, user, occurred_at FROM mz_audit_events ORDER BY id DESC LIMIT 1
 ----
-61  create  table  {"database":"materialize","id":"u16","item":"tt","schema":"public"}  materialize  1970-01-01␠00:00:00.666+00
+63  create  table  {"database":"materialize","id":"u16","item":"tt","schema":"public"}  materialize  1970-01-01␠00:00:00.666+00
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM RESET unsafe_mock_audit_event_timestamp
@@ -198,7 +200,7 @@ COMPLETE 0
 query ITTTT
 SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id DESC LIMIT 1
 ----
-64  grant  table  {"grantee_id":"u3","grantor_id":"u1","object_id":"Iu3","privileges":"r"}  mz_system
+66  grant  table  {"grantee_id":"u3","grantor_id":"u1","object_id":"Iu3","privileges":"r"}  mz_system
 
 simple conn=mz_system,user=mz_system
 REVOKE SELECT ON t FROM r1;
@@ -208,7 +210,7 @@ COMPLETE 0
 query ITTTT
 SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id DESC LIMIT 1
 ----
-65  revoke  table  {"grantee_id":"u3","grantor_id":"u1","object_id":"Iu3","privileges":"r"}  mz_system
+67  revoke  table  {"grantee_id":"u3","grantor_id":"u1","object_id":"Iu3","privileges":"r"}  mz_system
 
 simple conn=mz_system,user=mz_system
 ALTER DEFAULT PRIVILEGES FOR ROLE r1 IN SCHEMA public GRANT SELECT ON TABLES to PUBLIC;
@@ -218,7 +220,7 @@ COMPLETE 0
 query ITTTT
 SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id DESC LIMIT 1
 ----
-66  grant  table  {"database_id":"u1","grantee_id":"p","privileges":"r","role_id":"u3","schema_id":"u3"}  mz_system
+68  grant  table  {"database_id":"u1","grantee_id":"p","privileges":"r","role_id":"u3","schema_id":"u3"}  mz_system
 
 simple conn=mz_system,user=mz_system
 ALTER DEFAULT PRIVILEGES FOR ROLE r1 IN SCHEMA public REVOKE SELECT ON TABLES FROM PUBLIC;
@@ -228,7 +230,7 @@ COMPLETE 0
 query ITTTT
 SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id DESC LIMIT 1
 ----
-67  revoke  table  {"database_id":"u1","grantee_id":"p","privileges":"r","role_id":"u3","schema_id":"u3"}  mz_system
+69  revoke  table  {"database_id":"u1","grantee_id":"p","privileges":"r","role_id":"u3","schema_id":"u3"}  mz_system
 
 statement ok
 CREATE TABLE t1 (a INT);
@@ -241,4 +243,4 @@ COMPLETE 0
 query ITTTT
 SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id DESC LIMIT 1
 ----
-69  alter  table  {"new_owner_id":"u3","object_id":"Iu17","old_owner_id":"u1"}  mz_system
+71  alter  table  {"new_owner_id":"u3","object_id":"Iu17","old_owner_id":"u1"}  mz_system

--- a/test/sqllogictest/default_privileges.slt
+++ b/test/sqllogictest/default_privileges.slt
@@ -32,8 +32,10 @@ COMPLETE 0
 query TTTTTT
 SELECT * FROM mz_default_privileges
 ----
-p  NULL  NULL  TYPE     p   U
-p  NULL  NULL  CLUSTER  s2  U
+p  NULL  NULL  TYPE      p   U
+p  NULL  NULL  SCHEMA    s2  U
+p  NULL  NULL  CLUSTER   s2  U
+p  NULL  NULL  DATABASE  s2  U
 
 statement ok
 CREATE TYPE ty AS LIST (ELEMENT TYPE = int4);
@@ -3970,6 +3972,7 @@ sch  r2=U/materialize
 sch  r1=UC/materialize
 sch  r3=UC/materialize
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 statement ok
 DROP SCHEMA sch
@@ -3986,6 +3989,7 @@ sch  r4=C/materialize
 sch  r1=UC/materialize
 sch  r3=UC/materialize
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 statement ok
 DROP SCHEMA d1.sch
@@ -4002,6 +4006,7 @@ sch  r4=C/materialize
 sch  r1=UC/materialize
 sch  r3=UC/materialize
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 statement ok
 DROP SCHEMA d2.sch
@@ -4016,6 +4021,7 @@ SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
 ----
 sch  r8=C/r6
 sch  r6=UC/r6
+sch  mz_introspection=U/r6
 
 simple conn=r6,user=r6
 DROP SCHEMA materialize.sch
@@ -4032,6 +4038,7 @@ SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
 ----
 sch  r8=C/r7
 sch  r7=UC/r7
+sch  mz_introspection=U/r7
 
 simple conn=r7,user=r7
 DROP SCHEMA materialize.sch
@@ -4048,6 +4055,7 @@ SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
 ----
 sch  r10=C/r9
 sch  r9=UC/r9
+sch  mz_introspection=U/r9
 
 simple conn=r9,user=r9
 DROP SCHEMA d1.sch
@@ -4064,6 +4072,7 @@ SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
 ----
 sch  r10=C/r9
 sch  r9=UC/r9
+sch  mz_introspection=U/r9
 
 simple conn=r9,user=r9
 DROP SCHEMA d2.sch
@@ -4165,6 +4174,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
 ----
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 statement ok
 DROP SCHEMA sch
@@ -4176,6 +4186,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
 ----
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 statement ok
 DROP SCHEMA d1.sch
@@ -4187,6 +4198,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
 ----
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 statement ok
 DROP SCHEMA d2.sch
@@ -4200,6 +4212,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
 ----
 sch  r6=UC/r6
+sch  mz_introspection=U/r6
 
 simple conn=r6,user=r6
 DROP SCHEMA materialize.sch
@@ -4215,6 +4228,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
 ----
 sch  r7=UC/r7
+sch  mz_introspection=U/r7
 
 simple conn=r7,user=r7
 DROP SCHEMA materialize.sch
@@ -4230,6 +4244,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
 ----
 sch  r9=UC/r9
+sch  mz_introspection=U/r9
 
 simple conn=r9,user=r9
 DROP SCHEMA d1.sch
@@ -4245,6 +4260,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_schemas WHERE name = 'sch'
 ----
 sch  r9=UC/r9
+sch  mz_introspection=U/r9
 
 simple conn=r9,user=r9
 DROP SCHEMA d2.sch
@@ -4328,6 +4344,7 @@ d  r2=U/materialize
 d  r1=UC/materialize
 d  r3=UC/materialize
 d  materialize=UC/materialize
+d  mz_introspection=U/materialize
 
 statement ok
 DROP DATABASE d
@@ -4342,6 +4359,7 @@ SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
 ----
 d  r8=C/r6
 d  r6=UC/r6
+d  mz_introspection=U/r6
 
 simple conn=r6,user=r6
 DROP DATABASE d
@@ -4358,6 +4376,7 @@ SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
 ----
 d  r8=C/r7
 d  r7=UC/r7
+d  mz_introspection=U/r7
 
 simple conn=r7,user=r7
 DROP DATABASE d
@@ -4373,6 +4392,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
 ----
 d  r9=UC/r9
+d  mz_introspection=U/r9
 
 simple conn=r9,user=r9
 DROP DATABASE d
@@ -4440,6 +4460,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
 ----
 d  materialize=UC/materialize
+d  mz_introspection=U/materialize
 
 statement ok
 DROP DATABASE d
@@ -4453,6 +4474,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
 ----
 d  r6=UC/r6
+d  mz_introspection=U/r6
 
 simple conn=r6,user=r6
 DROP DATABASE d
@@ -4468,6 +4490,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
 ----
 d  r7=UC/r7
+d  mz_introspection=U/r7
 
 simple conn=r7,user=r7
 DROP DATABASE d
@@ -4483,6 +4506,7 @@ query TT
 SELECT name, unnest(privileges)::text FROM mz_databases WHERE name = 'd'
 ----
 d  r9=UC/r9
+d  mz_introspection=U/r9
 
 simple conn=r9,user=r9
 DROP DATABASE d

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -1709,9 +1709,11 @@ db error: ERROR: role "owner" cannot be dropped because some objects depend on i
 DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
 owner: privileges on SCHEMA "materialize.public" granted by mz_system
 owner: owner of DATABASE "db"
+owner: privileges granted on DATABASE "db" to mz_introspection
 owner: privileges on DATABASE "db" granted by owner
 owner: privileges granted on DATABASE "db" to owner
 owner: owner of SCHEMA "db.public"
+owner: privileges granted on SCHEMA "db.public" to mz_introspection
 owner: privileges on SCHEMA "db.public" granted by owner
 owner: privileges granted on SCHEMA "db.public" to owner
 owner: privileges granted on SCHEMA "db.public" to public
@@ -1792,6 +1794,7 @@ db error: ERROR: role "owner" cannot be dropped because some objects depend on i
 DETAIL: owner: privileges on DATABASE "materialize" granted by mz_system
 owner: privileges on SCHEMA "materialize.public" granted by mz_system
 owner: owner of SCHEMA "materialize.sc"
+owner: privileges granted on SCHEMA "materialize.sc" to mz_introspection
 owner: privileges on SCHEMA "materialize.sc" granted by owner
 owner: privileges granted on SCHEMA "materialize.sc" to owner
 owner: privileges on CLUSTER "default" granted by mz_system

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -212,6 +212,7 @@ SELECT * FROM database_privileges
 materialize  =U/mz_system
 materialize  mz_system=UC/mz_system
 materialize  materialize=UC/mz_system
+materialize  mz_introspection=U/mz_system
 
 query TT
 SELECT name, privilege FROM schema_privileges ORDER BY name
@@ -227,6 +228,7 @@ pg_catalog          mz_system=UC/mz_system
 public              =U/mz_system
 public              mz_system=UC/mz_system
 public              materialize=UC/mz_system
+public              mz_introspection=U/mz_system
 
 query TT
 SELECT * FROM cluster_privileges ORDER BY name
@@ -346,6 +348,7 @@ query TT
 SELECT * FROM database_privileges WHERE name = 'd'
 ----
 d  materialize=UC/materialize
+d  mz_introspection=U/materialize
 
 query TT
 SELECT name, privilege FROM schema_privileges WHERE name = 'public' ORDER BY name
@@ -355,6 +358,8 @@ public  =U/materialize
 public  mz_system=UC/mz_system
 public  materialize=UC/mz_system
 public  materialize=UC/materialize
+public  mz_introspection=U/mz_system
+public  mz_introspection=U/materialize
 
 statement ok
 CREATE SCHEMA sch;
@@ -363,6 +368,7 @@ query TT
 SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
 ----
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 # Changing the owner of an object should change the grantor of all privileges to the new owner and
 # transfer the privileges of the old owner to the new owner.
@@ -463,6 +469,7 @@ query TT
 SELECT * FROM database_privileges WHERE name = 'd'
 ----
 d  joe=UC/joe
+d  mz_introspection=U/joe
 
 simple conn=mz_system,user=mz_system
 ALTER SCHEMA sch OWNER TO joe
@@ -473,6 +480,7 @@ query TT
 SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
 ----
 sch  joe=UC/joe
+sch  mz_introspection=U/joe
 
 ## Switch the owners back to materialize
 
@@ -1621,6 +1629,7 @@ SELECT name, privilege FROM database_privileges WHERE name = 'd'
 ----
 d  joe=U/materialize
 d  materialize=UC/materialize
+d  mz_introspection=U/materialize
 
 query B
 SELECT has_database_privilege('joe', 'd', 'USAGE')
@@ -1651,6 +1660,7 @@ SELECT name, privilege FROM database_privileges WHERE name = 'd'
 ----
 d  joe=U/materialize
 d  materialize=UC/materialize
+d  mz_introspection=U/materialize
 
 statement ok
 GRANT USAGE, CREATE on DATABASE d TO PUBLIC
@@ -1661,6 +1671,7 @@ SELECT name, privilege FROM database_privileges WHERE name = 'd'
 d  =UC/materialize
 d  joe=U/materialize
 d  materialize=UC/materialize
+d  mz_introspection=U/materialize
 
 simple conn=joe9,user=joe
 GRANT USAGE on DATABASE d TO other
@@ -1678,6 +1689,7 @@ SELECT name, privilege FROM database_privileges WHERE name = 'd'
 ----
 d  =UC/materialize
 d  materialize=UC/materialize
+d  mz_introspection=U/materialize
 
 query B
 SELECT has_database_privilege('joe', 'd', 'USAGE')
@@ -1708,6 +1720,7 @@ SELECT name, privilege FROM database_privileges WHERE name = 'd'
 ----
 d  =UC/materialize
 d  materialize=UC/materialize
+d  mz_introspection=U/materialize
 
 statement ok
 DROP ROLE joe
@@ -1722,6 +1735,7 @@ query TT
 SELECT name, privilege FROM database_privileges WHERE name = 'd'
 ----
 d  materialize=UC/materialize
+d  mz_introspection=U/materialize
 
 statement error invalid privilege types SELECT, INSERT, UPDATE, DELETE for DATABASE
 GRANT INSERT, SELECT, UPDATE, DELETE ON DATABASE d TO joe
@@ -1756,6 +1770,7 @@ SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
 ----
 sch  joe=U/materialize
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 query B
 SELECT has_schema_privilege('joe', 'sch', 'USAGE')
@@ -1786,6 +1801,7 @@ SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
 ----
 sch  joe=U/materialize
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 statement ok
 GRANT USAGE, CREATE on SCHEMA sch TO PUBLIC
@@ -1796,6 +1812,7 @@ SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
 sch  =UC/materialize
 sch  joe=U/materialize
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 simple conn=joe10,user=joe
 GRANT USAGE on SCHEMA sch TO other
@@ -1813,6 +1830,7 @@ SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
 ----
 sch  =UC/materialize
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 query B
 SELECT has_schema_privilege('joe', 'sch', 'USAGE')
@@ -1843,6 +1861,7 @@ SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
 ----
 sch  =UC/materialize
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 statement ok
 DROP ROLE joe
@@ -1857,6 +1876,7 @@ query TT
 SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
 ----
 sch  materialize=UC/materialize
+sch  mz_introspection=U/materialize
 
 ## System
 

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -219,12 +219,16 @@ SELECT name, privilege FROM schema_privileges ORDER BY name
 ----
 information_schema  =U/mz_system
 information_schema  mz_system=UC/mz_system
+information_schema  mz_introspection=U/mz_system
 mz_catalog          =U/mz_system
 mz_catalog          mz_system=UC/mz_system
+mz_catalog          mz_introspection=U/mz_system
 mz_internal         =U/mz_system
 mz_internal         mz_system=UC/mz_system
+mz_internal         mz_introspection=U/mz_system
 pg_catalog          =U/mz_system
 pg_catalog          mz_system=UC/mz_system
+pg_catalog          mz_introspection=U/mz_system
 public              =U/mz_system
 public              mz_system=UC/mz_system
 public              materialize=UC/mz_system


### PR DESCRIPTION
This commit adds new default privileges to give the mz_introsepection role USAGE privileges on all schemas and databases. It also grants USAGE privileges to mz_introspection on all existing databases and schemas.

These privileges make it easier to use debugging tools via the mz_introspection role and matches the default privileges on clusters.

Works towards resolving #20478

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
