### PR TITLE
Fix several bugs around LIKE/ILIKE and regexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4646,7 +4646,6 @@ dependencies = [
  "ryu",
  "serde",
  "serde_json",
- "serde_regex",
  "smallvec",
  "thiserror",
  "timely",

--- a/doc/user/content/sql/functions/_index.md
+++ b/doc/user/content/sql/functions/_index.md
@@ -102,14 +102,14 @@ Operator | Computes
 Operator | Computes
 ---------|---------
 <code>&vert;&vert;</code> | Concatenation
-`~~` | Matches LIKE pattern case sensitively, using [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
-`~~*` | Matches LIKE pattern case insensitively (ILIKE), using [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
-`!~~` | Does not match LIKE pattern case sensitively, using [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
-`!~~*` | Does not match LIKE pattern case insensitively (ILIKE), using [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
+`~~` | Matches LIKE pattern case sensitively, see [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
+`~~*` | Matches LIKE pattern case insensitively (ILIKE), see [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
+`!~~` | Matches NOT LIKE pattern (case sensitive), see [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
+`!~~*` | Matches NOT ILIKE pattern (case insensitive), see [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
 `~` | Matches regular expression, case sensitive
 `~*` | Matches regular expression, case insensitive
-`!~` | Does not match regular expression, case sensitive
-`!~*` | Does not match regular expression, case insensitive
+`!~` | Matches regular expression case sensitively, and inverts the match
+`!~*` | Match regular expression case insensitively, and inverts the match
 
 The regular expression syntax supported by Materialize is documented by the
 [Rust `regex` crate](https://docs.rs/regex/*/#syntax).

--- a/doc/user/content/sql/functions/_index.md
+++ b/doc/user/content/sql/functions/_index.md
@@ -102,6 +102,10 @@ Operator | Computes
 Operator | Computes
 ---------|---------
 <code>&vert;&vert;</code> | Concatenation
+`~~` | Matches LIKE pattern case sensitively, using [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
+`~~*` | Matches LIKE pattern case insensitively (ILIKE), using [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
+`!~~` | Does not match LIKE pattern case sensitively, using [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
+`!~~*` | Does not match LIKE pattern case insensitively (ILIKE), using [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
 `~` | Matches regular expression, case sensitive
 `~*` | Matches regular expression, case insensitive
 `!~` | Does not match regular expression, case sensitive

--- a/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
@@ -11,7 +11,6 @@ from typing import List, Set
 from attr import dataclass
 
 from materialize.output_consistency.data_value.data_value import DataValue
-from materialize.output_consistency.enum.enum_constant import EnumConstant
 from materialize.output_consistency.execution.evaluation_strategy import (
     EvaluationStrategyKey,
 )
@@ -186,14 +185,6 @@ class PreExecutionInconsistencyIgnoreFilter:
                 # tracked with https://github.com/MaterializeInc/materialize/issues/19511
                 return YesIgnore("#19511")
 
-        if db_function.function_name_in_lower_case in {"regexp_match"}:
-            if len(expression.args) == 3 and isinstance(
-                expression.args[2], EnumConstant
-            ):
-                # This is a regexp_match function call with case-insensitive configuration.
-                # https://github.com/MaterializeInc/materialize/issues/18494
-                return YesIgnore("#18494")
-
         if db_function.function_name_in_lower_case in {
             "array_agg",
             "string_agg",
@@ -210,10 +201,6 @@ class PreExecutionInconsistencyIgnoreFilter:
         expression: ExpressionWithArgs,
         all_involved_characteristics: Set[ExpressionCharacteristics],
     ) -> IgnoreVerdict:
-        # https://github.com/MaterializeInc/materialize/issues/18494
-        if db_operation.pattern in {"$ ~* $", "$ !~* $"}:
-            return YesIgnore("#18494")
-
         return NoIgnore()
 
 

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -1898,7 +1898,7 @@ impl RustType<ProtoAnalyzedRegex> for AnalyzedRegex {
 
 impl AnalyzedRegex {
     pub fn new(s: &str) -> Result<Self, regex::Error> {
-        let r = regex::Regex::new(s)?;
+        let r = ReprRegex::new(s.to_string(), false)?;
         // TODO(benesch): remove potentially dangerous usage of `as`.
         #[allow(clippy::as_conversions)]
         let descs: Vec<_> = r
@@ -1917,7 +1917,7 @@ impl AnalyzedRegex {
                 nullable: true,
             })
             .collect();
-        Ok(Self(ReprRegex(r), descs))
+        Ok(Self(r, descs))
     }
     pub fn capture_groups_len(&self) -> usize {
         self.1.len()
@@ -1926,7 +1926,7 @@ impl AnalyzedRegex {
         self.1.iter()
     }
     pub fn inner(&self) -> &Regex {
-        &(self.0).0
+        &(self.0).regex
     }
 }
 

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -1897,8 +1897,8 @@ impl RustType<ProtoAnalyzedRegex> for AnalyzedRegex {
 }
 
 impl AnalyzedRegex {
-    pub fn new(s: &str) -> Result<Self, regex::Error> {
-        let r = ReprRegex::new(s.to_string(), false)?;
+    pub fn new(s: String) -> Result<Self, regex::Error> {
+        let r = ReprRegex::new(s, false)?;
         // TODO(benesch): remove potentially dangerous usage of `as`.
         #[allow(clippy::as_conversions)]
         let descs: Vec<_> = r

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -42,7 +42,7 @@ use mz_repr::adt::jsonb::JsonbRef;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::adt::numeric::{self, DecimalLike, Numeric, NumericMaxScale};
 use mz_repr::adt::range::{self, Range, RangeBound, RangeOps};
-use mz_repr::adt::regex::any_regex;
+use mz_repr::adt::regex::{any_regex, Regex};
 use mz_repr::adt::timestamp::{CheckedTimestamp, TimestampLike};
 use mz_repr::chrono::any_naive_datetime;
 use mz_repr::role_id::RoleId;
@@ -51,7 +51,6 @@ use num::traits::CheckedNeg;
 use proptest::prelude::*;
 use proptest::strategy::*;
 use proptest_derive::Arbitrary;
-use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
 use sha1::Sha1;
 use sha2::{Sha224, Sha256, Sha384, Sha512};
@@ -6092,20 +6091,20 @@ fn regexp_match_static<'a>(
     Ok(temp_storage.push_unary_row(row))
 }
 
-pub fn build_regex(needle: &str, flags: &str) -> Result<regex::Regex, EvalError> {
-    let mut regex = RegexBuilder::new(needle);
+pub fn build_regex(needle: &str, flags: &str) -> Result<Regex, EvalError> {
+    let mut case_insensitive = false;
     for f in flags.chars() {
         match f {
             'i' => {
-                regex.case_insensitive(true);
+                case_insensitive = true;
             }
             'c' => {
-                regex.case_insensitive(false);
+                case_insensitive = false;
             }
             _ => return Err(EvalError::InvalidRegexFlag(f)),
         }
     }
-    Ok(regex.build()?)
+    Ok(Regex::new(needle.to_string(), case_insensitive)?)
 }
 
 pub fn hmac_string<'a>(

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -6093,6 +6093,7 @@ fn regexp_match_static<'a>(
 
 pub fn build_regex(needle: &str, flags: &str) -> Result<Regex, EvalError> {
     let mut case_insensitive = false;
+    // Note: Postgres accepts it when both flags are present, taking the last one. We do the same.
     for f in flags.chars() {
         match f {
             'i' => {

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -827,7 +827,12 @@ impl<'a> EagerUnaryFunc<'a> for IsLikeMatch {
 
 impl fmt::Display for IsLikeMatch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} ~~", self.0.pattern.quoted())
+        write!(
+            f,
+            "{}like[{}]",
+            if self.0.case_insensitive { "i" } else { "" },
+            self.0.pattern.quoted()
+        )
     }
 }
 

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -854,7 +854,12 @@ impl<'a> EagerUnaryFunc<'a> for IsRegexpMatch {
 
 impl fmt::Display for IsRegexpMatch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} ~", self.0.as_str().quoted())
+        write!(
+            f,
+            "is_regexp_match[{}, case_insensitive={}]",
+            self.0.pattern.quoted(),
+            self.0.case_insensitive
+        )
     }
 }
 
@@ -942,7 +947,12 @@ impl LazyUnaryFunc for RegexpMatch {
 
 impl fmt::Display for RegexpMatch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "regexp_match[{}]", self.0.as_str())
+        write!(
+            f,
+            "regexp_match[{}, case_insensitive={}]",
+            self.0.pattern.quoted(),
+            self.0.case_insensitive
+        )
     }
 }
 

--- a/src/expr/src/scalar/like_pattern.proto
+++ b/src/expr/src/scalar/like_pattern.proto
@@ -20,4 +20,5 @@ message ProtoSubpattern {
 message ProtoMatcher {
     string pattern = 1;
     bool case_insensitive = 2;
+    reserved 3; // This was matcher_impl, which is not serialized anymore since cc8bcb13e32a87a60e42d3c85f7d37c9cc75a2b5
 }

--- a/src/expr/src/scalar/like_pattern.proto
+++ b/src/expr/src/scalar/like_pattern.proto
@@ -17,19 +17,7 @@ message ProtoSubpattern {
     string suffix = 3;
 }
 
-message ProtoMatcherImpl {
-    message ProtoSubpatternVec {
-        repeated ProtoSubpattern vec = 1;
-    }
-
-    oneof kind {
-        ProtoSubpatternVec string = 1;
-        string regex = 2;
-    }
-}
-
 message ProtoMatcher {
     string pattern = 1;
     bool case_insensitive = 2;
-    ProtoMatcherImpl matcher_impl = 3;
 }

--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -90,7 +90,7 @@ pub fn normalize_pattern(pattern: &str, escape: EscapeBehavior) -> Result<String
 }
 
 // This implementation supports a couple of different methods of matching
-// text against a SQL LIKE pattern.
+// text against a SQL LIKE or ILIKE pattern.
 //
 // The most general approach is to convert the LIKE pattern into a
 // regular expression and use the well-tested Regex library to perform the
@@ -100,7 +100,7 @@ pub fn normalize_pattern(pattern: &str, escape: EscapeBehavior) -> Result<String
 // That said, regular expressions aren't that efficient. For most patterns
 // we can do better using built-in string matching.
 
-/// An object that can test whether a string matches a LIKE pattern.
+/// An object that can test whether a string matches a LIKE or ILIKE pattern.
 #[derive(Debug, Clone, Deserialize, Serialize, Derivative, MzReflect)]
 #[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Matcher {

--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -128,7 +128,6 @@ impl RustType<ProtoMatcher> for Matcher {
         ProtoMatcher {
             pattern: self.pattern.clone(),
             case_insensitive: self.case_insensitive,
-            //matcher_impl: Some(self.matcher_impl.into_proto()),
         }
     }
 

--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -133,11 +133,9 @@ impl RustType<ProtoMatcher> for Matcher {
     }
 
     fn from_proto(proto: ProtoMatcher) -> Result<Self, TryFromProtoError> {
-        Ok(
-            compile(proto.pattern.as_str(), proto.case_insensitive).map_err(|eval_err| {
-                TryFromProtoError::LikePatternDeserializationError(eval_err.to_string())
-            })?,
-        )
+        compile(proto.pattern.as_str(), proto.case_insensitive).map_err(|eval_err| {
+            TryFromProtoError::LikePatternDeserializationError(eval_err.to_string())
+        })
     }
 }
 

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -42,7 +42,6 @@ regex = "1.7.0"
 ryu = "1.0.12"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision"] }
-serde_regex = "1.1.0"
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio-postgres = { version = "0.7.8" }

--- a/src/repr/src/adt/regex.proto
+++ b/src/repr/src/adt/regex.proto
@@ -12,5 +12,6 @@ syntax = "proto3";
 package mz_repr.adt.regex;
 
 message ProtoRegex {
-    string regex = 1;
+    string pattern = 1;
+    bool case_insensitive = 2;
 }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3350,7 +3350,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
             params!(String, String) => Operation::binary(move |_ecx, regex, haystack| {
                 let regex = match regex.into_literal_string() {
                     None => sql_bail!("regex_extract requires a string literal as its first argument"),
-                    Some(regex) => mz_expr::AnalyzedRegex::new(&regex).map_err(|e| sql_err!("analyzing regex: {}", e))?,
+                    Some(regex) => mz_expr::AnalyzedRegex::new(regex).map_err(|e| sql_err!("analyzing regex: {}", e))?,
                 };
                 let column_names = regex
                     .capture_groups_iter()

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3897,7 +3897,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(Char, String) => Operation::binary(|ecx, lhs, rhs| {
                 let length = ecx.scalar_type(&lhs).unwrap_char_length();
                 Ok(lhs.call_unary(UnaryFunc::PadChar(func::PadChar { length }))
-                    .call_binary(rhs, IsLikeMatch { case_insensitive: false })
+                    .call_binary(rhs, IsLikeMatch { case_insensitive: true })
                     .call_unary(UnaryFunc::Not(func::Not))
                 )
             }) => Bool, 1630;
@@ -3965,7 +3965,7 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(Char, String) => Operation::binary(|ecx, lhs, rhs| {
                 let length = ecx.scalar_type(&lhs).unwrap_char_length();
                 Ok(lhs.call_unary(UnaryFunc::PadChar(func::PadChar { length }))
-                    .call_binary(rhs, IsRegexpMatch { case_insensitive: true })
+                    .call_binary(rhs, IsRegexpMatch { case_insensitive: false })
                     .call_unary(UnaryFunc::Not(func::Not))
                 )
             }) => Bool, 1056;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -58,7 +58,6 @@ use mz_storage_client::types::sources::{
     TestScriptSourceConnection, Timeline, UnplannedSourceEnvelope, UpsertStyle,
 };
 use prost::Message;
-use regex::Regex;
 
 use crate::ast::display::AstDisplay;
 use crate::ast::{
@@ -1717,12 +1716,10 @@ fn get_encoding_inner(
                 })
             }
         },
-        Format::Regex(regex) => {
-            let regex = Regex::new(regex).map_err(|e| sql_err!("parsing regex: {e}"))?;
-            DataEncodingInner::Regex(RegexEncoding {
-                regex: mz_repr::adt::regex::Regex(regex),
-            })
-        }
+        Format::Regex(regex) => DataEncodingInner::Regex(RegexEncoding {
+            regex: mz_repr::adt::regex::Regex::new(regex.clone(), false)
+                .map_err(|e| sql_err!("parsing regex: {e}"))?,
+        }),
         Format::Csv { columns, delimiter } => {
             let columns = match columns {
                 CsvColumns::Header { names } => {

--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -311,7 +311,7 @@ async fn get_decoder(
         | DataEncodingInner::Regex(_) => {
             let after_delimiting = match encoding.inner {
                 DataEncodingInner::Regex(RegexEncoding { regex }) => {
-                    PreDelimitedFormat::Regex(regex.0, Default::default())
+                    PreDelimitedFormat::Regex(regex.regex, Default::default())
                 }
                 DataEncodingInner::Protobuf(encoding) => {
                     PreDelimitedFormat::Protobuf(ProtobufDecoderState::new(encoding).expect(

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -313,7 +313,7 @@ Explained Query:
               %5[#0]UKA » %0:item[#0]UKlf » %2:stock[#0, #1]KKlf » %1:supplier[#0]UKlf » %3:nation[#0]UKlf » %4:l0[#0]UKlf
             ArrangeBy keys=[[#0]] // { arity: 2 }
               Project (#0, #2) // { arity: 2 }
-                Filter "%b" ~~(padchar(#4)) // { arity: 5 }
+                Filter like["%b"](padchar(#4)) // { arity: 5 }
                   Get materialize.public.item // { arity: 5 }
             ArrangeBy keys=[[#0]] // { arity: 6 }
               Project (#0..=#4, #6) // { arity: 6 }
@@ -343,13 +343,13 @@ Explained Query:
       cte l0 =
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Project (#0) // { arity: 1 }
-            Filter "EUROP%" ~~(padchar(#1)) // { arity: 3 }
+            Filter like["EUROP%"](padchar(#1)) // { arity: 3 }
               Get materialize.public.region // { arity: 3 }
 
 Source materialize.public.item
-  filter=("%b" ~~(padchar(#4)))
+  filter=(like["%b"](padchar(#4)))
 Source materialize.public.region
-  filter=("EUROP%" ~~(padchar(#1)))
+  filter=(like["EUROP%"](padchar(#1)))
 
 Used Indexes:
   - materialize.public.fk_stock_supplier
@@ -388,7 +388,7 @@ Explained Query:
                 %0:customer[#2, #1, #0]UKKKlf » %2:order[#2, #1, #3]KKKAlif » %1:neworder[#0..=#2]UKKKlif » %3:orderline[#2, #1, #0]KKKAlif
               ArrangeBy keys=[[#2, #1, #0]] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
-                  Filter "A%" ~~(padchar(#9)) // { arity: 22 }
+                  Filter like["A%"](padchar(#9)) // { arity: 22 }
                     Get materialize.public.customer // { arity: 22 }
               ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                 Get materialize.public.neworder // { arity: 3 }
@@ -675,7 +675,7 @@ Explained Query:
                   %4:order[#3, #1, #2]KKKiif » %5:customer[#0..=#2]UKKKiif » %6:nation[#0]UKiif » %8:region[#0]UKeiif » %3:orderline[#2, #1, #0]KKKAeiiif » %2:stock[#0, #1]UKKeiiiif » %0:item[#0]UKeliiiiif » %1:supplier[#0]UKeliiiiif » %7:nation[#0]UKeliiiiif
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Project (#0) // { arity: 1 }
-                    Filter (#0 < 1000) AND "%b" ~~(padchar(#4)) // { arity: 5 }
+                    Filter (#0 < 1000) AND like["%b"](padchar(#4)) // { arity: 5 }
                       Get materialize.public.item // { arity: 5 }
                 ArrangeBy keys=[[#0]] // { arity: 2 }
                   Project (#0, #3) // { arity: 2 }
@@ -707,7 +707,7 @@ Explained Query:
                       Get materialize.public.region // { arity: 3 }
 
 Source materialize.public.item
-  filter=((#0 < 1000) AND "%b" ~~(padchar(#4)))
+  filter=((#0 < 1000) AND like["%b"](padchar(#4)))
 Source materialize.public.region
   filter=((#1 = "EUROPE"))
 
@@ -750,7 +750,7 @@ Explained Query:
               %4:order[#2, #1, #0]UKKK » %3:orderline[#2, #1, #0]KKKA » %1:stock[#0, #1]UKK » %0:item[#0]UKlf » %2:supplier[#0]UKlf » %5:nation[#0]UKlf
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter "%BB" ~~(padchar(#4)) // { arity: 5 }
+                Filter like["%BB"](padchar(#4)) // { arity: 5 }
                   Get materialize.public.item // { arity: 5 }
             ArrangeBy keys=[[#0, #1]] // { arity: 3 }
               Project (#0, #1, #17) // { arity: 3 }
@@ -768,7 +768,7 @@ Explained Query:
                 Get materialize.public.nation // { arity: 4 }
 
 Source materialize.public.item
-  filter=("%BB" ~~(padchar(#4)))
+  filter=(like["%BB"](padchar(#4)))
 
 Used Indexes:
   - materialize.public.fk_order_customer
@@ -997,7 +997,7 @@ Explained Query:
                 - ()
   With
     cte l0 =
-      Reduce aggregates=[sum(case when "PR%" ~~(padchar(#1)) then #0 else 0 end), sum(#0)] // { arity: 2 }
+      Reduce aggregates=[sum(case when like["PR%"](padchar(#1)) then #0 else 0 end), sum(#0)] // { arity: 2 }
         Project (#8, #11) // { arity: 2 }
           Filter (#12 < 2020-01-02 00:00:00) AND (#12 >= 2007-01-02 00:00:00) AND (#4) IS NOT NULL // { arity: 13 }
             Map (date_to_timestamp(#6)) // { arity: 13 }
@@ -1124,7 +1124,7 @@ Explained Query:
                         Get l1 // { arity: 1 }
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Project (#0) // { arity: 1 }
-                          Filter "%bad%" ~~(padchar(#6)) // { arity: 7 }
+                          Filter like["%bad%"](padchar(#6)) // { arity: 7 }
                             Get materialize.public.supplier // { arity: 7 }
                 Get l1 // { arity: 1 }
     With
@@ -1141,11 +1141,11 @@ Explained Query:
               Get materialize.public.stock // { arity: 18 }
             ArrangeBy keys=[[#0]] // { arity: 4 }
               Project (#0, #2..=#4) // { arity: 4 }
-                Filter NOT("zz%" ~~(padchar(#4))) // { arity: 5 }
+                Filter NOT(like["zz%"](padchar(#4))) // { arity: 5 }
                   Get materialize.public.item // { arity: 5 }
 
 Source materialize.public.item
-  filter=(NOT("zz%" ~~(padchar(#4))))
+  filter=(NOT(like["zz%"](padchar(#4))))
 
 Used Indexes:
   - materialize.public.fk_stock_item
@@ -1200,7 +1200,7 @@ Explained Query:
                           %0:item[#0]UKlf » %1:l0[#4]KAlf
                         ArrangeBy keys=[[#0]] // { arity: 1 }
                           Project (#0) // { arity: 1 }
-                            Filter "%b" ~~(padchar(#4)) // { arity: 5 }
+                            Filter like["%b"](padchar(#4)) // { arity: 5 }
                               Get materialize.public.item // { arity: 5 }
                         Get l0 // { arity: 10 }
     cte l0 =
@@ -1208,7 +1208,7 @@ Explained Query:
         Get materialize.public.orderline // { arity: 10 }
 
 Source materialize.public.item
-  filter=("%b" ~~(padchar(#4)))
+  filter=(like["%b"](padchar(#4)))
 
 Used Indexes:
   - materialize.public.fk_orderline_item
@@ -1298,7 +1298,7 @@ Explained Query:
     cte l0 =
       Reduce aggregates=[sum(#0)] // { arity: 1 }
         Project (#8) // { arity: 1 }
-          Filter (#7 <= 10) AND (#7 >= 1) AND (#4) IS NOT NULL AND (#12 OR #13 OR #14 OR #15 OR #16) AND (("%a" ~~(#17) AND (#12 OR #13 OR #14)) OR ("%b" ~~(#17) AND (#12 OR #13 OR #15)) OR ("%c" ~~(#17) AND (#12 OR #14 OR #16))) // { arity: 18 }
+          Filter (#7 <= 10) AND (#7 >= 1) AND (#4) IS NOT NULL AND (#12 OR #13 OR #14 OR #15 OR #16) AND ((like["%a"](#17) AND (#12 OR #13 OR #14)) OR (like["%b"](#17) AND (#12 OR #13 OR #15)) OR (like["%c"](#17) AND (#12 OR #14 OR #16))) // { arity: 18 }
             Map ((#2 = 1), (#2 = 2), (#2 = 3), (#2 = 4), (#2 = 5), padchar(#11)) // { arity: 18 }
               Join on=(#4 = #10) type=differential // { arity: 12 }
                 implementation
@@ -1307,12 +1307,12 @@ Explained Query:
                   Get materialize.public.orderline // { arity: 10 }
                 ArrangeBy keys=[[#0]] // { arity: 2 }
                   Project (#0, #4) // { arity: 2 }
-                    Filter (#3 <= 400000) AND (#3 >= 1) AND ("%a" ~~(#5) OR "%b" ~~(#5) OR "%c" ~~(#5)) // { arity: 6 }
+                    Filter (#3 <= 400000) AND (#3 >= 1) AND (like["%a"](#5) OR like["%b"](#5) OR like["%c"](#5)) // { arity: 6 }
                       Map (padchar(#4)) // { arity: 6 }
                         Get materialize.public.item // { arity: 5 }
 
 Source materialize.public.item
-  filter=((#3 <= 400000) AND (#3 >= 1) AND ("%a" ~~(#5) OR "%b" ~~(#5) OR "%c" ~~(#5)))
+  filter=((#3 <= 400000) AND (#3 >= 1) AND (like["%a"](#5) OR like["%b"](#5) OR like["%c"](#5)))
   map=(padchar(#4))
 
 Used Indexes:
@@ -1367,7 +1367,7 @@ Explained Query:
                             Get materialize.public.orderline // { arity: 10 }
                           ArrangeBy keys=[[#0]] // { arity: 1 }
                             Project (#0) // { arity: 1 }
-                              Filter "co%" ~~(padchar(#4)) // { arity: 5 }
+                              Filter like["co%"](padchar(#4)) // { arity: 5 }
                                 Get materialize.public.item // { arity: 5 }
     With
       cte l0 =
@@ -1383,7 +1383,7 @@ Explained Query:
                   Get materialize.public.nation // { arity: 4 }
 
 Source materialize.public.item
-  filter=("co%" ~~(padchar(#4)))
+  filter=(like["co%"](padchar(#4)))
 
 Used Indexes:
   - materialize.public.fk_orderline_item

--- a/test/sqllogictest/cockroach/like.slt
+++ b/test/sqllogictest/cockroach/like.slt
@@ -1032,3 +1032,51 @@ query B
 SELECT ('foo' !~~* NULL) IS NULL;
 ----
 true
+
+query T multiline
+EXPLAIN SELECT * FROM mz_functions WHERE name LIKE 'ABS';
+----
+Explained Query:
+  Filter like["ABS"](#3)
+    Get mz_catalog.mz_functions
+
+Source mz_catalog.mz_functions
+  filter=(like["ABS"](#3))
+
+EOF
+
+query T multiline
+EXPLAIN SELECT * FROM mz_functions WHERE name ILIKE 'ABS';
+----
+Explained Query:
+  Filter ilike["ABS"](#3)
+    Get mz_catalog.mz_functions
+
+Source mz_catalog.mz_functions
+  filter=(ilike["ABS"](#3))
+
+EOF
+
+query T multiline
+EXPLAIN SELECT * FROM mz_functions WHERE name NOT ILIKE 'ABS';
+----
+Explained Query:
+  Filter NOT(ilike["ABS"](#3))
+    Get mz_catalog.mz_functions
+
+Source mz_catalog.mz_functions
+  filter=(NOT(ilike["ABS"](#3)))
+
+EOF
+
+query T multiline
+EXPLAIN SELECT * FROM mz_functions WHERE NOT (name ILIKE 'ABS');
+----
+Explained Query:
+  Filter NOT(ilike["ABS"](#3))
+    Get mz_catalog.mz_functions
+
+Source mz_catalog.mz_functions
+  filter=(NOT(ilike["ABS"](#3)))
+
+EOF

--- a/test/sqllogictest/cockroach/like.slt
+++ b/test/sqllogictest/cockroach/like.slt
@@ -1033,50 +1033,124 @@ SELECT ('foo' !~~* NULL) IS NULL;
 ----
 true
 
+# The above tests go through const folding. The below tests avoid const folding.
+
+statement ok
+CREATE TABLE t(s string, like_pat string, regex_pat string);
+
+statement ok
+INSERT INTO t VALUES ('abc', 'a%', 'a.*'), ('ABC', 'a%', 'a.*'), ('ccc', 'a%', 'a.*');
+
 query T multiline
-EXPLAIN SELECT * FROM mz_functions WHERE name LIKE 'ABS';
+EXPLAIN
+SELECT s FROM t WHERE s LIKE 'a%';
 ----
 Explained Query:
-  Filter like["ABS"](#3)
-    Get mz_catalog.mz_functions
+  Project (#0)
+    Filter like["a%"](#0)
+      Get materialize.public.t
 
-Source mz_catalog.mz_functions
-  filter=(like["ABS"](#3))
+Source materialize.public.t
+  filter=(like["a%"](#0))
 
 EOF
 
+query T
+SELECT s FROM t WHERE s LIKE 'a%';
+----
+abc
+
 query T multiline
-EXPLAIN SELECT * FROM mz_functions WHERE name ILIKE 'ABS';
+EXPLAIN
+SELECT s FROM t WHERE s ILIKE 'a%';
 ----
 Explained Query:
-  Filter ilike["ABS"](#3)
-    Get mz_catalog.mz_functions
+  Project (#0)
+    Filter ilike["a%"](#0)
+      Get materialize.public.t
 
-Source mz_catalog.mz_functions
-  filter=(ilike["ABS"](#3))
+Source materialize.public.t
+  filter=(ilike["a%"](#0))
 
 EOF
 
+query T
+SELECT s FROM t WHERE s ILIKE 'a%';
+----
+ABC
+abc
+
 query T multiline
-EXPLAIN SELECT * FROM mz_functions WHERE name NOT ILIKE 'ABS';
+EXPLAIN
+SELECT s FROM t WHERE s NOT ILIKE 'a%';
 ----
 Explained Query:
-  Filter NOT(ilike["ABS"](#3))
-    Get mz_catalog.mz_functions
+  Project (#0)
+    Filter NOT(ilike["a%"](#0))
+      Get materialize.public.t
 
-Source mz_catalog.mz_functions
-  filter=(NOT(ilike["ABS"](#3)))
+Source materialize.public.t
+  filter=(NOT(ilike["a%"](#0)))
 
 EOF
 
+query T
+SELECT s FROM t WHERE s NOT ILIKE 'a%';
+----
+ccc
+
+
 query T multiline
-EXPLAIN SELECT * FROM mz_functions WHERE NOT (name ILIKE 'ABS');
+EXPLAIN
+SELECT s FROM t WHERE NOT (s ILIKE 'a%');
 ----
 Explained Query:
-  Filter NOT(ilike["ABS"](#3))
-    Get mz_catalog.mz_functions
+  Project (#0)
+    Filter NOT(ilike["a%"](#0))
+      Get materialize.public.t
 
-Source mz_catalog.mz_functions
-  filter=(NOT(ilike["ABS"](#3)))
+Source materialize.public.t
+  filter=(NOT(ilike["a%"](#0)))
 
 EOF
+
+# Binary versions (MirScalarExpr::reduce changes them into unary when the pattern is a constant, which we prevent here.)
+
+query T multiline
+EXPLAIN
+SELECT s FROM t WHERE s LIKE like_pat;
+----
+Explained Query:
+  Project (#0)
+    Filter (#0 like #1)
+      Get materialize.public.t
+
+Source materialize.public.t
+  filter=((#0 like #1))
+
+EOF
+
+query T
+SELECT s FROM t WHERE s LIKE like_pat;
+----
+abc
+
+query T multiline
+EXPLAIN
+SELECT s FROM t WHERE s ILIKE like_pat;
+----
+Explained Query:
+  Project (#0)
+    Filter (#0 ilike #1)
+      Get materialize.public.t
+
+Source materialize.public.t
+  filter=((#0 ilike #1))
+
+EOF
+
+query T
+SELECT s FROM t WHERE s ILIKE like_pat;
+----
+ABC
+abc

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -5289,3 +5289,109 @@ WHERE b = c and d = e
   "sources": []
 }
 EOF
+
+statement ok
+CREATE TABLE t2(s string, like_pat string, regex_pat string);
+
+statement ok
+INSERT INTO t2 VALUES ('abc', 'a%', 'a.*'), ('ABC', 'a%', 'a.*'), ('ccc', 'a%', 'a.*');
+
+# Our Regex wrapper struct's serde is currently not serializing the Regex itself, but all info should be visible in
+# the other fields.
+
+query T multiline
+EXPLAIN AS JSON
+SELECT s FROM t2 WHERE s ~ 'a.*';
+----
+{
+  "plans": [
+    {
+      "id": "Explained Query",
+      "plan": {
+        "Project": {
+          "input": {
+            "Filter": {
+              "input": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 13
+                    }
+                  },
+                  "typ": {
+                    "column_types": [
+                      {
+                        "scalar_type": "String",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "String",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "String",
+                        "nullable": true
+                      }
+                    ],
+                    "keys": []
+                  }
+                }
+              },
+              "predicates": [
+                {
+                  "CallUnary": {
+                    "func": {
+                      "IsRegexpMatch": {
+                        "pattern": "a.*",
+                        "case_insensitive": false
+                      }
+                    },
+                    "expr": {
+                      "Column": 0
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "outputs": [
+            0
+          ]
+        }
+      }
+    }
+  ],
+  "sources": [
+    {
+      "id": "materialize.public.t2",
+      "op": {
+        "expressions": [],
+        "predicates": [
+          [
+            1,
+            {
+              "CallUnary": {
+                "func": {
+                  "IsRegexpMatch": {
+                    "pattern": "a.*",
+                    "case_insensitive": false
+                  }
+                },
+                "expr": {
+                  "Column": 0
+                }
+              }
+            }
+          ]
+        ],
+        "projection": [
+          0,
+          1,
+          2
+        ],
+        "input_arity": 3
+      }
+    }
+  ]
+}
+EOF

--- a/test/sqllogictest/github-18708.slt
+++ b/test/sqllogictest/github-18708.slt
@@ -44,12 +44,12 @@ Explained Query:
               Filter (#0 <= #0) AND (#0 >= #0)
                 Get materialize.public.t5
           ArrangeBy keys=[[]]
-            Filter (#1 = text_to_char(text_to_varchar(boolean_to_text("0.31161855206970124" ~~(padchar(#1))))))
+            Filter (#1 = text_to_char(text_to_varchar(boolean_to_text(like["0.31161855206970124"](padchar(#1))))))
               Get materialize.public.t3
           ArrangeBy keys=[[]]
             Get materialize.public.t5
 
 Source materialize.public.t3
-  filter=((#1 = text_to_char(text_to_varchar(boolean_to_text("0.31161855206970124" ~~(padchar(#1)))))))
+  filter=((#1 = text_to_char(text_to_varchar(boolean_to_text(like["0.31161855206970124"](padchar(#1)))))))
 
 EOF

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -349,7 +349,7 @@ EXPLAIN WITH(types, no_fast_path) SELECT REGEXP_MATCH(col_not_null, 'aaa'), REGE
 ----
 Explained Query:
   Project (#2, #3) // { types: "(text[]?, text[]?)" }
-    Map (regexp_match[aaa](#1), regexp_match("aaa", #1)) // { types: "(text?, text, text[]?, text[]?)" }
+    Map (regexp_match["aaa", case_insensitive=false](#1), regexp_match("aaa", #1)) // { types: "(text?, text, text[]?, text[]?)" }
       Get materialize.public.str_table // { types: "(text?, text)" }
 
 EOF

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -56,7 +56,7 @@ EXPLAIN WITH(arity, join_impls) SELECT input ~ 'foo?' FROM data
 ----
 Explained Query:
   Project (#1) // { arity: 1 }
-    Map ("foo?" ~(#0)) // { arity: 2 }
+    Map (is_regexp_match["foo?", case_insensitive=false](#0)) // { arity: 2 }
       Get materialize.public.data // { arity: 1 }
 
 EOF
@@ -69,5 +69,242 @@ Explained Query:
   Project (#1) // { arity: 1 }
     Map ((#0 ~ #0)) // { arity: 2 }
       Get materialize.public.data // { arity: 1 }
+
+EOF
+
+query T multiline
+EXPLAIN
+SELECT regexp_match('ABC', 'a.*');
+----
+Explained Query (fast path):
+  Constant
+    - (null)
+
+EOF
+
+query T
+SELECT regexp_match('ABC', 'a.*');
+----
+NULL
+
+query T multiline
+EXPLAIN
+SELECT regexp_match('ABC', 'a.*', 'i');
+----
+Explained Query (fast path):
+  Constant
+    - ({"ABC"})
+
+EOF
+
+query T
+SELECT regexp_match('ABC', 'a.*', 'i');
+----
+{ABC}
+
+query error db error: ERROR: invalid regular expression: regex parse error:
+SELECT 'abs' ~ '\';
+
+# Case-insensitive vs. case-sensitive regexes when there is no full const folding, but MirScalarExpr::reduce changes
+# from the binary to unary versions.
+
+statement ok
+CREATE TABLE t(s string, like_pat string, regex_pat string);
+
+statement ok
+INSERT INTO t VALUES ('abc', 'a%', 'a.*'), ('ABC', 'a%', 'a.*'), ('ccc', 'a%', 'a.*');
+
+query T multiline
+EXPLAIN
+SELECT s FROM t WHERE s~'a.*';
+----
+Explained Query:
+  Project (#0)
+    Filter is_regexp_match["a.*", case_insensitive=false](#0)
+      Get materialize.public.t
+
+Source materialize.public.t
+  filter=(is_regexp_match["a.*", case_insensitive=false](#0))
+
+EOF
+
+query T
+SELECT s FROM t WHERE s~'a.*';
+----
+abc
+
+query T multiline
+EXPLAIN
+SELECT s FROM t WHERE s~*'a.*';
+----
+Explained Query:
+  Project (#0)
+    Filter is_regexp_match["a.*", case_insensitive=true](#0)
+      Get materialize.public.t
+
+Source materialize.public.t
+  filter=(is_regexp_match["a.*", case_insensitive=true](#0))
+
+EOF
+
+query T
+SELECT s FROM t WHERE s~*'a.*';
+----
+ABC
+abc
+
+query T multiline
+EXPLAIN
+SELECT s, regexp_match(s, 'a.*') FROM t;
+----
+Explained Query:
+  Project (#0, #3)
+    Map (regexp_match["a.*", case_insensitive=false](#0))
+      Get materialize.public.t
+
+EOF
+
+query TT
+SELECT s, regexp_match(s, 'a.*') FROM t;
+----
+ABC
+NULL
+ccc
+NULL
+abc
+{abc}
+
+query T multiline
+EXPLAIN
+SELECT s, regexp_match(s, 'a.*', 'i') FROM t;
+----
+Explained Query:
+  Project (#0, #3)
+    Map (regexp_match["a.*", case_insensitive=true](#0))
+      Get materialize.public.t
+
+EOF
+
+query TT
+SELECT s, regexp_match(s, 'a.*', 'i') FROM t;
+----
+ccc
+NULL
+ABC
+{ABC}
+abc
+{abc}
+
+query error db error: ERROR: Evaluation error: invalid regular expression: regex parse error:
+SELECT s FROM t WHERE s ~ '\';
+
+# Dynamic regexes (binary (or variadic) versions)
+
+query T multiline
+EXPLAIN
+SELECT s FROM t WHERE s ~ regex_pat;
+----
+Explained Query:
+  Project (#0)
+    Filter (#0 ~ #2)
+      Get materialize.public.t
+
+Source materialize.public.t
+  filter=((#0 ~ #2))
+
+EOF
+
+query T
+SELECT s FROM t WHERE s ~ regex_pat;
+----
+abc
+
+query T multiline
+EXPLAIN
+SELECT s FROM t WHERE s ~* regex_pat;
+----
+Explained Query:
+  Project (#0)
+    Filter (#0 ~* #2)
+      Get materialize.public.t
+
+Source materialize.public.t
+  filter=((#0 ~* #2))
+
+EOF
+
+query T
+SELECT s FROM t WHERE s ~* regex_pat;
+----
+ABC
+abc
+
+query T multiline
+EXPLAIN
+SELECT s, regex_pat, regexp_match(s, regex_pat) FROM t;
+----
+Explained Query:
+  Project (#0, #2, #3)
+    Map (regexp_match(#0, #2))
+      Get materialize.public.t
+
+EOF
+
+query TTT
+SELECT s, regex_pat, regexp_match(s, regex_pat) FROM t;
+----
+ABC
+a.*
+NULL
+ccc
+a.*
+NULL
+abc
+a.*
+{abc}
+
+query T multiline
+EXPLAIN
+SELECT s, regex_pat, regexp_match(s, regex_pat, 'i') FROM t;
+----
+Explained Query:
+  Project (#0, #2, #3)
+    Map (regexp_match(#0, #2, "i"))
+      Get materialize.public.t
+
+EOF
+
+query TTT
+SELECT s, regex_pat, regexp_match(s, regex_pat, 'i') FROM t;
+----
+ccc
+a.*
+NULL
+ABC
+a.*
+{ABC}
+abc
+a.*
+{abc}
+
+statement ok
+INSERT INTO T VALUES ('this is gonna be an invalid regex', '', '\');
+
+# Note: The actual error msg shows the regex itself (as it should), but it seems sqllogictest can't handle multiline
+# error msgs.
+query error db error: ERROR: Evaluation error: invalid regular expression: regex parse error:
+SELECT s FROM t WHERE s ~* regex_pat;
+
+# TODO: multiline literal errors should be printed somehow differently in EXPLAIN
+query T multiline
+EXPLAIN
+SELECT *, s~'\' FROM t;
+----
+Explained Query:
+  Map (error("invalid regular expression: regex parse error:
+    \
+    ^
+error: incomplete escape sequence, reached end of pattern prematurely"))
+    Get materialize.public.t
 
 EOF

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -102,6 +102,17 @@ SELECT regexp_match('ABC', 'a.*', 'i');
 ----
 {ABC}
 
+# We have to accept it when both flags are present (taking the last one), because Postgres also does the same.
+query T
+SELECT regexp_match('ABC', 'a.*', 'ic');
+----
+NULL
+
+query T
+SELECT regexp_match('ABC', 'a.*', 'ci');
+----
+{ABC}
+
 query error db error: ERROR: invalid regular expression: regex parse error:
 SELECT 'abs' ~ '\';
 
@@ -195,6 +206,26 @@ ABC
 abc
 {abc}
 
+query TT
+SELECT s, regexp_match(s, 'a.*', 'ic') FROM t;
+----
+ABC
+NULL
+ccc
+NULL
+abc
+{abc}
+
+query TT
+SELECT s, regexp_match(s, 'a.*', 'ci') FROM t;
+----
+ccc
+NULL
+ABC
+{ABC}
+abc
+{abc}
+
 query error db error: ERROR: Evaluation error: invalid regular expression: regex parse error:
 SELECT s FROM t WHERE s ~ '\';
 
@@ -276,6 +307,32 @@ EOF
 
 query TTT
 SELECT s, regex_pat, regexp_match(s, regex_pat, 'i') FROM t;
+----
+ccc
+a.*
+NULL
+ABC
+a.*
+{ABC}
+abc
+a.*
+{abc}
+
+query TTT
+SELECT s, regex_pat, regexp_match(s, regex_pat, 'ic') FROM t;
+----
+ABC
+a.*
+NULL
+ccc
+a.*
+NULL
+abc
+a.*
+{abc}
+
+query TTT
+SELECT s, regex_pat, regexp_match(s, regex_pat, 'ci') FROM t;
 ----
 ccc
 a.*

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -1429,6 +1429,21 @@ SELECT 'abc'::char(3) ~~ 'abc'::char(4);
 ----
 true
 
+query B
+SELECT 'abc'::char(3) !~~* 'Abc'::char(4);
+----
+false
+
+query B
+SELECT 'abc'::char(3) NOT ILIKE 'Abc'::char(4);
+----
+false
+
+query B
+SELECT 'abc'::char(3) !~ 'Abc'::char(4);
+----
+true
+
 # Regression for https://github.com/MaterializeInc/materialize/pull/7522#issuecomment-893343138
 
 query T

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -106,7 +106,7 @@ EXPLAIN SHOW INDEXES
 ----
 Explained Query (fast path):
   Project (#3..=#6)
-    Filter NOT("s%" ~~(#0)) AND (#1 = "u3")
+    Filter NOT(like["s%"](#0)) AND (#1 = "u3")
       ReadExistingIndex mz_internal.mz_show_indexes_ind
 
 Used Indexes:
@@ -268,7 +268,7 @@ Explained Query:
   With
     cte l2 =
       Project (#0..=#4, #9, #10)
-        Filter "u%" ~~(#0)
+        Filter like["u%"](#0)
           Join on=(#0 = #5) type=differential
             Get l1
             ArrangeBy keys=[[#0]]
@@ -278,7 +278,7 @@ Explained Query:
         Get l0
     cte l0 =
       Project (#0, #1, #3, #4, #6)
-        Filter "u%" ~~(#0)
+        Filter like["u%"](#0)
           Get mz_catalog.mz_sources
 
 Used Indexes:

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -268,7 +268,7 @@ Explained Query:
     With
       cte l4 =
         Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-          Filter (#5 = 15) AND (#26 = "EUROPE") AND (#0) IS NOT NULL AND (#9) IS NOT NULL AND (#12) IS NOT NULL AND (#23) IS NOT NULL AND "%BRASS" ~~(varchar_to_text(#4)) // { arity: 28 }
+          Filter (#5 = 15) AND (#26 = "EUROPE") AND (#0) IS NOT NULL AND (#9) IS NOT NULL AND (#12) IS NOT NULL AND (#23) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4)) // { arity: 28 }
             Join on=(#0 = #16 AND #9 = #17 AND #12 = #21 AND #23 = #25) type=delta // { arity: 28 }
               implementation
                 %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
@@ -728,7 +728,7 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last, #1 desc nulls_first] output=[#0..=#2]
     Reduce group_by=[#5, extract_year_d(#4)] aggregates=[sum(((#1 * (1 - #2)) - (#3 * #0)))] // { arity: 3 }
       Project (#20..=#22, #35, #41, #47) // { arity: 6 }
-        Filter (#0) IS NOT NULL AND (#9) IS NOT NULL AND (#12) IS NOT NULL AND (#16) IS NOT NULL AND "%green%" ~~(varchar_to_text(#1)) // { arity: 50 }
+        Filter (#0) IS NOT NULL AND (#9) IS NOT NULL AND (#12) IS NOT NULL AND (#16) IS NOT NULL AND like["%green%"](varchar_to_text(#1)) // { arity: 50 }
           Join on=(eq(#0, #17, #32) AND eq(#9, #18, #33) AND #12 = #46 AND #16 = #37) type=delta // { arity: 50 }
             implementation
               %0:part » %2:lineitem[#1]KA » %3:partsupp[#0, #1]KKA » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
@@ -1003,7 +1003,7 @@ Explained Query:
     With
       cte l0 =
         Project (#0..=#8) // { arity: 9 }
-          Filter (#0) IS NOT NULL AND NOT("%special%requests%" ~~(varchar_to_text(#16))) // { arity: 17 }
+          Filter (#0) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(#16))) // { arity: 17 }
             Join on=(#0 = #9) type=differential // { arity: 17 }
               implementation
                 %1:orders[#1]KAf » %0:customer[#0]KAf
@@ -1050,7 +1050,7 @@ Explained Query:
                 - ()
   With
     cte l0 =
-      Reduce aggregates=[sum(case when "PROMO%" ~~(varchar_to_text(#2)) then (#0 * (1 - #1)) else 0 end), sum((#0 * (1 - #1)))] // { arity: 2 }
+      Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2)) then (#0 * (1 - #1)) else 0 end), sum((#0 * (1 - #1)))] // { arity: 2 }
         Project (#5, #6, #20) // { arity: 3 }
           Filter (#10 >= 1995-09-01) AND (#1) IS NOT NULL AND (date_to_timestamp(#10) < 1995-10-01 00:00:00) // { arity: 25 }
             Join on=(#1 = #16) type=differential // { arity: 25 }
@@ -1192,7 +1192,7 @@ Explained Query:
                             Get l1 // { arity: 1 }
                           ArrangeBy keys=[[]] // { arity: 1 }
                             Project (#0) // { arity: 1 }
-                              Filter "%Customer%Complaints%" ~~(varchar_to_text(#6)) // { arity: 7 }
+                              Filter like["%Customer%Complaints%"](varchar_to_text(#6)) // { arity: 7 }
                                 Get materialize.public.supplier // { arity: 7 }
                 Get l1 // { arity: 1 }
     With
@@ -1202,7 +1202,7 @@ Explained Query:
             Get l0 // { arity: 4 }
       cte l0 =
         Project (#1, #8..=#10) // { arity: 4 }
-          Filter (#8 != "Brand#45") AND (#0) IS NOT NULL AND NOT("MEDIUM POLISHED%" ~~(varchar_to_text(#9))) AND ((#10 = 3) OR (#10 = 9) OR (#10 = 14) OR (#10 = 19) OR (#10 = 23) OR (#10 = 36) OR (#10 = 45) OR (#10 = 49)) // { arity: 14 }
+          Filter (#8 != "Brand#45") AND (#0) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9))) AND ((#10 = 3) OR (#10 = 9) OR (#10 = 14) OR (#10 = 19) OR (#10 = 23) OR (#10 = 36) OR (#10 = 45) OR (#10 = 49)) // { arity: 14 }
             Join on=(#0 = #5) type=differential // { arity: 14 }
               implementation
                 %1:part[#0]KAef » %0:partsupp[#0]KAef
@@ -1537,7 +1537,7 @@ Explained Query:
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Distinct group_by=[#0] // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Filter (#0) IS NOT NULL AND "forest%" ~~(varchar_to_text(#1)) // { arity: 9 }
+                  Filter (#0) IS NOT NULL AND like["forest%"](varchar_to_text(#1)) // { arity: 9 }
                     Get materialize.public.part // { arity: 9 }
       cte l0 =
         Project (#0..=#2) // { arity: 3 }

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -598,7 +598,7 @@ t3.x != t3.y AND
 ----
 Explained Query:
   Project (#0..=#14, #0, #16..=#29, #0, #31..=#44, #0, #46..=#59, #0, #61..=#74, #0, #76..=#89, #0, #91..=#104, #0, #106..=#119, #0, #121..=#134, #0, #136..=#149, #0, #151..=#153) // { arity: 154 }
-    Filter (#109) IS NULL AND "a%" ~~(#125) AND (#137 = 71) AND (#95 <= 8) AND (#81 > 5) AND (#95 >= 3) AND NOT("b%" ~~(#69)) AND (#39 != #40) AND (#53 != #54) // { arity: 154 }
+    Filter (#109) IS NULL AND like["a%"](#125) AND (#137 = 71) AND (#95 <= 8) AND (#81 > 5) AND (#95 >= 3) AND NOT(like["b%"](#69)) AND (#39 != #40) AND (#53 != #54) // { arity: 154 }
       Join on=(eq(#0, #15, #30, #45, #60, #75, #90, #105, #120, #135, #150)) type=delta // { arity: 154 }
         implementation
           %0:big » %9:big[#9]KAef » %8:big[#8]KAlf » %7:big[#7]KAnf » %6:big[#6]KAiif » %5:big[#5]KAif » %2:big[#2]KAf » %3:big[#3]KAf » %4:big[#4]KAf » %1:big[#1]KA » %10:big[#10]KA
@@ -664,7 +664,7 @@ t0.s LIKE 'a%'
 ----
 Explained Query:
   Project (#0..=#14, #0, #16..=#27, #29, #30, #0, #32..=#42) // { arity: 42 }
-    Filter "a%" ~~(#13) // { arity: 43 }
+    Filter like["a%"](#13) // { arity: 43 }
       Join on=(eq(#0, #15, #31)) type=delta // { arity: 43 }
         implementation
           %0:big » %1:big[#1]KAe » %2:big[#2]KA

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -543,7 +543,7 @@ WHERE (a < 3 OR a > 0 OR a < 7) AND b IN ('l1', 'l2', 'l3', 'l9') AND (b like 'l
 ----
 Explained Query (fast path):
   Project (#1)
-    Filter ((#1 < 3) OR (#1 < 7) OR (#1 > 0)) AND ("l%" ~~(#0) OR (#1 > 5))
+    Filter ((#1 < 3) OR (#1 < 7) OR (#1 > 0)) AND (like["l%"](#0) OR (#1 > 5))
       ReadExistingIndex materialize.public.idx_t1_b lookup_values=[("l1"); ("l2"); ("l3"); ("l9")]
 
 Used Indexes:
@@ -564,7 +564,7 @@ WHERE ((b = 'l1' AND a = 1) OR (a = 2 AND b = 'l2')) AND (b like 'nonono' OR (b 
 ----
 Explained Query (fast path):
   Project (#0, #1)
-    Filter ("nonono" ~~(#1) OR ("l%" ~~(#1) AND (#0 < 10)))
+    Filter (like["nonono"](#1) OR (like["l%"](#1) AND (#0 < 10)))
       ReadExistingIndex materialize.public.idx_t1_a_b lookup_values=[(1, "l1"); (2, "l2")]
 
 Used Indexes:
@@ -621,7 +621,7 @@ WHERE (
 ----
 Explained Query (fast path):
   Project (#0)
-    Filter ("aaa" ~~(#1) OR "l%" ~~(#1)) AND ((#0 = 2) OR ("nope" ~~(#1) AND (#0 = 1)))
+    Filter (like["aaa"](#1) OR like["l%"](#1)) AND ((#0 = 2) OR (like["nope"](#1) AND (#0 = 1)))
       ReadExistingIndex materialize.public.idx_t1_a lookup_values=[(1); (2)]
 
 Used Indexes:

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -269,7 +269,7 @@ Explained Query:
     Union // { non_negative: false }
       Get l0 // { non_negative: true }
       Negate // { non_negative: false }
-        Filter "J%" ~~(#0) // { non_negative: true }
+        Filter like["J%"](#0) // { non_negative: true }
           Get l0 // { non_negative: true }
   With
     cte l0 =
@@ -329,7 +329,7 @@ Explained Query:
     Union // { non_negative: false }
       Get l0 // { non_negative: false }
       Negate // { non_negative: false }
-        Filter "P%" ~~(#1) // { non_negative: false }
+        Filter like["P%"](#1) // { non_negative: false }
           Get l0 // { non_negative: false }
   With
     cte l0 =
@@ -337,7 +337,7 @@ Explained Query:
         Union // { non_negative: false }
           Get materialize.public.people // { non_negative: true }
           Negate // { non_negative: false }
-            Filter "J%" ~~(#1) // { non_negative: true }
+            Filter like["J%"](#1) // { non_negative: true }
               Get materialize.public.people // { non_negative: true }
 
 EOF


### PR DESCRIPTION
(Doc changes are only in the first commit. They are described [here](https://materializeinc.slack.com/archives/CPNFV9CVB/p1688728226054109).)

This is a fix for most of the bugs described here: https://github.com/MaterializeInc/materialize/issues/18494#issuecomment-1624061454
The only thing I didn't fix is the serde serialization, but this is not currently used for anything important (see comments in the code).

The approach for fixing the protobuf serialization is to add the pattern string and the `case_insensitive` flag in our `Regex` wrapper struct, and write a serializer for our wrapper struct that serializes these fields (but not the actual compiled regex), and rebuild the compiled regex from these fields when deserializing.

The last commit adds a lot more tests for all this functionality. This involves testing with 3 levels of const folding:
- Full const folding, where all mentions of regexes or LIKE disappear.
- Partial const folding, where the binary (or variadic) version of regex functions or LIKE functions are changed to unary versions that hardcode the regex (so that it doesn't need to be compiled at every invocation).
- No const folding, where the pattern comes from the data.

FYI @mjibson: we are probably gonna have some merge conflicts with https://github.com/MaterializeInc/materialize/pull/20585.

### Motivation

  * This PR fixes a recognized bug and several other bugs, see [here](https://github.com/MaterializeInc/materialize/issues/18494#issuecomment-1624061454).

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
