### PR TITLE
ALTER (SOURCE|SINK|MATERIALIZED VIEW) ... SET CLUSTER design

### DIFF
--- a/doc/developer/design/20230717_alter_set_cluster.md
+++ b/doc/developer/design/20230717_alter_set_cluster.md
@@ -31,19 +31,22 @@ Materialize:
 
 ```sql
 -- Move a source to cluster `clstr`:
-ALTER SOURCE src IN CLUSTER clstr;
+ALTER SOURCE src SET IN CLUSTER clstr;
 
 -- Move a sink to cluster `c2`:
-ALTER SINK snk IN CLUSTER c2;
+ALTER SINK snk SET IN CLUSTER c2;
 
 -- Move a materialized view to cluster `prod`:
-ALTER MATERIALIZED VIEW my_view IN CLUSTER prod;
+ALTER MATERIALIZED VIEW my_view SET IN CLUSTER prod;
 ```
+
+This corresponds to the `CREATE` syntax where the user specifies the cluster
+with an `IN CLUSTER` parameter.
 
 ## Detailed description
 
 The `ALTER SOURCE`, `ALTER SINK` and `ALTER MATERIALIZED VIEW` statements will
-learn a new option `IN CLUSTER clstr`:
+learn a new option `SET IN CLUSTER clstr`:
 * The cluster name `clstr` must match an existing cluster.
 * The usual constraints apply. For sources and sinks, the cluster must either be
   empty or only host sources and sinks. The replication factor must be 0 or 1.
@@ -68,7 +71,7 @@ Attempting to schedule incompatible objects will result in an error like the
 following:
 
 ```sql
-ALTER SOURCE src IN CLUSTER compute_cluster;
+ALTER SOURCE src SET IN CLUSTER compute_cluster;
 ERROR: cannot alter source cluster to cluster containing indexes or materialized views
 ```
 
@@ -77,7 +80,7 @@ replication factor. Attempting to do so will result in an error like the
 following:
 
 ```sql
-ALTER SOURCE src IN CLUSTER cluster;
+ALTER SOURCE src SET IN CLUSTER cluster;
 ERROR: cannot alter source cluster to cluster with more than one replica
 ```
 
@@ -109,7 +112,7 @@ ALTER SOURCE src SET CLUSTER clsname;
 ```
 
 Note that this is _intentionally_ lacking parens
-(`ALTER SOURCE src SET (CLUSTER = clstr)`;).
+(`ALTER SOURCE src SET (CLUSTER = clstr);`).
 This is for consistency with the analogous PostgreSQL command
 `ALTER TABLE ... SET {SCHEMA|TABLESPACE} {schema|tblspc}`.
 The rule is that only parameters configured in the `WITH` block go inside the

--- a/doc/developer/design/20230717_alter_set_cluster.md
+++ b/doc/developer/design/20230717_alter_set_cluster.md
@@ -1,0 +1,88 @@
+# Moving source and sinks
+
+Issue: [#17417](https://github.com/MaterializeInc/materialize/issues/17417)
+
+## Context
+
+Materialize's API today allows users to specify a target cluster for sources
+and sinks on creation, but does not allow for changing the cluster at a later
+time. To change the cluster, users have to drop and recreate the object.
+
+This is problematic:
+* Sources almost always have downstream dependencies that need to be recreated,
+  too.
+* Sinks require users to recreate the topic in the downstream Kafka broker.
+
+## Goals
+
+* Users chan change the cluster on which a source or sink runs.
+
+## Non-Goals
+
+* Mixing compute and storage workload on the same cluster.
+
+## Overview
+
+We'll add support for the following declarative source and sink management
+commands to Materialize:
+
+```sql
+-- Move a source to cluster `clstr`:
+ALTER SOURCE src SET CLUSTER clstr;
+
+-- Move a sink to cluster `c2`:
+ALTER SINK snk SET CLUSTER c2;
+```
+
+Note that this is _intentionally_ lacking parens
+(`ALTER SOURCE src SET (CLUSTER = clstr)`;).
+This is for consistency with the analogous PostgreSQL command
+`ALTER TABLE ... SET {SCHEMA|TABLESPACE} {schema|tblspc}`.
+The rule is that only parameters configured in the `WITH` block go inside the
+parens; parameters that have dedicated syntax, like schemas, tablespaces, and
+clusters, get dedicated `ALTER ... SET` syntax too.
+
+## Detailed description
+
+The `ALTER SOURCE` and `ALTER SINK` statements will learn a new option `SET CLUSTER clstr`:
+* The cluster name `clstr` must match an existing cluster.
+* The usual constraints apply. At the moment, the cluster must either be empty
+  or only host sources and sinks. The replication factor must be 0 or 1.
+* Clusters can be managed or unmanaged.
+
+When the command updates the cluster, Materialize will immediately drop the
+existing source or sink and recreate it in the target cluster.
+
+> **Warning**
+> 
+> In the initial implementation, changing the cluster associated will result in
+> downtime while the source or sink recreate.
+> 
+> We hope to change the behavior in a future release so that no downtime is
+> incurred, but this will require smarter source and sink scheduling.
+
+Users may not schedule compute objects together with sources and sinks.
+Attempting to schedule incompatible objects will result in an error like the
+following:
+
+```sql
+ALTER SOURCE src SET CLUSTER compute_cluster;
+ERROR: cannot alter source cluster to cluster containing indexes or materialized views
+```
+
+Users may not schedule sources or sinks on clusters with an incompatible
+replication factor. Attempting to do so will result in an error like the
+following:
+
+```sql
+ALTER SOURCE src SET CLUSTER cluster;
+ERROR: cannot source source cluster to cluster with more than one replica 
+```
+
+## Alternatives
+
+We could wait to improve the API until we have unified clusters.
+
+## Open questions
+
+* Is the syntax accepted?

--- a/doc/developer/design/20230717_alter_set_cluster.md
+++ b/doc/developer/design/20230717_alter_set_cluster.md
@@ -42,6 +42,11 @@ The rule is that only parameters configured in the `WITH` block go inside the
 parens; parameters that have dedicated syntax, like schemas, tablespaces, and
 clusters, get dedicated `ALTER ... SET` syntax too.
 
+We could offer an alternative syntax using `IN`:
+```sql
+ALTER SOURCE src IN CLUSTER clstr;
+```
+
 ## Detailed description
 
 The `ALTER SOURCE` and `ALTER SINK` statements will learn a new option `SET CLUSTER clstr`:
@@ -54,10 +59,11 @@ When the command updates the cluster, Materialize will immediately drop the
 existing source or sink and recreate it in the target cluster.
 
 > **Warning**
-> 
+>
 > In the initial implementation, changing the cluster associated will result in
-> downtime while the source or sink recreate.
-> 
+> downtime while the source or sink recreate. During this time, the source or
+> sink will not produce new data.
+>
 > We hope to change the behavior in a future release so that no downtime is
 > incurred, but this will require smarter source and sink scheduling.
 
@@ -76,13 +82,27 @@ following:
 
 ```sql
 ALTER SOURCE src SET CLUSTER cluster;
