### PR TITLE
doc: Remove warning on privilege docs

### DIFF
--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -60,6 +60,12 @@ the following conditions are met:
 Note that the cluster will not have settings for the availability zones, and
 compute-specific settings. If needed, these can be set explicitly.
 
+## Privileges
+
+The privileges required to execute this statement are:
+
+- Ownership of the cluster.
+
 ## See also
 
 - [`CREATE CLUSTER`](/sql/create-cluster/)

--- a/doc/user/content/sql/alter-connection.md
+++ b/doc/user/content/sql/alter-connection.md
@@ -50,8 +50,6 @@ be unable to authenticate with the bastion server.
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the connection.

--- a/doc/user/content/sql/alter-default-privileges.md
+++ b/doc/user/content/sql/alter-default-privileges.md
@@ -80,8 +80,6 @@ ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON TABLES TO managers;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Superuser user status.

--- a/doc/user/content/sql/alter-index.md
+++ b/doc/user/content/sql/alter-index.md
@@ -27,8 +27,6 @@ indexes.
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the index.

--- a/doc/user/content/sql/alter-owner.md
+++ b/doc/user/content/sql/alter-owner.md
@@ -38,8 +38,6 @@ ALTER CLUSTER REPLICA production.r1 OWNER TO admin;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Role membership in `new_owner`.

--- a/doc/user/content/sql/alter-rename.md
+++ b/doc/user/content/sql/alter-rename.md
@@ -122,8 +122,6 @@ SHOW VIEWS;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the object being renamed.

--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -52,8 +52,6 @@ rj  true
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATEROLE` privileges on the system.

--- a/doc/user/content/sql/alter-secret.md
+++ b/doc/user/content/sql/alter-secret.md
@@ -25,8 +25,6 @@ ALTER SECRET upstash_kafka_ca_cert AS decode('c2VjcmV0Cg==', 'base64');
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the secret being altered.

--- a/doc/user/content/sql/alter-sink.md
+++ b/doc/user/content/sql/alter-sink.md
@@ -19,8 +19,6 @@ _value_ | The new value for the sink size. Accepts values: `3xsmall`, `2xsmall`,
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the sink being altered.

--- a/doc/user/content/sql/alter-source.md
+++ b/doc/user/content/sql/alter-source.md
@@ -19,8 +19,6 @@ _value_ | The new value for the source size. Accepts values: `3xsmall`, `2xsmall
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the source being altered.

--- a/doc/user/content/sql/copy-from.md
+++ b/doc/user/content/sql/copy-from.md
@@ -81,8 +81,6 @@ COPY t FROM STDIN (DELIMITER '|');
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schema containing the table.

--- a/doc/user/content/sql/copy-to.md
+++ b/doc/user/content/sql/copy-to.md
@@ -40,8 +40,6 @@ COPY (SUBSCRIBE some_view) TO STDOUT WITH (FORMAT binary);
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schemas that all relations in the query are contained in.

--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -114,8 +114,6 @@ CREATE CLUSTER REPLICA c1.r1 SIZE = 'medium';
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATE` privileges on the containing cluster.

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -188,8 +188,6 @@ REPLICA`](../create-cluster-replica).
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATECLUSTER` privileges on the system.

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -568,8 +568,6 @@ SELECT * FROM mz_ssh_tunnel_connections;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATE` privileges on the containing schema.

--- a/doc/user/content/sql/create-database.md
+++ b/doc/user/content/sql/create-database.md
@@ -51,8 +51,6 @@ my_db
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATEDB` privileges on the system.

--- a/doc/user/content/sql/create-index.md
+++ b/doc/user/content/sql/create-index.md
@@ -163,8 +163,6 @@ For more details on using indexes to optimize queries, see [Optimization](../../
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of `obj_name`.

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -88,8 +88,6 @@ non-indexed, and so on."
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of existing `view_name` if `OR REPLACE` is specified.

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -57,8 +57,6 @@ SELECT name FROM mz_roles;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATEROLE` privileges on the system.

--- a/doc/user/content/sql/create-schema.md
+++ b/doc/user/content/sql/create-schema.md
@@ -46,8 +46,6 @@ my_schema
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATE` privileges on the containing database.

--- a/doc/user/content/sql/create-secret.md
+++ b/doc/user/content/sql/create-secret.md
@@ -26,8 +26,6 @@ CREATE SECRET upstash_kafka_ca_cert AS decode('c2VjcmV0Cg==', 'base64');
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATE` privileges on the containing schema.

