### PR TITLE
Fix CREATE CLUSTER syntax

### DIFF
--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -85,8 +85,6 @@ We plan to remove this restriction in a future version of Materialize.
 
 {{% cluster-options %}}
 
-We infer the value for `MANAGED` to be true unless you specify replicas manually.
-
 ## Unmanaged clusters
 
 ### Syntax

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -85,7 +85,9 @@ We plan to remove this restriction in a future version of Materialize.
 
 We infer the value for `MANAGED` to be true unless you specify replicas manually.
 
-## Syntax to create unmanaged clusters
+## Unmanaged clusters
+
+### Syntax
 
 {{< diagram "create-cluster.svg" >}}
 

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -81,7 +81,7 @@ We plan to remove this restriction in a future version of Materialize.
 
 {{< diagram "create-managed-cluster.svg" >}}
 
-### Cluster options
+#### `CLUSTER` options
 
 {{% cluster-options %}}
 

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -74,7 +74,8 @@ Managed clusters with sources and sinks only support a replication factor of zer
 We plan to remove this restriction in a future version of Materialize.
 {{< /warning >}}
 
-## Syntax
+## Syntax to create managed clusters
+
 
 {{< diagram "create-managed-cluster.svg" >}}
 
@@ -82,7 +83,9 @@ We plan to remove this restriction in a future version of Materialize.
 
 {{% cluster-options %}}
 
-## Syntax
+We infer the value for `MANAGED` to be true unless you specify replicas manually.
+
+## Syntax to create unmanaged clusters
 
 {{< diagram "create-cluster.svg" >}}
 

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -74,7 +74,9 @@ Managed clusters with sources and sinks only support a replication factor of zer
 We plan to remove this restriction in a future version of Materialize.
 {{< /warning >}}
 
-## Syntax to create managed clusters
+### Managed clusters
+
+### Syntax
 
 
 {{< diagram "create-managed-cluster.svg" >}}

--- a/doc/user/layouts/partials/sql-grammar/create-managed-cluster.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-managed-cluster.svg
@@ -1,49 +1,92 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="327" height="147">
-   <polygon points="11 17 3 13 3 21"/>
-   <polygon points="19 17 11 13 11 21"/>
-   <rect x="33" y="3" width="76" height="32" rx="10"/>
-   <rect x="31"
+<svg xmlns="http://www.w3.org/2000/svg" width="545" height="147">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="76" height="32" rx="10"/>
+   <rect x="29"
          y="1"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="21">CREATE</text>
-   <rect x="129" y="3" width="84" height="32" rx="10"/>
-   <rect x="127"
+   <text class="terminal" x="39" y="21">CREATE</text>
+   <rect x="127" y="3" width="84" height="32" rx="10"/>
+   <rect x="125"
          y="1"
          width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="137" y="21">CLUSTER</text>
-   <rect x="233" y="3" width="56" height="32"/>
-   <rect x="231" y="1" width="56" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="241" y="21">name</text>
-   <rect x="45" y="113" width="112" height="32"/>
-   <rect x="43" y="111" width="112" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="53" y="131">cluster_option</text>
-   <rect x="177" y="113" width="28" height="32" rx="10"/>
-   <rect x="175"
+   <text class="terminal" x="135" y="21">CLUSTER</text>
+   <rect x="231" y="3" width="56" height="32"/>
+   <rect x="229" y="1" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="239" y="21">name</text>
+   <rect x="307" y="3" width="50" height="32" rx="10"/>
+   <rect x="305"
+         y="1"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="315" y="21">SIZE</text>
+   <rect x="377" y="3" width="28" height="32" rx="10"/>
+   <rect x="375"
+         y="1"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="385" y="21">=</text>
+   <rect x="425" y="3" width="54" height="32"/>
+   <rect x="423" y="1" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="433" y="21">value</text>
+   <rect x="499" y="3" width="24" height="32" rx="10"/>
+   <rect x="497"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="507" y="21">,</text>
+   <rect x="89" y="113" width="114" height="32" rx="10"/>
+   <rect x="87"
+         y="111"
+         width="114"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="97" y="131">REPLICATION</text>
+   <rect x="223" y="113" width="78" height="32" rx="10"/>
+   <rect x="221"
+         y="111"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="231" y="131">FACTOR</text>
+   <rect x="341" y="113" width="28" height="32" rx="10"/>
+   <rect x="339"
          y="111"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="185" y="131">=</text>
-   <rect x="225" y="113" width="54" height="32"/>
-   <rect x="223" y="111" width="54" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="233" y="131">value</text>
-   <rect x="45" y="69" width="24" height="32" rx="10"/>
-   <rect x="43"
+   <text class="terminal" x="349" y="131">=</text>
+   <rect x="389" y="113" width="54" height="32"/>
+   <rect x="387" y="111" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="397" y="131">value</text>
+   <rect x="341" y="69" width="112" height="32"/>
+   <rect x="339" y="67" width="112" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="349" y="87">cluster_option</text>
+   <rect x="473" y="69" width="24" height="32" rx="10"/>
+   <rect x="471"
          y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="87">,</text>
