### PR TITLE
persist: introduce v2 rollups containing inlined diffs

### DIFF
--- a/src/persist-client/build.rs
+++ b/src/persist-client/build.rs
@@ -115,6 +115,7 @@ fn main() {
         .bytes([
             ".mz_persist_client.internal.diff.ProtoStateFieldDiffs",
             ".mz_persist_client.internal.state.ProtoHollowBatchPart",
+            ".mz_persist_client.internal.state.ProtoVersionedData",
             ".mz_persist_client.internal.service.ProtoPushDiff",
         ]);
 

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -39,7 +39,7 @@ use crate::internal::encoding::UntypedState;
 use crate::internal::paths::{
     BlobKey, BlobKeyPrefix, PartialBatchKey, PartialBlobKey, PartialRollupKey, WriterKey,
 };
-use crate::internal::state::{ProtoStateDiff, ProtoStateRollup, State};
+use crate::internal::state::{ProtoRollup, ProtoStateDiff, State};
 use crate::rpc::NoopPubSubSender;
 use crate::usage::{HumanBytes, StorageUsageClient};
 use crate::{Metrics, PersistClient, PersistConfig, ShardId, StateVersions};
@@ -225,10 +225,12 @@ pub async fn fetch_latest_state(args: &StateArgs) -> Result<impl serde::Serializ
     let versions = state_versions
         .fetch_recent_live_diffs::<u64>(&shard_id)
         .await;
-    let state = state_versions
-        .fetch_current_state::<u64>(&shard_id, versions.0.clone())
-        .await
-        .into_proto();
+    // let state = state_versions
+    //     .fetch_current_state::<u64>(&shard_id, versions.0.clone())
+    //     .await
+    //     .into_proto();
+    // WIP
+    let state = "abc";
     Ok(state)
 }
 
@@ -253,7 +255,7 @@ pub async fn fetch_state_rollup(
         .get(&rollup_key.complete(&shard_id))
         .await?
         .expect("fetching the specified state rollup");
-    let proto = ProtoStateRollup::decode(rollup_buf).expect("invalid encoded state");
+    let proto = ProtoRollup::decode(rollup_buf).expect("invalid encoded state");
     Ok(proto)
 }
 
@@ -286,7 +288,7 @@ pub async fn fetch_state_rollups(args: &StateArgs) -> Result<impl serde::Seriali
             .await
             .unwrap();
         if let Some(rollup_buf) = rollup_buf {
-            let proto = ProtoStateRollup::decode(rollup_buf).expect("invalid encoded state");
+            let proto = ProtoRollup::decode(rollup_buf).expect("invalid encoded state");
             rollup_states.insert(key.to_string(), proto);
         }
     }
@@ -301,14 +303,15 @@ pub async fn fetch_state_diffs(
     let shard_id = args.shard_id();
     let state_versions = args.open().await?;
 
-    let mut live_states = vec![];
+    // WIP
+    let mut live_states: Vec<&str> = vec![];
     let mut state_iter = state_versions
         .fetch_all_live_states::<u64>(shard_id)
         .await
         .expect("requested shard should exist")
         .check_ts_codec()?;
     while let Some(_) = state_iter.next(|_| {}) {
-        live_states.push(state_iter.into_proto());
+        // live_states.push(state_iter.into_proto());
     }
 
     Ok(live_states)

--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -27,12 +27,12 @@ use crate::error::CodecMismatch;
 use crate::internal::gc::GcReq;
 use crate::internal::maintenance::RoutineMaintenance;
 use crate::internal::metrics::{CmdMetrics, Metrics, ShardMetrics};
-use crate::internal::paths::{PartialRollupKey, RollupId};
+use crate::internal::paths::PartialRollupKey;
 use crate::internal::state::{
     ExpiryMetrics, HollowBatch, Since, SnapshotErr, StateCollections, TypedState, Upper,
 };
 use crate::internal::state_diff::StateDiff;
-use crate::internal::state_versions::{EncodedRollup, StateVersions};
+use crate::internal::state_versions::StateVersions;
 use crate::internal::trace::FueledMergeReq;
 use crate::internal::watch::StateWatch;
 use crate::rpc::PubSubSender;

--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -257,16 +257,11 @@ where
             })
     }
 
