### PR TITLE
sql: Fix has_X_privilege role memberships

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1712,7 +1712,7 @@ macro_rules! privilege_fn {
                 )
                 END
             ",
-            $catalog_tbl, $fn_name, $catalog_tbl, $catalog_tbl, RoleId::Public.to_string(),
+            $catalog_tbl, $fn_name, $catalog_tbl, $catalog_tbl, RoleId::Public,
         )
     };
 }
@@ -3218,7 +3218,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     false
                 )
                 END
-            ", RoleId::Public.to_string())) => Bool, oid::FUNC_HAS_CLUSTER_PRIVILEGE_OID_TEXT_TEXT_OID;
+            ", RoleId::Public)) => Bool, oid::FUNC_HAS_CLUSTER_PRIVILEGE_OID_TEXT_TEXT_OID;
             params!(String, String) => sql_impl_func("has_cluster_privilege(current_user, $1, $2)") => Bool, oid::FUNC_HAS_CLUSTER_PRIVILEGE_TEXT_TEXT_OID;
         },
         "has_connection_privilege" => Scalar {
@@ -3264,7 +3264,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     false
                 )
                 END
-            ", RoleId::Public.to_string())) => Bool, oid::FUNC_HAS_SYSTEM_PRIVILEGE_OID_TEXT_OID;
+            ", RoleId::Public)) => Bool, oid::FUNC_HAS_SYSTEM_PRIVILEGE_OID_TEXT_OID;
             params!(String) => sql_impl_func("has_system_privilege(current_user, $1)") => Bool, oid::FUNC_HAS_SYSTEM_PRIVILEGE_TEXT_OID;
         },
         "has_type_privilege" => Scalar {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -19,6 +19,7 @@ use mz_expr::func;
 use mz_ore::collections::CollectionExt;
 use mz_ore::str::StrExt;
 use mz_pgrepr::oid;
+use mz_repr::role_id::RoleId;
 use mz_repr::{ColumnName, ColumnType, Datum, RelationType, Row, ScalarBaseType, ScalarType};
 use once_cell::sync::Lazy;
 
@@ -1705,13 +1706,13 @@ macro_rules! privilege_fn {
                             LEFT JOIN mz_roles ON
                                     mz_internal.mz_aclitem_grantee(privilege) = mz_roles.id
                         WHERE
-                            mz_internal.mz_aclitem_grantee(privilege) = 'p' OR pg_has_role($1, mz_roles.oid, 'USAGE')
+                            mz_internal.mz_aclitem_grantee(privilege) = '{}' OR pg_has_role($1, mz_roles.oid, 'USAGE')
                     ),
                     false
                 )
                 END
             ",
-            $catalog_tbl, $fn_name, $catalog_tbl, $catalog_tbl
+            $catalog_tbl, $fn_name, $catalog_tbl, $catalog_tbl, RoleId::Public.to_string(),
         )
     };
 }
