### PR TITLE
stash: Fix tiny TODO

### DIFF
--- a/src/stash/src/objects.rs
+++ b/src/stash/src/objects.rs
@@ -182,7 +182,7 @@ mod test {
     use std::fs;
     use std::io::{BufRead, BufReader};
 
-    use crate::STASH_VERSION;
+    use crate::{MIN_STASH_VERSION, STASH_VERSION};
 
     // Note: Feel free to update this path if the protos move.
     const PROTO_DIRECTORY: &str = "protos";
@@ -201,10 +201,7 @@ mod test {
         assert!(filenames.remove("objects.proto"));
 
         // Assert snapshots exist for all of the versions we support.
-        //
-        // TODO(parkmycar): Change `15` to be MIN_STASH_VERSION, once we delete all of the JSON
-        // migration code.
-        for version in 15..=STASH_VERSION {
+        for version in MIN_STASH_VERSION..=STASH_VERSION {
             let filename = format!("objects_v{version}.proto");
             assert!(
                 filenames.remove(&filename),


### PR DESCRIPTION
### Motivation

Missed this when I merged #20601 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
