### PR TITLE
tests: fix webhooks.py in nightly ("IN CLUSTER" changes)

### DIFF
--- a/misc/python/materialize/checks/webhook.py
+++ b/misc/python/materialize/checks/webhook.py
@@ -21,7 +21,7 @@ def schemas() -> str:
 
 class Webhook(Check):
     def _can_run(self) -> bool:
-        return self.base_version >= MzVersion.parse("0.61.0-dev")
+        return self.base_version >= MzVersion.parse("0.62.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(


### PR DESCRIPTION
This fixes https://github.com/MaterializeInc/materialize/issues/20676.

This increases the version in `webhook.py` to `0.62-dev` because https://github.com/MaterializeInc/materialize/pull/20617 landed after 0.61.

Nightly: https://buildkite.com/materialize/nightlies/builds/2907