### PR TITLE
persist: make CRDB conn ttl knobs actually dynamic

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -81,6 +81,10 @@ fn persist_config(config: &SystemVars) -> PersistParameters {
         compaction_minimum_timeout: Some(config.persist_compaction_minimum_timeout()),
         consensus_connect_timeout: Some(config.crdb_connect_timeout()),
         consensus_tcp_user_timeout: Some(config.crdb_tcp_user_timeout()),
+        consensus_connection_pool_ttl: Some(config.persist_consensus_connection_pool_ttl()),
+        consensus_connection_pool_ttl_stagger: Some(
+            config.persist_consensus_connection_pool_ttl_stagger(),
+        ),
         sink_minimum_batch_updates: Some(config.persist_sink_minimum_batch_updates()),
         storage_sink_minimum_batch_updates: Some(
             config.storage_persist_sink_minimum_batch_updates(),

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -28,6 +28,8 @@ message ProtoPersistParameters {
     mz_proto.ProtoDuration consensus_tcp_user_timeout = 12;
     optional uint64 rollup_threshold = 13;
     optional uint64 blob_cache_mem_limit_bytes = 14;
+    mz_proto.ProtoDuration consensus_connection_pool_ttl = 15;
+    mz_proto.ProtoDuration consensus_connection_pool_ttl_stagger = 16;
 }
 
 message ProtoRetryParameters {

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -140,9 +140,11 @@ impl PersistConfig {
                 compaction_heuristic_min_parts: AtomicUsize::new(8),
                 compaction_heuristic_min_updates: AtomicUsize::new(1024),
                 compaction_memory_bound_bytes: AtomicUsize::new(1024 * MB),
-                compaction_minimum_timeout: Self::DEFAULT_COMPACTION_MINIMUM_TIMEOUT,
-                consensus_connection_pool_ttl: Duration::from_secs(300),
-                consensus_connection_pool_ttl_stagger: Duration::from_secs(6),
+                compaction_minimum_timeout: RwLock::new(Self::DEFAULT_COMPACTION_MINIMUM_TIMEOUT),
+                consensus_connection_pool_ttl: RwLock::new(Self::DEFAULT_CONSENSUS_CONNPOOL_TTL),
+                consensus_connection_pool_ttl_stagger: RwLock::new(
+                    Self::DEFAULT_CONSENSUS_CONNPOOL_TTL_STAGGER,
+                ),
                 consensus_connect_timeout: RwLock::new(Self::DEFAULT_CRDB_CONNECT_TIMEOUT),
                 consensus_tcp_user_timeout: RwLock::new(Self::DEFAULT_CRDB_TCP_USER_TIMEOUT),
                 gc_blob_delete_concurrency_limit: AtomicUsize::new(32),
@@ -226,6 +228,10 @@ impl PersistConfig {
     pub const DEFAULT_CRDB_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
     /// Default value for [`DynamicConfig::consensus_tcp_user_timeout`].
     pub const DEFAULT_CRDB_TCP_USER_TIMEOUT: Duration = Duration::from_secs(30);
+    /// Default value for [`DynamicConfig::consensus_connection_pool_ttl`].
+    pub const DEFAULT_CONSENSUS_CONNPOOL_TTL: Duration = Duration::from_secs(300);
+    /// Default value for [`DynamicConfig::consensus_connection_pool_ttl_stagger`].
+    pub const DEFAULT_CONSENSUS_CONNPOOL_TTL_STAGGER: Duration = Duration::from_secs(5);
     /// Default value for [`DynamicConfig::stats_audit_percent`].
     pub const DEFAULT_STATS_AUDIT_PERCENT: usize = 0;
     /// Default value for [`DynamicConfig::stats_collection_enabled`].
@@ -333,11 +339,14 @@ pub struct DynamicConfig {
     compaction_heuristic_min_parts: AtomicUsize,
     compaction_heuristic_min_updates: AtomicUsize,
     compaction_memory_bound_bytes: AtomicUsize,
+    compaction_minimum_timeout: RwLock<Duration>,
     gc_blob_delete_concurrency_limit: AtomicUsize,
     state_versions_recent_live_diffs_limit: AtomicUsize,
     usage_state_fetch_concurrency_limit: AtomicUsize,
     consensus_connect_timeout: RwLock<Duration>,
     consensus_tcp_user_timeout: RwLock<Duration>,
+    consensus_connection_pool_ttl: RwLock<Duration>,
+    consensus_connection_pool_ttl_stagger: RwLock<Duration>,
     sink_minimum_batch_updates: AtomicUsize,
     storage_sink_minimum_batch_updates: AtomicUsize,
     stats_audit_percent: AtomicUsize,
@@ -351,11 +360,6 @@ pub struct DynamicConfig {
     // We put them under a single RwLock to reduce the cost of reads
     // and to logically group them together.
     next_listen_batch_retryer: RwLock<RetryParameters>,
-
-    // TODO: Figure out how to make these dynamic.
-    compaction_minimum_timeout: Duration,
-    consensus_connection_pool_ttl: Duration,
-    consensus_connection_pool_ttl_stagger: Duration,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Arbitrary, Serialize, Deserialize)]
@@ -465,14 +469,20 @@ impl DynamicConfig {
     /// allow a compaction request to run before timing it out. A request may be
     /// given a timeout greater than this value depending on the inputs' size
     pub fn compaction_minimum_timeout(&self) -> Duration {
-        self.compaction_minimum_timeout
+        *self
+            .compaction_minimum_timeout
+            .read()
+            .expect("lock poisoned")
     }
 
     /// The minimum TTL of a connection to Postgres/CRDB before it is proactively
     /// terminated. Connections are routinely culled to balance load against the
     /// downstream database.
     pub fn consensus_connection_pool_ttl(&self) -> Duration {
-        self.consensus_connection_pool_ttl
+        *self
+            .consensus_connection_pool_ttl
+            .read()
+            .expect("lock poisoned")
     }
     /// The minimum time between TTLing connections to Postgres/CRDB. This delay is
     /// used to stagger reconnections to avoid stampedes and high tail latencies.
@@ -482,7 +492,10 @@ impl DynamicConfig {
     /// is likely a good place to start so that all connections are rotated when the
     /// pool is fully used.
     pub fn consensus_connection_pool_ttl_stagger(&self) -> Duration {
-        self.consensus_connection_pool_ttl_stagger
+        *self
+            .consensus_connection_pool_ttl_stagger
+            .read()
+            .expect("lock poisoned")
     }
     /// The duration to wait for a Consensus Postgres/CRDB connection to be made before retrying.
     pub fn consensus_connect_timeout(&self) -> Duration {
@@ -639,6 +652,10 @@ pub struct PersistParameters {
     pub consensus_connect_timeout: Option<Duration>,
     /// Configures [`DynamicConfig::consensus_tcp_user_timeout`].
     pub consensus_tcp_user_timeout: Option<Duration>,
+    /// Configures [`DynamicConfig::consensus_connection_pool_ttl`].
+    pub consensus_connection_pool_ttl: Option<Duration>,
+    /// Configures [`DynamicConfig::consensus_connection_pool_ttl_stagger`].
+    pub consensus_connection_pool_ttl_stagger: Option<Duration>,
     /// Configures [`DynamicConfig::next_listen_batch_retry_params`].
     pub next_listen_batch_retryer: Option<RetryParameters>,
     /// Configures [`PersistConfig::sink_minimum_batch_updates`].
@@ -670,6 +687,8 @@ impl PersistParameters {
             compaction_minimum_timeout: self_compaction_minimum_timeout,
             consensus_connect_timeout: self_consensus_connect_timeout,
             consensus_tcp_user_timeout: self_consensus_tcp_user_timeout,
+            consensus_connection_pool_ttl: self_consensus_connection_pool_ttl,
+            consensus_connection_pool_ttl_stagger: self_consensus_connection_pool_ttl_stagger,
             sink_minimum_batch_updates: self_sink_minimum_batch_updates,
             storage_sink_minimum_batch_updates: self_storage_sink_minimum_batch_updates,
             next_listen_batch_retryer: self_next_listen_batch_retryer,
@@ -686,6 +705,8 @@ impl PersistParameters {
             compaction_minimum_timeout: other_compaction_minimum_timeout,
             consensus_connect_timeout: other_consensus_connect_timeout,
             consensus_tcp_user_timeout: other_consensus_tcp_user_timeout,
+            consensus_connection_pool_ttl: other_consensus_connection_pool_ttl,
+            consensus_connection_pool_ttl_stagger: other_consensus_connection_pool_ttl_stagger,
             sink_minimum_batch_updates: other_sink_minimum_batch_updates,
             storage_sink_minimum_batch_updates: other_storage_sink_minimum_batch_updates,
             next_listen_batch_retryer: other_next_listen_batch_retryer,
@@ -710,6 +731,12 @@ impl PersistParameters {
         }
         if let Some(v) = other_consensus_tcp_user_timeout {
             *self_consensus_tcp_user_timeout = Some(v);
+        }
+        if let Some(v) = other_consensus_connection_pool_ttl {
+            *self_consensus_connection_pool_ttl = Some(v);
+        }
+        if let Some(v) = other_consensus_connection_pool_ttl_stagger {
+            *self_consensus_connection_pool_ttl_stagger = Some(v);
         }
         if let Some(v) = other_sink_minimum_batch_updates {
             *self_sink_minimum_batch_updates = Some(v);
@@ -752,6 +779,8 @@ impl PersistParameters {
             compaction_minimum_timeout,
             consensus_connect_timeout,
             consensus_tcp_user_timeout,
+            consensus_connection_pool_ttl,
+            consensus_connection_pool_ttl_stagger,
             sink_minimum_batch_updates,
             storage_sink_minimum_batch_updates,
             next_listen_batch_retryer,
@@ -767,6 +796,8 @@ impl PersistParameters {
             && compaction_minimum_timeout.is_none()
             && consensus_connect_timeout.is_none()
             && consensus_tcp_user_timeout.is_none()
+            && consensus_connection_pool_ttl.is_none()
+            && consensus_connection_pool_ttl_stagger.is_none()
             && sink_minimum_batch_updates.is_none()
             && storage_sink_minimum_batch_updates.is_none()
             && next_listen_batch_retryer.is_none()
@@ -791,6 +822,8 @@ impl PersistParameters {
             compaction_minimum_timeout,
             consensus_connect_timeout,
             consensus_tcp_user_timeout,
+            consensus_connection_pool_ttl,
+            consensus_connection_pool_ttl_stagger,
             sink_minimum_batch_updates,
             storage_sink_minimum_batch_updates,
             next_listen_batch_retryer,
@@ -811,8 +844,13 @@ impl PersistParameters {
                 .blob_cache_mem_limit_bytes
                 .store(*blob_cache_mem_limit_bytes, DynamicConfig::STORE_ORDERING);
         }
-        if let Some(_compaction_minimum_timeout) = compaction_minimum_timeout {
-            // TODO: Figure out how to represent Durations in DynamicConfig.
+        if let Some(compaction_minimum_timeout) = compaction_minimum_timeout {
+            let mut timeout = cfg
+                .dynamic
+                .compaction_minimum_timeout
+                .write()
+                .expect("lock poisoned");
+            *timeout = *compaction_minimum_timeout;
         }
         if let Some(consensus_connect_timeout) = consensus_connect_timeout {
             let mut timeout = cfg
@@ -829,6 +867,22 @@ impl PersistParameters {
                 .write()
                 .expect("lock poisoned");
             *timeout = *consensus_tcp_user_timeout;
+        }
+        if let Some(consensus_connection_pool_ttl) = consensus_connection_pool_ttl {
+            let mut ttl = cfg
+                .dynamic
+                .consensus_connection_pool_ttl
+                .write()
+                .expect("lock poisoned");
+            *ttl = *consensus_connection_pool_ttl;
+        }
+        if let Some(consensus_connection_pool_ttl_stagger) = consensus_connection_pool_ttl_stagger {
+            let mut stagger = cfg
+                .dynamic
+                .consensus_connection_pool_ttl_stagger
+                .write()
+                .expect("lock poisoned");
+            *stagger = *consensus_connection_pool_ttl_stagger;
         }
         if let Some(sink_minimum_batch_updates) = sink_minimum_batch_updates {
             cfg.dynamic
@@ -890,6 +944,10 @@ impl RustType<ProtoPersistParameters> for PersistParameters {
             compaction_minimum_timeout: self.compaction_minimum_timeout.into_proto(),
             consensus_connect_timeout: self.consensus_connect_timeout.into_proto(),
             consensus_tcp_user_timeout: self.consensus_tcp_user_timeout.into_proto(),
+            consensus_connection_pool_ttl: self.consensus_connection_pool_ttl.into_proto(),
+            consensus_connection_pool_ttl_stagger: self
+                .consensus_connection_pool_ttl_stagger
+                .into_proto(),
             sink_minimum_batch_updates: self.sink_minimum_batch_updates.into_proto(),
             storage_sink_minimum_batch_updates: self
                 .storage_sink_minimum_batch_updates
@@ -911,6 +969,10 @@ impl RustType<ProtoPersistParameters> for PersistParameters {
             compaction_minimum_timeout: proto.compaction_minimum_timeout.into_rust()?,
             consensus_connect_timeout: proto.consensus_connect_timeout.into_rust()?,
             consensus_tcp_user_timeout: proto.consensus_tcp_user_timeout.into_rust()?,
+            consensus_connection_pool_ttl: proto.consensus_connection_pool_ttl.into_rust()?,
+            consensus_connection_pool_ttl_stagger: proto
+                .consensus_connection_pool_ttl_stagger
+                .into_rust()?,
             sink_minimum_batch_updates: proto.sink_minimum_batch_updates.into_rust()?,
             storage_sink_minimum_batch_updates: proto
                 .storage_sink_minimum_batch_updates

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -231,7 +231,7 @@ impl PersistConfig {
     /// Default value for [`DynamicConfig::consensus_connection_pool_ttl`].
     pub const DEFAULT_CONSENSUS_CONNPOOL_TTL: Duration = Duration::from_secs(300);
     /// Default value for [`DynamicConfig::consensus_connection_pool_ttl_stagger`].
-    pub const DEFAULT_CONSENSUS_CONNPOOL_TTL_STAGGER: Duration = Duration::from_secs(5);
+    pub const DEFAULT_CONSENSUS_CONNPOOL_TTL_STAGGER: Duration = Duration::from_secs(6);
     /// Default value for [`DynamicConfig::stats_audit_percent`].
     pub const DEFAULT_STATS_AUDIT_PERCENT: usize = 0;
     /// Default value for [`DynamicConfig::stats_collection_enabled`].

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -554,6 +554,22 @@ const PERSIST_COMPACTION_MINIMUM_TIMEOUT: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
+/// Controls [`mz_persist_client::cfg::DynamicConfig::consensus_connection_pool_ttl`].
+const PERSIST_CONSENSUS_CONNECTION_POOL_TTL: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("persist_consensus_connection_pool_ttl"),
+    value: &PersistConfig::DEFAULT_CONSENSUS_CONNPOOL_TTL,
+    description: "The minimum TTL of a Consensus connection to Postgres/CRDB before it is proactively terminated",
+    internal: true,
+};
+
+/// Controls [`mz_persist_client::cfg::DynamicConfig::consensus_connection_pool_ttl_stagger`].
+const PERSIST_CONSENSUS_CONNECTION_POOL_TTL_STAGGER: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("persist_consensus_connection_pool_ttl_stagger"),
+    value: &PersistConfig::DEFAULT_CONSENSUS_CONNPOOL_TTL_STAGGER,
+    description: "The minimum time between TTLing Consensus connections to Postgres/CRDB.",
+    internal: true,
+};
+
 /// Controls initial backoff of [`mz_persist_client::cfg::DynamicConfig::next_listen_batch_retry_params`].
 const PERSIST_NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF: ServerVar<Duration> = ServerVar {
     name: UncasedStr::new("persist_next_listen_batch_retryer_initial_backoff"),
@@ -1756,6 +1772,8 @@ impl SystemVars {
             .with_var(&PERSIST_BLOB_TARGET_SIZE)
             .with_var(&PERSIST_BLOB_CACHE_MEM_LIMIT_BYTES)
             .with_var(&PERSIST_COMPACTION_MINIMUM_TIMEOUT)
+            .with_var(&PERSIST_CONSENSUS_CONNECTION_POOL_TTL)
+            .with_var(&PERSIST_CONSENSUS_CONNECTION_POOL_TTL_STAGGER)
             .with_var(&CRDB_CONNECT_TIMEOUT)
             .with_var(&CRDB_TCP_USER_TIMEOUT)
             .with_var(&DATAFLOW_MAX_INFLIGHT_BYTES)
@@ -2158,6 +2176,16 @@ impl SystemVars {
     /// Returns the `persist_compaction_minimum_timeout` configuration parameter.
     pub fn persist_compaction_minimum_timeout(&self) -> Duration {
         *self.expect_value(&PERSIST_COMPACTION_MINIMUM_TIMEOUT)
+    }
+
+    /// Returns the `persist_consensus_connection_pool_ttl` configuration parameter.
+    pub fn persist_consensus_connection_pool_ttl(&self) -> Duration {
+        *self.expect_value(&PERSIST_CONSENSUS_CONNECTION_POOL_TTL)
+    }
+
+    /// Returns the `persist_consensus_connection_pool_ttl_stagger` configuration parameter.
+    pub fn persist_consensus_connection_pool_ttl_stagger(&self) -> Duration {
+        *self.expect_value(&PERSIST_CONSENSUS_CONNECTION_POOL_TTL_STAGGER)
     }
 
     /// Returns the `pg_replication_connect_timeout` configuration parameter.
@@ -3678,6 +3706,8 @@ fn is_persist_config_var(name: &str) -> bool {
     name == PERSIST_BLOB_TARGET_SIZE.name()
         || name == PERSIST_BLOB_CACHE_MEM_LIMIT_BYTES.name()
         || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
+        || name == PERSIST_CONSENSUS_CONNECTION_POOL_TTL.name()
+        || name == PERSIST_CONSENSUS_CONNECTION_POOL_TTL_STAGGER.name()
         || name == CRDB_CONNECT_TIMEOUT.name()
         || name == CRDB_TCP_USER_TIMEOUT.name()
         || name == PERSIST_SINK_MINIMUM_BATCH_UPDATES.name()


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Long time coming -- when we first wired up `DynamicConfig` we didn't know how to best represent Durations, so three "dynamic" knobs weren't actually hooked up. We've since settled on `RwLock<Duration>` which has worked out well so far, and this PR hooks up those original knobs as such.

Most importantly, this makes CRDB connection TTLing truly dynamic, allowing us to more easily fine tune our TTL rate to better match our CRDB `connection_wait` (https://github.com/MaterializeInc/materialize/issues/20287)

### Motivation

Part of https://github.com/MaterializeInc/materialize/issues/20287 

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
