### PR TITLE
sql: Make `RETURNING` a reserved keyword

### DIFF
--- a/src/sql-lexer/src/keywords.rs
+++ b/src/sql-lexer/src/keywords.rs
@@ -65,7 +65,7 @@ impl Keyword {
         matches!(
             self,
             // Keywords that can appear at the top-level of a SELECT statement.
-            WITH | SELECT | FROM | WHERE | GROUP | HAVING | ORDER | LIMIT | OFFSET | FETCH | OPTIONS |
+            WITH | SELECT | FROM | WHERE | GROUP | HAVING | ORDER | LIMIT | OFFSET | FETCH | OPTIONS | RETURNING |
             // Set operations.
             UNION | EXCEPT | INTERSECT
         )

--- a/test/sqllogictest/returning.slt
+++ b/test/sqllogictest/returning.slt
@@ -62,17 +62,15 @@ INSERT INTO t (a) VALUES (100) RETURNING t.a
 ----
 100
 
-# Work around our table parse alias bug, but verify we can RETURNING results
-# of queries.
 query I
 INSERT INTO t SELECT count(*), 0 FROM t AS t RETURNING a
 ----
 10
 
-# TODO(mjibson): This works in Postgres. We currently parse the RETURNING as a
-# table alias for t.
-statement error Expected end of statement
+query I
 INSERT INTO t SELECT count(*), 0 FROM t RETURNING a
+----
+11
 
 # TODO(mjibson): This works in Postgres.
 statement error Expected right parenthesis
@@ -135,6 +133,7 @@ SELECT * FROM t ORDER BY a, b
 9  10
 10  0
 10  11
+11  0
 100  11
 NULL  10
 NULL  11


### PR DESCRIPTION
### Motivation

Fixes #20584 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
