### PR TITLE
testdrive: Fortify subscribe-output.td

### DIFF
--- a/test/testdrive/subscribe-output.td
+++ b/test/testdrive/subscribe-output.td
@@ -264,8 +264,10 @@ DELETE FROM t2 WHERE key = 1
 > FETCH 1 c
 <TIMESTAMP> true <null> <null> <null>
 
-> FETCH 2 c
+> FETCH 1 c
 <TIMESTAMP> false upsert 2 3
+
+> FETCH 1 c
 <TIMESTAMP> true <null> <null> <null>
 
 > COMMIT
@@ -382,8 +384,10 @@ DELETE FROM t2 WHERE key = 1
 > FETCH 1 c
 <TIMESTAMP> true <null> <null> <null> <null>
 
-> FETCH 2 c
+> FETCH 1 c
 <TIMESTAMP> false insert 2 <null> 3
+
+> FETCH 1 c
 <TIMESTAMP> true <null> <null> <null> <null>
 
 > COMMIT


### PR DESCRIPTION
FETCH 2 may legitimately return only 1 row, causing the test to fail.

Fortify by using two FETCH 1-s instead.

### Motivation

Fixes https://buildkite.com/materialize/nightlies/builds/2921#01898518-6591-4013-8562-fabc802b9b7e


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
