### PR TITLE
ci: Remove SQLancer from regular Tests run

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -645,54 +645,6 @@ steps:
           args: [--scenario=KafkaUpsertUnique]
     coverage: skip
 
-  - id: sqlancer-pqs
-    label: "SQLancer PQS"
-    depends_on: build-x86_64
-    artifact_paths: junit_*.xml
-    timeout_in_minutes: 15
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: sqlancer
-          args: [--runtime=600, --oracle=PQS, --no-qpg]
-
-  - id: sqlancer-norec
-    label: "SQLancer NoREC"
-    artifact_paths: junit_*.xml
-    depends_on: build-x86_64
-    timeout_in_minutes: 15
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: sqlancer
-          args: [--runtime=600, --oracle=NOREC]
-
-  - id: sqlancer-query-partitioning
-    label: "SQLancer QueryPartitioning"
-    artifact_paths: junit_*.xml
-    depends_on: build-x86_64
-    timeout_in_minutes: 15
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: sqlancer
-          args: [--runtime=600, --oracle=QUERY_PARTITIONING]
-
-  - id: sqlancer-having
-    label: "SQLancer Having"
-    artifact_paths: junit_*.xml
-    depends_on: build-x86_64
-    timeout_in_minutes: 15
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: sqlancer
-          args: [--runtime=600, --oracle=HAVING]
-
   - id: deploy-website
     label: Deploy website
     depends_on: lint-docs


### PR DESCRIPTION
Remains in nightly, which I consider more appropriate for a randomized test. I don't think this found anything yet in the Tests runs

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
