### PR TITLE
persist-client: fix unused_imports warnings in release mode

### DIFF
--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -9,7 +9,6 @@
 
 //! A durable, truncatable log of versions of [State].
 
-use std::borrow::Borrow;
 #[cfg(debug_assertions)]
 use std::collections::BTreeSet;
 use std::fmt::Debug;
@@ -21,13 +20,11 @@ use bytes::Bytes;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use mz_ore::cast::CastFrom;
-use mz_ore::collections::HashSet;
 use mz_persist::location::{
     Atomicity, Blob, CaSResult, Consensus, Indeterminate, SeqNo, VersionedData, SCAN_ALL,
 };
 use mz_persist::retry::Retry;
 use mz_persist_types::{Codec, Codec64};
-use timely::order::PartialOrder;
 use timely::progress::Timestamp;
 use tracing::{debug, debug_span, trace, warn, Instrument};
 
@@ -968,6 +965,11 @@ impl<T: Timestamp + Lattice + Codec64> ReferencedBlobValidator<T> {
         }
     }
     fn validate_against_state(&mut self, x: &State<T>) {
+        use std::borrow::Borrow;
+
+        use mz_ore::collections::HashSet;
+        use timely::PartialOrder;
+
         x.map_blobs(|x| match x {
             HollowBlobRef::Batch(x) => {
                 self.full_batches.insert(x.clone());


### PR DESCRIPTION
This PR fixes a couple `unused_imports` warnings when building persist-client without `debug_assertions`:

```
warning: unused import: `mz_ore::collections::HashSet`
  --> src/persist-client/src/internal/state_versions.rs:24:5
   |
24 | use mz_ore::collections::HashSet;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `timely::order::PartialOrder`
  --> src/persist-client/src/internal/state_versions.rs:30:5
   |
30 | use timely::order::PartialOrder;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `std::borrow::Borrow`
  --> src/persist-client/src/internal/state_versions.rs:12:5
   |
12 | use std::borrow::Borrow;
   |     ^^^^^^^^^^^^^^^^^^^
```

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

I opted to move the imports in question into the scope of the debug function, rather than littering more `#[cfg(...)]` annotations at the top. LMK if you prefer the other way.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
