### PR TITLE
persist: remove sql_stats_automatic_collection_enabled alter

### DIFF
--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -253,12 +253,8 @@ impl PostgresConsensus {
         // See: https://www.cockroachlabs.com/docs/stable/configure-zone.html#variables
         client
             .batch_execute(&format!(
-                "{} {} {}",
-                SCHEMA,
-                "ALTER TABLE consensus CONFIGURE ZONE USING gc.ttlseconds = 600;",
-                // This is in SCHEMA, which sets it for new tables, but we also
-                // need to set it for existing envs.
-                "ALTER TABLE consensus SET (sql_stats_automatic_collection_enabled = false);"
+                "{} {}",
+                SCHEMA, "ALTER TABLE consensus CONFIGURE ZONE USING gc.ttlseconds = 600;",
             ))
             .await?;
 


### PR DESCRIPTION
CRDB seems to be hanging on this in the crdb-restarts test. It's just to automatically fix up existing environments, so not worth digging into this too much. We'll just have to make sure that we manually backfill all envs after the CREATE TABLE change rolls out.

Fixes #20753

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