@@ -3178,7 +3179,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         // OID, and clusters do not have OIDs.
         "has_cluster_privilege" => Scalar {
             params!(String, String, String) => sql_impl_func("has_cluster_privilege(mz_internal.mz_role_oid($1), $2, $3)") => Bool, oid::FUNC_HAS_CLUSTER_PRIVILEGE_TEXT_TEXT_TEXT_OID;
-            params!(Oid, String, String) => sql_impl_func("
+            params!(Oid, String, String) => sql_impl_func(&format!("
                 CASE
                 -- We need to validate the name and privileges to return a proper error before
                 -- anything else.
@@ -3212,12 +3213,12 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                             LEFT JOIN mz_roles ON
                                     mz_internal.mz_aclitem_grantee(privilege) = mz_roles.id
                         WHERE
-                            mz_internal.mz_aclitem_grantee(privilege) = 'p' OR pg_has_role($1, mz_roles.oid, 'USAGE')
+                            mz_internal.mz_aclitem_grantee(privilege) = '{}' OR pg_has_role($1, mz_roles.oid, 'USAGE')
                     ),
                     false
                 )
                 END
-            ") => Bool, oid::FUNC_HAS_CLUSTER_PRIVILEGE_OID_TEXT_TEXT_OID;
+            ", RoleId::Public.to_string())) => Bool, oid::FUNC_HAS_CLUSTER_PRIVILEGE_OID_TEXT_TEXT_OID;
             params!(String, String) => sql_impl_func("has_cluster_privilege(current_user, $1, $2)") => Bool, oid::FUNC_HAS_CLUSTER_PRIVILEGE_TEXT_TEXT_OID;
         },
         "has_connection_privilege" => Scalar {
@@ -3238,7 +3239,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         },
         "has_system_privilege" => Scalar {
             params!(String, String) => sql_impl_func("has_system_privilege(mz_internal.mz_role_oid($1), $2)") => Bool, oid::FUNC_HAS_SYSTEM_PRIVILEGE_TEXT_TEXT_OID;
-            params!(Oid, String) => sql_impl_func("
+            params!(Oid, String) => sql_impl_func(&format!("
                 CASE
                 -- We need to validate the privileges to return a proper error before
                 -- anything else.
@@ -3258,12 +3259,12 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                         LEFT JOIN mz_roles ON
                                 mz_internal.mz_aclitem_grantee(privileges) = mz_roles.id
                         WHERE
-                            mz_internal.mz_aclitem_grantee(privileges) = 'p' OR pg_has_role($1, mz_roles.oid, 'USAGE')
+                            mz_internal.mz_aclitem_grantee(privileges) = '{}' OR pg_has_role($1, mz_roles.oid, 'USAGE')
                     ),
                     false
                 )
                 END
-            ") => Bool, oid::FUNC_HAS_SYSTEM_PRIVILEGE_OID_TEXT_OID;
+            ", RoleId::Public.to_string())) => Bool, oid::FUNC_HAS_SYSTEM_PRIVILEGE_OID_TEXT_OID;
             params!(String) => sql_impl_func("has_system_privilege(current_user, $1)") => Bool, oid::FUNC_HAS_SYSTEM_PRIVILEGE_TEXT_OID;
         },
         "has_type_privilege" => Scalar {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1705,7 +1705,7 @@ macro_rules! privilege_fn {
                             LEFT JOIN mz_roles ON
                                     mz_internal.mz_aclitem_grantee(privilege) = mz_roles.id
                         WHERE
-                            mz_roles.oid = $1
+                            mz_internal.mz_aclitem_grantee(privilege) = 'p' OR pg_has_role($1, mz_roles.oid, 'USAGE')
                     ),
                     false
                 )
@@ -3212,7 +3212,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                             LEFT JOIN mz_roles ON
                                     mz_internal.mz_aclitem_grantee(privilege) = mz_roles.id
                         WHERE
-                            mz_roles.oid = $1
+                            mz_internal.mz_aclitem_grantee(privilege) = 'p' OR pg_has_role($1, mz_roles.oid, 'USAGE')
                     ),
                     false
                 )
@@ -3258,7 +3258,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                         LEFT JOIN mz_roles ON
                                 mz_internal.mz_aclitem_grantee(privileges) = mz_roles.id
                         WHERE
-                            mz_roles.oid = $1
+                            mz_internal.mz_aclitem_grantee(privileges) = 'p' OR pg_has_role($1, mz_roles.oid, 'USAGE')
                     ),
                     false
                 )

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -545,10 +545,25 @@ CREATE ROLE other
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+CREATE ROLE child
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT joe TO child
+----
+COMPLETE 0
+
 ## Table
 
 query B
 SELECT has_table_privilege('joe', 't', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege('child', 't', 'SELECT')
 ----
 false
 
@@ -578,6 +593,11 @@ t  materialize=arwd/materialize
 
 query B
 SELECT has_table_privilege('joe', 't', 'SELECT')
+----
+true
+
+query B
+SELECT has_table_privilege('child', 't', 'SELECT')
 ----
 true
 
@@ -636,22 +656,27 @@ t  materialize=arwd/materialize
 query B
 SELECT has_table_privilege('joe', 't', 'SELECT')
 ----
-false
+true
+
+query B
+SELECT has_table_privilege('child', 't', 'SELECT')
+----
+true
 
 query B
 SELECT has_table_privilege('joe', (SELECT oid FROM mz_tables WHERE name = 't'), 'SELECT')
 ----
-false
+true
 
 query B
 SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 't', 'SELECT')
 ----
-false
+true
 
 query B
 SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_tables WHERE name = 't'), 'SELECT')
 ----
-false
+true
 
 ### Duplicate revokes have no effect
 statement ok
@@ -670,6 +695,9 @@ statement ok
 CREATE ROLE joe
 
 statement ok
+GRANT joe TO child
+
+statement ok
 REVOKE INSERT, UPDATE ON TABLE t FROM PUBLIC
 
 query TT
@@ -678,6 +706,34 @@ SELECT name, privilege FROM item_privileges WHERE name = 't'
 t  =r/materialize
 t  materialize=arwd/materialize
 
