### PR TITLE
compute-client: avoid incorrect history metrics

### DIFF
--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -316,14 +316,14 @@ impl StatsCollector<ProtoComputeCommand, ProtoComputeResponse> for ReplicaMetric
 /// Metrics keyed by `ComputeCommand` type.
 #[derive(Debug)]
 pub struct CommandMetrics<M> {
-    create_timely: M,
-    create_instance: M,
-    create_dataflow: M,
-    allow_compaction: M,
-    peek: M,
-    cancel_peek: M,
-    initialization_complete: M,
-    update_configuration: M,
+    pub create_timely: M,
+    pub create_instance: M,
+    pub create_dataflow: M,
+    pub allow_compaction: M,
+    pub peek: M,
+    pub cancel_peek: M,
+    pub initialization_complete: M,
+    pub update_configuration: M,
 }
 
 impl<M> CommandMetrics<M> {

--- a/src/compute-client/src/protocol/history.rs
+++ b/src/compute-client/src/protocol/history.rs
@@ -12,6 +12,7 @@
 use std::borrow::Borrow;
 use std::collections::{BTreeMap, BTreeSet};
 
+use mz_ore::cast::CastFrom;
 use mz_ore::metrics::UIntGauge;
 use timely::progress::Antichain;
 
@@ -52,25 +53,24 @@ where
     /// This action will reduce the history every time it doubles while retaining the
     /// provided peeks.
     pub fn push<V>(&mut self, command: ComputeCommand<T>, peeks: &BTreeMap<uuid::Uuid, V>) {
-        self.push_inner(command);
+        self.commands.push(command);
+
         if self.commands.len() > 2 * self.reduced_count {
             self.retain_peeks(peeks);
             self.reduce();
+        } else {
+            // Refresh reported metrics. `reduce` already refreshes metrics, so we only need to do
+            // that here in the non-reduce case.
+            let command = self.commands.last().expect("pushed above");
+            self.metrics
+                .command_counts
+                .for_command(command)
+                .borrow()
+                .inc();
+            if matches!(command, ComputeCommand::CreateDataflow(_)) {
+                self.metrics.dataflow_count.borrow().inc();
+            }
         }
-    }
-
-    /// Add a command to the history.
-    fn push_inner(&mut self, command: ComputeCommand<T>) {
-        self.metrics
-            .command_counts
-            .for_command(&command)
-            .borrow()
-            .inc();
-        if matches!(command, ComputeCommand::CreateDataflow(_)) {
-            self.metrics.dataflow_count.borrow().inc();
-        }
-
-        self.commands.push(command);
     }
 
     /// Reduces `self.history` to a minimal form.
@@ -173,46 +173,66 @@ where
         // Discard dataflows whose outputs have all been allowed to compact away.
         live_dataflows.retain(|dataflow| dataflow.as_of != Some(Antichain::new()));
 
-        // Record the volume of post-compaction commands.
-        let mut command_count = 1;
-        command_count += live_dataflows.len();
-        command_count += final_frontiers.len();
-        command_count += live_peeks.len();
-        command_count += live_cancels.len();
-        if !final_configuration.all_unset() {
-            command_count += 1;
-        }
-
-        self.metrics.reset();
-
         // Reconstitute the commands as a compact history.
+
+        // When we update `metrics`, we need to be careful to not transiently report incorrect
+        // counts, as they would be observable by other threads.
+        let command_counts = &self.metrics.command_counts;
+        let dataflow_count = &self.metrics.dataflow_count;
+
+        let count = u64::from(create_timely_command.is_some());
+        command_counts.create_timely.borrow().set(count);
         if let Some(create_timely_command) = create_timely_command {
-            self.push_inner(create_timely_command);
-        }
-        if let Some(create_inst_command) = create_inst_command {
-            self.push_inner(create_inst_command);
-        }
-        if !final_configuration.all_unset() {
-            self.push_inner(ComputeCommand::UpdateConfiguration(final_configuration));
-        }
-        for dataflow in live_dataflows {
-            self.push_inner(ComputeCommand::CreateDataflow(dataflow));
-        }
-        for peek in live_peeks {
-            self.push_inner(ComputeCommand::Peek(peek));
-        }
-        for uuid in live_cancels {
-            self.push_inner(ComputeCommand::CancelPeek { uuid });
-        }
-        // Allow compaction only after emmitting peek commands.
-        for (id, frontier) in final_frontiers {
-            self.push_inner(ComputeCommand::AllowCompaction { id, frontier });
-        }
-        if initialization_complete {
-            self.push_inner(ComputeCommand::InitializationComplete);
+            self.commands.push(create_timely_command);
         }
 
-        self.reduced_count = command_count;
+        let count = u64::from(create_inst_command.is_some());
+        command_counts.create_instance.borrow().set(count);
+        if let Some(create_inst_command) = create_inst_command {
+            self.commands.push(create_inst_command);
+        }
+
+        let count = u64::from(!final_configuration.all_unset());
+        command_counts.update_configuration.borrow().set(count);
+        if !final_configuration.all_unset() {
+            self.commands
+                .push(ComputeCommand::UpdateConfiguration(final_configuration));
+        }
+
+        let count = u64::cast_from(live_dataflows.len());
+        command_counts.create_dataflow.borrow().set(count);
+        dataflow_count.borrow().set(count);
+        for dataflow in live_dataflows {
+            self.commands.push(ComputeCommand::CreateDataflow(dataflow));
+        }
+
+        let count = u64::cast_from(live_peeks.len());
+        command_counts.peek.borrow().set(count);
+        for peek in live_peeks {
+            self.commands.push(ComputeCommand::Peek(peek));
+        }
+
+        let count = u64::cast_from(live_cancels.len());
+        command_counts.cancel_peek.borrow().set(count);
+        for uuid in live_cancels {
+            self.commands.push(ComputeCommand::CancelPeek { uuid });
+        }
+
+        // Allow compaction only after emmitting peek commands.
+        let count = u64::cast_from(final_frontiers.len());
+        command_counts.allow_compaction.borrow().set(count);
+        for (id, frontier) in final_frontiers {
+            self.commands
+                .push(ComputeCommand::AllowCompaction { id, frontier });
+        }
+
+        let count = u64::from(initialization_complete);
+        command_counts.initialization_complete.borrow().set(count);
+        if initialization_complete {
+            self.commands.push(ComputeCommand::InitializationComplete);
+        }
+
+        self.reduced_count = self.commands.len();
     }
 
     /// Retain only those peeks present in `peeks` and discard the rest.

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -337,11 +337,9 @@ def workflow_test_github_15531(c: Composition) -> None:
     assert controller_command_count > 0, "controller history cannot be empty"
     assert (
         controller_dataflow_count == 1
-    ), "more dataflows than expected in controller history"
+    ), "expected a single dataflow in controller history"
     assert replica_command_count > 0, "replica history cannot be empty"
