### PR TITLE
dbt-materialize: release v1.5.0

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,21 +1,24 @@
 # dbt-materialize Changelog
 
-## Unreleased
+## 1.5.0 - 2023-07-13
+
+* Upgrade to `dbt-postgres` v1.5.0. dbt contracts and dbt constraints are **not
+  supported** in this release (see [dbt-core #7213](https://github.com/dbt-labs/dbt-core/discussions/7213#discussioncomment-5903205)).
 
 * Fix a bug in the `materialize__list_relations_without_caching` macro which
   could cause the adapter to break for multi-output sources ([#20483](https://github.com/MaterializeInc/materialize/issues/20483)).
 
-* **Breaking change.** Expose `owner` in the dbt documentation, now that
-    Materialize supports [role-based access control (RBAC)](https://materialize.com/docs/manage/access-control/).
-
-  This change requires [Materialize >=0.48.0](https://materialize.com/docs/releases/v0.48/).
-  **Users of older versions should pin `dbt-materialize` to `v1.4.1`.**
+* Expose `owner` in the dbt documentation, now that Materialize supports
+  [role-based access control (RBAC)](https://materialize.com/docs/manage/access-control/).
 
 ## 1.4.1 - 2023-04-28
 
 * Let Materialize automatically run introspection queries in the
   `mz_introspection` cluster via the new `auto_route_introspection_queries`
   session variable, instead of hardcoding the cluster on connection.
+
+  This change requires [Materialize >=0.49.0](https://materialize.com/docs/releases/v0.49/).
+  **Users of older versions should pin `dbt-materialize` to `v1.4.0`.**
 
 ## 1.4.0 - 2023-02-03
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.4.1"
+version = "1.5.0"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.4.1",
+    version="1.5.0",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Release `dbt-materialize v1.5.0`. This release includes:

* https://github.com/MaterializeInc/materialize/pull/19295
* https://github.com/MaterializeInc/materialize/pull/20501