### PR TITLE
test/upgrade: fix RETURNING tests

### DIFF
--- a/test/upgrade/create-in-current_source-returning-keyword.td
+++ b/test/upgrade/create-in-current_source-returning-keyword.td
@@ -9,10 +9,6 @@
 
 $ postgres-connect name=materialize url=postgres://materialize:materialize@${testdrive.materialize-sql-addr}
 
-# Before v0.62, `returning` was accepted as a bare identifier.
-
-$ skip-if
-SELECT mz_version_num() >= 6200;
-
+# In v0.62+, `returning` must be quoted when used as an identifier.
 $ postgres-execute connection=materialize
-CREATE VIEW view_with_returning AS SELECT returning FROM (VALUES (1)) _ (returning)
+CREATE VIEW view_with_returning AS SELECT "returning" FROM (VALUES (1)) _ ("returning")


### PR DESCRIPTION
Fix two issues with the upgrade test for ensuring we correctly migrate views that use `RETURNING`:

  * Avoid using the `>` syntax in testdrive, which requires parsing the SQL statement. That doesn't work here because we always run the upgrade tests using the latest version of testdrive, which depends on the latest version of the Materialize SQL parser, which no longer supports unqouted `RETURNING`. Instead, use the `postgres-execute` command instead, which does not attempt to parse its input.

  * Add version conditionals to avoid attempting to create a view with an unquoted `returning` identifier in v0.62+.

These upgrade tests are mindbending with the way they intermingle versions, and it is not at all surprising that our first attempt to write these tests had these issues.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack: upgrade tests are failing on main.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