-    assert (
-        replica_dataflow_count == 1
-    ), "more dataflows than expected in replica history"
+    assert replica_dataflow_count == 1, "expected a single dataflow in replica history"
 
     # execute 400 fast- and slow-path peeks
     for _ in range(20):
@@ -370,8 +368,8 @@ def workflow_test_github_15531(c: Composition) -> None:
             """
         )
 
-    # check that dataflow count is the same and
-    # that history size is well-behaved
+    # Check that history size and dataflow count are well-behaved.
+    # Dataflow count can plausibly be more than 1, if compaction is delayed.
     (
         controller_command_count,
         controller_dataflow_count,
@@ -382,11 +380,17 @@ def workflow_test_github_15531(c: Composition) -> None:
         controller_command_count < 100
     ), "controller history grew more than expected after peeks"
     assert (
+        controller_dataflow_count > 0
+    ), "at least one dataflow expected in controller history"
+    assert (
         controller_dataflow_count < 5
     ), "more dataflows than expected in controller history"
     assert (
         replica_command_count < 100
     ), "replica history grew more than expected after peeks"
+    assert (
+        replica_dataflow_count > 0
+    ), "at least one dataflow expected in replica history"
     assert replica_dataflow_count < 5, "more dataflows than expected in replica history"
 
 


### PR DESCRIPTION
This PR changes the way the `ComputeCommandHistory` updates its metrics to ensure that no incorrect states are produced while the `reduce` logic is executing. These incorrect states (like command count transiently becomming 0) could be observed by outside consumers, leading to unnecessary confusion.

### Motivation

  * This PR fixes a recognized bug.

Fixes #20242.

### Tips for reviewer

Unfortunately, the new code is more boiler-platey, since we can't deduplicate metrics updates anymore. I tried my best to condense it without overcomplicating things.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