-ERROR: cannot source source cluster to cluster with more than one replica 
+ERROR: cannot alter source cluster to cluster with more than one replica
 ```
+
+### Linked clusters
+
+Sources and sinks can have linked clusters, which are clusters owned by the
+source or sink. Altering clusters of sources and sinks will cause any previously
+linked cluster to be dropped.
+
+We do not support moving a source or sink back to a linked cluster.
 
 ## Alternatives
 
-We could wait to improve the API until we have unified clusters.
+* We could wait to improve the API until we have unified clusters.
+
+* We could support moving a source or sink to a linked cluster when either a size
+  value was previously specified, or explicitly set on the `ALTER` command.
 
 ## Open questions
 
 * Is the syntax accepted?
+
+* Should we support `ALTER SOURCE src RESET CLUSTER`? I'm not sure what the
+  semantics should be.

--- a/doc/developer/design/20230717_alter_set_cluster.md
+++ b/doc/developer/design/20230717_alter_set_cluster.md
@@ -4,18 +4,21 @@ Issue: [#17417](https://github.com/MaterializeInc/materialize/issues/17417)
 
 ## Context
 
-Materialize's API today allows users to specify a target cluster for sources
-and sinks on creation, but does not allow for changing the cluster at a later
-time. To change the cluster, users have to drop and recreate the object.
+Materialize's API today allows users to specify a target cluster for sources,
+sinks and materialized views on creation, but does not allow for changing the
+cluster at a later time. To change the cluster, users have to drop and recreate
+the object.
 
 This is problematic:
 * Sources almost always have downstream dependencies that need to be recreated,
   too.
 * Sinks require users to recreate the topic in the downstream Kafka broker.
+* Materialized views can have downstream dependencies.
 
 ## Goals
 
-* Users chan change the cluster on which a source or sink runs.
+* Users chan change the cluster on which a source, sink, or materialized view
+  runs.
 
 ## Non-Goals
 
@@ -23,56 +26,49 @@ This is problematic:
 
 ## Overview
 
-We'll add support for the following declarative source and sink management
-commands to Materialize:
+We'll add support for the following declarative management commands to
+Materialize:
 
 ```sql
 -- Move a source to cluster `clstr`:
