### PR TITLE
expr: Use checked recursion in could_run_expensive_function

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1794,23 +1794,16 @@ impl MirRelationExpr {
     fn try_could_run_expensive_function(&self) -> Result<bool, RecursionLimitError> {
         let mut result = false;
         self.try_visit_pre(&mut |e| {
+            use MirRelationExpr::*;
+            use MirScalarExpr::*;
             // FlatMap has a table function; Reduce has an aggregate function.
             // Other constructs use MirScalarExpr to run a function
-            result = result
-                || matches!(
-                    e,
-                    MirRelationExpr::FlatMap { .. } | MirRelationExpr::Reduce { .. }
-                );
+            result = result || matches!(e, FlatMap { .. } | Reduce { .. });
             self.try_visit_scalars(&mut |scalar| {
                 result = result
                     || match scalar {
-                        MirScalarExpr::Column(_)
-                        | MirScalarExpr::Literal(_, _)
-                        | MirScalarExpr::CallUnmaterializable(_)
-                        | MirScalarExpr::If { .. } => false,
-                        MirScalarExpr::CallUnary { .. }
-                        | MirScalarExpr::CallBinary { .. }
-                        | MirScalarExpr::CallVariadic { .. } => true,
+                        Column(_) | Literal(_, _) | CallUnmaterializable(_) | If { .. } => false,
+                        CallUnary { .. } | CallBinary { .. } | CallVariadic { .. } => true,
                     };
                 Ok(())
             })

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1794,8 +1794,13 @@ impl MirRelationExpr {
     fn try_could_run_expensive_function(&self) -> Result<bool, RecursionLimitError> {
         let mut result = false;
         self.try_visit_pre(&mut |e| {
-            // FlapMap has a table function while all other constructs use MirScalarExpr to run a function
-            result = result || matches!(e, MirRelationExpr::FlatMap { .. });
+            // FlatMap has a table function; Reduce has an aggregate function.
+            // Other constructs use MirScalarExpr to run a function
+            result = result
+                || matches!(
+                    e,
+                    MirRelationExpr::FlatMap { .. } | MirRelationExpr::Reduce { .. }
+                );
             self.try_visit_scalars(&mut |scalar| {
                 result = result
                     || match scalar {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1789,33 +1789,28 @@ impl MirRelationExpr {
     /// The goal is to be a heuristic for "this expression is cheap to evaluate:
     /// ideally not creating a dataflow at all when optimized".
     pub fn could_run_expensive_function(&self) -> bool {
-        /// Returns whether a scalar expression can run an expensive function
-        fn scalar_could_run_expensive_function(scalar: &MirScalarExpr) -> bool {
-            match scalar {
-                MirScalarExpr::Column(_)
-                | MirScalarExpr::Literal(_, _)
-                | MirScalarExpr::CallUnmaterializable(_) => false,
-                MirScalarExpr::CallUnary { .. }
-                | MirScalarExpr::CallBinary { .. }
-                | MirScalarExpr::CallVariadic { .. } => true,
-                MirScalarExpr::If { cond, then, els } => {
-                    scalar_could_run_expensive_function(cond)
-                        || scalar_could_run_expensive_function(then)
-                        || scalar_could_run_expensive_function(els)
-                }
-            }
-        }
-
-        // FlapMap has a table function while all other constructs use MirScalarExpr to run a function
-        let mut result = match self {
-            MirRelationExpr::FlatMap { .. } => true,
-            _ => false,
-        };
-        self.visit_scalars(&mut |scalar| {
-            result = result || scalar_could_run_expensive_function(scalar)
-        });
-        self.visit_children(|e| result = result || e.could_run_expensive_function());
-        result
+        self.try_could_run_expensive_function().unwrap_or(true)
+    }
+    fn try_could_run_expensive_function(&self) -> Result<bool, RecursionLimitError> {
+        let mut result = false;
+        self.try_visit_pre(&mut |e| {
+            // FlapMap has a table function while all other constructs use MirScalarExpr to run a function
+            result = result || matches!(e, MirRelationExpr::FlatMap { .. });
+            self.try_visit_scalars(&mut |scalar| {
+                result = result
+                    || match scalar {
+                        MirScalarExpr::Column(_)
+                        | MirScalarExpr::Literal(_, _)
+                        | MirScalarExpr::CallUnmaterializable(_)
+                        | MirScalarExpr::If { .. } => false,
+                        MirScalarExpr::CallUnary { .. }
+                        | MirScalarExpr::CallBinary { .. }
+                        | MirScalarExpr::CallVariadic { .. } => true,
+                    };
+                Ok(())
+            })
+        })?;
+        Ok(result)
     }
 }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Follow up on review comments in #20372. Fixes #20551.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
