### PR TITLE
adapter: improve txn error message for select + subscribe

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -281,6 +281,7 @@ impl AdapterError {
             AdapterError::Storage(storage_error) => {
                 storage_error.source().map(|source_error| source_error.to_string_with_causes())
             }
+            AdapterError::ReadOnlyTransaction => Some("SELECT queries cannot be combined with other query types, including SUBSCRIBE.".into()),
             _ => None,
         }
     }

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -222,6 +222,7 @@ DECLARE c CURSOR FOR SUBSCRIBE t;
 FETCH 0 c;
 ----
 db error: ERROR: transaction in read-only mode
+DETAIL: SELECT queries cannot be combined with other query types, including SUBSCRIBE.
 
 # Using an AS OF in the SELECT or SUBSCRIBE allows lifting that restriction.
 


### PR DESCRIPTION
Fixes #20474

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a