### PR TITLE
adapter: Remove misc dead code

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5805,8 +5805,8 @@ impl Catalog {
                     let membership = RoleMembership::new();
                     let serialized_role = SerializedRole {
                         name: name.clone(),
-                        attributes: Some(attributes.clone()),
-                        membership: Some(membership.clone()),
+                        attributes: attributes.clone(),
+                        membership: membership.clone(),
                     };
                     let id = tx.insert_user_role(serialized_role)?;
                     state.add_to_audit_log(
@@ -7988,18 +7988,16 @@ impl From<ReplicaLocation> for SerializedReplicaLocation {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SerializedRole {
     pub name: String,
-    // TODO(jkosh44): Remove Option when stash consolidation bug is fixed
-    pub attributes: Option<RoleAttributes>,
-    // TODO(jkosh44): Remove Option in v0.49.0
-    pub membership: Option<RoleMembership>,
+    pub attributes: RoleAttributes,
+    pub membership: RoleMembership,
 }
 
 impl From<Role> for SerializedRole {
     fn from(role: Role) -> Self {
         SerializedRole {
             name: role.name,
-            attributes: Some(role.attributes),
-            membership: Some(role.membership),
+            attributes: role.attributes,
+            membership: role.membership,
         }
     }
 }
@@ -8008,8 +8006,8 @@ impl From<&BuiltinRole> for SerializedRole {
     fn from(role: &BuiltinRole) -> Self {
         SerializedRole {
             name: role.name.to_string(),
-            attributes: Some(role.attributes.clone()),
-            membership: Some(RoleMembership::new()),
+            attributes: role.attributes.clone(),
+            membership: RoleMembership::new(),
         }
     }
 }

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -362,8 +362,8 @@ impl Connection {
             .map_ok(|(k, v): (RoleKey, RoleValue)| Role {
                 id: k.id,
                 name: v.role.name,
-                attributes: v.role.attributes.expect("attributes not migrated"),
-                membership: v.role.membership.expect("membership not migrated"),
+                attributes: v.role.attributes,
+                membership: v.role.membership,
             })
             .collect::<Result<_, _>>()?;
 

--- a/src/adapter/src/catalog/storage/objects.rs
+++ b/src/adapter/src/catalog/storage/objects.rs
@@ -584,8 +584,8 @@ impl RustType<proto::RoleValue> for RoleValue {
     fn into_proto(&self) -> proto::RoleValue {
         proto::RoleValue {
             name: self.role.name.to_string(),
-            attributes: self.role.attributes.into_proto(),
-            membership: self.role.membership.into_proto(),
+            attributes: Some(self.role.attributes.into_proto()),
+            membership: Some(self.role.membership.into_proto()),
         }
     }
 
@@ -593,8 +593,12 @@ impl RustType<proto::RoleValue> for RoleValue {
         Ok(RoleValue {
             role: SerializedRole {
                 name: proto.name,
-                attributes: proto.attributes.into_rust()?,
-                membership: proto.membership.into_rust()?,
+                attributes: proto
+                    .attributes
+                    .into_rust_if_some("RoleValue::attributes")?,
+                membership: proto
+                    .membership
+                    .into_rust_if_some("RoleValue::membership")?,
             },
         })
     }


### PR DESCRIPTION


### Motivation
This PR refactors existing code.


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
