### PR TITLE
dbt-materialize: exclude subsources from introspection

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,16 @@
 # dbt-materialize Changelog
 
+## Unreleased
+
+* Fix a bug in the `materialize__list_relations_without_caching` macro which
+  could cause the adapter to break for multi-output sources ([#20483](https://github.com/MaterializeInc/materialize/issues/20483)).
+
+* **Breaking change.** Expose `owner` in the dbt documentation, now that
+    Materialize supports [role-based access control (RBAC)](https://materialize.com/docs/manage/access-control/).
+
+  This change requires [Materialize >=0.48.0](https://materialize.com/docs/releases/v0.48/).
+  **Users of older versions should pin `dbt-materialize` to `v1.4.1`.**
+
 ## 1.4.1 - 2023-04-28
 
 * Let Materialize automatically run introspection queries in the

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -96,11 +96,17 @@
         d.name as database,
         s.name as schema,
         o.name,
-        case when o.type = 'materialized-view' then 'materializedview' else o.type end as type
+        case when o.type = 'materialized-view' then 'materializedview'
+             else o.type
+        end as type
     from mz_objects o
+    left join mz_sources so on o.id = so.id
     join mz_schemas s on o.schema_id = s.id and s.name = '{{ schema_relation.schema }}'
     join mz_databases d on s.database_id = d.id and d.name = '{{ schema_relation.database }}'
-    where type in ('table', 'source', 'view', 'materialized-view', 'index', 'sink')
+    where o.type in ('table', 'source', 'view', 'materialized-view', 'index', 'sink')
+      --Exclude subsources and progress subsources, which aren't relevant in this
+      --context and can bork the adapter (see #20483)
+      and so.type not in ('subsource', 'progress')
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -106,7 +106,7 @@
     where o.type in ('table', 'source', 'view', 'materialized-view', 'index', 'sink')
       --Exclude subsources and progress subsources, which aren't relevant in this
       --context and can bork the adapter (see #20483)
-      and so.type not in ('subsource', 'progress')
+      and coalesce(so.type, '') not in ('subsource', 'progress')
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
@@ -24,14 +24,21 @@
             d.name as table_database,
             s.name as table_schema,
             o.name as table_name,
-            case when o.type = 'materialized-view' then 'materializedview' else o.type end as table_type,
+            case when o.type = 'materialized-view' then 'materializedview'
+                 --This macro is used for the dbt documentation. We use
+                 --the source type in mz_sources here instead of that
+                 --in mz_objects to correctly report subsources.
+                 when o.type = 'source' then so.type
+                 else o.type end as table_type,
             '' as table_comment,
             c.name as column_name,
             c.position as column_index,
             c.type as column_type,
             '' as column_comment,
-            '' as table_owner
+            r.name as table_owner
         from mz_objects o
+        left join mz_sources so on o.id = so.id
+        join mz_roles r on o.owner_id = r.id
         join mz_schemas s on o.schema_id = s.id
         join mz_databases d on s.database_id = d.id and d.name = '{{ database }}'
         join mz_columns c on c.id = o.id

--- a/misc/dbt-materialize/tests/adapter/fixtures.py
+++ b/misc/dbt-materialize/tests/adapter/fixtures.py
@@ -43,7 +43,7 @@ test_source = """
 {{ config(
     materialized='source',
     database='materialize',
-    pre_hook="CREATE CONNECTION kafka_connection TO KAFKA (BROKER '{{ env_var('KAFKA_ADDR', 'localhost:9092') }}')"
+    pre_hook="CREATE CONNECTION IF NOT EXISTS kafka_connection TO KAFKA (BROKER '{{ env_var('KAFKA_ADDR', 'localhost:9092') }}')"
     )
 }}
 
@@ -61,6 +61,18 @@ test_source_index = """
 CREATE SOURCE {{ this }}
 FROM KAFKA CONNECTION kafka_connection (TOPIC 'test-source')
 FORMAT BYTES
+"""
+
+test_subsources = """
+{{ config(
+    materialized='source',
+    database='materialize'
+    )
+}}
+
+CREATE SOURCE {{ this }}
+FROM LOAD GENERATOR AUCTION
+FOR ALL TABLES;
 """
 
 test_sink = """

--- a/misc/dbt-materialize/tests/adapter/test_basic.py
+++ b/misc/dbt-materialize/tests/adapter/test_basic.py
@@ -168,7 +168,7 @@ class TestDocsGenerateMaterialize(BaseDocsGenerate):
     def expected_catalog(self, project, profile_user):
         return base_expected_catalog(
             project,
-            role=None,
+            role="materialize",
             id_type="integer",
             text_type="text",
             time_type="timestamp",
@@ -183,7 +183,7 @@ class TestDocsGenReferencesMaterialize(BaseDocsGenReferences):
     def expected_catalog(self, project, profile_user):
         return expected_references_catalog(
             project,
-            role=None,
+            role="materialize",
             id_type="integer",
             text_type="text",
             time_type="timestamp",

--- a/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
+++ b/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
@@ -24,6 +24,7 @@ from fixtures import (
     test_sink,
     test_source,
     test_source_index,
+    test_subsources,
     test_view_index,
 )
 
@@ -48,6 +49,7 @@ class TestCustomMaterializations:
             "test_relation_name_loooooooooooooooooonger_than_postgres_63_limit.sql": test_relation_name_length,
             "test_source.sql": test_source,
             "test_source_index.sql": test_source_index,
+            "test_subsources.sql": test_subsources,
             "test_sink.sql": test_sink,
             "actual_indexes.sql": actual_indexes,
         }
@@ -60,7 +62,12 @@ class TestCustomMaterializations:
         # run models
         results = run_dbt(["run"])
         # run result length
-        assert len(results) == 8
+        assert len(results) == 9
+        # re-run models to ensure there are no lingering errors in recreating
+        # the materializations
+        results = run_dbt(["run"])
+        # re-run result length
+        assert len(results) == 9
         # relations_equal
         check_relations_equal(
             project.adapter, ["test_materialized_view", "test_view_index"]


### PR DESCRIPTION
Fixes #20483.

The issue was in the `materialize__list_relations_without_caching` macro, which listed subsources and progress subsources as `sources`. For multi-output sources, this meant that dbt would try to run a `DROP...CASCADE` statement for the source first, and then also for the subsources, which breaks. For future reference, you can get more detailed logging using `dbt --debug run`, @philip-stoev!

```sql
00:52:14  Began compiling node model.mz_get_started.accounts
00:52:14  Writing injected SQL for node "model.mz_get_started.accounts"
00:52:14  Timing info for model.mz_get_started.accounts (compile): 02:52:14.055838 => 02:52:14.061600
00:52:14  Began executing node model.mz_get_started.accounts
00:52:14  Using materialize connection "model.mz_get_started.accounts"
00:52:14  On model.mz_get_started.accounts: /* {"app": "dbt", "dbt_version": "1.5.2", "profile_name": "mz_get_started", "target_name": "dev", "node_id": "model.mz_get_started.accounts"} */

      drop source if exists "materialize"."qck"."accounts" cascade

00:52:14  Opening a new connection, currently in state closed
00:52:14  Materialize adapter: Enabling auto_route_introspection_queries
00:52:14  Postgres adapter: Postgres error: SOURCE "qck.accounts" is a subsource and must be dropped with ALTER SOURCE...DROP SUBSOURCE
HINT:  Use ALTER SOURCE qck.auction_house DROP SUBSOURCE qck.accounts

00:52:14  Postgres adapter: Error running SQL: macro drop_relation
00:52:14  Postgres adapter: Rolling back transaction.
00:52:14  Timing info for model.mz_get_started.accounts (execute): 02:52:14.062779 => 02:52:14.464442
00:52:14  On model.mz_get_started.accounts: Close
00:52:14  Database Error in model accounts (models/staging/accounts.sql)
  SOURCE "qck.accounts" is a subsource and must be dropped with ALTER SOURCE...DROP SUBSOURCE
  HINT:  Use ALTER SOURCE qck.auction_house DROP SUBSOURCE qck.accounts
```

Taking the chance to add very minimal quality-of-life improvements to `dbt docs`: populate `owner` in the dbt documentation, now that we have RBAC wired up, and use the `type` from `mz_sources` instead of `mz_objects` to correctly report subsources. The docs for the parent source object don't expose the object type, so we can live with it not being `source`, and rather one of `postgres`, `kafka` or `load-generator`
.
<img width="1435" alt="Screenshot 2023-07-13 at 03 50 37" src="https://github.com/MaterializeInc/materialize/assets/23521087/caf5dabe-25d6-425b-ab63-0be66fafccf1">