### PR TITLE
SQLsmith: ignore role "..." does not exist

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -148,6 +148,7 @@ known_errors = [
     "number of columns must be a positive integer literal",
     "regex_extract requires a string literal as its first argument",
     "out of valid range",
+    '" does not exist',  # role does not exist
 ]
 
 


### PR DESCRIPTION
Address

```
 --- [SQLsmith] Error XX000: ERROR:  role "mzcompose-test-00000000-0000-0000-0000-000000000000-0" does not exist 
```

in
```
	  SELECT  
	      CAST(pg_catalog.pg_has_role(
	        CAST('a' as text),
	        CAST(cast(coalesce(cast(null as oid), (select "adrelid" from pg_catalog.pg_attrdef limit 1 offset 1)) as oid) as oid),
	        CAST('USAGE' as text)
	    	) as bool);
```