+statement ok
+REVOKE SELECT ON TABLE t FROM PUBLIC
+
+query B
+SELECT has_table_privilege('joe', 't', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege('child', 't', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege('joe', (SELECT oid FROM mz_tables WHERE name = 't'), 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 't', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_tables WHERE name = 't'), 'SELECT')
+----
+false
+
 statement error invalid privilege types USAGE, CREATE for TABLE
 GRANT USAGE, CREATE ON TABLE t TO joe
 
@@ -685,6 +741,11 @@ GRANT USAGE, CREATE ON TABLE t TO joe
 
 query B
 SELECT has_table_privilege('joe', 'v', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege('child', 'v', 'SELECT')
 ----
 false
 
@@ -714,6 +775,11 @@ v  materialize=r/materialize
 
 query B
 SELECT has_table_privilege('joe', 'v', 'SELECT')
+----
+true
+
+query B
+SELECT has_table_privilege('child', 'v', 'SELECT')
 ----
 true
 
@@ -772,22 +838,27 @@ v  materialize=r/materialize
 query B
 SELECT has_table_privilege('joe', 'v', 'SELECT')
 ----
-false
+true
+
+query B
+SELECT has_table_privilege('child', 'v', 'SELECT')
+----
+true
 
 query B
 SELECT has_table_privilege('joe', (SELECT oid FROM mz_views WHERE name = 'v'), 'SELECT')
 ----
-false
+true
 
 query B
 SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'v', 'SELECT')
 ----
-false
+true
 
 query B
 SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_views WHERE name = 'v'), 'SELECT')
 ----
-false
+true
 
 ### Duplicate revokes have no effect
 statement ok
@@ -806,12 +877,40 @@ statement ok
 CREATE ROLE joe
 
 statement ok
+GRANT joe TO child
+
+statement ok
 REVOKE SELECT ON TABLE v FROM PUBLIC
 
 query TT
 SELECT name, privilege FROM item_privileges WHERE name = 'v'
 ----
 v  materialize=r/materialize
+
+query B
+SELECT has_table_privilege('joe', 'v', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege('child', 'v', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege('joe', (SELECT oid FROM mz_views WHERE name = 'v'), 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'v', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_views WHERE name = 'v'), 'SELECT')
+----
+false
 
 statement error invalid privilege types USAGE, CREATE for VIEW
 GRANT INSERT, UPDATE, DELETE, USAGE, CREATE ON TABLE v TO joe
@@ -820,6 +919,11 @@ GRANT INSERT, UPDATE, DELETE, USAGE, CREATE ON TABLE v TO joe
 
 query B
 SELECT has_table_privilege('joe', 'mv', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege('child', 'mv', 'SELECT')
 ----
 false
 
@@ -849,6 +953,11 @@ mv  materialize=r/materialize
 
 query B
 SELECT has_table_privilege('joe', 'mv', 'SELECT')
+----
+true
+
+query B
+SELECT has_table_privilege('child', 'mv', 'SELECT')
 ----
 true
 
@@ -907,22 +1016,27 @@ mv  materialize=r/materialize
 query B
 SELECT has_table_privilege('joe', 'mv', 'SELECT')
 ----
-false
+true
+
+query B
+SELECT has_table_privilege('child', 'mv', 'SELECT')
+----
+true
 
 query B
 SELECT has_table_privilege('joe', (SELECT oid FROM mz_materialized_views WHERE name = 'mv'), 'SELECT')
 ----
-false
+true
 
 query B
 SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'mv', 'SELECT')
 ----
-false
+true
 
 query B
 SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_materialized_views WHERE name = 'mv'), 'SELECT')
 ----
-false
+true
 
 ### Duplicate revokes have no effect
 statement ok
@@ -941,12 +1055,40 @@ statement ok
 CREATE ROLE joe
 
 statement ok
+GRANT joe TO child
+
+statement ok
 REVOKE SELECT ON TABLE mv FROM PUBLIC
 
 query TT
 SELECT name, privilege FROM item_privileges WHERE name = 'mv'
 ----
 mv  materialize=r/materialize
+
+query B
+SELECT has_table_privilege('joe', 'mv', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege('child', 'mv', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege('joe', (SELECT oid FROM mz_materialized_views WHERE name = 'mv'), 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'mv', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_materialized_views WHERE name = 'mv'), 'SELECT')
+----
+false
 
 statement error invalid privilege types USAGE, CREATE for MATERIALIZED VIEW
 GRANT INSERT, UPDATE, DELETE, USAGE, CREATE ON TABLE mv TO joe
@@ -955,6 +1097,11 @@ GRANT INSERT, UPDATE, DELETE, USAGE, CREATE ON TABLE mv TO joe
 
 query B
 SELECT has_table_privilege('joe', 's', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege('child', 's', 'SELECT')
 ----
 false
 
@@ -984,6 +1131,11 @@ s  materialize=r/materialize
 
 query B
 SELECT has_table_privilege('joe', 's', 'SELECT')
+----
+true
+
+query B
+SELECT has_table_privilege('child', 's', 'SELECT')
 ----
 true
 
@@ -1042,22 +1194,27 @@ s  materialize=r/materialize
 query B
 SELECT has_table_privilege('joe', 's', 'SELECT')
 ----
-false
+true
+
+query B
+SELECT has_table_privilege('child', 's', 'SELECT')
+----
+true
 
 query B
 SELECT has_table_privilege('joe', (SELECT oid FROM mz_sources WHERE name = 's'), 'SELECT')
 ----
-false
+true
 
 query B
 SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 's', 'SELECT')
 ----
-false
+true
 
 query B
 SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_sources WHERE name = 's'), 'SELECT')
 ----
