### PR TITLE
sqlsmith: Silence error due to new ACL-related functions

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -150,6 +150,7 @@ known_errors = [
     "out of valid range",
     '" does not exist',  # role does not exist
     "csv_extract number of columns too large",
+    "coalesce types text and oid cannot be matched",  # with ACL-related functions
 ]
 
 


### PR DESCRIPTION
Some of those functions return OIDs which in turn confuses COALESCE.


### Motivation

Nightly SQLsmith was reporting an unhandled error.