### PR TITLE
test: Add upgrade test for RETURNING keyword

### DIFF
--- a/test/upgrade/check-from-v0.27.0-returning-keyword.td
+++ b/test/upgrade/check-from-v0.27.0-returning-keyword.td
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SHOW CREATE VIEW view_with_returning;
+materialize.public.view_with_returning "CREATE VIEW \"materialize\".\"public\".\"view_with_returning\" AS SELECT \"returning\" FROM (VALUES (1)) AS \"_\" (\"returning\")"

--- a/test/upgrade/create-in-v0.27.0-returning-keyword.td
+++ b/test/upgrade/create-in-v0.27.0-returning-keyword.td
@@ -7,4 +7,4 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> CREATE VIEW v AS SELECT returning FROM (VALUES (1)) _ (returning)
+> CREATE VIEW view_with_returning AS SELECT returning FROM (VALUES (1)) _ (returning)

--- a/test/upgrade/create-in-v0.61.0-returning-keyword.td
+++ b/test/upgrade/create-in-v0.61.0-returning-keyword.td
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE VIEW v AS SELECT returning FROM (VALUES (1)) _ (returning)


### PR DESCRIPTION
### Motivation

Follow up of #20668, we want to make sure that users with persisted SQL that contain the "returning" keyword can still be parsed after that change.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
