### PR TITLE
storage/pg: only open replication connection for snapshot leader

### DIFF
--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -491,6 +491,27 @@ true
 true
 
 #
+# Ensure we can start a source with more workers than the default max_wal_senders param (10)
+#
+
+> CREATE SOURCE large_cluster
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES ("pk_table" AS large_cluster_pk_table)
+  WITH (SIZE = '16');
+
+> SELECT * FROM large_cluster_pk_table;
+13 three
+14 four
+2 two_two
+5 five
+
+# TODO: should only be 'running' w/ resolution of #20666
+> SELECT status = 'starting' OR status = 'running' FROM mz_internal.mz_source_statuses WHERE name = 'large_cluster_pk_table';
+true
+
+> DROP SOURCE large_cluster;
+
+#
 # Remove all data on the Postgres side
 #
 


### PR DESCRIPTION
Prior to this commit, users could not start PG sources on clusters with more workers than their PG database permitted concurrent WAL senders.

This commit resolves that issue by only opening a single WAL sender during snapshotting (the snapshot leader). Other workers can instead use normal connections.

### Motivation

This PR fixes a recognized bug--[internal Slack convo](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1689775193851249)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix a bug that prevented creating Postgres sources on clusters with more workers than the upstream Postgres database's `max_wal_senders` value.
