### PR TITLE
webhooks: Special case error! message in CI

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -55,6 +55,8 @@ ERROR_RE = re.compile(
     (?!.*timely\ communication\ error:)
     # Expected once compute cluster has panicked, only happens in CI
     (?!.*aborting\ because\ propagate_crashes\ is\ enabled)
+    # Emitted by webhook source tests that explicitly panic the validation.
+    (?!.*panic\ while\ validating\ webhook\ request')
     """,
     re.VERBOSE,
 )


### PR DESCRIPTION
### Motivation

Fixes #20544

For webhook sources we catch any panic that occurs during validation, and then complain about it loudly using `tracing::error!`, which gets reported to Sentry. We have a testdrive case that purposefully panics CI, this PR special cases the error message we return as to not fail CI.

Note: if there actually is a panic caused in CI, then we would return a 500 for the webhook request, or fail to append data, so a different assert could catch the panic.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