-    pub async fn write_rollup_blob(&self, rollup_id: &RollupId) -> EncodedRollup {
-        let rollup = self
-            .state
+    pub fn clone_state_for_rollup(&self) -> TypedState<K, V, T, D> {
+        self.state
             .read_lock(&self.metrics.locks.applier_read_noncacheable, |state| {
-                let key = PartialRollupKey::new(state.seqno, rollup_id);
-                self.state_versions
-                    .encode_rollup_blob(&self.shard_metrics, state, key)
-            });
-        let () = self.state_versions.write_rollup_blob(&rollup).await;
-        rollup
+                state.clone_for_rollup()
+            })
     }
 
     pub async fn apply_unbatched_cmd<

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -192,6 +192,7 @@ mod tests {
                         };
                         let mut state = state.lock().await;
                         let res = match tc.directive.as_str() {
+                            "add-rollup" => machine_dd::add_rollup(&mut state, args).await,
                             "apply-merge-res" => {
                                 machine_dd::apply_merge_res(&mut state, args).await
                             }

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -28,7 +28,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
-use tracing::debug;
+use tracing::{debug, info};
 use uuid::Uuid;
 
 use crate::critical::CriticalReaderId;
@@ -762,8 +762,11 @@ impl RustType<ProtoInlinedDiffs> for InlinedDiffs {
     }
 
     fn from_proto(proto: ProtoInlinedDiffs) -> Result<Self, TryFromProtoError> {
+        info!("Decoding inlined diffs: {:?}", proto);
         let description: Description<SeqNo> = proto.description.into_rust_if_some("description")?;
+        info!("Decoded description: {:?}", description);
         let mut seqno = description.lower().first().expect("lower seqno").clone();
+        info!("Seqno: {}", seqno);
         let mut diffs = Vec::with_capacity(proto.diffs.len());
 
         for data in proto.diffs {
@@ -774,10 +777,12 @@ impl RustType<ProtoInlinedDiffs> for InlinedDiffs {
             seqno = seqno.next();
         }
 
-        assert_eq!(
-            seqno.next(),
-            *description.upper().first().expect("upper seqno")
-        );
+        info!("Seqno after: {}", seqno);
+
+        // assert_eq!(
+        //     seqno.next(),
+        //     *description.upper().first().expect("upper seqno")
+        // );
 
         Ok(Self { description, diffs })
     }

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -39,9 +39,9 @@ use crate::internal::state::{
     CriticalReaderState, HandleDebugState, HollowBatch, HollowBatchPart, HollowRollup,
     IdempotencyToken, LeasedReaderState, OpaqueState, ProtoCriticalReaderState,
     ProtoHandleDebugState, ProtoHollowBatch, ProtoHollowBatchPart, ProtoHollowRollup,
-    ProtoLeasedReaderState, ProtoStateDiff, ProtoStateField, ProtoStateFieldDiffType,
-    ProtoStateFieldDiffs, ProtoStateRollup, ProtoTrace, ProtoU64Antichain, ProtoU64Description,
-    ProtoWriterState, State, StateCollections, TypedState, WriterState,
+    ProtoInlinedDiffs, ProtoLeasedReaderState, ProtoRollup, ProtoStateDiff, ProtoStateField,
+    ProtoStateFieldDiffType, ProtoStateFieldDiffs, ProtoTrace, ProtoU64Antichain,
+    ProtoU64Description, ProtoWriterState, State, StateCollections, TypedState, WriterState,
 };
 use crate::internal::state_diff::{
     ProtoStateFieldDiff, ProtoStateFieldDiffsWriter, StateDiff, StateFieldDiff, StateFieldValDiff,
@@ -571,80 +571,7 @@ where
     Ok(())
 }
 
-impl<K, V, T, D> TypedState<K, V, T, D>
-where
-    K: Codec,
-    V: Codec,
-    T: Timestamp + Lattice + Codec64,
-    D: Codec64,
-{
-    pub fn encode<B>(&self, buf: &mut B)
-    where
-        B: bytes::BufMut,
-    {
-        self.into_proto()
-            .encode(buf)
-            .expect("no required fields means no initialization errors");
-    }
-
-    pub(crate) fn into_proto(&self) -> ProtoStateRollup {
-        self.state
-            .into_proto(K::codec_name(), V::codec_name(), D::codec_name())
-    }
-}
-
-impl<T> State<T>
-where
-    T: Timestamp + Lattice + Codec64,
-{
-    pub(crate) fn into_proto(
-        &self,
-        key_codec: String,
-        val_codec: String,
-        diff_codec: String,
-    ) -> ProtoStateRollup {
-        ProtoStateRollup {
-            applier_version: self.applier_version.to_string(),
-            shard_id: self.shard_id.into_proto(),
-            seqno: self.seqno.into_proto(),
-            walltime_ms: self.walltime_ms.into_proto(),
-            hostname: self.hostname.into_proto(),
-            key_codec,
-            val_codec,
-            ts_codec: T::codec_name(),
-            diff_codec,
-            last_gc_req: self.collections.last_gc_req.into_proto(),
-            rollups: self
-                .collections
-                .rollups
-                .iter()
-                .map(|(seqno, key)| (seqno.into_proto(), key.into_proto()))
-                .collect(),
-            deprecated_rollups: Default::default(),
-            leased_readers: self
-                .collections
-                .leased_readers
-                .iter()
-                .map(|(id, state)| (id.into_proto(), state.into_proto()))
-                .collect(),
-            critical_readers: self
-                .collections
-                .critical_readers
-                .iter()
-                .map(|(id, state)| (id.into_proto(), state.into_proto()))
-                .collect(),
-            writers: self
-                .collections
-                .writers
-                .iter()
-                .map(|(id, state)| (id.into_proto(), state.into_proto()))
-                .collect(),
-            trace: Some(self.collections.trace.into_proto()),
-        }
-    }
-}
-
-/// A decoded version of [ProtoStateRollup] for which we have not yet checked
+/// A decoded version of [ProtoRollup::state] for which we have not yet checked
 /// that codecs match the ones in durable state.
 #[derive(Debug)]
 #[cfg_attr(any(test, debug_assertions), derive(PartialEq))]
@@ -733,28 +660,121 @@ impl<T: Timestamp + Lattice + Codec64> UntypedState<T> {
     }
 
     pub fn decode(build_version: &Version, buf: impl Buf) -> Self {
-        let proto = ProtoStateRollup::decode(buf)
+        let proto = ProtoRollup::decode(buf)
             // We received a State that we couldn't decode. This could happen if
             // persist messes up backward/forward compatibility, if the durable
             // data was corrupted, or if operations messes up deployment. In any
             // case, fail loudly.
             .expect("internal error: invalid encoded state");
-        let state = Self::from_proto(proto).expect("internal error: invalid encoded state");
+        let state = StateRollup::from_proto(proto)
+            .expect("internal error: invalid encoded state")
+            .state;
         check_applier_version(build_version, &state.state.applier_version);
         state
     }
 }
 
-impl<T: Timestamp + Lattice + Codec64> RustType<ProtoStateRollup> for UntypedState<T> {
-    fn into_proto(&self) -> ProtoStateRollup {
-        self.state.into_proto(
-            self.key_codec.clone(),
-            self.val_codec.clone(),
-            self.diff_codec.clone(),
-        )
+#[derive(Debug)]
+struct StateRollup<T> {
+    pub(crate) state: UntypedState<T>,
+    pub(crate) diffs: Option<InlinedDiffs>,
+}
+
+#[derive(Debug)]
+struct InlinedDiffs {
+    description: Description<SeqNo>,
+    diffs: Vec<VersionedData>,
+}
+
+impl RustType<ProtoInlinedDiffs> for InlinedDiffs {
+    fn into_proto(&self) -> ProtoInlinedDiffs {
+        ProtoInlinedDiffs {
+            description: Some(self.description.into_proto()),
+            diffs: self
+                .diffs
+                .iter()
+                // cloning a Bytes is cheap
+                .map(|x| x.data.clone().into())
+                .collect::<Vec<_>>(),
+        }
     }
 
-    fn from_proto(x: ProtoStateRollup) -> Result<Self, TryFromProtoError> {
+    fn from_proto(proto: ProtoInlinedDiffs) -> Result<Self, TryFromProtoError> {
+        let description: Description<SeqNo> = proto.description.into_rust_if_some("description")?;
+        let mut seqno = description.lower().first().expect("lower seqno").clone();
+        let mut diffs = Vec::with_capacity(proto.diffs.len());
+
+        for data in proto.diffs {
+            diffs.push(VersionedData {
+                seqno,
+                data: Bytes::from(data),
+            });
+            seqno = seqno.next();
+        }
+
+        assert_eq!(
+            seqno.next(),
+            *description.upper().first().expect("upper seqno")
+        );
+
+        Ok(Self { description, diffs })
+    }
+}
+
+impl<T> StateRollup<T> {}
+
+impl<T: Timestamp + Lattice + Codec64> RustType<ProtoRollup> for StateRollup<T> {
+    fn into_proto(&self) -> ProtoRollup {
+        ProtoRollup {
+            applier_version: self.state.state.applier_version.to_string(),
+            shard_id: self.state.state.shard_id.into_proto(),
+            seqno: self.state.state.seqno.into_proto(),
+            walltime_ms: self.state.state.walltime_ms.into_proto(),
+            hostname: self.state.state.hostname.into_proto(),
+            key_codec: self.state.key_codec.into_proto(),
+            val_codec: self.state.val_codec.into_proto(),
+            ts_codec: T::codec_name(),
+            diff_codec: self.state.diff_codec.into_proto(),
+            last_gc_req: self.state.state.collections.last_gc_req.into_proto(),
+            rollups: self
+                .state
+                .state
+                .collections
+                .rollups
+                .iter()
+                .map(|(seqno, key)| (seqno.into_proto(), key.into_proto()))
+                .collect(),
+            deprecated_rollups: Default::default(),
+            leased_readers: self
+                .state
+                .state
+                .collections
+                .leased_readers
+                .iter()
+                .map(|(id, state)| (id.into_proto(), state.into_proto()))
+                .collect(),
+            critical_readers: self
+                .state
+                .state
+                .collections
+                .critical_readers
+                .iter()
+                .map(|(id, state)| (id.into_proto(), state.into_proto()))
+                .collect(),
+            writers: self
+                .state
+                .state
+                .collections
+                .writers
+                .iter()
+                .map(|(id, state)| (id.into_proto(), state.into_proto()))
+                .collect(),
+            trace: Some(self.state.state.collections.trace.into_proto()),
+            diffs: self.diffs.as_ref().map(|x| x.into_proto()),
+        }
+    }
+
+    fn from_proto(x: ProtoRollup) -> Result<Self, TryFromProtoError> {
         let applier_version = if x.applier_version.is_empty() {
             // Backward compatibility with versions of ProtoState before we set
             // this field: if it's missing (empty), assume an infinitely old
@@ -810,12 +830,15 @@ impl<T: Timestamp + Lattice + Codec64> RustType<ProtoStateRollup> for UntypedSta
             hostname: x.hostname,
             collections,
         };
-        Ok(UntypedState {
-            state,
-            key_codec: x.key_codec.into_rust()?,
-            val_codec: x.val_codec.into_rust()?,
-            ts_codec: x.ts_codec.into_rust()?,
-            diff_codec: x.diff_codec.into_rust()?,
+        Ok(StateRollup {
+            state: UntypedState {
+                state,
+                key_codec: x.key_codec.into_rust()?,
+                val_codec: x.val_codec.into_rust()?,
+                ts_codec: x.ts_codec.into_rust()?,
+                diff_codec: x.diff_codec.into_rust()?,
+            },
+            diffs: x.diffs.into_rust_if_some("diffs").ok(),
         })
     }
 }

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -949,7 +949,7 @@ impl RustType<ProtoVersionedData> for VersionedData {
     fn from_proto(proto: ProtoVersionedData) -> Result<Self, TryFromProtoError> {
         Ok(Self {
             seqno: proto.seqno.into_rust()?,
-            data: Bytes::clone(&proto.data),
+            data: proto.data,
         })
     }
 }

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -757,6 +757,14 @@ pub(crate) struct InlinedDiffs {
 }
 
 impl InlinedDiffs {
+    pub(crate) fn lower(&self) -> SeqNo {
+        *self.description.lower().first().expect("seqno")
+    }
+
+    pub(crate) fn upper(&self) -> SeqNo {
+        *self.description.upper().first().expect("seqno")
+    }
+
     fn from(lower: SeqNo, upper: SeqNo, diffs: Vec<VersionedData>) -> Self {
         for diff in &diffs {
             assert!(diff.seqno >= lower);
@@ -919,10 +927,8 @@ impl<T: Timestamp + Lattice + Codec64> RustType<ProtoRollup> for Rollup<T> {
 
         let diffs: Option<InlinedDiffs> = x.diffs.into_rust_if_some("diffs").ok();
         if let Some(diffs) = &diffs {
-            assert_eq!(
-                state.latest_rollup().0.next(),
-                *diffs.description.lower().first().expect("seqno")
-            );
+            assert_eq!(diffs.lower(), state.latest_rollup().0.next());
+            assert_eq!(diffs.upper(), state.seqno.next());
         }
 
         Ok(Rollup {

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -698,10 +698,10 @@ where
 
 /// A struct that maps 1:1 with ProtoRollup.
 ///
-/// Contains State, and optionally the diffs between (state.latest_rollup.seqno, state.seqno].
+/// Contains State, and optionally the diffs between (state.latest_rollup.seqno, state.seqno]
 ///
-/// `diffs` is expected to be `None` for the initial state, and may be `None` when deserializing
-/// persisted rollups that were written before we started inlining diffs.
+/// `diffs` is always expected to be `Some` when writing new rollups, but may be `None`
+/// when deserializing rollups that were persisted before we started inlining diffs.
 #[derive(Debug)]
 pub struct Rollup<T> {
     pub(crate) state: UntypedState<T>,

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -572,7 +572,7 @@ where
     Ok(())
 }
 
-/// A decoded version of [ProtoRollup::state] for which we have not yet checked
+/// The decoded state of [ProtoRollup] for which we have not yet checked
 /// that codecs match the ones in durable state.
 #[derive(Debug)]
 #[cfg_attr(any(test, debug_assertions), derive(Clone, PartialEq))]

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1031,7 +1031,6 @@ where
 #[cfg(test)]
 pub mod datadriven {
     use std::collections::BTreeMap;
-    use std::marker::PhantomData;
     use std::sync::Arc;
 
     use anyhow::anyhow;
@@ -1049,7 +1048,6 @@ pub mod datadriven {
     use crate::internal::encoding::Schemas;
     use crate::internal::gc::GcReq;
     use crate::internal::paths::{BlobKey, BlobKeyPrefix, PartialBlobKey};
-    use crate::internal::state::TypedState;
     use crate::internal::state_versions::EncodedRollup;
     use crate::read::{Listen, ListenEvent};
     use crate::rpc::NoopPubSubSender;

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1050,6 +1050,7 @@ pub mod datadriven {
     use crate::internal::gc::GcReq;
     use crate::internal::paths::{BlobKey, BlobKeyPrefix, PartialBlobKey};
     use crate::internal::state::TypedState;
+    use crate::internal::state_versions::EncodedRollup;
     use crate::read::{Listen, ListenEvent};
     use crate::rpc::NoopPubSubSender;
     use crate::tests::new_test_client;
@@ -1066,6 +1067,7 @@ pub mod datadriven {
         pub machine: Machine<String, (), u64, i64>,
         pub gc: GarbageCollector<String, (), u64, i64>,
         pub batches: BTreeMap<String, HollowBatch<u64>>,
+        pub rollups: BTreeMap<String, EncodedRollup>,
         pub listens: BTreeMap<String, Listen<String, (), u64, i64>>,
         pub routine: Vec<RoutineMaintenance>,
     }
@@ -1114,6 +1116,7 @@ pub mod datadriven {
                 machine,
                 gc,
                 batches: BTreeMap::default(),
+                rollups: BTreeMap::default(),
                 listens: BTreeMap::default(),
                 routine: Vec::new(),
             }
@@ -1267,42 +1270,44 @@ pub mod datadriven {
         datadriven: &mut MachineState,
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
-        let seqno: SeqNo = args.expect("seqno");
+        let output = args.expect_str("output");
 
-        let mut all_live_states = datadriven
+        let state = datadriven.machine.applier.clone_state_for_rollup();
+        let rollup = datadriven
             .machine
             .applier
             .state_versions
-            .fetch_all_live_states::<u64>(datadriven.shard_id)
+            .write_rollup_for_state(
+                datadriven.machine.applier.shard_metrics.as_ref(),
+                state,
+                &RollupId::new(),
+            )
             .await
-            .expect("shard initialized")
-            .check_ts_codec()
-            .expect("codec matches");
+            .expect("rollup");
 
-        while let Some(state) = all_live_states.next(|_| {}) {
-            if state.seqno == seqno {
-                break;
-            }
-        }
+        datadriven
+            .rollups
+            .insert(output.to_string(), rollup.clone());
 
-        let state = all_live_states.state();
-        if state.seqno != seqno {
-            return Err(anyhow!(
-                "seqno {} cannot be reached while writing rollup",
-                seqno
-            ));
-        }
+        Ok(format!(
+            "state={} diffs=[{}, {})\n",
+            rollup.seqno,
+            rollup._desc.lower().first().expect("seqno"),
+            rollup._desc.upper().first().expect("seqno"),
+        ))
+    }
 
-        let typed_state = TypedState::<String, (), u64, i64> {
-            state: state.clone(),
-            _phantom: PhantomData::default(),
-        };
-        let rollup = datadriven.state_versions.encode_rollup_blob(
-            datadriven.machine.applier.shard_metrics.as_ref(),
-            &typed_state,
-            PartialRollupKey::new(state.seqno, &RollupId::new()),
-        );
-        let () = datadriven.state_versions.write_rollup_blob(&rollup).await;
+    pub async fn add_rollup(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let input = args.expect_str("input");
+        let rollup = datadriven
+            .rollups
+            .get(input)
+            .expect("unknown batch")
+            .clone();
+
         let (applied, maintenance) = datadriven
             .machine
             .add_rollup((rollup.seqno, &rollup.to_hollow()))
@@ -1313,7 +1318,7 @@ pub mod datadriven {
         }
 
         datadriven.routine.push(maintenance);
-        Ok(format!("{}\n", datadriven.machine.seqno()))
+        Ok("ok\n".to_string())
     }
 
     pub async fn write_batch(

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1052,10 +1052,19 @@ pub struct StateMetrics {
     pub(crate) writer_added: IntCounter,
     pub(crate) writer_removed: IntCounter,
     pub(crate) force_apply_hostname: IntCounter,
+    pub(crate) rollup_write_success: IntCounter,
+    pub(crate) rollup_write_noop_latest: IntCounter,
+    pub(crate) rollup_write_noop_truncated: IntCounter,
 }
 
 impl StateMetrics {
     pub(crate) fn new(registry: &MetricsRegistry) -> Self {
+        let rollup_write_noop: IntCounterVec = registry.register(metric!(
+                name: "mz_persist_state_rollup_write_noop",
+                help: "count of no-op rollup writes",
+                var_labels: ["reason"],
+        ));
+
         StateMetrics {
             apply_spine_fast_path: registry.register(metric!(
                 name: "mz_persist_state_apply_spine_fast_path",
@@ -1117,6 +1126,12 @@ impl StateMetrics {
                 name: "mz_persist_state_force_applied_hostname",
                 help: "count of when hostname diffs needed to be force applied",
             )),
+            rollup_write_success: registry.register(metric!(
+                name: "mz_persist_state_rollup_write_success",
+                help: "count of rollups written successful (may not be linked in to state)",
+            )),
+            rollup_write_noop_latest: rollup_write_noop.with_label_values(&["latest"]),
+            rollup_write_noop_truncated: rollup_write_noop.with_label_values(&["truncated"]),
         }
     }
 }

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -80,7 +80,9 @@ message ProtoHandleDebugState {
 
 message ProtoInlinedDiffs {
     ProtoU64Description description = 1;
-    repeated bytes diffs = 2;
+
+    repeated uint64 seqnos = 2;
+    repeated bytes diffs = 3;
 }
 
 message ProtoRollup {

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -78,7 +78,12 @@ message ProtoHandleDebugState {
     string purpose = 2;
 }
 
-message ProtoStateRollup {
+message ProtoInlinedDiffs {
+    ProtoU64Description description = 1;
+    repeated bytes diffs = 2;
+}
+
+message ProtoRollup {
     string applier_version = 11;
 
     string shard_id = 1;
@@ -96,6 +101,8 @@ message ProtoStateRollup {
     map<string, ProtoLeasedReaderState> leased_readers = 8;
     map<string, ProtoCriticalReaderState> critical_readers = 13;
     map<string, ProtoWriterState> writers = 9;
+
+    ProtoInlinedDiffs diffs = 17;
 
     // MIGRATION: We previously stored rollups as a `SeqNo -> string Key` map,
     // but now the value is a `struct HollowRollup`.

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -78,11 +78,16 @@ message ProtoHandleDebugState {
     string purpose = 2;
 }
 
-message ProtoInlinedDiffs {
-    ProtoU64Description description = 1;
+message ProtoVersionedData {
+    uint64 seqno = 1;
+    bytes data = 2;
+}
 
-    repeated uint64 seqnos = 2;
-    repeated bytes diffs = 3;
+message ProtoInlinedDiffs {
+    uint64 lower = 1;
+    uint64 upper = 2;
+
+    repeated ProtoVersionedData diffs = 3;
 }
 
 message ProtoRollup {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -32,10 +32,9 @@ use timely::PartialOrder;
 use tracing::info;
 use uuid::Uuid;
 
-use crate::cli::inspect::V;
 use crate::critical::CriticalReaderId;
 use crate::error::{Determinacy, InvalidUsage};
-use crate::internal::encoding::{parse_id, LazyPartStats, UntypedState};
+use crate::internal::encoding::{parse_id, LazyPartStats};
 use crate::internal::gc::GcReq;
 use crate::internal::paths::{PartialBatchKey, PartialRollupKey};
 use crate::internal::trace::{ApplyMergeResult, FueledMergeReq, FueledMergeRes, Trace};

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -643,7 +643,8 @@ impl StateVersions {
     {
         let buf = self.metrics.codecs.state.encode(|| {
             let mut buf = Vec::new();
-            state.encode(&mut buf);
+            // WIP: replace
+            // state.encode(&mut buf);
             Bytes::from(buf)
         });
         shard_metrics
@@ -902,14 +903,6 @@ impl<T: Timestamp + Lattice + Codec64> StateVersionsIter<T> {
 
     pub fn state(&self) -> &State<T> {
         &self.state
-    }
-
-    pub fn into_proto(&self) -> impl serde::Serialize {
-        self.state.into_proto(
-            self.key_codec.clone(),
-            self.val_codec.clone(),
-            self.diff_codec.clone(),
-        )
     }
 }
 

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -734,7 +734,7 @@ impl StateVersions {
         }
         assert_eq!(verify_seqno, state.seqno);
 
-        let rollup = Rollup::from(UntypedState::<T>::from(state), diffs);
+        let rollup = Rollup::from(state.into(), diffs);
         let desc = rollup
             .diffs
             .as_ref()

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -1002,7 +1002,14 @@ impl<T: Timestamp + Lattice + Codec64> StateVersionsIter<T> {
 
     pub fn into_rollup_proto_without_diffs(&self) -> impl serde::Serialize {
         Rollup::from_state_without_diffs(
-            self.state.clone(),
+            State {
+                applier_version: self.state.applier_version.clone(),
+                shard_id: self.state.shard_id.clone(),
+                seqno: self.state.seqno.clone(),
+                walltime_ms: self.state.walltime_ms.clone(),
+                hostname: self.state.hostname.clone(),
+                collections: self.state.collections.clone(),
+            },
             self.key_codec.clone(),
             self.val_codec.clone(),
             T::codec_name(),

--- a/src/persist-client/tests/machine/gc
+++ b/src/persist-client/tests/machine/gc
@@ -34,13 +34,6 @@ compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 v2 [1]
 
-# referencing seqnos directly is a bit fragile. as any changes
-# that add or subtract linearized operations from Machine
-# setup could throw off the indexing here.
-#
-# at the time of writing here, seqno 3 refers to the compare-
-# and-append batch written above
-
 # verify we have a new state that references the latest batch
 consensus-scan from_seqno=v3
 ----
@@ -69,9 +62,13 @@ consensus-scan from_seqno=v3
 seqno=v3 batches=b0,b1 rollups=v1
 
 # add a rollup
-write-rollup seqno=v3
+write-rollup output=v3
 ----
-v4
+state=v3 diffs=[v2, v4)
+
+add-rollup input=v3
+----
+ok
 
 # run gc up to our latest seqno. gc should truncate up to the latest rollup
 # and introduce its own seqno (to remove the older rollup from state)
@@ -98,6 +95,11 @@ seqno=v4 batches=b0,b1 rollups=v1,v3
 seqno=v5 batches=b0,b1 rollups=v3
 seqno=v6 batches=b0,b1,b2 rollups=v3
 
+# write a rollup at v6, the last seqno referencing b0 and b1
+write-rollup output=v6_last_b0_b1_reference
+----
+state=v6 diffs=[v4, v7)
+
 # compact and merge b0 and b1 into b0_1
 compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
@@ -116,53 +118,60 @@ seqno=v5 batches=b0,b1 rollups=v3
 seqno=v6 batches=b0,b1,b2 rollups=v3
 seqno=v7 batches=b0_1,b2 rollups=v3
 
-# write a rollup that contains last seqno referencing b0 and b1
-write-rollup seqno=v7
+write-rollup output=v7
 ----
-v8
+state=v7 diffs=[v4, v8)
+
+# now add in rollup from v6 and run gc. should clear only the b0,b1 seqnos
+add-rollup input=v6_last_b0_b1_reference
+----
+ok
 
 # run gc to clear only the b0,b1 seqnos
 gc to_seqno=v7
 ----
-v9 batch_parts=2 rollups=1 truncated=v7 state_rollups=v3
+v9 batch_parts=0 rollups=1 truncated=v6 state_rollups=v3
 
 consensus-scan from_seqno=v0
 ----
+seqno=v6 batches=b0,b1,b2 rollups=v3
 seqno=v7 batches=b0_1,b2 rollups=v3
-seqno=v8 batches=b0_1,b2 rollups=v3,v7
-seqno=v9 batches=b0_1,b2 rollups=v7
+seqno=v8 batches=b0_1,b2 rollups=v3,v6
+seqno=v9 batches=b0_1,b2 rollups=v6
 
-# verify that b0 and b1 still exist, because they're referenced in seqno 7
+# verify that b0 and b1 still exist, because they're referenced in seqno 6
 fetch-batch input=b0
 ----
 <part 0>
-<empty>
+k1 0 1
 <run 0>
 part 0
 
 fetch-batch input=b1
 ----
 <part 0>
-<empty>
+k2 1 -1
+k3 1 1
 <run 0>
 part 0
 
-# write a new rollup at v7 so we can GC v7 on our next call
-write-rollup seqno=v7
+# write a new rollup at v7 so we can GC v6, the last reference to b0 and b1, on our next call
+add-rollup input=v7
 ----
-error: failed to apply rollup for: v7
+ok
 
 gc to_seqno=v7
 ----
-v10 batch_parts=0 rollups=0 truncated= state_rollups=
+v11 batch_parts=2 rollups=0 truncated=v7 state_rollups=v6
 
 # we should only have b0_1,b2 now
 consensus-scan from_seqno=v0
 ----
 seqno=v7 batches=b0_1,b2 rollups=v3
-seqno=v8 batches=b0_1,b2 rollups=v3,v7
-seqno=v9 batches=b0_1,b2 rollups=v7
-seqno=v10 batches=b0_1,b2 rollups=v7
+seqno=v8 batches=b0_1,b2 rollups=v3,v6
+seqno=v9 batches=b0_1,b2 rollups=v6
+seqno=v10 batches=b0_1,b2 rollups=v6,v7
+seqno=v11 batches=b0_1,b2 rollups=v7
 
 # and b0 and b1 should no longer exist in the blob store, as no states still reference them
 fetch-batch input=b0

--- a/src/persist-client/tests/machine/gc
+++ b/src/persist-client/tests/machine/gc
@@ -68,7 +68,7 @@ state=v3 diffs=[v2, v4)
 
 add-rollup input=v3
 ----
-ok
+v4
 
 # run gc up to our latest seqno. gc should truncate up to the latest rollup
 # and introduce its own seqno (to remove the older rollup from state)
@@ -125,7 +125,7 @@ state=v7 diffs=[v4, v8)
 # now add in rollup from v6 and run gc. should clear only the b0,b1 seqnos
 add-rollup input=v6_last_b0_b1_reference
 ----
-ok
+v8
 
 # run gc to clear only the b0,b1 seqnos
 gc to_seqno=v7
@@ -158,7 +158,7 @@ part 0
 # write a new rollup at v7 so we can GC v6, the last reference to b0 and b1, on our next call
 add-rollup input=v7
 ----
-ok
+v10
 
 gc to_seqno=v7
 ----

--- a/src/persist-client/tests/machine/gc_rollups
+++ b/src/persist-client/tests/machine/gc_rollups
@@ -32,107 +32,136 @@ compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 v3 [2]
 
+write-rollup output=v3
+----
+state=v3 diffs=[v2, v4)
+
+compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v4 [3]
+
+write-rollup output=v4
+----
+state=v4 diffs=[v2, v5)
+
 # write a bunch of rollups to verify GC bounds
-write-rollup seqno=v3
+add-rollup input=v3
 ----
-v4
+ok
 
-write-rollup seqno=v4
+write-rollup output=v5
 ----
-v5
+state=v5 diffs=[v4, v6)
 
-write-rollup seqno=v5
+add-rollup input=v4
 ----
-v6
+ok
+
+add-rollup input=v5
+----
+ok
 
 consensus-scan from_seqno=v1
 ----
 seqno=v1 batches= rollups=v1
 seqno=v2 batches=b0 rollups=v1
 seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1 rollups=v1,v3
-seqno=v5 batches=b0,b1 rollups=v1,v3,v4
-seqno=v6 batches=b0,b1 rollups=v1,v3,v4,v5
+seqno=v4 batches=b0,b1,b2 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1,v3
+seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
 
 # gc at the first seqno should be a no-op (no rollups to remove)
 gc to_seqno=v1
 ----
-v6 batch_parts=0 rollups=0 truncated= state_rollups=
+v7 batch_parts=0 rollups=0 truncated= state_rollups=
 
 consensus-scan from_seqno=v1
 ----
 seqno=v1 batches= rollups=v1
 seqno=v2 batches=b0 rollups=v1
 seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1 rollups=v1,v3
-seqno=v5 batches=b0,b1 rollups=v1,v3,v4
-seqno=v6 batches=b0,b1 rollups=v1,v3,v4,v5
+seqno=v4 batches=b0,b1,b2 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1,v3
+seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
 
 # there is only 1 rollup <= seqno 2, so this should also be a no-op
 gc to_seqno=v2
 ----
-v6 batch_parts=0 rollups=0 truncated= state_rollups=
+v7 batch_parts=0 rollups=0 truncated= state_rollups=
 
 consensus-scan from_seqno=v1
 ----
 seqno=v1 batches= rollups=v1
 seqno=v2 batches=b0 rollups=v1
 seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1 rollups=v1,v3
-seqno=v5 batches=b0,b1 rollups=v1,v3,v4
-seqno=v6 batches=b0,b1 rollups=v1,v3,v4,v5
+seqno=v4 batches=b0,b1,b2 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1,v3
+seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
 
 # ok! now it gets interesting, let's gc to v3 which the latest state
 # has a rollup for. we should be able to remove v1 and states [v1, v3)
 gc to_seqno=v3
 ----
-v7 batch_parts=0 rollups=0 truncated=v3 state_rollups=v1
+v8 batch_parts=0 rollups=0 truncated=v3 state_rollups=v1
 
 consensus-scan from_seqno=v1
 ----
 seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1 rollups=v1,v3
-seqno=v5 batches=b0,b1 rollups=v1,v3,v4
-seqno=v6 batches=b0,b1 rollups=v1,v3,v4,v5
-seqno=v7 batches=b0,b1 rollups=v3,v4,v5
+seqno=v4 batches=b0,b1,b2 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1,v3
+seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
+seqno=v8 batches=b0,b1,b2 rollups=v3,v4,v5
 
 # if we run the same GC again, or less, they should be no-ops
 # and perform no truncations
 gc to_seqno=v3
 ----
-v7 batch_parts=0 rollups=0 truncated= state_rollups=
+v8 batch_parts=0 rollups=0 truncated= state_rollups=
 
 gc to_seqno=v2
 ----
-v7 batch_parts=0 rollups=0 truncated= state_rollups=
+v8 batch_parts=0 rollups=0 truncated= state_rollups=
+
+write-rollup output=v8
+----
+state=v8 diffs=[v6, v9)
 
 # let's try GC'ing many rollups at once. here, we both ask
 # to remove >1 rollup at once, and pass in a to_seqno that is
 # not exactly covered by a rollup. we expect to see all rollups
 # <= the latest to be removed
-gc to_seqno=v7
+gc to_seqno=v8
 ----
-v8 batch_parts=0 rollups=0 truncated=v4,v5 state_rollups=v3,v4
+v9 batch_parts=0 rollups=0 truncated=v4,v5 state_rollups=v3,v4
 
 consensus-scan from_seqno=v1
 ----
-seqno=v5 batches=b0,b1 rollups=v1,v3,v4
-seqno=v6 batches=b0,b1 rollups=v1,v3,v4,v5
-seqno=v7 batches=b0,b1 rollups=v3,v4,v5
-seqno=v8 batches=b0,b1 rollups=v5
+seqno=v5 batches=b0,b1,b2 rollups=v1,v3
+seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
+seqno=v8 batches=b0,b1,b2 rollups=v3,v4,v5
+seqno=v9 batches=b0,b1,b2 rollups=v5
 
 # let's verify that rollups are physically deleted too.
 # it's subtle, but v8 was the first transition that
 # removed a rollup from state, so we need to GC up to
 # v8 to verify the rollup blob is deleted.
 
-write-rollup seqno=v8
+write-rollup output=v9
 ----
-v9
+state=v9 diffs=[v6, v10)
 
-write-rollup seqno=v9
+add-rollup input=v8
 ----
-v10
+ok
+
+add-rollup input=v9
+----
+ok
 
 # (this is also subtle, but we GC to v8 again like before.
 # this time we can make further progress though, as previously
@@ -140,14 +169,15 @@ v10
 # the latest rollup so everything below it can be removed)
 gc to_seqno=v8
 ----
-v11 batch_parts=0 rollups=3 truncated=v8 state_rollups=v5
+v12 batch_parts=0 rollups=1 truncated=v8 state_rollups=v5
 
 consensus-scan from_seqno=v1
 ----
-seqno=v8 batches=b0,b1 rollups=v5
-seqno=v9 batches=b0,b1 rollups=v5,v8
-seqno=v10 batches=b0,b1 rollups=v5,v8,v9
-seqno=v11 batches=b0,b1 rollups=v8,v9
+seqno=v8 batches=b0,b1,b2 rollups=v3,v4,v5
+seqno=v9 batches=b0,b1,b2 rollups=v5
+seqno=v10 batches=b0,b1,b2 rollups=v5,v8
+seqno=v11 batches=b0,b1,b2 rollups=v5,v8,v9
+seqno=v12 batches=b0,b1,b2 rollups=v8,v9
 
 # truncate Consensus out-of-band to mirror overlapping GC
 # processes. we'll remove v8 from Consensus but "fail"
@@ -158,20 +188,23 @@ consensus-truncate to_seqno=v9
 
 consensus-scan from_seqno=v1
 ----
-seqno=v9 batches=b0,b1 rollups=v5,v8
-seqno=v10 batches=b0,b1 rollups=v5,v8,v9
-seqno=v11 batches=b0,b1 rollups=v8,v9
+seqno=v9 batches=b0,b1,b2 rollups=v5
+seqno=v10 batches=b0,b1,b2 rollups=v5,v8
+seqno=v11 batches=b0,b1,b2 rollups=v5,v8,v9
+seqno=v12 batches=b0,b1,b2 rollups=v8,v9
 
 # even though the row v8 doesn't exist any more, GC
 # should still know to remove it from state. it should
 # additionally perform no actual truncate calls because
 # it started at a state greater than to_seqno
-gc to_seqno=v7
+gc to_seqno=v9
 ----
-v11 batch_parts=0 rollups=0 truncated= state_rollups=
+v13 batch_parts=0 rollups=0 truncated= state_rollups=v8
 
 consensus-scan from_seqno=v1
 ----
-seqno=v9 batches=b0,b1 rollups=v5,v8
-seqno=v10 batches=b0,b1 rollups=v5,v8,v9
-seqno=v11 batches=b0,b1 rollups=v8,v9
+seqno=v9 batches=b0,b1,b2 rollups=v5
+seqno=v10 batches=b0,b1,b2 rollups=v5,v8
+seqno=v11 batches=b0,b1,b2 rollups=v5,v8,v9
+seqno=v12 batches=b0,b1,b2 rollups=v8,v9
+seqno=v13 batches=b0,b1,b2 rollups=v9

--- a/src/persist-client/tests/machine/gc_rollups
+++ b/src/persist-client/tests/machine/gc_rollups
@@ -47,7 +47,7 @@ state=v4 diffs=[v2, v5)
 # write a bunch of rollups to verify GC bounds
 add-rollup input=v3
 ----
-ok
+v5
 
 write-rollup output=v5
 ----
@@ -55,11 +55,11 @@ state=v5 diffs=[v4, v6)
 
 add-rollup input=v4
 ----
-ok
+v6
 
 add-rollup input=v5
 ----
-ok
+v7
 
 consensus-scan from_seqno=v1
 ----
@@ -157,11 +157,11 @@ state=v9 diffs=[v6, v10)
 
 add-rollup input=v8
 ----
-ok
+v10
 
 add-rollup input=v9
 ----
-ok
+v11
 
 # (this is also subtle, but we GC to v8 again like before.
 # this time we can make further progress though, as previously

--- a/src/persist-client/tests/machine/regression_gc_behind
+++ b/src/persist-client/tests/machine/regression_gc_behind
@@ -21,14 +21,19 @@ compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 v2 [1]
 
+write-rollup output=v2
+----
+state=v2 diffs=[v2, v3)
+
+add-rollup input=v2
+----
+ok
+
 consensus-scan from_seqno=v0
 ----
 seqno=v1 batches= rollups=v1
 seqno=v2 batches=b0 rollups=v1
-
-write-rollup seqno=v2
-----
-v3
+seqno=v3 batches=b0 rollups=v1,v2
 
 # Run gc up to our latest seqno
 gc to_seqno=v3

--- a/src/persist-client/tests/machine/regression_gc_behind
+++ b/src/persist-client/tests/machine/regression_gc_behind
@@ -27,7 +27,7 @@ state=v2 diffs=[v2, v3)
 
 add-rollup input=v2
 ----
-ok
+v3
 
 consensus-scan from_seqno=v0
 ----

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -17,7 +17,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::u64_to_usize;
-use mz_persist_types::Codec64;
 use mz_proto::RustType;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -87,26 +86,6 @@ impl RustType<u64> for SeqNo {
 
     fn from_proto(proto: u64) -> Result<Self, mz_proto::TryFromProtoError> {
         Ok(SeqNo(proto))
-    }
-}
-
-impl Default for SeqNo {
-    fn default() -> Self {
-        Self::minimum()
-    }
-}
-
-impl Codec64 for SeqNo {
-    fn codec_name() -> String {
-        "seqno".to_string()
-    }
-
-    fn encode(&self) -> [u8; 8] {
-        self.0.to_le_bytes()
-    }
-
-    fn decode(buf: [u8; 8]) -> Self {
-        SeqNo(u64::from_le_bytes(buf))
     }
 }
 

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -48,6 +48,12 @@ impl std::fmt::Display for SeqNo {
     }
 }
 
+impl timely::PartialOrder for SeqNo {
+    fn less_equal(&self, other: &Self) -> bool {
+        self <= other
+    }
+}
+
 impl std::str::FromStr for SeqNo {
     type Err = String;
 
@@ -87,30 +93,6 @@ impl RustType<u64> for SeqNo {
 impl Default for SeqNo {
     fn default() -> Self {
         Self::minimum()
-    }
-}
-
-impl timely::PartialOrder for SeqNo {
-    fn less_equal(&self, other: &Self) -> bool {
-        self <= other
-    }
-}
-
-impl timely::progress::Timestamp for SeqNo {
-    type Summary = SeqNo;
-
-    fn minimum() -> Self {
-        SeqNo::minimum()
-    }
-}
-
-impl timely::progress::PathSummary<SeqNo> for SeqNo {
-    fn results_in(&self, src: &SeqNo) -> Option<SeqNo> {
-        Some(SeqNo(self.0.checked_add(src.0)?))
-    }
-
-    fn followed_by(&self, other: &Self) -> Option<Self> {
-        Some(SeqNo(self.0.checked_add(other.0)?))
     }
 }
 

--- a/test/storage-usage/mzcompose.py
+++ b/test/storage-usage/mzcompose.py
@@ -172,7 +172,7 @@ database_objects = [
               FOR TABLES (pg_table);
             """
         ),
-        expected_size=1024,
+        expected_size=4 * 1024,
     ),
     # The pg-cdc data is expected to be in the sub-source,
     # unaffected by the presence of other tables


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

This PR inlines the diffs from `(last_rollup.seqno, current_state.seqno]` into each rollup going forward, serving as a building block for a number of future ideas like RO shards.

There are three-ish logical changes in this PR (unfortunately not broken out into individual commits, my git-fu is too weak for that):

1) Fetching the diffs between the current state's latest rollup and its seqno
2) The introduction of `v1` rollups (just state) and the new `v2` rollups (state + diffs). Per @bkirwi's suggestion, it seems safest to use new paths to distinguish the rollups given their different and non-backwards-compatible encodings.
3) Codification of the `add_rollup_for_current_seqno` API -- the only way to write a rollup is for the current state. This was already true in production code paths, but I've rewritten the tests to abide by this as well to consolidate some code paths (previously, in test, one could add rollups for any live seqno)

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