-ALTER SOURCE src SET CLUSTER clstr;
+ALTER SOURCE src IN CLUSTER clstr;
 
 -- Move a sink to cluster `c2`:
-ALTER SINK snk SET CLUSTER c2;
-```
+ALTER SINK snk IN CLUSTER c2;
 
-Note that this is _intentionally_ lacking parens
-(`ALTER SOURCE src SET (CLUSTER = clstr)`;).
-This is for consistency with the analogous PostgreSQL command
-`ALTER TABLE ... SET {SCHEMA|TABLESPACE} {schema|tblspc}`.
-The rule is that only parameters configured in the `WITH` block go inside the
-parens; parameters that have dedicated syntax, like schemas, tablespaces, and
-clusters, get dedicated `ALTER ... SET` syntax too.
-
-We could offer an alternative syntax using `IN`:
-```sql
-ALTER SOURCE src IN CLUSTER clstr;
+-- Move a materialized view to cluster `prod`:
+ALTER MATERIALIZED VIEW my_view IN CLUSTER prod;
 ```
 
 ## Detailed description
 
-The `ALTER SOURCE` and `ALTER SINK` statements will learn a new option `SET CLUSTER clstr`:
+The `ALTER SOURCE`, `ALTER SINK` and `ALTER MATERIALIZED VIEW` statements will
+learn a new option `IN CLUSTER clstr`:
 * The cluster name `clstr` must match an existing cluster.
-* The usual constraints apply. At the moment, the cluster must either be empty
-  or only host sources and sinks. The replication factor must be 0 or 1.
+* The usual constraints apply. For sources and sinks, the cluster must either be
+  empty or only host sources and sinks. The replication factor must be 0 or 1.
+  For materialized views, the cluster must not host sources or sinks.
 * Clusters can be managed or unmanaged.
 
 When the command updates the cluster, Materialize will immediately drop the
-existing source or sink and recreate it in the target cluster.
+existing source, sink, or materialized view and recreate it in the target
+cluster.
 
 > **Warning**
 >
 > In the initial implementation, changing the cluster associated will result in
-> downtime while the source or sink recreate. During this time, the source or
-> sink will not produce new data.
+> downtime while the object recreates. During this time, the source, sink, or
+> materialized view will not produce new data.
 >
 > We hope to change the behavior in a future release so that no downtime is
-> incurred, but this will require smarter source and sink scheduling.
+> incurred, but this will require smarter scheduling.
 
 Users may not schedule compute objects together with sources and sinks.
 Attempting to schedule incompatible objects will result in an error like the
 following:
 
 ```sql
-ALTER SOURCE src SET CLUSTER compute_cluster;
+ALTER SOURCE src IN CLUSTER compute_cluster;
 ERROR: cannot alter source cluster to cluster containing indexes or materialized views
 ```
 
@@ -81,9 +77,12 @@ replication factor. Attempting to do so will result in an error like the
 following:
 
 ```sql
-ALTER SOURCE src SET CLUSTER cluster;
+ALTER SOURCE src IN CLUSTER cluster;
 ERROR: cannot alter source cluster to cluster with more than one replica
 ```
+
+Users cannot move system objects to different clusters, and users cannot move
+user objects to system clusters.
 
 ### Linked clusters
 
@@ -100,6 +99,27 @@ We do not support moving a source or sink back to a linked cluster.
 * We could support moving a source or sink to a linked cluster when either a size
   value was previously specified, or explicitly set on the `ALTER` command.
 
+### `SET CLUSTER`
+
+We rejected the syntax to handle the cluster of an object as a `WITH` parameter
+that the user could set as follows:
+
+```sql
+ALTER SOURCE src SET CLUSTER clsname;
+```
+
+Note that this is _intentionally_ lacking parens
+(`ALTER SOURCE src SET (CLUSTER = clstr)`;).
+This is for consistency with the analogous PostgreSQL command
+`ALTER TABLE ... SET {SCHEMA|TABLESPACE} {schema|tblspc}`.
+The rule is that only parameters configured in the `WITH` block go inside the
+parens; parameters that have dedicated syntax, like schemas, tablespaces, and
+clusters, get dedicated `ALTER ... SET` syntax too.
+
+We could offer an alternative syntax using `IN`:
+```sql
+ALTER SOURCE src IN CLUSTER clstr;
+```
 ## Open questions
 
 * Is the syntax accepted?


### PR DESCRIPTION
### Motivation

Issue: #17417

Add a design doc for changing the cluster a source or sink is running on. This design doc proposes the following syntax:

```sql
ALTER SOURCE src SET CLUSTER clstr;
ALTER SINK snk SET CLUSTER clstr;
ALTER MATERIALIZED VIEW v SET CLUSTER clstr;
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
