### PR TITLE
Fix `AS OF` handling in `sqllogictest`'s `--auto-index-selects` option

### DIFF
--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -51,7 +51,6 @@ tests=(
 tests_without_views=(
     # errors:
     test/sqllogictest/array_fill.slt
-    test/sqllogictest/as_of.slt
     test/sqllogictest/cluster.slt
     test/sqllogictest/cte_lowering.slt
     test/sqllogictest/current_database.slt
@@ -94,7 +93,6 @@ tests_without_views=(
     test/sqllogictest/schemas.slt
     test/sqllogictest/subquery.slt
     test/sqllogictest/table_func.slt
-    test/sqllogictest/temporal.slt
     test/sqllogictest/timedomain.slt
     test/sqllogictest/transactions.slt
     test/sqllogictest/transform/filter_index.slt
@@ -112,7 +110,6 @@ tests_without_views=(
     test/sqllogictest/cluster.slt # different indexes auto-created
     test/sqllogictest/interval.slt # https://github.com/MaterializeInc/materialize/issues/20110
     test/sqllogictest/operator.slt # https://github.com/MaterializeInc/materialize/issues/20110
-    test/sqllogictest/temporal.slt # https://github.com/MaterializeInc/materialize/issues/20110
 )
 # Exclude tests_without_views from tests
 for f in "${tests_without_views[@]}"; do

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1975,8 +1975,8 @@ fn generate_view_sql(
     // DDL cost drops dramatically in the future.
     let stmts = parser::parse_statements(sql).unwrap_or_default();
     assert!(stmts.len() == 1);
-    let query = match &stmts[0] {
-        Statement::Select(stmt) => &stmt.query,
+    let (query, query_as_of) = match &stmts[0] {
+        Statement::Select(stmt) => (&stmt.query, &stmt.as_of),
         _ => unreachable!("This function should only be called for SELECTs"),
     };
 
@@ -2110,7 +2110,7 @@ fn generate_view_sql(
             limit: None,
             offset: None,
         },
-        as_of: None,
+        as_of: query_as_of.clone(),
     })
     .to_ast_string_stable();
 


### PR DESCRIPTION
This PR fixes the handling of the `AS OF` clause in `sqllogictest`'s `--auto-index-selects` option. Previously, the `AS OF` clause of a `SELECT` statement was ignored. With the commit, the `AS OF` clause is now considered in the view-based execution by getting attached to the query on the indexed view created for the `SELECT`. This fix enables `temporal.slt` and `as_of.slt` to pass without any inconsistent view outcome failures.

### Motivation

  * This PR fixes a previously unreported bug.

This bug was observed in these [two](https://github.com/MaterializeInc/materialize/issues/20110#issuecomment-1633284113) [comments](https://github.com/MaterializeInc/materialize/issues/20110#issuecomment-1633943686). The `AS OF` clause was ignored in the view-based execution of `sqllogicttest`, causing tests to emit output failures for queries on indexed views but not for one-shot `SELECT`s. With the fix, the `AS OF` clause is considered as in the following example:
```
    SELECT * FROM data AS OF now()
    CREATE VIEW "v1bc6a231b0304b299a2503d52c8b9275" AS SELECT * FROM "data"
    CREATE DEFAULT INDEX ON "v1bc6a231b0304b299a2503d52c8b9275"
    SELECT * FROM "v1bc6a231b0304b299a2503d52c8b9275" AS OF "now"()
    DROP VIEW "v1bc6a231b0304b299a2503d52c8b9275"
```
### Tips for reviewer

This is a small fix that should be pretty uncontroversial.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR is sufficiently small to not require a design.
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
