### PR TITLE
webhooks: tiny improvement, don't eagerly clone strings

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -233,7 +233,7 @@ impl Client {
         schema: String,
         name: String,
         conn_id: ConnectionId,
-    ) -> Result<Option<AppendWebhookResponse>, AdapterError> {
+    ) -> Result<AppendWebhookResponse, AdapterError> {
         let (tx, rx) = oneshot::channel();
 
         // Send our request.

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -108,7 +108,7 @@ pub enum Command {
         schema: String,
         name: String,
         conn_id: ConnectionId,
-        tx: oneshot::Sender<Result<Option<AppendWebhookResponse>, AdapterError>>,
+        tx: oneshot::Sender<Result<AppendWebhookResponse, AdapterError>>,
     },
 
     GetSystemVars {

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -173,6 +173,12 @@ pub enum AdapterError {
         cluster_name: String,
         replica_name: String,
     },
+    /// The named webhook source does not exist.
+    UnknownWebhookSource {
+        database: String,
+        schema: String,
+        name: String,
+    },
     /// The named setting does not exist.
     UnrecognizedConfigurationParam(String),
     /// A generic error occurred.
@@ -415,6 +421,7 @@ impl AdapterError {
             AdapterError::UnknownPreparedStatement(_) => SqlState::UNDEFINED_PSTATEMENT,
             AdapterError::UnknownLoginRole(_) => SqlState::INVALID_AUTHORIZATION_SPECIFICATION,
             AdapterError::UnknownClusterReplica { .. } => SqlState::UNDEFINED_OBJECT,
+            AdapterError::UnknownWebhookSource { .. } => SqlState::UNDEFINED_OBJECT,
             AdapterError::UnmaterializableFunction(_) => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::UnrecognizedConfigurationParam(_) => SqlState::UNDEFINED_OBJECT,
             AdapterError::UnstableDependency { .. } => SqlState::FEATURE_NOT_SUPPORTED,
@@ -611,6 +618,14 @@ impl fmt::Display for AdapterError {
             } => write!(
                 f,
                 "cluster replica '{cluster_name}.{replica_name}' does not exist"
+            ),
+            AdapterError::UnknownWebhookSource {
+                database,
+                schema,
+                name,
+            } => write!(
+                f,
+                "webhook source '{database}.{schema}.{name}' does not exist"
             ),
             AdapterError::UnrecognizedConfigurationParam(setting_name) => write!(
                 f,


### PR DESCRIPTION
### Motivation

Previously for each webhook append request we'd clone the `database`, `schema`, and `name` provided in the request, so we could later use it in a `NotFound` error. This is 😔😔😔 though because we generally won't need to return this error and the clone was a waste. Instead this PR adds a new `UnknownWebhookSource` error to `AdapterError` and passes that back with the owned `String`s to prevent the need to clone them.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
