### PR TITLE
adapter: Check privileges before validating conn

### DIFF
--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -117,7 +117,7 @@ impl PendingWriteTxn {
 /// deferring work.
 #[macro_export]
 macro_rules! guard_write_critical_section {
-    ($coord:expr, $ctx:expr, $plan_to_defer:expr, $source_ids:expr) => {
+    ($coord:expr, $ctx:expr, $plan_to_defer:expr, $dependency_ids:expr) => {
         if !$ctx.session().has_write_lock() {
             if $coord
                 .try_grant_session_write_lock($ctx.session_mut())
@@ -128,7 +128,7 @@ macro_rules! guard_write_critical_section {
                     plan: $plan_to_defer,
                     validity: PlanValidity {
                         transient_revision: $coord.catalog().transient_revision(),
-                        source_ids: $source_ids,
+                        dependency_ids: $dependency_ids,
                         cluster_id: None,
                         replica_id: None,
                     },

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -42,10 +42,7 @@ use crate::command::{
 };
 use crate::coord::appends::{Deferred, PendingWriteTxn};
 use crate::coord::peek::PendingPeek;
-use crate::coord::{
-    ConnMeta, Coordinator, CreateConnectionValidationReady, CreateSourceStatementReady, Message,
-    PendingTxn,
-};
+use crate::coord::{ConnMeta, Coordinator, CreateSourceStatementReady, Message, PendingTxn};
 use crate::error::AdapterError;
 use crate::notice::AdapterNotice;
 use crate::session::{PreparedStatement, Session, TransactionStatus};
@@ -620,52 +617,6 @@ impl Coordinator {
             Statement::CreateSubsource(_) => ctx.retire(Err(AdapterError::Unsupported(
                 "CREATE SUBSOURCE statements",
             ))),
-
-            // `CREATE CONNECTION` statements might need validation which happens off the main
-            // coordinator thread of control.
-            stmt @ Statement::CreateConnection(_) => {
-                let plan = match self.plan_statement(ctx.session_mut(), stmt, &params) {
-                    Ok(Plan::CreateConnection(plan)) => plan,
-                    Ok(_) => unreachable!(),
-                    Err(e) => {
-                        ctx.retire(Err(e));
-                        return;
-                    }
-                };
-
-                if plan.validate {
-                    let internal_cmd_tx = self.internal_cmd_tx.clone();
-                    let conn_id = ctx.session().conn_id().clone();
-                    let connection_context = self.connection_context.clone();
-                    let otel_ctx = OpenTelemetryContext::obtain();
-                    task::spawn(|| format!("validate_connection:{conn_id}"), async move {
-                        let connection = &plan.connection.connection;
-                        let result = match connection.validate(&connection_context).await {
-                            Ok(()) => Ok(plan),
-                            Err(err) => Err(err.into()),
-                        };
-
-                        // It is not an error for validation to complete after `internal_cmd_rx` is dropped.
-                        let result =
-                            internal_cmd_tx.send(Message::CreateConnectionValidationReady(
-                                CreateConnectionValidationReady {
-                                    ctx,
-                                    result,
-                                    params,
-                                    resolved_ids,
-                                    original_stmt,
-                                    otel_ctx,
-                                },
-                            ));
-                        if let Err(e) = result {
-                            tracing::warn!("internal_cmd_rx dropped before we could send: {:?}", e);
-                        }
-                    });
-                } else {
-                    self.sequence_plan(ctx, Plan::CreateConnection(plan), resolved_ids)
-                        .await;
-                }
-            }
 
             // All other statements are handled immediately.
             _ => match self.plan_statement(ctx.session_mut(), stmt, &params) {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -48,7 +48,7 @@ use crate::{rbac, ExecuteContext};
 // initialized and we need to skip directly to creating role. We have a specific method,
 // `sequence_create_role_for_startup` for this purpose.
 // - Methods that continue the execution of some plan that was being run asynchronously, such as
-// `sequence_peek_stage`.
+// `sequence_peek_stage` and `sequence_create_connection_stage_finish`.
 mod cluster;
 mod inner;
 mod linked_cluster;
@@ -130,10 +130,8 @@ impl Coordinator {
                 ctx.retire(result);
             }
             Plan::CreateConnection(plan) => {
-                let result = self
-                    .sequence_create_connection(ctx.session_mut(), plan, resolved_ids)
+                self.sequence_create_connection(ctx, plan, resolved_ids)
                     .await;
-                ctx.retire(result);
             }
             Plan::CreateDatabase(plan) => {
                 let result = self.sequence_create_database(ctx.session_mut(), plan).await;


### PR DESCRIPTION
This commit shuffles around the connection validation logic in CREATE CONNECTION so that the validation happens after privileges are checked.

Fixes #20489

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
