### PR TITLE
coverage: Ignore mz_ore::test in reports

### DIFF
--- a/misc/python/materialize/cli/ci_coverage_pr_report.py
+++ b/misc/python/materialize/cli/ci_coverage_pr_report.py
@@ -28,8 +28,15 @@ SOURCE_RE = re.compile(
     "^/var/lib/buildkite-agent/builds/buildkite-.*/materialize/coverage/(.*$)"
 )
 # Deriving generates more code, but we don't expect to cover this in most
-# cases, so ignore such lines.
-IGNORE_RE = re.compile(r"#\[derive\(.*\)\]")
+# cases, so ignore such lines. Same for mz_ore::test
+IGNORE_RE = re.compile(
+    r"""
+    ( #\[derive\(.*\)\]
+    | #\[mz_ore::test.*\]
+    )
+    """,
+    re.VERBOSE,
+)
 
 
 def find_modified_lines() -> Coverage:


### PR DESCRIPTION
As reported by Rainer: https://buildkite.com/materialize/coverage/builds/181

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