--- a/doc/user/content/sql/create-sink/_index.md
+++ b/doc/user/content/sql/create-sink/_index.md
@@ -55,8 +55,6 @@ capacity.
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATE` privileges on the containing schema.

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -244,8 +244,6 @@ capacity.
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATE` privileges on the containing schema.

--- a/doc/user/content/sql/create-table.md
+++ b/doc/user/content/sql/create-table.md
@@ -90,8 +90,6 @@ b          false     text
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATE` privileges on the containing schema.

--- a/doc/user/content/sql/create-type.md
+++ b/doc/user/content/sql/create-type.md
@@ -144,8 +144,6 @@ custom_nested_row_type
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATE` privileges on the containing schema.

--- a/doc/user/content/sql/create-view.md
+++ b/doc/user/content/sql/create-view.md
@@ -62,8 +62,6 @@ AS
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of existing `view_name` if `OR REPLACE` is specified.

--- a/doc/user/content/sql/delete.md
+++ b/doc/user/content/sql/delete.md
@@ -70,8 +70,6 @@ SELECT * FROM delete_me;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schemas that all relations in the query are contained in.

--- a/doc/user/content/sql/drop-cluster-replica.md
+++ b/doc/user/content/sql/drop-cluster-replica.md
@@ -37,8 +37,6 @@ DROP CLUSTER REPLICA auction_house.bigger;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped cluster replica.

--- a/doc/user/content/sql/drop-cluster.md
+++ b/doc/user/content/sql/drop-cluster.md
@@ -56,8 +56,6 @@ DROP CLUSTER auction_house CASCADE;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped cluster.

--- a/doc/user/content/sql/drop-connection.md
+++ b/doc/user/content/sql/drop-connection.md
@@ -59,8 +59,6 @@ DROP CONNECTION kafka_connection CASCADE;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped connection.

--- a/doc/user/content/sql/drop-database.md
+++ b/doc/user/content/sql/drop-database.md
@@ -46,8 +46,6 @@ DROP DATABASE IF EXISTS my_db;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped database.

--- a/doc/user/content/sql/drop-index.md
+++ b/doc/user/content/sql/drop-index.md
@@ -69,8 +69,6 @@ DROP INDEX IF EXISTS q01_geo_idx;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped index.

--- a/doc/user/content/sql/drop-materialized-view.md
+++ b/doc/user/content/sql/drop-materialized-view.md
@@ -45,8 +45,6 @@ upon by catalog item 'materialize.public.wb_custom_art'
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped materialized view.

--- a/doc/user/content/sql/drop-owned.md
+++ b/doc/user/content/sql/drop-owned.md
@@ -36,8 +36,6 @@ DROP OWNED BY joe, george CASCADE;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Role membership in `role_name`.

--- a/doc/user/content/sql/drop-role.md
+++ b/doc/user/content/sql/drop-role.md
@@ -25,8 +25,6 @@ You cannot drop the current role.
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATEROLE` privileges on the system.

--- a/doc/user/content/sql/drop-schema.md
+++ b/doc/user/content/sql/drop-schema.md
@@ -67,8 +67,6 @@ DROP SCHEMA IF EXISTS my_schema;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped schema.

--- a/doc/user/content/sql/drop-secret.md
+++ b/doc/user/content/sql/drop-secret.md
@@ -57,8 +57,6 @@ DROP SECRET upstash_sasl_password CASCADE;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped secret.

--- a/doc/user/content/sql/drop-sink.md
+++ b/doc/user/content/sql/drop-sink.md
@@ -35,8 +35,6 @@ DROP SINK
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped sink.

--- a/doc/user/content/sql/drop-source.md
+++ b/doc/user/content/sql/drop-source.md
@@ -68,8 +68,6 @@ DROP SOURCE IF EXISTS my_source;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped source.

--- a/doc/user/content/sql/drop-table.md
+++ b/doc/user/content/sql/drop-table.md
@@ -100,8 +100,6 @@ DROP TABLE IF EXISTS t;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped table.

--- a/doc/user/content/sql/drop-type.md
+++ b/doc/user/content/sql/drop-type.md
@@ -101,8 +101,6 @@ DROP TYPE IF EXISTS int4_list;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped type.

--- a/doc/user/content/sql/drop-user.md
+++ b/doc/user/content/sql/drop-user.md
@@ -23,8 +23,6 @@ _role_name_ | The role you want to drop. For available roles, see [`mz_roles`](/
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATEROLE` privileges on the system.

