### PR TITLE
ci: upload debuginfo to polar signals

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -179,6 +179,7 @@ case "$cmd" in
             --env NIGHTLY_CANARY_CONFLUENT_CLOUD_API_KEY
             --env NIGHTLY_CANARY_CONFLUENT_CLOUD_API_SECRET
             --env NO_COLOR
+            --env POLAR_SIGNALS_API_TOKEN
             --env PYPI_TOKEN
             # For Miri with nightly Rust
             --env ZOOKEEPER_ADDR

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -103,7 +103,7 @@ files=$(cat \
         <(git diff --name-only -z 4b825dc642cb6eb9a060e54bf8d69288fbee4904 ci/builder) \
         <(git ls-files --others --exclude-standard -z ci/builder) \
     | LC_ALL=C sort -z \
-    | xargs -0 sha1sum)
+    | xargs -0 "$shasum")
 files+="
 rust-version:$rust_version
 rust-date:$rust_date

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -128,7 +128,7 @@ RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.3.0/au
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose \
     && curl -fsSL https://github.com/christian-korneck/docker-pushrm/releases/download/v1.9.0/docker-pushrm_linux_$ARCH_GO > /usr/local/lib/docker/cli-plugins/docker-pushrm \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-pushrm \
-    && curl -fsSL https://github.com/parca-dev/parca-debuginfo/releases/download/v0.7.0/parca-debuginfo_0.7.0_Linux_$($ARCH_GCC | sed "s/aarch64/arm64/").tar.gz \
+    && curl -fsSL https://github.com/parca-dev/parca-debuginfo/releases/download/v0.7.0/parca-debuginfo_0.7.0_Linux_$(echo "$ARCH_GCC" | sed "s/aarch64/arm64/").tar.gz \
     | tar xz -C /usr/local/bin parca-debuginfo
 
 ENTRYPOINT ["autouseradd", "--user", "materialize"]

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -127,7 +127,9 @@ RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.3.0/au
     && curl -fsSL https://github.com/docker/compose/releases/download/v2.15.1/docker-compose-linux-$ARCH_GCC > /usr/local/lib/docker/cli-plugins/docker-compose \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose \
     && curl -fsSL https://github.com/christian-korneck/docker-pushrm/releases/download/v1.9.0/docker-pushrm_linux_$ARCH_GO > /usr/local/lib/docker/cli-plugins/docker-pushrm \
-    && chmod +x /usr/local/lib/docker/cli-plugins/docker-pushrm
+    && chmod +x /usr/local/lib/docker/cli-plugins/docker-pushrm \
+    && curl -fsSL https://github.com/parca-dev/parca-debuginfo/releases/download/v0.7.0/parca-debuginfo_0.7.0_Linux_$($ARCH_GCC | sed "s/aarch64/arm64/").tar.gz \
+    | tar xz -C /usr/local/bin parca-debuginfo
 
 ENTRYPOINT ["autouseradd", "--user", "materialize"]
 

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -295,6 +295,21 @@ class S3UploadDebuginfo(PreImage):
                     Tagging={"TagSet": [{"Key": "ephemeral", "Value": ephemeral_str}]},
                 )
 
+            polar_signals_api_token = os.getenv("POLAR_SIGNALS_API_TOKEN")
+            if self.rd.stable and polar_signals_api_token is not None:
+                print("Attempting to upload debug info to polar signals")
+                spawn.runv(
+                    [
+                        "/usr/local/bin/parca-debuginfo",
+                        "upload",
+                        "--store-address=grpc.polarsignals.com:443",
+                        "--no-extract",
+                        self.dbg_path,
+                    ],
+                    cwd=self.rd.root,
+                    env={"PARCA_DEBUGINFO_BEARER_TOKEN": polar_signals_api_token},
+                )
+
     def inputs(self) -> Set[str]:
         return {self.exe_path, self.dbg_path}
 


### PR DESCRIPTION

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
