### PR TITLE
adapter: resolve unmat fns in smoketest; fix fallout

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -139,6 +139,7 @@ use crate::subscribe::ActiveSubscribe;
 use crate::util::{ClientTransmitter, CompletedClientTransmitter, ComputeSinkId, ResultExt};
 use crate::{flags, AdapterNotice};
 
+pub(crate) mod dataflows;
 pub(crate) mod id_bundle;
 pub(crate) mod peek;
 pub(crate) mod statement_logging;
@@ -147,7 +148,6 @@ pub(crate) mod timestamp_selection;
 
 mod appends;
 mod command_handler;
-mod dataflows;
 mod ddl;
 mod indexes;
 mod introspection;

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -7332,7 +7332,7 @@ impl VariadicFunc {
                 timezone_time(
                     tz,
                     ds[1].unwrap_time(),
-                    &ds[1].unwrap_timestamptz().naive_utc(),
+                    &ds[2].unwrap_timestamptz().naive_utc(),
                 )
                 .into()
             }),


### PR DESCRIPTION
Teach test_smoketest_all_builtins how to resolve unmaterializable functions so that mir evaluation can proceed if those are present.

This allows a variant of `timezone()` to get tested that was previously ignored because it called `CurrentTimestamp`. Testing this reveals a previously discovered bug that is now fixed.

Fixes #20704

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a