### PR TITLE
slt: Fix error msg in builtin_function.slt and failure in main test with linter

### DIFF
--- a/ci/slt/pipeline.yml
+++ b/ci/slt/pipeline.yml
@@ -19,7 +19,7 @@ steps:
 
   - id: sqllogictest
     label: ":bulb: SQL logic tests %n"
-    timeout_in_minutes: 600
+    timeout_in_minutes: 180
     parallelism: 10
     artifact_paths: junit_*.xml
     agents:

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -184,7 +184,7 @@ The view is defined as the transitive closure of [`mz_object_dependencies`](#mz_
 <!-- RELATION_SPEC mz_internal.mz_object_transitive_dependencies -->
 | Field                   | Type         | Meaning                                                                                                               |
 | ----------------------- | ------------ | --------                                                                                                              |
-| `id`             | [`text`]     | The ID of the dependent object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects).                          |
+| `object_id`             | [`text`]     | The ID of the dependent object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects).                          |
 | `referenced_object_id`  | [`text`]     | The ID of the (possibly transitively) referenced object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects). |
 
 ### `mz_postgres_sources`

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -112,7 +112,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_object_transitive_dependencies' ORDER BY position
 ----
-1  id  text
+1  object_id  text
 2  referenced_object_id  text
 
 query ITT

--- a/test/sqllogictest/cockroach/builtin_function.slt
+++ b/test/sqllogictest/cockroach/builtin_function.slt
@@ -1453,7 +1453,7 @@ SELECT OVERLAY(foo.* PLACING 'string' FROM 'string') FROM (VALUES (1)) AS foo(x)
 query error cannot use "nonexistent.\*" without a FROM clause
 SELECT nonexistent.* IS NOT TRUE
 
-query error unsupported comparison operator: <tuple{int AS x}> IS DISTINCT FROM <bool>
+query error unsupported comparison operator: <tuple\{int AS x\}> IS DISTINCT FROM <bool>
 SELECT foo.* IS NOT TRUE FROM (VALUES (1)) AS foo(x)
 
 query T


### PR DESCRIPTION
Failed in https://buildkite.com/materialize/sql-logic-tests/builds/5610#_
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "In test/sqllogictest/cockroach/builtin_function.slt:\nregex parse error:\n    unsupported comparison operator: <tuple{int AS x}> IS DISTINCT FROM <bool>\n                                            ^\nerror: repetition quantifier expects a valid decimal"', /home/deen/git/materialize3/src/sqllogictest/src/runner.rs:1696:14
```

Test ran through locally with this. SLT run started: https://buildkite.com/materialize/sql-logic-tests/builds/5613

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
