### PR TITLE
Allow more general Stream type in `RecordFirstRowStream`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4516,6 +4516,7 @@ dependencies = [
  "postgres",
  "tokio",
  "tokio-openssl",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "workspace-hack",

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -38,6 +38,7 @@ use mz_sql::plan::Plan;
 use serde::{Deserialize, Serialize};
 use tokio::{select, time};
 use tokio_postgres::error::SqlState;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::debug;
 use tungstenite::protocol::frame::coding::CloseCode;
 
@@ -1070,7 +1071,7 @@ async fn execute_stmt<S: ResultSender>(
             StatementResult::Subscribe {
                 tag: "SUBSCRIBE".into(),
                 desc: desc.relation_desc.unwrap(),
-                rx: RecordFirstRowStream::new(rx, execute_started, client),
+                rx: RecordFirstRowStream::new(Box::new(UnboundedReceiverStream::new(rx)), execute_started, client),
             }
         },
         res @ (ExecuteResponse::Fetch { .. }

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -25,6 +25,7 @@ mz-sql = { path = "../sql" }
 openssl = { version = "0.10.48", features = ["vendored"] }
 postgres = { version = "0.19.5" }
 tokio = "1.24.2"
+tokio-stream = "0.1.11"
 tokio-openssl = "0.6.3"
 tokio-util = { version = "0.7.4", features = ["codec"] }
 tracing = "0.1.37"


### PR DESCRIPTION
As part of the upcoming statement logging PR, I have different types of row stream that I may want to return to the client (for example, if the rows are immediately available). This PR unblocks that. As of now, it does not change any behavior, but as it shouldn't cause any issues, I hope folks won't mind landing it.


- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None
