### PR TITLE
expr: allow using current_schema when cluster is invalid

### DIFF
--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -745,6 +745,14 @@ fn eval_unmaterializable_func(
 
     match f {
         UnmaterializableFunc::CurrentDatabase => pack(Datum::from(session.vars().database())),
+        UnmaterializableFunc::CurrentSchema => {
+            let catalog = Catalog::for_session_state(state, session);
+            let schema = catalog
+                .search_path()
+                .first()
+                .map(|(db, schema)| &*state.get_schema(db, schema, session.conn_id()).name.schema);
+            pack(Datum::from(schema))
+        }
         UnmaterializableFunc::CurrentSchemasWithSystem => {
             let catalog = Catalog::for_session_state(state, session);
             let search_path = catalog.effective_search_path(false);

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -95,6 +95,7 @@ message ProtoUnmaterializableFunc {
         google.protobuf.Empty current_setting = 15;
         google.protobuf.Empty is_rbac_enabled = 16;
         google.protobuf.Empty session_user = 17;
+        google.protobuf.Empty current_schema = 18;
     }
 }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1894,8 +1894,10 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
             params!(Float64) => UnaryFunc::Cot(func::Cot) => Float64, 1607;
         },
         "current_schema" => Scalar {
-            // TODO: this should be name
-            params!() => sql_impl_func("pg_catalog.current_schemas(false)[1]") => String, 1402;
+            // TODO: this should be `name`. This is tricky in Materialize
+            // because `name` truncates to 63 characters but Materialize does
+            // not have a limit on identifier length.
+            params!() => UnmaterializableFunc::CurrentSchema => String, 1402;
         },
         "current_schemas" => Scalar {
             params!(Bool) => Operation::unary(|_ecx, e| {
@@ -1904,7 +1906,9 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     then: Box::new(HirScalarExpr::CallUnmaterializable(UnmaterializableFunc::CurrentSchemasWithSystem)),
                     els: Box::new(HirScalarExpr::CallUnmaterializable(UnmaterializableFunc::CurrentSchemasWithoutSystem)),
                 })
-                // TODO: this should be name[]
+                // TODO: this should be `name[]`. This is tricky in Materialize
+                // because `name` truncates to 63 characters but Materialize
+                // does not have a limit on identifier length.
             }) => ScalarType::Array(Box::new(ScalarType::String)), 1403;
         },
         "current_database" => Scalar {

--- a/test/sqllogictest/schemas.slt
+++ b/test/sqllogictest/schemas.slt
@@ -53,6 +53,30 @@ SELECT current_schemas(true)
 ----
 {mz_catalog,pg_catalog}
 
+# Ensure both `current_schemas` and `current_schema` work when the specified
+# cluster is invalid.
+
+statement ok
+SET cluster = noexist
+
+query T
+SELECT current_schema()
+----
+NULL
+
+query T
+SELECT current_schemas(false)
+----
+{}
+
+query T
+SELECT current_schemas(true)
+----
+{mz_catalog,pg_catalog}
+
+statement ok
+SET cluster = default
+
 statement error no schema has been selected to create in
 CREATE TABLE t (i INT)
 


### PR DESCRIPTION
Since 6a93648, we can execute `SELECT current_schemas()` without a valid cluster. Unfortunately the same was not true for `SELECT current_schema`, since it was implemented as `SELECT current_schemas()[1]`, and we can't execute array subscripts without a valid cluster.

Implement `current_schema` with a dedicated unmaterializable function, so that it does not require an array subscript operation and therefore does not require a valid cluster.

This fixes an issue with PopSQL, which executes `SELECT current_schema` to validate a connection. We don't want this connection validation to depend on the active cluster existing, as otherwise you can't use PopSQL to run `CREATE CLUSTER default` if you have dropped the default cluster.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
