### PR TITLE
docs: Consolidate access privilege function docs

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -746,16 +746,6 @@
   - signature: 'is_rbac_enabled() -> boolean'
     description: Reports whether RBAC is enabled for the current session.
 
-- type: Access privilege inquiry
-  description: |
-    Functions that return information about access privileges.
-  functions:
-    - signature: 'has_table_privilege([role: text or oid, ]relation: text or oid, privileges: text) -> bool'
-      description: >-
-        Reports whether the role with the specified role name or `oid` has the
-        specified privileges on the relation with the specified relation name
-        or `oid`. If the role is omitted, the `current_role` is assumed.
-
 - type: PostgreSQL compatibility
   description: |
     Functions whose primary purpose is to facilitate compatibility with PostgreSQL tools.


### PR DESCRIPTION
Previously, there were two identical function types in the function documentation for access privilege inquiry functions. All access privilege inquiry functions were spread across the two types. This was likely due to merge skew and not done on purpose. This commit consolidates the two types into a single type.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
