### PR TITLE
Override from frankmcsherry/columnation to MaterializeInc/columnation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7657,7 +7657,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#15ac623dba44463e15b8bb7dd06be2b37edc28ad"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#53adc68bb890c1ce60f0b507d6a4996a3d577f21"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7675,12 +7675,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#15ac623dba44463e15b8bb7dd06be2b37edc28ad"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#53adc68bb890c1ce60f0b507d6a4996a3d577f21"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#15ac623dba44463e15b8bb7dd06be2b37edc28ad"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#53adc68bb890c1ce60f0b507d6a4996a3d577f21"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#15ac623dba44463e15b8bb7dd06be2b37edc28ad"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#53adc68bb890c1ce60f0b507d6a4996a3d577f21"
 dependencies = [
  "columnation",
  "serde",
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#15ac623dba44463e15b8bb7dd06be2b37edc28ad"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#53adc68bb890c1ce60f0b507d6a4996a3d577f21"
 
 [[package]]
 name = "tiny-keccak"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,3 +174,7 @@ rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git" }
 # Waiting on https://github.com/openssh-rust/openssh/pull/120 to make it into
 # a release.
 openssh = { git = "https://github.com/MaterializeInc/openssh.git" }
+
+[patch."https://github.com/frankmcsherry/columnation"]
+# Projects that do not reliably release to crates.io.
+columnation = { git = "https://github.com/MaterializeInc/columnation.git" }

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.68"
 bytesize = "1.1.0"
-columnation = "0.1.0"
+columnation = { git = "https://github.com/frankmcsherry/columnation" }
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 differential-dataflow = "0.12.0"
 futures = "0.3.25"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -18,7 +18,7 @@ harness = false
 anyhow = "1.0.66"
 bitflags = "1.3.2"
 bytes = "1.3.0"
-columnation = "0.1.0"
+columnation = { git = "https://github.com/frankmcsherry/columnation" }
 chrono = { version = "0.4.23", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
 dec = "0.4.8"


### PR DESCRIPTION
See https://github.com/MaterializeInc/timely-dataflow/pull/2 for context.

We want to keep the Materialize fork of timely buildable (which requires making it depend on frankmcsherry/columnation, because columnation is not available on crates.io), and we also want to avoid pointing it at the Materialize fork of `columnation`. But we want to use the Materialize fork of columnation in Materialize.
