### PR TITLE
adapter: Add usage checks to item schemas

### DIFF
--- a/doc/user/content/sql/copy-to.md
+++ b/doc/user/content/sql/copy-to.md
@@ -44,7 +44,7 @@ COPY (SUBSCRIBE some_view) TO STDOUT WITH (FORMAT binary);
 
 The privileges required to execute this statement are:
 
-- `USAGE` privileges on the schemas that all relations in the query are contained in.
+- `USAGE` privileges on the schemas that all relations and types in the query are contained in.
 - `SELECT` privileges on all relations in the query.
     - NOTE: if any item is a view, then the view owner must also have the necessary privileges to
       execute the view definition.

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -574,6 +574,7 @@ The privileges required to execute this statement are:
 
 - `CREATE` privileges on the containing schema.
 - `USAGE` privileges on all connections and secrets used in the connection definition.
+- `USAGE` privileges on the schemas that all connections and secrets in the statement are contained in.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-index.md
+++ b/doc/user/content/sql/create-index.md
@@ -171,6 +171,7 @@ The privileges required to execute this statement are:
 - `CREATE` privileges on the containing schema.
 - `CREATE` privileges on the containing cluster.
 - `USAGE` privileges on all types used in the index definition.
+- `USAGE` privileges on the schemas that all types in the statement are contained in.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -96,6 +96,7 @@ The privileges required to execute this statement are:
 - `CREATE` privileges on the containing schema.
 - `CREATE` privileges on the containing cluster.
 - `USAGE` privileges on all types used in the materialized view definition.
+- `USAGE` privileges on the schemas that all types in the statement are contained in.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-sink/_index.md
+++ b/doc/user/content/sql/create-sink/_index.md
@@ -66,6 +66,7 @@ The privileges required to execute this statement are:
 - `CREATE` privileges on the containing cluster if the sink is created in an existing cluster.
 - `CREATECLUSTER` privileges on the system if the sink is not created in an existing cluster.
 - `USAGE` privileges on all connections and secrets used in the sink definition.
+- `USAGE` privileges on the schemas that all connections and secrets in the statement are contained in.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -252,6 +252,7 @@ The privileges required to execute this statement are:
 - `CREATE` privileges on the containing cluster if the source is created in an existing cluster.
 - `CREATECLUSTER` privileges on the system if the source is not created in an existing cluster.
 - `USAGE` privileges on all connections and secrets used in the source definition.
+- `USAGE` privileges on the schemas that all connections and secrets in the statement are contained in.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-table.md
+++ b/doc/user/content/sql/create-table.md
@@ -96,6 +96,7 @@ The privileges required to execute this statement are:
 
 - `CREATE` privileges on the containing schema.
 - `USAGE` privileges on all types used in the table definition.
+- `USAGE` privileges on the schemas that all types in the statement are contained in.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-type.md
+++ b/doc/user/content/sql/create-type.md
@@ -150,6 +150,7 @@ The privileges required to execute this statement are:
 
 - `CREATE` privileges on the containing schema.
 - `USAGE` privileges on all types used in the type definition.
+- `USAGE` privileges on the schemas that all types in the statement are contained in.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-view.md
+++ b/doc/user/content/sql/create-view.md
@@ -69,6 +69,7 @@ The privileges required to execute this statement are:
 - Ownership of existing `view_name` if `OR REPLACE` is specified.
 - `CREATE` privileges on the containing schema.
 - `USAGE` privileges on all types used in the view definition.
+- `USAGE` privileges on the schemas that all types in the statement are contained in.
 
 ## Related pages
 

--- a/doc/user/content/sql/delete.md
+++ b/doc/user/content/sql/delete.md
@@ -74,7 +74,7 @@ SELECT * FROM delete_me;
 
 The privileges required to execute this statement are:
 
