### PR TITLE
adapter: Add metrics for time spent in message_linearize_reads

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::iter;
 use std::num::{NonZeroI64, NonZeroUsize};
 use std::panic::AssertUnwindSafe;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use futures::future::BoxFuture;
@@ -95,8 +95,8 @@ use crate::coord::timestamp_selection::{
 };
 use crate::coord::{
     peek, Coordinator, ExecuteContext, Message, PeekStage, PeekStageFinish, PeekStageOptimize,
-    PeekStageTimestamp, PeekStageValidate, PendingReadTxn, PendingTxn, PendingTxnResponse,
-    PlanValidity, RealTimeRecencyContext, SinkConnectionReady, TargetCluster,
+    PeekStageTimestamp, PeekStageValidate, PendingRead, PendingReadTxn, PendingTxn,
+    PendingTxnResponse, PlanValidity, RealTimeRecencyContext, SinkConnectionReady, TargetCluster,
     DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
 };
 use crate::error::AdapterError;
@@ -1746,13 +1746,17 @@ impl Coordinator {
                     == &IsolationLevel::StrictSerializable =>
             {
                 self.strict_serializable_reads_tx
-                    .send(PendingReadTxn::Read {
-                        txn: PendingTxn {
-                            ctx,
-                            response,
-                            action,
+                    .send(PendingReadTxn {
+                        txn: PendingRead::Read {
+                            txn: PendingTxn {
+                                ctx,
+                                response,
+                                action,
+                            },
+                            timestamp_context: determination.timestamp_context,
                         },
-                        timestamp_context: determination.timestamp_context,
+                        created: Instant::now(),
+                        num_requeues: 0,
                     })
                     .expect("sending to strict_serializable_reads_tx cannot fail");
                 return;
@@ -3488,9 +3492,13 @@ impl Coordinator {
             if let Some(TimestampContext::TimelineTimestamp(timeline, read_ts)) = timestamp_context
             {
                 let (tx, rx) = tokio::sync::oneshot::channel();
-                let result = strict_serializable_reads_tx.send(PendingReadTxn::ReadThenWrite {
-                    tx,
-                    timestamp: (read_ts, timeline),
+                let result = strict_serializable_reads_tx.send(PendingReadTxn {
+                    txn: PendingRead::ReadThenWrite {
+                        tx,
+                        timestamp: (read_ts, timeline),
+                    },
+                    created: Instant::now(),
+                    num_requeues: 0,
                 });
                 // It is not an error for these results to be ready after `strict_serializable_reads_rx` has been dropped.
                 if let Err(e) = result {

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -25,6 +25,7 @@ pub struct Metrics {
     pub storage_usage_collection_time_seconds: HistogramVec,
     pub subscribe_outputs: IntCounterVec,
     pub canceled_peeks: IntCounterVec,
+    pub linearize_message_seconds: HistogramVec,
 }
 
 impl Metrics {
@@ -73,6 +74,12 @@ impl Metrics {
             canceled_peeks: registry.register(metric!(
                 name: "mz_canceled_peeks_total",
                 help: "The total number of canceled peeks since process start.",
+            )),
+            linearize_message_seconds: registry.register(metric!(
+                name: "mz_linearize_message_seconds",
+                help: "The number of seconds it takes to linearize strict serializable messages",
+                var_labels: ["type", "immediately_handled"],
+                buckets: histogram_seconds_buckets(0.000_128, 8.0),
             )),
         }
     }


### PR DESCRIPTION

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
I don't expect this to take a large amount of time but all strict serializable queries go through this code path that needs to confirm this coordinator is still the leader. Part of #20530. Tested manually.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I split up the PendingReadTxn struct b/c both enum variants need this extra metadata (`created` and `num_requeues`)

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
