### PR TITLE
Revert "parser: enable various working scalar tests"

### DIFF
--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -238,120 +238,121 @@ EXTRACT(YEAR FROM d)
 ----
 Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("year")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
-parse-scalar roundtrip
-EXTRACT(YEAR FROM d)
-----
-extract('year', d)
+# TODO: Fix, need some help to find out where, is it in Expr::Function in expr.rs?
+#parse-scalar roundtrip
+#EXTRACT(YEAR FROM d)
+#----
+#EXTRACT(YEAR FROM d)
 
 parse-scalar
 EXTRACT(MILLENIUM FROM d)
 ----
 Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("millenium")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
-parse-scalar roundtrip
-EXTRACT(MILLENNIUM FROM d)
-----
-extract('millennium', d)
+#parse-scalar roundtrip
+#EXTRACT(MILLENNIUM FROM d)
+#----
+#EXTRACT(MILLENNIUM FROM d)
 
 parse-scalar
 EXTRACT(CENTURY FROM d)
 ----
 Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("century")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
-parse-scalar roundtrip
-EXTRACT(CENTURY FROM d)
-----
-extract('century', d)
+#parse-scalar roundtrip
+#EXTRACT(CENTURY FROM d)
+#----
+#EXTRACT(CENTURY FROM d)
 
 parse-scalar
 EXTRACT(ISOYEAR FROM d)
 ----
 Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("isoyear")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
-parse-scalar roundtrip
-EXTRACT(ISOYEAR FROM d)
-----
-extract('isoyear', d)
+#parse-scalar roundtrip
+#EXTRACT(ISOYEAR FROM d)
+#----
+#EXTRACT(ISOYEAR FROM d)
 
 parse-scalar
 EXTRACT(QUARTER FROM d)
 ----
 Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("quarter")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
-parse-scalar roundtrip
-EXTRACT(QUARTER FROM d)
-----
-extract('quarter', d)
+#parse-scalar roundtrip
+#EXTRACT(QUARTER FROM d)
+#----
+#EXTRACT(QUARTER FROM d)
 
 parse-scalar
 EXTRACT(MONTH FROM d)
 ----
 Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("month")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
-parse-scalar roundtrip
-EXTRACT(MONTH FROM d)
-----
-extract('month', d)
+#parse-scalar roundtrip
+#EXTRACT(MONTH FROM d)
+#----
+#EXTRACT(MONTH FROM d)
 
 parse-scalar
 EXTRACT(DAY FROM d)
 ----
 Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("day")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
-parse-scalar roundtrip
-EXTRACT(DAY FROM d)
-----
-extract('day', d)
+#parse-scalar roundtrip
+#EXTRACT(DAY FROM d)
+#----
+#EXTRACT(DAY FROM d)
 
 parse-scalar
 EXTRACT(HOUR FROM d)
 ----
 Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("hour")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
-parse-scalar roundtrip
-EXTRACT(HOUR FROM d)
-----
-extract('hour', d)
+#parse-scalar roundtrip
+#EXTRACT(HOUR FROM d)
+#----
+#EXTRACT(HOUR FROM d)
 
 parse-scalar
 EXTRACT(MINUTE FROM d)
 ----
 Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("minute")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
-parse-scalar roundtrip
-EXTRACT(MINUTE FROM d)
-----
-extract('minute', d)
+#parse-scalar roundtrip
+#EXTRACT(MINUTE FROM d)
+#----
+#EXTRACT(MINUTE FROM d)
 
 parse-scalar
 EXTRACT(SECOND FROM d)
 ----
 Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("second")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
-parse-scalar roundtrip
-EXTRACT(SECOND FROM d)
-----
-extract('second', d)
+#parse-scalar roundtrip
+#EXTRACT(SECOND FROM d)
+#----
+#EXTRACT(SECOND FROM d)
 
 parse-scalar
 EXTRACT(MILLISECONDS FROM d)
 ----
 Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("milliseconds")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
-parse-scalar roundtrip
-EXTRACT(MILLISECOND FROM d)
-----
-extract('millisecond', d)
+#parse-scalar roundtrip
+#EXTRACT(MILLISECOND FROM d)
+#----
+#EXTRACT(MILLISECOND FROM d)
 
 parse-scalar
 EXTRACT(MICROSECONDS FROM d)
 ----
 Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("microseconds")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
-parse-scalar roundtrip
-EXTRACT(MICROSECONDS FROM d)
-----
-extract('microseconds', d)
+#parse-scalar roundtrip
+#EXTRACT(MICROSECONDS FROM d)
+#----
+#EXTRACT(MICROSECONDS FROM d)
 
 parse-scalar
 EXTRACT(TIMEZONE FROM d)
@@ -593,10 +594,11 @@ parse-scalar roundtrip
 ----
 1 / 2
 
-parse-scalar roundtrip
-1 OPERATOR(+) 2
-----
-1 + 2
+# TODO: Enable when fixed
+#parse-scalar roundtrip
+#1 OPERATOR(+) 2
+#----
+#1 OPERATOR(+) 2
 
 parse-scalar roundtrip
 1 OPERATOR(pg_catalog.+) 2


### PR DESCRIPTION
This reverts commit a0581936991d3398b0a56a7bd8bf304594b382e8.

As I wrote in https://github.com/MaterializeInc/materialize/pull/20562#pullrequestreview-1531110231 these are still broken and will be broken in every MV that uses them.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