-- `USAGE` privileges on the schemas that all relations in the query are contained in.
+- `USAGE` privileges on the schemas that all relations and types in the query are contained in.
 - `DELETE` privileges on `table_name`.
 - `SELECT` privileges on all relations in the query.
   - NOTE: if any item is a view, then the view owner must also have the necessary privileges to

--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -403,7 +403,7 @@ Each source contains two frontiers:
 
 The privileges required to execute this statement are:
 
-- `USAGE` privileges on the schemas that all relations in the query are contained in.
+- `USAGE` privileges on the schemas that all relations and types in the query are contained in.
 - `SELECT` privileges on all relations in the query.
     - NOTE: if any item is a view, then the view owner must also have the necessary privileges to
       execute the view definition.

--- a/doc/user/content/sql/insert.md
+++ b/doc/user/content/sql/insert.md
@@ -99,7 +99,7 @@ SELECT * FROM t;
 
 The privileges required to execute this statement are:
 
-- `USAGE` privileges on the schemas that all relations in the query are contained in.
+- `USAGE` privileges on the schemas that all relations and types in the query are contained in.
 - `INSERT` privileges on `table_name`.
 - `SELECT` privileges on all relations in the query.
   - NOTE: if any item is a view, then the view owner must also have the necessary privileges to

--- a/doc/user/content/sql/select.md
+++ b/doc/user/content/sql/select.md
@@ -246,7 +246,7 @@ knowledge.
 
 The privileges required to execute this statement are:
 
-- `USAGE` privileges on the schemas that all relations in the query are contained in.
+- `USAGE` privileges on the schemas that all relations and types in the query are contained in.
 - `SELECT` privileges on all relations in the query.
  - NOTE: if any item is a view, then the view owner must also have the necessary privileges to
    execute the view definition.

--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -522,7 +522,7 @@ DROP SOURCE counter;
 
 The privileges required to execute this statement are:
 
-- `USAGE` privileges on the schemas that all relations in the query are contained in.
+- `USAGE` privileges on the schemas that all relations and types in the query are contained in.
 - `SELECT` privileges on all relations in the query.
   - NOTE: if any item is a view, then the view owner must also have the necessary privileges to
   execute the view definition.

--- a/doc/user/content/sql/update.md
+++ b/doc/user/content/sql/update.md
@@ -59,7 +59,7 @@ SELECT * FROM update_me;
 
 The privileges required to execute this statement are:
 
-- `USAGE` privileges on the schemas that all relations in the query are contained in.
+- `USAGE` privileges on the schemas that all relations and types in the query are contained in.
 - `UPDATE` privileges on `table_name`.
 - `SELECT` privileges on all relations in the query.
   - NOTE: if any item is a view, then the view owner must also have the necessary privileges to

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -463,6 +463,21 @@ COMPLETE 0
 simple conn=joe,user=joe
 CREATE TABLE t (a ty);
 ----
+db error: ERROR: permission denied for SCHEMA "materialize.public"
+
+simple conn=child,user=child
+CREATE TABLE t (a ty);
+----
+db error: ERROR: permission denied for SCHEMA "materialize.public"
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA materialize.public TO joe;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+CREATE TABLE t (a ty);
+----
 db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=child,user=child
@@ -506,7 +521,7 @@ CREATE TABLE t1 (a ty);
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-REVOKE CREATE ON SCHEMA materialize.public FROM joe;
+REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM joe;
 ----
 COMPLETE 0
 
@@ -519,6 +534,21 @@ COMPLETE 0
 
 simple conn=mz_system,user=mz_system
 REVOKE USAGE ON TYPE ty FROM joe;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+CREATE VIEW v AS SELECT ROW(1)::ty;
+----
+db error: ERROR: permission denied for SCHEMA "materialize.public"
+
+simple conn=child,user=child
+CREATE VIEW v AS SELECT ROW(1)::ty;
+----
+db error: ERROR: permission denied for SCHEMA "materialize.public"
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA materialize.public TO joe;
 ----
 COMPLETE 0
 
