### PR TITLE
Configure backpressure max bytes in flight based on cluster size

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -876,7 +876,10 @@ impl Coordinator {
         // Inform the controllers about their initial configuration.
         let compute_config = flags::compute_config(self.catalog().system_config());
         self.controller.compute.update_configuration(compute_config);
-        let storage_config = flags::storage_config(self.catalog().system_config());
+        let storage_config = flags::storage_config(
+            self.catalog().system_config(),
+            self.catalog().cluster_replica_sizes(),
+        );
         self.controller.storage.update_configuration(storage_config);
 
         // Capture identifiers that need to have their read holds relaxed once the bootstrap completes.

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -680,7 +680,10 @@ impl Coordinator {
     }
 
     fn update_storage_config(&mut self) {
-        let config_params = flags::storage_config(self.catalog().system_config());
+        let config_params = flags::storage_config(
+            self.catalog().system_config(),
+            self.catalog().cluster_replica_sizes(),
+        );
         self.controller.storage.update_configuration(config_params);
     }
 

--- a/src/cluster-client/src/client.proto
+++ b/src/cluster-client/src/client.proto
@@ -21,4 +21,6 @@ message ProtoTimelyConfig {
     uint64 process = 2;
     repeated string addresses = 3;
     uint32 idle_arrangement_merge_effort = 4;
+    optional string cluster_size = 5;
+
 }

--- a/src/cluster-client/src/client.proto
+++ b/src/cluster-client/src/client.proto
@@ -22,5 +22,4 @@ message ProtoTimelyConfig {
     repeated string addresses = 3;
     uint32 idle_arrangement_merge_effort = 4;
     optional string cluster_size = 5;
-
 }

--- a/src/cluster-client/src/client.rs
+++ b/src/cluster-client/src/client.rs
@@ -139,6 +139,7 @@ pub struct TimelyConfig {
     ///
     /// See `differential_dataflow::Config::idle_merge_effort`.
     pub idle_arrangement_merge_effort: u32,
+    pub cluster_size: Option<String>,
 }
 
 impl RustType<ProtoTimelyConfig> for TimelyConfig {
@@ -148,6 +149,7 @@ impl RustType<ProtoTimelyConfig> for TimelyConfig {
             addresses: self.addresses.into_proto(),
             process: self.process.into_proto(),
             idle_arrangement_merge_effort: self.idle_arrangement_merge_effort,
+            cluster_size: self.cluster_size.into_proto(),
         }
     }
 
@@ -157,6 +159,7 @@ impl RustType<ProtoTimelyConfig> for TimelyConfig {
             workers: proto.workers.into_rust()?,
             addresses: proto.addresses.into_rust()?,
             idle_arrangement_merge_effort: proto.idle_arrangement_merge_effort,
+            cluster_size: proto.cluster_size.into_rust()?,
         })
     }
 }

--- a/src/cluster-client/src/client.rs
+++ b/src/cluster-client/src/client.rs
@@ -139,6 +139,7 @@ pub struct TimelyConfig {
     ///
     /// See `differential_dataflow::Config::idle_merge_effort`.
     pub idle_arrangement_merge_effort: u32,
+    /// The human readable materialize cluster size for this timely cluster
     pub cluster_size: Option<String>,
 }
 

--- a/src/cluster/src/server.rs
+++ b/src/cluster/src/server.rs
@@ -175,16 +175,13 @@ where
                 idle_merge_effort: Some(isize::cast_from(config.idle_arrangement_merge_effort)),
             },
         );
-        if let Some(cluster_size) = &config.cluster_size {
-            worker_config.set(
-                "materialize/storage.cluster_size".to_string(),
-                cluster_size.to_owned(),
-            );
-        }
+
+        let cluster_size = config.cluster_size.clone();
 
         let worker_guards = execute_from(builders, other, worker_config, move |timely_worker| {
             let timely_worker_index = timely_worker.index();
             let _tokio_guard = tokio_executor.enter();
+            let cluster_size = cluster_size.clone();
             let client_rx = client_rxs.lock().unwrap()[timely_worker_index % config.workers]
                 .take()
                 .unwrap();
@@ -197,6 +194,7 @@ where
                 client_rx,
                 persist_clients,
                 tracing_handle,
+                cluster_size,
             )
         })
         .map_err(|e| anyhow!("{e}"))?;

