### PR TITLE
ci: Give larger instances to some Platform Checks scenarios

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -369,7 +369,8 @@ steps:
     timeout_in_minutes: 60
     artifact_paths: junit_*.xml
     agents:
-      queue: linux-x86_64
+      # A larger instance is needed due to frequent OOMs
+      queue: builder-linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
@@ -380,7 +381,8 @@ steps:
     timeout_in_minutes: 60
     artifact_paths: junit_*.xml
     agents:
-      queue: linux-x86_64
+      # A larger instance is needed due to frequent OOMs
+      queue: builder-linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks


### PR DESCRIPTION
Certain Platform Checks scenarios are OOM-ing, as the default CI instance provides 16Gb, which is apparently not enough to hold the peak memory consumption of the clusterds that serve the default cluster in the Platform Checks framework.

### Motivation

There are repeated OOMs in those two scenarios. The process that is being OOM-killed is clusterd serving the default cluster . Its peak memory usage is 4Gb, which is too much for a 16Gb machine.

The default cluster serves a bunch of dataflows, but from an examination, they all appear to be important for testing. There was no obvious opportunity to reduce the memory usage without diminishing the value of all PlatformChecks-based tests.
