### PR TITLE
persist: wire in new Diagnostics, put global id in shard metrics

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -22,6 +22,7 @@ use mz_ore::collections::HashMap;
 use mz_persist_client::batch::{Batch, BatchBuilder};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::write::WriterEnrichedHollowBatch;
+use mz_persist_client::Diagnostics;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::controller::CollectionMetadata;
@@ -336,9 +337,12 @@ where
         let mut write = persist_client
             .open_writer::<SourceData, (), Timestamp, Diff>(
                 shard_id,
-                &format!("compute::persist_sink::mint_batch_descriptions {}", sink_id),
                 Arc::new(target_relation_desc),
                 Arc::new(UnitSchema),
+                Diagnostics::new(
+                    &sink_id.to_string(),
+                    &format!("compute::persist_sink::mint_batch_descriptions {}", sink_id),
+                ),
             )
             .await
             .expect("could not open persist shard");
@@ -614,9 +618,12 @@ where
         let mut write = persist_client
             .open_writer::<SourceData, (), Timestamp, Diff>(
                 shard_id,
-                &format!("compute::persist_sink::write_batches {}", sink_id),
                 Arc::new(target_relation_desc),
                 Arc::new(UnitSchema),
+                Diagnostics::new(
+                    &sink_id.to_string(),
+                    &format!("compute::persist_sink::write_batches {}", sink_id),
+                ),
             )
             .await
             .expect("could not open persist shard");
@@ -970,9 +977,12 @@ where
         let mut write = persist_client
             .open_writer::<SourceData, (), Timestamp, Diff>(
                 shard_id,
-                &format!("persist_sink::append_batches {}", sink_id),
                 Arc::new(target_relation_desc),
-                Arc::new(UnitSchema)
+                Arc::new(UnitSchema),
+                    Diagnostics::new(&sink_id.to_string(),
+                                     &format!("persist_sink::append_batches {}", sink_id)
+                    )
+
             )
             .await
             .expect("could not open persist shard");

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -339,10 +339,13 @@ where
                 shard_id,
                 Arc::new(target_relation_desc),
                 Arc::new(UnitSchema),
-                Diagnostics::new(
-                    &sink_id.to_string(),
-                    &format!("compute::persist_sink::mint_batch_descriptions {}", sink_id),
-                ),
+                Diagnostics {
+                    shard_name: sink_id.to_string(),
+                    handle_purpose: format!(
+                        "compute::persist_sink::mint_batch_descriptions {}",
+                        sink_id
+                    ),
+                },
             )
             .await
             .expect("could not open persist shard");
@@ -620,10 +623,10 @@ where
                 shard_id,
                 Arc::new(target_relation_desc),
                 Arc::new(UnitSchema),
-                Diagnostics::new(
-                    &sink_id.to_string(),
-                    &format!("compute::persist_sink::write_batches {}", sink_id),
-                ),
+                Diagnostics {
+                    shard_name: sink_id.to_string(),
+                    handle_purpose: format!("compute::persist_sink::write_batches {}", sink_id),
+                },
             )
             .await
             .expect("could not open persist shard");
@@ -979,10 +982,10 @@ where
                 shard_id,
                 Arc::new(target_relation_desc),
                 Arc::new(UnitSchema),
-                    Diagnostics::new(&sink_id.to_string(),
-                                     &format!("persist_sink::append_batches {}", sink_id)
-                    )
-
+                Diagnostics {
+                    shard_name: sink_id.to_string(),
+                    handle_purpose: format!("persist_sink::append_batches {}", sink_id),
+                },
             )
             .await
             .expect("could not open persist shard");

--- a/src/persist-client/benches/porcelain.rs
+++ b/src/persist-client/benches/porcelain.rs
@@ -15,7 +15,7 @@ use mz_ore::cast::{CastFrom, TryCastFrom};
 use mz_ore::task;
 use mz_persist::workload::DataGenerator;
 use mz_persist_client::read::ListenEvent;
-use mz_persist_client::{PersistClient, ShardId};
+use mz_persist_client::{Diagnostics, PersistClient, ShardId};
 use mz_persist_types::codec_impls::VecU8Schema;
 use mz_persist_types::Codec64;
 use timely::progress::Antichain;