-false
+true
 
 ### Duplicate revokes have no effect
 statement ok
@@ -1076,6 +1233,9 @@ statement ok
 CREATE ROLE joe
 
 statement ok
+GRANT joe TO child
+
+statement ok
 REVOKE SELECT ON TABLE s FROM PUBLIC
 
 query TT
@@ -1083,13 +1243,46 @@ SELECT name, privilege FROM item_privileges WHERE name = 's'
 ----
 s  materialize=r/materialize
 
+query B
+SELECT has_table_privilege('joe', 's', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege('child', 's', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege('joe', (SELECT oid FROM mz_sources WHERE name = 's'), 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 's', 'SELECT')
+----
+false
+
+query B
+SELECT has_table_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_sources WHERE name = 's'), 'SELECT')
+----
+false
+
 statement error invalid privilege types USAGE, CREATE for SOURCE
 GRANT INSERT, UPDATE, DELETE, USAGE, CREATE ON TABLE s TO joe
 
 ## Type
 
+statement ok
+REVOKE USAGE on TYPE ty FROM PUBLIC
+
 query B
 SELECT has_type_privilege('joe', 'ty', 'USAGE')
+----
+false
+
+query B
+SELECT has_type_privilege('child', 'ty', 'USAGE')
 ----
 false
 
@@ -1110,37 +1303,50 @@ false
 
 statement ok
 GRANT USAGE on TYPE ty TO joe
-
-query B
-SELECT has_type_privilege('joe', 'ty', 'USAGE')
-----
-true
-
-query B
-SELECT has_type_privilege('joe', (SELECT oid FROM mz_types WHERE name = 'ty'), 'USAGE')
-----
-true
-
-query B
-SELECT has_type_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'ty', 'USAGE')
-----
-true
-
-query B
-SELECT has_type_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_types WHERE name = 'ty'), 'USAGE')
-----
-true
 
 query TT
 SELECT name, privilege FROM item_privileges WHERE name = 'ty'
 ----
-ty  =U/materialize
 ty  joe=U/materialize
 ty  materialize=U/materialize
+
+query B
+SELECT has_type_privilege('joe', 'ty', 'USAGE')
+----
+true
+
+query B
+SELECT has_type_privilege('child', 'ty', 'USAGE')
+----
+true
+
+query B
+SELECT has_type_privilege('joe', (SELECT oid FROM mz_types WHERE name = 'ty'), 'USAGE')
+----
+true
+
+query B
+SELECT has_type_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'ty', 'USAGE')
+----
+true
+
+query B
+SELECT has_type_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_types WHERE name = 'ty'), 'USAGE')
+----
+true
 
 ### Duplicate grants have no effect
 statement ok
 GRANT USAGE on TYPE ty TO joe
+
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'ty'
+----
+ty  joe=U/materialize
+ty  materialize=U/materialize
+
+statement ok
+GRANT USAGE on TYPE ty TO PUBLIC
 
 query TT
 SELECT name, privilege FROM item_privileges WHERE name = 'ty'
@@ -1160,31 +1366,36 @@ DROP ROLE joe
 statement ok
 REVOKE USAGE on TYPE ty FROM joe
 
-query B
-SELECT has_type_privilege('joe', 'ty', 'SELECT')
-----
-false
-
-query B
-SELECT has_type_privilege('joe', (SELECT oid FROM mz_types WHERE name = 'ty'), 'USAGE')
-----
-false
-
-query B
-SELECT has_type_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'ty', 'USAGE')
-----
-false
-
-query B
-SELECT has_type_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_types WHERE name = 'ty'), 'USAGE')
-----
-false
-
 query TT
 SELECT name, privilege FROM item_privileges WHERE name = 'ty'
 ----
 ty  =U/materialize
 ty  materialize=U/materialize
+
+query B
+SELECT has_type_privilege('joe', 'ty', 'SELECT')
+----
+true
+
+query B
+SELECT has_type_privilege('child', 'ty', 'USAGE')
+----
+true
+
+query B
+SELECT has_type_privilege('joe', (SELECT oid FROM mz_types WHERE name = 'ty'), 'USAGE')
+----
+true
+
+query B
+SELECT has_type_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'ty', 'USAGE')
+----
+true
+
+query B
+SELECT has_type_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_types WHERE name = 'ty'), 'USAGE')
+----
+true
 
 ### Duplicate revokes have no effect
 statement ok