@@ -568,7 +598,7 @@ CREATE VIEW v1 AS SELECT ROW(1)::ty;
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-REVOKE CREATE ON SCHEMA materialize.public FROM joe;
+REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM joe;
 ----
 COMPLETE 0
 
@@ -581,6 +611,21 @@ COMPLETE 0
 
 simple conn=mz_system,user=mz_system
 REVOKE USAGE ON TYPE ty FROM joe;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+CREATE MATERIALIZED VIEW mv AS SELECT ROW(1)::ty;
+----
+db error: ERROR: permission denied for SCHEMA "materialize.public"
+
+simple conn=child,user=child
+CREATE MATERIALIZED VIEW mv AS SELECT ROW(1)::ty;
+----
+db error: ERROR: permission denied for SCHEMA "materialize.public"
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA materialize.public TO joe;
 ----
 COMPLETE 0
 
@@ -645,7 +690,7 @@ CREATE MATERIALIZED VIEW mv1 AS SELECT ROW(1)::ty;
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-REVOKE CREATE ON SCHEMA materialize.public FROM joe;
+REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM joe;
 ----
 COMPLETE 0
 
@@ -663,6 +708,21 @@ COMPLETE 0
 
 simple conn=mz_system,user=mz_system
 REVOKE USAGE ON TYPE ty FROM joe;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+CREATE INDEX i ON t (a::ty);
+----
+db error: ERROR: permission denied for SCHEMA "materialize.public"
+
+simple conn=child,user=child
+CREATE INDEX i ON t (a::ty);
+----
+db error: ERROR: permission denied for SCHEMA "materialize.public"
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA materialize.public TO joe;
 ----
 COMPLETE 0
 
@@ -727,7 +787,7 @@ CREATE INDEX i1 ON t (a::ty);
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-REVOKE CREATE ON SCHEMA materialize.public FROM joe;
+REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM joe;
 ----
 COMPLETE 0
 
@@ -1161,21 +1221,6 @@ COMPLETE 0
 simple conn=joe,user=joe
 SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for TYPE "materialize.public.ty"
-
-simple conn=child,user=child
-SELECT a::ty FROM t;
-----
-db error: ERROR: permission denied for TYPE "materialize.public.ty"
-
-simple conn=mz_system,user=mz_system
-GRANT USAGE ON TYPE ty TO joe;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-SELECT a::ty FROM t;
-----
 db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
@@ -1185,6 +1230,21 @@ db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+SELECT a::ty FROM t;
+----
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
+
+simple conn=child,user=child
+SELECT a::ty FROM t;
+----
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON TYPE ty TO joe;
 ----
 COMPLETE 0
 
@@ -1439,21 +1499,6 @@ COMPLETE 0
 simple conn=joe,user=joe
 EXPLAIN SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for TYPE "materialize.public.ty"
-
-simple conn=child,user=child
-EXPLAIN SELECT a::ty FROM t;
-----
-db error: ERROR: permission denied for TYPE "materialize.public.ty"
-
-simple conn=mz_system,user=mz_system
-GRANT USAGE ON TYPE ty TO joe;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-EXPLAIN SELECT a::ty FROM t;
-----
 db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=child,user=child
@@ -1463,6 +1508,21 @@ db error: ERROR: permission denied for SCHEMA "materialize.public"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+EXPLAIN SELECT a::ty FROM t;
+----
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
+
+simple conn=child,user=child
+EXPLAIN SELECT a::ty FROM t;
+----
+db error: ERROR: permission denied for TYPE "materialize.public.ty"
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON TYPE ty TO joe;
 ----
 COMPLETE 0
 

--- a/test/testdrive/privilege_checks.td
+++ b/test/testdrive/privilege_checks.td
@@ -37,6 +37,16 @@ REVOKE ALL PRIVILEGES ON SYSTEM FROM materialize;
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
   WITH (SIZE '1')
