### PR TITLE
feature-benchmark: Disable the KafkaRestart scenario

### DIFF
--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -894,7 +894,7 @@ $ kafka-ingest format=avro topic=upsert-unique key-format=avro key-schema=${{key
 
 class KafkaRestart(ScenarioDisabled):
     """This scenario dates from the pre-persistence era where the entire topic was re-ingested from scratch.
-    With presistence however, no reingestion takes place and the scenario ehibits extreme variability.
+    With presistence however, no reingestion takes place and the scenario exhibits extreme variability.
     Instead of re-ingestion, we are measuring mostly the speed of COUNT(*), further obscured by
     the one second timestamp granularity
     """

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -23,6 +23,7 @@ from materialize.feature_benchmark.scenario import (
     BenchmarkingSequence,
     Scenario,
     ScenarioBig,
+    ScenarioDisabled,
 )
 
 
@@ -891,7 +892,13 @@ $ kafka-ingest format=avro topic=upsert-unique key-format=avro key-schema=${{key
         )
 
 
-class KafkaRestart(Scenario):
+class KafkaRestart(ScenarioDisabled):
+    """This scenario dates from the pre-persistence era where the entire topic was re-ingested from scratch.
+    With presistence however, no reingestion takes place and the scenario ehibits extreme variability.
+    Instead of re-ingestion, we are measuring mostly  the speed of COUNT(*), further obscured by
+    the one second timestamp granularity
+    """
+
     def shared(self) -> Action:
         return TdAction(
             self.keyschema()

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -895,7 +895,7 @@ $ kafka-ingest format=avro topic=upsert-unique key-format=avro key-schema=${{key
 class KafkaRestart(ScenarioDisabled):
     """This scenario dates from the pre-persistence era where the entire topic was re-ingested from scratch.
     With presistence however, no reingestion takes place and the scenario ehibits extreme variability.
-    Instead of re-ingestion, we are measuring mostly  the speed of COUNT(*), further obscured by
+    Instead of re-ingestion, we are measuring mostly the speed of COUNT(*), further obscured by
     the one second timestamp granularity
     """
 


### PR DESCRIPTION
This scenario was used to measure re-ingestion speed in the pre-persistence days. With persistence available, no re-ingestion takes place so the scenario measures mostly background noise which leads to false positives.

### Motivation

Nightly CI was failing.