### PR TITLE
sql: Add design doc for RBAC `SHOW` commands

### DIFF
--- a/doc/developer/design/20230714_show_privileges.md
+++ b/doc/developer/design/20230714_show_privileges.md
@@ -39,33 +39,30 @@ We will also add an `owner` column to the existing show commands.
 
 Will show object privileges.
 
-The syntax will be: `SHOW PRIVILEGES [ON <object-type>] [FOR {<role> | ALL ROLES}] [FROM {SCHEMA <schema-name> | ALL SCHEMAS | DATABASE <database> | ALL DATABASES}]`.
+The syntax will be: `SHOW [<object-type>] PRIVILEGES [FOR {<role> | ALL ROLES}] [FROM {SCHEMA <schema-name> | ALL SCHEMAS | DATABASE <database> | ALL DATABASES}]`.
 
-- `ON <object-type>` will filter the output to only include objects of type `<object-type>`. Valid
-  values are:
-    - `TABLES`
-    - `VIEWS`
-    - `MATERIALIZED VIEWS`
-    - `SOURCES`
-    - `SINKS`
-    - `TYPES`
-    - `CLUSTERS`
-    - `SECRETS`
-    - `CONNECTIONS`
-    - `DATABASES`
-    - `SCHEMAS`
-    - `SYSTEM`
+- `<object-type>` will filter the output to only include objects of type `<object-type>`. Valid
+values are:
+  - `OBJECT`
+  - `DATABASE`
+  - `SCHEMA`
+  - `CLUSTER`
+  - `SYSTEM`
 - `FOR <role>` will filter the output to only include privileges granted to `<role>`.
   - If a role or `ALL ROLES` is not specified then the current role is assumed.
 - `FOR ALL ROLES` will display privileges granted to all roles.
 - `FROM SCHEMA <schema-name>` will filter the output to exclude items not in schema `<schema-name>`.
-    - This has no effect on database, schema, cluster, or system privileges.
-    - If a schema or `ALL SCHEMAS` is not specified then the active schema is assumed.
+  - This has no effect on database, schema, cluster, or system privileges.
+  - If a schema or `ALL SCHEMAS` is not specified then the active schema is assumed.
+  - Invalid if an object type of `DATABASE`, `SCHEMA`, `CLUSTER`, or `SYSTEM` has been specified.
 - `FROM ALL SCHEMAS` will include all items.
+  - Invalid if an object type of `DATABASE`, `SCHEMA`, `CLUSTER`, or `SYSTEM` has been specified.
 - `FROM DATABASE <database>` will filter the output to exclude schemas not in database `<database>`.
   - This has no effect on item, database, cluster, or cluster privileges.
   - If a database or `ALL DATABASES` is not specified then the active database is assumed.
+  - Invalid if an object type of `DATABASE`, `CLUSTER`, or `SYSTEM` has been specified. 
 - `FROM ALL DATABASES` will include all schemas.
+  - Invalid if an object type of `DATABASE`, `CLUSTER`, or `SYSTEM` has been specified. 
 
 The output will include the following columns:
 
@@ -96,7 +93,6 @@ SHOW PRIVILEGES FOR ROLE ceo;
  database    | schema | name        | object_type | privileges
 -------------+--------+-------------+-------------+--------------------------------
  materialize | public | my_table    | table       | SELECT, INSERT, UPDATE, DELETE
- materialize | public | my_view     | view        | SELECT
  materialize | NULL   | public      | schema      | CREATE, USAGE
  NULL        | NULL   | materialize | database    | CREATE, USAGE
  NULL        | NULL   | my_db       | database    | CREATE, USAGE
@@ -104,11 +100,12 @@ SHOW PRIVILEGES FOR ROLE ceo;
 ```
 
 ```sql
-SHOW PRIVILEGES ON TABLES;
+SHOW OBJECT PRIVILEGES;
 
  database    | schema | name       | object_type | privileges
 -------------+--------+------------+-------------+----------------
  materialize | public | my_table   | table       | SELECT, INSERT
+ materialize | public | my_view    | view        | SELECT
 ```
 
 ```sql
@@ -124,10 +121,11 @@ SHOW PRIVILEGES FROM SCHEMA qa;
 ```
 
 ```sql
