### PR TITLE
Prevent user from calling `current` functions with parentheses

### DIFF
--- a/doc/developer/design/20230216_role_based_access_control.md
+++ b/doc/developer/design/20230216_role_based_access_control.md
@@ -165,11 +165,11 @@ revoked.
 
 We will add the following functions:
 
-- `current_role()`
+- `current_role`
     - Returns the current role of the session.
-- `current_user()`
-    - Alias for `current_role()`.
-- `session_user()`
+- `current_user`
+    - Alias for `current_role`.
+- `session_user`
     - Returns the role that initiated the database connection.
 
 NOTE: Since we won't support `SET ROLE` yet, these functions will all behave identically.

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -723,15 +723,15 @@
     description: >-
       Returns the name of the current database.
     unmaterializable: true
-  - signature: 'current_role() -> text'
+  - signature: 'current_role -> text'
     description: >-
       Alias for `current_user`.
     unmaterializable: true
-  - signature: 'current_user() -> text'
+  - signature: 'current_user -> text'
     description: >-
       Returns the name of the user who executed the containing query.
     unmaterializable: true
-  - signature: 'session_user() -> text'
+  - signature: 'session_user -> text'
     description: >-
       Returns the name of the user who initiated the database connection.
     unmaterializable: true
@@ -757,7 +757,7 @@
   functions:
   - signature: 'format_type(oid: int, typemod: int) -> text'
     description: Returns the canonical SQL name for the type specified by `oid` with `typemod` applied.
-  - signature: 'current_schema() -> text'
+  - signature: 'current_schema -> text'
     description: >-
       Returns the name of the first non-implicit schema on the search path, or
       `NULL` if the search path is empty.

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -488,7 +488,7 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
                     .build()
                     .unwrap();
                 let res = query_http_api(
-                    "SELECT pg_catalog.current_user()",
+                    "SELECT pg_catalog.current_user",
                     &uri,
                     headers,
                     configure,
@@ -554,7 +554,7 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
                     .unwrap();
 
                 ws.write_message(Message::Text(
-                    r#"{"query": "SELECT pg_catalog.current_user()"}"#.into(),
+                    r#"{"query": "SELECT pg_catalog.current_user"}"#.into(),
                 ))
                 .unwrap();
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -784,6 +784,23 @@ impl<'a> Parser<'a> {
                 None
             };
 
+        // According to PostgresSQL documentation: https://www.postgresql.org/docs/current/functions-info.html
+        // current_schema, current_user, current_role, and session_user must be called without trailing parentheses.
+        // Here we prevent user from calling these functions using trailing parentheses.
+        if name.to_string().as_str() == "current_schema"
+            || name.to_string().as_str() == "current_user"
+            || name.to_string().as_str() == "current_role"
+            || name.to_string().as_str() == "session_user"
+        {
+            return Err(self.error(
+                self.peek_prev_pos() - 1,
+                format!(
+                    "Function {} must be called without trailing parantheses.",
+                    name.to_string().as_str()
+                ),
+            ));
+        }
+
         Ok(Function {
             name,
             args,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1526,9 +1526,9 @@ fn plan_set_expr(
             // now we just disallow any `SHOW` commands in views.
             //
             // Ideally, the `SHOW` commands that use the current schema would expand to use the
-            // `current_schema()` function, instead of hard-coding the current schema id, so that
+            // `current_schema` function, instead of hard-coding the current schema id, so that
             // planning can correctly identify that they are unmaterializable. However, that's a
-            // little tricky because `current_schema()` returns a schema name not id, which is what
+            // little tricky because `current_schema` returns a schema name not id, which is what
             // we need.
             if qcx.lifetime == QueryLifetime::Static {
                 return Err(PlanError::ShowCommandInView);

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -540,7 +540,7 @@ impl Stash {
                     r#"
             SELECT EXISTS (
                 SELECT 1 FROM pg_tables
-                WHERE schemaname = current_schema() AND tablename = 'fence'
+                WHERE schemaname = current_schema AND tablename = 'fence'
             )"#,
                     &[],
                 )

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -226,7 +226,7 @@ SELECT pg_get_userbyid(4294967295);
 # Test concurrently dropped role
 
 simple conn=foo,user=foo
-SELECT current_user();
+SELECT current_user;
 ----
 foo
 COMPLETE 1
@@ -235,7 +235,7 @@ statement ok
 DROP ROLE foo
 
 simple conn=foo,user=foo
-SELECT current_user();
+SELECT current_user;
 ----
 db error: ERROR: role u4 was concurrently dropped
 DETAIL: Please disconnect and re-connect with a valid role.

--- a/test/sqllogictest/schemas.slt
+++ b/test/sqllogictest/schemas.slt
@@ -39,7 +39,7 @@ show search_path
 "ba r", foo, "x, y", "a, b"
 
 query T
-SELECT current_schema()
+SELECT current_schema
 ----
 NULL
 
@@ -60,7 +60,7 @@ statement ok
 SET cluster = noexist
 
 query T
-SELECT current_schema()
+SELECT current_schema
 ----
 NULL
 
@@ -85,7 +85,7 @@ CREATE SCHEMA foo
 ----
 
 query T
-SELECT current_schema()
+SELECT current_schema
 ----
 foo
 
@@ -116,7 +116,7 @@ show search_path
 pg_catalog
 
 query T
-SELECT current_schema()
+SELECT current_schema
 ----
 pg_catalog
 


### PR DESCRIPTION
Prevent user from calling `current_role()`, `current_user()`, `current_schema`, and `session_user()` with trailing parentheses to align with PostgreSQL. 

### Motivation
This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/18824

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - `current_user`, `current_role`, `current_schema`, and `session_user` are now called only without trailing parentheses.