@@ -1203,12 +1414,40 @@ statement ok
 CREATE ROLE joe
 
 statement ok
+GRANT joe TO child
+
+statement ok
 REVOKE USAGE ON TYPE ty FROM PUBLIC
 
 query TT
 SELECT name, privilege FROM item_privileges WHERE name = 'ty'
 ----
 ty  materialize=U/materialize
+
+query B
+SELECT has_type_privilege('joe', 'ty', 'SELECT')
+----
+false
+
+query B
+SELECT has_type_privilege('child', 'ty', 'USAGE')
+----
+false
+
+query B
+SELECT has_type_privilege('joe', (SELECT oid FROM mz_types WHERE name = 'ty'), 'USAGE')
+----
+false
+
+query B
+SELECT has_type_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'ty', 'USAGE')
+----
+false
+
+query B
+SELECT has_type_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_types WHERE name = 'ty'), 'USAGE')
+----
+false
 
 statement ok
 GRANT USAGE on TYPE ty TO PUBLIC
@@ -1230,6 +1469,11 @@ SELECT has_secret_privilege('joe', 'se', 'USAGE')
 false
 
 query B
+SELECT has_secret_privilege('child', 'se', 'USAGE')
+----
+false
+
+query B
 SELECT has_secret_privilege('joe', (SELECT oid FROM mz_secrets WHERE name = 'se'), 'USAGE')
 ----
 false
@@ -1247,8 +1491,19 @@ false
 statement ok
 GRANT USAGE on SECRET se TO joe
 
+query TT
+SELECT name, privilege FROM item_privileges WHERE name = 'se'
+----
+se  joe=U/materialize
+se  materialize=U/materialize
+
 query B
 SELECT has_secret_privilege('joe', 'se', 'USAGE')
+----
+true
+
+query B
+SELECT has_secret_privilege('child', 'se', 'USAGE')
 ----
 true
 
@@ -1266,12 +1521,6 @@ query B
 SELECT has_secret_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_secrets WHERE name = 'se'), 'USAGE')
 ----
 true
-
-query TT
-SELECT name, privilege FROM item_privileges WHERE name = 'se'
-----
-se  joe=U/materialize
-se  materialize=U/materialize
 
 ### Duplicate grants have no effect
 statement ok
@@ -1304,31 +1553,36 @@ DROP ROLE joe
 statement ok
 REVOKE USAGE on SECRET se FROM joe
 
-query B
-SELECT has_secret_privilege('joe', 'se', 'USAGE')
-----
-false
-
-query B
-SELECT has_secret_privilege('joe', (SELECT oid FROM mz_secrets WHERE name = 'se'), 'USAGE')
-----
-false
-
-query B
-SELECT has_secret_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'se', 'USAGE')
-----
-false
-
-query B
-SELECT has_secret_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_secrets WHERE name = 'se'), 'USAGE')
-----
-false
-
 query TT
 SELECT name, privilege FROM item_privileges WHERE name = 'se'
 ----
 se  =U/materialize
 se  materialize=U/materialize
+
+query B
+SELECT has_secret_privilege('joe', 'se', 'USAGE')
+----
+true
+
+query B
+SELECT has_secret_privilege('child', 'se', 'USAGE')
+----
+true
+
+query B
+SELECT has_secret_privilege('joe', (SELECT oid FROM mz_secrets WHERE name = 'se'), 'USAGE')
+----
+true
+
+query B
+SELECT has_secret_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'se', 'USAGE')
+----
+true
+
+query B
+SELECT has_secret_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_secrets WHERE name = 'se'), 'USAGE')
+----
+true
 
 ### Duplicate revokes have no effect
 statement ok
@@ -1347,12 +1601,40 @@ statement ok
 CREATE ROLE joe
 
 statement ok
+GRANT joe TO child
+
+statement ok
 REVOKE USAGE ON SECRET se FROM PUBLIC
 
 query TT
 SELECT name, privilege FROM item_privileges WHERE name = 'se'
 ----
 se  materialize=U/materialize
+
+query B
+SELECT has_secret_privilege('joe', 'se', 'USAGE')
+----
+false
+
+query B
+SELECT has_secret_privilege('child', 'se', 'USAGE')
+----
+false
+
+query B
+SELECT has_secret_privilege('joe', (SELECT oid FROM mz_secrets WHERE name = 'se'), 'USAGE')
+----
+false
+
+query B
+SELECT has_secret_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'se', 'USAGE')
+----
+false
+
+query B
+SELECT has_secret_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_secrets WHERE name = 'se'), 'USAGE')
+----
+false
 
 statement error invalid privilege types SELECT, INSERT, UPDATE, DELETE, CREATE for SECRET
 GRANT INSERT, SELECT, UPDATE, DELETE, CREATE ON SECRET se TO joe
