### PR TITLE
Minimal subset of statement logging needed for collecting metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1982,6 +1982,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "exclusion-set"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3708c48ed7245587498d116a41566942d6d9943f5b3207fbf522e2bd0b72d0"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "fail"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,6 +2277,19 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
 ]
 
 [[package]]
@@ -3110,6 +3132,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3434,6 +3469,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "prost",
+ "qcell",
  "rand",
  "rdkafka",
  "regex",
@@ -6376,6 +6412,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "qcell"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f6c04aa3dea4dab485f6d87449ba94d5664c388c0f1fe2b07c4891175513345"
+dependencies = [
+ "exclusion-set",
+ "once_cell",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6769,6 +6815,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 1.0.107",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -8516,6 +8568,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,7 @@ wrappers = [
     "env_logger",
     "eventsource-client",
     "fail",
+    "generator",
     "globset",
     "hyper-rustls",
     "jsonpath_lib",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -54,6 +54,7 @@ prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
+qcell = "0.5"
 rand = "0.8.5"
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = "1.7.0"

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -717,7 +717,7 @@ impl CatalogState {
         // case during catalog rehydration in order to avoid panics.
         session_catalog.system_vars_mut().enable_all_feature_flags();
 
-        let stmt = mz_sql::parse::parse(&create_sql)?.into_element();
+        let stmt = mz_sql::parse::parse(&create_sql)?.into_element().ast;
         let (stmt, resolved_ids) = mz_sql::names::resolve(&session_catalog, stmt)?;
         let plan = mz_sql::plan::plan(None, &session_catalog, stmt, &Params::empty())?;
         Ok(match plan {
@@ -2487,7 +2487,8 @@ impl CatalogItem {
         let do_rewrite = |create_sql: String| -> Result<String, String> {
             let mut create_stmt = mz_sql::parse::parse(&create_sql)
                 .expect("invalid create sql persisted to catalog")
-                .into_element();
+                .into_element()
+                .ast;
             if rename_self {
                 mz_sql::ast::transform::create_stmt_rename(&mut create_stmt, to_item_name.clone());
             }
@@ -3082,7 +3083,8 @@ impl CatalogItemRebuilder {
             assert_ne!(create_sql.to_lowercase(), CREATE_SQL_TODO.to_lowercase());
             let mut create_stmt = mz_sql::parse::parse(&create_sql)
                 .expect("invalid create sql persisted to catalog")
-                .into_element();
+                .into_element()
+                .ast;
             mz_sql::ast::transform::create_stmt_replace_ids(&mut create_stmt, ancestor_ids);
             Self::Object {
                 id,
@@ -5461,7 +5463,8 @@ impl Catalog {
                     // (And then make any other changes to the source definition to match.)
                     let mut stmt = mz_sql::parse::parse(&old_sink.create_sql)
                         .expect("invalid create sql persisted to catalog")
-                        .into_element();
+                        .into_element()
+                        .ast;
 
                     let create_stmt = match &mut stmt {
                         Statement::CreateSink(s) => s,
@@ -5551,7 +5554,8 @@ impl Catalog {
                     // (And then make any other changes to the source definition to match.)
                     let mut stmt = mz_sql::parse::parse(&old_source.create_sql)
                         .expect("invalid create sql persisted to catalog")
-                        .into_element();
+                        .into_element()
+                        .ast;
 
                     let create_stmt = match &mut stmt {
                         Statement::CreateSource(s) => s,
@@ -7327,7 +7331,7 @@ impl Catalog {
         // case during catalog rehydration in order to avoid panics.
         session_catalog.system_vars_mut().enable_all_feature_flags();
 
-        let stmt = mz_sql::parse::parse(&create_sql)?.into_element();
+        let stmt = mz_sql::parse::parse(&create_sql)?.into_element().ast;
         let (stmt, resolved_ids) = mz_sql::names::resolve(&session_catalog, stmt)?;
         let plan = mz_sql::plan::plan(pcx, &session_catalog, stmt, &Params::empty())?;
         Ok(match plan {
@@ -9707,7 +9711,8 @@ mod tests {
                 "create view public.foo as select 1 as bar",
             )
             .expect("")
-            .into_element();
+            .into_element()
+            .ast;
 
             let (stmt, _) = names::resolve(scx.catalog, parsed).expect("");
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -655,10 +655,11 @@ impl CatalogState {
         view: &View,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
-        let create_sql = mz_sql::parse::parse(&view.create_sql)
+        let create_stmt = mz_sql::parse::parse(&view.create_sql)
             .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", view.create_sql))
-            .into_element();
-        let query = match create_sql {
+            .into_element()
+            .ast;
+        let query = match create_stmt {
             Statement::CreateView(stmt) => stmt.definition.query,
             _ => unreachable!(),
         };
@@ -694,10 +695,11 @@ impl CatalogState {
         mview: &MaterializedView,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
-        let create_sql = mz_sql::parse::parse(&mview.create_sql)
+        let create_stmt = mz_sql::parse::parse(&mview.create_sql)
             .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", mview.create_sql))
-            .into_element();
-        let query = match create_sql {
+            .into_element()
+            .ast;
+        let query = match create_stmt {
             Statement::CreateMaterializedView(stmt) => stmt.query,
             _ => unreachable!(),
         };
@@ -788,6 +790,7 @@ impl CatalogState {
         let key_sqls = match mz_sql::parse::parse(&index.create_sql)
             .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", index.create_sql))
             .into_element()
+            .ast
         {
             Statement::CreateIndex(CreateIndexStatement { key_parts, .. }) => {
                 key_parts.expect("key_parts is filled in during planning")

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -42,7 +42,7 @@ where
         privileges: _,
     } in items
     {
-        let mut stmt = mz_sql::parse::parse(&create_sql)?.into_element();
+        let mut stmt = mz_sql::parse::parse(&create_sql)?.into_element().ast;
 
         f(tx, &cat, &mut stmt).await?;
 

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -27,7 +27,7 @@ use mz_sql::ast::{Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
 use mz_sql::session::hint::ApplicationNameHint;
 use mz_sql::session::user::{User, INTROSPECTION_USER};
-use mz_sql_parser::parser::ParserStatementError;
+use mz_sql_parser::parser::{ParserStatementError, StatementParseResult};
 use prometheus::Histogram;
 use serde_json::json;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -204,12 +204,12 @@ impl Client {
         if stmts.len() != 1 {
             bail!("must supply exactly one query");
         }
-        let stmt = stmts.into_element();
+        let StatementParseResult { ast: stmt, sql } = stmts.into_element();
 
         const EMPTY_PORTAL: &str = "";
         session_client.start_transaction(Some(1))?;
         session_client
-            .declare(EMPTY_PORTAL.into(), stmt, vec![])
+            .declare(EMPTY_PORTAL.into(), stmt, sql.to_string(), vec![])
             .await?;
         match session_client
             .execute(EMPTY_PORTAL.into(), futures::future::pending())
@@ -283,10 +283,10 @@ pub struct SessionClient {
 impl SessionClient {
     /// Parses a SQL expression, reporting failures as a telemetry event if
     /// possible.
-    pub fn parse(
+    pub fn parse<'a>(
         &self,
-        sql: &str,
-    ) -> Result<Result<Vec<Statement<Raw>>, ParserStatementError>, String> {
+        sql: &'a str,
+    ) -> Result<Result<Vec<StatementParseResult<'a>>, ParserStatementError>, String> {
         match mz_sql::parse::parse_with_limit(sql) {
             Ok(Err(e)) => {
                 self.track_statement_parse_failure(&e);
@@ -376,11 +376,13 @@ impl SessionClient {
         &mut self,
         name: String,
         stmt: Option<Statement<Raw>>,
+        sql: String,
         param_types: Vec<Option<ScalarType>>,
     ) -> Result<(), AdapterError> {
         self.send(|tx, session| Command::Prepare {
             name,
             stmt,
+            sql,
             param_types,
             session,
             tx,
@@ -393,11 +395,13 @@ impl SessionClient {
         &mut self,
         name: String,
         stmt: Statement<Raw>,
+        sql: String,
         param_types: Vec<Option<ScalarType>>,
     ) -> Result<(), AdapterError> {
         self.send(|tx, session| Command::Declare {
             name,
             stmt,
+            inner_sql: sql,
             param_types,
             session,
             tx,

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -48,6 +48,7 @@ pub enum Command {
     Declare {
         name: String,
         stmt: Statement<Raw>,
+        inner_sql: String,
         param_types: Vec<Option<ScalarType>>,
         session: Session,
         tx: oneshot::Sender<Response<ExecuteResponse>>,
@@ -56,6 +57,7 @@ pub enum Command {
     Prepare {
         name: String,
         stmt: Option<Statement<Raw>>,
+        sql: String,
         param_types: Vec<Option<ScalarType>>,
         session: Session,
         tx: oneshot::Sender<Response<()>>,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -141,6 +141,7 @@ use crate::{flags, AdapterNotice};
 
 pub(crate) mod id_bundle;
 pub(crate) mod peek;
+pub(crate) mod statement_logging;
 pub(crate) mod timeline;
 pub(crate) mod timestamp_selection;
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -30,11 +30,11 @@ use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::{introspection, Coordinator, Message};
 use crate::error::AdapterError;
 use crate::notice::AdapterNotice;
-use crate::session::{EndTransactionAction, PreparedStatement, Session, TransactionStatus};
+use crate::session::{EndTransactionAction, Session, TransactionStatus};
 use crate::util::send_immediate_rows;
 use crate::{rbac, ExecuteContext};
 
-// DO NOT make this visible in anyway, i.e. do not add any version of
+// DO NOT make this visible in any way, i.e. do not add any version of
 // `pub` to this mod. The inner `sequence_X` methods are hidden in this
 // private module to prevent anyone from calling them directly. All
 // sequencing should be done through the `sequence_plan` method.
@@ -396,7 +396,7 @@ impl Coordinator {
             }
             Plan::Declare(plan) => {
                 let param_types = vec![];
-                self.declare(ctx, plan.name, plan.stmt, param_types);
+                self.declare(ctx, plan.name, plan.stmt, plan.sql, param_types);
             }
             Plan::Fetch(FetchPlan {
                 name,
@@ -426,11 +426,10 @@ impl Coordinator {
                 } else {
                     ctx.session_mut().set_prepared_statement(
                         plan.name,
-                        PreparedStatement::new(
-                            Some(plan.stmt),
-                            plan.desc,
-                            self.catalog().transient_revision(),
-                        ),
+                        Some(plan.stmt),
+                        plan.sql,
+                        plan.desc,
+                        self.catalog().transient_revision(),
                     );
                     ctx.retire(Ok(ExecuteResponse::Prepare));
                 }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -430,6 +430,7 @@ impl Coordinator {
                         plan.sql,
                         plan.desc,
                         self.catalog().transient_revision(),
+                        self.now(),
                     );
                     ctx.retire(Ok(ExecuteResponse::Prepare));
                 }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -12,6 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::iter;
 use std::num::{NonZeroI64, NonZeroUsize};
 use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
@@ -4402,7 +4403,8 @@ impl Coordinator {
         let stmt = ps.stmt().cloned();
         let desc = ps.desc().clone();
         let revision = ps.catalog_revision;
-        session.create_new_portal(stmt, desc, plan.params, Vec::new(), revision)
+        let logging = Arc::clone(ps.logging());
+        session.create_new_portal(stmt, logging, desc, plan.params, Vec::new(), revision)
     }
 
     pub(super) async fn sequence_grant_privileges(

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -112,7 +112,7 @@ use crate::util::{
 };
 use crate::{guard_write_critical_section, PeekResponseUnary, TimestampExplanation};
 
-/// Attempts to execute an expression. If an error is returned then the error is sent
+/// Attempts to evaluate an expression. If an error is returned then the error is sent
 /// to the client and the function is exited.
 macro_rules! return_if_err {
     ($expr:expr, $ctx:expr) => {
@@ -3785,6 +3785,7 @@ impl Coordinator {
             let create_source_stmt = match mz_sql::parse::parse(create_source_sql)
                 .expect("invalid create sql persisted to catalog")
                 .into_element()
+                .ast
             {
                 Statement::CreateSource(stmt) => stmt,
                 _ => unreachable!("proved type is source"),

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -57,17 +57,18 @@ impl Coordinator {
         catalog: &Catalog,
         name: String,
         stmt: Statement<Raw>,
-        // TODO[btv] - This will be used by statement logging
-        _sql: String,
+        sql: String,
         param_types: Vec<Option<ScalarType>>,
     ) -> Result<(), AdapterError> {
         let desc = describe(catalog, stmt.clone(), &param_types, session)?;
         let params = vec![];
         let result_formats = vec![mz_pgrepr::Format::Text; desc.arity()];
+        let logging = session.mint_logging(sql);
         session.set_portal(
             name,
             desc,
             Some(stmt),
+            logging,
             params,
             result_formats,
             catalog.transient_revision(),

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -1,0 +1,68 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use mz_ore::{cast::CastFrom, now::EpochMillis};
+use qcell::QCell;
+use uuid::Uuid;
+
+use crate::session::Session;
+
+use super::Coordinator;
+
+/// Metadata required for logging a prepared statement.
+#[derive(Debug)]
+pub enum PreparedStatementLoggingInfo {
+    /// The statement has already been logged; we don't need to log it
+    /// again if a future execution hits the sampling rate; we merely
+    /// need to reference the corresponding UUID.
+    ///
+    /// In this PR, this variant is never instantiated, because we are not
+    /// actually logging the prepared statements yet.
+    AlreadyLogged { uuid: Uuid },
+    /// The statement has not yet been logged; if a future execution
+    /// hits the sampling rate, we need to log it at that point.
+    StillToLog {
+        /// The SQL text of the statement.
+        sql: String,
+        /// When the statement was prepared
+        prepared_at: EpochMillis,
+        /// The name with which the statement was prepared
+        name: String,
+        /// The ID of the session that prepared the statement
+        session_id: Uuid,
+        /// Whether we have already recorded this in the "would have logged" metric
+        accounted: bool,
+    },
+}
+
+impl Coordinator {
+    /// Record metrics related to the future "statement logging" feature.
+    pub fn begin_statement_execution(
+        &mut self,
+        session: &mut Session,
+        logging: &Arc<QCell<PreparedStatementLoggingInfo>>,
+    ) {
+        if let Some((sql, accounted)) = match session.qcell_rw(logging) {
+            PreparedStatementLoggingInfo::AlreadyLogged { .. } => None,
+            PreparedStatementLoggingInfo::StillToLog { sql, accounted, .. } => {
+                Some((sql, accounted))
+            }
+        } {
+            if !*accounted {
+                self.metrics
+                    .statement_logging_unsampled_bytes
+                    .with_label_values(&[])
+                    .inc_by(u64::cast_from(sql.len()));
+                *accounted = true;
+            }
+        }
+    }
+}

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -29,6 +29,7 @@ pub struct Metrics {
     pub canceled_peeks: IntCounterVec,
     pub linearize_message_seconds: HistogramVec,
     pub time_to_first_row_seconds: HistogramVec,
+    pub statement_logging_unsampled_bytes: IntCounterVec,
 }
 
 impl Metrics {
@@ -96,6 +97,10 @@ impl Metrics {
                 var_labels: ["isolation_level"],
                 buckets: histogram_seconds_buckets(0.000_128, 8.0)
             }),
+            statement_logging_unsampled_bytes: registry.register(metric!(
+                name: "mz_statement_logging_unsampled_bytes",
+                help: "The total amount of SQL text that would have been logged if statement logging were unsampled.",
+            )),
         }
     }
 }

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -1146,7 +1146,11 @@ fn generate_required_privileges(
         | Plan::AlterSystemSet(AlterSystemSetPlan { name: _, value: _ })
         | Plan::AlterSystemReset(AlterSystemResetPlan { name: _ })
         | Plan::AlterSystemResetAll(AlterSystemResetAllPlan {})
-        | Plan::Declare(DeclarePlan { name: _, stmt: _ })
+        | Plan::Declare(DeclarePlan {
+            name: _,
+            stmt: _,
+            sql: _,
+        })
         | Plan::Fetch(FetchPlan {
             name: _,
             count: _,
@@ -1157,6 +1161,7 @@ fn generate_required_privileges(
             name: _,
             stmt: _,
             desc: _,
+            sql: _,
         })
         | Plan::Execute(ExecutePlan { name: _, params: _ })
         | Plan::Deallocate(DeallocatePlan { name: _ })

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -493,7 +493,20 @@ impl<T: TimestampManipulation> Session<T> {
     }
 
     /// Registers the prepared statement under `name`.
-    pub fn set_prepared_statement(&mut self, name: String, statement: PreparedStatement) {
+    pub fn set_prepared_statement(
+        &mut self,
+        name: String,
+        stmt: Option<Statement<Raw>>,
+        // TODO[btv] - This will be used by statement logging
+        _sql: String,
+        desc: StatementDesc,
+        catalog_revision: u64,
+    ) {
+        let statement = PreparedStatement {
+            stmt,
+            desc,
+            catalog_revision,
+        };
         self.prepared_statements.insert(name, statement);
     }
 
@@ -735,19 +748,6 @@ pub struct PreparedStatement {
 }
 
 impl PreparedStatement {
-    /// Constructs a new prepared statement.
-    pub fn new(
-        stmt: Option<Statement<Raw>>,
-        desc: StatementDesc,
-        catalog_revision: u64,
-    ) -> PreparedStatement {
-        PreparedStatement {
-            stmt,
-            desc,
-            catalog_revision,
-        }
-    }
-
     /// Returns the AST associated with this prepared statement,
     /// if the prepared statement was not the empty query.
     pub fn stmt(&self) -> Option<&Statement<Raw>> {

--- a/src/adapter/tests/parameters.rs
+++ b/src/adapter/tests/parameters.rs
@@ -176,7 +176,7 @@ async fn test_parameter_type_inference() {
     Catalog::with_debug(NOW_ZERO.clone(), |catalog| async move {
         let catalog = catalog.for_system_session();
         for (sql, types) in test_cases {
-            let stmt = mz_sql::parse::parse(sql).unwrap().into_element();
+            let stmt = mz_sql::parse::parse(sql).unwrap().into_element().ast;
             let (stmt, _) = mz_sql::names::resolve(&catalog, stmt).unwrap();
             let desc = mz_sql::plan::describe(&PlanContext::zero(), &catalog, stmt, &[]).unwrap();
             assert_eq!(desc.param_types, types);

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -179,7 +179,7 @@ async fn datadriven() {
                             let pcx = &PlanContext::zero();
                             let scx = StatementContext::new(Some(pcx), &catalog);
                             let qcx = QueryContext::root(&scx, QueryLifetime::OneShot);
-                            let q = parsed[0].clone();
+                            let q = parsed[0].ast.clone();
                             let q = match q {
                                 Statement::Select(s) => s.query,
                                 _ => unreachable!(),

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -9,6 +9,7 @@
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::anyhow;
@@ -947,10 +948,12 @@ async fn execute_stmt<S: ResultSender>(
     let desc = prep_stmt.desc().clone();
     let revision = prep_stmt.catalog_revision;
     let stmt = prep_stmt.stmt().cloned();
+    let logging = Arc::clone(prep_stmt.logging());
     if let Err(err) = client.session().set_portal(
         EMPTY_PORTAL.into(),
         desc,
         stmt,
+        logging,
         params,
         result_formats,
         revision,

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -92,7 +92,9 @@ use mz_environmentd::http::{
     BecomeLeaderResponse, BecomeLeaderResult, LeaderStatus, LeaderStatusResponse,
 };
 use mz_environmentd::WebSocketResponse;
+use mz_ore::cast::CastFrom;
 use mz_ore::cast::CastLossy;
+use mz_ore::cast::TryCastFrom;
 use mz_ore::now::NowFn;
 use mz_ore::retry::Retry;
 use mz_ore::task;
@@ -188,6 +190,78 @@ fn test_persistence() {
             .collect::<Vec<String>>(),
         vec!["u1", "u2", "u3", "u4", "u5", "u6", "u7"]
     );
+}
+
+#[mz_ore::test]
+fn test_statement_logging_unsampled_metrics() {
+    let server = util::start_server(util::Config::default()).unwrap();
+    let mut client = server.connect(postgres::NoTls).unwrap();
+
+    // TODO[btv]
+    //
+    // The point of these metrics is to show how much SQL text we
+    // would have logged had statement logging been turned on.
+    // Since there is no way (yet) to turn statement logging off or on,
+    // this test is valid as-is currently. However, once we turn statement logging on,
+    // we should make sure to turn it _off_ in this test.
+    let batch_queries = [
+        "SELECT 'Hello, world!';SELECT 1;;",
+        "SELECT 'Hello, world again!'",
+    ];
+    let batch_total: usize = batch_queries
+        .iter()
+        .map(|s| s.as_bytes().iter().filter(|&&ch| ch != b';').count())
+        .sum();
+    let single_queries = ["SELECT 'foo'", "SELECT 'bar';;;"];
+    let single_total: usize = single_queries
+        .iter()
+        .map(|s| s.as_bytes().iter().filter(|&&ch| ch != b';').count())
+        .sum();
+    let prepared_queries = ["SELECT 'baz';;;", "SELECT 'quux';"];
+    let prepared_total: usize = prepared_queries
+        .iter()
+        .map(|s| s.as_bytes().iter().filter(|&&ch| ch != b';').count())
+        .sum();
+
+    let named_prepared_inner = "SELECT 42";
+    let named_prepared_outer = format!("PREPARE p AS {named_prepared_inner};EXECUTE p;");
+    let named_prepared_total = named_prepared_inner.len()
+        + named_prepared_outer
+            .as_bytes()
+            .iter()
+            .filter(|&&ch| ch != b';')
+            .count();
+
+    for q in batch_queries {
+        client.batch_execute(q).unwrap();
+    }
+
+    for q in single_queries {
+        client.execute(q, &[]).unwrap();
+    }
+
+    for q in prepared_queries {
+        let s = client.prepare(q).unwrap();
+        client.execute(&s, &[]).unwrap();
+    }
+
+    client.batch_execute(&named_prepared_outer).unwrap();
+
+    // This should NOT be logged, since we never actually execute it.
+    client.prepare("SELECT 'Hello, not counted!'").unwrap();
+
+    let expected_total = batch_total + single_total + prepared_total + named_prepared_total;
+    let metric_value = server
+        .metrics_registry
+        .gather()
+        .into_iter()
+        .find(|m| m.get_name() == "mz_statement_logging_unsampled_bytes")
+        .unwrap()
+        .take_metric()[0]
+        .get_counter()
+        .get_value();
+    let metric_value = usize::cast_from(u64::try_cast_from(metric_value).unwrap());
+    assert_eq!(expected_total, metric_value);
 }
 
 // Test that sources and sinks require an explicit `SIZE` parameter outside of

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -925,11 +925,13 @@ where
 
         let desc = stmt.desc().clone();
         let revision = stmt.catalog_revision;
+        let logging = Arc::clone(stmt.logging());
         let stmt = stmt.stmt().cloned();
         if let Err(err) = self.adapter_client.session().set_portal(
             portal_name,
             desc,
             stmt,
+            logging,
             params,
             result_formats,
             revision,

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -32,6 +32,7 @@ use mz_pgcopy::CopyFormatParams;
 use mz_repr::{Datum, GlobalId, RelationDesc, RelationType, Row, RowArena, ScalarType};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{FetchDirection, Ident, Raw, Statement};
+use mz_sql::parse::StatementParseResult;
 use mz_sql::plan::{CopyFormat, ExecuteTimeout, StatementDesc};
 use mz_sql::session::user::{ExternalUserMetadata, User, INTERNAL_USER_NAMES};
 use mz_sql::session::vars::{ConnectionCounter, DropConnection, VarInput};
@@ -575,14 +576,14 @@ where
         }
     }
 
-    async fn one_query(&mut self, stmt: Statement<Raw>) -> Result<State, io::Error> {
+    async fn one_query(&mut self, stmt: Statement<Raw>, sql: String) -> Result<State, io::Error> {
         // Bind the portal. Note that this does not set the empty string prepared
         // statement.
         let param_types = vec![];
         const EMPTY_PORTAL: &str = "";
         if let Err(e) = self
             .adapter_client
-            .declare(EMPTY_PORTAL.to_string(), stmt, param_types)
+            .declare(EMPTY_PORTAL.to_string(), stmt, sql, param_types)
             .await
         {
             return self
@@ -655,7 +656,7 @@ where
         assert!(res.is_ok());
     }
 
-    fn parse_sql(&self, sql: &str) -> Result<Vec<Statement<Raw>>, ErrorResponse> {
+    fn parse_sql<'b>(&self, sql: &'b str) -> Result<Vec<StatementParseResult<'b>>, ErrorResponse> {
         match self.adapter_client.parse(sql) {
             Ok(result) => result.map_err(|e| {
                 // Convert our 0-based byte position to pgwire's 1-based character
@@ -683,7 +684,7 @@ where
         let num_stmts = stmts.len();
 
         // Compare with postgres' backend/tcop/postgres.c exec_simple_query.
-        for stmt in stmts {
+        for StatementParseResult { ast: stmt, sql } in stmts {
             // In an aborted transaction, reject all commands except COMMIT/ROLLBACK.
             if self.is_aborted_txn() && !is_txn_exit_stmt(Some(&stmt)) {
                 self.aborted_txn_error().await?;
@@ -699,7 +700,7 @@ where
             // statement.
             self.start_transaction(Some(num_stmts));
 
-            match self.one_query(stmt).await? {
+            match self.one_query(stmt, sql.to_string()).await? {
                 State::Ready => (),
                 State::Drain => break,
                 State::Done => return Ok(State::Done),
@@ -769,13 +770,16 @@ where
                 ))
                 .await;
         }
-        let maybe_stmt = stmts.into_iter().next();
+        let (maybe_stmt, sql) = match stmts.into_iter().next() {
+            None => (None, ""),
+            Some(StatementParseResult { ast, sql }) => (Some(ast), sql),
+        };
         if self.is_aborted_txn() && !is_txn_exit_stmt(maybe_stmt.as_ref()) {
             return self.aborted_txn_error().await;
         }
         match self
             .adapter_client
-            .prepare(name, maybe_stmt, param_types)
+            .prepare(name, maybe_stmt, sql.to_string(), param_types)
             .await
         {
             Ok(()) => {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2882,6 +2882,7 @@ pub enum IfExistsBehavior {
 pub struct DeclareStatement<T: AstInfo> {
     pub name: Ident,
     pub stmt: Box<T::NestedStatement>,
+    pub sql: String,
 }
 
 impl<T: AstInfo> AstDisplay for DeclareStatement<T> {
@@ -2982,6 +2983,7 @@ impl_display!(FetchDirection);
 pub struct PrepareStatement<T: AstInfo> {
     pub name: Ident,
     pub stmt: Box<T::NestedStatement>,
+    pub sql: String,
 }
 
 impl<T: AstInfo> AstDisplay for PrepareStatement<T> {

--- a/src/sql-parser/src/ast/visit.rs
+++ b/src/sql-parser/src/ast/visit.rs
@@ -91,7 +91,7 @@
 //!
 //!     let mut counter = SubqueryCounter { count: 0 };
 //!     for stmt in &stmts {
-//!         counter.visit_statement(stmt);
+//!         counter.visit_statement(&stmt.ast);
 //!     }
 //!     assert_eq!(counter.count, 5);
 //!     Ok(())
@@ -135,7 +135,7 @@
 //!
 //!     let mut collector = IdentCollector { idents: vec![] };
 //!     for stmt in &stmts {
-//!         collector.visit_statement(stmt);
+//!         collector.visit_statement(&stmt.ast);
 //!     }
 //!     assert_eq!(collector.idents, &[
 //!         &Ident::new("a"), &Ident::new("b"), &Ident::new("c"),

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -129,9 +129,9 @@ fn datadriven() {
                 if s.len() != 1 {
                     return "expected exactly one statement\n".to_string();
                 }
-                let stmt = s.into_element();
+                let stmt = s.into_element().ast;
                 let parsed = match parser::parse_statements(&stmt.to_string()) {
-                    Ok(parsed) => parsed.into_element(),
+                    Ok(parsed) => parsed.into_element().ast,
                     Err(err) => panic!("reparse failed: {}: {}\n", stmt, err),
                 };
                 if parsed != stmt {
@@ -375,7 +375,7 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
         seen_idents: Vec::new(),
     };
     for stmt in &stmts {
-        Visit::visit_statement(&mut visitor, stmt);
+        Visit::visit_statement(&mut visitor, &stmt.ast);
     }
     assert_eq!(visitor.seen_idents, expected);
 

--- a/src/sql-parser/tests/testdata/cursor
+++ b/src/sql-parser/tests/testdata/cursor
@@ -18,14 +18,14 @@ DECLARE "c" CURSOR WITHOUT HOLD FOR SELECT * FROM t
 ----
 DECLARE c CURSOR FOR SELECT * FROM t
 =>
-Declare(DeclareStatement { name: Ident("c"), stmt: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }) })
+Declare(DeclareStatement { name: Ident("c"), stmt: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }), sql: "SELECT * FROM t" })
 
 parse-statement
 DECLARE c CURSOR FOR SUBSCRIBE t
 ----
 DECLARE c CURSOR FOR SUBSCRIBE t
 =>
-Declare(DeclareStatement { name: Ident("c"), stmt: Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("t")]))), options: [], as_of: None, up_to: None, output: Diffs }) })
+Declare(DeclareStatement { name: Ident("c"), stmt: Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("t")]))), options: [], as_of: None, up_to: None, output: Diffs }), sql: "SUBSCRIBE t" })
 
 parse-statement
 DECLARE c CURSOR WITH HOLD FOR SELECT * FROM t;

--- a/src/sql-parser/tests/testdata/prepare
+++ b/src/sql-parser/tests/testdata/prepare
@@ -18,7 +18,7 @@ PREPARE a AS SELECT 1 + $1
 ----
 PREPARE a AS SELECT 1 + $1
 =>
-Prepare(PrepareStatement { name: Ident("a"), stmt: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Parameter(1)) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }) })
+Prepare(PrepareStatement { name: Ident("a"), stmt: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Parameter(1)) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }), sql: "SELECT 1 + $1" })
 
 parse-statement
 EXECUTE a

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -418,6 +418,7 @@ fn sql_impl_table_func_inner(
     let query = match mz_sql_parser::parser::parse_statements(sql)
         .expect("static function definition failed to parse")
         .expect_element(|| "static function definition must have exactly one statement")
+        .ast
     {
         Statement::Select(SelectStatement { query, as_of: None }) => query,
         _ => panic!("static function definition expected SELECT statement"),

--- a/src/sql/src/parse.rs
+++ b/src/sql/src/parse.rs
@@ -11,4 +11,5 @@
 
 pub use mz_sql_parser::parser::{
     parse_statements as parse, parse_statements_with_limit as parse_with_limit,
+    StatementParseResult,
 };

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -937,6 +937,7 @@ pub struct RotateKeysPlan {
 pub struct DeclarePlan {
     pub name: String,
     pub stmt: Statement<Raw>,
+    pub sql: String,
 }
 
 #[derive(Debug)]
@@ -955,6 +956,7 @@ pub struct ClosePlan {
 pub struct PreparePlan {
     pub name: String,
     pub stmt: Statement<Raw>,
+    pub sql: String,
     pub desc: StatementDesc,
 }
 

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -280,7 +280,7 @@ pub fn plan_explain(
             }
             let parsed = crate::parse::parse(view.create_sql())
                 .expect("Sql for existing view should be valid sql");
-            let query = match parsed.into_last() {
+            let query = match parsed.into_last().ast {
                 Statement::CreateView(CreateViewStatement {
                     definition: ViewDefinition { query, .. },
                     ..
@@ -305,7 +305,7 @@ pub fn plan_explain(
             }
             let parsed = crate::parse::parse(mview.create_sql())
                 .expect("Sql for existing materialized view should be valid sql");
-            let query = match parsed.into_last() {
+            let query = match parsed.into_last().ast {
                 Statement::CreateMaterializedView(CreateMaterializedViewStatement {
                     query,
                     ..

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -164,11 +164,12 @@ pub fn describe_declare(
 
 pub fn plan_declare(
     _: &StatementContext,
-    DeclareStatement { name, stmt }: DeclareStatement<Aug>,
+    DeclareStatement { name, stmt, sql }: DeclareStatement<Aug>,
 ) -> Result<Plan, PlanError> {
     Ok(Plan::Declare(DeclarePlan {
         name: name.to_string(),
         stmt: *stmt,
+        sql,
     }))
 }
 
@@ -234,7 +235,7 @@ pub fn describe_prepare(
 
 pub fn plan_prepare(
     scx: &StatementContext,
-    PrepareStatement { name, stmt }: PrepareStatement<Aug>,
+    PrepareStatement { name, stmt, sql }: PrepareStatement<Aug>,
 ) -> Result<Plan, PlanError> {
     // TODO: PREPARE supports specifying param types.
     let param_types = [];
@@ -244,6 +245,7 @@ pub fn plan_prepare(
         name: name.to_string(),
         stmt: *stmt,
         desc,
+        sql,
     }))
 }
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -675,7 +675,7 @@ impl<'a> ShowSelect<'a> {
             order.unwrap_or("q.*")
         );
         let stmts = parse::parse(&query).expect("ShowSelect::new called with invalid SQL");
-        let stmt = match stmts.into_element() {
+        let stmt = match stmts.into_element().ast {
             Statement::Select(select) => select,
             _ => panic!("ShowSelect::new called with non-SELECT statement"),
         };
@@ -701,7 +701,7 @@ impl<'a> ShowSelect<'a> {
 }
 
 fn simplify_names(catalog: &dyn SessionCatalog, sql: &str) -> Result<String, PlanError> {
-    let parsed = parse::parse(sql)?.into_element();
+    let parsed = parse::parse(sql)?.into_element().ast;
     let (mut resolved, _) = names::resolve(catalog, parsed)?;
     let mut simplifier = NameSimplifier { catalog };
     simplifier.visit_statement_mut(&mut resolved);

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1084,7 +1084,8 @@ macro_rules! feature_flags {
                     name: UncasedStr::new(stringify!($name)),
                     value: &false,
                     description: concat!("Whether ", $feature_desc, " is allowed (Materialize)."),
-                    internal: true                };
+                    internal: true
+                };
 
                 pub static [<$name:upper >]: FeatureFlag = FeatureFlag {
                     flag: &[<$name:upper _VAR>],

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1269,7 +1269,7 @@ impl OwnedVarInput {
 
 /// Session variables.
 ///
-/// See the `mz_sql::session` module documentation for more details on the
+/// See the [`crate::session::vars`] module documentation for more details on the
 /// Materialize configuration model.
 #[derive(Debug)]
 pub struct SessionVars {
@@ -1761,7 +1761,7 @@ impl DropConnection {
 
 /// On disk variables.
 ///
-/// See the `mz_sql::session` module documentation for more details on the
+/// See the [`crate::session::vars`] module documentation for more details on the
 /// Materialize configuration model.
 #[derive(Debug)]
 pub struct SystemVars {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1246,7 +1246,7 @@ impl<'a> RunnerInner<'a> {
         };
         let statement = match &*statements {
             [] => bail!("Got zero statements?"),
-            [statement] => statement,
+            [statement] => &statement.ast,
             _ => bail!("Got multiple statements: {:?}", statements),
         };
         let (is_select, num_attributes) = match statement {
@@ -2048,7 +2048,7 @@ fn generate_view_sql(
     // DDL cost drops dramatically in the future.
     let stmts = parser::parse_statements(sql).unwrap_or_default();
     assert!(stmts.len() == 1);
-    let (query, query_as_of) = match &stmts[0] {
+    let (query, query_as_of) = match &stmts[0].ast {
         Statement::Select(stmt) => (&stmt.query, &stmt.as_of),
         _ => unreachable!("This function should only be called for SELECTs"),
     };
@@ -2323,7 +2323,7 @@ fn mutate(sql: &str) -> Vec<String> {
     let stmts = parser::parse_statements(sql).unwrap_or_default();
     let mut additional = Vec::new();
     for stmt in stmts {
-        match stmt {
+        match stmt.ast {
             AstStatement::CreateTable(stmt) => additional.push(
                 // CREATE TABLE -> CREATE INDEX. Specify all columns manually in case CREATE
                 // DEFAULT INDEX ever goes away.

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -39,7 +39,7 @@ pub async fn run_sql(mut cmd: SqlCommand, state: &mut State) -> Result<ControlFl
     if stmts.len() != 1 {
         bail!("expected one statement, but got {}", stmts.len());
     }
-    let stmt = stmts.into_element();
+    let stmt = stmts.into_element().ast;
     if let SqlOutput::Full { expected_rows, .. } = &mut cmd.expected_output {
         // TODO(benesch): one day we'll support SQL queries where order matters.
         expected_rows.sort();
@@ -344,7 +344,7 @@ pub async fn run_fail_sql(
             if s.len() != 1 {
                 bail!("expected one statement, but got {}", s.len());
             }
-            Some(s.into_element())
+            Some(s.into_element().ast)
         }
         Err(_) => None,
     };


### PR DESCRIPTION
This is NOT the full statement logging PR, but it is a significant enough chunk of it that it will let us collect metrics on how many bytes of SQL we would be logging in `mz_prepared_statement_history` if the feature were turned on.

The commits are explained by their commit messages; thus, this PR should be reviewed commit-by-commit.

### Motivation

  * This PR adds a feature that has not yet been specified.

    Add metrics to see how expensive statement logging will be.

### Tips for reviewer

Review commit-by-commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None