-SHOW PRIVILEGES ON VIEWS FROM SCHEMA public;
+SHOW OBJECT PRIVILEGES FROM SCHEMA public;
 
  database    | schema | name       | object_type | privileges
 -------------+--------+------------+-------------+----------------
+ materialize | public | my_table   | table       | SELECT, INSERT
  materialize | public | my_view    | view        | SELECT
 ```
 
@@ -174,17 +172,15 @@ SHOW PRIVILEGES FROM ALL DATABASES;
 
 Will show all default privileges
 
-The syntax will be `SHOW DEFAULT PRIVILEGES [ON <object-type>]`.
+The syntax will be `SHOW DEFAULT [<object-type>] PRIVILEGES [ON <object-type>]`.
 
-- `ON <object-type>` will filter the output to only include objects of type `<object-type>`. Valid
-  values are:
-  - `TABLES` (includes views, materialized views, and sources)
-  - `TYPES`
-  - `CLUSTERS`
-  - `SECRETS`
-  - `CONNECTIONS`
-  - `DATABASES`
-  - `SCHEMAS`
+- `<object-type>` will filter the output to only include objects of type `<object-type>`. Valid
+values are:
+  - `OBJECT`
+  - `DATABASE`
+  - `SCHEMA`
+  - `CLUSTER`
+  - `SYSTEM`
 
 The output will include the following columns:
 
@@ -209,12 +205,13 @@ SHOW DEFAULT PRIVILEGES;
 ```
 
 ```sql
-SHOW DEFAULT PRIVILEGES ON TABLES;
+SHOW DEFAULT OBJECT PRIVILEGES ON TABLES;
 
  role   | database    | schema | object_type | grantee   | privileges
 --------+-------------+--------+-------------+-----------+----------------
  PUBLIC | NULL        | NULL   | table       | dev       | INSERT, SELECT
  joe    | materialize | NULL   | table       | PUBLIC    | SELECT
+ qa     | materialize | public | type        | scientist | USAGE
 ```
 
 ### `SHOW ROLE MEMBERSHIPS`

--- a/doc/developer/design/20230714_show_privileges.md
+++ b/doc/developer/design/20230714_show_privileges.md
@@ -29,7 +29,7 @@ We will add the following SQL commands:
 
 - `SHOW PRIVILEGES`: shows the privileges of the current user.
 - `SHOW DEFAULT PRIVILEGES`: shows default privileges.
-- `SHOW ROLE MEMBERSHIP`
+- `SHOW ROLE MEMBERSHIPS`
 
 We will also add an `owner` column to the existing show commands.
 
@@ -161,11 +161,11 @@ SHOW DEFAULT PRIVILEGES ON TABLES;
  PUBLIC | NULL        | NULL   | table       | dev       | INSERT, SELECT
 ```
 
-### `SHOW ROLE MEMBERSHIP`
+### `SHOW ROLE MEMBERSHIPS`
 
 Will show the role membership of the current session.
 
-The syntax will be: `SHOW ROLE MEMBERSHIP`.
+The syntax will be: `SHOW ROLE MEMBERSHIPS`.
 
 The output will include the following columns:
 
@@ -174,7 +174,7 @@ The output will include the following columns:
 Here is an example query:
 
 ```sql
-SHOW ROLE MEMBERSHIP;
+SHOW ROLE MEMBERSHIPS;
 
  name
 ----------------

--- a/doc/developer/design/20230714_show_privileges.md
+++ b/doc/developer/design/20230714_show_privileges.md
@@ -164,7 +164,7 @@ SHOW PRIVILEGES FROM ALL DATABASES;
  materialize | public | my_table    | table       | SELECT, INSERT
  materialize | public | my_view     | view        | SELECT
  materialize | NULL   | public      | schema      | USAGE
- db2         | NULL   | my_schema   | schema      | CREATE 
+ db2         | NULL   | my_schema   | schema      | CREATE
  NULL        | NULL   | materialize | database    | USAGE
  NULL        | NULL   | my_db       | database    | USAGE
  NULL        | NULL   | my_cluster  | cluster     | CREATE

