### PR TITLE
adapter: remove `ConnCatalog::into_owned()`

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1668,7 +1668,7 @@ pub struct ConnCatalog<'a> {
     database: Option<DatabaseId>,
     search_path: Vec<(ResolvedDatabaseSpecifier, SchemaSpecifier)>,
     role_id: RoleId,
-    prepared_statements: Option<Cow<'a, BTreeMap<String, PreparedStatement>>>,
+    prepared_statements: Option<&'a BTreeMap<String, PreparedStatement>>,
     notices_tx: UnboundedSender<AdapterNotice>,
 }
 
@@ -1696,20 +1696,6 @@ impl ConnCatalog<'_> {
             "only the system role can mark IDs unresolvable",
         );
         self.unresolvable_ids.insert(id);
-    }
-
-    pub fn into_owned(self) -> ConnCatalog<'static> {
-        ConnCatalog {
-            state: Cow::Owned(self.state.into_owned()),
-            unresolvable_ids: self.unresolvable_ids.clone(),
-            conn_id: self.conn_id,
-            cluster: self.cluster,
-            database: self.database,
-            search_path: self.search_path,
-            role_id: self.role_id,
-            prepared_statements: self.prepared_statements.map(|s| Cow::Owned(s.into_owned())),
-            notices_tx: self.notices_tx,
-        }
     }
 
     /// Returns the schemas:
@@ -4665,7 +4651,7 @@ impl Catalog {
             database,
             search_path,
             role_id: session.current_role_id().clone(),
-            prepared_statements: Some(Cow::Borrowed(session.prepared_statements())),
+            prepared_statements: Some(session.prepared_statements()),
             notices_tx: session.retain_notice_transmitter(),
         }
     }


### PR DESCRIPTION
Teach purification about #18285 which added the ability to get a task-safe reference to a Catalog instead of cloning a bunch of stuff. This simplifies ConnCatalog a bit, but still requires a Cow for the CatalogState because of `fn insert_item` which needs a writeable reference, which the Cow provides.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a