### PR TITLE
storage/pg: produce definite errors at latest LSN

### DIFF
--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -241,7 +241,7 @@ impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
                                 .await
                                 .expect("error creating persist client");
 
-                            let write_handle = client
+                            let mut write_handle = client
                                 .open_writer::<SourceData, (), T, Diff>(
                                     *data_shard,
                                     Arc::new(relation_desc.clone()),
@@ -253,7 +253,8 @@ impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
                                 )
                                 .await
                                 .unwrap();
-                            resume_uppers.insert(*id, write_handle.upper().clone());
+                            let upper = write_handle.fetch_recent_upper().await;
+                            resume_uppers.insert(*id, upper.clone());
                             write_handle.expire().await;
 
                             // TODO(petrosagg): The as_of of the ingestion should normally be based


### PR DESCRIPTION
In #20370 experienced a flake in the `pg-cdc` test. @petrosagg and I determined this was caused by the definite error we expected in one of the tests getting "swallowed" by the "self-correcting" behavior of the persist sink, which ignores any data produced at times less than its upper.

We're investigating why this regression occurred under the conditions in #20370, but this change is unobjectionable irrespective of the outcome of that investigation.

### Motivation

This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/pull/20370#issuecomment-1642715755

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
