### PR TITLE
Add a wrapper parameter to run

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -11,6 +11,7 @@
 
 import argparse
 import os
+import shlex
 import shutil
 import signal
 import sys
@@ -120,6 +121,10 @@ def main() -> int:
         default=False,
         action="store_true",
     )
+    parser.add_argument(
+        "--wrapper",
+        help="Wrapper command for the program",
+    )
     args = parser.parse_intermixed_args()
 
     # Handle `+toolchain` like rustup.
@@ -146,7 +151,11 @@ def main() -> int:
         elif sys.platform == "darwin":
             _macos_codesign(path)
 
-        command = [str(path)]
+        if args.wrapper:
+            command = shlex.split(args.wrapper)
+        else:
+            command = []
+        command.append(str(path))
         if args.tokio_console:
             command += ["--tokio-console-listen-addr=127.0.0.1:6669"]
         if args.program == "environmentd":


### PR DESCRIPTION
This allows users to call `bin/environmentd` with `--wrapper 'perf record'` for example.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
