### PR TITLE
tests: stabilize "Checks + restart source Postgres"

### DIFF
--- a/misc/python/materialize/checks/debezium.py
+++ b/misc/python/materialize/checks/debezium.py
@@ -26,7 +26,7 @@ class DebeziumPostgres(Check):
 
                 $ http-request method=POST url=http://debezium:8083/connectors content-type=application/json
                 {
-                    "name": "psql-connector",
+                  "name": "psql-connector",
                   "config": {
                     "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
                     "database.hostname": "postgres",
@@ -111,7 +111,7 @@ class DebeziumPostgres(Check):
                 BEGIN;
                 INSERT INTO debezium_table SELECT 'F', generate_series, 1, REPEAT('X', 16) FROM generate_series(1,1000);
                 UPDATE debezium_table SET f3 = f3 + 1;
-                COMMIT
+                COMMIT;
 
                 > CREATE MATERIALIZED VIEW debezium_view3 AS SELECT f1, f3, SUM(LENGTH(f4)) FROM debezium_source3 GROUP BY f1, f3;
                 """,

--- a/misc/python/materialize/checks/debezium.py
+++ b/misc/python/materialize/checks/debezium.py
@@ -122,6 +122,10 @@ class DebeziumPostgres(Check):
         return Testdrive(
             dedent(
                 """
+                # restart debezium after Postgres restart to avoid flakiness
+                $ http-request method=POST url=http://debezium:8083/connectors/psql-connector/restart content-type=application/json
+                { }
+                
                 > SELECT * FROM debezium_view1;
                 A 5 16000
                 B 5 16000

--- a/misc/python/materialize/checks/debezium.py
+++ b/misc/python/materialize/checks/debezium.py
@@ -122,7 +122,9 @@ class DebeziumPostgres(Check):
         return Testdrive(
             dedent(
                 """
-                # restart debezium after Postgres restart to avoid flakiness
+                # Restart Debezium in case the Scenario in which this Check is being run restarts Postgres
+                # The Debezium connector is unable to handle all Postgres restarts -- it will stop replicating
+                # and require a manual restart via its REST API in order to continue.
                 $ http-request method=POST url=http://debezium:8083/connectors/psql-connector/restart content-type=application/json
                 { }
 

--- a/misc/python/materialize/checks/debezium.py
+++ b/misc/python/materialize/checks/debezium.py
@@ -125,7 +125,7 @@ class DebeziumPostgres(Check):
                 # restart debezium after Postgres restart to avoid flakiness
                 $ http-request method=POST url=http://debezium:8083/connectors/psql-connector/restart content-type=application/json
                 { }
-                
+
                 > SELECT * FROM debezium_view1;
                 A 5 16000
                 B 5 16000


### PR DESCRIPTION
This closes https://github.com/MaterializeInc/materialize/issues/20391.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