@@ -1361,6 +1643,11 @@ GRANT INSERT, SELECT, UPDATE, DELETE, CREATE ON SECRET se TO joe
 
 query B
 SELECT has_connection_privilege('joe', 'conn', 'USAGE')
+----
+false
+
+query B
+SELECT has_connection_privilege('child', 'conn', 'USAGE')
 ----
 false
 
@@ -1390,6 +1677,11 @@ conn  materialize=U/materialize
 
 query B
 SELECT has_connection_privilege('joe', 'conn', 'USAGE')
+----
+true
+
+query B
+SELECT has_connection_privilege('child', 'conn', 'USAGE')
 ----
 true
 
@@ -1448,22 +1740,27 @@ conn  materialize=U/materialize
 query B
 SELECT has_connection_privilege('joe', 'conn', 'USAGE')
 ----
-false
+true
+
+query B
+SELECT has_connection_privilege('child', 'conn', 'USAGE')
+----
+true
 
 query B
 SELECT has_connection_privilege('joe', (SELECT oid FROM mz_connections WHERE name = 'conn'), 'USAGE')
 ----
-false
+true
 
 query B
 SELECT has_connection_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'conn', 'USAGE')
 ----
-false
+true
 
 query B
 SELECT has_connection_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_connections WHERE name = 'conn'), 'USAGE')
 ----
-false
+true
 
 ### Duplicate revokes have no effect
 statement ok
@@ -1482,12 +1779,40 @@ statement ok
 CREATE ROLE joe
 
 statement ok
+GRANT joe TO child
+
+statement ok
 REVOKE USAGE ON CONNECTION conn FROM PUBLIC
 
 query TT
 SELECT name, privilege FROM item_privileges WHERE name = 'conn'
 ----
 conn  materialize=U/materialize
+
+query B
+SELECT has_connection_privilege('joe', 'conn', 'USAGE')
+----
+false
+
+query B
+SELECT has_connection_privilege('child', 'conn', 'USAGE')
+----
+false
+
+query B
+SELECT has_connection_privilege('joe', (SELECT oid FROM mz_connections WHERE name = 'conn'), 'USAGE')
+----
+false
+
+query B
+SELECT has_connection_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'conn', 'USAGE')
+----
+false
+
+query B
+SELECT has_connection_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_connections WHERE name = 'conn'), 'USAGE')
+----
+false
 
 statement error invalid privilege types SELECT, INSERT, UPDATE, DELETE, CREATE for CONNECTION
 GRANT INSERT, SELECT, UPDATE, DELETE, CREATE ON CONNECTION conn TO joe
@@ -1496,6 +1821,11 @@ GRANT INSERT, SELECT, UPDATE, DELETE, CREATE ON CONNECTION conn TO joe
 
 query B
 SELECT has_cluster_privilege('joe', 'c', 'USAGE')
+----
+false
+
+query B
+SELECT has_cluster_privilege('child', 'c', 'USAGE')
 ----
 false
 
@@ -1516,6 +1846,11 @@ c  mz_introspection=U/materialize
 
 query B
 SELECT has_cluster_privilege('joe', 'c', 'USAGE')
+----
+true
+
+query B
+SELECT has_cluster_privilege('child', 'c', 'USAGE')
 ----
 true
 
@@ -1567,12 +1902,17 @@ c  mz_introspection=U/materialize
 query B
 SELECT has_cluster_privilege('joe', 'c', 'USAGE')
 ----
-false
+true
+
+query B
+SELECT has_cluster_privilege('child', 'c', 'USAGE')
+----
+true
 
 query B
 SELECT has_cluster_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'c', 'USAGE')
 ----
-false
+true
 
 ### Duplicate revokes have no effect
 statement ok
@@ -1592,6 +1932,9 @@ statement ok
 CREATE ROLE joe
 
 statement ok
+GRANT joe TO child
+
+statement ok
 REVOKE CREATE, USAGE ON CLUSTER c FROM PUBLIC
 
 query TT
@@ -1600,6 +1943,21 @@ SELECT name, privilege FROM cluster_privileges WHERE name = 'c'
 c  materialize=UC/materialize
 c  mz_introspection=U/materialize
 
