### PR TITLE
adapter: remove final pcx reference from QueryContext

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -4683,7 +4683,7 @@ mod tests {
             };
             let pcx = PlanContext::zero();
             let scx = StatementContext::new(Some(&pcx), &conn_catalog);
-            let qcx = QueryContext::root(&scx, QueryLifetime::OneShot(&pcx));
+            let qcx = QueryContext::root(&scx, QueryLifetime::OneShot);
             let ecx = ExprContext {
                 qcx: &qcx,
                 name: "smoketest",

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -178,10 +178,7 @@ async fn datadriven() {
                             let parsed = mz_sql::parse::parse(&test_case.input).unwrap();
                             let pcx = &PlanContext::zero();
                             let scx = StatementContext::new(Some(pcx), &catalog);
-                            let qcx = QueryContext::root(
-                                &scx,
-                                QueryLifetime::OneShot(scx.pcx().unwrap()),
-                            );
+                            let qcx = QueryContext::root(&scx, QueryLifetime::OneShot);
                             let q = parsed[0].clone();
                             let q = match q {
                                 Statement::Select(s) => s.query,

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -432,6 +432,8 @@ message ProtoBinaryFunc {
         bool rev = 2;
     }
 
+    reserved 93; // timezone_time
+    reserved "timezone_time";
     oneof kind {
         google.protobuf.Empty add_int16 = 46;
         google.protobuf.Empty add_int32 = 11;
@@ -523,7 +525,6 @@ message ProtoBinaryFunc {
         google.protobuf.Empty date_trunc_interval = 90;
         google.protobuf.Empty timezone_timestamp = 91;
         google.protobuf.Empty timezone_timestamp_tz = 92;
-        mz_repr.chrono.ProtoNaiveDateTime timezone_time = 93;
         google.protobuf.Empty timezone_interval_timestamp = 94;
         google.protobuf.Empty timezone_interval_timestamp_tz = 95;
         google.protobuf.Empty timezone_interval_time = 96;
@@ -661,6 +662,7 @@ message ProtoVariadicFunc {
         google.protobuf.Empty date_diff_timestamp_tz = 34;
         google.protobuf.Empty date_diff_date = 35;
         google.protobuf.Empty date_diff_time = 36;
+        google.protobuf.Empty timezone_time = 37;
     }
 }
 

--- a/src/sql/src/plan/side_effecting_func.rs
+++ b/src/sql/src/plan/side_effecting_func.rs
@@ -47,7 +47,7 @@ use crate::plan::query::{self, ExprContext, QueryLifetime};
 use crate::plan::scope::Scope;
 use crate::plan::statement::StatementContext;
 use crate::plan::typeconv::CastContext;
-use crate::plan::{self, HirScalarExpr, Params};
+use crate::plan::{HirScalarExpr, Params};
 use crate::plan::{PlanError, QueryContext};
 
 /// A side-effecting function is a function whose evaluation triggers side
@@ -197,8 +197,7 @@ fn extract_sef_call(
 
     // Plan and coerce all argument expressions.
     let mut args_out = vec![];
-    let pcx = plan::PlanContext::zero();
-    let qcx = QueryContext::root(scx, QueryLifetime::OneShot(&pcx));
+    let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
     let ecx = ExprContext {
         qcx: &qcx,
         name: sef_impl.name,

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -170,7 +170,7 @@ pub fn describe_select(
     }
 
     let query::PlannedQuery { desc, .. } =
-        query::plan_root_query(scx, stmt.query, QueryLifetime::OneShot(scx.pcx()?))?;
+        query::plan_root_query(scx, stmt.query, QueryLifetime::OneShot)?;
     Ok(StatementDesc::new(Some(desc)))
 }
 
@@ -186,12 +186,7 @@ pub fn plan_select(
 
     let query::PlannedQuery {
         expr, finishing, ..
-    } = plan_query(
-        scx,
-        select.query,
-        params,
-        QueryLifetime::OneShot(scx.pcx()?),
-    )?;
+    } = plan_query(scx, select.query, params, QueryLifetime::OneShot)?;
     let when = query::plan_as_of(scx, select.as_of)?;
     Ok(Plan::Select(SelectPlan {
         source: expr,
@@ -292,7 +287,7 @@ pub fn plan_explain(
                 }) => query,
                 _ => panic!("Sql for existing view should parse as a view"),
             };
-            let qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx().unwrap()));
+            let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
             (
                 mz_repr::explain::Explainee::Dataflow(view.id()),
                 names::resolve(qcx.scx.catalog, query)?.0,
@@ -319,7 +314,7 @@ pub fn plan_explain(
                     panic!("Sql for existing materialized view should parse as a materialized view")
                 }
             };
-            let qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx().unwrap()));
+            let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
             (
                 mz_repr::explain::Explainee::Dataflow(mview.id()),
                 names::resolve(qcx.scx.catalog, query)?.0,
@@ -334,7 +329,7 @@ pub fn plan_explain(
         desc,
         finishing,
         scope: _,
-    } = query::plan_root_query(scx, query, QueryLifetime::OneShot(scx.pcx()?))?;
+    } = query::plan_root_query(scx, query, QueryLifetime::OneShot)?;
     let finishing = if is_view {
         // views don't use a separate finishing
         expr.finish(finishing);
@@ -412,7 +407,7 @@ pub fn describe_subscribe(
         }
         SubscribeRelation::Query(query) => {
             let query::PlannedQuery { desc, .. } =
-                query::plan_root_query(scx, query, QueryLifetime::OneShot(scx.pcx()?))?;
+                query::plan_root_query(scx, query, QueryLifetime::OneShot)?;
             desc
         }
     };
@@ -509,12 +504,7 @@ pub fn plan_subscribe(
             // user-supplied query is planned as a subquery whose `ORDER
             // BY`/`LIMIT`/`OFFSET` clauses turn into a TopK operator.
             let query = Query::query(query);
-            let query = plan_query(
-                scx,
-                query,
-                &Params::empty(),
-                QueryLifetime::OneShot(scx.pcx()?),
-            )?;
+            let query = plan_query(scx, query, &Params::empty(), QueryLifetime::OneShot)?;
             assert!(query.finishing.is_trivial(query.desc.arity()));
             let desc = query.desc.clone();
             (
@@ -531,7 +521,7 @@ pub fn plan_subscribe(
     let when = query::plan_as_of(scx, as_of)?;
     let up_to = up_to.map(|up_to| plan_up_to(scx, up_to)).transpose()?;
 
-    let qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
+    let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
     let ecx = ExprContext {
         qcx: &qcx,
         name: "",


### PR DESCRIPTION
We had a single straggler when UnmaterializableFunc was added that still was referencing a PlanContext when it should have been using the corresponding unmat fn instead. Correcting that allows the removal of pcx from the QueryLifetime.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a