+contains:permission denied for SCHEMA "materialize.public"
+
+$ postgres-execute connection=mz_system
+GRANT USAGE ON SCHEMA materialize.public TO materialize;
+
+! CREATE SINK s FROM t
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+  WITH (SIZE '1')
 contains:permission denied for CONNECTION "materialize.public.kafka_conn"
 
 $ postgres-execute connection=mz_system
@@ -61,16 +71,6 @@ contains:permission denied for SCHEMA "materialize.public"
 
 $ postgres-execute connection=mz_system
 GRANT CREATE ON SCHEMA materialize.public TO materialize;
-
-! CREATE SINK s FROM t
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE DEBEZIUM
-  WITH (SIZE '1')
-contains:permission denied for SCHEMA "materialize.public"
-
-$ postgres-execute connection=mz_system
-GRANT USAGE ON SCHEMA materialize.public TO materialize;
 
 ! CREATE SINK s FROM t
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
@@ -153,6 +153,17 @@ CREATE SECRET confluent_password AS 'password';
       SASL USERNAME = SECRET confluent_username,
       SASL PASSWORD = SECRET confluent_password
   ) WITH (VALIDATE = false);
+contains:permission denied for SCHEMA "materialize.public"
+
+$ postgres-execute connection=mz_system
+GRANT USAGE ON SCHEMA materialize.public TO materialize;
+
+! CREATE CONNECTION conn TO KAFKA (
+      BROKER '${testdrive.kafka-addr}',
+      SASL MECHANISMS = 'PLAIN',
+      SASL USERNAME = SECRET confluent_username,
+      SASL PASSWORD = SECRET confluent_password
+  ) WITH (VALIDATE = false);
 contains:permission denied for SECRET "materialize.public.confluent_username"
 
 $ postgres-execute connection=mz_system
@@ -188,7 +199,7 @@ GRANT CREATE ON SCHEMA materialize.public TO materialize;
   ) WITH (VALIDATE = false);
 
 $ postgres-execute connection=mz_system
-REVOKE CREATE ON SCHEMA materialize.public FROM materialize;
+REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM materialize;
 REVOKE USAGE ON SECRET confluent_username, confluent_password FROM materialize;
 DROP CONNECTION conn;
 DROP SECRET confluent_username;
@@ -204,6 +215,16 @@ $ kafka-ingest format=avro topic=rbac schema=${int-schema} timestamp=1
 {"f1": 123}
 
 ## WITH SIZE
+
+! CREATE SOURCE s
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rbac-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+  WITH (SIZE '1')
+contains:permission denied for SCHEMA "materialize.public"
+
+$ postgres-execute connection=mz_system
+GRANT USAGE ON SCHEMA materialize.public TO materialize;
 
 ! CREATE SOURCE s
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rbac-${testdrive.seed}')
@@ -271,7 +292,7 @@ GRANT CREATE ON CLUSTER source_cluster TO materialize;
   ENVELOPE NONE
 
 $ postgres-execute connection=mz_system
-REVOKE CREATE ON SCHEMA materialize.public FROM materialize;
+REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM materialize;
 REVOKE USAGE ON CONNECTION kafka_conn, csr_conn FROM materialize;
 REVOKE CREATECLUSTER ON SYSTEM FROM materialize;
 REVOKE CREATE ON CLUSTER source_cluster FROM materialize;


### PR DESCRIPTION
This commit requires callers to have USAGE privileges on the schemas of all connections, secrets, and types used in a query. Previously this privilege was left out, but was often implicitly included if the target of the query was in the same schema. For example,
`SELECT a::schema.ty FROM schema.table` would include the privilege since `t` was in the same schema as `ty`.
`SELECT a::other_schema.ty FROM schema.table` would not include the privilege because `t` was in a different schema as `ty`.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Require callers to have USAGE privileges on the schemas of all connections, secrets, and types used in a query.
