### PR TITLE
Make scrollbars in darkmode pleasant

### DIFF
--- a/doc/user/assets/sass/_base.scss
+++ b/doc/user/assets/sass/_base.scss
@@ -79,6 +79,7 @@ body.dark {
     --bg-sub: var(--black-light);
     --card: var(--black-mid);
     --card-light: var(--black-light);
+    --color-scheme: dark;
     --divider: var(--black-lighter);
     --divider-light: var(--black-lightest);
 
@@ -109,6 +110,7 @@ body.light {
     --bg-sub: var(--gray-lighter);
     --card: var(--gray-lightest);
     --card-light: var(--white);
+    --color-scheme: light;
     --divider: var(--gray);
     --divider-light: var(--gray-lighter);
 
@@ -147,6 +149,7 @@ html {
 body {
     font-family: "Inter", sans-serif;
     color: var(--important);
+    color-scheme: var(--color-scheme);
     background: var(--bg);
     font-size: var(--base);
     line-height: 1.7;

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -872,6 +872,7 @@ p+p {
     font-weight: 300;
     border: none;
     background-color: $grey-light;
+    color: var(--black);
     height: 26px;
     padding: 0 12px;
     cursor: pointer;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


  * This PR adds a feature that has not yet been specified.

- The scrollbars in dark mode have always bugged me. This simple fix makes them fit the theme. Didn't change the color of the outer scrollbar since we might want that to have parity with the non-doc Materialize web pages. 

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]


   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer
- Tested on safari and chrome. Scrollbars were always dark in firefox.
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->
- Look at the url of the page to compare. localhost = new changes, materialize.com = old changes
https://github.com/MaterializeInc/materialize/assets/29664023/fcdfd8e2-3b84-4e80-a2e8-1486305b3910



### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