--- a/doc/developer/design/20230714_show_privileges.md
+++ b/doc/developer/design/20230714_show_privileges.md
@@ -1,0 +1,202 @@
+# SHOW PRIVILEGES
+
+Associated:
+
+- [GitHub issue](https://github.com/MaterializeInc/materialize/issues/20452)
+- [RBAC design doc](20230216_role_based_access_control.md)
+- [System privilege design doc](20230531_system_privileges.md)
+- [Default privilege design doc](20230602_default_privileges.md)
+
+## Context
+
+Role based access control comprises a set of features that allow customers to control the
+privileges of individual users. Privileges can be granted to a user which allows them to take
+certain actions in a Materialize deployment. All objects have an owner, and certain actions are
+limited to only object owners. Roles can be members of other roles and inherit all of their
+privileges. Privileges, owners, and role membership are all stored within the database catalog.
+
+Currently, it's difficult for a user to discover RBAC related information.
+
+## Goals
+
+- Make it easy for users to discover the set of privileges that they have.
+- Make it easy for users to discover the owner of objects.
+- Make it easy for users to discover the roles that they are a member of.
+
+## Overview
+
+We will add the following SQL commands:
+
+- `SHOW PRIVILEGES`: shows the privileges of the current user.
+- `SHOW DEFAULT PRIVILEGES`: shows default privileges.
+- `SHOW ROLE MEMBERSHIP`
+
+We will also add an `owner` column to the existing show commands.
+
+## Detailed description
+
+- We will add an internal unmaterializable function, `mz_internal.mz_role_membership() -> text[]`,
+  that returns an array of all the role IDs that the session's current role is a member of.
+- We will add an internal unary function, `mz_internal.mz_format_privileges(text) -> text`,
+  that accepts a privilege string descriptor and returns a human-readable version. For
+  example: `mz_internal.mz_format_privileges('ar') = 'INSERT, SELECT'`.
+
+These two functions will help implement the `SHOW` commands described below.
+
+### `SHOW PRIVILEGES`
+
+Will show all privileges held by the current session.
+
+The syntax will be: `SHOW PRIVILEGES [ON <object-type>] [FROM <schema-name>]`.
+
+- `ON <object-type>` will filter the output to only include objects of type `<object-type>`. Valid
+  values are:
+    - `TABLES`
+    - `VIEWS`
+    - `MATERIALIZED VIEWS`
+    - `SOURCES`
+    - `SINKS`
+    - `TYPES`
+    - `CLUSTERS`
+    - `SECRETS`
+    - `CONNECTIONS`
+    - `DATABASES`
+    - `SCHEMAS`
+    - `SYSTEM`
+- `FROM <schema-name>` will filter the output to only exclude objects in a schema other `<schema-name>`.
+    - If specified, top level objects, such as database, schemas, and clusters are not included.
+    - If not specified then objects are limited to the current schema and top level objects are
+    - shown.
+
+The output will include the following columns:
+
+- `name: text` The name of the object.
+- `object_type: text` The type of the object.
+- `privileges: text` Human readable version of the privileges that held by the current session.
+
+Here are some example queries:
+
+```sql
+SHOW PRIVILEGES;
+
+ name       | object_type | privileges
+------------+-------------+----------------
+ my_table   | TABLE       | SELECT, INSERT
+ my_view    | VIEW        | SELECT
+ my_cluster | CLUSTER     | CREATE
+```
+
+```sql
+SHOW PRIVILEGES ON TABLES;
+
+ name       | object_type | privileges
+------------+-------------+----------------
+ my_table   | TABLE       | SELECT, INSERT
+```
+
+```sql
+SHOW PRIVILEGES FROM public;
+
+ name       | object_type | privileges
+------------+-------------+----------------
+ my_table   | TABLE       | SELECT, INSERT
+ my_view    | VIEW        | SELECT
+```
+
+```sql
+SHOW PRIVILEGES ON VIEWS FROM public;
+
+ name       | object_type | privileges
+------------+-------------+----------------
+ my_view    | VIEW        | SELECT
+```
+
+### `SHOW DEFAULT PRIVILEGES`
+
+Will show all default privileges
+
+The syntax will be `SHOW DEFAULT PRIVILEGES [ON <object-type>]`.
+
+- `ON <object-type>` will filter the output to only include objects of type `<object-type>`. Valid
+  values are:
+  - `TABLES`
+  - `VIEWS`
+  - `MATERIALIZED VIEWS`
+  - `SOURCES`
+  - `SINKS`
+  - `TYPES`
+  - `CLUSTERS`
+  - `SECRETS`
+  - `CONNECTIONS`
+  - `DATABASES`
+  - `SCHEMAS`
+
+The output will include the following columns:
+
+- `role: text` The name of the affected role.
+- `database: text` The name of the affected database.
+- `schema: text` The name of the affected schema.
+- `object_type: text` The type of object.
+- `grantee: text` The role being granted privileges.
+- `privileges: text` Human readable version of the privileges that will be granted.
+
+Here are some example queries:
+
+```sql
+SHOW DEFAULT PRIVILEGES;
+
+ role   | database    | schema | object_type | grantee   | privileges
+--------+-------------+--------+-------------+-----------+----------------
+ PUBLIC | NULL        | NULL   | TABLE       | dev       | INSERT, SELECT
+ joe    | materialize | NULL   | VIEW        | PUBLIC    | SELECT
+ qa     | materialize | public | TYPE        | scientist | USAGE
+```
+
+```sql
+SHOW DEFAULT PRIVILEGES ON TABLES;
+
+ role   | database    | schema | object_type | grantee   | privileges
+--------+-------------+--------+-------------+-----------+----------------
+ PUBLIC | NULL        | NULL   | TABLE       | dev       | INSERT, SELECT
+```
+
+### `SHOW ROLE MEMBERSHIP`
+
+Will show the role membership of the current session.
+
+The syntax will be: `SHOW ROLE MEMBERSHIP`.
+
+The output will include the following columns:
+
+- `name: text` The name of the role.
+
+Here is an example query:
+
+```sql
+SHOW ROLE MEMBERSHIP;
+
+ name       
+----------------
+ data_scientist
+ dev
+ qa
+```
+
+### `SHOW <OBJECTS>`
+
+The following columns will be added to all existing `SHOW <OBJECTS>` commands:
+
+- `owner: text` the role name of the object owner.
+
+## Alternatives
+
+- Create documentation with queries against catalog tables that would return the equivalent results
+  as the `SHOW` commands.
+- Add syntax, to specify the database instead of the schema in `SHOW PRIVILEGES`.
+- Return a list from `mz_internal.mz_role_membership()` instead of an array.
+- Add a column to `SHOW PRIVILEGES` to indicate which role a privilege comes from.
+- Don't limit the results of `SHOW PRIVILEGES` to a single schema.
+
+## Open questions
+
+- None.

--- a/doc/developer/design/20230714_show_privileges.md
+++ b/doc/developer/design/20230714_show_privileges.md
@@ -150,6 +150,7 @@ SHOW DEFAULT PRIVILEGES;
  PUBLIC | NULL        | NULL   | table       | dev       | INSERT, SELECT
  joe    | materialize | NULL   | view        | PUBLIC    | SELECT
  qa     | materialize | public | type        | scientist | USAGE
+ PUBLIC | NULL        | NULL   | cluster     | mike      | CREATE
 ```
 
 ```sql

--- a/doc/developer/design/20230714_show_privileges.md
+++ b/doc/developer/design/20230714_show_privileges.md
@@ -235,11 +235,11 @@ Here is an example query:
 ```sql
 SHOW ROLE MEMBERSHIPS;
 
- name
-----------------
- data_scientist
- dev
- qa
+ role_name      | member_name
+----------------+-------------
+ data_scientist | joe
+ dev            | mike
+ qa             | arjun
 ```
 
 ### `SHOW <OBJECTS>`

--- a/doc/developer/design/20230714_show_privileges.md
+++ b/doc/developer/design/20230714_show_privileges.md
@@ -81,9 +81,9 @@ SHOW PRIVILEGES;
 
  name       | object_type | privileges
 ------------+-------------+----------------
- my_table   | TABLE       | SELECT, INSERT
- my_view    | VIEW        | SELECT
- my_cluster | CLUSTER     | CREATE
+ my_table   | table       | SELECT, INSERT
+ my_view    | view        | SELECT
+ my_cluster | cluster     | CREATE
 ```
 
 ```sql
@@ -91,7 +91,7 @@ SHOW PRIVILEGES ON TABLES;
 
  name       | object_type | privileges
 ------------+-------------+----------------
- my_table   | TABLE       | SELECT, INSERT
+ my_table   | table       | SELECT, INSERT
 ```
 
 ```sql
@@ -99,8 +99,8 @@ SHOW PRIVILEGES FROM public;
 
  name       | object_type | privileges
 ------------+-------------+----------------
- my_table   | TABLE       | SELECT, INSERT
- my_view    | VIEW        | SELECT
+ my_table   | table       | SELECT, INSERT
+ my_view    | view        | SELECT
 ```
 
 ```sql
@@ -108,7 +108,7 @@ SHOW PRIVILEGES ON VIEWS FROM public;
 
  name       | object_type | privileges
 ------------+-------------+----------------
- my_view    | VIEW        | SELECT
+ my_view    | view        | SELECT
 ```
 
 ### `SHOW DEFAULT PRIVILEGES`
@@ -147,9 +147,9 @@ SHOW DEFAULT PRIVILEGES;
 
  role   | database    | schema | object_type | grantee   | privileges
 --------+-------------+--------+-------------+-----------+----------------
- PUBLIC | NULL        | NULL   | TABLE       | dev       | INSERT, SELECT
- joe    | materialize | NULL   | VIEW        | PUBLIC    | SELECT
- qa     | materialize | public | TYPE        | scientist | USAGE
+ PUBLIC | NULL        | NULL   | table       | dev       | INSERT, SELECT
+ joe    | materialize | NULL   | view        | PUBLIC    | SELECT
+ qa     | materialize | public | type        | scientist | USAGE
 ```
 
 ```sql
@@ -157,7 +157,7 @@ SHOW DEFAULT PRIVILEGES ON TABLES;
 
  role   | database    | schema | object_type | grantee   | privileges
 --------+-------------+--------+-------------+-----------+----------------
- PUBLIC | NULL        | NULL   | TABLE       | dev       | INSERT, SELECT
+ PUBLIC | NULL        | NULL   | table       | dev       | INSERT, SELECT
 ```
 
 ### `SHOW ROLE MEMBERSHIP`

--- a/doc/developer/design/20230714_show_privileges.md
+++ b/doc/developer/design/20230714_show_privileges.md
@@ -47,7 +47,7 @@ These two functions will help implement the `SHOW` commands described below.
 
 Will show all privileges held by the current session.
 
-The syntax will be: `SHOW PRIVILEGES [ON <object-type>] [FROM <schema-name>]`.
+The syntax will be: `SHOW PRIVILEGES [ON <object-type>] [FROM <schema-name>] [FOR <role>]`.
 
 - `ON <object-type>` will filter the output to only include objects of type `<object-type>`. Valid
   values are:
@@ -63,10 +63,12 @@ The syntax will be: `SHOW PRIVILEGES [ON <object-type>] [FROM <schema-name>]`.
     - `DATABASES`
     - `SCHEMAS`
     - `SYSTEM`
-- `FROM <schema-name>` will filter the output to only exclude objects in a schema other `<schema-name>`.
+- `FROM <schema-name>` will filter the output to exclude objects in a schema other `<schema-name>`.
     - If specified, top level objects, such as database, schemas, and clusters are not included.
     - If not specified then objects are limited to the current schema and top level objects are
     - shown.
+- `FOR <role>` will filter the output to only include privileges granted to `<role>` instead of the
+current session.
 
 The output will include the following columns:
 
@@ -162,7 +164,10 @@ SHOW DEFAULT PRIVILEGES ON TABLES;
 
 Will show the role membership of the current session.
 
-The syntax will be: `SHOW ROLE MEMBERSHIPS`.
+The syntax will be: `SHOW ROLE MEMBERSHIPS [FOR <role>]`.
+
+- `FOR <role>` will filter the output to only include roles that `<role>` is a member of instead of
+the current session.
 
 The output will include the following columns:
 

--- a/doc/developer/design/20230714_show_privileges.md
+++ b/doc/developer/design/20230714_show_privileges.md
@@ -70,102 +70,104 @@ The output will include the following columns:
 - `schema: text` - The schema of the object. `NULL` for databases, schemas, and clusters.
 - `name: text` - The name of the object.
 - `object_type: text` -  The type of the object.
+- `grantee: text` - The role name of the grantee.
 - `privileges: text` - Human readable version of the privileges that held by the current session.
+- `grantor: text` - The role name of the grantor.
 
 Here are some example queries:
 
 ```sql
 SHOW PRIVILEGES;
 
- database    | schema | name        | object_type | privileges
--------------+--------+-------------+-------------+----------------
- materialize | public | my_table    | table       | SELECT, INSERT
- materialize | public | my_view     | view        | SELECT
- materialize | NULL   | public      | schema      | USAGE
- NULL        | NULL   | materialize | database    | USAGE
- NULL        | NULL   | my_db       | database    | USAGE
- NULL        | NULL   | my_cluster  | cluster     | CREATE
+ database    | schema | name        | object_type | grantee | privileges     | grantor
+-------------+--------+-------------+-------------+---------+----------------+---------
+ materialize | public | my_table    | table       | r1      | SELECT, INSERT | r2
+ materialize | public | my_view     | view        | r1      | SELECT         | r2
+ materialize | NULL   | public      | schema      | r1      | USAGE          | r2
+ NULL        | NULL   | materialize | database    | r1      | USAGE          | r2
+ NULL        | NULL   | my_db       | database    | r1      | USAGE          | r2
+ NULL        | NULL   | my_cluster  | cluster     | r1      | CREATE         | r2
 ```
 
 ```sql
 SHOW PRIVILEGES FOR ROLE ceo;
 
- database    | schema | name        | object_type | privileges
--------------+--------+-------------+-------------+--------------------------------
- materialize | public | my_table    | table       | SELECT, INSERT, UPDATE, DELETE
- materialize | NULL   | public      | schema      | CREATE, USAGE
- NULL        | NULL   | materialize | database    | CREATE, USAGE
- NULL        | NULL   | my_db       | database    | CREATE, USAGE
- NULL        | NULL   | my_cluster  | cluster     | CREATE, USAGE
+ database    | schema | name        | object_type | grantee | privileges                     | grantor
+-------------+--------+-------------+-------------+---------+--------------------------------+---------
+ materialize | public | my_table    | table       | r1      | SELECT, INSERT, UPDATE, DELETE | r2
+ materialize | NULL   | public      | schema      | r1      | CREATE, USAGE                  | r2
+ NULL        | NULL   | materialize | database    | r1      | CREATE, USAGE                  | r2
+ NULL        | NULL   | my_db       | database    | r1      | CREATE, USAGE                  | r2
+ NULL        | NULL   | my_cluster  | cluster     | r1      | CREATE, USAGE                  | r2
 ```
 
 ```sql
 SHOW OBJECT PRIVILEGES;
 
- database    | schema | name       | object_type | privileges
--------------+--------+------------+-------------+----------------
- materialize | public | my_table   | table       | SELECT, INSERT
- materialize | public | my_view    | view        | SELECT
+ database    | schema | name       | object_type | grantee | privileges     | grantor
+-------------+--------+------------+-------------+---------+----------------+---------
+ materialize | public | my_table   | table       | r1      | SELECT, INSERT | r2
+ materialize | public | my_view    | view        | r1      | SELECT         | r2
 ```
 
 ```sql
 SHOW PRIVILEGES FROM SCHEMA qa;
 
- database    | schema | name        | object_type | privileges
--------------+--------+-------------+-------------+----------------
- materialize | qa     | my_secret   | secret      | USAGE
- materialize | NULL   | public      | schema      | USAGE
- NULL        | NULL   | materialize | database    | USAGE
- NULL        | NULL   | my_db       | database    | USAGE
- NULL        | NULL   | my_cluster  | cluster     | CREATE
+ database    | schema | name        | object_type | grantee | privileges | grantor
+-------------+--------+-------------+-------------+---------+------------+---------
+ materialize | qa     | my_secret   | secret      | r1      | USAGE      | r2
+ materialize | NULL   | public      | schema      | r1      | USAGE      | r2
+ NULL        | NULL   | materialize | database    | r1      | USAGE      | r2
+ NULL        | NULL   | my_db       | database    | r1      | USAGE      | r2
+ NULL        | NULL   | my_cluster  | cluster     | r1      | CREATE     | r2
 ```
 
 ```sql
 SHOW OBJECT PRIVILEGES FROM SCHEMA public;
 
- database    | schema | name       | object_type | privileges
--------------+--------+------------+-------------+----------------
- materialize | public | my_table   | table       | SELECT, INSERT
- materialize | public | my_view    | view        | SELECT
+ database    | schema | name       | object_type | grantee | privileges     | grantor
+-------------+--------+------------+-------------+---------+----------------+---------
+ materialize | public | my_table   | table       | r1      | SELECT, INSERT | r2
+ materialize | public | my_view    | view        | r1      | SELECT         | r2
 ```
 
 ```sql
 SHOW PRIVILEGES FROM DATABASE db2;
 
- database    | schema | name        | object_type | privileges
--------------+--------+-------------+-------------+----------------
- db2         | NULL   | my_schema   | schema      | CREATE
- NULL        | NULL   | materialize | database    | USAGE
- NULL        | NULL   | my_db       | database    | USAGE
- NULL        | NULL   | my_cluster  | cluster     | CREATE
+ database    | schema | name        | object_type | grantee | privileges | grantor
+-------------+--------+-------------+-------------+---------+------------+---------
+ db2         | NULL   | my_schema   | schema      | r1      | CREATE     | r2
+ NULL        | NULL   | materialize | database    | r1      | USAGE      | r2
+ NULL        | NULL   | my_db       | database    | r1      | USAGE      | r2
+ NULL        | NULL   | my_cluster  | cluster     | r1      | CREATE     | r2
 ```
 
 ```sql
 SHOW PRIVILEGES FROM ALL SCHEMAS;
 
- database    | schema | name        | object_type | privileges
--------------+--------+-------------+-------------+----------------
- materialize | public | my_table    | table       | SELECT, INSERT
- materialize | public | my_view     | view        | SELECT
- materialize | qa     | my_secret   | secret      | USAGE
- materialize | NULL   | public      | schema      | USAGE
- NULL        | NULL   | materialize | database    | USAGE
- NULL        | NULL   | my_db       | database    | USAGE
- NULL        | NULL   | my_cluster  | cluster     | CREATE
+ database    | schema | name        | object_type | grantee | privileges     | grantor
+-------------+--------+-------------+-------------+---------+----------------+---------
+ materialize | public | my_table    | table       | r1      | SELECT, INSERT | r2
+ materialize | public | my_view     | view        | r1      | SELECT         | r2
+ materialize | qa     | my_secret   | secret      | r1      | USAGE          | r2
+ materialize | NULL   | public      | schema      | r1      | USAGE          | r2
+ NULL        | NULL   | materialize | database    | r1      | USAGE          | r2
+ NULL        | NULL   | my_db       | database    | r1      | USAGE          | r2
+ NULL        | NULL   | my_cluster  | cluster     | r1      | CREATE         | r2
 ```
 
 ```sql
 SHOW PRIVILEGES FROM ALL DATABASES;
 
- database    | schema | name        | object_type | privileges
--------------+--------+-------------+-------------+----------------
- materialize | public | my_table    | table       | SELECT, INSERT
- materialize | public | my_view     | view        | SELECT
- materialize | NULL   | public      | schema      | USAGE
- db2         | NULL   | my_schema   | schema      | CREATE
- NULL        | NULL   | materialize | database    | USAGE
- NULL        | NULL   | my_db       | database    | USAGE
- NULL        | NULL   | my_cluster  | cluster     | CREATE
+ database    | schema | name        | object_type | grantee | privileges     | grantor
+-------------+--------+-------------+-------------+---------+----------------+---------
+ materialize | public | my_table    | table       | r1      | SELECT, INSERT | r2
+ materialize | public | my_view     | view        | r1      | SELECT         | r2
+ materialize | NULL   | public      | schema      | r1      | USAGE          | r2
+ db2         | NULL   | my_schema   | schema      | r1      | CREATE         | r2
+ NULL        | NULL   | materialize | database    | r1      | USAGE          | r2
+ NULL        | NULL   | my_db       | database    | r1      | USAGE          | r2
+ NULL        | NULL   | my_cluster  | cluster     | r1      | CREATE         | r2
 ```
 
 ### `SHOW DEFAULT PRIVILEGES`
@@ -229,17 +231,18 @@ The output will include the following columns:
 
 - `role_name: text` - Name of the role.
 - `member_name: text` - Name of a role that is a member of `role_name`.
+- `grantor_name: text` - Name of a role that granted the membership.
 
 Here is an example query:
 
 ```sql
 SHOW ROLE MEMBERSHIPS;
 
- role_name      | member_name
-----------------+-------------
- data_scientist | joe
- dev            | mike
- qa             | arjun
+ role_name      | member_name | grantor
+----------------+-------------+-----------
+ data_scientist | joe         | mz_system
+ dev            | mike        | mz_system
+ qa             | arjun       | mz_system
 ```
 
 ### `SHOW <OBJECTS>`

--- a/doc/developer/design/20230714_show_privileges.md
+++ b/doc/developer/design/20230714_show_privileges.md
@@ -175,7 +175,7 @@ Here is an example query:
 ```sql
 SHOW ROLE MEMBERSHIP;
 
- name       
+ name
 ----------------
  data_scientist
  dev

--- a/doc/developer/design/20230714_show_privileges.md
+++ b/doc/developer/design/20230714_show_privileges.md
@@ -60,9 +60,9 @@ values are:
 - `FROM DATABASE <database>` will filter the output to exclude schemas not in database `<database>`.
   - This has no effect on item, database, cluster, or cluster privileges.
   - If a database or `ALL DATABASES` is not specified then the active database is assumed.
-  - Invalid if an object type of `DATABASE`, `CLUSTER`, or `SYSTEM` has been specified. 
+  - Invalid if an object type of `DATABASE`, `CLUSTER`, or `SYSTEM` has been specified.
 - `FROM ALL DATABASES` will include all schemas.
-  - Invalid if an object type of `DATABASE`, `CLUSTER`, or `SYSTEM` has been specified. 
+  - Invalid if an object type of `DATABASE`, `CLUSTER`, or `SYSTEM` has been specified.
 
 The output will include the following columns:
 

--- a/doc/developer/design/20230714_show_privileges.md
+++ b/doc/developer/design/20230714_show_privileges.md
@@ -119,11 +119,7 @@ The syntax will be `SHOW DEFAULT PRIVILEGES [ON <object-type>]`.
 
 - `ON <object-type>` will filter the output to only include objects of type `<object-type>`. Valid
   values are:
-  - `TABLES`
-  - `VIEWS`
-  - `MATERIALIZED VIEWS`
-  - `SOURCES`
-  - `SINKS`
+  - `TABLES` (includes views, materialized views, and sources)
   - `TYPES`
   - `CLUSTERS`
   - `SECRETS`
@@ -148,7 +144,7 @@ SHOW DEFAULT PRIVILEGES;
  role   | database    | schema | object_type | grantee   | privileges
 --------+-------------+--------+-------------+-----------+----------------
  PUBLIC | NULL        | NULL   | table       | dev       | INSERT, SELECT
- joe    | materialize | NULL   | view        | PUBLIC    | SELECT
+ joe    | materialize | NULL   | table       | PUBLIC    | SELECT
  qa     | materialize | public | type        | scientist | USAGE
  PUBLIC | NULL        | NULL   | cluster     | mike      | CREATE
 ```
@@ -159,6 +155,7 @@ SHOW DEFAULT PRIVILEGES ON TABLES;
  role   | database    | schema | object_type | grantee   | privileges
 --------+-------------+--------+-------------+-----------+----------------
  PUBLIC | NULL        | NULL   | table       | dev       | INSERT, SELECT
+ joe    | materialize | NULL   | table       | PUBLIC    | SELECT
 ```
 
 ### `SHOW ROLE MEMBERSHIPS`


### PR DESCRIPTION
This commit adds a design doc for updates to the `SHOW` commands for RBAC related features.

Works towards resolving #20452 

### Motivation

Design doc.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
