### PR TITLE
catalog: Fix custom array type names

### DIFF
--- a/ci/test/lint-docs-catalog.py
+++ b/ci/test/lint-docs-catalog.py
@@ -98,7 +98,7 @@ def main() -> None:
                 type_name = table_match[1]
                 # We currently cannot determine the type of lists from the catalog.
                 if type_name == "mz_aclitem array":
-                    type_name = "mz_aclitem_array"
+                    type_name = "mz_aclitem[]"
                 elif type_name == "text array":
                     type_name = "text[]"
                 elif "list" in type_name:

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -433,7 +433,7 @@ pub static UINT8: Lazy<postgres_types::Type> = Lazy::new(|| {
 /// An anonymous [`Type::Array`], akin to [`postgres_types::Type::INT2_ARRAY`].
 pub static UINT2_ARRAY: Lazy<postgres_types::Type> = Lazy::new(|| {
     postgres_types::Type::new(
-        "uint2_array".to_owned(),
+        "_uint2".to_owned(),
         oid::TYPE_UINT2_ARRAY_OID,
         postgres_types::Kind::Pseudo,
         MZ_CATALOG_SCHEMA.to_owned(),
@@ -443,7 +443,7 @@ pub static UINT2_ARRAY: Lazy<postgres_types::Type> = Lazy::new(|| {
 /// An anonymous [`Type::Array`], akin to [`postgres_types::Type::INT4_ARRAY`].
 pub static UINT4_ARRAY: Lazy<postgres_types::Type> = Lazy::new(|| {
     postgres_types::Type::new(
-        "uint4_array".to_owned(),
+        "_uint4".to_owned(),
         oid::TYPE_UINT4_ARRAY_OID,
         postgres_types::Kind::Pseudo,
         MZ_CATALOG_SCHEMA.to_owned(),
@@ -453,7 +453,7 @@ pub static UINT4_ARRAY: Lazy<postgres_types::Type> = Lazy::new(|| {
 /// An anonymous [`Type::Array`], akin to [`postgres_types::Type::INT8_ARRAY`].
 pub static UINT8_ARRAY: Lazy<postgres_types::Type> = Lazy::new(|| {
     postgres_types::Type::new(
-        "uint8_array".to_owned(),
+        "_uint8".to_owned(),
         oid::TYPE_UINT8_ARRAY_OID,
         postgres_types::Kind::Pseudo,
         MZ_CATALOG_SCHEMA.to_owned(),
@@ -473,7 +473,7 @@ pub static MZ_TIMESTAMP: Lazy<postgres_types::Type> = Lazy::new(|| {
 /// An anonymous [`Type::Array`], akin to [`postgres_types::Type::TEXT_ARRAY`].
 pub static MZ_TIMESTAMP_ARRAY: Lazy<postgres_types::Type> = Lazy::new(|| {
     postgres_types::Type::new(
-        "mz_timestamp_array".to_owned(),
+        "_mz_timestamp".to_owned(),
         oid::TYPE_MZ_TIMESTAMP_ARRAY_OID,
         postgres_types::Kind::Pseudo,
         MZ_CATALOG_SCHEMA.to_owned(),
@@ -493,7 +493,7 @@ pub static MZ_ACL_ITEM: Lazy<postgres_types::Type> = Lazy::new(|| {
 /// An anonymous [`Type::Array`], akin to [`postgres_types::Type::TEXT_ARRAY`].
 pub static MZ_ACL_ITEM_ARRAY: Lazy<postgres_types::Type> = Lazy::new(|| {
     postgres_types::Type::new(
-        "mz_aclitem_array".to_owned(),
+        "_mz_aclitem".to_owned(),
         oid::TYPE_MZ_ACL_ITEM_ARRAY_OID,
         postgres_types::Kind::Pseudo,
         MZ_CATALOG_SCHEMA.to_owned(),
@@ -777,6 +777,7 @@ impl Type {
         // postgres_types' `name()` uses the pg_catalog name, and not the pretty
         // SQL standard name.
         match self.inner() {
+            &postgres_types::Type::ACLITEM_ARRAY => "aclitem[]",
             &postgres_types::Type::BOOL_ARRAY => "boolean[]",
             &postgres_types::Type::BYTEA_ARRAY => "bytea[]",
             &postgres_types::Type::BPCHAR_ARRAY => "character[]",
@@ -810,7 +811,14 @@ impl Type {
             &postgres_types::Type::REGPROC_ARRAY => "regproc[]",
             &postgres_types::Type::REGTYPE_ARRAY => "regtype[]",
             &postgres_types::Type::INT2_VECTOR => "int2vector",
-            other => other.name(),
+            other => match other.oid() {
+                oid::TYPE_UINT2_ARRAY_OID => "uint2[]",
+                oid::TYPE_UINT4_ARRAY_OID => "uint4[]",
+                oid::TYPE_UINT8_ARRAY_OID => "uint8[]",
+                oid::TYPE_MZ_TIMESTAMP_ARRAY_OID => "mz_timestamp[]",
+                oid::TYPE_MZ_ACL_ITEM_ARRAY_OID => "mz_aclitem[]",
+                _ => other.name(),
+            },
         }
     }
 

--- a/test/sqllogictest/autogenerated/mz_catalog.slt
+++ b/test/sqllogictest/autogenerated/mz_catalog.slt
@@ -73,7 +73,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 1  id  text
 2  name  text
 3  owner_id  text
-4  privileges  mz_aclitem_array
+4  privileges  mz_aclitem[]
 5  managed  boolean
 6  size  text
 7  replication_factor  uint4
@@ -100,7 +100,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 4  name  text
 5  type  text
 6  owner_id  text
-7  privileges  mz_aclitem_array
+7  privileges  mz_aclitem[]
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_databases' ORDER BY position
@@ -109,7 +109,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 2  oid  oid
 3  name  text
 4  owner_id  text
-5  privileges  mz_aclitem_array
+5  privileges  mz_aclitem[]
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_default_privileges' ORDER BY position
@@ -194,7 +194,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 5  cluster_id  text
 6  definition  text
 7  owner_id  text
-8  privileges  mz_aclitem_array
+8  privileges  mz_aclitem[]
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_objects' ORDER BY position
@@ -205,7 +205,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 4  name  text
 5  type  text
 6  owner_id  text
-7  privileges  mz_aclitem_array
+7  privileges  mz_aclitem[]
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_pseudo_types' ORDER BY position
@@ -221,7 +221,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 4  name  text
 5  type  text
 6  owner_id  text
-7  privileges  mz_aclitem_array
+7  privileges  mz_aclitem[]
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_roles' ORDER BY position
@@ -246,7 +246,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 3  database_id  text
 4  name  text
 5  owner_id  text
-6  privileges  mz_aclitem_array
+6  privileges  mz_aclitem[]
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_secrets' ORDER BY position
@@ -256,7 +256,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 3  schema_id  text
 4  name  text
 5  owner_id  text
-6  privileges  mz_aclitem_array
+6  privileges  mz_aclitem[]
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_ssh_tunnel_connections' ORDER BY position
@@ -292,7 +292,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 8  envelope_type  text
 9  cluster_id  text
 10  owner_id  text
-11  privileges  mz_aclitem_array
+11  privileges  mz_aclitem[]
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_storage_usage' ORDER BY position
@@ -314,7 +314,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 3  schema_id  text
 4  name  text
 5  owner_id  text
-6  privileges  mz_aclitem_array
+6  privileges  mz_aclitem[]
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_types' ORDER BY position
@@ -325,7 +325,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 4  name  text
 5  category  text
 6  owner_id  text
-7  privileges  mz_aclitem_array
+7  privileges  mz_aclitem[]
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_views' ORDER BY position
@@ -336,7 +336,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 4  name  text
 5  definition  text
 6  owner_id  text
-7  privileges  mz_aclitem_array
+7  privileges  mz_aclitem[]
 
 query T
 SELECT DISTINCT object FROM objects WHERE schema IN ('mz_catalog') ORDER BY object

--- a/test/sqllogictest/typeof.slt
+++ b/test/sqllogictest/typeof.slt
@@ -93,3 +93,28 @@ query T
 SELECT pg_typeof(ROW('1', '2', 2.0)::other.composite)
 ----
 other.composite
+
+query T
+SELECT pg_typeof(ARRAY[1::uint2])
+----
+uint2[]
+
+query T
+SELECT pg_typeof(ARRAY[1::uint4])
+----
+uint4[]
+
+query T
+SELECT pg_typeof(ARRAY[1::uint8])
+----
+uint8[]
+
+query T
+SELECT pg_typeof(ARRAY[1::mz_timestamp])
+----
+mz_timestamp[]
+
+query T
+SELECT pg_typeof(ARRAY[mz_internal.make_mz_aclitem('u1', 'u2', 'CREATE')])
+----
+mz_aclitem[]


### PR DESCRIPTION
For all custom types, we created two custom `postgres_types::Type` types. One to represent the type itself and one to represent an array containing that type. The naming convention of the array types were `<type-name>_array`. However, in our catalog we stored the array types with a naming convention of `_<type-name>`, which is how all non-custom array types are named. If we ever tried to resolve an array of custom types using the `<type-name>_array` format, it would fail.

This commit updates the naming convention of custom array types to always be `_<type_name>`.

This never caused any issues previously because we never tried to resolve a custom array using the name from `postgres_types::Type`. Had we created a function that accepted a custom array type, then we would have seen the issue.

Additionally, this commit updates the human-readable names of these
custom array types to match the human-readable names of non-custom
array types. That is, `<type-name>[]`.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
