### PR TITLE
    ci: Increase the CRDB sync timeout to 60s

### DIFF
--- a/misc/cockroach/setup_materialize.sql
+++ b/misc/cockroach/setup_materialize.sql
@@ -13,6 +13,8 @@
 -- See: https://github.com/MaterializeInc/materialize/issues/16726
 SET CLUSTER SETTING sql.stats.forecasts.enabled = false;
 
+SET CLUSTER SETTING storage.max_sync_duration.fatal.enabled = false;
+
 CREATE SCHEMA IF NOT EXISTS consensus;
 CREATE SCHEMA IF NOT EXISTS adapter;
 CREATE SCHEMA IF NOT EXISTS storage;

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -59,6 +59,12 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_next_listen_batch_retryer_initial_backoff": "1200ms",
 }
 
+DEFAULT_CRDB_ENVIRONMENT = [
+    "COCKROACH_ENGINE_MAX_SYNC_DURATION_DEFAULT=60s",
+    "COCKROACH_LOG_MAX_SYNC_DURATION=60s",
+]
+
+
 # TODO(benesch): change to `docker-mzcompose` once v0.39 ships.
 DEFAULT_MZ_ENVIRONMENT_ID = "mzcompose-test-00000000-0000-0000-0000-000000000000-0"
 
@@ -115,6 +121,7 @@ class Materialized(Service):
             "MZ_LOG_FILTER",
             "CLUSTERD_LOG_FILTER",
             *environment_extra,
+            *DEFAULT_CRDB_ENVIRONMENT,
         ]
 
         if system_parameter_defaults is None:
@@ -561,6 +568,7 @@ class Cockroach(Service):
                 "init": True,
                 "healthcheck": healthcheck,
                 "restart": restart,
+                "environment": DEFAULT_CRDB_ENVIRONMENT,
             },
         )
 


### PR DESCRIPTION
```
commit 006ed232eb4d868bdfdc7d10b66e196a787e9e98 (HEAD -> crdb-disable-fail, origin/crdb-disable-fail)
Author: Philip Stoev <pstoev@materialize.com>
Date:   Tue Jul 25 11:44:36 2023 +0200

    ci: Increase the CRDB sync timeout to 60s
    
    In the CI, CRDB get starved, which causes it to fail with
    
    * FATAL: disk stall detected: unable to sync log files within 20s
    
    increase the relevant timeouts (which seems to work) as well as make
    an attempt to make the condition non-fatal (which does not seem to
    work as advertised).
    
    Fixes: #19809

```
### Motivation

The message was pervasive throughout the CI and this particular set of settings is the only one that allows the Release Qualification feature benchmark to run to completion.