### PR TITLE
Support `ALTER MATERIALIZED VIEW ... SET CLUSTER`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,6 +3880,7 @@ dependencies = [
  "timely",
  "tonic-build",
  "tracing",
+ "uuid",
  "workspace-hack",
 ]
 
@@ -5320,6 +5321,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
+ "uuid",
  "workspace-hack",
 ]
 

--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -10,6 +10,7 @@
 
 from materialize.checks.aggregation import *  # noqa: F401 F403
 from materialize.checks.alter_index import *  # noqa: F401 F403
+from materialize.checks.alter_mv_set_cluster import *  # noqa: F401 F403
 from materialize.checks.array_type import *  # noqa: F401 F403
 from materialize.checks.boolean_type import *  # noqa: F401 F403
 from materialize.checks.cast import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/alter_mv_set_cluster.py
+++ b/misc/python/materialize/checks/alter_mv_set_cluster.py
@@ -1,0 +1,101 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
+from materialize.util import MzVersion
+
+
+class AlterMvSetCluster(Check):
+    def _can_run(self, e: Executor) -> bool:
+        return self.base_version >= MzVersion.parse("0.70.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > CREATE TABLE alter_mv_set_cluster_table (f1 INTEGER);
+                > CREATE CLUSTER alter_mv_set_cluster_cluster1 REPLICAS (replica1 (SIZE '1'));
+                > CREATE MATERIALIZED VIEW alter_mv_set_cluster_view1 AS SELECT f1 + 1 AS f1 FROM alter_mv_set_cluster_table;
+                > CREATE DEFAULT INDEX ON alter_mv_set_cluster_view1;
+                > INSERT INTO alter_mv_set_cluster_table VALUES (1);
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(
+                dedent(
+                    """
+                    $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                    ALTER SYSTEM SET enable_alter_set_cluster = true
+
+                    > CREATE MATERIALIZED VIEW alter_mv_set_cluster_view2 AS SELECT f1 + 1 AS f1 FROM alter_mv_set_cluster_view1;
+                    > CREATE DEFAULT INDEX ON alter_mv_set_cluster_view2;
+                    > ALTER MATERIALIZED VIEW alter_mv_set_cluster_view1 SET CLUSTER alter_mv_set_cluster_cluster1;
+                    > INSERT INTO alter_mv_set_cluster_table VALUES (2);
+
+                    > CREATE CLUSTER alter_mv_set_cluster_cluster2 REPLICAS (replica1 (SIZE '1'));
+                    """
+                )
+            ),
+            Testdrive(
+                dedent(
+                    """
+                    > CREATE MATERIALIZED VIEW alter_mv_set_cluster_view3 AS SELECT f1 + 1 AS f1 FROM alter_mv_set_cluster_view2;
+                    > CREATE DEFAULT INDEX ON alter_mv_set_cluster_view3;
+
+                    > ALTER MATERIALIZED VIEW alter_mv_set_cluster_view1 SET CLUSTER alter_mv_set_cluster_cluster2;
+                    > ALTER MATERIALIZED VIEW alter_mv_set_cluster_view2 SET CLUSTER alter_mv_set_cluster_cluster2;
+                    > ALTER MATERIALIZED VIEW alter_mv_set_cluster_view3 SET CLUSTER alter_mv_set_cluster_cluster2;
+
+                    > INSERT INTO alter_mv_set_cluster_table VALUES (3);
+                    """
+                )
+            ),
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT * FROM alter_mv_set_cluster_view1;
+                2
+                3
+                4
+
+                > SELECT * FROM alter_mv_set_cluster_view2;
+                3
+                4
+                5
+
+                > SELECT * FROM alter_mv_set_cluster_view3;
+                4
+                5
+                6
+
+                > SHOW MATERIALIZED VIEWS LIKE 'alter_mv_set_cluster_view%';
+                alter_mv_set_cluster_view1 alter_mv_set_cluster_cluster2
+                alter_mv_set_cluster_view2 alter_mv_set_cluster_cluster2
+                alter_mv_set_cluster_view3 alter_mv_set_cluster_cluster2
+
+                # Indexes remain where they were
+                > SELECT mz_clusters.name
+                  FROM mz_indexes
+                  JOIN mz_clusters ON (cluster_id = mz_clusters.id)
+                  WHERE mz_indexes.name like 'alter_mv_set_cluster_view%';
+                default
+                default
+                default
+                """
+            )
+        )

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4359,7 +4359,7 @@ impl Catalog {
 
                     info!("update role {name} ({id})");
                 }
-                Op::AlterSetCluster { id, cluster } => Self::transact_alter_set_cluster(
+                Op::AlterSetCluster { id, item } => Self::transact_alter_set_cluster(
                     state,
                     tx,
                     builtin_table_updates,
@@ -4368,7 +4368,7 @@ impl Catalog {
                     audit_events,
                     session,
                     id,
-                    cluster,
+                    item,
                 )?,
                 Op::AlterSink { id, cluster_config } => {
                     use mz_sql::ast::Value;
@@ -6776,7 +6776,7 @@ impl From<UpdatePrivilegeVariant> for EventType {
 pub enum Op {
     AlterSetCluster {
         id: GlobalId,
-        cluster: ClusterId,
+        item: CatalogItem,
     },
     AlterSink {
         id: GlobalId,

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -275,6 +275,18 @@ impl Coordinator {
         )
         .map_err(AdapterError::Internal)
     }
+
+    /// Actively drop collections on a specific instance.
+    pub(crate) fn force_drop_collections(
+        &mut self,
+        collection_ids: Vec<GlobalId>,
+        instance: ComputeInstanceId,
+    ) {
+        self.controller
+            .active_compute()
+            .force_drop_collections(instance, collection_ids)
+            .unwrap_or_terminate("drop collections cannot fail");
+    }
 }
 
 /// Returns an ID bundle with the given dataflows imports.

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -177,6 +177,30 @@ impl<T: Eq + Hash + Ord> ReadHolds<T> {
         }
         self.holds.retain(|_, id_bundle| !id_bundle.is_empty());
     }
+
+    /// If the read hold contains a compute ID equal to `id` in `compute_instance`, update the read
+    /// hold to `new_compute_instance`.
+    pub fn migrate_compute_id(
+        &mut self,
+        compute_instance: ComputeInstanceId,
+        id: GlobalId,
+        new_compute_instance: ComputeInstanceId,
+    ) {
+        for (_, id_bundle) in &mut self.holds {
+            if let Some(true) = id_bundle
+                .compute_ids
+                .get_mut(&compute_instance)
+                .map(|compute_ids| compute_ids.remove(&id))
+            {
+                id_bundle
+                    .compute_ids
+                    .entry(new_compute_instance)
+                    .or_default()
+                    .insert(id);
+            }
+        }
+        self.holds.retain(|_, id_bundle| !id_bundle.is_empty());
+    }
 }
 
 impl crate::coord::Coordinator {

--- a/src/adapter/src/coord/sequencer/alter_set_cluster.rs
+++ b/src/adapter/src/coord/sequencer/alter_set_cluster.rs
@@ -7,29 +7,183 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_sql::plan::AlterSetClusterPlan;
+use std::iter::once;
 
+use mz_ore::collections::CollectionExt;
+use mz_repr::RelationDesc;
+use mz_sql::catalog::{CatalogItem as SqlCatalogItem, ObjectType};
+use mz_sql::plan::{
+    AlterSetClusterPlan, CreateMaterializedViewPlan, OptimizerConfig, Params, Plan,
+};
+use mz_sql_parser::ast::display::AstDisplay;
+use mz_sql_parser::ast::{IfExistsBehavior, RawClusterName, Statement};
+use mz_transform::Optimizer;
+
+use crate::catalog::CatalogItem;
 use crate::coord::Coordinator;
 use crate::session::Session;
-use crate::{AdapterError, ExecuteResponse};
+use crate::util::ResultExt;
+use crate::{catalog, AdapterError, ExecuteResponse};
 
 impl Coordinator {
     /// Convert a [`AlterSetClusterPlan`] to a sequence of catalog operators and adjust state.
     pub(super) async fn sequence_alter_set_cluster(
         &mut self,
-        _session: &Session,
-        AlterSetClusterPlan { id, set_cluster: _ }: AlterSetClusterPlan,
+        session: &Session,
+        AlterSetClusterPlan { id, set_cluster }: AlterSetClusterPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        // TODO: This function needs to be implemented.
-
-        // Satisfy Clippy that this is an async func.
-        async {}.await;
         let entry = self.catalog().get_entry(&id);
-        match entry.item().typ() {
-            _ => {
-                // Unexpected; planner permitted unsupported plan.
-                Err(AdapterError::Unsupported("ALTER SET CLUSTER"))
+
+        let system_catalog = self.catalog().for_system_session();
+        let debug_name = self
+            .catalog
+            .resolve_full_name(entry.name(), None)
+            .to_string();
+
+        // Since the catalog serializes the items using only their creation statement
+        // and context, we need to parse and rewrite the cluster option in that statement.
+        // (And then make any other changes to the object definition to match.)
+        let mut stmt = mz_sql::parse::parse(entry.create_sql())
+            .expect("invalid create sql persisted to catalog")
+            .into_element()
+            .ast;
+
+        // Patch AST.
+        let stmt_in_cluster = match &mut stmt {
+            Statement::CreateIndex(s) => &mut s.in_cluster,
+            Statement::CreateMaterializedView(s) => &mut s.in_cluster,
+            Statement::CreateSink(s) => &mut s.in_cluster,
+            Statement::CreateSource(s) => &mut s.in_cluster,
+            // Planner produced wrong plan.
+            _ => coord_bail!("object {id} does not have an associated cluster"),
+        };
+        *stmt_in_cluster = Some(RawClusterName::Resolved(set_cluster.to_string()));
+
+        // Update catalog item with new cluster.
+        let create_sql = stmt.to_ast_string_stable();
+        let stmt = mz_sql::parse::parse(&create_sql)?.into_element().ast;
+        let (mut stmt, resolved_ids) = mz_sql::names::resolve(&system_catalog, stmt)?;
+
+        match &mut stmt {
+            Statement::CreateMaterializedView(s) => {
+                // Planning for materialized views fails if the object already exists.
+                // Force to skip behavior, which is OK because it still lowers the query.
+                // We need to be careful to not save the new behavior in the catalog. Planning
+                // changes this to Error.
+                s.if_exists = IfExistsBehavior::Skip;
             }
+            _ => {}
+        }
+
+        let plan =
+            mz_sql::plan::plan(None, &system_catalog, stmt, &Params::empty(), &resolved_ids)?;
+
+        match entry.item() {
+            CatalogItem::Index(_old_index) => Err(AdapterError::Unsupported("ALTER SET CLUSTER")),
+            CatalogItem::MaterializedView(old_mv) => {
+                if !self.is_compute_cluster(set_cluster) {
+                    let cluster_name = self.catalog().get_cluster(set_cluster).name.clone();
+                    return Err(AdapterError::BadItemInStorageCluster { cluster_name });
+                }
+
+                let old_cluster_id = old_mv.cluster_id;
+
+                let (optimized_expr, desc, create_sql) = match plan {
+                    Plan::CreateMaterializedView(CreateMaterializedViewPlan {
+                        materialized_view: mv,
+                        ..
+                    }) => {
+                        let optimizer =
+                            Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
+                        let decorrelated_expr = mv.expr.optimize_and_lower(&OptimizerConfig {})?;
+                        let optimized_expr = optimizer.optimize(decorrelated_expr)?;
+                        let desc = RelationDesc::new(optimized_expr.typ(), mv.column_names);
+                        assert_eq!(mv.cluster_id, set_cluster);
+
+                        (optimized_expr, desc, mv.create_sql)
+                    }
+                    _ => {
+                        return Err(catalog::Error::new(catalog::ErrorKind::Corruption {
+                            detail: "catalog entry generated inappropriate plan".to_string(),
+                        })
+                        .into())
+                    }
+                };
+
+                let item = CatalogItem::MaterializedView(catalog::MaterializedView {
+                    create_sql,
+                    optimized_expr,
+                    desc,
+                    resolved_ids,
+                    cluster_id: set_cluster,
+                });
+
+                // Allocate a unique ID that can be used by the dataflow builder to
+                // connect the view dataflow to the storage sink.
+                let internal_view_id = self.allocate_transient_id()?;
+                let op = catalog::Op::AlterSetCluster { id, item };
+                // Update catalog
+                let (mut dataflow, df_metainfo) = self
+                    .catalog_transact_with(Some(session.conn_id()), vec![op], |txn| {
+                        // Create a dataflow that materializes the view query and sinks
+                        // it to storage.
+                        let CatalogItem::MaterializedView(mv) = txn.catalog.get_entry(&id).item()
+                        else {
+                            unreachable!()
+                        };
+
+                        let mut builder = txn.dataflow_builder(set_cluster);
+                        builder.build_materialized_view(
+                            id,
+                            internal_view_id,
+                            debug_name,
+                            &mv.optimized_expr,
+                            &mv.desc,
+                        )
+                    })
+                    .await?;
+                self.emit_optimizer_notices(session, &df_metainfo.optimizer_notices);
+
+                self.catalog_mut().set_optimized_plan(id, dataflow.clone());
+                self.catalog_mut().set_dataflow_metainfo(id, df_metainfo);
+
+                // Pick the least valid read timestamp as the as-of for the view
+                // dataflow. This makes the materialized view include the maximum possible
+                // amount of historical detail.
+                let as_of = self.bootstrap_materialized_view_as_of(&dataflow, set_cluster);
+                dataflow.set_as_of(as_of);
+
+                self.migrate_compute_ids_in_timeline(once((old_cluster_id, id)), set_cluster);
+
+                // Send the dataflow to the new cluster.
+                let dataflow_plan = self.must_finalize_dataflow(dataflow, set_cluster);
+                self.controller
+                    .active_compute()
+                    .create_dataflow(set_cluster, dataflow_plan.clone())
+                    .unwrap_or_terminate("cannot fail to create dataflows");
+                self.catalog_mut().set_physical_plan(id, dataflow_plan);
+
+                self.force_drop_collections(vec![id], old_cluster_id);
+
+                Ok(ExecuteResponse::AlteredObject(ObjectType::MaterializedView))
+            }
+            CatalogItem::Sink(_old_sink) => Err(AdapterError::Unsupported("ALTER SET CLUSTER")),
+            CatalogItem::Source(old_source) => {
+                match &old_source.data_source {
+                    catalog::DataSourceDesc::Ingestion(_ingestion) => {
+                        Err(AdapterError::Unsupported("ALTER SET CLUSTER"))
+                    }
+                    catalog::DataSourceDesc::Source
+                    | catalog::DataSourceDesc::Introspection(_)
+                    | catalog::DataSourceDesc::Progress
+                    | catalog::DataSourceDesc::Webhook { .. } => {
+                        // Planner produced wrong plan.
+                        coord_bail!("source {id} does not have an associated cluster");
+                    }
+                }
+            }
+            // Planner produced wrong plan.
+            _ => coord_bail!("object {id} does not have an associated cluster"),
         }
     }
 }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -5510,7 +5510,7 @@ fn alter_storage_cluster_config(size: AlterOptionParameter) -> Option<SourceSink
 
 impl Coordinator {
     /// Forward notices that we got from the optimizer.
-    fn emit_optimizer_notices(
+    pub(crate) fn emit_optimizer_notices(
         &mut self,
         session: &Session,
         optimizer_notices: &Vec<OptimizerNotice>,

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -645,6 +645,9 @@ pub struct CollectionState<T> {
     write_frontier: Antichain<T>,
     /// The write frontiers reported by individual replicas.
     replica_write_frontiers: BTreeMap<ReplicaId, Antichain<T>>,
+
+    /// The unique identifier of the collection.
+    uuid: Uuid,
 }
 
 impl<T: Timestamp> CollectionState<T> {
@@ -653,6 +656,7 @@ impl<T: Timestamp> CollectionState<T> {
         since: Antichain<T>,
         storage_dependencies: Vec<GlobalId>,
         compute_dependencies: Vec<GlobalId>,
+        uuid: Uuid,
     ) -> Self {
         let mut read_capabilities = MutableAntichain::new();
         read_capabilities.update_iter(since.iter().map(|time| (time.clone(), 1)));
@@ -666,12 +670,13 @@ impl<T: Timestamp> CollectionState<T> {
             compute_dependencies,
             write_frontier: Antichain::from_elem(Timestamp::minimum()),
             replica_write_frontiers: BTreeMap::new(),
+            uuid,
         }
     }
 
     pub fn new_log_collection() -> Self {
         let since = Antichain::from_elem(Timestamp::minimum());
-        let mut state = Self::new(since, Vec::new(), Vec::new());
+        let mut state = Self::new(since, Vec::new(), Vec::new(), Uuid::nil());
         state.log_collection = true;
         state
     }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -489,6 +489,18 @@ where
         Ok(())
     }
 
+    /// Drop the read capability for the given collections and allow their resources to be
+    /// reclaimed.
+    pub fn force_drop_collections(
+        &mut self,
+        instance_id: ComputeInstanceId,
+        collection_ids: Vec<GlobalId>,
+    ) -> Result<(), CollectionUpdateError> {
+        self.instance(instance_id)?
+            .force_drop_collections(collection_ids)?;
+        Ok(())
+    }
+
     /// Initiate a peek request for the contents of the given collection at `timestamp`.
     pub fn peek(
         &mut self,

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -781,6 +781,19 @@ where
         self.set_read_policy(policies.collect())
     }
 
+    /// Drops the read capability for the given collections and allows their resources to be
+    /// reclaimed.
+    pub fn force_drop_collections(&mut self, ids: Vec<GlobalId>) -> Result<(), CollectionMissing> {
+        self.drop_collections(ids.clone())?;
+
+        for id in &ids {
+            if self.compute.collections.contains_key(id) {
+                self.compute.remove_collection(*id);
+            }
+        }
+        Ok(())
+    }
+
     /// Initiate a peek request for the contents of `id` at `timestamp`.
     #[tracing::instrument(level = "debug", skip(self))]
     pub fn peek(

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -259,11 +259,14 @@ where
             ComputeResponse::FrontierUpper {
                 id,
                 upper: new_shard_upper,
+                uuid,
             } => {
                 // Initialize frontier tracking state for this collection, if necessary.
                 if !self.uppers.contains_key(&id) {
                     self.start_frontier_tracking(id);
                 }
+
+                // TODO: Check that the uuid matches the expected value.
 
                 let (frontier, shard_frontiers) = self.uppers.get_mut(&id).unwrap();
 
@@ -279,6 +282,7 @@ where
                     Some(Ok(ComputeResponse::FrontierUpper {
                         id,
                         upper: new_upper.to_owned(),
+                        uuid,
                     }))
                 } else {
                     None

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -21,6 +21,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tracing = "0.1.37"
+uuid = { version = "1.2.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]

--- a/src/compute-types/src/dataflows.proto
+++ b/src/compute-types/src/dataflows.proto
@@ -13,6 +13,7 @@ import "compute-types/src/plan.proto";
 import "compute-types/src/sinks.proto";
 import "compute-types/src/sources.proto";
 import "expr/src/scalar.proto";
+import "proto/src/proto.proto";
 import "repr/src/antichain.proto";
 import "repr/src/global_id.proto";
 import "repr/src/relation_and_scalar.proto";
@@ -52,6 +53,7 @@ message ProtoDataflowDescription {
     optional mz_repr.antichain.ProtoU64Antichain as_of = 6;
     mz_repr.antichain.ProtoU64Antichain until = 7;
     string debug_name = 8;
+    mz_proto.ProtoU128 uuid = 9;
 }
 
 message ProtoIndexDesc {

--- a/src/compute-types/src/plan/mod.rs
+++ b/src/compute-types/src/plan/mod.rs
@@ -31,6 +31,7 @@ use proptest::prelude::*;
 use proptest::strategy::Strategy;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::dataflows::{BuildDesc, DataflowDescription, IndexImport};
 use crate::plan::join::{DeltaJoinPlan, JoinPlan, LinearJoinPlan};
@@ -1848,6 +1849,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
             as_of: desc.as_of,
             until: desc.until,
             debug_name: desc.debug_name,
+            uuid: Uuid::nil(),
         };
 
         mz_repr::explain::trace_plan(&dataflow);

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -245,6 +245,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                         as_of: dataflow.as_of.clone(),
                         until: dataflow.until.clone(),
                         debug_name: dataflow.debug_name.clone(),
+                        uuid: dataflow.uuid,
                     })
                     .map(ComputeCommand::CreateDataflow)
                     .collect()
@@ -555,6 +556,11 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                                 old_dataflows.remove(&export_ids);
                                 for id in export_ids.iter() {
                                     old_compaction.insert(*id, as_of.clone());
+                                    compute_state
+                                        .collections
+                                        .get_mut(id)
+                                        .expect("collection missing")
+                                        .uuid = dataflow.uuid;
                                 }
                                 retain_ids.extend(export_ids);
                             } else {

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -50,6 +50,7 @@ tokio = { version = "1.32.0", features = [
 tokio-stream = "0.1.11"
 tonic = "0.9.2"
 tracing = "0.1.37"
+uuid = { version = "1.2.2" }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]

--- a/src/storage-client/src/client.proto
+++ b/src/storage-client/src/client.proto
@@ -60,6 +60,7 @@ message ProtoFrontierUppersKind {
 message ProtoTrace {
     mz_repr.global_id.ProtoGlobalId id = 1;
     mz_repr.antichain.ProtoU64Antichain upper = 2;
+    optional mz_proto.ProtoU128 uuid = 3;
 }
 
 message ProtoStorageCommand {

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -37,6 +37,7 @@ use serde::{Deserialize, Serialize};
 use timely::progress::frontier::{Antichain, MutableAntichain};
 use timely::PartialOrder;
 use tonic::{Request, Status, Streaming};
+use uuid::Uuid;
 
 use crate::client::proto_storage_server::ProtoStorage;
 use crate::metrics::RehydratingStorageClientMetrics;
@@ -710,6 +711,7 @@ impl RustType<ProtoTrace> for (GlobalId, Antichain<mz_repr::Timestamp>) {
         ProtoTrace {
             id: Some(self.0.into_proto()),
             upper: Some(self.1.into_proto()),
+            uuid: None,
         }
     }
 
@@ -717,6 +719,24 @@ impl RustType<ProtoTrace> for (GlobalId, Antichain<mz_repr::Timestamp>) {
         Ok((
             proto.id.into_rust_if_some("ProtoTrace::id")?,
             proto.upper.into_rust_if_some("ProtoTrace::upper")?,
+        ))
+    }
+}
+
+impl RustType<ProtoTrace> for (GlobalId, Antichain<mz_repr::Timestamp>, Uuid) {
+    fn into_proto(&self) -> ProtoTrace {
+        ProtoTrace {
+            id: Some(self.0.into_proto()),
+            upper: Some(self.1.into_proto()),
+            uuid: Some(self.2.into_proto()),
+        }
+    }
+
+    fn from_proto(proto: ProtoTrace) -> Result<Self, TryFromProtoError> {
+        Ok((
+            proto.id.into_rust_if_some("ProtoTrace::id")?,
+            proto.upper.into_rust_if_some("ProtoTrace::upper")?,
+            proto.uuid.into_rust_if_some("ProtoTrace::uuid")?,
         ))
     }
 }

--- a/src/testdrive/src/error.rs
+++ b/src/testdrive/src/error.rs
@@ -129,7 +129,7 @@ impl ErrorLocation {
                     &mut snippet,
                     "{:4} | {} ... [rest of line truncated for security]",
                     i + 1,
-                    l.get(0..20).unwrap()
+                    l.get(0..std::cmp::min(l.len(), 20)).unwrap()
                 )
                 .unwrap();
             } else if i + 2 >= line {

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -73,7 +73,7 @@ ALTER MATERIALIZED VIEW mv SET CLUSTER default
 query error db error: ERROR: unknown cluster 'does_not_exist'
 ALTER MATERIALIZED VIEW mv SET CLUSTER does_not_exist
 
-query error db error: ERROR: ALTER SET CLUSTER are not supported
+statement ok
 ALTER MATERIALIZED VIEW mv SET CLUSTER other_cluster
 
 query error db error: ERROR: ALTER VIEW SET CLUSTER is not supported, for more information consult the documentation at https://materialize\.com/docs/sql/alter\-set\-cluster/
@@ -84,3 +84,178 @@ ALTER MATERIALIZED VIEW v SET CLUSTER default
 
 query error db error: ERROR: ALTER SINK SET CLUSTER not yet supported, see https://github\.com/MaterializeInc/materialize/issues/20841 for more details
 ALTER SINK v SET CLUSTER default
+
+statement ok
+CREATE MATERIALIZED VIEW mv_const AS SELECT 1
+
+query I
+SELECT * FROM mv_const
+----
+1
+
+statement ok
+ALTER MATERIALIZED VIEW mv_const SET CLUSTER other_cluster
+
+query I
+SELECT * FROM mv_const
+----
+1
+
+statement ok
+ALTER MATERIALIZED VIEW mv_const SET CLUSTER default
+
+query I
+SELECT * FROM mv_const
+----
+1
+
+statement ok
+DROP MATERIALIZED VIEW mv_const
+
+statement ok
+CREATE CLUSTER c1 SIZE '1', REPLICATION FACTOR 3
+
+statement ok
+CREATE TABLE t1(a int)
+
+statement ok
+CREATE MATERIALIZED VIEW mv_t1 AS SELECT * from t1
+
+statement ok
+INSERT INTO t1 VALUES (1)
+
+query I
+SELECT a FROM mv_t1 ORDER BY a
+----
+1
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER c1
+
+statement ok
+INSERT INTO t1 VALUES (2)
+
+query I
+SELECT a FROM mv_t1 ORDER BY a
+----
+1
+2
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER default
+
+statement ok
+INSERT INTO t1 VALUES (3)
+
+query I
+SELECT a FROM mv_t1 ORDER BY a
+----
+1
+2
+3
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER c1
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER default
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER c1
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER default
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER c1
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER default
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER c1
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER default
+
+statement ok
+INSERT INTO t1 VALUES (4)
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER c1
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER default
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER c1
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER default
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER c1
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER default
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER c1
+
+statement ok
+ALTER MATERIALIZED VIEW mv_t1 SET CLUSTER default
+
+statement ok
+INSERT INTO t1 VALUES (5)
+
+query I
+SELECT a FROM mv_t1 ORDER BY a
+----
+1
+2
+3
+4
+5
+
+
+statement ok
+CREATE TABLE alter_mv_set_cluster_table (f1 INTEGER)
+
+statement ok
+CREATE CLUSTER alter_mv_set_cluster_cluster1 REPLICAS (replica1 (SIZE '1'));
+
+statement ok
+CREATE MATERIALIZED VIEW alter_mv_set_cluster_view1 AS SELECT f1 + 1 AS f1 FROM alter_mv_set_cluster_table;
+
+statement ok
+CREATE DEFAULT INDEX ON alter_mv_set_cluster_view1;
+
+statement ok
+INSERT INTO alter_mv_set_cluster_table VALUES (1);
+
+statement ok
+CREATE MATERIALIZED VIEW alter_mv_set_cluster_view2 AS SELECT f1 + 1 AS f1 FROM alter_mv_set_cluster_view1;
+
+statement ok
+CREATE DEFAULT INDEX ON alter_mv_set_cluster_view2;
+
+statement ok
+ALTER MATERIALIZED VIEW alter_mv_set_cluster_view1 SET CLUSTER alter_mv_set_cluster_cluster1;
+
+statement ok
+INSERT INTO alter_mv_set_cluster_table VALUES (2);
+
+statement ok
+CREATE CLUSTER alter_mv_set_cluster_cluster2 REPLICAS (replica1 (SIZE '1'));
+
+statement ok
+CREATE MATERIALIZED VIEW alter_mv_set_cluster_view3 AS SELECT f1 + 1 AS f1 FROM alter_mv_set_cluster_view2;
+
+statement ok
+CREATE DEFAULT INDEX ON alter_mv_set_cluster_view3;
+
+statement ok
+ALTER MATERIALIZED VIEW alter_mv_set_cluster_view1 SET CLUSTER alter_mv_set_cluster_cluster2;
+
+statement ok
+ALTER MATERIALIZED VIEW alter_mv_set_cluster_view2 SET CLUSTER alter_mv_set_cluster_cluster2;

--- a/test/testdrive/alter_mv_set_schema.td
+++ b/test/testdrive/alter_mv_set_schema.td
@@ -1,0 +1,82 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Addiitonal tests for ALTER MATERIALIZED VIEW SET SCHEMA, to complement those
+# in sqllogictest/alter.slt
+#
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_alter_set_cluster = true
+
+# Check that moving the schema does not count towards the max_materialized_views limit
+
+> CREATE TABLE t1 (f1 INTEGER);
+> CREATE CLUSTER alter_mv_set_cluster REPLICAS (replica1 (SIZE '1'));
+> CREATE MATERIALIZED VIEW mv1 AS SELECT f1 + 1 AS f1 FROM t1;
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET max_materialized_views=1
+> ALTER MATERIALIZED VIEW mv1 SET CLUSTER alter_mv_set_cluster;
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET max_materialized_views
+
+# The cluster that contains the moved view should not be droppable
+! DROP CLUSTER alter_mv_set_cluster
+contains: cannot drop cluster with active objects
+
+# And should not allow sources to be created
+! CREATE SOURCE lgc IN CLUSTER alter_mv_set_cluster FROM LOAD GENERATOR COUNTER;
+contains: cannot create source in cluster containing indexes or materialized views
+
+# Sinks should survive a MOVE
+
+> CREATE TABLE sink_table (f1 INTEGER);
+
+> INSERT INTO sink_table VALUES (1);
+
+> CREATE MATERIALIZED VIEW sink_view AS SELECT f1 + 1 AS f1 FROM sink_table;
+
+> CREATE DEFAULT INDEX ON sink_view;
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> CREATE SINK sink_sink
+  FROM sink_view
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'alter-mv-set-schema-sink-topic')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+> CREATE SOURCE sink_source
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'alter-mv-set-schema-sink-topic')
+  FORMAT BYTES
+  ENVELOPE NONE
+
+> SELECT COUNT(*) FROM sink_source;
+1
+
+> ALTER MATERIALIZED VIEW sink_view SET CLUSTER alter_mv_set_cluster;
+
+> INSERT INTO sink_table VALUES (2);
+
+> SELECT COUNT(*) FROM sink_source;
+2
+
+# TODO(#21956): Remove once fixed
+> DROP SOURCE sink_source;
+> DROP SINK sink_sink;
+> DROP MATERIALIZED VIEW mv1, sink_view;
+
+# Cleanup
+# TODO(#21956): Add CASCADE once fixed and explicit drop removed
+> DROP CLUSTER alter_mv_set_cluster;

--- a/test/testdrive/alter_set_cluster.td
+++ b/test/testdrive/alter_set_cluster.td
@@ -1,0 +1,47 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test moving various objects between clusters
+
+> CREATE TABLE alter_mv_set_cluster_table (f1 INTEGER);
+
+> CREATE CLUSTER alter_mv_set_cluster_cluster1 REPLICAS (replica1 (SIZE '1'));
+
+> CREATE MATERIALIZED VIEW alter_mv_set_cluster_view1 AS SELECT f1 + 1 AS f1 FROM alter_mv_set_cluster_table;
+> CREATE DEFAULT INDEX ON alter_mv_set_cluster_view1;
+> INSERT INTO alter_mv_set_cluster_table VALUES (1);
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_alter_set_cluster = true
+
+> CREATE MATERIALIZED VIEW alter_mv_set_cluster_view2 AS SELECT f1 + 1 AS f1 FROM alter_mv_set_cluster_view1;
+
+> CREATE DEFAULT INDEX ON alter_mv_set_cluster_view2;
+
+> ALTER MATERIALIZED VIEW alter_mv_set_cluster_view1 SET CLUSTER alter_mv_set_cluster_cluster1;
+
+> INSERT INTO alter_mv_set_cluster_table VALUES (2);
+
+> CREATE CLUSTER alter_mv_set_cluster_cluster2 REPLICAS (replica1 (SIZE '1'));
+
+> CREATE MATERIALIZED VIEW alter_mv_set_cluster_view3 AS SELECT f1 + 1 AS f1 FROM alter_mv_set_cluster_view2;
+
+> CREATE DEFAULT INDEX ON alter_mv_set_cluster_view3;
+
+> ALTER MATERIALIZED VIEW alter_mv_set_cluster_view1 SET CLUSTER alter_mv_set_cluster_cluster2;
+
+> ALTER MATERIALIZED VIEW alter_mv_set_cluster_view2 SET CLUSTER alter_mv_set_cluster_cluster2;
+
+# TODO(#21956): Remove once fixed
+> DROP MATERIALIZED VIEW alter_mv_set_cluster_view3
+> DROP MATERIALIZED VIEW alter_mv_set_cluster_view2
+> DROP MATERIALIZED VIEW alter_mv_set_cluster_view1;
+
+# Cleanup
+# TODO(#21956): Add CASCADE once fixed and explicit drop removed
+> DROP CLUSTER alter_mv_set_cluster_cluster2, alter_mv_set_cluster_cluster1


### PR DESCRIPTION
### Motivation

Implement `ALTER MATERIALIZED VIEW mat_view SET IN CLUSTER clsname`.

Related: #17417

TODOs for this PR:
* [x] Do not recreate the dataflow if the write frontier is empty.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
