### PR TITLE
Fix: adapt the old mz to work with the new region api

### DIFF
--- a/src/mz/src/api.rs
+++ b/src/mz/src/api.rs
@@ -62,22 +62,20 @@ impl FromStr for CloudProviderRegion {
 }
 
 #[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Region {
-    pub environment_controller_url: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Environment {
-    pub environmentd_pgwire_address: String,
-    pub environmentd_https_address: String,
+pub struct RegionInfo {
+    pub sql_address: String,
+    pub http_address: String,
     pub resolvable: bool,
 }
 
-impl Environment {
+#[derive(Debug, Deserialize, Clone)]
+pub struct Region {
+    pub region_info: RegionInfo,
+}
+
+impl Region {
     pub fn sql_url(&self, profile: &ValidProfile) -> Url {
-        let mut url = Url::parse(&format!("postgres://{}", &self.environmentd_pgwire_address))
+        let mut url = Url::parse(&format!("postgres://{}", &self.region_info.sql_address))
             .expect("url known to be valid");
         url.set_username(profile.profile.get_email()).unwrap();
         url.set_path("materialize");
@@ -113,7 +111,7 @@ pub struct CloudProviderAndRegion {
 }
 
 /// Enables a particular cloud provider's region
-pub async fn enable_region_environment(
+pub async fn enable_region(
     client: &Client,
     cloud_provider: &CloudProvider,
     version: Option<String>,
@@ -138,7 +136,7 @@ pub async fn enable_region_environment(
     };
 
     client
-        .post(format!("{:}/api/environmentassignment", cloud_provider.api_url).as_str())
+        .patch(format!("{:}/api/region", cloud_provider.api_url).as_str())
         .authenticate(&valid_profile.frontegg_auth)
         .json(&body)
         .send()
@@ -148,7 +146,7 @@ pub async fn enable_region_environment(
 }
 
 /// Disables a particular cloud provider's region.
-pub async fn disable_region_environment(
+pub async fn disable_region(
     client: &Client,
     cloud_provider: &CloudProvider,
     valid_profile: &ValidProfile<'_>,
@@ -158,7 +156,7 @@ pub async fn disable_region_environment(
         .max_duration(Duration::from_secs(30))
         .retry_async(|_| async {
             client
-                .delete(format!("{:}/api/environmentassignment", cloud_provider.api_url).as_str())
+                .delete(format!("{:}/api/region", cloud_provider.api_url).as_str())
                 .authenticate(&valid_profile.frontegg_auth)
                 .send()
                 .await?
@@ -169,13 +167,13 @@ pub async fn disable_region_environment(
 }
 
 //// Get a cloud provider's regions
-pub async fn get_cloud_provider_region_details(
+pub async fn get_region(
     client: &Client,
     cloud_provider_region: &CloudProvider,
     valid_profile: &ValidProfile<'_>,
-) -> Result<Vec<Region>, anyhow::Error> {
+) -> Result<Region, anyhow::Error> {
     let mut region_api_url = cloud_provider_region.api_url.clone();
-    region_api_url.push_str("/api/environmentassignment");
+    region_api_url.push_str("/api/region");
 
     let response = client
         .get(region_api_url)
@@ -183,35 +181,7 @@ pub async fn get_cloud_provider_region_details(
         .send()
         .await?;
     ensure!(response.status().is_success());
-    Ok(response.json::<Vec<Region>>().await?)
-}
-
-//// Get a cloud provider's region's environment
-pub async fn region_environment_details(
-    client: &Client,
-    region: &Region,
-    valid_profile: &ValidProfile<'_>,
-) -> Result<Option<Vec<Environment>>, Error> {
-    let mut region_api_url = region.environment_controller_url
-        [0..region.environment_controller_url.len() - 4]
-        .to_string();
-    region_api_url.push_str("/api/environment");
-
-    let response = client
-        .get(region_api_url)
-        .authenticate(&valid_profile.frontegg_auth)
-        .send()
-        .await?;
-    match response.content_length() {
-        Some(length) => {
-            if length > 0 {
-                Ok(Some(response.json::<Vec<Environment>>().await?))
-            } else {
-                Ok(None)
-            }
-        }
-        None => Ok(None),
-    }
+    Ok(response.json::<Region>().await?)
 }
 
 /// List all the available regions for a list of cloud providers.
@@ -224,16 +194,15 @@ pub async fn list_regions(
     let mut cloud_providers_and_regions: Vec<CloudProviderAndRegion> = Vec::new();
 
     for cloud_provider in cloud_providers {
-        let cloud_provider_region_details =
-            get_cloud_provider_region_details(client, cloud_provider, valid_profile)
-                .await
-                .with_context(|| "Retrieving region details.")?;
-        match cloud_provider_region_details.get(0) {
-            Some(region) => cloud_providers_and_regions.push(CloudProviderAndRegion {
+        let possible_region = get_region(client, cloud_provider, valid_profile)
+            .await
+            .with_context(|| "Retrieving region details.");
+        match possible_region {
+            Ok(region) => cloud_providers_and_regions.push(CloudProviderAndRegion {
                 cloud_provider: cloud_provider.clone(),
                 region: Some(region.to_owned()),
             }),
-            None => cloud_providers_and_regions.push(CloudProviderAndRegion {
+            _ => cloud_providers_and_regions.push(CloudProviderAndRegion {
                 cloud_provider: cloud_provider.clone(),
                 region: None,
             }),
@@ -259,7 +228,7 @@ pub async fn list_cloud_providers(
         .await
 }
 
-pub async fn get_provider_by_region_name(
+pub async fn get_cloud_provider(
     client: &Client,
     valid_profile: &ValidProfile<'_>,
     cloud_provider_region: &CloudProviderRegion,
@@ -278,55 +247,18 @@ pub async fn get_provider_by_region_name(
     Ok(cloud_provider)
 }
 
-pub async fn get_provider_region(
+pub async fn get_region_by_cloud_provider(
     client: &Client,
     valid_profile: &ValidProfile<'_>,
     cloud_provider_region: &CloudProviderRegion,
 ) -> Result<Region> {
-    let cloud_provider = get_provider_by_region_name(client, valid_profile, cloud_provider_region)
+    let cloud_provider = get_cloud_provider(client, valid_profile, cloud_provider_region)
         .await
         .with_context(|| "Retrieving cloud provider.")?;
 
-    let cloud_provider_region_details =
-        get_cloud_provider_region_details(client, &cloud_provider, valid_profile)
-            .await
-            .with_context(|| "Retrieving region details.")?;
-
-    let region = cloud_provider_region_details
-        .get(0)
-        .with_context(|| "Region unavailable")?;
-
-    Ok(region.to_owned())
-}
-
-pub async fn get_region_environment(
-    client: &Client,
-    valid_profile: &ValidProfile<'_>,
-    region: &Region,
-) -> Result<Environment> {
-    let environment_details = region_environment_details(client, region, valid_profile)
+    let region = get_region(client, &cloud_provider, valid_profile)
         .await
-        .with_context(|| "Environment unavailable")?;
-    let environment_list = environment_details.with_context(|| "Environment unlisted")?;
-    let environment = environment_list
-        .get(0)
-        .with_context(|| "Missing environment")?;
+        .with_context(|| "Retrieving region.")?;
 
-    Ok(environment.to_owned())
-}
-
-pub async fn get_provider_region_environment(
-    client: &Client,
-    valid_profile: &ValidProfile<'_>,
-    cloud_provider_region: &CloudProviderRegion,
-) -> Result<Environment> {
-    let region = get_provider_region(client, valid_profile, cloud_provider_region)
-        .await
-        .with_context(|| "Retrieving region data.")?;
-
-    let environment = get_region_environment(client, valid_profile, &region)
-        .await
-        .with_context(|| "Retrieving environment data")?;
-
-    Ok(environment)
+    Ok(region)
 }

--- a/src/mz/src/bin/mz/region.rs
+++ b/src/mz/src/bin/mz/region.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use anyhow::Result;
-use mz::api::{CloudProviderAndRegion, Environment};
+use mz::api::{CloudProviderAndRegion, Region};
 use mz::configuration::ValidProfile;
 
 /// Prints if a region is enabled or not
@@ -31,15 +31,15 @@ pub(crate) fn print_region_enabled(cloud_provider_and_region: &CloudProviderAndR
 }
 
 ///
-/// Prints an environment's status and addresses
+/// Prints a region status and addresses
 ///
 /// Healthy:                {yes/no}
 /// SQL address:            foo.materialize.cloud:6875
 /// HTTPS address:          <https://foo.materialize.cloud>
 /// Connection string:      postgres://{user}@{address}/materialize?sslmode=require
-pub(crate) fn print_environment_status(
+pub(crate) fn print_region_status(
     valid_profile: &ValidProfile,
-    environment: Environment,
+    region: Region,
     health: bool,
 ) -> Result<()> {
     if health {
@@ -50,13 +50,9 @@ pub(crate) fn print_environment_status(
 
     println!(
         "HTTPS address: \t\thttps://{}",
-        &environment.environmentd_https_address
-            [0..environment.environmentd_https_address.len() - 4]
+        &region.region_info.http_address[0..region.region_info.http_address.len() - 4]
     );
-    println!(
-        "SQL connection string: \t{}",
-        environment.sql_url(valid_profile)
-    );
+    println!("SQL connection string: \t{}", region.sql_url(valid_profile));
 
     Ok(())
 }

--- a/src/mz/src/bin/mz/secrets.rs
+++ b/src/mz/src/bin/mz/secrets.rs
@@ -12,7 +12,7 @@ use std::fs::read_to_string;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use mz::api::{get_provider_region_environment, CloudProviderRegion};
+use mz::api::{get_region_by_cloud_provider, CloudProviderRegion};
 use mz::configuration::ValidProfile;
 use postgres_protocol::escape::{escape_identifier, escape_literal};
 use reqwest::Client;
@@ -194,13 +194,11 @@ async fn execute_query(
     cloud_provider_region: CloudProviderRegion,
     sql: Sql,
 ) -> Result<(), anyhow::Error> {
-    let environment =
-        get_provider_region_environment(client, valid_profile, &cloud_provider_region)
-            .await
-            .context("retrieving cloud provider region")?;
+    let region = get_region_by_cloud_provider(client, valid_profile, &cloud_provider_region)
+        .await
+        .context("retrieving cloud provider region")?;
 
-    let endpoint = &environment.environmentd_https_address
-        [0..environment.environmentd_https_address.len() - 4];
+    let endpoint = &region.region_info.http_address[0..region.region_info.http_address.len() - 4];
     let url = format!("https://{endpoint}/api/sql");
 
     let results = client


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

The idea of this PR is to make work the old `mz` with the new [Region API](https://github.com/MaterializeInc/cloud/blob/main/doc/design/20230421_region_api.md) and enable developers and internal CI/CD workflows to keep working in peace with the new implementation.

Environment doesn't has importance anymore and the concept was removed almost completely. All the requests are done to retrieve the cloud providers and region details.

There is still some work pending to do about how `region_info` is handled.

### Motivation

This PR adds a known-desirable feature. https://github.com/MaterializeInc/cloud/issues/5775

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer


As the `src/cloud-api` [PR](https://github.com/MaterializeInc/materialize/pull/20686) version says:

> This is in draft mode and not yet testable until the following Cloud PRs are merged & deployed to our staging environment:
> https://github.com/MaterializeInc/cloud/pull/6961
> https://github.com/MaterializeInc/cloud/pull/6981
> Once those are deployed, it may make sense to test this PR by combining with  https://github.com/MaterializeInc/materialize/pull/19340 and leveraging the tests defined there against our staging environment, however I'm open to other ideas on methods to validate this

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
