### PR TITLE
Include the undecodable string in JSON avro decoding error messages

### DIFF
--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -1158,7 +1158,7 @@ pub mod public_decoders {
                     serde_json::from_slice(&buf).map_err(|e| {
                         AvroError::Decode(DecodeError::BadJson {
                             category: e.classify(),
-                            original_bytes: Some(buf.to_owned()),
+                            string: buf.to_owned(),
                         })
                     })?
                 }

--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -1155,8 +1155,12 @@ pub mod public_decoders {
                     let mut buf = vec![];
                     buf.resize_with(len, Default::default);
                     r.read_exact(&mut buf)?;
-                    serde_json::from_slice(&buf)
-                        .map_err(|e| AvroError::Decode(DecodeError::BadJson(e.classify())))?
+                    serde_json::from_slice(&buf).map_err(|e| {
+                        AvroError::Decode(DecodeError::BadJson {
+                            category: e.classify(),
+                            original_bytes: Some(buf.to_owned()),
+                        })
+                    })?
                 }
             };
             Ok(Value::Json(val))

--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -1158,7 +1158,7 @@ pub mod public_decoders {
                     serde_json::from_slice(&buf).map_err(|e| {
                         AvroError::Decode(DecodeError::BadJson {
                             category: e.classify(),
-                            string: buf.to_owned(),
+                            bytes: buf.to_owned(),
                         })
                     })?
                 }

