### PR TITLE
stash: Clean up stash code

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -7234,11 +7234,6 @@ impl Catalog {
 
         *privileges = PrivilegeMap::from_mz_acl_items(flat_privileges);
     }
-
-    pub async fn consolidate(&self, collections: &[mz_stash::Id]) -> Result<(), AdapterError> {
-        Ok(self.storage().await.consolidate(collections).await?)
-    }
-
     pub async fn confirm_leadership(&self) -> Result<(), AdapterError> {
         Ok(self.storage().await.confirm_leadership().await?)
     }

--- a/src/stash/benches/postgres.rs
+++ b/src/stash/benches/postgres.rs
@@ -132,39 +132,5 @@ fn bench_update_many(c: &mut Criterion) {
     });
 }
 
-fn bench_append(c: &mut Criterion) {
-    c.bench_function("append", |b| {
-        let (runtime, mut stash) = init_bench();
-        const MAX: i64 = 1000;
-
-        let orders = runtime
-            .block_on(async {
-                let orders = stash.collection::<String, String>("orders").await?;
-                let mut batch = orders.make_batch(&mut stash).await?;
-                // Skip 0 so it can be added initially.
-                for i in 1..MAX {
-                    orders.append_to_batch(&mut batch, &i.to_string(), &format!("_{i}"), 1);
-                }
-                stash.append(vec![batch]).await?;
-                Result::<_, StashError>::Ok(orders)
-            })
-            .unwrap();
-        let mut i = 0;
-        b.iter(|| {
-            runtime.block_on(async {
-                let mut batch = orders.make_batch(&mut stash).await.unwrap();
-                let j = i % MAX;
-                let k = (i + 1) % MAX;
-                // Add the current i which doesn't exist, delete the next i
-                // which is known to exist.
-                orders.append_to_batch(&mut batch, &j.to_string(), &format!("_{j}"), 1);
-                orders.append_to_batch(&mut batch, &k.to_string(), &format!("_{k}"), -1);
-                stash.append(vec![batch]).await.unwrap();
-                i += 1;
-            })
-        })
-    });
-}
-
-criterion_group!(benches, bench_append, bench_update, bench_update_many);
+criterion_group!(benches, bench_update, bench_update_many);
 criterion_main!(benches);

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -32,8 +32,8 @@ use tracing::{error, event, info, warn, Level};
 
 use crate::upgrade;
 use crate::{
-    AppendBatch, Data, Diff, Id, InternalStashError, StashCollection, StashError, Timestamp,
-    COLLECTION_CONFIG, MIN_STASH_VERSION, STASH_VERSION, USER_VERSION_KEY,
+    Diff, Id, InternalStashError, StashError, Timestamp, COLLECTION_CONFIG, MIN_STASH_VERSION,
+    STASH_VERSION, USER_VERSION_KEY,
 };
 
 // TODO: Change the indexes on data to be more applicable to the current
@@ -173,7 +173,7 @@ impl<'a> CountedStatements<'a> {
         }
     }
 
