### PR TITLE
cloud-canary: Use consistent naming for env variables

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -176,8 +176,8 @@ case "$cmd" in
             --env LAUNCHDARKLY_API_TOKEN
             --env LAUNCHDARKLY_SDK_KEY
             --env NIGHTLY_CANARY_APP_PASSWORD
-            --env NIGHTLY_CANARY_CONFLUENT_CLOUD_API_KEY
-            --env NIGHTLY_CANARY_CONFLUENT_CLOUD_API_SECRET
+            --env CONFLUENT_CLOUD_DEVEX_KAFKA_USERNAME
+            --env CONFLUENT_CLOUD_DEVEX_KAFKA_PASSWORD
             --env NO_COLOR
             --env POLAR_SIGNALS_API_TOKEN
             --env PYPI_TOKEN

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -28,9 +28,9 @@ VERSION = "devel-" + os.environ["BUILDKITE_COMMIT"]
 # The DevEx account in the Confluent Cloud is used to provide Kafka services
 KAFKA_BOOTSTRAP_SERVER = "pkc-n00kk.us-east-1.aws.confluent.cloud:9092"
 SCHEMA_REGISTRY_ENDPOINT = "https://psrc-8kz20.us-east-2.aws.confluent.cloud"
-# The actual values are stored as Pulumi secrets in the i2 repository
-CONFLUENT_API_KEY = os.environ["NIGHTLY_CANARY_CONFLUENT_CLOUD_API_KEY"]
-CONFLUENT_API_SECRET = os.environ["NIGHTLY_CANARY_CONFLUENT_CLOUD_API_SECRET"]
+# The actual values are stored in the i2 repository
+CONFLUENT_API_KEY = os.environ["CONFLUENT_CLOUD_DEVEX_KAFKA_USERNAME"]
+CONFLUENT_API_SECRET = os.environ["CONFLUENT_CLOUD_DEVEX_KAFKA_PASSWORD"]
 
 SERVICES = [
     Cockroach(setup_materialize=True),


### PR DESCRIPTION
The naming of the env variables holding Kafka and CSR secrets has been revampted in

https://github.com/MaterializeInc/i2/pull/980