### PR TITLE
doc/user: document that `ALTER SECRET` may take weeks to apply

### DIFF
--- a/doc/user/content/sql/alter-secret.md
+++ b/doc/user/content/sql/alter-secret.md
@@ -17,6 +17,46 @@ Field | Use
 _name_ | The identifier of the secret you want to alter.
 _value_ | The new value for the secret. The _value_ expression may not reference any relations, and must be implicitly castable to `bytea`.
 
+## Details
+
+After an `ALTER SECRET` command is executed:
+
+  * Future [`CREATE CONNECTION`], [`CREATE SOURCE`], and [`CREATE SINK`]
+    commands will use the new value of the secret immediately.
+
+  * Running sources and sinks that reference the secret will **not** immediately
+    use the new value of the secret. Sources and sinks may cache the old secret
+    value for several weeks.
+
+    To force a running source or sink to refresh its secrets:
+
+      * If the source or sink was created with the `IN CLUSTER` option, drop and
+        recreate all replicas of the cluster hosting the source or sink.
+
+        For a managed cluster:
+
+        ```
+        ALTER CLUSTER storage_cluster SET (REPLICATION FACTOR = 0);
+        ALTER CLUSTER storage_cluster SET (REPLICATION FACTOR = 1);
+        ```
+
+        For an unmanaged cluster:
+
+        ```
+        DROP CLUSTER REPLICA storage_cluster.r1;
+        CREATE CLUSTER REPLICA storage_cluster.r1 (SIZE = '<original size>');
+        ```
+
+      * If the source or sink was created with the `SIZE` option, use [`ALTER
+        SOURCE`] or [`ALTER SINK`] to temporarily scale down the source and then
+        scale it back to its original size. For example, if source `s` is
+        currently running with size `small`:
+
+        ```sql
+        ALTER SOURCE src SET (SIZE = 'xsmall'); -- Any size that is not `small` will work.
+        ALTER SOURCE src SET (SIZE = 'small');
+        ```
+
 ## Examples
 
 ```sql
@@ -36,3 +76,9 @@ The privileges required to execute this statement are:
 - [`ALTER...RENAME`](/sql/alter-rename/)
 - [`SHOW SECRETS`](/sql/show-secrets)
 - [`DROP SECRET`](/sql/drop-secret)
+
+[`CREATE CONNECTION`]: /sql/create-connection/
+[`CREATE SOURCE`]: /sql/create-source
+[`CREATE SINK`]: /sql/create-sink
+[`ALTER SOURCE`]: /sql/alter-source
+[`ALTER SINK`]: /sql/alter-sink


### PR DESCRIPTION
And suggest workarounds to force a refresh.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR improves documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
