### PR TITLE
Ignore all editable Python installation artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,5 @@ scratch
 **/flake.lock
 
 /misc/python/materialize/build/
-/misc/python/materialize/mz_test_base.egg-info/
+/misc/python/materialize/*.egg-info/
 /misc/python/materialize/dist/


### PR DESCRIPTION
As of #19906 we have a couple of Python packages we define for test
purposes that are installed in "editable" mode. This ensures that none
of them confuse Git too much.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): None