+   <text class="terminal" x="481" y="87">,</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-308 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m112 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m-274 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m254 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-254 0 h10 m24 0 h10 m0 0 h210 m23 44 h-3"/>
-   <polygon points="317 127 325 123 325 131"/>
-   <polygon points="317 127 309 123 309 131"/>
+         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-478 110 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m114 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m0 0 h54 m-196 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m176 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-176 0 h10 m112 0 h10 m0 0 h10 m24 0 h10 m23 44 h-3"/>
+   <polygon points="535 127 543 123 543 131"/>
+   <polygon points="535 127 527 123 527 131"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-managed-cluster.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-managed-cluster.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="545" height="147">
+<svg xmlns="http://www.w3.org/2000/svg" width="379" height="147">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="76" height="32" rx="10"/>
@@ -28,65 +28,30 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="315" y="21">SIZE</text>
-   <rect x="377" y="3" width="28" height="32" rx="10"/>
-   <rect x="375"
-         y="1"
-         width="28"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="385" y="21">=</text>
-   <rect x="425" y="3" width="54" height="32"/>
-   <rect x="423" y="1" width="54" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="433" y="21">value</text>
-   <rect x="499" y="3" width="24" height="32" rx="10"/>
-   <rect x="497"
-         y="1"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="507" y="21">,</text>
-   <rect x="89" y="113" width="114" height="32" rx="10"/>
-   <rect x="87"
-         y="111"
-         width="114"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="97" y="131">REPLICATION</text>
-   <rect x="223" y="113" width="78" height="32" rx="10"/>
-   <rect x="221"
-         y="111"
-         width="78"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="231" y="131">FACTOR</text>
-   <rect x="341" y="113" width="28" height="32" rx="10"/>
-   <rect x="339"
+   <rect x="175" y="113" width="28" height="32" rx="10"/>
+   <rect x="173"
          y="111"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="349" y="131">=</text>
-   <rect x="389" y="113" width="54" height="32"/>
-   <rect x="387" y="111" width="54" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="397" y="131">value</text>
-   <rect x="341" y="69" width="112" height="32"/>
-   <rect x="339" y="67" width="112" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="349" y="87">cluster_option</text>
-   <rect x="473" y="69" width="24" height="32" rx="10"/>
-   <rect x="471"
+   <text class="terminal" x="183" y="131">=</text>
+   <rect x="223" y="113" width="54" height="32"/>
+   <rect x="221" y="111" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="231" y="131">value</text>
+   <rect x="175" y="69" width="112" height="32"/>
+   <rect x="173" y="67" width="112" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="183" y="87">cluster_option</text>
+   <rect x="307" y="69" width="24" height="32" rx="10"/>
+   <rect x="305"
          y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="481" y="87">,</text>
+   <text class="terminal" x="315" y="87">,</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-478 110 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m114 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m0 0 h54 m-196 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m176 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-176 0 h10 m112 0 h10 m0 0 h10 m24 0 h10 m23 44 h-3"/>
-   <polygon points="535 127 543 123 543 131"/>
-   <polygon points="535 127 527 123 527 131"/>
+         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m50 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-246 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m0 0 h54 m-196 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m176 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-176 0 h10 m112 0 h10 m0 0 h10 m24 0 h10 m23 44 h-3"/>
+   <polygon points="369 127 377 123 377 131"/>
+   <polygon points="369 127 361 123 361 131"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-managed-cluster.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-managed-cluster.svg
@@ -1,73 +1,49 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="469" height="135">
-   <polygon points="9 17 1 13 1 21"/>
-   <polygon points="17 17 9 13 9 21"/>
-   <rect x="31" y="3" width="76" height="32" rx="10"/>
-   <rect x="29"
+<svg xmlns="http://www.w3.org/2000/svg" width="327" height="147">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="76" height="32" rx="10"/>
+   <rect x="31"
          y="1"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="21">CREATE</text>
-   <rect x="127" y="3" width="84" height="32" rx="10"/>
-   <rect x="125"
+   <text class="terminal" x="41" y="21">CREATE</text>
+   <rect x="129" y="3" width="84" height="32" rx="10"/>
+   <rect x="127"
          y="1"
          width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="135" y="21">CLUSTER</text>
