### PR TITLE
storage: add some basic backpressure metrics

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -218,6 +218,8 @@ pub fn build_compute_dataflow<A: Allocate>(
                         progress_stream: flow_control_input,
                         max_inflight_bytes: compute_state.dataflow_max_inflight_bytes,
                         summary: mz_repr::Timestamp::minimum().step_forward(),
+                        // TODO(guswynn): add metrics for compute flow control
+                        metrics: None,
                     };
 
                     // Note: For correctness, we require that sources only emit times advanced by

--- a/src/storage-client/src/lib.rs
+++ b/src/storage-client/src/lib.rs
@@ -75,12 +75,12 @@
 
 //! Materialize's storage layer.
 
-mod metrics;
 mod ssh_tunnels;
 
 pub mod client;
 pub mod controller;
 pub mod healthcheck;
+pub mod metrics;
 pub mod sink;
 pub mod source;
 pub mod types;

--- a/src/storage-client/src/metrics.rs
+++ b/src/storage-client/src/metrics.rs
@@ -13,9 +13,12 @@ use std::sync::Arc;
 
 use mz_ore::cast::{CastFrom, TryCastFrom};
 use mz_ore::metric;
-use mz_ore::metrics::{DeleteOnDropHistogram, HistogramVecExt, MetricsRegistry};
+use mz_ore::metrics::{
+    DeleteOnDropCounter, DeleteOnDropGauge, DeleteOnDropHistogram, HistogramVecExt, MetricsRegistry,
+};
 use mz_ore::stats::HISTOGRAM_BYTE_BUCKETS;
 use mz_service::codec::StatsCollector;
+use prometheus::core::AtomicU64;
 
 use crate::client::{ProtoStorageCommand, ProtoStorageResponse};
 use crate::types::instances::StorageInstanceId;
@@ -94,4 +97,16 @@ impl StatsCollector<ProtoStorageCommand, ProtoStorageResponse> for RehydratingSt
             ),
         }
     }
+}
+
+/// Metrics used by the `backpressure` operator.
+#[derive(Debug, Clone)]
+pub struct BackpressureMetrics {
+    /// A counter with the number of emitted bytes.
+    pub emitted_bytes: Arc<DeleteOnDropCounter<'static, AtomicU64, Vec<String>>>,
+    /// The last count of bytes we are waiting to be retired in the operator. This cannot
+    /// be directly compared to `retired_bytes`, but CAN indicate that backpressure is happening.
+    pub last_backpressured_bytes: Arc<DeleteOnDropGauge<'static, AtomicU64, Vec<String>>>,
+    /// A counter with the number of bytes retired by downstream processing.
+    pub retired_bytes: Arc<DeleteOnDropCounter<'static, AtomicU64, Vec<String>>>,
 }

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -21,6 +21,7 @@ use futures::future::FutureExt;
 use itertools::Itertools;
 use mz_ore::error::ErrorExt;
 use mz_repr::{Datum, DatumVec, Diff, Row};
+use mz_storage_client::metrics::BackpressureMetrics;
 use mz_storage_client::types::errors::{DataflowError, EnvelopeError, UpsertError};
 use mz_storage_client::types::sources::UpsertEnvelope;
 use mz_timely_util::builder_async::{
@@ -146,6 +147,7 @@ pub(crate) fn upsert<G: Scope, O: timely::ExchangeData + Ord>(
     source_config: crate::source::RawSourceCreationConfig,
     instance_context: &StorageInstanceContext,
     dataflow_paramters: &crate::internal_control::DataflowParameters,
+    backpressure_metrics: Option<BackpressureMetrics>,
 ) -> (
     Collection<G, Result<Row, DataflowError>, Diff>,
     Stream<G, (OutputIndex, HealthStatusUpdate)>,
@@ -157,6 +159,7 @@ where
         &source_config.base_metrics,
         source_config.id,
         source_config.worker_id,
+        backpressure_metrics,
     );
 
     if let Some(scratch_directory) = instance_context.scratch_directory.as_ref() {


### PR DESCRIPTION
Self-explanatory in regards to the title. Note that I only added metrics for storage dataflows. Also, the metrics I chose *I think* are reasonable starts, @moulimukherjee let me know if you have any better ideas.

### Motivation
  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