--- a/src/cluster/src/server.rs
+++ b/src/cluster/src/server.rs
@@ -175,6 +175,12 @@ where
                 idle_merge_effort: Some(isize::cast_from(config.idle_arrangement_merge_effort)),
             },
         );
+        if let Some(cluster_size) = &config.cluster_size {
+            worker_config.set(
+                "materialize/storage.cluster_size".to_string(),
+                cluster_size.to_owned(),
+            );
+        }
 
         let worker_guards = execute_from(builders, other, worker_config, move |timely_worker| {
             let timely_worker_index = timely_worker.index();

--- a/src/cluster/src/types.rs
+++ b/src/cluster/src/types.rs
@@ -40,6 +40,7 @@ pub trait AsRunnableWorker<C, R> {
         )>,
         persist_clients: Arc<PersistClientCache>,
         tracing_handle: Arc<TracingHandle>,
+        cluster_size: Option<String>,
     );
 }
 

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -166,6 +166,7 @@ where
             process: 0,
             addresses: config.location.dataflow_addrs,
             idle_arrangement_merge_effort: config.idle_arrangement_merge_effort,
+            cluster_size: None,
         };
         let cmd_spec = CommandSpecialization {
             logging_config: config.logging,

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -161,6 +161,7 @@ impl mz_cluster::types::AsRunnableWorker<ComputeCommand, ComputeResponse> for Co
         )>,
         persist_clients: Arc<PersistClientCache>,
         tracing_handle: Arc<TracingHandle>,
