### PR TITLE
metrics: Add `application_name` to `query_total` metric

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -411,10 +411,11 @@ impl Coordinator {
             .expect("known to exist");
 
         let session_type = metrics::session_type_label_value(ctx.session().user());
+        let application_name = ctx.session().application_name();
         let stmt_type = metrics::statement_type_label_value(&stmt);
         self.metrics
             .query_total
-            .with_label_values(&[session_type, stmt_type])
+            .with_label_values(&[session_type, stmt_type, application_name])
             .inc();
         match &stmt {
             Statement::Subscribe(SubscribeStatement { output, .. })

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -38,7 +38,7 @@ impl Metrics {
             query_total: registry.register(metric!(
                 name: "mz_query_total",
                 help: "The total number of queries issued of the given type since process start.",
-                var_labels: ["session_type", "statement_type"],
+                var_labels: ["session_type", "statement_type", "application_name"],
             )),
             active_sessions: registry.register(metric!(
                 name: "mz_active_sessions",

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -34,6 +34,10 @@ pub struct Metrics {
 
 impl Metrics {
     pub(crate) fn register_into(registry: &MetricsRegistry) -> Self {
+        // Note: In a couple of these metrics we log `application_name`, but we need to be __VERY__
+        // careful when doing so because it can have a high cardinality! If you need to add
+        // `application_name` to another metric please consider using `ApplicationNameHint` which
+        // maps to a known set of names, or consule with the Cloud Team.
         Self {
             query_total: registry.register(metric!(
                 name: "mz_query_total",


### PR DESCRIPTION
### Motivation

Recently when debugging and issue for GOAT ([Slack](https://materializeinc.slack.com/archives/CM7ATT65S/p1689192726686219)) we noticed something was starting and rolling back thousands of transactions. It would have been helpful to get a hint as to _what_ was causing this, which prompted this addition of `application_name` to the `query_total` Prometheus metric.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