@@ -67,9 +67,9 @@ async fn bench_writes_one_iter(
     let mut write = client
         .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(
             ShardId::new(),
-            "bench",
             Arc::new(VecU8Schema),
             Arc::new(VecU8Schema),
+            Diagnostics::new("", "bench"),
         )
         .await?;
 
@@ -121,9 +121,9 @@ async fn bench_write_to_listen_one_iter(
     let (mut write, read) = client
         .open::<Vec<u8>, Vec<u8>, u64, i64>(
             ShardId::new(),
-            "bench",
             Arc::new(VecU8Schema),
             Arc::new(VecU8Schema),
+            Diagnostics::new("", "bench"),
         )
         .await?;
 
@@ -212,9 +212,9 @@ pub fn bench_snapshot(
             let mut write = client
                 .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(
                     shard_id,
-                    "bench",
                     Arc::new(VecU8Schema),
                     Arc::new(VecU8Schema),
+                    Diagnostics::new("", "bench"),
                 )
                 .await
                 .expect("failed to open shard");
@@ -237,9 +237,9 @@ async fn bench_snapshot_one_iter(
     let mut read = client
         .open_leased_reader::<Vec<u8>, Vec<u8>, u64, i64>(
             *shard_id,
-            "bench",
             Arc::new(VecU8Schema),
             Arc::new(VecU8Schema),
+            Diagnostics::new("", "bench"),
         )
         .await?;
 

--- a/src/persist-client/benches/porcelain.rs
+++ b/src/persist-client/benches/porcelain.rs
@@ -69,7 +69,7 @@ async fn bench_writes_one_iter(
             ShardId::new(),
             Arc::new(VecU8Schema),
             Arc::new(VecU8Schema),
-            Diagnostics::new("", "bench"),
+            Diagnostics::from_purpose("bench"),
         )
         .await?;
 
@@ -123,7 +123,7 @@ async fn bench_write_to_listen_one_iter(
             ShardId::new(),
             Arc::new(VecU8Schema),
             Arc::new(VecU8Schema),
-            Diagnostics::new("", "bench"),
+            Diagnostics::from_purpose("bench"),
         )
         .await?;
 
@@ -214,7 +214,7 @@ pub fn bench_snapshot(
                     shard_id,
                     Arc::new(VecU8Schema),
                     Arc::new(VecU8Schema),
-                    Diagnostics::new("", "bench"),
+                    Diagnostics::from_purpose("bench"),
                 )
                 .await
                 .expect("failed to open shard");
@@ -239,7 +239,7 @@ async fn bench_snapshot_one_iter(
             *shard_id,
             Arc::new(VecU8Schema),
             Arc::new(VecU8Schema),
-            Diagnostics::new("", "bench"),
+            Diagnostics::from_purpose("bench"),
         )
         .await?;
 

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -141,7 +141,7 @@ impl Transactor {
                 shard_id,
                 Arc::new(MaelstromKeySchema),
                 Arc::new(MaelstromValSchema),
-                Diagnostics::new("", "maelstrom long-lived"),
+                Diagnostics::from_purpose("maelstrom long-lived"),
             )
             .await?;
         // Use the CONTROLLER_CRITICAL_SINCE id for all nodes so we get coverage
@@ -150,7 +150,7 @@ impl Transactor {
             .open_critical_since(
                 shard_id,
                 PersistClient::CONTROLLER_CRITICAL_SINCE,
-                Diagnostics::new("", "maelstrom since"),
+                Diagnostics::from_purpose("maelstrom since"),
             )
             .await?;
         let read_ts = Self::maybe_init_shard(&mut write).await?;
@@ -271,7 +271,7 @@ impl Transactor {
                     self.shard_id,
                     Arc::new(MaelstromKeySchema),
                     Arc::new(MaelstromValSchema),
-                    Diagnostics::new("", "maelstrom short-lived"),
+                    Diagnostics::from_purpose("maelstrom short-lived"),
                 )
                 .await
                 .expect("codecs should match");
@@ -303,7 +303,7 @@ impl Transactor {
                         .open_critical_since(
                             self.shard_id,
                             PersistClient::CONTROLLER_CRITICAL_SINCE,
-                            Diagnostics::new("", "maelstrom since"),
+                            Diagnostics::from_purpose("maelstrom since"),
                         )
                         .await?;
                     continue;
@@ -337,7 +337,7 @@ impl Transactor {
                         .open_critical_since(
                             self.shard_id,
                             PersistClient::CONTROLLER_CRITICAL_SINCE,
-                            Diagnostics::new("", "maelstrom since"),
+                            Diagnostics::from_purpose("maelstrom since"),
                         )
                         .await?;
                     continue;

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -29,7 +29,7 @@ use mz_persist_client::metrics::Metrics;
 use mz_persist_client::read::{Listen, ListenEvent};
 use mz_persist_client::rpc::PubSubClientConnection;
 use mz_persist_client::write::WriteHandle;
-use mz_persist_client::{PersistClient, ShardId};
+use mz_persist_client::{Diagnostics, PersistClient, ShardId};
 use timely::order::TotalOrder;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -139,9 +139,9 @@ impl Transactor {
         let (mut write, mut read) = client
             .open(
                 shard_id,
-                "maelstrom long-lived",
                 Arc::new(MaelstromKeySchema),
                 Arc::new(MaelstromValSchema),
+                Diagnostics::new("", "maelstrom long-lived"),
             )
             .await?;
         // Use the CONTROLLER_CRITICAL_SINCE id for all nodes so we get coverage
@@ -150,7 +150,7 @@ impl Transactor {
             .open_critical_since(
                 shard_id,
                 PersistClient::CONTROLLER_CRITICAL_SINCE,
-                "maelstrom since",
+                Diagnostics::new("", "maelstrom since"),
             )
             .await?;
         let read_ts = Self::maybe_init_shard(&mut write).await?;
@@ -269,9 +269,9 @@ impl Transactor {
                 .client
                 .open_leased_reader(
                     self.shard_id,
-                    "maelstrom short-lived",
                     Arc::new(MaelstromKeySchema),
                     Arc::new(MaelstromValSchema),
+                    Diagnostics::new("", "maelstrom short-lived"),
                 )
                 .await
                 .expect("codecs should match");
@@ -303,7 +303,7 @@ impl Transactor {
                         .open_critical_since(
                             self.shard_id,
                             PersistClient::CONTROLLER_CRITICAL_SINCE,
-                            "maelstrom since",
+                            Diagnostics::new("", "maelstrom since"),
                         )
                         .await?;
                     continue;
@@ -337,7 +337,7 @@ impl Transactor {
                         .open_critical_since(
                             self.shard_id,
                             PersistClient::CONTROLLER_CRITICAL_SINCE,
-                            "maelstrom since",
+                            Diagnostics::new("", "maelstrom since"),
                         )
                         .await?;
                     continue;

--- a/src/persist-client/examples/open_loop.rs
+++ b/src/persist-client/examples/open_loop.rs
@@ -515,7 +515,7 @@ mod raw_persist_benchmark {
                     id,
                     Arc::new(VecU8Schema),
                     Arc::new(VecU8Schema),
-                    Diagnostics::new("", "open loop"),
+                    Diagnostics::from_purpose("open loop"),
                 )
                 .await?;
 
@@ -550,7 +550,7 @@ mod raw_persist_benchmark {
                     id,
                     Arc::new(VecU8Schema),
                     Arc::new(VecU8Schema),
-                    Diagnostics::new("", "open loop"),
+                    Diagnostics::from_purpose("open loop"),
                 )
                 .await?;
 
@@ -599,7 +599,7 @@ mod raw_persist_benchmark {
                     id,
                     Arc::new(VecU8Schema),
                     Arc::new(VecU8Schema),
-                    Diagnostics::new("", "open loop"),
+                    Diagnostics::from_purpose("open loop"),
                 )
                 .await?;
 

--- a/src/persist-client/examples/open_loop.rs
+++ b/src/persist-client/examples/open_loop.rs
@@ -479,7 +479,7 @@ mod raw_persist_benchmark {
     use mz_ore::cast::CastFrom;
     use mz_persist::indexed::columnar::ColumnarRecords;
     use mz_persist_client::read::{Listen, ListenEvent};
-    use mz_persist_client::{PersistClient, ShardId};
+    use mz_persist_client::{Diagnostics, PersistClient, ShardId};
     use mz_persist_types::codec_impls::VecU8Schema;
     use mz_persist_types::Codec64;
     use timely::progress::Antichain;
@@ -513,9 +513,9 @@ mod raw_persist_benchmark {
             let (_writer, reader) = persist
                 .open::<Vec<u8>, Vec<u8>, u64, i64>(
                     id,
-                    "open loop",
                     Arc::new(VecU8Schema),
                     Arc::new(VecU8Schema),
+                    Diagnostics::new("", "open loop"),
                 )
                 .await?;
 
@@ -548,9 +548,9 @@ mod raw_persist_benchmark {
             let mut write = persist
                 .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(
                     id,
-                    "open loop",
                     Arc::new(VecU8Schema),
                     Arc::new(VecU8Schema),
+                    Diagnostics::new("", "open loop"),
                 )
                 .await?;
 
@@ -597,9 +597,9 @@ mod raw_persist_benchmark {
             let mut write = persist
                 .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(
                     id,
-                    "open loop",
                     Arc::new(VecU8Schema),
                     Arc::new(VecU8Schema),
+                    Diagnostics::new("", "open loop"),
                 )
                 .await?;
 

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -38,7 +38,7 @@ use crate::internal::metrics::{LockMetrics, Metrics, MetricsBlob, MetricsConsens
 use crate::internal::state::TypedState;
 use crate::internal::watch::StateWatchNotifier;
 use crate::rpc::{PubSubClientConnection, PubSubSender, ShardSubscriptionToken};
-use crate::{PersistClient, PersistConfig, PersistLocation, ShardId};
+use crate::{Diagnostics, PersistClient, PersistConfig, PersistLocation, ShardId};
 
 /// A cache of [PersistClient]s indexed by [PersistLocation]s.
 ///
@@ -401,6 +401,7 @@ impl StateCache {
         &self,
         shard_id: ShardId,
         mut init_fn: InitFn,
+        diagnostics: &Diagnostics,
     ) -> Result<Arc<LockingTypedState<K, V, T, D>>, Box<CodecMismatch>>
     where
         K: Debug + Codec,
@@ -442,6 +443,7 @@ impl StateCache {
                                 Arc::clone(&self.metrics),
                                 Arc::clone(&self.cfg),
                                 Arc::clone(&self.pubsub_sender).subscribe(&shard_id),
+                                diagnostics,
                             ));
                             let ret = Arc::downgrade(&state);
                             did_init = Some(state);
@@ -568,13 +570,14 @@ impl<K, V, T, D> LockingTypedState<K, V, T, D> {
         metrics: Arc<Metrics>,
         cfg: Arc<PersistConfig>,
         subscription_token: Arc<ShardSubscriptionToken>,
+        diagnostics: &Diagnostics,
     ) -> Self {
         Self {
             shard_id,
             notifier: StateWatchNotifier::new(Arc::clone(&metrics)),
             state: RwLock::new(initial_state),
             cfg: Arc::clone(&cfg),
-            shard_metrics: metrics.shards.shard(&shard_id),
+            shard_metrics: metrics.shards.shard(&shard_id, &diagnostics.shard_name),
             metrics,
             _subscription_token: subscription_token,
         }
@@ -757,8 +760,12 @@ mod tests {
         // Panic'ing during init_fn .
         let s = Arc::clone(&states);
         let res = spawn(|| "test", async move {
-            s.get::<(), (), u64, i64, _, _>(s1, || async { panic!("boom") })
-                .await
+            s.get::<(), (), u64, i64, _, _>(
+                s1,
+                || async { panic!("boom") },
+                &Diagnostics::for_tests(),
+            )
+            .await
         })
         .await;
         assert!(res.is_err());
@@ -766,12 +773,16 @@ mod tests {
 
         // Returning an error from init_fn doesn't initialize an entry in the cache.
         let res = states
-            .get::<(), (), u64, i64, _, _>(s1, || async {
-                Err(Box::new(CodecMismatch {
-                    requested: ("".into(), "".into(), "".into(), "".into(), None),
-                    actual: ("".into(), "".into(), "".into(), "".into(), None),
-                }))
-            })
+            .get::<(), (), u64, i64, _, _>(
+                s1,
+                || async {
+                    Err(Box::new(CodecMismatch {
+                        requested: ("".into(), "".into(), "".into(), "".into(), None),
+                        actual: ("".into(), "".into(), "".into(), "".into(), None),
+                    }))
+                },
+                &Diagnostics::for_tests(),
+            )
             .await;
         assert!(res.is_err());
         assert_eq!(states.initialized_count(), 0);
@@ -779,13 +790,17 @@ mod tests {
         // Initialize one shard.
         let did_work = Arc::new(AtomicBool::new(false));
         let s1_state1 = states
-            .get::<(), (), u64, i64, _, _>(s1, || {
-                let did_work = Arc::clone(&did_work);
-                async move {
-                    did_work.store(true, Ordering::SeqCst);
-                    Ok(new_state(s1))
-                }
-            })
+            .get::<(), (), u64, i64, _, _>(
+                s1,
+                || {
+                    let did_work = Arc::clone(&did_work);
+                    async move {
+                        did_work.store(true, Ordering::SeqCst);
+                        Ok(new_state(s1))
+                    }
+                },
+                &Diagnostics::for_tests(),
+            )
             .await
             .expect("should successfully initialize");
         assert_eq!(did_work.load(Ordering::SeqCst), true);
@@ -795,14 +810,18 @@ mod tests {
         // Trying to initialize it again does no work and returns the same state.
         let did_work = Arc::new(AtomicBool::new(false));
         let s1_state2 = states
-            .get::<(), (), u64, i64, _, _>(s1, || {
-                let did_work = Arc::clone(&did_work);
-                async move {
-                    did_work.store(true, Ordering::SeqCst);
-                    did_work.store(true, Ordering::SeqCst);
-                    Ok(new_state(s1))
-                }
-            })
+            .get::<(), (), u64, i64, _, _>(
+                s1,
+                || {
+                    let did_work = Arc::clone(&did_work);
+                    async move {
+                        did_work.store(true, Ordering::SeqCst);
+                        did_work.store(true, Ordering::SeqCst);
+                        Ok(new_state(s1))
+                    }
+                },
+                &Diagnostics::for_tests(),
+            )
             .await
             .expect("should successfully initialize");
         assert_eq!(did_work.load(Ordering::SeqCst), false);
@@ -813,13 +832,17 @@ mod tests {
         // Trying to initialize with different types doesn't work.
         let did_work = Arc::new(AtomicBool::new(false));
         let res = states
-            .get::<String, (), u64, i64, _, _>(s1, || {
-                let did_work = Arc::clone(&did_work);
-                async move {
-                    did_work.store(true, Ordering::SeqCst);
-                    Ok(new_state(s1))
-                }
-            })
+            .get::<String, (), u64, i64, _, _>(
+                s1,
+                || {
+                    let did_work = Arc::clone(&did_work);
+                    async move {
+                        did_work.store(true, Ordering::SeqCst);
+                        Ok(new_state(s1))
+                    }
+                },
+                &Diagnostics::for_tests(),
+            )
             .await;
         assert_eq!(did_work.load(Ordering::SeqCst), false);
         assert_eq!(
@@ -832,13 +855,21 @@ mod tests {
         // We can add a shard of a different type.
         let s2 = ShardId::new();
         let s2_state1 = states
-            .get::<String, (), u64, i64, _, _>(s2, || async { Ok(new_state(s2)) })
+            .get::<String, (), u64, i64, _, _>(
+                s2,
+                || async { Ok(new_state(s2)) },
+                &Diagnostics::for_tests(),
+            )
             .await
             .expect("should successfully initialize");
         assert_eq!(states.initialized_count(), 2);
         assert_eq!(states.strong_count(), 2);
         let s2_state2 = states
-            .get::<String, (), u64, i64, _, _>(s2, || async { Ok(new_state(s2)) })
+            .get::<String, (), u64, i64, _, _>(
+                s2,
+                || async { Ok(new_state(s2)) },
+                &Diagnostics::for_tests(),
+            )
             .await
             .expect("should successfully initialize");
         assert_same(&s2_state1, &s2_state2);
@@ -854,7 +885,11 @@ mod tests {
 
         // But we can re-init that shard if necessary.
         let s1_state1 = states
-            .get::<(), (), u64, i64, _, _>(s1, || async { Ok(new_state(s1)) })
+            .get::<(), (), u64, i64, _, _>(
+                s1,
+                || async { Ok(new_state(s1)) },
+                &Diagnostics::for_tests(),
+            )
             .await
             .expect("should successfully initialize");
         assert_eq!(states.initialized_count(), 2);
@@ -871,17 +906,22 @@ mod tests {
         const COUNT: usize = 1000;
         let id = ShardId::new();
         let cache = StateCache::new_no_metrics();
+        let diagnostics = Diagnostics::for_tests();
 
         let mut futures = (0..COUNT)
             .map(|_| {
-                cache.get::<(), (), u64, i64, _, _>(id, || async {
-                    Ok(TypedState::new(
-                        DUMMY_BUILD_INFO.semver_version(),
-                        id,
-                        "host".into(),
-                        0,
-                    ))
-                })
+                cache.get::<(), (), u64, i64, _, _>(
+                    id,
+                    || async {
+                        Ok(TypedState::new(
+                            DUMMY_BUILD_INFO.semver_version(),
+                            id,
+                            "host".into(),
+                            0,
+                        ))
+                    },
+                    &diagnostics,
+                )
             })
             .collect::<FuturesUnordered<_>>();
 

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -439,7 +439,7 @@ async fn make_machine(
         Arc::new(StateCache::new(cfg, metrics, Arc::new(NoopPubSubSender))),
         Arc::new(NoopPubSubSender),
         Arc::new(IsolatedRuntime::new()),
-        Diagnostics::new("unknown", "admin"),
+        Diagnostics::from_purpose("admin"),
     )
     .await?;
 

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -39,7 +39,7 @@ use crate::internal::metrics::{MetricsBlob, MetricsConsensus};
 use crate::internal::trace::{ApplyMergeResult, FueledMergeRes};
 use crate::rpc::NoopPubSubSender;
 use crate::write::WriterId;
-use crate::{Metrics, PersistConfig, ShardId, StateVersions, BUILD_INFO};
+use crate::{Diagnostics, Metrics, PersistConfig, ShardId, StateVersions, BUILD_INFO};
 
 /// Commands for read-write administration of persist state
 #[derive(Debug, clap::Args)]
@@ -439,6 +439,7 @@ async fn make_machine(
         Arc::new(StateCache::new(cfg, metrics, Arc::new(NoopPubSubSender))),
         Arc::new(NoopPubSubSender),
         Arc::new(IsolatedRuntime::new()),
+        Diagnostics::new("unknown", "admin"),
     )
     .await?;
 

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -339,7 +339,7 @@ mod tests {
     use serde_json::json;
 
     use crate::tests::new_test_client;
-    use crate::{PersistClient, ShardId};
+    use crate::{Diagnostics, PersistClient, ShardId};
 
     use super::*;
 
@@ -383,7 +383,11 @@ mod tests {
         let shard_id = crate::ShardId::new();
 
         let mut since = client
-            .open_critical_since::<(), (), u64, i64, i64>(shard_id, CriticalReaderId::new(), "")
+            .open_critical_since::<(), (), u64, i64, i64>(
+                shard_id,
+                CriticalReaderId::new(),
+                Diagnostics::for_tests(),
+            )
             .await
             .expect("codec mismatch");
 
@@ -412,7 +416,7 @@ mod tests {
             .open_critical_since::<(), (), u64, i64, i64>(
                 shard_id,
                 PersistClient::CONTROLLER_CRITICAL_SINCE,
-                "",
+                Diagnostics::for_tests(),
             )
             .await
             .expect("codec mismatch");
@@ -432,7 +436,7 @@ mod tests {
             .open_critical_since::<(), (), u64, i64, i64>(
                 shard_id,
                 PersistClient::CONTROLLER_CRITICAL_SINCE,
-                "",
+                Diagnostics::for_tests(),
             )
             .await
             .expect("codec mismatch");

--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -36,7 +36,7 @@ use crate::internal::state_versions::{EncodedRollup, StateVersions};
 use crate::internal::trace::FueledMergeReq;
 use crate::internal::watch::StateWatch;
 use crate::rpc::PubSubSender;
-use crate::{PersistConfig, ShardId};
+use crate::{Diagnostics, PersistConfig, ShardId};
 
 /// An applier of persist commands.
 ///
@@ -93,14 +93,19 @@ where
         state_versions: Arc<StateVersions>,
         shared_states: Arc<StateCache>,
         pubsub_sender: Arc<dyn PubSubSender>,
+        diagnostics: Diagnostics,
     ) -> Result<Self, Box<CodecMismatch>> {
-        let shard_metrics = metrics.shards.shard(&shard_id);
+        let shard_metrics = metrics.shards.shard(&shard_id, &diagnostics.shard_name);
         let state = shared_states
-            .get::<K, V, T, D, _, _>(shard_id, || {
-                metrics.cmds.init_state.run_cmd(&shard_metrics, || {
-                    state_versions.maybe_init_shard(&shard_metrics)
-                })
-            })
+            .get::<K, V, T, D, _, _>(
+                shard_id,
+                || {
+                    metrics.cmds.init_state.run_cmd(&shard_metrics, || {
+                        state_versions.maybe_init_shard(&shard_metrics)
+                    })
+                },
+                &diagnostics,
+            )
             .await?;
         let ret = Applier {
             cfg,

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -1059,10 +1059,8 @@ mod tests {
             CompactConfig::new(&write.cfg, &write.writer_id),
             Arc::clone(&write.blob),
             Arc::clone(&write.metrics),
-            write.metrics.shards.shard(&write.machine.shard_id()),
-            Arc::new(IsolatedRuntime::new()),
             write.metrics.shards.shard(&write.machine.shard_id(), ""),
-            Arc::new(CpuHeavyRuntime::new()),
+            Arc::new(IsolatedRuntime::new()),
             req.clone(),
             schemas,
         )
@@ -1145,10 +1143,8 @@ mod tests {
             CompactConfig::new(&write.cfg, &write.writer_id),
             Arc::clone(&write.blob),
             Arc::clone(&write.metrics),
-            write.metrics.shards.shard(&write.machine.shard_id()),
-            Arc::new(IsolatedRuntime::new()),
             write.metrics.shards.shard(&write.machine.shard_id(), ""),
-            Arc::new(CpuHeavyRuntime::new()),
+            Arc::new(IsolatedRuntime::new()),
             req.clone(),
             schemas,
         )

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -1061,6 +1061,8 @@ mod tests {
             Arc::clone(&write.metrics),
             write.metrics.shards.shard(&write.machine.shard_id()),
             Arc::new(IsolatedRuntime::new()),
+            write.metrics.shards.shard(&write.machine.shard_id(), ""),
+            Arc::new(CpuHeavyRuntime::new()),
             req.clone(),
             schemas,
         )
@@ -1145,6 +1147,8 @@ mod tests {
             Arc::clone(&write.metrics),
             write.metrics.shards.shard(&write.machine.shard_id()),
             Arc::new(IsolatedRuntime::new()),
+            write.metrics.shards.shard(&write.machine.shard_id(), ""),
+            Arc::new(CpuHeavyRuntime::new()),
             req.clone(),
             schemas,
         )
@@ -1222,7 +1226,7 @@ mod tests {
         let shard_id = ShardId::new();
         let blob = &client.blob;
         let metrics = &client.metrics;
-        let shard_metrics = &client.metrics.shards.shard(&shard_id);
+        let shard_metrics = &client.metrics.shards.shard(&shard_id, "");
 
         // NB: In the below, parts within a run are separated by `,` and runs
         // are separated by `|`. Example: `r0p0,r0p1|r1p0|r2p0,r2p1,r2p2`

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1159,143 +1159,143 @@ impl ShardsMetrics {
             since: registry.register(metric!(
                 name: "mz_persist_shard_since",
                 help: "since by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             upper: registry.register(metric!(
                 name: "mz_persist_shard_upper",
                 help: "upper by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             encoded_rollup_size: registry.register(metric!(
                 name: "mz_persist_shard_rollup_size_bytes",
                 help: "total encoded rollup size by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             encoded_diff_size: registry.register(metric!(
                 name: "mz_persist_shard_diff_size_bytes",
                 help: "total encoded diff size by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             hollow_batch_count: registry.register(metric!(
                 name: "mz_persist_shard_hollow_batch_count",
                 help: "count of hollow batches by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             spine_batch_count: registry.register(metric!(
                 name: "mz_persist_shard_spine_batch_count",
                 help: "count of spine batches by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             batch_part_count: registry.register(metric!(
                 name: "mz_persist_shard_batch_part_count",
                 help: "count of batch parts by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             update_count: registry.register(metric!(
                 name: "mz_persist_shard_update_count",
                 help: "count of updates by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             rollup_count: registry.register(metric!(
                 name: "mz_persist_shard_rollup_count",
                 help: "count of rollups by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             largest_batch_size: registry.register(metric!(
                 name: "mz_persist_shard_largest_batch_size",
                 help: "largest encoded batch size by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             seqnos_held: registry.register(metric!(
                 name: "mz_persist_shard_seqnos_held",
                 help: "maximum count of gc-ineligible states by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             seqnos_since_last_rollup: registry.register(metric!(
                 name: "mz_persist_shard_seqnos_since_last_rollup",
                 help: "count of seqnos since last rollup",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             gc_seqno_held_parts: registry.register(metric!(
                 name: "mz_persist_shard_gc_seqno_held_parts",
                 help: "count of parts referenced by some live state but not the current state (ie. parts kept only to satisfy seqno holds) at GC time",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             gc_live_diffs: registry.register(metric!(
                 name: "mz_persist_shard_gc_live_diffs",
                 help: "the number of diffs (or, alternatively, the number of seqnos) present in consensus state at GC time",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             gc_finished: registry.register(metric!(
                 name: "mz_persist_shard_gc_finished",
                 help: "count of garbage collections finished by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             compaction_applied: registry.register(metric!(
                 name: "mz_persist_shard_compaction_applied",
                 help: "count of compactions applied to state by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             cmd_succeeded: registry.register(metric!(
                 name: "mz_persist_shard_cmd_succeeded",
                 help: "count of commands succeeded by shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             usage_current_state_batches_bytes: registry.register(metric!(
                 name: "mz_persist_shard_usage_current_state_batches_bytes",
                 help: "data in batches/parts referenced by current version of state",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             usage_current_state_rollups_bytes: registry.register(metric!(
                 name: "mz_persist_shard_usage_current_state_rollups_bytes",
                 help: "data in rollups referenced by current version of state",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             usage_referenced_not_current_state_bytes: registry.register(metric!(
                 name: "mz_persist_shard_usage_referenced_not_current_state_bytes",
                 help: "data referenced only by a previous version of state",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             usage_not_leaked_not_referenced_bytes: registry.register(metric!(
                 name: "mz_persist_shard_usage_not_leaked_not_referenced_bytes",
                 help: "data written by an active writer but not referenced by any version of state",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             usage_leaked_bytes: registry.register(metric!(
                 name: "mz_persist_shard_usage_leaked_bytes",
                 help: "data reclaimable by a leaked blob detector",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             pubsub_push_diff_applied: registry.register(metric!(
                 name: "mz_persist_shard_pubsub_diff_applied",
                 help: "number of diffs received via pubsub that applied",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             pubsub_push_diff_not_applied_stale: registry.register(metric!(
                 name: "mz_persist_shard_pubsub_diff_not_applied_stale",
                 help: "number of diffs received via pubsub that did not apply due to staleness",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             pubsub_push_diff_not_applied_out_of_order: registry.register(metric!(
                 name: "mz_persist_shard_pubsub_diff_not_applied_out_of_order",
                 help: "number of diffs received via pubsub that did not apply due to out-of-order delivery",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             blob_gets: registry.register(metric!(
                 name: "mz_persist_shard_blob_gets",
                 help: "number of Blob::get calls for this shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             blob_sets: registry.register(metric!(
                 name: "mz_persist_shard_blob_sets",
                 help: "number of Blob::set calls for this shard",
-                var_labels: ["shard"],
+                var_labels: ["shard", "name"],
             )),
             shards,
         }
     }
 
-    pub fn shard(&self, shard_id: &ShardId) -> Arc<ShardMetrics> {
+    pub fn shard(&self, shard_id: &ShardId, name: &str) -> Arc<ShardMetrics> {
         let mut shards = self.shards.lock().expect("mutex poisoned");
         if let Some(shard) = shards.get(shard_id) {
             if let Some(shard) = shard.upgrade() {
@@ -1304,7 +1304,7 @@ impl ShardsMetrics {
                 assert!(shards.remove(shard_id).is_some());
             }
         }
-        let shard = Arc::new(ShardMetrics::new(shard_id, self));
+        let shard = Arc::new(ShardMetrics::new(shard_id, name, self));
         assert!(shards
             .insert(shard_id.clone(), Arc::downgrade(&shard))
             .is_none());
@@ -1365,91 +1365,91 @@ pub struct ShardMetrics {
 }
 
 impl ShardMetrics {
-    pub fn new(shard_id: &ShardId, shards_metrics: &ShardsMetrics) -> Self {
+    pub fn new(shard_id: &ShardId, name: &str, shards_metrics: &ShardsMetrics) -> Self {
         let shard = shard_id.to_string();
         ShardMetrics {
             shard_id: *shard_id,
             since: shards_metrics
                 .since
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             upper: shards_metrics
                 .upper
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             latest_rollup_size: shards_metrics
                 .encoded_rollup_size
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             encoded_diff_size: shards_metrics
                 .encoded_diff_size
-                .get_delete_on_drop_counter(vec![shard.clone()]),
+                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
             hollow_batch_count: shards_metrics
                 .hollow_batch_count
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             spine_batch_count: shards_metrics
                 .spine_batch_count
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             batch_part_count: shards_metrics
                 .batch_part_count
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             update_count: shards_metrics
                 .update_count
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             rollup_count: shards_metrics
                 .rollup_count
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             largest_batch_size: shards_metrics
                 .largest_batch_size
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             seqnos_held: shards_metrics
                 .seqnos_held
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             seqnos_since_last_rollup: shards_metrics
                 .seqnos_since_last_rollup
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             gc_seqno_held_parts: shards_metrics
                 .gc_seqno_held_parts
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             gc_live_diffs: shards_metrics
                 .gc_live_diffs
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             gc_finished: shards_metrics
                 .gc_finished
-                .get_delete_on_drop_counter(vec![shard.clone()]),
+                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
             compaction_applied: shards_metrics
                 .compaction_applied
-                .get_delete_on_drop_counter(vec![shard.clone()]),
+                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
             cmd_succeeded: shards_metrics
                 .cmd_succeeded
-                .get_delete_on_drop_counter(vec![shard.clone()]),
+                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
             usage_current_state_batches_bytes: shards_metrics
                 .usage_current_state_batches_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             usage_current_state_rollups_bytes: shards_metrics
                 .usage_current_state_rollups_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             usage_referenced_not_current_state_bytes: shards_metrics
                 .usage_referenced_not_current_state_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             usage_not_leaked_not_referenced_bytes: shards_metrics
                 .usage_not_leaked_not_referenced_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             usage_leaked_bytes: shards_metrics
                 .usage_leaked_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
             pubsub_push_diff_applied: shards_metrics
                 .pubsub_push_diff_applied
-                .get_delete_on_drop_counter(vec![shard.clone()]),
+                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
             pubsub_push_diff_not_applied_stale: shards_metrics
                 .pubsub_push_diff_not_applied_stale
-                .get_delete_on_drop_counter(vec![shard.clone()]),
+                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
             pubsub_push_diff_not_applied_out_of_order: shards_metrics
                 .pubsub_push_diff_not_applied_out_of_order
-                .get_delete_on_drop_counter(vec![shard.clone()]),
+                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
             blob_gets: shards_metrics
                 .blob_gets
-                .get_delete_on_drop_counter(vec![shard.clone()]),
+                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
             blob_sets: shards_metrics
                 .blob_sets
-                .get_delete_on_drop_counter(vec![shard]),
+                .get_delete_on_drop_counter(vec![shard, name.to_string()]),
         }
     }
 

--- a/src/persist-client/src/internal/watch.rs
+++ b/src/persist-client/src/internal/watch.rs
@@ -150,7 +150,7 @@ mod tests {
     use crate::cfg::{PersistConfig, PersistParameters, RetryParameters};
     use crate::internal::state::TypedState;
     use crate::tests::new_test_client;
-    use crate::ShardId;
+    use crate::{Diagnostics, ShardId};
 
     use super::*;
 
@@ -164,14 +164,18 @@ mod tests {
         let cache = StateCache::new_no_metrics();
         let shard_id = ShardId::new();
         let state = cache
-            .get::<(), (), u64, i64, _, _>(shard_id, || async {
-                Ok(TypedState::new(
-                    DUMMY_BUILD_INFO.semver_version(),
-                    shard_id,
-                    "host".to_owned(),
-                    0u64,
-                ))
-            })
+            .get::<(), (), u64, i64, _, _>(
+                shard_id,
+                || async {
+                    Ok(TypedState::new(
+                        DUMMY_BUILD_INFO.semver_version(),
+                        shard_id,
+                        "host".to_owned(),
+                        0u64,
+                    ))
+                },
+                &Diagnostics::for_tests(),
+            )
             .await
             .unwrap();
         assert_eq!(state.read_lock(&metrics.locks.watch, |x| x.seqno), SeqNo(0));
@@ -211,14 +215,18 @@ mod tests {
         let cache = StateCache::new_no_metrics();
         let shard_id = ShardId::new();
         let state = cache
-            .get::<(), (), u64, i64, _, _>(shard_id, || async {
-                Ok(TypedState::new(
-                    DUMMY_BUILD_INFO.semver_version(),
-                    shard_id,
-                    "host".to_owned(),
-                    0u64,
-                ))
-            })
+            .get::<(), (), u64, i64, _, _>(
+                shard_id,
+                || async {
+                    Ok(TypedState::new(
+                        DUMMY_BUILD_INFO.semver_version(),
+                        shard_id,
+                        "host".to_owned(),
+                        0u64,
+                    ))
+                },
+                &Diagnostics::for_tests(),
+            )
             .await
             .unwrap();
         assert_eq!(state.read_lock(&metrics.locks.watch, |x| x.seqno), SeqNo(0));

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -268,9 +268,10 @@ impl Diagnostics {
 /// # let client: mz_persist_client::PersistClient = unimplemented!();
 /// # let timeout: std::time::Duration = unimplemented!();
 /// # let id = mz_persist_client::ShardId::new();
+/// # let diagnostics = mz_persist_client::Diagnostics::new("", "");
 /// # async {
-/// tokio::time::timeout(timeout, client.open::<String, String, u64, i64>(id, "desc",
-///     Arc::new(StringSchema),Arc::new(StringSchema))).await
+/// tokio::time::timeout(timeout, client.open::<String, String, u64, i64>(id,
+///     Arc::new(StringSchema),Arc::new(StringSchema),diagnostics)).await
 /// # };
 /// ```
 #[derive(Debug, Clone)]

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -232,21 +232,23 @@ impl ShardId {
 /// e.g. for logging, metric labels, etc.
 #[derive(Clone, Debug)]
 pub struct Diagnostics {
-    shard_name: String,
-    handle_purpose: String,
+    /// A user-friendly name for the shard.
+    pub shard_name: String,
+    /// A purpose for the handle.
+    pub handle_purpose: String,
 }
 
 impl Diagnostics {
-    /// Create a new `Diagnostics`.
-    pub fn new(shard_name: &str, handle_purpose: &str) -> Self {
+    /// Create a new `Diagnostics` from `handle_purpose`.
+    pub fn from_purpose(handle_purpose: &str) -> Self {
         Self {
-            shard_name: shard_name.to_string(),
+            shard_name: "unknown".to_string(),
             handle_purpose: handle_purpose.to_string(),
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn for_tests() -> Self {
+    /// Create a new `Diagnostics` for testing.
+    pub fn for_tests() -> Self {
         Self {
             shard_name: "test-shard-name".to_string(),
             handle_purpose: "test-purpose".to_string(),
@@ -268,7 +270,7 @@ impl Diagnostics {
 /// # let client: mz_persist_client::PersistClient = unimplemented!();
 /// # let timeout: std::time::Duration = unimplemented!();
 /// # let id = mz_persist_client::ShardId::new();
-/// # let diagnostics = mz_persist_client::Diagnostics::new("", "");
+/// # let diagnostics = mz_persist_client::Diagnostics { shard_name: "".into(), handle_purpose: "".into() };
 /// # async {
 /// tokio::time::timeout(timeout, client.open::<String, String, u64, i64>(id,
 ///     Arc::new(StringSchema),Arc::new(StringSchema),diagnostics)).await

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -248,8 +248,8 @@ impl Diagnostics {
     #[cfg(test)]
     pub(crate) fn for_tests() -> Self {
         Self {
-            shard_name: "test".to_string(),
-            handle_purpose: "test".to_string(),
+            shard_name: "test-shard-name".to_string(),
+            handle_purpose: "test-purpose".to_string(),
         }
     }
 }

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -42,7 +42,7 @@ use crate::cache::PersistClientCache;
 use crate::fetch::{FetchedPart, SerdeLeasedBatchPart};
 use crate::read::ListenEvent;
 use crate::stats::PartStats;
-use crate::{PersistLocation, ShardId};
+use crate::{Diagnostics, PersistLocation, ShardId};
 
 /// Creates a new source that reads from a persist shard, distributing the work
 /// of reading data to all timely workers.
@@ -271,9 +271,10 @@ where
             let read = client
                 .open_leased_reader::<K, V, G::Timestamp, D>(
                     shard_id,
-                    &format!("shard_source({})", name_owned),
                     key_schema,
                     val_schema,
+                    Diagnostics::new(&name_owned,
+                                     &format!("shard_source({})", name_owned)),
                 )
                 .await
                 .expect("could not open persist shard");
@@ -621,6 +622,7 @@ where
     );
     let (mut fetched_output, fetched_stream) = builder.new_output();
     let (mut completed_fetches_output, completed_fetches_stream) = builder.new_output();
+    let name_owned = name.to_owned();
 
     let shutdown_button = builder.build(move |_capabilities| async move {
         let fetcher = {
@@ -629,7 +631,15 @@ where
                 .await
                 .expect("location should be valid");
             client
-                .create_batch_fetcher::<K, V, T, D>(shard_id, key_schema, val_schema)
+                .create_batch_fetcher::<K, V, T, D>(
+                    shard_id,
+                    key_schema,
+                    val_schema,
+                    Diagnostics::new(
+                        &name_owned,
+                        &format!("shard_source_fetch batch fetcher {}", name_owned),
+                    ),
+                )
                 .await
         };
 
@@ -674,7 +684,7 @@ mod tests {
 
     use crate::cache::PersistClientCache;
     use crate::operators::shard_source::shard_source;
-    use crate::{PersistLocation, ShardId};
+    use crate::{Diagnostics, PersistLocation, ShardId};
 
     /// Verifies that a `shard_source` will downgrade it's output frontier to
     /// the `since` of the shard when no explicit `as_of` is given. Even if
@@ -806,9 +816,9 @@ mod tests {
         let mut read_handle = persist_client
             .open_leased_reader::<String, String, u64, u64>(
                 shard_id,
-                "tests",
                 Arc::new(<std::string::String as mz_persist_types::Codec>::Schema::default()),
                 Arc::new(<std::string::String as mz_persist_types::Codec>::Schema::default()),
+                Diagnostics::new("tests", "tests"),
             )
             .await
             .expect("invalid usage");

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -273,8 +273,10 @@ where
                     shard_id,
                     key_schema,
                     val_schema,
-                    Diagnostics::new(&name_owned,
-                                     &format!("shard_source({})", name_owned)),
+                    Diagnostics {
+                        shard_name: name_owned.clone(),
+                        handle_purpose: format!("shard_source({})", name_owned),
+                    }
                 )
                 .await
                 .expect("could not open persist shard");
@@ -635,10 +637,10 @@ where
                     shard_id,
                     key_schema,
                     val_schema,
-                    Diagnostics::new(
-                        &name_owned,
-                        &format!("shard_source_fetch batch fetcher {}", name_owned),
-                    ),
+                    Diagnostics {
+                        shard_name: name_owned.clone(),
+                        handle_purpose: format!("shard_source_fetch batch fetcher {}", name_owned),
+                    },
                 )
                 .await
         };
@@ -818,7 +820,7 @@ mod tests {
                 shard_id,
                 Arc::new(<std::string::String as mz_persist_types::Codec>::Schema::default()),
                 Arc::new(<std::string::String as mz_persist_types::Codec>::Schema::default()),
-                Diagnostics::new("tests", "tests"),
+                Diagnostics::for_tests(),
             )
             .await
             .expect("invalid usage");

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -197,7 +197,7 @@ impl StorageUsageClient {
             .check_ts_codec()
             .expect("ts should be a u64 in all prod shards");
 
-        let shard_metrics = &self.metrics.shards.shard(&shard_id);
+        let shard_metrics = &self.metrics.shards.shard(&shard_id, "unknown");
         shard_metrics
             .gc_live_diffs
             .set(u64::cast_from(states_iter.len()));
@@ -441,7 +441,7 @@ impl StorageUsageClient {
             .inc_by(now.duration_since(start).as_secs_f64());
         start = now;
 
-        let shard_metrics = self.metrics.shards.shard(&shard_id);
+        let shard_metrics = self.metrics.shards.shard(&shard_id, "unknown");
         shard_metrics
             .gc_live_diffs
             .set(u64::cast_from(states_iter.len()));

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -2977,6 +2977,7 @@ where
                         shard_id,
                         Arc::new(RelationDesc::empty()),
                         Arc::new(UnitSchema),
+                        // TODO: thread the global ID into the shard finalization WAL
                         Diagnostics::new("unknown", "finalizing shards"),
                     )
                     .await
@@ -2990,6 +2991,7 @@ where
                             shard_id,
                             Arc::new(RelationDesc::empty()),
                             Arc::new(UnitSchema),
+                            // TODO: thread the global ID into the shard finalization WAL
                             Diagnostics::new("unknown", "finalizing shards"),
                         )
                         .await

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -40,7 +40,7 @@ use mz_persist_client::critical::SinceHandle;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_client::stats::SnapshotStats;
 use mz_persist_client::write::WriteHandle;
-use mz_persist_client::{PersistClient, PersistLocation, ShardId};
+use mz_persist_client::{Diagnostics, PersistClient, PersistLocation, ShardId};
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::{Codec64, Opaque};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
@@ -1350,7 +1350,7 @@ where
 
                 let (write, since_handle) = this
                     .open_data_handles(
-                        format!("controller data {}", id).as_str(),
+                        &id,
                         metadata.data_shard,
                         description.since.as_ref(),
                         metadata.relation_desc.clone(),
@@ -1912,9 +1912,9 @@ where
         let mut read_handle = persist_client
             .open_leased_reader::<SourceData, (), _, _>(
                 metadata.data_shard,
-                &format!("snapshot {}", id),
                 Arc::new(metadata.relation_desc.clone()),
                 Arc::new(UnitSchema),
+                Diagnostics::new(&id.to_string(), &format!("snapshot {}", id)),
             )
             .await
             .expect("invalid persist usage");
@@ -2533,7 +2533,7 @@ where
     /// current epoch.
     async fn open_data_handles(
         &self,
-        purpose: &str,
+        id: &GlobalId,
         shard: ShardId,
         since: Option<&Antichain<T>>,
         relation_desc: RelationDesc,
@@ -2542,12 +2542,13 @@ where
         WriteHandle<SourceData, (), T, Diff>,
         SinceHandle<SourceData, (), T, Diff, PersistEpoch>,
     ) {
+        let diagnostics = Diagnostics::new(&id.to_string(), &format!("controller data for {}", id));
         let write = persist_client
             .open_writer(
                 shard,
-                purpose,
                 Arc::new(relation_desc),
                 Arc::new(UnitSchema),
+                diagnostics.clone(),
             )
             .await
             .expect("invalid persist usage");
@@ -2557,7 +2558,7 @@ where
             // This block's aim is to ensure the handle is in terms of our epoch
             // by the time we return it.
             let mut handle: SinceHandle<_, _, _, _, PersistEpoch> = persist_client
-                .open_critical_since(shard, PersistClient::CONTROLLER_CRITICAL_SINCE, purpose)
+                .open_critical_since(shard, PersistClient::CONTROLLER_CRITICAL_SINCE, diagnostics)
                 .await
                 .expect("invalid persist usage");
 
@@ -2925,7 +2926,7 @@ where
             // already updated all the persistent state (in stash).
             let (write, since_handle) = self
                 .open_data_handles(
-                    format!("controller data for {id}").as_str(),
+                    &id,
                     data_shard,
                     collection_desc.since.as_ref(),
                     relation_desc,
@@ -2974,9 +2975,9 @@ where
                 let read_handle: ReadHandle<SourceData, (), T, Diff> = persist_client
                     .open_leased_reader(
                         shard_id,
-                        "finalizing shards",
                         Arc::new(RelationDesc::empty()),
                         Arc::new(UnitSchema),
+                        Diagnostics::new("unknown", "finalizing shards"),
                     )
                     .await
                     .expect("invalid persist usage");
@@ -2987,9 +2988,9 @@ where
                     let mut write_handle: WriteHandle<SourceData, (), T, Diff> = persist_client
                         .open_writer(
                             shard_id,
-                            "finalizing shards",
                             Arc::new(RelationDesc::empty()),
                             Arc::new(UnitSchema),
+                            Diagnostics::new("unknown", "finalizing shards"),
                         )
                         .await
                         .expect("invalid persist usage");

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1914,7 +1914,10 @@ where
                 metadata.data_shard,
                 Arc::new(metadata.relation_desc.clone()),
                 Arc::new(UnitSchema),
-                Diagnostics::new(&id.to_string(), &format!("snapshot {}", id)),
+                Diagnostics {
+                    shard_name: id.to_string(),
+                    handle_purpose: format!("snapshot {}", id),
+                },
             )
             .await
             .expect("invalid persist usage");
@@ -2542,7 +2545,10 @@ where
         WriteHandle<SourceData, (), T, Diff>,
         SinceHandle<SourceData, (), T, Diff, PersistEpoch>,
     ) {
-        let diagnostics = Diagnostics::new(&id.to_string(), &format!("controller data for {}", id));
+        let diagnostics = Diagnostics {
+            shard_name: id.to_string(),
+            handle_purpose: format!("controller data for {}", id),
+        };
         let write = persist_client
             .open_writer(
                 shard,
@@ -2978,7 +2984,7 @@ where
                         Arc::new(RelationDesc::empty()),
                         Arc::new(UnitSchema),
                         // TODO: thread the global ID into the shard finalization WAL
-                        Diagnostics::new("unknown", "finalizing shards"),
+                        Diagnostics::from_purpose("finalizing shards"),
                     )
                     .await
                     .expect("invalid persist usage");
@@ -2992,7 +2998,7 @@ where
                             Arc::new(RelationDesc::empty()),
                             Arc::new(UnitSchema),
                             // TODO: thread the global ID into the shard finalization WAL
-                            Diagnostics::new("unknown", "finalizing shards"),
+                            Diagnostics::from_purpose("finalizing shards"),
                         )
                         .await
                         .expect("invalid persist usage");

--- a/src/storage-client/src/controller/persist_handles.rs
+++ b/src/storage-client/src/controller/persist_handles.rs
@@ -582,7 +582,7 @@ mod tests {
     use mz_persist_client::cache::PersistClientCache;
     use mz_persist_client::cfg::PersistConfig;
     use mz_persist_client::rpc::PubSubClientConnection;
-    use mz_persist_client::{PersistClient, PersistLocation, ShardId};
+    use mz_persist_client::{Diagnostics, PersistClient, PersistLocation, ShardId};
     use mz_persist_types::codec_impls::UnitSchema;
     use mz_repr::{RelationDesc, Row};
 
@@ -604,15 +604,19 @@ mod tests {
         .unwrap();
         let shard_id = ShardId::new();
         let since_handle = client
-            .open_critical_since(shard_id, PersistClient::CONTROLLER_CRITICAL_SINCE, "test")
+            .open_critical_since(
+                shard_id,
+                PersistClient::CONTROLLER_CRITICAL_SINCE,
+                Diagnostics::new("test", "test"),
+            )
             .await
             .unwrap();
         let mut write_handle = client
             .open_writer::<SourceData, (), u64, i64>(
                 shard_id,
-                "test",
                 Arc::new(RelationDesc::empty()),
                 Arc::new(UnitSchema),
+                Diagnostics::new("test", "test"),
             )
             .await
             .unwrap();

--- a/src/storage-client/src/controller/persist_handles.rs
+++ b/src/storage-client/src/controller/persist_handles.rs
@@ -607,7 +607,7 @@ mod tests {
             .open_critical_since(
                 shard_id,
                 PersistClient::CONTROLLER_CRITICAL_SINCE,
-                Diagnostics::new("test", "test"),
+                Diagnostics::for_tests(),
             )
             .await
             .unwrap();
@@ -616,7 +616,7 @@ mod tests {
                 shard_id,
                 Arc::new(RelationDesc::empty()),
                 Arc::new(UnitSchema),
-                Diagnostics::new("test", "test"),
+                Diagnostics::for_tests(),
             )
             .await
             .unwrap();

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -44,7 +44,8 @@ pub async fn write_to_persist(
             Arc::new(relation_desc.clone()),
             Arc::new(UnitSchema),
             Diagnostics {
-                shard_name: status_shard.to_string(),
+                // TODO: plumb through the GlobalId of the status collection
+                shard_name: format!("status({})", collection_id),
                 handle_purpose: format!("healthcheck::write_to_persist {}", collection_id),
             },
         )

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -44,7 +44,7 @@ pub async fn write_to_persist(
             Arc::new(relation_desc.clone()),
             Arc::new(UnitSchema),
             Diagnostics {
-                shard_name: collection_id.to_string(),
+                shard_name: status_shard.to_string(),
                 handle_purpose: format!("healthcheck::write_to_persist {}", collection_id),
             },
         )

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -43,10 +43,10 @@ pub async fn write_to_persist(
             status_shard,
             Arc::new(relation_desc.clone()),
             Arc::new(UnitSchema),
-            Diagnostics::new(
-                &collection_id.to_string(),
-                &format!("healthcheck::write_to_persist {}", collection_id),
-            ),
+            Diagnostics {
+                shard_name: collection_id.to_string(),
+                handle_purpose: format!("healthcheck::write_to_persist {}", collection_id),
+            },
         )
         .await
         .expect(

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use differential_dataflow::lattice::Lattice;
 use mz_ore::now::NowFn;
-use mz_persist_client::{PersistClient, ShardId};
+use mz_persist_client::{Diagnostics, PersistClient, ShardId};
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::{GlobalId, RelationDesc, Timestamp};
 use mz_storage_client::types::sources::SourceData;
@@ -41,9 +41,12 @@ pub async fn write_to_persist(
     let mut handle = client
         .open_writer(
             status_shard,
-            &format!("healthcheck::write_to_persist {}", collection_id),
             Arc::new(relation_desc.clone()),
             Arc::new(UnitSchema),
+            Diagnostics::new(
+                &collection_id.to_string(),
+                &format!("healthcheck::write_to_persist {}", collection_id),
+            ),
         )
         .await
         .expect(

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -104,6 +104,7 @@ use mz_ore::collections::HashMap;
 use mz_persist_client::batch::Batch;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::write::WriterEnrichedHollowBatch;
+use mz_persist_client::Diagnostics;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::{Codec, Codec64};
 use mz_repr::{Diff, GlobalId, Row};
@@ -448,12 +449,15 @@ where
             let write = persist_client
                 .open_writer::<SourceData, (), mz_repr::Timestamp, Diff>(
                     shard_id,
-                    &format!(
-                        "compute::persist_sink::mint_batch_descriptions {}",
-                        collection_id
-                    ),
                     Arc::new(target_relation_desc),
                     Arc::new(UnitSchema),
+                    Diagnostics::new(
+                        &collection_id.to_string(),
+                        &format!(
+                            "compute::persist_sink::mint_batch_descriptions {}",
+                            collection_id
+                        ),
+                    ),
                 )
                 .await
                 .expect("could not open persist shard");
@@ -606,9 +610,11 @@ where
         let mut write = persist_client
             .open_writer::<SourceData, (), mz_repr::Timestamp, Diff>(
                 shard_id,
-                &format!("compute::persist_sink::write_batches {}", collection_id),
                 Arc::new(target_relation_desc),
                 Arc::new(UnitSchema),
+                Diagnostics::new(&collection_id.to_string(),
+                                 &format!("compute::persist_sink::write_batches {}", collection_id)
+                )
             )
             .await
             .expect("could not open persist shard");
@@ -990,9 +996,11 @@ where
         let mut write = persist_client
             .open_writer::<SourceData, (), mz_repr::Timestamp, Diff>(
                 shard_id,
-                &format!("persist_sink::append_batches {}", collection_id),
                 Arc::new(target_relation_desc),
                 Arc::new(UnitSchema),
+                Diagnostics::new(&collection_id.to_string(),
+                                 &format!("persist_sink::append_batches {}", collection_id)
+                ),
             )
             .await
             .expect("could not open persist shard");

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -451,13 +451,13 @@ where
                     shard_id,
                     Arc::new(target_relation_desc),
                     Arc::new(UnitSchema),
-                    Diagnostics::new(
-                        &collection_id.to_string(),
-                        &format!(
+                    Diagnostics {
+                        shard_name: collection_id.to_string(),
+                        handle_purpose: format!(
                             "compute::persist_sink::mint_batch_descriptions {}",
                             collection_id
                         ),
-                    ),
+                    },
                 )
                 .await
                 .expect("could not open persist shard");
@@ -612,9 +612,10 @@ where
                 shard_id,
                 Arc::new(target_relation_desc),
                 Arc::new(UnitSchema),
-                Diagnostics::new(&collection_id.to_string(),
-                                 &format!("compute::persist_sink::write_batches {}", collection_id)
-                )
+                Diagnostics {
+                    shard_name: collection_id.to_string(),
+                    handle_purpose: format!("compute::persist_sink::write_batches {}", collection_id),
+                },
             )
             .await
             .expect("could not open persist shard");
@@ -998,9 +999,10 @@ where
                 shard_id,
                 Arc::new(target_relation_desc),
                 Arc::new(UnitSchema),
-                Diagnostics::new(&collection_id.to_string(),
-                                 &format!("persist_sink::append_batches {}", collection_id)
-                ),
+                Diagnostics {
+                    shard_name:collection_id.to_string(),
+                    handle_purpose: format!("persist_sink::append_batches {}", collection_id)
+                },
             )
             .await
             .expect("could not open persist shard");

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -126,6 +126,7 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
             &storage_state.source_uppers[&description.remap_collection_id],
         ),
         params,
+        remap_collection_id: description.remap_collection_id.clone(),
     };
 
     // Build the _raw_ ok and error sources using `create_raw_source` and the

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -517,7 +517,7 @@ mod tests {
                 shard_id,
                 Arc::new(MZ_SINK_STATUS_HISTORY_DESC.clone()),
                 Arc::new(UnitSchema),
-                Diagnostics::new("", "tests::dump_storage_collection"),
+                Diagnostics::from_purpose("tests::dump_storage_collection"),
             )
             .await
             .unwrap();

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -193,7 +193,7 @@ mod tests {
     use mz_ore::now::SYSTEM_TIME;
     use mz_persist_client::cfg::PersistConfig;
     use mz_persist_client::rpc::PubSubClientConnection;
-    use mz_persist_client::{PersistLocation, ShardId};
+    use mz_persist_client::{Diagnostics, PersistLocation, ShardId};
     use mz_persist_types::codec_impls::UnitSchema;
     use mz_repr::Row;
     use mz_storage_client::types::sources::SourceData;
@@ -515,9 +515,9 @@ mod tests {
         let (write_handle, mut read_handle) = persist_client
             .open::<SourceData, (), mz_repr::Timestamp, i64>(
                 shard_id,
-                "tests::dump_storage_collection",
                 Arc::new(MZ_SINK_STATUS_HISTORY_DESC.clone()),
                 Arc::new(UnitSchema),
+                Diagnostics::new("", "tests::dump_storage_collection"),
             )
             .await
             .unwrap();

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -696,6 +696,7 @@ mod tests {
             0,
             1,
             PROGRESS_DESC.clone(),
+            GlobalId::Explain,
         )
         .await
         .unwrap();

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -802,7 +802,7 @@ mod tests {
                 remap_shard,
                 Arc::new(PROGRESS_DESC.clone()),
                 Arc::new(UnitSchema),
-                Diagnostics::new("", "test_since_hold"),
+                Diagnostics::from_purpose("test_since_hold"),
             )
             .await
             .expect("error opening persist shard");
@@ -1090,7 +1090,7 @@ mod tests {
                 remap_shard,
                 Arc::new(PROGRESS_DESC.clone()),
                 Arc::new(UnitSchema),
-                Diagnostics::new("", "test_since_hold"),
+                Diagnostics::from_purpose("test_since_hold"),
             )
             .await
             .expect("error opening persist shard");
@@ -1287,7 +1287,7 @@ mod tests {
                 remap_shard,
                 Arc::new(PROGRESS_DESC.clone()),
                 Arc::new(UnitSchema),
-                Diagnostics::new("", "test_since_hold"),
+                Diagnostics::from_purpose("test_since_hold"),
             )
             .await
             .expect("error opening persist shard");
@@ -1479,7 +1479,7 @@ mod tests {
                 binding_shard,
                 Arc::new(PROGRESS_DESC.clone()),
                 Arc::new(UnitSchema),
-                Diagnostics::new("", "test_since_hold"),
+                Diagnostics::from_purpose("test_since_hold"),
             )
             .await
             .expect("error opening persist shard");

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -618,7 +618,7 @@ mod tests {
     use mz_persist_client::cache::PersistClientCache;
     use mz_persist_client::cfg::PersistConfig;
     use mz_persist_client::rpc::PubSubClientConnection;
-    use mz_persist_client::{PersistLocation, ShardId};
+    use mz_persist_client::{Diagnostics, PersistLocation, ShardId};
     use mz_persist_types::codec_impls::UnitSchema;
     use mz_repr::{GlobalId, RelationDesc, ScalarType, Timestamp};
     use mz_storage_client::controller::CollectionMetadata;
@@ -800,9 +800,9 @@ mod tests {
         let mut remap_read_handle = persist_client
             .open_leased_reader::<SourceData, (), Timestamp, Diff>(
                 remap_shard,
-                "test_since_hold",
                 Arc::new(PROGRESS_DESC.clone()),
                 Arc::new(UnitSchema),
+                Diagnostics::new("", "test_since_hold"),
             )
             .await
             .expect("error opening persist shard");
@@ -1088,9 +1088,9 @@ mod tests {
         let mut remap_read_handle = persist_client
             .open_leased_reader::<SourceData, (), Timestamp, Diff>(
                 remap_shard,
-                "test_since_hold",
                 Arc::new(PROGRESS_DESC.clone()),
                 Arc::new(UnitSchema),
+                Diagnostics::new("", "test_since_hold"),
             )
             .await
             .expect("error opening persist shard");
@@ -1285,9 +1285,9 @@ mod tests {
         let mut remap_read_handle = persist_client
             .open_leased_reader::<SourceData, (), Timestamp, Diff>(
                 remap_shard,
-                "test_since_hold",
                 Arc::new(PROGRESS_DESC.clone()),
                 Arc::new(UnitSchema),
+                Diagnostics::new("", "test_since_hold"),
             )
             .await
             .expect("error opening persist shard");
@@ -1477,9 +1477,9 @@ mod tests {
         let read_handle = persist_client
             .open_leased_reader::<SourceData, (), Timestamp, Diff>(
                 binding_shard,
-                "test_since_hold",
                 Arc::new(PROGRESS_DESC.clone()),
                 Arc::new(UnitSchema),
+                Diagnostics::new("", "test_since_hold"),
             )
             .await
             .expect("error opening persist shard");

--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -76,6 +76,7 @@ where
         //
         // TODO(guswynn): use the type-system to prevent misuse here.
         remap_relation_desc: RelationDesc,
+        remap_collection_id: GlobalId,
     ) -> anyhow::Result<Self> {
         let remap_shard = metadata.remap_shard.ok_or_else(|| {
             anyhow!("cannot create remap PersistHandle for collection without remap shard")
@@ -92,8 +93,8 @@ where
                 Arc::new(remap_relation_desc),
                 Arc::new(UnitSchema),
                 Diagnostics {
-                    shard_name: id.to_string(),
-                    handle_purpose: format!("reclock {}", id),
+                    shard_name: remap_collection_id.to_string(),
+                    handle_purpose: format!("reclock for {}", id),
                 },
             )
             .await

--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -91,7 +91,10 @@ where
                 remap_shard,
                 Arc::new(remap_relation_desc),
                 Arc::new(UnitSchema),
-                Diagnostics::new(&id.to_string(), &format!("reclock {}", id)),
+                Diagnostics {
+                    shard_name: id.to_string(),
+                    handle_purpose: format!("reclock {}", id),
+                },
             )
             .await
             .context("error opening persist shard")?;

--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -24,6 +24,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::error::UpperMismatch;
 use mz_persist_client::read::ListenEvent;
 use mz_persist_client::write::WriteHandle;
+use mz_persist_client::Diagnostics;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::Codec64;
 use mz_repr::{Diff, GlobalId, RelationDesc};
@@ -88,9 +89,9 @@ where
         let (write_handle, mut read_handle) = persist_client
             .open(
                 remap_shard,
-                &format!("reclock {}", id),
                 Arc::new(remap_relation_desc),
                 Arc::new(UnitSchema),
+                Diagnostics::new(&id.to_string(), &format!("reclock {}", id)),
             )
             .await
             .context("error opening persist shard")?;

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -141,6 +141,8 @@ pub struct RawSourceCreationConfig {
     pub shared_remap_upper: Rc<RefCell<Antichain<mz_repr::Timestamp>>>,
     /// Configuration parameters, possibly from LaunchDarkly
     pub params: SourceCreationParams,
+    /// The ID of this source remap/progress collection.
+    pub remap_collection_id: GlobalId,
 }
 
 impl RawSourceCreationConfig {
@@ -693,6 +695,7 @@ where
         source_statistics: _,
         shared_remap_upper,
         params: _,
+        remap_collection_id,
     } = config;
 
     let chosen_worker = usize::cast_from(id.hashed() % u64::cast_from(worker_count));
@@ -722,6 +725,7 @@ where
             worker_id,
             worker_count,
             remap_relation_desc,
+            remap_collection_id,
         )
         .await
         .unwrap_or_else(|e| panic!("Failed to create remap handle for source {}: {}", name, e.display_with_causes()));
@@ -849,6 +853,7 @@ where
         source_statistics: _,
         shared_remap_upper: _,
         params: _,
+        remap_collection_id: _,
     } = config;
 
     let bytes_read_counter = base_metrics.bytes_read.clone();

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -385,7 +385,10 @@ impl SinkHandle {
                     shard_id,
                     Arc::new(from_relation_desc),
                     Arc::new(UnitSchema),
-                    Diagnostics::new(&sink_id.to_string(), &format!("sink::since {}", sink_id)),
+                    Diagnostics {
+                        shard_name: sink_id.to_string(),
+                        handle_purpose: format!("sink::since {}", sink_id),
+                    },
                 )
                 .await
                 .expect("opening reader for shard");

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -90,7 +90,7 @@ use mz_ore::tracing::TracingHandle;
 use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::read::ReadHandle;
-use mz_persist_client::ShardId;
+use mz_persist_client::{Diagnostics, ShardId};
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::{Diff, GlobalId, Timestamp};
 use mz_storage_client::client::{
@@ -383,9 +383,9 @@ impl SinkHandle {
             let mut read_handle: ReadHandle<SourceData, (), Timestamp, Diff> = client
                 .open_leased_reader(
                     shard_id,
-                    &format!("sink::since {}", sink_id),
                     Arc::new(from_relation_desc),
                     Arc::new(UnitSchema),
+                    Diagnostics::new(&sink_id.to_string(), &format!("sink::since {}", sink_id)),
                 )
                 .await
                 .expect("opening reader for shard");

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -133,7 +133,10 @@ where
                             metadata.remap_shard.clone().unwrap(),
                             Arc::new(ingestion_description.desc.connection.timestamp_desc()),
                             Arc::new(UnitSchema),
-                            Diagnostics::new("unknown", "reclock"),
+                            Diagnostics::new(
+                                &ingestion_description.remap_collection_id.to_string(),
+                                &format!("reclock for {}", ingestion_description),
+                            ),
                         )
                         .await
                         .expect("shard unavailable");
@@ -279,7 +282,9 @@ impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
                                                 ),
                                                 Arc::new(UnitSchema),
                                                 Diagnostics::new(
-                                                    &id.to_string(),
+                                                    &ingestion_description
+                                                        .remap_collection_id
+                                                        .to_string(),
                                                     &format!("resumption data {}", id),
                                                 ),
                                             )

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -287,7 +287,7 @@ impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
                                                         .remap_collection_id
                                                         .to_string(),
                                                     handle_purpose: format!(
-                                                        "resumption data {}",
+                                                        "resumption data for {}",
                                                         id
                                                     ),
                                                 },

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -332,7 +332,7 @@ where
                                 // schema.
                                 Arc::new(RelationDesc::empty()),
                                 Arc::new(UnitSchema),
-                                Diagnostics::new("", "tests::check_loop"),
+                                Diagnostics::from_purpose("tests::check_loop"),
                             )
                             .await
                             .unwrap();

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -90,6 +90,7 @@ use mz_ore::task::RuntimeExt;
 use mz_ore::tracing::TracingHandle;
 use mz_persist_client::cfg::PersistConfig;
 use mz_persist_client::rpc::PubSubClientConnection;
+use mz_persist_client::Diagnostics;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::{Diff, GlobalId, RelationDesc, Row, Timestamp, TimestampManipulation};
 use mz_storage::internal_control::{InternalCommandSender, InternalStorageCommand};
@@ -327,11 +328,11 @@ where
                         let (mut data_write_handle, data_read_handle) = persist_client
                             .open::<SourceData, (), Timestamp, Diff>(
                                 data_shard.clone(),
-                                "tests::check_loop",
                                 // TODO(guswynn|danhhz): replace this with a real desc when persist requires a
                                 // schema.
                                 Arc::new(RelationDesc::empty()),
                                 Arc::new(UnitSchema),
+                                Diagnostics::new("", "tests::check_loop"),
                             )
                             .await
                             .unwrap();


### PR DESCRIPTION
Replacement for https://github.com/MaterializeInc/materialize/pull/20205

* Creates a new Diagnostics struct that's passed into Persist. This minimizes the impact of wiring up new diagnostic fields going forward (e.g. fixing hostname)
* Maps "shard_name" to the "name" label on per-shard metrics

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