+        _cluster_size: Option<String>,
     ) {
         Worker {
             timely_worker,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -851,6 +851,18 @@ const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar 
     internal: true,
 };
 
+///
+const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT: ServerVar<Option<usize>> =
+    ServerVar {
+        name: UncasedStr::new("storage_dataflow_max_inflight_bytes_to_cluster_size_percent"),
+        value: &None,
+        description:
+            "The percentage of the cluster replica size to be used as the maximum number of \
+    in-flight bytes emitted by persist_sources feeding storage dataflows. \
+    If not configured, the storage_dataflow_max_inflight_bytes value will be used.",
+        internal: true,
+    };
+
 /// Controls [`mz_persist_client::cfg::PersistConfig::sink_minimum_batch_updates`].
 const PERSIST_SINK_MINIMUM_BATCH_UPDATES: ServerVar<usize> = ServerVar {
     name: UncasedStr::new("persist_sink_minimum_batch_updates"),
@@ -1838,6 +1850,7 @@ impl SystemVars {
             .with_var(&CRDB_TCP_USER_TIMEOUT)
             .with_var(&DATAFLOW_MAX_INFLIGHT_BYTES)
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES)
+            .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT)
             .with_var(&PERSIST_SINK_MINIMUM_BATCH_UPDATES)
             .with_var(&STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
             .with_var(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)
@@ -2300,6 +2313,11 @@ impl SystemVars {
     /// Returns the `storage_dataflow_max_inflight_bytes` configuration parameter.
     pub fn storage_dataflow_max_inflight_bytes(&self) -> Option<usize> {
         *self.expect_value(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES)
+    }
+
+    /// Returns the `storage_dataflow_max_inflight_bytes_to_cluster_size_percent` configuration parameter.
+    pub fn storage_dataflow_max_inflight_bytes_to_cluster_size_percent(&self) -> Option<usize> {
+        *self.expect_value(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT)
     }
 
     /// Returns the `persist_sink_minimum_batch_updates` configuration parameter.
@@ -3760,6 +3778,7 @@ pub fn is_storage_config_var(name: &str) -> bool {
         || name == PG_REPLICATION_KEEPALIVES_RETRIES.name()
         || name == PG_REPLICATION_TCP_USER_TIMEOUT.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
+        || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT.name()
         || is_upsert_rocksdb_config_var(name)
         || is_persist_config_var(name)
         || is_tracing_var(name)

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -851,7 +851,10 @@ const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar 
     internal: true,
 };
 
-///
+/// The percentage of the cluster replica size to be used as the maximum number of
+/// in-flight bytes emitted by persist_sources feeding storage dataflows.
+/// If not configured, the storage_dataflow_max_inflight_bytes value will be used.
+/// For this value to be used storage_dataflow_max_inflight_bytes needs to be set.
 const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT: ServerVar<Option<usize>> =
     ServerVar {
         name: UncasedStr::new("storage_dataflow_max_inflight_bytes_to_cluster_size_percent"),

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -282,6 +282,7 @@ pub trait StorageController: Debug + Send {
         &mut self,
         id: StorageInstanceId,
         location: ClusterReplicaLocation,
+        // The human readable `string` cluster size if there is one
         cluster_size: Option<String>,
     );
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -278,7 +278,12 @@ pub trait StorageController: Debug + Send {
     /// In the future, this API will be adjusted to support active replication
     /// of storage instances (i.e., multiple replicas attached to a given
     /// storage instance).
-    fn connect_replica(&mut self, id: StorageInstanceId, location: ClusterReplicaLocation);
+    fn connect_replica(
+        &mut self,
+        id: StorageInstanceId,
+        location: ClusterReplicaLocation,
+        cluster_size: Option<String>,
+    );
 
     /// Disconnects the storage instance from the specified replica.
     fn drop_replica(
@@ -1177,13 +1182,18 @@ where
         assert!(client.is_some(), "storage instance {id} does not exist");
     }
 
-    fn connect_replica(&mut self, id: StorageInstanceId, location: ClusterReplicaLocation) {
+    fn connect_replica(
+        &mut self,
+        id: StorageInstanceId,
+        location: ClusterReplicaLocation,
+        cluster_size: Option<String>,
+    ) {
         let client = self
             .state
             .clients
             .get_mut(&id)
             .unwrap_or_else(|| panic!("instance {id} does not exist"));
-        client.connect(location);
+        client.connect(location, cluster_size);
     }
 
     fn drop_replica(

--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -93,9 +93,12 @@ where
     }
 
     /// Connects to the storage replica at the specified network address.
-    pub fn connect(&mut self, location: ClusterReplicaLocation) {
+    pub fn connect(&mut self, location: ClusterReplicaLocation, cluster_size: Option<String>) {
         self.command_tx
-            .send(RehydrationCommand::Connect { location })
+            .send(RehydrationCommand::Connect {
+                location,
+                cluster_size,
+            })
             .expect("rehydration task should not drop first");
     }
 
@@ -125,6 +128,7 @@ enum RehydrationCommand<T> {
     Connect {
         /// The location of the (singular) replica we are going to connect to.
         location: ClusterReplicaLocation,
+        cluster_size: Option<String>,
     },
     /// Send the contained storage command to the replica.
     Send(StorageCommand<T>),
@@ -168,12 +172,14 @@ enum RehydrationTaskState<T: Timestamp + Lattice> {
     Rehydrate {
         /// The location of the storage replica.
         location: ClusterReplicaLocation,
+        cluster_size: Option<String>,
     },
     /// Communication with the storage replica is live. Commands and responses
     /// should be forwarded until an error occurs.
     Pump {
         /// The location of the storage replica.
         location: ClusterReplicaLocation,
+        cluster_size: Option<String>,
         /// The connected client for the replica.
         client: PartitionedClient<T>,
     },
@@ -192,10 +198,15 @@ where
         loop {
             state = match state {
                 RehydrationTaskState::AwaitAddress => self.step_await_address().await,
-                RehydrationTaskState::Rehydrate { location } => self.step_rehydrate(location).await,
-                RehydrationTaskState::Pump { location, client } => {
-                    self.step_pump(location, client).await
-                }
+                RehydrationTaskState::Rehydrate {
+                    location,
+                    cluster_size,
+                } => self.step_rehydrate(location, cluster_size).await,
+                RehydrationTaskState::Pump {
+                    location,
+                    cluster_size,
+                    client,
+                } => self.step_pump(location, cluster_size, client).await,
                 RehydrationTaskState::Done => break,
             }
         }
@@ -205,8 +216,14 @@ where
         loop {
             match self.command_rx.recv().await {
                 None => break RehydrationTaskState::Done,
-                Some(RehydrationCommand::Connect { location }) => {
-                    break RehydrationTaskState::Rehydrate { location }
+                Some(RehydrationCommand::Connect {
+                    location,
+                    cluster_size,
+                }) => {
+                    break RehydrationTaskState::Rehydrate {
+                        location,
+                        cluster_size,
+                    }
                 }
                 Some(RehydrationCommand::Send(command)) => {
                     self.absorb_command(&command);
@@ -219,6 +236,7 @@ where
     async fn step_rehydrate(
         &mut self,
         location: ClusterReplicaLocation,
+        cluster_size: Option<String>,
     ) -> RehydrationTaskState<T> {
         // Reconnect to the storage replica.
         let stream = Retry::default()
@@ -234,8 +252,14 @@ where
             // to a new storage replica.
             loop {
                 match self.command_rx.try_recv() {
-                    Ok(RehydrationCommand::Connect { location }) => {
-                        return RehydrationTaskState::Rehydrate { location };
+                    Ok(RehydrationCommand::Connect {
+                        location,
+                        cluster_size,
+                    }) => {
+                        return RehydrationTaskState::Rehydrate {
+                            location,
+                            cluster_size,
+                        };
                     }
                     Ok(RehydrationCommand::Send(command)) => {
                         self.absorb_command(&command);
@@ -257,6 +281,7 @@ where
                 // TODO(guswynn): cluster-unification: ensure this is cleaned up when
                 // the compute and storage command streams are merged.
                 idle_arrangement_merge_effort: 1337,
+                cluster_size: cluster_size.clone(),
             };
             let dests = location
                 .ctl_addrs
@@ -317,22 +342,24 @@ where
         if self.initialized {
             commands.push(StorageCommand::InitializationComplete)
         }
-        self.send_commands(location, client, commands).await
+        self.send_commands(location, cluster_size, client, commands)
+            .await
     }
 
     async fn step_pump(
         &mut self,
         location: ClusterReplicaLocation,
+        cluster_size: Option<String>,
         mut client: PartitionedClient<T>,
     ) -> RehydrationTaskState<T> {
         select! {
             // Command from controller to forward to storage cluster.
             command = self.command_rx.recv() => match command {
                 None => RehydrationTaskState::Done,
-                Some(RehydrationCommand::Connect { location }) => RehydrationTaskState::Rehydrate { location },
+                Some(RehydrationCommand::Connect { location, cluster_size }) => RehydrationTaskState::Rehydrate { location, cluster_size },
                 Some(RehydrationCommand::Send(command)) => {
                     self.absorb_command(&command);
-                    self.send_commands(location, client, vec![command]).await
+                    self.send_commands(location, cluster_size, client, vec![command]).await
                 }
                 Some(RehydrationCommand::Reset) => {
                     RehydrationTaskState::AwaitAddress
@@ -351,7 +378,7 @@ where
                     Some(response) => response,
                 };
 
-                self.send_response(location, client, response)
+                self.send_response(location, cluster_size, client, response)
             }
         }
     }
@@ -359,20 +386,26 @@ where
     async fn send_commands(
         &mut self,
         location: ClusterReplicaLocation,
+        cluster_size: Option<String>,
         mut client: PartitionedClient<T>,
         commands: impl IntoIterator<Item = StorageCommand<T>>,
     ) -> RehydrationTaskState<T> {
         for command in commands {
             if let Err(e) = client.send(command).await {
-                return self.send_response(location.clone(), client, Err(e));
+                return self.send_response(location.clone(), cluster_size.clone(), client, Err(e));
             }
         }
-        RehydrationTaskState::Pump { location, client }
+        RehydrationTaskState::Pump {
+            location,
+            cluster_size,
+            client,
+        }
     }
 
     fn send_response(
         &mut self,
         location: ClusterReplicaLocation,
+        cluster_size: Option<String>,
         client: PartitionedClient<T>,
         response: Result<StorageResponse<T>, anyhow::Error>,
     ) -> RehydrationTaskState<T> {
@@ -382,15 +415,26 @@ where
                     if self.response_tx.send(response).is_err() {
                         RehydrationTaskState::Done
                     } else {
-                        RehydrationTaskState::Pump { location, client }
+                        RehydrationTaskState::Pump {
+                            location,
+                            cluster_size,
+                            client,
+                        }
                     }
                 } else {
-                    RehydrationTaskState::Pump { location, client }
+                    RehydrationTaskState::Pump {
+                        location,
+                        cluster_size,
+                        client,
+                    }
                 }
             }
             Err(e) => {
                 warn!("storage cluster produced error, reconnecting: {e}");
-                RehydrationTaskState::Rehydrate { location }
+                RehydrationTaskState::Rehydrate {
+                    location,
+                    cluster_size,
+                }
             }
         }
     }

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -26,7 +26,7 @@ message ProtoStorageParameters {
     uint64 keep_n_sink_status_history_entries = 7;
     mz_tracing.params.ProtoTracingParameters tracing = 8;
     ProtoUpsertAutoSpillConfig upsert_auto_spill_config = 9;
-    optional uint64 storage_dataflow_max_inflight_bytes = 10;
+    ProtoStorageMaxInflightBytesConfig storage_dataflow_max_inflight_bytes_config = 10;
 }
 
 
@@ -41,4 +41,10 @@ message ProtoPgReplicationTimeouts {
 message ProtoUpsertAutoSpillConfig {
     bool allow_spilling_to_disk = 1;
     uint64 spill_to_disk_threshold_bytes = 2;
+}
+
+message ProtoStorageMaxInflightBytesConfig {
+    optional uint64 max_in_flight_bytes_default = 1;
+    optional uint64 max_in_flight_bytes_cluster_size_percent = 2;
+    map<string, uint64> cluster_size_memory_map = 3;
 }

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -50,10 +50,10 @@ pub struct StorageParameters {
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct StorageMaxInflightBytesConfig {
     /// The default value for the max in-flight bytes
-    pub max_in_flight_bytes_default: Option<usize>,
+    pub max_inflight_bytes_default: Option<usize>,
     /// Specified percentage which will be used to calculate the max in-flight from the
     /// memory limit of the cluster in use.
-    pub max_in_flight_bytes_cluster_size_percent: Option<usize>,
+    pub max_inflight_bytes_cluster_size_percent: Option<usize>,
     /// A map of different cluster sizes and their corresponding memory limits in bytes
     /// This will be used to find out the memory limit of the cluster in use.
     pub cluster_size_memory_map: BTreeMap<String, usize>,
@@ -62,9 +62,9 @@ pub struct StorageMaxInflightBytesConfig {
 impl RustType<ProtoStorageMaxInflightBytesConfig> for StorageMaxInflightBytesConfig {
     fn into_proto(&self) -> ProtoStorageMaxInflightBytesConfig {
         ProtoStorageMaxInflightBytesConfig {
-            max_in_flight_bytes_default: self.max_in_flight_bytes_default.map(u64::cast_from),
+            max_in_flight_bytes_default: self.max_inflight_bytes_default.map(u64::cast_from),
             max_in_flight_bytes_cluster_size_percent: self
-                .max_in_flight_bytes_cluster_size_percent
+                .max_inflight_bytes_cluster_size_percent
                 .map(u64::cast_from),
             cluster_size_memory_map: self
                 .cluster_size_memory_map
@@ -81,8 +81,8 @@ impl RustType<ProtoStorageMaxInflightBytesConfig> for StorageMaxInflightBytesCon
             cluster_size_memory_map.insert(cluster_size, usize::cast_from(memory_limit));
         }
         Ok(Self {
-            max_in_flight_bytes_default: proto.max_in_flight_bytes_default.map(usize::cast_from),
-            max_in_flight_bytes_cluster_size_percent: proto
+            max_inflight_bytes_default: proto.max_in_flight_bytes_default.map(usize::cast_from),
+            max_inflight_bytes_cluster_size_percent: proto
                 .max_in_flight_bytes_cluster_size_percent
                 .map(usize::cast_from),
             cluster_size_memory_map,

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -9,6 +9,8 @@
 
 //! Configuration parameter types.
 
+use std::collections::BTreeMap;
+
 use mz_ore::cast::CastFrom;
 use mz_persist_client::cfg::PersistParameters;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
@@ -38,9 +40,54 @@ pub struct StorageParameters {
     /// finalization.
     pub finalize_shards: bool,
     pub tracing: TracingParameters,
-    /// A set of parameters used configure auto spill behaviour if disk is used.
+    /// A set of parameters used to configure auto spill behaviour if disk is used.
     pub upsert_auto_spill_config: UpsertAutoSpillConfig,
-    pub storage_dataflow_max_inflight_bytes: Option<usize>,
+    /// A set of parameters used to configure the maximum number of in-flight bytes
+    /// emitted by persist_sources feeding storage dataflows
+    pub storage_dataflow_max_inflight_bytes_config: StorageMaxInflightBytesConfig,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct StorageMaxInflightBytesConfig {
+    /// The default value for the max in-flight bytes
+    pub max_in_flight_bytes_default: Option<usize>,
+    /// Specified percentage which will be used to calculate the max in-flight from the
+    /// memory limit of the cluster in use.
+    pub max_in_flight_bytes_cluster_size_percent: Option<usize>,
+    /// A map of different cluster sizes and their corresponding memory limits in bytes
+    /// This will be used to find out the memory limit of the cluster in use.
+    pub cluster_size_memory_map: BTreeMap<String, usize>,
+}
+
+impl RustType<ProtoStorageMaxInflightBytesConfig> for StorageMaxInflightBytesConfig {
+    fn into_proto(&self) -> ProtoStorageMaxInflightBytesConfig {
+        ProtoStorageMaxInflightBytesConfig {
+            max_in_flight_bytes_default: self.max_in_flight_bytes_default.map(u64::cast_from),
+            max_in_flight_bytes_cluster_size_percent: self
+                .max_in_flight_bytes_cluster_size_percent
+                .map(u64::cast_from),
+            cluster_size_memory_map: self
+                .cluster_size_memory_map
+                .iter()
+                .map(|(cluster_size, memory_limit)| {
+                    (cluster_size.into_proto(), u64::cast_from(*memory_limit))
+                })
+                .collect(),
+        }
+    }
+    fn from_proto(proto: ProtoStorageMaxInflightBytesConfig) -> Result<Self, TryFromProtoError> {
+        let mut cluster_size_memory_map = BTreeMap::new();
+        for (cluster_size, memory_limit) in proto.cluster_size_memory_map {
+            cluster_size_memory_map.insert(cluster_size, usize::cast_from(memory_limit));
+        }
+        Ok(Self {
+            max_in_flight_bytes_default: proto.max_in_flight_bytes_default.map(usize::cast_from),
+            max_in_flight_bytes_cluster_size_percent: proto
+                .max_in_flight_bytes_cluster_size_percent
+                .map(usize::cast_from),
+            cluster_size_memory_map,
+        })
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
@@ -80,7 +127,7 @@ impl StorageParameters {
             finalize_shards,
             tracing,
             upsert_auto_spill_config,
-            storage_dataflow_max_inflight_bytes,
+            storage_dataflow_max_inflight_bytes_config,
         }: StorageParameters,
     ) {
         self.persist.update(persist);
@@ -92,7 +139,8 @@ impl StorageParameters {
         self.tracing.update(tracing);
         self.finalize_shards = finalize_shards;
         self.upsert_auto_spill_config = upsert_auto_spill_config;
-        self.storage_dataflow_max_inflight_bytes = storage_dataflow_max_inflight_bytes;
+        self.storage_dataflow_max_inflight_bytes_config =
+            storage_dataflow_max_inflight_bytes_config;
     }
 }
 
@@ -111,9 +159,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             finalize_shards: self.finalize_shards,
             tracing: Some(self.tracing.into_proto()),
             upsert_auto_spill_config: Some(self.upsert_auto_spill_config.into_proto()),
-            storage_dataflow_max_inflight_bytes: self
-                .storage_dataflow_max_inflight_bytes
-                .map(u64::cast_from),
+            storage_dataflow_max_inflight_bytes_config: Some(
+                self.storage_dataflow_max_inflight_bytes_config.into_proto(),
+            ),
         }
     }
 
@@ -141,9 +189,11 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             upsert_auto_spill_config: proto
                 .upsert_auto_spill_config
                 .into_rust_if_some("ProtoStorageParameters::upsert_auto_spill_config")?,
-            storage_dataflow_max_inflight_bytes: proto
-                .storage_dataflow_max_inflight_bytes
-                .map(usize::cast_from),
+            storage_dataflow_max_inflight_bytes_config: proto
+                .storage_dataflow_max_inflight_bytes_config
+                .into_rust_if_some(
+                    "ProtoStorageParameters::storage_dataflow_max_inflight_bytes_config",
+                )?,
         })
     }
 }

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -44,7 +44,7 @@ impl DataflowParameters {
         pg_replication_timeouts: mz_postgres_util::ReplicationTimeouts,
         rocksdb_params: mz_rocksdb::RocksDBTuningParameters,
         auto_spill_config: mz_storage_client::types::parameters::UpsertAutoSpillConfig,
-        storage_dataflow_max_inflight_bytes_config:mz_storage_client::types::parameters::StorageMaxInflightBytesConfig,
+        storage_dataflow_max_inflight_bytes_config: mz_storage_client::types::parameters::StorageMaxInflightBytesConfig,
     ) {
         self.pg_replication_timeouts = pg_replication_timeouts;
         self.upsert_rocksdb_tuning_config.apply(rocksdb_params);

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -31,9 +31,10 @@ pub struct DataflowParameters {
     /// A set of parameters to configure auto spill to disk behaviour for a `DISK`
     /// enabled upsert source
     pub auto_spill_config: mz_storage_client::types::parameters::UpsertAutoSpillConfig,
-    /// A loose boundary on the number of inflight bytes used by parts in `persist_source`,
+    /// Configuration options for the number of inflight bytes used by parts in `persist_source`,
     /// used in `UPSERT/DEBEZIUM` sources.
-    pub storage_dataflow_max_inflight_bytes: Option<usize>,
+    pub storage_dataflow_max_inflight_bytes_config:
+        mz_storage_client::types::parameters::StorageMaxInflightBytesConfig,
 }
 
 impl DataflowParameters {
@@ -43,12 +44,13 @@ impl DataflowParameters {
         pg_replication_timeouts: mz_postgres_util::ReplicationTimeouts,
         rocksdb_params: mz_rocksdb::RocksDBTuningParameters,
         auto_spill_config: mz_storage_client::types::parameters::UpsertAutoSpillConfig,
-        storage_dataflow_max_inflight_bytes: Option<usize>,
+        storage_dataflow_max_inflight_bytes_config:mz_storage_client::types::parameters::StorageMaxInflightBytesConfig,
     ) {
         self.pg_replication_timeouts = pg_replication_timeouts;
         self.upsert_rocksdb_tuning_config.apply(rocksdb_params);
         self.auto_spill_config = auto_spill_config;
-        self.storage_dataflow_max_inflight_bytes = storage_dataflow_max_inflight_bytes;
+        self.storage_dataflow_max_inflight_bytes_config =
+            storage_dataflow_max_inflight_bytes_config;
     }
 }
 
@@ -95,7 +97,8 @@ pub enum InternalStorageCommand {
         /// RocksDB configuration.
         rocksdb: mz_rocksdb::RocksDBTuningParameters,
         /// Backpressure configuration.
-        storage_dataflow_max_inflight_bytes: Option<usize>,
+        storage_dataflow_max_inflight_bytes_config:
+            mz_storage_client::types::parameters::StorageMaxInflightBytesConfig,
         /// Upsert autospill configuration.
         auto_spill_config: mz_storage_client::types::parameters::UpsertAutoSpillConfig,
     },

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -208,7 +208,7 @@ use timely::communication::Allocate;
 use timely::dataflow::operators::{Concatenate, ConnectLoop, Feedback};
 use timely::dataflow::Scope;
 use timely::progress::Antichain;
-use timely::worker::{AsWorker, Worker as TimelyWorker};
+use timely::worker::Worker as TimelyWorker;
 
 use crate::source::types::SourcePersistSinkMetrics;
 use crate::storage_state::StorageState;
@@ -236,10 +236,6 @@ pub fn build_ingestion_dataflow<A: Allocate>(
     let worker_logging = timely_worker.log_register().get("timely");
     let debug_name = primary_source_id.to_string();
     let name = format!("Source dataflow: {debug_name}");
-    let cluster_size: Option<String> = timely_worker
-        .config()
-        .get("materialize/storage.cluster_size")
-        .map(|s: &String| s.clone());
     timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, root_scope| {
         // Here we need to create two scopes. One timestamped with `()`, which is the root scope,
         // and one timestamped with `mz_repr::Timestamp` which is the final scope of the dataflow.
@@ -262,7 +258,6 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 source_resume_uppers,
                 &feedback,
                 storage_state,
-                cluster_size.as_ref(),
             );
             tokens.push(token);
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -77,6 +77,7 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
     source_resume_uppers: BTreeMap<GlobalId, Vec<Row>>,
     resume_stream: &Stream<Child<'g, G, mz_repr::Timestamp>, ()>,
     storage_state: &mut crate::storage_state::StorageState,
+    cluster_size: Option<&String>,
 ) -> (
     Vec<(
         Collection<Child<'g, G, mz_repr::Timestamp>, Row, Diff>,
@@ -214,6 +215,7 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
             error_collections,
             storage_state,
             base_source_config.clone(),
+            cluster_size,
         );
         needed_tokens.extend(extra_tokens);
         outputs.push((ok, err));
@@ -235,6 +237,7 @@ fn render_source_stream<G>(
     mut error_collections: Vec<Collection<G, DataflowError, Diff>>,
     storage_state: &mut crate::storage_state::StorageState,
     base_source_config: RawSourceCreationConfig,
+    cluster_size: Option<&String>,
 ) -> (
     Collection<G, Row, Diff>,
     Collection<G, DataflowError, Diff>,
@@ -244,6 +247,7 @@ fn render_source_stream<G>(
 where
     G: Scope<Timestamp = Timestamp>,
 {
+    println!("********* mouli cluster_size: {:?}", cluster_size);
     let mut needed_tokens: Vec<Rc<dyn Any>> = vec![];
 
     let SourceDesc {

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -105,6 +105,7 @@ impl mz_cluster::types::AsRunnableWorker<StorageCommand, StorageResponse> for Co
         )>,
         persist_clients: Arc<PersistClientCache>,
         tracing_handle: Arc<TracingHandle>,
+        cluster_size: Option<String>,
     ) {
         Worker::new(
             timely_worker,
@@ -117,6 +118,7 @@ impl mz_cluster::types::AsRunnableWorker<StorageCommand, StorageResponse> for Co
             config.instance_context,
             persist_clients,
             tracing_handle,
+            cluster_size,
         )
         .run();
     }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -162,6 +162,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
         instance_context: StorageInstanceContext,
         persist_clients: Arc<PersistClientCache>,
         tracing_handle: Arc<TracingHandle>,
+        cluster_size: Option<String>,
     ) -> Self {
         // It is very important that we only create the internal control
         // flow/command sequencer once because a) the worker state is re-used
@@ -228,6 +229,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
             async_worker,
             dataflow_parameters: Default::default(),
             tracing_handle,
+            cluster_size,
         };
 
         // TODO(aljoscha): We might want `async_worker` and `internal_cmd_tx` to
@@ -314,6 +316,8 @@ pub struct StorageState {
 
     /// A process-global handle to tracing configuration.
     pub tracing_handle: Arc<TracingHandle>,
+    /// The materialize cluster size the worker belongs to
+    pub cluster_size: Option<String>,
 }
 
 /// Extra context for a storage instance.

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -850,13 +850,13 @@ impl<'w, A: Allocate> Worker<'w, A> {
             InternalStorageCommand::UpdateConfiguration {
                 pg,
                 rocksdb,
-                storage_dataflow_max_inflight_bytes,
+                storage_dataflow_max_inflight_bytes_config,
                 auto_spill_config,
             } => self.storage_state.dataflow_parameters.update(
                 pg,
                 rocksdb,
                 auto_spill_config,
-                storage_dataflow_max_inflight_bytes,
+                storage_dataflow_max_inflight_bytes_config,
             ),
         }
     }
@@ -1169,8 +1169,8 @@ impl StorageState {
                     internal_cmd_tx.broadcast(InternalStorageCommand::UpdateConfiguration {
                         pg: params.pg_replication_timeouts,
                         rocksdb: params.upsert_rocksdb_tuning_config,
-                        storage_dataflow_max_inflight_bytes: params
-                            .storage_dataflow_max_inflight_bytes,
+                        storage_dataflow_max_inflight_bytes_config: params
+                            .storage_dataflow_max_inflight_bytes_config,
                         auto_spill_config: params.upsert_auto_spill_config,
                     })
                 }

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -245,6 +245,7 @@ where
                     ),
                     Arc::clone(&persist_clients),
                     Arc::new(TracingHandle::disabled()),
+                    None,
                 )
             };
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Introduced a new variable to take the percent of a cluster's memory limit as the in-flight bytes. If this is not provided then the `storage_dataflow_max_inflight_bytes` will be used. `storage_dataflow_max_inflight_bytes` has to be provided for backpressure to be used.

Tested manually, following is the logged storage parameters:
```
 storage_dataflow_max_inflight_bytes_config: StorageMaxInflightBytesConfig { max_in_flight_bytes_default: Some(190), max_in_flight_bytes_cluster_size_percent: Some(70), cluster_size_memory_map: {"mem-16": 17179869184, "mem-2": 2147483648, "mem-32": 34359738368, "mem-4": 4294967296, "mem-8": 8589934592} }

```

### Motivation

This makes the in flight bytes value proportional to a cluster size.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