+query B
+SELECT has_cluster_privilege('joe', 'c', 'USAGE')
+----
+false
+
+query B
+SELECT has_cluster_privilege('child', 'c', 'USAGE')
+----
+false
+
+query B
+SELECT has_cluster_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'c', 'USAGE')
+----
+false
+
 statement error invalid privilege types SELECT, INSERT, UPDATE, DELETE for CLUSTER
 GRANT INSERT, SELECT, UPDATE, DELETE ON CLUSTER c TO joe
 
@@ -1607,6 +1965,11 @@ GRANT INSERT, SELECT, UPDATE, DELETE ON CLUSTER c TO joe
 
 query B
 SELECT has_database_privilege('joe', 'd', 'USAGE')
+----
+false
+
+query B
+SELECT has_database_privilege('child', 'd', 'USAGE')
 ----
 false
 
@@ -1637,6 +2000,11 @@ d  mz_introspection=U/materialize
 
 query B
 SELECT has_database_privilege('joe', 'd', 'USAGE')
+----
+true
+
+query B
+SELECT has_database_privilege('child', 'd', 'USAGE')
 ----
 true
 
@@ -1698,22 +2066,27 @@ d  mz_introspection=U/materialize
 query B
 SELECT has_database_privilege('joe', 'd', 'USAGE')
 ----
-false
+true
+
+query B
+SELECT has_database_privilege('child', 'd', 'USAGE')
+----
+true
 
 query B
 SELECT has_database_privilege('joe', (SELECT oid FROM mz_databases WHERE name = 'd'), 'USAGE')
 ----
-false
+true
 
 query B
 SELECT has_database_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'd', 'USAGE')
 ----
-false
+true
 
 query B
 SELECT has_database_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_databases WHERE name = 'd'), 'USAGE')
 ----
-false
+true
 
 ### Duplicate revokes have no effect
 statement ok
@@ -1733,6 +2106,9 @@ statement ok
 CREATE ROLE joe
 
 statement ok
+GRANT joe TO child
+
+statement ok
 REVOKE CREATE, USAGE ON DATABASE d FROM PUBLIC
 
 query TT
@@ -1741,6 +2117,31 @@ SELECT name, privilege FROM database_privileges WHERE name = 'd'
 d  materialize=UC/materialize
 d  mz_introspection=U/materialize
 
+query B
+SELECT has_database_privilege('joe', 'd', 'USAGE')
+----
+false
+
+query B
+SELECT has_database_privilege('child', 'd', 'USAGE')
+----
+false
+
+query B
+SELECT has_database_privilege('joe', (SELECT oid FROM mz_databases WHERE name = 'd'), 'USAGE')
+----
+false
+
+query B
+SELECT has_database_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'd', 'USAGE')
+----
+false
+
+query B
+SELECT has_database_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_databases WHERE name = 'd'), 'USAGE')
+----
+false
+
 statement error invalid privilege types SELECT, INSERT, UPDATE, DELETE for DATABASE
 GRANT INSERT, SELECT, UPDATE, DELETE ON DATABASE d TO joe
 
@@ -1748,6 +2149,11 @@ GRANT INSERT, SELECT, UPDATE, DELETE ON DATABASE d TO joe
 
 query B
 SELECT has_schema_privilege('joe', 'sch', 'USAGE')
+----
+false
+
+query B
+SELECT has_schema_privilege('child', 'sch', 'USAGE')
 ----
 false
 
@@ -1778,6 +2184,11 @@ sch  mz_introspection=U/materialize
 
 query B
 SELECT has_schema_privilege('joe', 'sch', 'USAGE')
+----
+true
+
+query B
+SELECT has_schema_privilege('child', 'sch', 'USAGE')
 ----
 true
 
@@ -1839,22 +2250,27 @@ sch  mz_introspection=U/materialize
 query B
 SELECT has_schema_privilege('joe', 'sch', 'USAGE')
 ----
-false
+true
+
+query B
+SELECT has_schema_privilege('child', 'sch', 'USAGE')
+----
+true
 
 query B
 SELECT has_schema_privilege('joe', (SELECT oid FROM mz_schemas WHERE name = 'sch'), 'USAGE')
 ----
-false
+true
 
 query B
 SELECT has_schema_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'sch', 'USAGE')
 ----
-false
+true
 
 query B
 SELECT has_schema_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_schemas WHERE name = 'sch'), 'USAGE')
 ----
-false
+true
 
 ### Duplicate revokes have no effect
 statement ok
@@ -1874,6 +2290,9 @@ statement ok
 CREATE ROLE joe
 
 statement ok
+GRANT joe TO child
+
+statement ok
 REVOKE CREATE, USAGE ON SCHEMA sch FROM PUBLIC
 
 query TT
@@ -1881,6 +2300,31 @@ SELECT name, privilege FROM schema_privileges WHERE name = 'sch'
 ----
 sch  materialize=UC/materialize
 sch  mz_introspection=U/materialize
