### PR TITLE
Revert "metrics: Add `application_name` to `query_total` metric (#206…

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -411,11 +411,10 @@ impl Coordinator {
             .expect("known to exist");
 
         let session_type = metrics::session_type_label_value(ctx.session().user());
-        let application_name = ctx.session().application_name();
         let stmt_type = metrics::statement_type_label_value(&stmt);
         self.metrics
             .query_total
-            .with_label_values(&[session_type, stmt_type, application_name])
+            .with_label_values(&[session_type, stmt_type])
             .inc();
         match &stmt {
             Statement::Subscribe(SubscribeStatement { output, .. })

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -34,15 +34,11 @@ pub struct Metrics {
 
 impl Metrics {
     pub(crate) fn register_into(registry: &MetricsRegistry) -> Self {
-        // Note: In a couple of these metrics we log `application_name`, but we need to be __VERY__
-        // careful when doing so because it can have a high cardinality! If you need to add
-        // `application_name` to another metric please consider using `ApplicationNameHint` which
-        // maps to a known set of names, or consule with the Cloud Team.
         Self {
             query_total: registry.register(metric!(
                 name: "mz_query_total",
                 help: "The total number of queries issued of the given type since process start.",
-                var_labels: ["session_type", "statement_type", "application_name"],
+                var_labels: ["session_type", "statement_type"],
             )),
             active_sessions: registry.register(metric!(
                 name: "mz_active_sessions",


### PR DESCRIPTION
This reverts commit 7ffd8a1b68330c5c3d2e3b8df899d302bbd6e102.

In #20669 we added the `application_name` label to the `query_total` metric for debugging purposes. There is a location in the code base where we aggregate `query_total` based on label values for reporting, this API requires you to specify the exact value for each label. Given `application_name` varies, there doesn't exist a way to replicate our current stats reporting with this new label, e.g. `let deletes = with_label_values(["user", "delete", "*"])` is not supported.

In the Go prometheus library there is [`DeletePartialMatch`](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#MetricVec.DeletePartialMatch), so there is some precedent for partially matching metrics, but nothing of the sort exists in Rust. We could probably add our own extension to do this partial matching, but given this issue is blocking the release, I'm opting to revert for now.

### Motivation

Fixes #20738 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
