### PR TITLE
adapter: hook up group commit tracing span for table writes

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -24,6 +24,7 @@ use mz_ore::id_gen::{IdAllocator, IdHandle};
 use mz_ore::now::{to_datetime, EpochMillis, NowFn};
 use mz_ore::task::{AbortOnDropHandle, JoinHandleExt};
 use mz_ore::thread::JoinOnDropHandle;
+use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::{GlobalId, Row, ScalarType};
 use mz_sql::ast::{Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
@@ -468,6 +469,7 @@ impl SessionClient {
             action,
             session,
             tx,
+            otel_ctx: OpenTelemetryContext::obtain(),
         })
         .await
     }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -21,6 +21,7 @@ use anyhow::Context;
 use derivative::Derivative;
 use enum_kinds::EnumKind;
 use mz_ore::str::StrExt;
+use mz_ore::tracing::OpenTelemetryContext;
 use mz_pgcopy::CopyFormatParams;
 use mz_repr::{ColumnType, Datum, GlobalId, Row, RowArena, ScalarType};
 use mz_secrets::cache::CachingSecretsReader;
@@ -82,6 +83,10 @@ pub enum Command {
         action: EndTransactionAction,
         session: Session,
         tx: oneshot::Sender<Response<ExecuteResponse>>,
+        // TODO: Ideally this would just be a tracing::Span, but that seems like
+        // it might be tickling a bug in tracing_opentelemetry:
+        // https://github.com/tokio-rs/tracing-opentelemetry/issues/14
+        otel_ctx: OpenTelemetryContext,
     },
 
     CancelRequest {

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -248,7 +248,9 @@ impl Coordinator {
                 action,
                 session,
                 tx,
+                otel_ctx,
             } => {
+                otel_ctx.attach_as_parent();
                 let tx = ClientTransmitter::new(tx, self.internal_cmd_tx.clone());
                 // We reach here not through a statement execution, but from the
                 // "commit" pgwire command. Thus, we just generate a default statement
@@ -273,6 +275,7 @@ impl Coordinator {
                     }
                 };
                 self.sequence_plan(ctx, plan, ResolvedIds(BTreeSet::new()))
+                    .instrument(tracing::debug_span!("message_command (commit)"))
                     .await;
             }
 

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -69,9 +69,7 @@ impl Coordinator {
             Message::WriteLockGrant(write_lock_guard) => {
                 self.message_write_lock_grant(write_lock_guard).await;
             }
-            Message::GroupCommitInitiate => {
-                self.try_group_commit().await;
-            }
+            Message::GroupCommitInitiate(span) => self.try_group_commit().instrument(span).await,
             Message::GroupCommitApply(timestamp, responses, write_lock_guard) => {
                 self.group_commit_apply(timestamp, responses, write_lock_guard)
                     .await;

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -15,6 +15,7 @@
 use inner::return_if_err;
 use mz_controller::clusters::ClusterId;
 use mz_expr::OptimizedMirRelationExpr;
+use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::explain::ExplainFormat;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::catalog::CatalogCluster;
@@ -559,6 +560,7 @@ impl Coordinator {
                     action: EndTransactionAction::Commit,
                     session,
                     tx: sub_tx,
+                    otel_ctx: OpenTelemetryContext::obtain(),
                 }));
                 let Ok(commit_response) = sub_rx.await else {
                     // Coordinator went away.


### PR DESCRIPTION
Group commits can be kicked off by two things: a table write or the advance_timelines_interval. For the former, hook up the tracing spans such that the group commit gets the table write as a parent. For the latter, give the group commit a new root span (with follows_from set because why not I suppose).

This makes group commit (and the resulting persist operations) show up in the trace given out by `emit_trace_id_notice` for the table write.

Also hook up a span for Command::Commit, so we get the commit traces included for implicit transactions.


### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
