### PR TITLE
environmentd: support max_rows in http/ws endpoints

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1118,7 +1118,7 @@ fn test_ws_passes_options() {
     };
 
     if let WebSocketResponse::Rows(rows) = columns {
-        let names: Vec<&str> = rows.columns.iter().map(|c| c.name.as_str()).collect();
+        let names: Vec<&str> = rows.desc.columns.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(names, ["application_name"]);
     } else {
         panic!("wrong message!, {columns:?}");

--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -456,3 +456,41 @@ http
 ----
 200 OK
 {"results":[{"error":{"message":"cannot materialize call to current_timestamp","code":"0A000","detail":"See: https://materialize.com/docs/sql/functions/now_and_mz_now/","hint":"Try using `mz_now()` here instead."},"notices":[]}]}
+
+# Test max_rows.
+http
+{"query":"VALUES (1), (2), (3)", "max_rows":0}
+----
+200 OK
+{"results":[{"tag":"SELECT 3","rows":[],"desc":{"columns":[{"name":"column1","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[],"rows_remaining":3}]}
+
+http
+{"query":"VALUES (1), (2), (3)", "max_rows":1}
+----
+200 OK
+{"results":[{"tag":"SELECT 3","rows":[[1]],"desc":{"columns":[{"name":"column1","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[],"rows_remaining":2}]}
+
+http
+{"query":"VALUES (1), (2), (3)", "max_rows":2}
+----
+200 OK
+{"results":[{"tag":"SELECT 3","rows":[[1],[2]],"desc":{"columns":[{"name":"column1","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[],"rows_remaining":1}]}
+
+http
+{"query":"VALUES (1), (2), (3)", "max_rows":3}
+----
+200 OK
+{"results":[{"tag":"SELECT 3","rows":[[1],[2],[3]],"desc":{"columns":[{"name":"column1","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[],"rows_remaining":0}]}
+
+http
+{"query":"VALUES (1), (2), (3)", "max_rows":4}
+----
+200 OK
+{"results":[{"tag":"SELECT 3","rows":[[1],[2],[3]],"desc":{"columns":[{"name":"column1","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[],"rows_remaining":0}]}
+
+# Test max_rows with multiple statements in a single query.
+http
+{"query":"VALUES (1), (2), (3); VALUES ('a'), ('b'), ('c'), ('d')", "max_rows":2}
+----
+200 OK
+{"results":[{"tag":"SELECT 3","rows":[[1],[2]],"desc":{"columns":[{"name":"column1","type_oid":23,"type_len":4,"type_mod":-1}]},"notices":[],"rows_remaining":1},{"tag":"SELECT 4","rows":[["a"],["b"]],"desc":{"columns":[{"name":"column1","type_oid":25,"type_len":-1,"type_mod":-1}]},"notices":[],"rows_remaining":2}]}

--- a/src/environmentd/tests/testdata/http/ws
+++ b/src/environmentd/tests/testdata/http/ws
@@ -290,6 +290,41 @@ ws-text
 {"type":"Notice","payload":{"message":"query was automatically run on the \"mz_introspection\" cluster","severity":"debug"}}
 {"type":"ReadyForQuery","payload":"I"}
 
+ws-text
+{"query":"VALUES (1), (2), (3)", "max_rows":1}
+----
+{"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
+{"type":"Rows","payload":{"columns":[{"name":"column1","type_oid":23,"type_len":4,"type_mod":-1}],"rows_remaining":2}}
+{"type":"Row","payload":[1]}
+{"type":"CommandComplete","payload":"SELECT 3"}
+{"type":"ReadyForQuery","payload":"I"}
+
+ws-text
+{"queries": [
+  {"query": "VALUES (1), (2), (3)", "max_rows": 2},
+  {"query": "VALUES (1), (2), (3)"},
+  {"query": "VALUES (1), (2), (3)", "max_rows": 4}
+]}
+----
+{"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
+{"type":"Rows","payload":{"columns":[{"name":"column1","type_oid":23,"type_len":4,"type_mod":-1}],"rows_remaining":1}}
+{"type":"Row","payload":[1]}
+{"type":"Row","payload":[2]}
+{"type":"CommandComplete","payload":"SELECT 3"}
+{"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
+{"type":"Rows","payload":{"columns":[{"name":"column1","type_oid":23,"type_len":4,"type_mod":-1}]}}
+{"type":"Row","payload":[1]}
+{"type":"Row","payload":[2]}
+{"type":"Row","payload":[3]}
+{"type":"CommandComplete","payload":"SELECT 3"}
+{"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
+{"type":"Rows","payload":{"columns":[{"name":"column1","type_oid":23,"type_len":4,"type_mod":-1}],"rows_remaining":0}}
+{"type":"Row","payload":[1]}
+{"type":"Row","payload":[2]}
+{"type":"Row","payload":[3]}
+{"type":"CommandComplete","payload":"SELECT 3"}
+{"type":"ReadyForQuery","payload":"I"}
+
 ws-text rows=2 fixtimestamp=true
 {"query": "SUBSCRIBE t"}
 ----


### PR DESCRIPTION
This allows the console to put a limit on the number of returned rows.

See https://github.com/MaterializeInc/console/issues/482

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a