--- a/src/avro/src/error.rs
+++ b/src/avro/src/error.rs
@@ -91,7 +91,11 @@ pub enum DecodeError {
     IntDecodeOverflow,
     BadJson {
         category: serde_json::error::Category,
-        original_bytes: Option<Vec<u8>>,
+        /// A string representation of what we attempted to decode.
+        /// Ideally the original bytes,
+        /// but might be a re-serialization of a deserialized value,
+        /// if we no longer have access to the original.
+        string: Vec<u8>,
     },
     BadUuid(uuid::Error),
     MismatchedBlockHeader {
@@ -171,16 +175,9 @@ impl DecodeError {
             DecodeError::StringUtf8Error => write!(f, "String was not valid UTF-8"),
             DecodeError::UuidUtf8Error => write!(f, "UUID was not valid UTF-8"),
             DecodeError::IntConversionError => write!(f, "Integer conversion failed"),
-            DecodeError::BadJson {
-                category,
-                original_bytes,
-            } => {
+            DecodeError::BadJson { category, string } => {
                 write!(f, "Json decoding failed: {:?}", category)?;
-                if let Some(original_bytes) = original_bytes {
-                    write!(f, " (got {})", String::from_utf8_lossy(original_bytes))
-                } else {
-                    Ok(())
-                }
+                write!(f, " (got {})", String::from_utf8_lossy(string))
             }
             DecodeError::BadUuid(inner) => write!(f, "UUID decoding failed: {}", inner),
             DecodeError::MismatchedBlockHeader { expected, actual } => write!(

--- a/src/avro/src/error.rs
+++ b/src/avro/src/error.rs
@@ -95,7 +95,7 @@ pub enum DecodeError {
         /// Ideally the original bytes,
         /// but might be a re-serialization of a deserialized value,
         /// if we no longer have access to the original.
-        string: Vec<u8>,
+        bytes: Vec<u8>,
     },
     BadUuid(uuid::Error),
     MismatchedBlockHeader {
@@ -175,9 +175,9 @@ impl DecodeError {
             DecodeError::StringUtf8Error => write!(f, "String was not valid UTF-8"),
             DecodeError::UuidUtf8Error => write!(f, "UUID was not valid UTF-8"),
             DecodeError::IntConversionError => write!(f, "Integer conversion failed"),
-            DecodeError::BadJson { category, string } => {
+            DecodeError::BadJson { category, bytes } => {
                 write!(f, "Json decoding failed: {:?}", category)?;
-                write!(f, " (got {})", String::from_utf8_lossy(string))
+                write!(f, " (got {})", String::from_utf8_lossy(bytes))
             }
             DecodeError::BadUuid(inner) => write!(f, "UUID decoding failed: {}", inner),
             DecodeError::MismatchedBlockHeader { expected, actual } => write!(

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -442,16 +442,20 @@ impl<'a, 'row> AvroDecode for AvroFlatDecoder<'a, 'row> {
             ValueOrReader::Value(val) => {
                 JsonbPacker::new(self.packer)
                     .pack_serde_json(val.clone())
-                    .map_err(|e| e.to_string_with_causes())
-                    .map_err(DecodeError::Custom)?;
+                    .map_err(|e| DecodeError::BadJson {
+                        category: e.classify(),
+                        original_bytes: None,
+                    })?;
             }
             ValueOrReader::Reader { len, r } => {
                 self.buf.resize_with(len, Default::default);
                 r.read_exact(self.buf)?;
                 JsonbPacker::new(self.packer)
                     .pack_slice(self.buf)
-                    .map_err(|e| e.to_string_with_causes())
-                    .map_err(DecodeError::Custom)?;
+                    .map_err(|e| DecodeError::BadJson {
+                        category: e.classify(),
+                        original_bytes: Some(self.buf.to_owned()),
+                    })?;
             }
         }
         Ok(())

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -451,7 +451,7 @@ impl<'a, 'row> AvroDecode for AvroFlatDecoder<'a, 'row> {
 
                         DecodeError::BadJson {
                             category: e.classify(),
-                            string: bytes,
+                            bytes,
                         }
                     })?;
             }
@@ -462,7 +462,7 @@ impl<'a, 'row> AvroDecode for AvroFlatDecoder<'a, 'row> {
                     .pack_slice(self.buf)
                     .map_err(|e| DecodeError::BadJson {
                         category: e.classify(),
-                        string: self.buf.to_owned(),
+                        bytes: self.buf.to_owned(),
                     })?;
             }
         }

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -262,7 +262,7 @@ impl<'a, 'row> JsonbPacker<'a, 'row> {
 
     /// Parses and packs a JSON-formatted string.
     ///
-    /// Errors if the string is not valid or JSON or if any of the contained
+    /// Errors if the string is not valid JSON or if any of the contained
     /// integers cannot be represented exactly as an [`f64`].
     pub fn pack_str(self, s: &str) -> Result<(), serde_json::Error> {
         let mut commands = vec![];

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -240,7 +240,7 @@ impl<'a, 'row> JsonbPacker<'a, 'row> {
     ///
     /// Errors if any of the contained integers cannot be represented exactly as
     /// an [`f64`].
-    pub fn pack_serde_json(self, val: serde_json::Value) -> Result<(), anyhow::Error> {
+    pub fn pack_serde_json(self, val: serde_json::Value) -> Result<(), serde_json::Error> {
         let mut commands = vec![];
         Collector(&mut commands).deserialize(val)?;
         pack(self.packer, &commands);
@@ -251,7 +251,7 @@ impl<'a, 'row> JsonbPacker<'a, 'row> {
     ///
     /// Errors if the slice is not valid JSON or if any of the contained
     /// integers cannot be represented exactly as an [`f64`].
-    pub fn pack_slice(self, buf: &[u8]) -> Result<(), anyhow::Error> {
+    pub fn pack_slice(self, buf: &[u8]) -> Result<(), serde_json::Error> {
         let mut commands = vec![];
         let mut deserializer = serde_json::Deserializer::from_slice(buf);
         Collector(&mut commands).deserialize(&mut deserializer)?;
@@ -264,7 +264,7 @@ impl<'a, 'row> JsonbPacker<'a, 'row> {
     ///
     /// Errors if the string is not valid or JSON or if any of the contained
     /// integers cannot be represented exactly as an [`f64`].
-    pub fn pack_str(self, s: &str) -> Result<(), anyhow::Error> {
+    pub fn pack_str(self, s: &str) -> Result<(), serde_json::Error> {
         let mut commands = vec![];
         let mut deserializer = serde_json::Deserializer::from_str(s);
         Collector(&mut commands).deserialize(&mut deserializer)?;

--- a/test/testdrive/avro-decode-bad-json.td
+++ b/test/testdrive/avro-decode-bad-json.td
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Check that we get a meaningful error when JSON fails to decode.
+#
+
+$ set writer={"type": "record", "name": "value", "fields": [ { "name": "f1", "type": "string" } ] }
+$ set reader={"type": "record", "name": "value", "fields": [ { "name": "f1", "type": {"type": "string", "connect.name": "io.debezium.data.Json" } } ] }
+
+$ kafka-create-topic topic=avro-bad-json
+
+$ kafka-ingest format=avro topic=avro-types-uuid schema=${writer} timestamp=1
+{"f1": "__debezium_unavailable_value"}
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE SOURCE avro_bad_json
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-avro-bad-json-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${reader}'
+  ENVELOPE NONE
+
+! SELECT * FROM avro_bad_json
+contains: (got __debezium_unavailable_value)

--- a/test/testdrive/avro-decode-bad-json.td
+++ b/test/testdrive/avro-decode-bad-json.td
@@ -16,7 +16,7 @@ $ set reader={"type": "record", "name": "value", "fields": [ { "name": "f1", "ty
 
 $ kafka-create-topic topic=avro-bad-json
 
-$ kafka-ingest format=avro topic=avro-types-uuid schema=${writer} timestamp=1
+$ kafka-ingest format=avro topic=avro-bad-json schema=${writer} timestamp=1
 {"f1": "__debezium_unavailable_value"}
 
 > CREATE CONNECTION kafka_conn


### PR DESCRIPTION
```
[2/5.8.1]{1}brennan@New-Orleans:~/code/materialize> cargo run --bin avro-decode -- --confluent-wire-format ~/avro.out ~/avro.schema
    Finished dev [unoptimized + debuginfo] target(s) in 0.45s
     Running `target/debug/avro-decode --confluent-wire-format /home/brennan/avro.out /home/brennan/avro.schema`
schema id: 159
decoding data: unable to decode row : Decode error: Decoding error: Json decoding failed: Syntax (got __debezium_unavailable_value)
```

### Motivation

  * This PR fixes a previously unreported bug.

    It is hard to tell what JSON string caused an avro message to fail to parse.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improve error messages when a JSON subfield of an Avro message fails to decode.