+
+query B
+SELECT has_schema_privilege('joe', 'sch', 'USAGE')
+----
+false
+
+query B
+SELECT has_schema_privilege('child', 'sch', 'USAGE')
+----
+false
+
+query B
+SELECT has_schema_privilege('joe', (SELECT oid FROM mz_schemas WHERE name = 'sch'), 'USAGE')
+----
+false
+
+query B
+SELECT has_schema_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'sch', 'USAGE')
+----
+false
+
+query B
+SELECT has_schema_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), (SELECT oid FROM mz_schemas WHERE name = 'sch'), 'USAGE')
+----
+false
 
 ## System
 
@@ -1891,6 +2335,11 @@ COMPLETE 0
 
 query B
 SELECT has_system_privilege('joe', 'CREATEDB')
+----
+false
+
+query B
+SELECT has_system_privilege('child', 'CREATEDB')
 ----
 false
 
@@ -1912,6 +2361,11 @@ mz_system=RBN/mz_system
 
 query B
 SELECT has_system_privilege('joe', 'CREATEDB')
+----
+true
+
+query B
+SELECT has_system_privilege('child', 'CREATEDB')
 ----
 true
 
@@ -1961,12 +2415,17 @@ mz_system=RBN/mz_system
 query B
 SELECT has_system_privilege('joe', 'CREATEDB')
 ----
-false
+true
+
+query B
+SELECT has_system_privilege('child', 'CREATEDB')
+----
+true
 
 query B
 SELECT has_system_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'CREATEDB')
 ----
-false
+true
 
 ### Duplicate revokes have no effect
 simple conn=mz_system,user=mz_system
@@ -1986,6 +2445,9 @@ DROP ROLE joe
 statement ok
 CREATE ROLE joe
 
+statement ok
+GRANT joe TO child
+
 simple conn=mz_system,user=mz_system
 REVOKE CREATEROLE, CREATECLUSTER ON SYSTEM FROM PUBLIC
 ----
@@ -1995,6 +2457,21 @@ query T
 SELECT privileges::text FROM mz_system_privileges
 ----
 mz_system=RBN/mz_system
+
+query B
+SELECT has_system_privilege('joe', 'CREATEDB')
+----
+false
+
+query B
+SELECT has_system_privilege('child', 'CREATEDB')
+----
+false
+
+query B
+SELECT has_system_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'CREATEDB')
+----
+false
 
 ## Test misc error scenarios
 
@@ -2999,6 +3476,11 @@ true
 
 ### Type
 
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON TYPE ty FROM PUBLIC
+----
+COMPLETE 0
+
 query B
 SELECT has_type_privilege('materialize', 'ty', 'USAGE')
 ----
@@ -3043,6 +3525,11 @@ query B
 SELECT has_type_privilege((SELECT oid FROM mz_types WHERE name = 'ty'), 'USAGE')
 ----
 true
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON TYPE ty TO PUBLIC
+----
+COMPLETE 0
 
 # Test multi-object GRANT/REVOKE
 
@@ -3277,6 +3764,11 @@ false
 
 ## Types
 
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON ALL TYPES FROM PUBLIC
+----
+COMPLETE 0
+
 query B
 SELECT has_type_privilege('ty1', 'USAGE')
 ----
@@ -3346,6 +3838,11 @@ query B
 SELECT has_type_privilege('ty4', 'USAGE')
 ----
 false
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON ALL TYPES TO PUBLIC
+----
+COMPLETE 0
 
 ## Secrets
 
@@ -3567,6 +4064,11 @@ false
 
 ## Types
 
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON ALL TYPES FROM PUBLIC
+----
+COMPLETE 0
+
 query B
 SELECT has_type_privilege('ty1', 'USAGE')
 ----
@@ -3636,6 +4138,11 @@ query B
 SELECT has_type_privilege('ty4', 'USAGE')
 ----
 false
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON ALL TYPES TO PUBLIC
+----
+COMPLETE 0
 
 ## Secrets
 
@@ -3899,6 +4406,11 @@ false
 
 ## Types
 
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON ALL TYPES FROM PUBLIC
+----
+COMPLETE 0
+
 query B
 SELECT has_type_privilege('ty1', 'USAGE')
 ----
@@ -3968,6 +4480,11 @@ query B
 SELECT has_type_privilege('ty4', 'USAGE')
 ----
 false
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON ALL TYPES TO PUBLIC
+----
+COMPLETE 0
 
 ## Secrets
 


### PR DESCRIPTION
This commit fixes the logic used to implement has_X_privilege functions
so that they consider role membership.

Fixes https://github.com/MaterializeInc/materialize/issues/20097

### Motivation

This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix `has_X_privilege` functions to consider role membership.
