### PR TITLE
doc/user: polish v0.61 release notes

### DIFF
--- a/doc/user/content/releases/v0.61.md
+++ b/doc/user/content/releases/v0.61.md
@@ -1,11 +1,41 @@
 ---
 title: "Materialize v0.61"
 date: 2023-07-19
-released: false
+released: true
 ---
 
 ## v0.61.0
 
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
+[//]: # "NOTE(morsapaes) v0.61 includes a first version of webhook sources
+released behind a feature flag."
+
+#### SQL
+
+* Improve and extend the base implementation of **Role-based
+  access control** (RBAC):
+
+  * Include `GRANT`, `REVOKE`, `ALTER DEFAULT PRIVILEGES`, and `ALTER OWNER`
+    events in the [`mz_audit_events`](/sql/system-catalog/mz_catalog/#mz_audit_events)
+    system catalog table.
+
+  * Require connection and secret `USAGE` privileges to execute [`CREATE SINK`](/sql/create-sink/)
+    commands.
+
+  It's important to note that role-based access control (RBAC) is **disabled by
+  default**. You must [contact us](https://materialize.com/contact/) to enable
+  this feature in your Materialize region.
+
+#### Bug fixes and other improvements
+
+* Do not require a valid active cluster to run specific types of queries, like
+  `SELECT n` health checks {{% gh 20420 %}}. This fixes a known issue in the
+  `dbt-materialize` adapter, where specific commands that run such queries as
+  part of their execution (e.g. `dbt debug`) would fail in the absence of the
+  pre-installed `default` cluster.
+
+* Extend `pg_catalog` and `information_schema` system catalog coverage for
+  compatibility with external tools like DBeaver and PopSQL {{% gh 20429 %}}
+  {{% gh 20314 %}} {{% gh 20427 %}}.
+
+* Avoid panicking in the presence of concurrent DDL and `UPDATE`, `DELETE`, or
+  `INSERT INTO` statements {{% gh 20420 %}}.

--- a/doc/user/content/releases/v0.62.md
+++ b/doc/user/content/releases/v0.62.md
@@ -1,0 +1,11 @@
+---
+title: "Materialize v0.62"
+date: 2023-07-26
+released: false
+---
+
+## v0.62.0
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}


### PR DESCRIPTION
Release notes for v0.61. 🍝 

## Tips for reviewer

Skipped #20171(!), since the first version of webhook sources is gated behind a feature flag. Added a [changelog issue](https://github.com/MaterializeInc/www/issues/612) to the queue.