### PR TITLE
bug: Fix potential OOM in csv_extract

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3122,12 +3122,22 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     Some(ncols) => ncols,
                 };
                 let ncols = usize::try_from(ncols).expect("known to be greater than zero");
+
+                // Prevent OOMing if the user requests some extremely large number of columns.
+                let mut column_names = Vec::new();
+                if let Err(_) = column_names.try_reserve(ncols) {
+                    sql_bail!("csv_extract number of columns too large");
+                };
+                for i in 1..=ncols {
+                    column_names.push(format!("column{}", i).into());
+                }
+
                 Ok(TableFuncPlan {
                     expr: HirRelationExpr::CallTable {
                         func: TableFunc::CsvExtract(ncols),
                         exprs: vec![input],
                     },
-                    column_names: (1..=ncols).map(|i| format!("column{}", i).into()).collect(),
+                    column_names,
                 })
             }) => ReturnType::set_of(RecordAny), oid::FUNC_CSV_EXTRACT_OID;
         },

--- a/test/testdrive/oom.td
+++ b/test/testdrive/oom.td
@@ -104,3 +104,6 @@ contains:result exceeds max size of 56 B
 
 $ postgres-execute connection=mz_system
 ALTER SYSTEM RESET max_result_size
+
+! SELECT csv_extract(9223372036854775807, '');
+contains:csv_extract number of columns too large


### PR DESCRIPTION
### Motivation

Fixes #20545 

In `csv_extract` we allocate a Vec of column names based on a user provided Int64. This made it possible for a user to request a Vec that contains Int64::MAX number of items, for which we'd certainly OOM. This PR uses the `Vec::try_reserve` API and bails if we can't store the requested number of column names.

It also adds a test in `oom.td` that I verified panicked before the fix, and returns the expected error after the fix.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes a possible, but never reported, panic in csv_extract
