### PR TITLE
doc/user: improve `EXPLAIN TIMESTAMP` UX

### DIFF
--- a/doc/user/content/sql/begin.md
+++ b/doc/user/content/sql/begin.md
@@ -30,7 +30,7 @@ Transactions in Materialize do not support interleaving arbitrary kinds of state
 A **read-only** transaction starts with a [`SELECT`](/sql/select) statement and allows only `SELECT` statements.
 Because Materialize does not know which objects (sources, tables, or views) will be queried during the transaction, the objects in the first `SELECT` and any other object in the same schemas are assumed to be possible query targets.
 Other queries can only reference these same-schema objects.
-During the first query, a timestamp is chosen that is valid for all of those objects.
+During the first query, a timestamp is chosen that is greater than the [read frontier](/sql/explain#source-frontiers) for all of those objects.
 This timestamp will be used for all other queries.
 The transaction will additionally hold back normal compaction of the objects, potentially increasing memory usage for very long running transactions.
 

--- a/doc/user/content/sql/consistency.md
+++ b/doc/user/content/sql/consistency.md
@@ -5,6 +5,12 @@ aliases:
   - /sql/consistency
   - /sql/isolation-level
   - /overview/isolation-level/
+  - /get-started/isolation-level
+menu:
+  main:
+    parent: 'reference'
+    name: 'Consistency guarantees'
+    weight: 20
 ---
 
 The SQL standard defines four levels of transaction isolation. In order of least strict to most strict they are:
@@ -116,6 +122,35 @@ executed immediately. A consistent snapshot is guaranteed to be available for qu
 (which includes queries against a single materialized view that was created using multiple objects). Such queries will
 therefore never block, and always be executed immediately.
 
+## Conceptual model
+
+### Timestamps
+
+All data in Materialize is associated with a logical timestamp. Every
+transaction executes at a specific logical time and can observe only the data
+whose timestamp is less than or equal to the transaction's timestamp. See the
+[`BEGIN`](/sql/begin) documentation for details on how Materialize selects the
+timestamp for a transaction.
+
+### Queryable objects
+
+There are four types of objects in Materialize that store data: sources, tables,
+indexes, and materialized views. We refer to these objects as **queryable
+objects**. Each queryable object has a read frontier and a write frontier:
+
+  * The **read frontier** is the earliest time at which the object's data is
+    known.
+  * The **write frontier** is the earliest time at which the object's data may
+    change.
+
+The data in a queryable object is known for all times that are less than the
+write frontier but greater than the read frontier.
+
+Queries **may not** to execute at a timestamp that is less than the read
+frontier of any referenced object. Queries **may** execute at a timestamp that
+is greater than or equal to the write frontier of a referenced object, but they
+will block until the write frontier of the object advances beyond the query
+timestamp.
 
 ## Learn more
 


### PR DESCRIPTION
Noodle on some UX improvements to `EXPLAIN TIMESTAMP` by way of trying to improve its documentation. The documentation here is somewhat optimistic, in that it describes a version of `EXPLAIN TIMESTAMP` that does not actually exist. The terms that the actual `EXPLAIN TIMESTAMP` uses today are hard enough to explain that it seemed worth revisting them.

To merge this, someone would need to write some sort of design doc for `EXPLAIN TIMESTAMP` improvements, and then actually code them up.

Slack context: https://materializeinc.slack.com/archives/CPNFV9CVB/p1689712117898399

### Motivation

* This PR improves documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
