### PR TITLE
secrets: Add a CachingSecretsReader for use in the Coordinator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4782,7 +4782,10 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "mz-ore",
  "mz-repr",
+ "tokio",
+ "tracing",
  "workspace-hack",
 ]
 

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -108,6 +108,7 @@ impl Coordinator {
         let mut update_compute_config = false;
         let mut update_storage_config = false;
         let mut update_metrics_retention = false;
+        let mut update_caching_config = false;
 
         for op in &ops {
             match op {
@@ -192,6 +193,7 @@ impl Coordinator {
                     update_compute_config |= vars::is_compute_config_var(name);
                     update_storage_config |= vars::is_storage_config_var(name);
                     update_metrics_retention |= name == vars::METRICS_RETENTION.name();
+                    update_caching_config |= vars::is_caching_var(name);
                 }
                 catalog::Op::ResetAllSystemConfiguration => {
                     // Assume they all need to be updated.
@@ -201,6 +203,7 @@ impl Coordinator {
                     update_compute_config = true;
                     update_storage_config = true;
                     update_metrics_retention = true;
+                    update_caching_config = true;
                 }
                 _ => (),
             }
@@ -454,6 +457,9 @@ impl Coordinator {
             if update_tracing_config {
                 self.update_tracing_config();
             }
+            if update_caching_config {
+                self.update_caching_config();
+            }
         }
         .await;
 
@@ -667,6 +673,11 @@ impl Coordinator {
         self.catalog_transact(Some(session), ops)
             .await
             .expect("unable to drop temporary items for conn_id");
+    }
+
+    fn update_caching_config(&mut self) {
+        let config = flags::caching_config(self.catalog.system_config());
+        self.caching_secrets_reader.set_policy(config);
     }
 
     fn update_tracing_config(&mut self) {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -108,7 +108,7 @@ impl Coordinator {
         let mut update_compute_config = false;
         let mut update_storage_config = false;
         let mut update_metrics_retention = false;
-        let mut update_caching_config = false;
+        let mut update_secrets_caching_config = false;
 
         for op in &ops {
             match op {
@@ -193,7 +193,7 @@ impl Coordinator {
                     update_compute_config |= vars::is_compute_config_var(name);
                     update_storage_config |= vars::is_storage_config_var(name);
                     update_metrics_retention |= name == vars::METRICS_RETENTION.name();
-                    update_caching_config |= vars::is_caching_var(name);
+                    update_secrets_caching_config |= vars::is_secrets_caching_var(name);
                 }
                 catalog::Op::ResetAllSystemConfiguration => {
                     // Assume they all need to be updated.
@@ -203,7 +203,7 @@ impl Coordinator {
                     update_compute_config = true;
                     update_storage_config = true;
                     update_metrics_retention = true;
-                    update_caching_config = true;
+                    update_secrets_caching_config = true;
                 }
                 _ => (),
             }
@@ -457,8 +457,8 @@ impl Coordinator {
             if update_tracing_config {
                 self.update_tracing_config();
             }
-            if update_caching_config {
-                self.update_caching_config();
+            if update_secrets_caching_config {
+                self.update_secrets_caching_config();
             }
         }
         .await;
@@ -675,7 +675,7 @@ impl Coordinator {
             .expect("unable to drop temporary items for conn_id");
     }
 
-    fn update_caching_config(&mut self) {
+    fn update_secrets_caching_config(&mut self) {
         let config = flags::caching_config(self.catalog.system_config());
         self.caching_secrets_reader.set_policy(config);
     }

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::time::Duration;
+
 use mz_compute_client::protocol::command::ComputeParameters;
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
@@ -105,9 +107,10 @@ pub fn tracing_config(config: &SystemVars) -> TracingParameters {
 }
 
 pub fn caching_config(config: &SystemVars) -> mz_secrets::CachingPolicy {
+    let ttl_secs = config.webhooks_secrets_caching_ttl_secs();
     mz_secrets::CachingPolicy {
-        enabled: config.enable_coordinator_secrets_caching(),
-        ttl: config.coordinator_secrets_caching_ttl(),
+        enabled: ttl_secs > 0,
+        ttl: Duration::from_secs(u64::cast_from(ttl_secs)),
     }
 }
 

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -104,6 +104,13 @@ pub fn tracing_config(config: &SystemVars) -> TracingParameters {
     }
 }
 
+pub fn caching_config(config: &SystemVars) -> mz_secrets::CachingPolicy {
+    mz_secrets::CachingPolicy {
+        enabled: config.enable_coordinator_secrets_caching(),
+        ttl: config.coordinator_secrets_caching_ttl(),
+    }
+}
+
 fn persist_config(config: &SystemVars) -> PersistParameters {
     PersistParameters {
         blob_target_size: Some(config.persist_blob_target_size()),

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -8,9 +8,14 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.66"
-mz-repr = { path = "../repr" }
 async-trait = "0.1.68"
+mz-repr = { path = "../repr" }
+tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+
+[dev-dependencies]
+mz-ore = { path = "../ore" }
+tokio = { version = "1.24.2", features = ["macros", "rt"] }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/secrets/src/cache.rs
+++ b/src/secrets/src/cache.rs
@@ -1,0 +1,378 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use mz_repr::GlobalId;
+
+use crate::{CachingPolicy, SecretsReader};
+
+/// Default "time to live" for a single cache value, represented in __seconds__.
+pub const DEFAULT_TTL_SECS: AtomicU64 = AtomicU64::new(Duration::from_secs(300).as_secs());
+
+#[derive(Debug)]
+struct CachingParameters {
+    /// Whether caching is enabled, can be changed at runtime.
+    enabled: AtomicBool,
+    /// Cache values only live for so long.
+    ttl_secs: AtomicU64,
+}
+
+impl CachingParameters {
+    fn enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    fn set_enabled(&self, enabled: bool) -> bool {
+        self.enabled.swap(enabled, Ordering::Relaxed)
+    }
+
+    fn ttl(&self) -> Duration {
+        let secs = self.ttl_secs.load(Ordering::Relaxed);
+        Duration::from_secs(secs)
+    }
+
+    fn set_ttl(&self, ttl: Duration) -> Duration {
+        // Maintain a minimum TTL of 1 second just incase someone provides a Duration that is
+        // sub-second.
+        let secs = std::cmp::max(ttl.as_secs(), 1);
+        let prev = self.ttl_secs.swap(secs, Ordering::Relaxed);
+        Duration::from_secs(prev)
+    }
+}
+
+impl Default for CachingParameters {
+    fn default() -> Self {
+        CachingParameters {
+            enabled: AtomicBool::new(true),
+            ttl_secs: DEFAULT_TTL_SECS,
+        }
+    }
+}
+
+/// Values we store in the cache.
+///
+/// Note: we manually implement Debug to prevent leaking secrets in logs.
+struct CacheItem {
+    secret: Vec<u8>,
+    ts: Instant,
+}
+
+impl CacheItem {
+    fn new(secret: Vec<u8>, ts: Instant) -> Self {
+        CacheItem { secret, ts }
+    }
+}
+
+impl fmt::Debug for CacheItem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CacheItem")
+            .field("secret", &"( ... )")
+            .field("ts", &self.ts)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct CachingSecretsReader {
+    /// The underlying secrets, source of truth.
+    inner: Arc<dyn SecretsReader>,
+    /// In-memory cache, not having a size limit or eviction policy is okay because we limit users
+    /// to 100 secrets, which should not be a problem to store in-memory.
+    cache: Arc<RwLock<BTreeMap<GlobalId, CacheItem>>>,
+    /// Caching policy, can change at runtime, e.g. via LaunchDarkly.
+    policy: Arc<CachingParameters>,
+}
+
+impl CachingSecretsReader {
+    pub fn new(reader: Arc<dyn SecretsReader>) -> Self {
+        CachingSecretsReader {
+            inner: reader,
+            cache: Arc::new(RwLock::new(BTreeMap::new())),
+            policy: Arc::new(CachingParameters::default()),
+        }
+    }
+
+    pub fn set_policy(&self, policy: CachingPolicy) {
+        if policy.enabled {
+            let prev = self.enable_caching();
+            tracing::info!("Enabling secrets caching, previously enabled {prev}");
+        } else {
+            let prev = self.disable_caching();
+            tracing::info!("Disabling secrets caching, previously enabled {prev}");
+        }
+
+        let prev_ttl = self.set_ttl(policy.ttl);
+        if prev_ttl != policy.ttl {
+            tracing::info!(
+                "Updated secrets caching TTL, new {} seconds, prev {} seconds",
+                policy.ttl.as_secs(),
+                prev_ttl.as_secs()
+            );
+        }
+    }
+
+    /// Enables caching, returning whether we were previously enabled.
+    fn enable_caching(&self) -> bool {
+        self.policy.set_enabled(true)
+    }
+
+    /// Disables caching, returning whether we were previously enabled.
+    fn disable_caching(&self) -> bool {
+        // Disable and clear the cache of all existing values.
+        let was_enabled = self.policy.set_enabled(false);
+        self.cache
+            .write()
+            .expect("CachingSecretsReader panicked!")
+            .clear();
+
+        was_enabled
+    }
+
+    /// Sets a new "time to live" for cache values, returning the old TTL.
+    fn set_ttl(&self, ttl: Duration) -> Duration {
+        self.policy.set_ttl(ttl)
+    }
+}
+
+#[async_trait]
+impl SecretsReader for CachingSecretsReader {
+    async fn read(&self, id: GlobalId) -> Result<Vec<u8>, anyhow::Error> {
+        // Iff our cache is enabled will we read from it.
+        if self.policy.enabled() {
+            let read_guard = self.cache.read().expect("CachingSecretsReader panicked!");
+            let ttl = self.policy.ttl();
+
+            // If we have a cached value we still need to check if it's expired.
+            if let Some(CacheItem { secret, ts }) = read_guard.get(&id) {
+                if Instant::now().duration_since(*ts) < ttl {
+                    return Ok(secret.clone());
+                }
+            }
+        }
+
+        // Otherwise, we need to read from source!
+        let value = self.inner.read(id).await?;
+
+        // Cache it, if caching is enabled.
+        if self.policy.enabled() {
+            let cache_value = CacheItem::new(value.clone(), Instant::now());
+            self.cache
+                .write()
+                .expect("CachingSecretsReader panicked!")
+                .insert(id, cache_value);
+        }
+
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use mz_repr::GlobalId;
+
+    use crate::cache::CachingSecretsReader;
+    use crate::{InMemorySecretsController, SecretsController, SecretsReader};
+
+    #[mz_ore::test(tokio::test)]
+    async fn test_read_from_cache() {
+        let controller = InMemorySecretsController::new();
+        let testing_reader = TestingSecretsReader::new(controller.reader());
+        let caching_reader = CachingSecretsReader::new(Arc::new(testing_reader.clone()));
+
+        let secret = [42, 42, 42, 42];
+        let id = GlobalId::User(1);
+
+        // Add a new secret and read it back.
+        controller
+            .ensure(GlobalId::User(1), &secret[..])
+            .await
+            .expect("success");
+        let roundtrip = caching_reader.read(id).await.expect("success");
+
+        // The secret should be correct.
+        assert_eq!(roundtrip, secret.to_vec());
+
+        // Read it a second time, our cache should be populated now.
+        let roundtrip2 = caching_reader.read(id).await.expect("success");
+        assert_eq!(roundtrip2, secret.to_vec());
+
+        let reads = testing_reader.drain();
+        assert_eq!(reads.len(), 1);
+
+        // We should only have one read, as the second should have hit the cache.
+        assert_eq!(reads[0], id);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn test_reading_expired_secret() {
+        let controller = InMemorySecretsController::new();
+        let testing_reader = TestingSecretsReader::new(controller.reader());
+        let caching_reader = CachingSecretsReader::new(Arc::new(testing_reader.clone()));
+
+        // Update the caching policy the expire secrets quickly.
+        caching_reader.set_ttl(Duration::from_secs(1));
+
+        let secret = [42, 42, 42, 42];
+        let id = GlobalId::User(1);
+
+        // Store our secret.
+        controller.ensure(id, &secret).await.expect("success");
+        // Read it once to populate the cache.
+        caching_reader.read(id).await.expect("success");
+
+        // Wait for it to timeout.
+        std::thread::sleep(Duration::from_secs(2));
+
+        // Read it again, which should hit the underlying source.
+        caching_reader.read(id).await.expect("success");
+
+        let reads = testing_reader.drain();
+        assert_eq!(reads.len(), 2);
+
+        // Our value should have expired so we should have read from the underlying source.
+        assert_eq!(reads[0], id);
+        assert_eq!(reads[1], id);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn test_disabling_cache() {
+        let controller = InMemorySecretsController::new();
+        let testing_reader = TestingSecretsReader::new(controller.reader());
+        let caching_reader = CachingSecretsReader::new(Arc::new(testing_reader.clone()));
+
+        let secret = [42, 42, 42, 42];
+        let id = GlobalId::User(1);
+
+        // Store a value.
+        controller.ensure(id, &secret).await.expect("success");
+
+        // Read twice, which should hit the cache the second time.
+        caching_reader.read(id).await.expect("success");
+        caching_reader.read(id).await.expect("success");
+
+        let reads = testing_reader.drain();
+        assert_eq!(reads.len(), 1);
+
+        // Disable caching.
+        caching_reader.disable_caching();
+
+        // Read twice again, both should hit the source.
+        caching_reader.read(id).await.expect("success");
+        caching_reader.read(id).await.expect("success");
+
+        let reads = testing_reader.drain();
+        assert_eq!(reads.len(), 2);
+
+        // Re-enable caching.
+        caching_reader.enable_caching();
+
+        // Read twice again, first should populate the cache, second should hit it.
+        caching_reader.read(id).await.expect("success");
+        caching_reader.read(id).await.expect("success");
+
+        let reads = testing_reader.drain();
+        assert_eq!(reads.len(), 1);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn updating_cache_values() {
+        let controller = InMemorySecretsController::new();
+        let testing_reader = TestingSecretsReader::new(controller.reader());
+        let caching_reader = CachingSecretsReader::new(Arc::new(testing_reader.clone()));
+
+        let secret = [42, 42, 42, 42];
+        let id = GlobalId::User(1);
+
+        // Store an initial value.
+        controller.ensure(id, &secret).await.expect("success");
+        // Read to load the value into the cache.
+        caching_reader.read(id).await.expect("success");
+
+        // Update the stored secret.
+        let new_secret = [100, 100];
+        controller.ensure(id, &new_secret).await.expect("success");
+
+        // Reading from the cache should give us the _old_ value.
+        let cached_secret = caching_reader.read(id).await.expect("success");
+        assert_eq!(cached_secret, secret);
+
+        // We should only have registered one read, since we made a stale read from the cache.
+        let reads = testing_reader.drain();
+        assert_eq!(reads.len(), 1);
+
+        // Wait for the secret to expire.
+        caching_reader.set_ttl(Duration::from_secs(2));
+        std::thread::sleep(Duration::from_secs(2));
+
+        // Since the cache value is expired, we should read from source, and get the new value.
+        let read1 = caching_reader.read(id).await.expect("success");
+        let read2 = caching_reader.read(id).await.expect("success");
+        assert_eq!(read1, new_secret);
+        assert_eq!(read1, read2);
+
+        // Should only have one read since we updated the cache.
+        let reads = testing_reader.drain();
+        assert_eq!(reads.len(), 1);
+    }
+
+    /// A "secrets controller" that logs all of the actions it takes and allows us to inject
+    /// failures. Used to test the implementation of our caching secrets controller.
+    #[derive(Debug, Clone)]
+    pub struct TestingSecretsReader {
+        /// The underlying secrets controller.
+        reader: Arc<dyn SecretsReader>,
+        /// A log of reads that have been made.
+        reads: Arc<Mutex<Vec<GlobalId>>>,
+    }
+
+    impl TestingSecretsReader {
+        pub fn new(reader: Arc<dyn SecretsReader>) -> Self {
+            TestingSecretsReader {
+                reader,
+                reads: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        /// Drain all of the actions for introspection.
+        pub fn drain(&self) -> Vec<GlobalId> {
+            self.reads
+                .lock()
+                .expect("TracingSecretsController panicked!")
+                .drain(..)
+                .collect()
+        }
+
+        /// Record that an action has occurred.
+        fn record(&self, id: GlobalId) {
+            self.reads
+                .lock()
+                .expect("TracingSecretsController panicked!")
+                .push(id);
+        }
+    }
+
+    #[async_trait]
+    impl SecretsReader for TestingSecretsReader {
+        async fn read(&self, id: GlobalId) -> Result<Vec<u8>, anyhow::Error> {
+            let result = self.reader.read(id).await;
+            self.record(id);
+            result
+        }
+    }
+}

--- a/src/secrets/src/cache.rs
+++ b/src/secrets/src/cache.rs
@@ -44,10 +44,7 @@ impl CachingParameters {
     }
 
     fn set_ttl(&self, ttl: Duration) -> Duration {
-        // Maintain a minimum TTL of 1 second just incase someone provides a Duration that is
-        // sub-second.
-        let secs = std::cmp::max(ttl.as_secs(), 1);
-        let prev = self.ttl_secs.swap(secs, Ordering::Relaxed);
+        let prev = self.ttl_secs.swap(ttl.as_secs(), Ordering::Relaxed);
         Duration::from_secs(prev)
     }
 }

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -78,10 +78,13 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::Context;
 use async_trait::async_trait;
 use mz_repr::GlobalId;
+
+pub mod cache;
 
 /// Securely manages user secrets.
 #[async_trait]
@@ -99,6 +102,14 @@ pub trait SecretsController: Debug + Send + Sync {
 
     /// Returns a reader for the secrets managed by this controller.
     fn reader(&self) -> Arc<dyn SecretsReader>;
+}
+
+#[derive(Debug)]
+pub struct CachingPolicy {
+    /// Whether or not caching is enabled.
+    pub enabled: bool,
+    /// "time to live" of records within the cache.
+    pub ttl: Duration,
 }
 
 /// Securely reads secrets that are managed by a [`SecretsController`].


### PR DESCRIPTION
This PR adds a `CachingSecretsReader`, which will cache the value for a secret in-memory, expiring with only a TTL. Expiring values in this way is okay because we don't promise that `ALTER SECRET` takes place in any time frame. The default TTL is 5 minutes, but this is configurable via LaunchDarkly.

This adds two new LaunchDarkly flags:

1. `enable_coordinator_secrets_caching`
2. `coordinator_secrets_caching_ttl`

I couldn't figure out a good way to test the reader end-to-end, because I couldn't inject the `TestingSecretsReader` into our integration testing harness. But I manually tested the LaunchDarkly integration by running `environmentd`, using `ALTER SYSTEM SET`, and observing the cache getting enabled/disabled and the TTL changing.

### Motivation

This is required to support `SECRET`s for webhook sources, see [Slack](https://materializeinc.slack.com/archives/CL68GT3AT/p1689797856040739), which is implemented in https://github.com/MaterializeInc/materialize/pull/20642.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
