### PR TITLE
ore/tracing: add metric to count on_close events sent to otel

### DIFF
--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -194,12 +194,16 @@ async fn main() {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
+    let metrics_registry = MetricsRegistry::new();
     let (tracing_handle, _tracing_guard) = args
         .tracing
-        .configure_tracing(StaticTracingConfig {
-            service_name: "clusterd",
-            build_info: BUILD_INFO,
-        })
+        .configure_tracing(
+            StaticTracingConfig {
+                service_name: "clusterd",
+                build_info: BUILD_INFO,
+            },
+            metrics_registry.clone(),
+        )
         .await?;
 
     if args.tracing.log_filter.is_some() {
@@ -228,7 +232,6 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
 
     emit_boot_diagnostics!(&BUILD_INFO);
 
-    let metrics_registry = MetricsRegistry::new();
     mz_alloc::register_metrics_into(&metrics_registry).await;
 
     let mut _pid_file = None;

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -382,6 +382,7 @@ impl Listeners {
                 build_version: mz_environmentd::BUILD_INFO.version,
                 build_sha: mz_environmentd::BUILD_INFO.sha,
                 build_time: mz_environmentd::BUILD_INFO.time,
+                registry: metrics_registry.clone(),
             };
             let (tracing_handle, tracing_guard) =
                 self.runtime.block_on(mz_ore::tracing::configure(config))?;

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -94,6 +94,7 @@ use mz_orchestrator::{
     ServiceProcessMetrics,
 };
 use mz_ore::cli::KeyValueArg;
+use mz_ore::metrics::MetricsRegistry;
 #[cfg(feature = "tokio-console")]
 use mz_ore::netio::SocketAddr;
 #[cfg(feature = "tokio-console")]
@@ -269,6 +270,7 @@ impl TracingCliArgs {
             service_name,
             build_info,
         }: StaticTracingConfig,
+        registry: MetricsRegistry,
     ) -> Result<(TracingHandle, TracingGuard), anyhow::Error> {
         mz_ore::tracing::configure(TracingConfig {
             service_name,
@@ -320,6 +322,7 @@ impl TracingCliArgs {
             build_version: build_info.version,
             build_sha: build_info.sha,
             build_time: build_info.time,
+            registry,
         })
         .await
     }

--- a/src/persist-client/examples/persistcli.rs
+++ b/src/persist-client/examples/persistcli.rs
@@ -85,6 +85,7 @@ use mz_build_info::{build_info, BuildInfo};
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::error::ErrorExt;
+use mz_ore::metrics::MetricsRegistry;
 use mz_ore::task::RuntimeExt;
 use tokio::runtime::Handle;
 use tracing::{info_span, Instrument};
@@ -126,10 +127,13 @@ fn main() {
         .expect("Failed building the Runtime");
 
     let _ = runtime
-        .block_on(args.tracing.configure_tracing(StaticTracingConfig {
-            service_name: "persist-open-loop",
-            build_info: BUILD_INFO,
-        }))
+        .block_on(args.tracing.configure_tracing(
+            StaticTracingConfig {
+                service_name: "persist-open-loop",
+                build_info: BUILD_INFO,
+            },
+            MetricsRegistry::new(),
+        ))
         .expect("failed to init tracing");
 
     let root_span = info_span!("persistcli");

--- a/src/storage/examples/upsert_open_loop.rs
+++ b/src/storage/examples/upsert_open_loop.rs
@@ -341,10 +341,13 @@ fn main() {
         .expect("Failed building the Runtime");
 
     let _ = runtime
-        .block_on(args.tracing.configure_tracing(StaticTracingConfig {
-            service_name: "upsert-open-loop",
-            build_info: BUILD_INFO,
-        }))
+        .block_on(args.tracing.configure_tracing(
+            StaticTracingConfig {
+                service_name: "upsert-open-loop",
+                build_info: BUILD_INFO,
+            },
+            MetricsRegistry::new(),
+        ))
         .expect("failed to init tracing");
 
     let root_span = info_span!("upsert_open_loop");


### PR DESCRIPTION
This will help us reason about how much we're sending to Tempo. I'd have loved to also add a counter for the byte size, but couldn't figure out a way that wasn't super invasive.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

I manually confirmed with bin/environmentd that this seems to respect the `opentelemetry_filter` setting.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
