### PR TITLE
Fix remaining `cloud.materialize.com` references.

### DIFF
--- a/doc/developer/platform/ux.md
+++ b/doc/developer/platform/ux.md
@@ -74,8 +74,8 @@ concepts](#user-facing-concepts) section below.
 
 ### Web UI
 
-We will evolve the existing Materialize Cloud web UI
-(<https://cloud.materialize.com>) to reflect the new hierarchy of concepts. The
+We will evolve the existing Materialize web UI
+(<https://console.materialize.com>) to reflect the new hierarchy of concepts. The
 following wireframe is a very rough sketch of what the Materialize Platform
 UI could look like:
 
@@ -118,7 +118,7 @@ authentication. Here is a rough sketch of the interface:
 
 ```shell
 $ mzcloud login aj@foocorp.com
-Opening https://cloud.materialize.com/login/SFB33-47281 in your browser...
+Opening https://console.materialize.com/login/SFB33-47281 in your browser...
 $ mzcloud connect aws:us-east-1
 psql (14.1)
 Type "help" for help.

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -266,7 +266,7 @@
 
 * Support the `sslcert`, `sslkey`, and `sslrootcert` parameters for specifying a
   TLS client certificate. Notably, this allows using `dbt-materialize` with the
-  new architecture of [Materialize](https://cloud.materialize.com).
+  new architecture of [Materialize](https://console.materialize.com).
 
 ## 0.18.1.post2 - 2021-04-21
 


### PR DESCRIPTION
### Motivation

Fix links that still point to `cloud.materialize.com`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
