### PR TITLE
adapter: Prevent dangling refs in default privs

### DIFF
--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -58,5 +58,9 @@
   {
     "name": "objects_v28.proto",
     "md5": "891db1de528b10e073463cb8108556e0"
+  },
+  {
+    "name": "objects_v29.proto",
+    "md5": "a79ba1c1f4536c945ac6ee26fcc38946"
   }
 ]

--- a/src/stash/protos/objects_v29.proto
+++ b/src/stash/protos/objects_v29.proto
@@ -1,0 +1,582 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// This protobuf file defines the types we store in the Stash.
+//
+// Before and after modifying this file, make sure you have a snapshot of the before version,
+// e.g. a copy of this file named 'objects_v{STASH_VERSION}.proto', and a snapshot of the file
+// after your modifications, e.g. 'objects_v{STASH_VERSION + 1}.proto'. Then you can write a
+// migration using these two files, and no matter how they types change in the future, we'll always
+// have these snapshots to facilitate the migration.
+
+
+syntax = "proto3";
+
+package objects_v29;
+
+message ConfigKey {
+    string key = 1;
+}
+
+message ConfigValue {
+    uint64 value = 1;
+}
+
+message SettingKey {
+    string name = 1;
+}
+
+message SettingValue {
+    string value = 1;
+}
+
+message IdAllocKey {
+    string name = 1;
+}
+
+message IdAllocValue {
+    uint64 next_id = 1;
+}
+
+message GidMappingKey {
+    string schema_name = 1;
+    CatalogItemType object_type = 2;
+    string object_name = 3;
+}
+
+message GidMappingValue {
+    uint64 id = 1;
+    string fingerprint = 2;
+}
+
+message ClusterKey {
+    ClusterId id = 1;
+}
+
+message ClusterValue {
+    string name = 1;
+    GlobalId linked_object_id = 2;
+    RoleId owner_id = 3;
+    repeated MzAclItem privileges = 4;
+    ClusterConfig config = 5;
+}
+
+message ClusterIntrospectionSourceIndexKey {
+    ClusterId cluster_id = 1;
+    string name = 2;
+}
+
+message ClusterIntrospectionSourceIndexValue {
+    uint64 index_id = 1;
+}
+
+message ClusterReplicaKey {
+    ReplicaId id = 1;
+}
+
+message ClusterReplicaValue {
+    ClusterId cluster_id = 1;
+    string name = 2;
+    ReplicaConfig config = 3;
+    RoleId owner_id = 4;
+}
+
+message DatabaseKey {
+    DatabaseId id = 1;
+}
+
+message DatabaseValue {
+    string name = 1;
+    RoleId owner_id = 2;
+    repeated MzAclItem privileges = 3;
+}
+
+message SchemaKey {
+    SchemaId id = 1;
+}
+
+message SchemaValue {
+    DatabaseId database_id = 1;
+    string name = 2;
+    RoleId owner_id = 3;
+    repeated MzAclItem privileges = 4;
+}
+
+message ItemKey {
+    GlobalId gid = 1;
+}
+
+message ItemValue {
+    SchemaId schema_id = 1;
+    string name = 2;
+    CatalogItem definition = 3;
+    RoleId owner_id = 4;
+    repeated MzAclItem privileges = 5;
+}
+
+message RoleKey {
+    RoleId id = 1;
+}
+
+message RoleValue {
+    string name = 1;
+    RoleAttributes attributes = 2;
+    RoleMembership membership = 3;
+}
+
+message TimestampKey {
+    string id = 1;
+}
+
+message TimestampValue {
+    Timestamp ts = 1;
+}
+
+message ServerConfigurationKey {
+    string name = 1;
+}
+
+message ServerConfigurationValue {
+    string value = 1;
+}
+
+message AuditLogKey {
+    oneof event {
+        AuditLogEventV1 v1 = 1;
+    }
+}
+
+message StorageUsageKey {
+    message StorageUsageV1 {
+        uint64 id = 1;
+        StringWrapper shard_id = 2;
+        uint64 size_bytes = 3;
+        EpochMillis collection_timestamp = 4;
+    }
+
+    oneof usage {
+        StorageUsageV1 v1 = 1;
+    }
+}
+
+message SinkAsOf {
+    TimestampAntichain frontier = 1;
+    bool strict = 2;
+}
+
+message DurableCollectionMetadata {
+    reserved 1;
+    reserved "remap_shard";
+
+    // StringWrapper remap_shard = 1;
+    string data_shard = 2;
+}
+
+message DurableExportMetadata {
+    SinkAsOf initial_as_of = 1;
+}
+
+// ---- Common Types
+//
+// Note: Normally types like this would go in some sort of `common.proto` file, but we want to keep
+// our proto definitions in a single file to make snapshotting easier, hence them living here.
+
+message Empty { /* purposefully empty */ }
+
+// In protobuf a "None" string is the same thing as an empty string. To get the same semantics of
+// an `Option<String>` from Rust, we need to wrap a string in a message.
+message StringWrapper {
+    string inner = 1;
+}
+
+message Duration {
+    uint64 secs = 1;
+    uint32 nanos = 2;
+}
+
+message EpochMillis {
+    uint64 millis = 1;
+}
+
+// Opaque timestamp type that is specific to Materialize.
+message Timestamp {
+    uint64 internal = 1;
+}
+
+enum CatalogItemType {
+    CATALOG_ITEM_TYPE_UNKNOWN = 0;
+    CATALOG_ITEM_TYPE_TABLE = 1;
+    CATALOG_ITEM_TYPE_SOURCE = 2;
+    CATALOG_ITEM_TYPE_SINK = 3;
+    CATALOG_ITEM_TYPE_VIEW = 4;
+    CATALOG_ITEM_TYPE_MATERIALIZED_VIEW = 5;
+    CATALOG_ITEM_TYPE_INDEX = 6;
+    CATALOG_ITEM_TYPE_TYPE = 7;
+    CATALOG_ITEM_TYPE_FUNC = 8;
+    CATALOG_ITEM_TYPE_SECRET = 9;
+    CATALOG_ITEM_TYPE_CONNECTION = 10;
+}
+
+message CatalogItem {
+    message V1 {
+        string create_sql = 1;
+    }
+
+    oneof value {
+        V1 v1 = 1;
+    }
+}
+
+message GlobalId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        uint64 transient = 3;
+        Empty explain = 4;
+    }
+}
+
+message ClusterId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message DatabaseId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message SchemaId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message ReplicaId {
+    uint64 value = 1;
+}
+
+message ReplicaLogging {
+    bool log_logging = 1;
+    Duration interval = 2;
+}
+
+message ReplicaMergeEffort {
+    uint32 effort = 1;
+}
+
+message ClusterConfig {
+    message ManagedCluster {
+        string size = 1;
+        uint32 replication_factor = 2;
+        repeated string availability_zones = 3;
+        ReplicaLogging logging = 4;
+        ReplicaMergeEffort idle_arrangement_merge_effort = 5;
+        bool disk = 6;
+    }
+
+    oneof variant {
+        Empty unmanaged = 1;
+        ManagedCluster managed = 2;
+    }
+}
+
+message ReplicaConfig {
+    message UnmanagedLocation {
+        repeated string storagectl_addrs = 1;
+        repeated string storage_addrs = 2;
+        repeated string computectl_addrs = 3;
+        repeated string compute_addrs = 4;
+        uint64 workers = 5;
+    }
+
+    message ManagedLocation {
+        string size = 1;
+        string availability_zone = 2;
+        bool az_user_specified = 3;
+        bool disk = 4;
+    }
+
+    oneof location {
+        UnmanagedLocation unmanaged = 1;
+        ManagedLocation managed = 2;
+    }
+    ReplicaLogging logging = 3;
+    ReplicaMergeEffort idle_arrangement_merge_effort = 4;
+}
+
+message RoleId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        Empty public = 3;
+    }
+}
+
+message RoleAttributes {
+    bool inherit = 1;
+}
+
+message RoleMembership {
+    message Entry {
+        RoleId key = 1;
+        RoleId value = 2;
+    }
+
+    repeated Entry map = 1;
+}
+
+message AclMode {
+    // A bit flag representing all the privileges that can be granted to a role.
+    uint64 bitflags = 1;
+}
+
+message MzAclItem {
+    RoleId grantee = 1;
+    RoleId grantor = 2;
+    AclMode acl_mode = 3;
+}
+
+message TimestampAntichain {
+    repeated Timestamp elements = 1;
+}
+
+enum ObjectType {
+    OBJECT_TYPE_UNKNOWN = 0;
+    OBJECT_TYPE_TABLE = 1;
+    OBJECT_TYPE_VIEW = 2;
+    OBJECT_TYPE_MATERIALIZED_VIEW = 3;
+    OBJECT_TYPE_SOURCE = 4;
+    OBJECT_TYPE_SINK = 5;
+    OBJECT_TYPE_INDEX = 6;
+    OBJECT_TYPE_TYPE = 7;
+    OBJECT_TYPE_ROLE = 8;
+    OBJECT_TYPE_CLUSTER = 9;
+    OBJECT_TYPE_CLUSTER_REPLICA = 10;
+    OBJECT_TYPE_SECRET = 11;
+    OBJECT_TYPE_CONNECTION = 12;
+    OBJECT_TYPE_DATABASE = 13;
+    OBJECT_TYPE_SCHEMA = 14;
+    OBJECT_TYPE_FUNC = 15;
+}
+
+message DefaultPrivilegesKey {
+    RoleId role_id = 1;
+    DatabaseId database_id = 2;
+    SchemaId schema_id = 3;
+    ObjectType object_type = 4;
+    RoleId grantee = 5;
+}
+
+message DefaultPrivilegesValue {
+    AclMode privileges = 1;
+}
+
+message SystemPrivilegesKey {
+    RoleId grantee = 1;
+    RoleId grantor = 2;
+}
+
+message SystemPrivilegesValue {
+    AclMode acl_mode = 1;
+}
+
+message AuditLogEventV1 {
+    enum EventType {
+        EVENT_TYPE_UNKNOWN = 0;
+        EVENT_TYPE_CREATE = 1;
+        EVENT_TYPE_DROP = 2;
+        EVENT_TYPE_ALTER = 3;
+        EVENT_TYPE_GRANT = 4;
+        EVENT_TYPE_REVOKE = 5;
+    }
+
+    enum ObjectType {
+        OBJECT_TYPE_UNKNOWN = 0;
+        OBJECT_TYPE_CLUSTER = 1;
+        OBJECT_TYPE_CLUSTER_REPLICA = 2;
+        OBJECT_TYPE_CONNECTION = 3;
+        OBJECT_TYPE_DATABASE = 4;
+        OBJECT_TYPE_FUNC = 5;
+        OBJECT_TYPE_INDEX = 6;
+        OBJECT_TYPE_MATERIALIZED_VIEW = 7;
+        OBJECT_TYPE_ROLE = 8;
+        OBJECT_TYPE_SECRET = 9;
+        OBJECT_TYPE_SCHEMA = 10;
+        OBJECT_TYPE_SINK = 11;
+        OBJECT_TYPE_SOURCE = 12;
+        OBJECT_TYPE_TABLE = 13;
+        OBJECT_TYPE_TYPE = 14;
+        OBJECT_TYPE_VIEW = 15;
+        OBJECT_TYPE_SYSTEM = 16;
+    }
+
+    message IdFullNameV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+    }
+
+    message FullNameV1 {
+        string database = 1;
+        string schema = 2;
+        string item = 3;
+    }
+
+    message IdNameV1 {
+        string id = 1;
+        string name = 2;
+    }
+
+    message RenameClusterV1 {
+        string id = 1;
+        string old_name = 2;
+        string new_name = 3;
+    }
+
+    message RenameClusterReplicaV1 {
+        string cluster_id = 1;
+        string replica_id = 2;
+        string old_name = 3;
+        string new_name = 4;
+    }
+
+    message RenameItemV1 {
+        string id = 1;
+        FullNameV1 old_name = 2;
+        FullNameV1 new_name = 3;
+    }
+
+    message CreateClusterReplicaV1 {
+        string cluster_id = 1;
+        string cluser_name = 2;
+        StringWrapper replica_id = 3;
+        string replica_name = 4;
+        string logical_size = 5;
+        bool disk = 6;
+    }
+
+    message DropClusterReplicaV1 {
+        string cluster_id = 1;
+        string cluster_name = 2;
+        StringWrapper replica_id = 3;
+        string replica_name = 4;
+    }
+
+    message CreateSourceSinkV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper size = 3;
+    }
+
+    message CreateSourceSinkV2 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper size = 3;
+        string external_type = 4;
+    }
+
+    message AlterSourceSinkV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper old_size = 3;
+        StringWrapper new_size = 4;
+    }
+
+    message GrantRoleV1 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+    }
+
+    message GrantRoleV2 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+        string executed_by = 4;
+    }
+
+    message RevokeRoleV1 {
+        string role_id = 1;
+        string member_id = 2;
+    }
+
+    message RevokeRoleV2 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+        string executed_by = 4;
+    }
+
+    message UpdatePrivilegeV1 {
+        string object_id = 1;
+        string grantee_id = 2;
+        string grantor_id = 3;
+        string privileges = 4;
+    }
+
+    message AlterDefaultPrivilegeV1 {
+        string role_id = 1;
+        StringWrapper database_id = 2;
+        StringWrapper schema_id = 3;
+        string grantee_id= 4;
+        string privileges = 5;
+    }
+
+    message UpdateOwnerV1 {
+        string object_id = 1;
+        string old_owner_id = 2;
+        string new_owner_id = 3;
+    }
+
+    message SchemaV1 {
+        string id = 1;
+        string name = 2;
+        string database_name = 3;
+    }
+
+    message SchemaV2 {
+        string id = 1;
+        string name = 2;
+        StringWrapper database_name = 3;
+    }
+
+    uint64 id = 1;
+    EventType event_type = 2;
+    ObjectType object_type = 3;
+    StringWrapper user = 4;
+    EpochMillis occurred_at = 5;
+
+    // next-id: 25
+    oneof details {
+        CreateClusterReplicaV1 create_cluster_replica_v1 = 6;
+        DropClusterReplicaV1 drop_cluster_replica_v1 = 7;
+        CreateSourceSinkV1 create_source_sink_v1 = 8;
+        CreateSourceSinkV2 create_source_sink_v2 = 9;
+        AlterSourceSinkV1 alter_source_sink_v1 = 10;
+        GrantRoleV1 grant_role_v1 = 11;
+        GrantRoleV2 grant_role_v2 = 12;
+        RevokeRoleV1 revoke_role_v1 = 13;
+        RevokeRoleV2 revoke_role_v2 = 14;
+        UpdatePrivilegeV1 update_privilege_v1 = 22;
+        AlterDefaultPrivilegeV1 alter_default_privilege_v1 = 23;
+        UpdateOwnerV1 update_owner_v1 = 24;
+        IdFullNameV1 id_full_name_v1 = 15;
+        RenameClusterV1 rename_cluster_v1 = 20;
+        RenameClusterReplicaV1 rename_cluster_replica_v1 = 21;
+        RenameItemV1 rename_item_v1 = 16;
+        IdNameV1 id_name_v1 = 17;
+        SchemaV1 schema_v1 = 18;
+        SchemaV2 schema_v2 = 19;
+    }
+}

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -103,7 +103,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 28;
+pub const STASH_VERSION: u64 = 29;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -919,6 +919,7 @@ impl Stash {
                             25 => upgrade::v25_to_v26::upgrade(),
                             26 => upgrade::v26_to_v27::upgrade(),
                             27 => upgrade::v27_to_v28::upgrade(&mut tx).await?,
+                            28 => upgrade::v28_to_v29::upgrade(&mut tx).await?,
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -58,6 +58,7 @@ pub(crate) mod v24_to_v25;
 pub(crate) mod v25_to_v26;
 pub(crate) mod v26_to_v27;
 pub(crate) mod v27_to_v28;
+pub(crate) mod v28_to_v29;
 
 pub(crate) enum MigrationAction<K1, K2, V2> {
     /// Deletes the provided key.

--- a/src/stash/src/upgrade/v28_to_v29.rs
+++ b/src/stash/src/upgrade/v28_to_v29.rs
@@ -1,0 +1,425 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::upgrade::MigrationAction;
+use crate::{StashError, Transaction, TypedCollection};
+use std::collections::BTreeSet;
+
+pub mod objects_v28 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v28.rs"));
+}
+
+pub mod objects_v29 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v29.rs"));
+}
+
+/// Remove dangling references from default privileges.
+///
+/// Author - jkosh44
+pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {
+    const DEFAULT_PRIVILEGES_COLLECTION: TypedCollection<
+        objects_v28::DefaultPrivilegesKey,
+        objects_v28::DefaultPrivilegesValue,
+    > = TypedCollection::new("default_privileges");
+    const DATABASES_COLLECTION: TypedCollection<
+        objects_v28::DatabaseKey,
+        objects_v28::DatabaseValue,
+    > = TypedCollection::new("database");
+    const SCHEMAS_COLLECTION: TypedCollection<objects_v28::SchemaKey, objects_v28::SchemaValue> =
+        TypedCollection::new("schema");
+
+    let database_ids: BTreeSet<_> = tx
+        .peek_one(
+            tx.collection::<objects_v28::DatabaseKey, objects_v28::DatabaseValue>(
+                DATABASES_COLLECTION.name(),
+            )
+            .await?,
+        )
+        .await?
+        .keys()
+        .filter_map(|key: &objects_v28::DatabaseKey| key.id.clone())
+        .collect();
+
+    let schema_ids: BTreeSet<_> = tx
+        .peek_one(
+            tx.collection::<objects_v28::SchemaKey, objects_v28::SchemaValue>(
+                SCHEMAS_COLLECTION.name(),
+            )
+            .await?,
+        )
+        .await?
+        .keys()
+        .filter_map(|key: &objects_v28::SchemaKey| key.id.clone())
+        .collect();
+
+    DEFAULT_PRIVILEGES_COLLECTION
+        .migrate_to(tx, |entries| {
+            let mut updates = Vec::new();
+
+            for (key, value) in entries {
+                if matches!(&key.database_id, Some(database_id) if !database_ids.contains(database_id))
+                    || matches!(&key.schema_id, Some(schema_id) if !schema_ids.contains(schema_id)) {
+                    updates.push(MigrationAction::Delete(key.clone()));
+                } else {
+                    let new_key: objects_v29::DefaultPrivilegesKey = key.clone().into();
+                    let new_value: objects_v29::DefaultPrivilegesValue = value.clone().into();
+                    updates.push(MigrationAction::Update(key.clone(), (new_key, new_value)));
+                }
+            }
+
+            updates
+        })
+        .await?;
+
+    Ok(())
+}
+
+impl From<objects_v28::DatabaseId> for objects_v29::DatabaseId {
+    fn from(id: objects_v28::DatabaseId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v28::database_id::Value::User(id)) => {
+                Some(objects_v29::database_id::Value::User(id))
+            }
+            Some(objects_v28::database_id::Value::System(id)) => {
+                Some(objects_v29::database_id::Value::System(id))
+            }
+        };
+        objects_v29::DatabaseId { value }
+    }
+}
+
+impl From<objects_v28::DatabaseKey> for objects_v29::DatabaseKey {
+    fn from(key: objects_v28::DatabaseKey) -> Self {
+        Self {
+            id: key.id.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v28::RoleId> for objects_v29::RoleId {
+    fn from(id: objects_v28::RoleId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v28::role_id::Value::User(id)) => {
+                Some(objects_v29::role_id::Value::User(id))
+            }
+            Some(objects_v28::role_id::Value::System(id)) => {
+                Some(objects_v29::role_id::Value::System(id))
+            }
+            Some(objects_v28::role_id::Value::Public(_)) => {
+                Some(objects_v29::role_id::Value::Public(Default::default()))
+            }
+        };
+        objects_v29::RoleId { value }
+    }
+}
+
+impl From<objects_v28::AclMode> for objects_v29::AclMode {
+    fn from(acl_mode: objects_v28::AclMode) -> Self {
+        objects_v29::AclMode {
+            bitflags: acl_mode.bitflags,
+        }
+    }
+}
+
+impl From<objects_v28::MzAclItem> for objects_v29::MzAclItem {
+    fn from(item: objects_v28::MzAclItem) -> Self {
+        Self {
+            grantee: item.grantee.map(Into::into),
+            grantor: item.grantor.map(Into::into),
+            acl_mode: item.acl_mode.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v28::DatabaseValue> for objects_v29::DatabaseValue {
+    fn from(value: objects_v28::DatabaseValue) -> Self {
+        Self {
+            name: value.name,
+            owner_id: value.owner_id.map(Into::into),
+            privileges: value.privileges.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<objects_v28::SchemaId> for objects_v29::SchemaId {
+    fn from(id: objects_v28::SchemaId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v28::schema_id::Value::User(id)) => {
+                Some(objects_v29::schema_id::Value::User(id))
+            }
+            Some(objects_v28::schema_id::Value::System(id)) => {
+                Some(objects_v29::schema_id::Value::System(id))
+            }
+        };
+        objects_v29::SchemaId { value }
+    }
+}
+
+impl From<objects_v28::SchemaKey> for objects_v29::SchemaKey {
+    fn from(key: objects_v28::SchemaKey) -> Self {
+        Self {
+            id: key.id.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v28::SchemaValue> for objects_v29::SchemaValue {
+    fn from(value: objects_v28::SchemaValue) -> Self {
+        Self {
+            database_id: value.database_id.map(Into::into),
+            name: value.name,
+            owner_id: value.owner_id.map(Into::into),
+            privileges: value.privileges.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<objects_v28::ObjectType> for objects_v29::ObjectType {
+    fn from(object_type: objects_v28::ObjectType) -> Self {
+        match object_type {
+            objects_v28::ObjectType::Unknown => objects_v29::ObjectType::Unknown,
+            objects_v28::ObjectType::Table => objects_v29::ObjectType::Table,
+            objects_v28::ObjectType::View => objects_v29::ObjectType::View,
+            objects_v28::ObjectType::MaterializedView => objects_v29::ObjectType::MaterializedView,
+            objects_v28::ObjectType::Source => objects_v29::ObjectType::Source,
+            objects_v28::ObjectType::Sink => objects_v29::ObjectType::Sink,
+            objects_v28::ObjectType::Index => objects_v29::ObjectType::Index,
+            objects_v28::ObjectType::Type => objects_v29::ObjectType::Type,
+            objects_v28::ObjectType::Role => objects_v29::ObjectType::Role,
+            objects_v28::ObjectType::Cluster => objects_v29::ObjectType::Cluster,
+            objects_v28::ObjectType::ClusterReplica => objects_v29::ObjectType::ClusterReplica,
+            objects_v28::ObjectType::Secret => objects_v29::ObjectType::Secret,
+            objects_v28::ObjectType::Connection => objects_v29::ObjectType::Connection,
+            objects_v28::ObjectType::Database => objects_v29::ObjectType::Database,
+            objects_v28::ObjectType::Schema => objects_v29::ObjectType::Schema,
+            objects_v28::ObjectType::Func => objects_v29::ObjectType::Func,
+        }
+    }
+}
+
+impl From<objects_v28::DefaultPrivilegesKey> for objects_v29::DefaultPrivilegesKey {
+    fn from(key: objects_v28::DefaultPrivilegesKey) -> Self {
+        objects_v29::DefaultPrivilegesKey {
+            role_id: key.role_id.map(Into::into),
+            database_id: key.database_id.map(Into::into),
+            schema_id: key.schema_id.map(Into::into),
+            object_type: key.object_type,
+            grantee: key.grantee.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v28::DefaultPrivilegesValue> for objects_v29::DefaultPrivilegesValue {
+    fn from(value: objects_v28::DefaultPrivilegesValue) -> Self {
+        objects_v29::DefaultPrivilegesValue {
+            privileges: value.privileges.map(Into::into),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::upgrade;
+
+    use crate::upgrade::v28_to_v29::{objects_v28, objects_v29};
+    use crate::{DebugStashFactory, TypedCollection};
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn smoke_test() {
+        const DATABASE_ID_V28: objects_v28::DatabaseKey = objects_v28::DatabaseKey {
+            id: Some(objects_v28::DatabaseId {
+                value: Some(objects_v28::database_id::Value::User(42)),
+            }),
+        };
+        const DANGLING_DATABASE_ID_V28: objects_v28::DatabaseKey = objects_v28::DatabaseKey {
+            id: Some(objects_v28::DatabaseId {
+                value: Some(objects_v28::database_id::Value::User(1)),
+            }),
+        };
+        const DATABASE_ID_V29: objects_v29::DatabaseKey = objects_v29::DatabaseKey {
+            id: Some(objects_v29::DatabaseId {
+                value: Some(objects_v29::database_id::Value::User(42)),
+            }),
+        };
+        const DANGLING_DATABASE_ID_V29: objects_v29::DatabaseKey = objects_v29::DatabaseKey {
+            id: Some(objects_v29::DatabaseId {
+                value: Some(objects_v29::database_id::Value::User(1)),
+            }),
+        };
+
+        const SCHEMA_ID_V28: objects_v28::SchemaKey = objects_v28::SchemaKey {
+            id: Some(objects_v28::SchemaId {
+                value: Some(objects_v28::schema_id::Value::User(42)),
+            }),
+        };
+        const DANGLING_SCHEMA_ID_V28: objects_v28::SchemaKey = objects_v28::SchemaKey {
+            id: Some(objects_v28::SchemaId {
+                value: Some(objects_v28::schema_id::Value::User(1)),
+            }),
+        };
+        const SCHEMA_ID_V29: objects_v29::SchemaKey = objects_v29::SchemaKey {
+            id: Some(objects_v29::SchemaId {
+                value: Some(objects_v29::schema_id::Value::User(42)),
+            }),
+        };
+        const DANGLING_SCHEMA_ID_V29: objects_v29::SchemaKey = objects_v29::SchemaKey {
+            id: Some(objects_v29::SchemaId {
+                value: Some(objects_v29::schema_id::Value::User(1)),
+            }),
+        };
+
+        const ACL_MODE_USAGE_V28: objects_v28::AclMode = objects_v28::AclMode { bitflags: 1 << 8 };
+        const ACL_MODE_USAGE_V29: objects_v29::AclMode = objects_v29::AclMode { bitflags: 1 << 8 };
+        const ROLE_ID_V28: objects_v28::RoleId = objects_v28::RoleId {
+            value: Some(objects_v28::role_id::Value::User(1)),
+        };
+        const ROLE_ID_V29: objects_v29::RoleId = objects_v29::RoleId {
+            value: Some(objects_v29::role_id::Value::User(1)),
+        };
+
+        // Connect to the Stash.
+        let factory = DebugStashFactory::new().await;
+        let mut stash = factory.open_debug().await;
+
+        // Insert a database.
+        let databases_v28: TypedCollection<objects_v28::DatabaseKey, objects_v28::DatabaseValue> =
+            TypedCollection::new("database");
+        databases_v28
+            .insert_without_overwrite(
+                &mut stash,
+                vec![(
+                    DATABASE_ID_V28,
+                    objects_v28::DatabaseValue {
+                        name: "db".into(),
+                        owner_id: Some(ROLE_ID_V28),
+                        privileges: vec![],
+                    },
+                )],
+            )
+            .await
+            .unwrap();
+
+        // Insert a schema.
+        let schemas_v28: TypedCollection<objects_v28::SchemaKey, objects_v28::SchemaValue> =
+            TypedCollection::new("schema");
+        schemas_v28
+            .insert_without_overwrite(
+                &mut stash,
+                vec![(
+                    SCHEMA_ID_V28,
+                    objects_v28::SchemaValue {
+                        database_id: Some(objects_v28::DatabaseId {
+                            value: Some(objects_v28::database_id::Value::User(42)),
+                        }),
+                        name: "sch".into(),
+                        owner_id: Some(ROLE_ID_V28),
+                        privileges: vec![],
+                    },
+                )],
+            )
+            .await
+            .unwrap();
+
+        // Insert default privileges.
+        let default_privileges_v28: TypedCollection<
+            objects_v28::DefaultPrivilegesKey,
+            objects_v28::DefaultPrivilegesValue,
+        > = TypedCollection::new("default_privileges");
+        default_privileges_v28
+            .insert_without_overwrite(
+                &mut stash,
+                vec![
+                    // Valid references
+                    (
+                        objects_v28::DefaultPrivilegesKey {
+                            role_id: Some(ROLE_ID_V28),
+                            database_id: DATABASE_ID_V28.id,
+                            schema_id: SCHEMA_ID_V28.id,
+                            object_type: objects_v28::ObjectType::Table.into(),
+                            grantee: Some(ROLE_ID_V28),
+                        },
+                        objects_v28::DefaultPrivilegesValue {
+                            privileges: Some(ACL_MODE_USAGE_V28),
+                        },
+                    ),
+                    // Dangling database.
+                    (
+                        objects_v28::DefaultPrivilegesKey {
+                            role_id: Some(ROLE_ID_V28),
+                            database_id: DANGLING_DATABASE_ID_V28.id,
+                            schema_id: SCHEMA_ID_V28.id,
+                            object_type: objects_v28::ObjectType::Table.into(),
+                            grantee: Some(ROLE_ID_V28),
+                        },
+                        objects_v28::DefaultPrivilegesValue {
+                            privileges: Some(ACL_MODE_USAGE_V28),
+                        },
+                    ),
+                    // Dangling schema.
+                    (
+                        objects_v28::DefaultPrivilegesKey {
+                            role_id: Some(ROLE_ID_V28),
+                            database_id: DATABASE_ID_V28.id,
+                            schema_id: DANGLING_SCHEMA_ID_V28.id,
+                            object_type: objects_v28::ObjectType::Table.into(),
+                            grantee: Some(ROLE_ID_V28),
+                        },
+                        objects_v28::DefaultPrivilegesValue {
+                            privileges: Some(ACL_MODE_USAGE_V28),
+                        },
+                    ),
+                ],
+            )
+            .await
+            .unwrap();
+
+        // Run our migration.
+        stash
+            .with_transaction(|mut tx| {
+                Box::pin(async move {
+                    upgrade(&mut tx).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .expect("migration failed");
+
+        // Read back the default privileges.
+        let default_privileges: TypedCollection<
+            objects_v29::DefaultPrivilegesKey,
+            objects_v29::DefaultPrivilegesValue,
+        > = TypedCollection::new("default_privileges");
+        let privileges = default_privileges.iter(&mut stash).await.unwrap();
+        // Filter down to just the keys and values to make comparisons easier.
+        let privileges: Vec<_> = privileges
+            .into_iter()
+            .map(|((key, value), _timestamp, _diff)| (key, value))
+            .collect();
+
+        assert_eq!(
+            privileges,
+            vec![(
+                objects_v29::DefaultPrivilegesKey {
+                    role_id: Some(ROLE_ID_V29),
+                    database_id: DATABASE_ID_V29.id,
+                    schema_id: SCHEMA_ID_V29.id,
+                    object_type: objects_v29::ObjectType::Table.into(),
+                    grantee: Some(ROLE_ID_V29),
+                },
+                objects_v29::DefaultPrivilegesValue {
+                    privileges: Some(ACL_MODE_USAGE_V29),
+                }
+            )]
+        );
+    }
+}

--- a/test/sqllogictest/default_privileges.slt
+++ b/test/sqllogictest/default_privileges.slt
@@ -5116,6 +5116,49 @@ ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO mz_system
 statement error role name "mz_introspection" is reserved
 ALTER DEFAULT PRIVILEGES REVOKE USAGE ON CLUSTERS FROM mz_introspection
 
+# Test that we don't retain dangling pointers in default privileges
+
+statement ok
+CREATE DATABASE d
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN DATABASE d GRANT SELECT ON TABLES TO PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL  NULL  type   PUBLIC  U
+materialize  d     NULL  table  PUBLIC  r
+
+statement ok
+DROP DATABASE d
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC  NULL  NULL  type  PUBLIC  U
+
+statement ok
+CREATE SCHEMA s
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA s GRANT SELECT ON TABLES TO PUBLIC
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC       NULL         NULL  type   PUBLIC  U
+materialize  materialize  s     table  PUBLIC  r
+
+statement ok
+DROP SCHEMA s
+
+query TTTTTT
+SELECT * FROM default_privileges
+----
+PUBLIC  NULL  NULL  type  PUBLIC  U
+
+
 # Disable rbac checks.
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;


### PR DESCRIPTION
Default privileges contain optional references to databases and schemas. Previously, when we dropped a database or schema, we didn't check to see if there's a reference to that database or schema in the default privileges tables. That allows default privileges to contain dangling references to dropped databases and schemas.

This commit updates the DROP DATABASE and DROP SCHEMA command to revoke default privileges if they contain references to the dropped database or schema.

Fixes #20721

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix bug to prevent and remove dangling references in default privileges
