### PR TITLE
mzcompose: Add pg_cron to the Postgres docker image

### DIFF
--- a/test/postgres/Dockerfile
+++ b/test/postgres/Dockerfile
@@ -13,6 +13,10 @@ FROM postgres:15.2-bullseye
 
 ENV POSTGRES_PASSWORD=postgres
 
+RUN apt update
+
+RUN apt install postgresql-15-cron
+
 COPY --chown=postgres --from=certs /secrets/* /share/secrets/
 COPY pg_hba.conf /share/conf/pg_hba.conf
 COPY setup-postgres.sh /docker-entrypoint-initdb.d/setup-postgres.sh

--- a/test/postgres/setup-postgres.sh
+++ b/test/postgres/setup-postgres.sh
@@ -21,4 +21,6 @@ wal_level = logical
 fsync = off
 max_wal_senders = 20
 max_replication_slots = 20
+shared_preload_libraries = 'pg_cron'
+cron.database_name = 'postgres'
 EOCONF


### PR DESCRIPTION
pg_cron will be used to drive Postgres traffic to Materialize without having to constantly issue individual DMLs against Postgres.


### Motivation

This is needed to develop locally a workload for the comprehensive cloud canary environment. The workload will then be copied over to an Amazon RDS instance (that also supports pg_cron) in order to obtain a Postgres server that constantly emits replication events without requiring an always-connected SQL client to drive the workload.