-   <rect x="231" y="3" width="56" height="32"/>
-   <rect x="229" y="1" width="56" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="239" y="21">name</text>
-   <rect x="307" y="3" width="26" height="32" rx="10"/>
-   <rect x="305"
-         y="1"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="315" y="21">(</text>
-   <rect x="353" y="3" width="94" height="32" rx="10"/>
-   <rect x="351"
-         y="1"
-         width="94"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="361" y="21">MANAGED</text>
-   <rect x="77" y="85" width="24" height="32" rx="10"/>
-   <rect x="75"
-         y="83"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="85" y="103">,</text>
-   <rect x="121" y="85" width="112" height="32"/>
-   <rect x="119" y="83" width="112" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="129" y="103">cluster_option</text>
-   <rect x="253" y="85" width="28" height="32" rx="10"/>
-   <rect x="251"
-         y="83"
+   <text class="terminal" x="137" y="21">CLUSTER</text>
+   <rect x="233" y="3" width="56" height="32"/>
+   <rect x="231" y="1" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="241" y="21">name</text>
+   <rect x="45" y="113" width="112" height="32"/>
+   <rect x="43" y="111" width="112" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="53" y="131">cluster_option</text>
+   <rect x="177" y="113" width="28" height="32" rx="10"/>
+   <rect x="175"
+         y="111"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="261" y="103">=</text>
-   <rect x="301" y="85" width="54" height="32"/>
-   <rect x="299" y="83" width="54" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="309" y="103">value</text>
-   <rect x="415" y="85" width="26" height="32" rx="10"/>
-   <rect x="413"
-         y="83"
-         width="26"
+   <text class="terminal" x="185" y="131">=</text>
+   <rect x="225" y="113" width="54" height="32"/>
+   <rect x="223" y="111" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="233" y="131">value</text>
+   <rect x="45" y="69" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="67"
+         width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="423" y="103">)</text>
+   <text class="terminal" x="53" y="87">,</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m94 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 82 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m24 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m-318 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m298 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-298 0 h10 m0 0 h288 m-338 32 h20 m338 0 h20 m-378 0 q10 0 10 10 m358 0 q0 -10 10 -10 m-368 10 v14 m358 0 v-14 m-358 14 q0 10 10 10 m338 0 q10 0 10 -10 m-348 10 h10 m0 0 h328 m20 -34 h10 m26 0 h10 m3 0 h-3"/>
-   <polygon points="459 99 467 95 467 103"/>
-   <polygon points="459 99 451 95 451 103"/>
+         d="m19 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-308 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m112 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m-274 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m254 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-254 0 h10 m24 0 h10 m0 0 h210 m23 44 h-3"/>
+   <polygon points="317 127 325 123 325 131"/>
+   <polygon points="317 127 309 123 309 131"/>
 </svg>

--- a/doc/user/layouts/shortcodes/cluster-options.html
+++ b/doc/user/layouts/shortcodes/cluster-options.html
@@ -1,6 +1,6 @@
 Field                               | Value      | Description
 ------------------------------------|------------|-------------------------------------
-`MANAGED`                           | `bool`     | Default: `true`. Indicates whether the cluster is a [managed cluster](/sql/create-cluster/#managed-and-unmanaged-clusters).
+`MANAGED`                           | `bool`     | Default: `true`. Indicates whether the cluster is a [managed cluster](/sql/create-cluster/#managed-and-unmanaged-clusters). We infer the value for `MANAGED` to be true unless you specify replicas manually.
 `SIZE`                              | `text`     | The size of the cluster replicas. For valid sizes, see [cluster replica sizes](/sql/create-cluster-replica#sizes).
 `REPLICATION FACTOR`                | `text`     | The replication factor of the cluster. Can be 0 to disable computations.
 `AVAILABILITY ZONES`                | `text[]`   | If you want the cluster replicas to reside in specific availability zones. You must specify a list of [AWS availability zone IDs] in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -49,7 +49,7 @@ create_cluster ::=
     'REPLICAS' '(' (replica_definition (',' replica_definition)*)? ')'
   )?
 create_managed_cluster ::=
-  'CREATE' 'CLUSTER' name cluster_option '=' value (',' cluster_option '=' value)*
+  'CREATE' 'CLUSTER' name 'SIZE' '=' value ',' 'REPLICATION' 'FACTOR' '=' value (',' cluster_option '=' value)*
 cluster_replica_def ::=
   replica_name '(' replica_option '=' value ( ',' replica_option '=' value )* ')'
 create_cluster_replica ::=

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -49,7 +49,7 @@ create_cluster ::=
     'REPLICAS' '(' (replica_definition (',' replica_definition)*)? ')'
   )?
 create_managed_cluster ::=
-  'CREATE' 'CLUSTER' name '(' 'MANAGED' (',' cluster_option '=' value)* ')'
+  'CREATE' 'CLUSTER' name cluster_option '=' value (',' cluster_option '=' value)*
 cluster_replica_def ::=
   replica_name '(' replica_option '=' value ( ',' replica_option '=' value )* ')'
 create_cluster_replica ::=

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -49,7 +49,7 @@ create_cluster ::=
     'REPLICAS' '(' (replica_definition (',' replica_definition)*)? ')'
   )?
 create_managed_cluster ::=
-  'CREATE' 'CLUSTER' name 'SIZE' '=' value ',' 'REPLICATION' 'FACTOR' '=' value (',' cluster_option '=' value)*
+  'CREATE' 'CLUSTER' name 'SIZE' '=' value (',' cluster_option '=' value)*
 cluster_replica_def ::=
   replica_name '(' replica_option '=' value ( ',' replica_option '=' value )* ')'
 create_cluster_replica ::=


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug. The `CREATE CLUSTER` syntax diagram was incorrect.

Preview: https://preview.materialize.com/materialize/20648/sql/create-cluster/

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
