### PR TITLE
dbt-materialize: release v1.5.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,7 +13,7 @@ Business Source License 1.1
 
 Licensor:                  Materialize, Inc.
 
-Licensed Work:             Materialize Version 20230723
+Licensed Work:             Materialize Version 20230724
                            The Licensed Work is © 2023 Materialize, Inc.
 
 Additional Use Grant:      Within a single installation of Materialize, you
@@ -32,7 +32,7 @@ Additional Use Grant:      Within a single installation of Materialize, you
                            whose definitions are controlled by such third
                            parties.
 
-Change Date:               July 23, 2027
+Change Date:               July 24, 2027
 
 Change License:            Apache License, Version 2.0
 

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,9 @@
 # dbt-materialize Changelog
 
+## 1.5.1 - 2023-07-24
+
+* Enable the `indexes` config for `table` materializations.
+
 ## 1.5.0 - 2023-07-13
 
 * Upgrade to `dbt-postgres` v1.5.0. dbt contracts and dbt constraints are **not

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.5.0"
+version = "1.5.1"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.5.0",
+    version="1.5.1",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Release dbt-materialize `v1.5.1`. This release includes:

#20737 (**needs to be merged first**)