--- a/doc/user/content/sql/drop-view.md
+++ b/doc/user/content/sql/drop-view.md
@@ -46,8 +46,6 @@ DROP VIEW
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of the dropped view.

--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -399,8 +399,6 @@ Each source contains two frontiers:
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schemas that all relations in the query are contained in.

--- a/doc/user/content/sql/grant-privilege.md
+++ b/doc/user/content/sql/grant-privilege.md
@@ -90,8 +90,6 @@ GRANT CREATEDB ON SYSTEM TO joe;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of affected objects.

--- a/doc/user/content/sql/grant-role.md
+++ b/doc/user/content/sql/grant-role.md
@@ -32,8 +32,6 @@ GRANT data_scientist TO joe, mike;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATEROLE` privileges on the systems.

--- a/doc/user/content/sql/insert.md
+++ b/doc/user/content/sql/insert.md
@@ -95,8 +95,6 @@ SELECT * FROM t;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schemas that all relations in the query are contained in.

--- a/doc/user/content/sql/reassign-owned.md
+++ b/doc/user/content/sql/reassign-owned.md
@@ -34,8 +34,6 @@ REASSIGN OWNED BY joe, george TO mike;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Role membership in `old_role` and `new_role`.

--- a/doc/user/content/sql/revoke-privilege.md
+++ b/doc/user/content/sql/revoke-privilege.md
@@ -91,8 +91,6 @@ REVOKE CREATEDB ON SYSTEM FROM joe;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - Ownership of affected objects.

--- a/doc/user/content/sql/revoke-role.md
+++ b/doc/user/content/sql/revoke-role.md
@@ -37,8 +37,6 @@ REVOKE data_scientist FROM joe, mike;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `CREATEROLE` privileges on the systems.

--- a/doc/user/content/sql/select.md
+++ b/doc/user/content/sql/select.md
@@ -242,8 +242,6 @@ knowledge.
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schemas that all relations in the query are contained in.

--- a/doc/user/content/sql/show-columns.md
+++ b/doc/user/content/sql/show-columns.md
@@ -64,8 +64,6 @@ SHOW COLUMNS FROM my_source;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schema containing `item_ref`.

--- a/doc/user/content/sql/show-create-connection.md
+++ b/doc/user/content/sql/show-create-connection.md
@@ -30,8 +30,6 @@ SHOW CREATE CONNECTION kafka_connection;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schema containing the connection.

--- a/doc/user/content/sql/show-create-index.md
+++ b/doc/user/content/sql/show-create-index.md
@@ -40,8 +40,6 @@ SHOW CREATE INDEX my_view_idx;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schema containing the index.

--- a/doc/user/content/sql/show-create-materialized-view.md
+++ b/doc/user/content/sql/show-create-materialized-view.md
@@ -29,8 +29,6 @@ SHOW CREATE MATERIALIZED VIEW winning_bids;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schema containing the materialized view.

--- a/doc/user/content/sql/show-create-sink.md
+++ b/doc/user/content/sql/show-create-sink.md
@@ -40,8 +40,6 @@ SHOW CREATE SINK my_view_sink;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schema containing the sink.

--- a/doc/user/content/sql/show-create-source.md
+++ b/doc/user/content/sql/show-create-source.md
@@ -30,8 +30,6 @@ SHOW CREATE SOURCE market_orders_raw;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schema containing the source.

--- a/doc/user/content/sql/show-create-table.md
+++ b/doc/user/content/sql/show-create-table.md
@@ -33,8 +33,6 @@ SHOW CREATE TABLE t;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schema containing the table.

--- a/doc/user/content/sql/show-create-view.md
+++ b/doc/user/content/sql/show-create-view.md
@@ -29,8 +29,6 @@ SHOW CREATE VIEW my_view;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schema containing the view.

--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -518,8 +518,6 @@ DROP SOURCE counter;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schemas that all relations in the query are contained in.

--- a/doc/user/content/sql/update.md
+++ b/doc/user/content/sql/update.md
@@ -55,8 +55,6 @@ SELECT * FROM update_me;
 
 ## Privileges
 
-{{< private-preview />}}
-
 The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schemas that all relations in the query are contained in.


### PR DESCRIPTION
This commit removes the warning on the privilege sections in the documentation of each SQL command. The warning was confusing users and making people think that the command itself was in preview, not the privileges for the command.

### Motivation
Update docs.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