-    pub fn inc<S: Into<String>>(&self, name: S) {
+    fn inc<S: Into<String>>(&self, name: S) {
         if let Some(counts) = &self.counts {
             let mut map = counts.lock().unwrap();
             *map.entry(name.into()).or_default() += 1;
@@ -181,42 +181,46 @@ impl<'a> CountedStatements<'a> {
         }
     }
 
-    pub fn fetch_epoch(&self) -> &Statement {
+    fn fetch_epoch(&self) -> &Statement {
         self.inc("fetch_epoch");
         &self.stmts.fetch_epoch
     }
-    pub fn iter_key(&self) -> &Statement {
+    pub(crate) fn iter_key(&self) -> &Statement {
         self.inc("iter_key");
         &self.stmts.iter_key
     }
-    pub fn since(&self) -> &Statement {
+    pub(crate) fn since(&self) -> &Statement {
         self.inc("since");
         &self.stmts.since
     }
-    pub fn upper(&self) -> &Statement {
+    pub(crate) fn upper(&self) -> &Statement {
         self.inc("upper");
         &self.stmts.upper
     }
-    pub fn collection(&self) -> &Statement {
+    pub(crate) fn collection(&self) -> &Statement {
         self.inc("collection");
         &self.stmts.collection
     }
-    pub fn iter(&self) -> &Statement {
+    pub(crate) fn iter(&self) -> &Statement {
         self.inc("iter");
         &self.stmts.iter
     }
-    pub fn seal(&self) -> &Statement {
+    pub(crate) fn seal(&self) -> &Statement {
         self.inc("seal");
         &self.stmts.seal
     }
-    pub fn compact(&self) -> &Statement {
+    pub(crate) fn compact(&self) -> &Statement {
         self.inc("compact");
         &self.stmts.compact
     }
     /// Returns a ToStatement to INSERT a specified number of rows. First
     /// statement parameter is collection_id. Then key, value, time, diff as
     /// sets of 4 for each row.
-    pub async fn update(&self, client: &Client, rows: usize) -> Result<Statement, StashError> {
+    pub(crate) async fn update(
+        &self,
+        client: &Client,
+        rows: usize,
+    ) -> Result<Statement, StashError> {
         self.inc(format!("update[{rows}]"));
 
         match self.stmts.update_many.lock().await.entry(rows) {
@@ -381,7 +385,7 @@ struct Metrics {
 }
 
 impl Metrics {
-    pub fn register_into(registry: &MetricsRegistry) -> Metrics {
+    fn register_into(registry: &MetricsRegistry) -> Metrics {
         let metrics = Metrics {
             transactions: registry.register(metric!(
                 name: "mz_stash_transactions",
@@ -885,7 +889,7 @@ impl Stash {
         // Run migrations until we're up-to-date.
         while run_upgrade(self).await? < STASH_VERSION {}
 
-        pub async fn run_upgrade(stash: &mut Stash) -> Result<u64, StashError> {
+        async fn run_upgrade(stash: &mut Stash) -> Result<u64, StashError> {
             stash
                 .with_transaction(move |mut tx| {
                     async move {
@@ -937,7 +941,7 @@ impl Stash {
     }
 }
 
-pub(crate) enum TransactionError<T> {
+enum TransactionError<T> {
     /// A failure occurred pre-transaction.
     Connect(StashError),
     /// The epoch check failed.
@@ -1009,7 +1013,7 @@ impl<T> TransactionError<T> {
     }
 
     /// Reports whether this error can safely be retried.
-    pub fn retryable(&self) -> bool {
+    fn retryable(&self) -> bool {
         // Only attempt to retry postgres-related errors. Others come from stash
         // code and can't be retried.
         if self.pgerr().is_none() {
@@ -1052,65 +1056,9 @@ impl<T> TransactionError<T> {
 }
 
 impl Stash {
-    pub async fn collection<K, V>(
-        &mut self,
-        name: &str,
-    ) -> Result<StashCollection<K, V>, StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        let name = name.to_string();
-        self.with_transaction(move |tx| Box::pin(async move { tx.collection(&name).await }))
-            .await
-    }
-
     pub async fn collections(&mut self) -> Result<BTreeMap<Id, String>, StashError> {
         self.with_transaction(move |tx| Box::pin(async move { tx.collections().await }))
             .await
-    }
-
-    /// Performs a synchronous consolidation (the rows are guaranteed to be removed from disk after this
-    /// future resolves).
-    pub async fn consolidate_now(&mut self, id: Id) -> Result<(), StashError> {
-        let since = self
-            .with_transaction(move |tx| Box::pin(async move { tx.since(id).await }))
-            .await?;
-        let (tx, rx) = oneshot::channel();
-        self.sinces_tx
-            .send(ConsolidateRequest {
-                id,
-                since,
-                done: Some(tx),
-            })
-            .expect("consolidator unexpectedly gone");
-        rx.await.expect("consolidator unexpectedly gone");
-        Ok(())
-    }
-
-    pub async fn consolidate(&mut self, collection: Id) -> Result<(), StashError> {
-        self.consolidate_batch(&[collection]).await
-    }
-
-    pub async fn consolidate_batch(&mut self, collections: &[Id]) -> Result<(), StashError> {
-        let collections = collections.to_vec();
-        let sinces = self
-            .with_transaction(move |tx| {
-                Box::pin(async move { tx.sinces_batch(&collections).await })
-            })
-            .await?;
-        // On successful transact, send consolidation sinces to the
-        // Consolidator.
-        for (id, since) in sinces {
-            self.sinces_tx
-                .send(ConsolidateRequest {
-                    id,
-                    since,
-                    done: None,
-                })
-                .expect("consolidator unexpectedly gone");
-        }
-        Ok(())
     }
 
     pub async fn confirm_leadership(&mut self) -> Result<(), StashError> {
@@ -1134,42 +1082,6 @@ impl From<tokio_postgres::Error> for StashError {
     }
 }
 
-impl Stash {
-    #[tracing::instrument(level = "debug", skip_all)]
-    /// Like `append` but doesn't consolidate.
-    pub async fn append_batch(&mut self, batches: Vec<AppendBatch>) -> Result<(), StashError> {
-        if batches.is_empty() {
-            return Ok(());
-        }
-        self.with_transaction(move |tx| {
-            Box::pin(async move {
-                let batches = batches.clone();
-                tx.append(batches).await
-            })
-        })
-        .await
-    }
-
-    /// Atomically adds entries, seals, compacts, and consolidates multiple
-    /// collections.
-    ///
-    /// The `lower` of each `AppendBatch` is checked to be the existing `upper` of the collection.
-    /// The `upper` of the `AppendBatch` will be the new `upper` of the collection.
-    /// The `compact` of each `AppendBatch` will be the new `since` of the collection.
-    ///
-    /// If this method returns `Ok`, the entries have been made durable and uppers
-    /// advanced, otherwise no changes were committed.
-    pub async fn append(&mut self, batches: Vec<AppendBatch>) -> Result<(), StashError> {
-        if batches.is_empty() {
-            return Ok(());
-        }
-        let ids: Vec<_> = batches.iter().map(|batch| batch.collection_id).collect();
-        self.append_batch(batches).await?;
-        self.consolidate_batch(&ids).await?;
-        Ok(())
-    }
-}
-
 /// The Consolidator receives since advancements on a channel and
 /// transactionally consolidates them. These can safely be done at a later time
 /// in a separate connection that doesn't do leader or epoch checking because 1)
@@ -1190,7 +1102,7 @@ struct Consolidator {
 }
 
 impl Consolidator {
-    pub fn start(
+    fn start(
         config: Arc<tokio::sync::Mutex<Config>>,
         tls: MakeTlsConnector,
         sinces_rx: mpsc::UnboundedReceiver<ConsolidateRequest>,

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -48,26 +48,25 @@ use crate::{
 pub mod json_to_proto;
 pub mod legacy_types;
 
-pub mod v13_to_v14;
-pub mod v14_to_v15;
-pub mod v15_to_v16;
-pub mod v16_to_v17;
-pub mod v17_to_v18;
-pub mod v18_to_v19;
-pub mod v19_to_v20;
-pub mod v20_to_v21;
-pub mod v21_to_v22;
-pub mod v22_to_v23;
-pub mod v23_to_v24;
-pub mod v24_to_v25;
-pub mod v25_to_v26;
-pub mod v26_to_v27;
-pub mod v27_to_v28;
+pub(crate) mod v13_to_v14;
+pub(crate) mod v14_to_v15;
+pub(crate) mod v15_to_v16;
+pub(crate) mod v16_to_v17;
+pub(crate) mod v17_to_v18;
+pub(crate) mod v18_to_v19;
+pub(crate) mod v19_to_v20;
+pub(crate) mod v20_to_v21;
+pub(crate) mod v21_to_v22;
+pub(crate) mod v22_to_v23;
+pub(crate) mod v23_to_v24;
+pub(crate) mod v24_to_v25;
+pub(crate) mod v25_to_v26;
+pub(crate) mod v26_to_v27;
+pub(crate) mod v27_to_v28;
 
-pub use json_to_proto::migrate_json_to_proto;
-
-pub enum MigrationAction<K1, K2, V2> {
+pub(crate) enum MigrationAction<K1, K2, V2> {
     /// Deletes the provided key.
+    #[allow(dead_code)]
     Delete(K1),
     /// Inserts the provided key-value pair. The key must not currently exist!
     Insert(K2, V2),
@@ -82,7 +81,7 @@ where
 {
     /// Provided a closure, will migrate a [`TypedCollection`] of types `K` and `V` to types `K2`
     /// and `V2`.
-    pub async fn migrate_to<K2, V2>(
+    pub(crate) async fn migrate_to<K2, V2>(
         &self,
         tx: &mut Transaction<'_>,
         f: impl for<'a> FnOnce(&'a BTreeMap<K, V>) -> Vec<MigrationAction<K, K2, V2>>,
@@ -170,7 +169,7 @@ where
 }
 
 impl TypedCollection<ConfigKey, ConfigValue> {
-    pub async fn version(&self, tx: &mut Transaction<'_>) -> Result<u64, StashError> {
+    pub(crate) async fn version(&self, tx: &mut Transaction<'_>) -> Result<u64, StashError> {
         let key = ConfigKey {
             key: USER_VERSION_KEY.to_string(),
         };
@@ -185,7 +184,7 @@ impl TypedCollection<ConfigKey, ConfigValue> {
         Ok(version.value)
     }
 
-    pub async fn set_version(
+    pub(crate) async fn set_version(
         &self,
         tx: &mut Transaction<'_>,
         version: u64,


### PR DESCRIPTION
This commit cleans up some of the code in the stash by doing the
following:

  - Remove dead code.
  - Add doc-comments to public functions.
  - Restrict the visibility of functions that are only used with the
  same crate to `pub(crate)`.
  - Move functions that are only used in integration tests to the
  integration test file.
    - Some functions had to be left in the stash crate because they
    relied on private fields.
    - Updating the integration test to not rely on these functions is
    left for future work.

This is all done in attempt to clarify the boundaries and uses of the
stash.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
