### PR TITLE
ssh-util, postgres-util, storage: trace postgres connections

### DIFF
--- a/src/ssh-util/src/tunnel.rs
+++ b/src/ssh-util/src/tunnel.rs
@@ -92,8 +92,9 @@ impl SshTunnelConfig {
                 return Err(e);
             }
         };
-        let local_port = Arc::new(AtomicU16::new(local_port));
+        info!(%tunnel_id, %local_port, "connected to ssh tunnel");
 
+        let local_port = Arc::new(AtomicU16::new(local_port));
         let join_handle = task::spawn(|| format!("ssh_session_{remote_host}:{remote_port}"), {
             let config = self.clone();
             let remote_host = remote_host.to_string();

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -240,6 +240,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
 
             // Nothing needs to be snapshot.
             if exports_to_snapshot.is_empty() {
+                trace!(%id, "no exports to snapshot");
                 return Ok(());
             }
 


### PR DESCRIPTION
Add additional tracing to the PostgreSQL connection logic. This would have helped in MaterializeInc/cloud#6878, in which a PostgreSQL connection stalled out, to track down whether the PostgreSQL connection or the SSH tunnel connection was to blame.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR improves our ability to debug an escalation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
