### PR TITLE
limits test: Try lifting limits

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -140,10 +140,6 @@ class Subscribe(Generator):
 
 
 class Indexes(Generator):
-    COUNT = min(
-        Generator.COUNT, 100
-    )  # https://github.com/MaterializeInc/materialize/issues/11134
-
     @classmethod
     def body(cls) -> None:
         print("$ postgres-execute connection=mz_system")
@@ -694,7 +690,7 @@ class SubqueriesExistWhereClause(Generator):
 class SubqueriesInWhereClauseCorrelated(Generator):
     COUNT = min(
         Generator.COUNT, 10
-    )  # https://github.com/MaterializeInc/materialize/issues/8605
+    )  # https://github.com/MaterializeInc/materialize/issues/20557
 
     @classmethod
     def body(cls) -> None:
@@ -711,7 +707,7 @@ class SubqueriesInWhereClauseCorrelated(Generator):
 class SubqueriesInWhereClauseUncorrelated(Generator):
     COUNT = min(
         Generator.COUNT, 10
-    )  # https://github.com/MaterializeInc/materialize/issues/8605
+    )  # https://github.com/MaterializeInc/materialize/issues/20557
 
     @classmethod
     def body(cls) -> None:

--- a/test/sqllogictest/unsigned_int.slt
+++ b/test/sqllogictest/unsigned_int.slt
@@ -1337,7 +1337,7 @@ SELECT STDDEV(a) FROM t4
 query error cannot take square root
 SELECT STDDEV(a) FROM t8
 
-# Avoid overflow (known issue https://github.com/MaterializeInc/materialize/issues/14695)
+# Avoid overflow (known issue https://github.com/MaterializeInc/materialize/issues/15186)
 statement ok
 DROP TABLE t8
 


### PR DESCRIPTION
After relevant issue has been fixed, let's see how high it can go now. New issue, so couldn't increase 2 limits, test runs fine now: https://buildkite.com/materialize/nightlies/builds/2840

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
