### PR TITLE
adapter: Add metric for difference in timestamp selection for strict serializable vs serializable

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2237,7 +2237,7 @@ impl Coordinator {
                         determine_bundle,
                         when,
                         cluster_id,
-                        timeline_context,
+                        &timeline_context,
                         real_time_recency_ts,
                     )?;
                     // We only need read holds if the read depends on a timestamp. We don't set the
@@ -2437,7 +2437,7 @@ impl Coordinator {
             .sufficient_collections(&depends_on);
         let timeline = self.validate_timeline_context(id_bundle.iter())?;
         let as_of = self
-            .determine_timestamp(session, &id_bundle, &when, cluster_id, timeline, None)?
+            .determine_timestamp(session, &id_bundle, &when, cluster_id, &timeline, None)?
             .timestamp_context
             .timestamp_or_default();
 

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -472,10 +472,9 @@ impl Coordinator {
                     self.metrics
                         .timestamp_difference_for_strict_serializable
                         .with_label_values(&[&compute_instance.to_string()])
-                        .observe(
-                            f64::cast_lossy(u64::from(strict.saturating_sub(*serializable)))
-                                / 1000.0,
-                        );
+                        .observe(f64::cast_lossy(u64::from(
+                            strict.saturating_sub(*serializable),
+                        )));
                 }
             }
         }

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -470,7 +470,7 @@ impl Coordinator {
                 )?;
                 if let Some(serializable) = serializable_det.timestamp_context.timestamp() {
                     self.metrics
-                        .timestamp_difference_for_strict_serializable
+                        .timestamp_difference_for_strict_serializable_ms
                         .with_label_values(&[&compute_instance.to_string()])
                         .observe(f64::cast_lossy(u64::from(
                             strict.saturating_sub(*serializable),

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -472,9 +472,9 @@ impl Coordinator {
                     .metrics
                     .timestamp_difference_for_strict_serializable
                     .with_label_values(&[&compute_instance.to_string()])
-                    .observe(f64::cast_lossy(u64::from(
-                        strict.saturating_sub(*serializable),
-                    ))),
+                    .observe(
+                        f64::cast_lossy(u64::from(strict.saturating_sub(*serializable))) / 1000.0,
+                    ),
                 _ => (),
             }
         }

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -453,7 +453,8 @@ impl Coordinator {
                 &compute_instance.to_string(),
             ])
             .inc();
-        if isolation_level == &IsolationLevel::StrictSerializable {
+        if isolation_level == &IsolationLevel::StrictSerializable && real_time_recency_ts.is_none()
+        {
             let serializable_det = self.determine_timestamp_for(
                 self.catalog().state(),
                 session,

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -21,6 +21,7 @@ pub struct Metrics {
     pub active_subscribes: IntGaugeVec,
     pub queue_busy_seconds: HistogramVec,
     pub determine_timestamp: IntCounterVec,
+    pub timestamp_difference_for_strict_serializable: HistogramVec,
     pub commands: IntCounterVec,
     pub storage_usage_collection_time_seconds: HistogramVec,
     pub subscribe_outputs: IntCounterVec,
@@ -54,6 +55,12 @@ impl Metrics {
                 name: "mz_determine_timestamp",
                 help: "The total number of calls to determine_timestamp.",
                 var_labels:["respond_immediately", "isolation_level", "compute_instance"],
+            )),
+            timestamp_difference_for_strict_serializable: registry.register(metric!(
+                name: "mz_timestamp_difference_for_strict_serializable",
+                help: "Difference in timestamp in seconds for running in strict serializable vs serializable isolation level.",
+                var_labels:["compute_instance"],
+                buckets: histogram_seconds_buckets(0.000_128, 32.0),
             )),
             commands: registry.register(metric!(
                 name: "mz_adapter_commands",

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -9,7 +9,7 @@
 
 use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::stats::histogram_seconds_buckets;
+use mz_ore::stats::{histogram_milliseconds_buckets, histogram_seconds_buckets};
 use mz_sql::ast::{AstInfo, Statement, StatementKind, SubscribeOutput};
 use mz_sql::session::user::User;
 use prometheus::{HistogramVec, IntCounterVec, IntGaugeVec};
@@ -58,9 +58,9 @@ impl Metrics {
             )),
             timestamp_difference_for_strict_serializable: registry.register(metric!(
                 name: "mz_timestamp_difference_for_strict_serializable",
-                help: "Difference in timestamp in seconds for running in strict serializable vs serializable isolation level.",
+                help: "Difference in timestamp in milliseconds for running in strict serializable vs serializable isolation level.",
                 var_labels:["compute_instance"],
-                buckets: histogram_seconds_buckets(0.000_128, 32.0),
+                buckets: histogram_milliseconds_buckets(0.128, 8000.),
             )),
             commands: registry.register(metric!(
                 name: "mz_adapter_commands",

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -21,7 +21,7 @@ pub struct Metrics {
     pub active_subscribes: IntGaugeVec,
     pub queue_busy_seconds: HistogramVec,
     pub determine_timestamp: IntCounterVec,
-    pub timestamp_difference_for_strict_serializable: HistogramVec,
+    pub timestamp_difference_for_strict_serializable_ms: HistogramVec,
     pub commands: IntCounterVec,
     pub storage_usage_collection_time_seconds: HistogramVec,
     pub subscribe_outputs: IntCounterVec,
@@ -56,11 +56,11 @@ impl Metrics {
                 help: "The total number of calls to determine_timestamp.",
                 var_labels:["respond_immediately", "isolation_level", "compute_instance"],
             )),
-            timestamp_difference_for_strict_serializable: registry.register(metric!(
-                name: "mz_timestamp_difference_for_strict_serializable",
+            timestamp_difference_for_strict_serializable_ms: registry.register(metric!(
+                name: "mz_timestamp_difference_for_strict_serializable_ms",
                 help: "Difference in timestamp in milliseconds for running in strict serializable vs serializable isolation level.",
                 var_labels:["compute_instance"],
-                buckets: histogram_milliseconds_buckets(0.128, 8000.),
+                buckets: histogram_milliseconds_buckets(1., 8000.),
             )),
             commands: registry.register(metric!(
                 name: "mz_adapter_commands",

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -95,6 +95,7 @@ use mz_compute_client::controller::ComputeInstanceId;
 use mz_expr::MirScalarExpr;
 use mz_repr::{Datum, GlobalId, ScalarType, Timestamp};
 use mz_sql::plan::QueryWhen;
+use mz_sql::session::vars::IsolationLevel;
 use mz_sql_parser::ast::TransactionIsolationLevel;
 use mz_storage_client::types::sources::Timeline;
 use serde::{Deserialize, Serialize};
@@ -317,6 +318,7 @@ fn test_timestamp_selection() {
                             det.instance.parse().unwrap(),
                             TimelineContext::TimestampDependent,
                             None,
+                            &IsolationLevel::from(isolation),
                         )
                         .unwrap();
                     if tc.args.contains_key("full") {

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -316,7 +316,7 @@ fn test_timestamp_selection() {
                             &det.id_bundle.into(),
                             &parse_query_when(&det.when),
                             det.instance.parse().unwrap(),
-                            TimelineContext::TimestampDependent,
+                            &TimelineContext::TimestampDependent,
                             None,
                             &IsolationLevel::from(isolation),
                         )

--- a/src/ore/src/stats.rs
+++ b/src/ore/src/stats.rs
@@ -40,6 +40,31 @@ pub fn histogram_seconds_buckets(from: f64, to: f64) -> Vec<f64> {
     vec
 }
 
+/// A standard range of buckets for timing data, measured in seconds.
+/// Individual histograms may only need a subset of this range, in which case,
+/// see `histogram_seconds_buckets` below.
+///
+/// Note that any changes to this range may modify buckets for existing metrics.
+const HISTOGRAM_MILLISECOND_BUCKETS: [f64; 19] = [
+    0.128, 0.256, 0.512, 1., 2., 4., 8., 16., 32., 64., 128., 256., 512., 1000., 2000., 4000.,
+    8000., 16000., 32000.,
+];
+
+/// Returns a `Vec` of time buckets that are both present in our standard
+/// buckets above and within the provided inclusive range. (This makes it
+/// more meaningful to compare latency percentiles across histograms if needed,
+/// without requiring all metrics to use exactly the same buckets.)
+pub fn histogram_milliseconds_buckets(from_ms: f64, to_ms: f64) -> Vec<f64> {
+    let mut vec = Vec::with_capacity(HISTOGRAM_MILLISECOND_BUCKETS.len());
+    vec.extend(
+        HISTOGRAM_MILLISECOND_BUCKETS
+            .iter()
+            .copied()
+            .filter(|&b| b >= from_ms && b <= to_ms),
+    );
+    vec
+}
+
 /// Buckets that capture sizes of 64 bytes up to a gigabyte
 pub const HISTOGRAM_BYTE_BUCKETS: [f64; 7] = [
     64.0,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Goal is for this metric to quantify the penalty that strict serializable timestamp selection has compared to serializable timestamp selection. Part of #20530 

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I know Timestamp is supposed to be opaque; not sure if this is the right way of getting a seconds value of it.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
