### PR TITLE
doc/user: document ALTER SOURCE...(ADD|DROP) SUBSOURCE...

### DIFF
--- a/doc/user/content/sql/alter-source.md
+++ b/doc/user/content/sql/alter-source.md
@@ -1,21 +1,83 @@
 ---
 title: "ALTER SOURCE"
-description: "`ALTER SOURCE` changes the provisioned size of a source."
+description: "`ALTER SOURCE` changes certain characteristics of a source, such as its size."
 menu:
   main:
     parent: 'commands'
 ---
 
-`ALTER SOURCE` changes the provisioned [size](/sql/create-source/#sizing-a-source) of a source.
+`ALTER SOURCE` changes certain characteristics of a source, such as its size.
 
 ## Syntax
 
 {{< diagram "alter-source.svg" >}}
 
+#### alter_source_add_clause
+
+{{< diagram "alter-source-add-clause.svg" >}}
+
+#### alter_source_drop_clause
+
+{{< diagram "alter-source-drop-clause.svg" >}}
+
+#### alter_source_set_clause
+
+{{< diagram "alter-source-set-clause.svg" >}}
+
+#### with_options
+
+{{< diagram "with-options.svg" >}}
+
 Field   | Use
 --------|-----
 _name_  | The identifier of the source you want to alter.
-_value_ | The new value for the source size. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`.
+**ADD SUBSOURCE** ... | PostgreSQL sources only: Add the identified tables from the upstream database (`table_name`) to the named source, with the option of choosing the name for the subsource in Materialize (`subsrc_name`). Supports [additional options](#add-subsource-with_options).
+**DROP SUBSOURCE** ... | PostgreSQL sources only: Drop the identified subsources from the source. Specifying **CASCADE** also drops all objects that depend on the subsource. **RESTRICT** (default) will not drop the subsource if it has any dependencies.
+_value_ | The new value for the source [size](/sql/create-source/#sizing-a-source). Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`.
+
+### **ADD SUBSOURCE** `with_options`
+
+Field                                | Value     | Description
+-------------------------------------|-----------|-------------------------------------
+`TEXT COLUMNS`                       | A list of names | Decode data as `text` for specific columns that contain PostgreSQL types that are unsupported in Materialize.
+
+## Context
+
+### Adding PostgreSQL subsources/tables
+
+When adding subsources to a PostgreSQL source, Materialize opens a temporary
+replication slot to snapshot the new subsources' current states. After
+completing the snapshot, the table will be kept up-to-date, just as all other
+tables in the publication.
+
+Note that using a combination of dropping and adding subsources lets you change
+the schema the PostgreSQL sources ingest.
+
+### Dropping PostgreSQL subsources/tables
+
+Dropping a subsource prevents Materialize from ingesting any data from it, in
+addition to dropping any state that Materialize previously had for the table
+(such as its contents).
+
+If a subsource encounters a deterministic error, such as an incompatible schema
+change (e.g. dropping an ingested column), you can drop the subsource. If you
+want to ingest it with its new schema, you can then add it as a new subsource.
+
+You cannot drop the "progress subsource".
+
+## Examples
+
+### Adding subsources
+
+```sql
+ALTER SOURCE pg_src ADD SUBSOURCE tbl_a, tbl_b AS b WITH (TEXT COLUMNS [tbl_a.col]);
+```
+
+### Dropping subsources
+
+```sql
+ALTER SOURCE pg_src DROP SUBSOURCE tbl_a, b CASCADE;
+```
 
 ## Privileges
 

--- a/doc/user/layouts/partials/sql-grammar/alter-source-add-clause.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-source-add-clause.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="537" height="223">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="50" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">ADD</text>
+   <rect x="123" y="3" width="108" height="32" rx="10"/>
+   <rect x="121"
+         y="1"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="131" y="21">SUBSOURCE</text>
+   <rect x="123" y="47" width="66" height="32" rx="10"/>
+   <rect x="121"
+         y="45"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="131" y="65">TABLE</text>
+   <rect x="45" y="157" width="96" height="32"/>
+   <rect x="43" y="155" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="53" y="175">table_name</text>
+   <rect x="181" y="189" width="40" height="32" rx="10"/>
+   <rect x="179"
+         y="187"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="189" y="207">AS</text>
+   <rect x="241" y="189" width="106" height="32"/>
+   <rect x="239" y="187" width="106" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="249" y="207">subsrc_name</text>
+   <rect x="45" y="113" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="111"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="131">,</text>
+   <rect x="407" y="157" width="102" height="32"/>
+   <rect x="405" y="155" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="415" y="175">with_options</text>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m50 0 h10 m20 0 h10 m108 0 h10 m-148 0 h20 m128 0 h20 m-168 0 q10 0 10 10 m148 0 q0 -10 10 -10 m-158 10 v24 m148 0 v-24 m-148 24 q0 10 10 10 m128 0 q10 0 10 -10 m-138 10 h10 m66 0 h10 m0 0 h42 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-270 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m20 44 h10 m102 0 h10 m3 0 h-3"/>
+   <polygon points="527 171 535 167 535 175"/>
+   <polygon points="527 171 519 167 519 175"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/alter-source-drop-clause.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-source-drop-clause.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="447" height="255">
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="60" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">DROP</text>
+   <rect x="131" y="47" width="108" height="32" rx="10"/>
+   <rect x="129"
+         y="45"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="139" y="65">SUBSOURCE</text>
+   <rect x="131" y="91" width="66" height="32" rx="10"/>
+   <rect x="129"
+         y="89"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="139" y="109">TABLE</text>
+   <rect x="299" y="47" width="106" height="32"/>
+   <rect x="297" y="45" width="106" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="307" y="65">subsrc_name</text>
+   <rect x="299" y="3" width="24" height="32" rx="10"/>
+   <rect x="297"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="307" y="21">,</text>
+   <rect x="309" y="177" width="90" height="32" rx="10"/>
+   <rect x="307"
+         y="175"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="317" y="195">RESTRICT</text>
+   <rect x="309" y="221" width="90" height="32" rx="10"/>
+   <rect x="307"
+         y="219"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="317" y="239">CASCADE</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m60 0 h10 m20 0 h10 m108 0 h10 m-148 0 h20 m128 0 h20 m-168 0 q10 0 10 10 m148 0 q0 -10 10 -10 m-158 10 v24 m148 0 v-24 m-148 24 q0 10 10 10 m128 0 q10 0 10 -10 m-138 10 h10 m66 0 h10 m0 0 h42 m40 -44 h10 m106 0 h10 m-146 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m126 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-126 0 h10 m24 0 h10 m0 0 h82 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-180 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m-120 -10 v20 m130 0 v-20 m-130 20 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m23 -76 h-3"/>
+   <polygon points="437 159 445 155 445 163"/>
+   <polygon points="437 159 429 155 429 163"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/alter-source-set-clause.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-source-set-clause.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="341" height="37">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="46" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SET</text>
+   <rect x="97" y="3" width="26" height="32" rx="10"/>
+   <rect x="95"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="105" y="21">(</text>
+   <rect x="143" y="3" width="50" height="32" rx="10"/>
+   <rect x="141"
+         y="1"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="21">SIZE</text>
+   <rect x="213" y="3" width="54" height="32"/>
+   <rect x="211" y="1" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="221" y="21">value</text>
+   <rect x="287" y="3" width="26" height="32" rx="10"/>
+   <rect x="285"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="295" y="21">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="331 17 339 13 339 21"/>
+   <polygon points="331 17 323 13 323 21"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/alter-source.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-source.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="551" height="135">
+<svg xmlns="http://www.w3.org/2000/svg" width="439" height="223">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="66" height="32" rx="10"/>
@@ -28,43 +28,17 @@
    <rect x="361" y="3" width="56" height="32"/>
    <rect x="359" y="1" width="56" height="32" class="nonterminal"/>
    <text class="nonterminal" x="369" y="21">name</text>
-   <rect x="437" y="3" width="46" height="32" rx="10"/>
-   <rect x="435"
-         y="1"
-         width="46"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="445" y="21">SET</text>
-   <rect x="503" y="3" width="26" height="32" rx="10"/>
-   <rect x="501"
-         y="1"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="511" y="21">(</text>
-   <rect x="353" y="101" width="50" height="32" rx="10"/>
-   <rect x="351"
-         y="99"
-         width="50"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="361" y="119">SIZE</text>
-   <rect x="423" y="101" width="54" height="32"/>
-   <rect x="421" y="99" width="54" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="431" y="119">value</text>
-   <rect x="497" y="101" width="26" height="32" rx="10"/>
-   <rect x="495"
-         y="99"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="505" y="119">)</text>
+   <rect x="205" y="101" width="180" height="32"/>
+   <rect x="203" y="99" width="180" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="213" y="119">alter_source_add_clause</text>
+   <rect x="205" y="145" width="186" height="32"/>
+   <rect x="203" y="143" width="186" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="213" y="163">alter_source_drop_clause</text>
+   <rect x="205" y="189" width="176" height="32"/>
+   <rect x="203" y="187" width="176" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="213" y="207">alter_source_set_clause</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m56 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-220 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m50 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"/>
-   <polygon points="541 115 549 111 549 119"/>
-   <polygon points="541 115 533 111 533 119"/>
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-276 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m180 0 h10 m0 0 h6 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v24 m226 0 v-24 m-226 24 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m186 0 h10 m-216 -10 v20 m226 0 v-20 m-226 20 v24 m226 0 v-24 m-226 24 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m176 0 h10 m0 0 h10 m23 -88 h-3"/>
+   <polygon points="429 115 437 111 437 119"/>
+   <polygon points="429 115 421 111 421 119"/>
 </svg>

--- a/doc/user/layouts/shortcodes/postgres-direct/before-you-begin.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/before-you-begin.html
@@ -2,6 +2,4 @@
 
 - Make sure [`psql`](https://www.postgresql.org/docs/current/app-psql.html) is installed on your workstation.
 
-  You'll use `psql` to interact with your PostgreSQL database and with Materialize.
-
-- Make sure there are no schema changes planned or in progress on the tables that you want to replicate.
+You'll use `psql` to interact with your PostgreSQL database and with Materialize.

--- a/doc/user/layouts/shortcodes/postgres-direct/postgres-schema-changes.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/postgres-schema-changes.html
@@ -1,4 +1,22 @@
-Materialize does not support changes to schemas for existing publications, and
-will set the source into an error state if a breaking DDL change is detected
-upstream. To handle schema changes, you need to drop the existing sources and
-then recreate them after creating new publications for the updated schemas.
+Materialize supports changes to PostgreSQL sources' ingested tables (known as
+"subsources") in the following ways:
+
+#### Compatible schema changes
+
+- Adding columns to tables. Materialize will not ingest these columns.
+- Dropping columns that were added after the source was created. These columns
+are never ingested, so can be dropped without issue.
+- Adding or removing `NOT NULL` constraints to tables that were nullable when
+the source was created.
+
+#### Incompatible schema changes
+
+- All other changes to tables' schemas are considered "definite errors," and
+Materialize will prevent you from reading from the subsource after it detects
+this change occurred.
+
+However, if you make an incompatible schema change to a subsource's upstream
+table, you use use [`ALTER SOURCE`](/sql/alter-source/) to first drop the
+subsource (`DROP SUBSOURCE`), and then add it back to the source (`ADD
+SUBSOURCE`). When you add the subsource, it will have the Postgres table's
+current schema.

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -24,7 +24,16 @@ alter_secret ::=
 alter_sink ::=
   'ALTER' 'SINK' 'IF EXISTS'? name 'SET' '(' 'SIZE' value ')'
 alter_source ::=
-  'ALTER' 'SOURCE' 'IF EXISTS'? name 'SET' '(' 'SIZE' value ')'
+  'ALTER' 'SOURCE' 'IF EXISTS'? name (
+    alter_source_add_clause
+    | alter_source_drop_clause
+    | alter_source_set_clause
+  )
+alter_source_add_clause ::=
+  'ADD' ('SUBSOURCE' | 'TABLE') table_name ('AS' subsrc_name)?  (',' table_name ('AS' subsrc_name)? )* with_options
+alter_source_drop_clause ::=
+  'DROP' ('SUBSOURCE' | 'TABLE') subsrc_name ( ',' subsrc_name )* ('RESTRICT' | 'CASCADE')?
+alter_source_set_clause ::= 'SET' '(' 'SIZE' value ')'
 array_agg ::=
   'array_agg' '(' values  ( 'ORDER' 'BY' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? ( ',' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? )* )? ')' ('FILTER' '(' 'WHERE' filter_clause ')')?
 as_of ::=

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4256,7 +4256,11 @@ impl<'a> Parser<'a> {
                         .parse_comma_separated(Parser::parse_item_name)
                         .map_parser_err(StatementKind::AlterSource)?;
 
-                    let cascade = self.parse_keyword(CASCADE);
+                    let cascade = matches!(
+                        self.parse_at_most_one_keyword(&[CASCADE, RESTRICT], "ALTER SOURCE...DROP")
+                            .map_parser_err(StatementKind::AlterSource)?,
+                        Some(CASCADE),
+                    );
 
                     Statement::AlterSource(AlterSourceStatement {
                         source_name,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1093,6 +1093,26 @@ ALTER SOURCE IF EXISTS n DROP SUBSOURCE IF EXISTS x, y, z CASCADE
 =>
 AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: true, action: DropSubsources { if_exists: true, cascade: true, names: [UnresolvedItemName([Ident("x")]), UnresolvedItemName([Ident("y")]), UnresolvedItemName([Ident("z")])] } })
 
+parse-statement
+ALTER SOURCE n DROP SUBSOURCE x, y, z RESTRICT
+----
+ALTER SOURCE n DROP SUBSOURCE x, y, z
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: DropSubsources { if_exists: false, cascade: false, names: [UnresolvedItemName([Ident("x")]), UnresolvedItemName([Ident("y")]), UnresolvedItemName([Ident("z")])] } })
+
+parse-statement
+ALTER SOURCE n DROP SUBSOURCE IF EXISTS x, y, z RESTRICT
+----
+ALTER SOURCE n DROP SUBSOURCE IF EXISTS x, y, z
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: DropSubsources { if_exists: true, cascade: false, names: [UnresolvedItemName([Ident("x")]), UnresolvedItemName([Ident("y")]), UnresolvedItemName([Ident("z")])] } })
+
+parse-statement
+ALTER SOURCE IF EXISTS n DROP SUBSOURCE IF EXISTS x, y, z RESTRICT
+----
+ALTER SOURCE IF EXISTS n DROP SUBSOURCE IF EXISTS x, y, z
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: true, action: DropSubsources { if_exists: true, cascade: false, names: [UnresolvedItemName([Ident("x")]), UnresolvedItemName([Ident("y")]), UnresolvedItemName([Ident("z")])] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -242,6 +242,9 @@ mv_f default
 ! ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e;
 contains:cannot drop source table_e: still depended upon by materialized view mv_e
 
+! ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e RESTRICT;
+contains:cannot drop source table_e: still depended upon by materialized view mv_e
+
 # CASCADE works
 > ALTER SOURCE mz_source DROP SUBSOURCE table_e CASCADE;
 


### PR DESCRIPTION
### Motivation

Documented new `ALTER SOURCE...(ADD|DROP) SUBSOURCE` statements for PG sources, as well as one small parsing bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
