### PR TITLE
Build and publish the lexer to npm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3158,6 +3158,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lol_alloc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36aabc32b791f1a506e0bb90e0fa03e983500549d7b1f2dad45b5fc20ef45974"
+dependencies = [
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "loom"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4945,11 +4954,13 @@ name = "mz-sql-lexer"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "lol_alloc",
  "mz-ore",
  "phf",
  "phf_codegen",
  "serde",
  "uncased",
+ "wasm-bindgen",
  "workspace-hack",
 ]
 
@@ -6705,7 +6716,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -7387,6 +7398,15 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "ssh-key"

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -171,14 +171,15 @@ case "$cmd" in
             --env AWS_SESSION_TOKEN
             --env CI
             --env CI_COVERAGE_ENABLED
+            --env CONFLUENT_CLOUD_DEVEX_KAFKA_PASSWORD
+            --env CONFLUENT_CLOUD_DEVEX_KAFKA_USERNAME
             --env GITHUB_TOKEN
             --env GPG_KEY
             --env LAUNCHDARKLY_API_TOKEN
             --env LAUNCHDARKLY_SDK_KEY
             --env NIGHTLY_CANARY_APP_PASSWORD
-            --env CONFLUENT_CLOUD_DEVEX_KAFKA_USERNAME
-            --env CONFLUENT_CLOUD_DEVEX_KAFKA_PASSWORD
             --env NO_COLOR
+            --env NPM_TOKEN
             --env POLAR_SIGNALS_API_TOKEN
             --env PYPI_TOKEN
             # For Miri with nightly Rust

--- a/bin/wasm-build
+++ b/bin/wasm-build
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# wasm-build — build a crate for WASM32
+
+set -euo pipefail
+
+. misc/shlib/shlib.bash
+
+# Unset existing flags because several linker-specific ones don't play nicely with WASM targets
+export RUSTFLAGS=
+
+if [[ $# -lt 1 ]]
+then
+    echo "usage: $0 <path>
+
+Builds a WASM32 target and NPM metadata for the specified crate
+
+    path        the path to the crate"
+    exit 1
+fi
+crate=$1
+
+exec "$(dirname "$0")"/xcompile \
+    tool \
+    --no-name-target-prefix \
+    wasm-pack \
+    build \
+    --release \
+    --scope materializeinc \
+    "$crate" \
+    -- \
+    --no-default-features

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -164,7 +164,11 @@ RUN mkdir rust \
         PATH=$PATH:/root/.cargo/bin cargo miri setup \
         ;; \
     esac \
-    && rm -rf rust \
+    && curl -fsSL https://static.rust-lang.org/dist$RUST_DATE/rust-std-$RUST_VERSION-wasm32-unknown-unknown.tar.gz > rust.tar.gz \
+    && curl -fsSL https://static.rust-lang.org/dist$RUST_DATE/rust-std-$RUST_VERSION-wasm32-unknown-unknown.tar.gz.asc > rust.asc \
+    && gpg --verify rust.asc rust.tar.gz \
+    && tar -xzf rust.tar.gz -C /usr/local/lib/rustlib/ --strip-components=4 \
+    && rm -rf rust.asc rust.tar.gz rust \
     && cargo install --root /usr/local --version "=0.5.2" --locked cargo-about \
     && cargo install --root /usr/local --version "=1.40.5" --locked cargo-deb \
     && cargo install --root /usr/local --version "=0.12.2" --locked cargo-deny \
@@ -174,7 +178,8 @@ RUN mkdir rust \
     && `: Until https://github.com/est31/cargo-udeps/pull/147 is released in cargo-udeps` \
     && cargo install --root /usr/local --git https://github.com/est31/cargo-udeps --rev=b84d478ef3efd7264dba8c15c31a50c6399dc5bb --locked cargo-udeps --features=vendored-openssl \
     && cargo install --root /usr/local --version "=0.2.15" --no-default-features --features=s3,openssl/vendored sccache \
-    && cargo install --root /usr/local --version "=0.3.6" cargo-binutils
+    && cargo install --root /usr/local --version "=0.3.6" cargo-binutils \
+    && cargo install --root /usr/local --version "=0.12.1" wasm-pack
 
 # Link the system lld into the cross-compiling sysroot.
 

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -97,6 +97,7 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
     lld \
     llvm \
     make \
+    npm \
     openssh-client \
     pkg-config \
     postgresql-client-14 \

--- a/ci/deploy/npm.py
+++ b/ci/deploy/npm.py
@@ -1,0 +1,167 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import requests
+from semver.version import VersionInfo
+
+from materialize import ROOT, cargo, spawn
+
+logging.basicConfig(
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    level=os.environ.get("MZ_DEV_LOG", "INFO").upper(),
+)
+logger = logging.getLogger(__name__)
+
+PUBLISH_CRATES = ["mz-sql-lexer"]
+
+
+@dataclass(frozen=True)
+class Version:
+    rust: VersionInfo
+    node: str
+    is_development: bool
+
+
+def generate_version(
+    crate_version: VersionInfo, build_identifier: Optional[int]
+) -> Version:
+    node_version = str(crate_version)
+    is_development = False
+    if crate_version.prerelease == "dev":
+        if build_identifier is None:
+            raise ValueError(
+                "a build identifier must be provided for prerelease builds"
+            )
+        node_version = str(crate_version.replace(prerelease=f"dev.{build_identifier}"))
+        is_development = True
+    else:
+        buildkite_tag = os.environ.get("BUILDKITE_TAG")
+        assert (
+            buildkite_tag == node_version
+        ), f"Buildkite tag ({buildkite_tag}) does not match environmentd version ({crate_version})"
+    return Version(rust=crate_version, node=node_version, is_development=is_development)
+
+
+def build_package(version: Version, crate_path: Path) -> Path:
+    spawn.runv(["bin/wasm-build", str(crate_path)])
+    package_path = crate_path / "pkg"
+    shutil.copyfile(str(ROOT / "LICENSE"), str(package_path / "LICENSE"))
+    with open(package_path / "package.json", "r+") as package_file:
+        package = json.load(package_file)
+        # Since all packages are scoped to the MaterializeInc org, names don't need prefixes
+        package["name"] = package["name"].replace("/mz-", "/")
+        package["version"] = version.node
+        package["license"] = "SEE LICENSE IN 'LICENSE'"
+        package["repository"] = "github:MaterializeInc/materialize"
+        package_file.seek(0)
+        json.dump(package, package_file, indent=2)
+    return package_path
+
+
+def release_package(version: Version, package_path: Path) -> None:
+    with open(package_path / "package.json", "r") as package_file:
+        package = json.load(package_file)
+    name = package["name"]
+    dist_tag = "dev" if version.is_development else "latest"
+    if version_exists_in_npm(name, version):
+        logger.warning("%s %s already released, skipping.", name, version.node)
+        return
+    else:
+        logger.info("Releasing %s %s", name, version.node)
+        set_npm_credentials(package_path)
+        spawn.runv(
+            ["npm", "publish", "--access", "public", "--tag", dist_tag],
+            cwd=package_path,
+        )
+
+
+def build_all(
+    workspace: cargo.Workspace, version: Version, *, do_release: bool = True
+) -> None:
+    for crate_name in PUBLISH_CRATES:
+        crate_path = workspace.crates[crate_name].path
+        logger.info("Building %s @ %s", crate_path, version.node)
+        package_path = build_package(version, crate_path)
+        logger.info("Built %s", crate_path)
+        if do_release:
+            release_package(version, package_path)
+            logger.info("Released %s", package_path)
+        else:
+            logger.info("Skipping release for %s", package_path)
+
+
+def version_exists_in_npm(name: str, version: Version) -> bool:
+    quoted = urllib.parse.quote(name)
+    res = requests.get(f"https://registry.npmjs.org/{quoted}/{version.node}")
+    if res.status_code == 404:
+        # This is a new package
+        return False
+    res.raise_for_status()
+    return True
+
+
+def set_npm_credentials(package_path: Path) -> None:
+    (package_path / ".npmrc").write_text(
+        "//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        "npm.py", description="build and publish NPM packages"
+    )
+    parser.add_argument(
+        "-v,--verbose",
+        action="store_true",
+        dest="verbose",
+        help="Enable verbose logging",
+    )
+    parser.add_argument(
+        "--release",
+        action=argparse.BooleanOptionalAction,
+        dest="do_release",
+        default=True,
+        help="Whether or not the built package should be released",
+    )
+    parser.add_argument(
+        "--build-id",
+        type=int,
+        help="An optional build identifier. Used in pre-release version numbers",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+    build_id = args.build_id
+    if os.environ.get("BUILDKITE_BUILD_NUMBER") is not None:
+        if build_id is not None:
+            logger.warning(
+                "Build ID specified via both envvar and CLI arg. Using CLI value"
+            )
+        else:
+            build_id = int(os.environ["BUILDKITE_BUILD_NUMBER"])
+    if args.do_release and "NPM_TOKEN" not in os.environ:
+        raise ValueError("'NPM_TOKEN' must be set")
+    workspace = cargo.Workspace(ROOT)
+    crate_version = workspace.crates["mz-environmentd"].version
+    version = generate_version(crate_version, build_id)
+    build_all(workspace, version, do_release=args.do_release)

--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -39,6 +39,16 @@ steps:
       manual:
         permit_on_passed: true
 
+  - command: bin/ci-builder run stable bin/pyactivate -m ci.deploy.npm
+    timeout_in_minutes: 30
+    concurrency: 1
+    concurrency_group: deploy/npm
+    agents:
+      queue: linux-x86_64
+    retry:
+      manual:
+        permit_on_passed: true
+
   - label: ":bulb: Full SQL Logic Tests"
     trigger: sql-logic-tests
     async: true

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -40,6 +40,16 @@ steps:
       queue: builder-linux-aarch64
     coverage: skip
 
+  - id: build-wasm
+    label: Build WASM
+    command: bin/ci-builder run stable bin/pyactivate -m ci.deploy.npm --no-release
+    inputs:
+      - "*"
+    timeout_in_minutes: 10
+    agents:
+      queue: linux-x86_64
+    coverage: skip
+
   - id: check-merge-with-target
     label: Merge skew cargo check
     command: ci/test/check-merge-with-target.sh

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,9 @@ multiple-versions = "deny"
 skip = [
     # One-time exception for base64 due to its prevalence in the crate graph.
     { name = "base64", version = "0.13.1" },
+    # `ring` depends on an older version of this crate. The dependency will be
+    #  upgraded to 0.9 when they publish 0.17.
+    { name = "spin", version = "0.9.8" },
     # `syn` is a core crate that a huge part of the ecosystem either directly, or
     # transitively depends on. They just released v2.0 which not all crates have
     # migrated to yet.

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -85,6 +85,22 @@ Confluent Platform, as it is a rather heavy dependency. Most Materialize
 employees, or other major contributors, will probably need to run the full test
 suite and should therefore install the Confluent Platform.
 
+
+### WebAssembly / WASM
+
+Some crates are compiled to WebAssembly and published to npm. This is
+accomplished through `wasm-pack`. Install it by running:
+
+```shell
+cargo install wasm-pack
+```
+
+WASM builds can then be initiated through
+
+```shell
+./bin/wasm-build <path/to/crate>
+```
+
 #### All platforms
 
 First, install the CLI. As of early July 2022 you can run this command on

--- a/misc/python/materialize/cli/xcompile.py
+++ b/misc/python/materialize/cli/xcompile.py
@@ -57,6 +57,12 @@ def main() -> int:
     tool_parser = subparsers.add_parser(
         "tool", help="run a cross-compiling binutils tool"
     )
+    tool_parser.add_argument(
+        "--name-target-prefix",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="whether the tool name should be prefixed with the target name",
+    )
     tool_parser.add_argument("tool", metavar="TOOL", help="the binutils tool to invoke")
     tool_parser.add_argument(
         "subargs", nargs=argparse.REMAINDER, help="the arguments to pass to the tool"
@@ -78,7 +84,9 @@ def main() -> int:
     elif args.command == "tool":
         spawn.runv(
             [
-                *xcompile.tool(args.arch, args.tool),
+                *xcompile.tool(
+                    args.arch, args.tool, prefix_name=args.name_target_prefix
+                ),
                 *args.subargs,
             ]
         )

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -119,22 +119,27 @@ def cargo(
     ]
 
 
-def tool(arch: Arch, name: str, channel: Optional[str] = None) -> List[str]:
+def tool(
+    arch: Arch, name: str, channel: Optional[str] = None, prefix_name: bool = True
+) -> List[str]:
     """Constructs a cross-compiling binutils tool invocation.
 
     Args:
         arch: The CPU architecture to build for.
         name: The name of the binutils tool to invoke.
         channel: The Rust toolchain channel to use. Either None/"stable" or "nightly".
+        prefix_name: Whether or not the tool name should be prefixed with the target
+            architecture.
 
     Returns:
         A list of arguments specifying the beginning of the command to invoke.
     """
     if sys.platform == "darwin":
         _bootstrap_darwin(arch)
+    tool_name = f"{target(arch)}-{name}" if prefix_name else name
     return [
         *_enter_builder(arch, channel),
-        f"{target(arch)}-{name}",
+        tool_name,
     ]
 
 

--- a/src/sql-lexer/Cargo.toml
+++ b/src/sql-lexer/Cargo.toml
@@ -6,12 +6,19 @@ edition.workspace = true
 rust-version.workspace = true
 publish = false
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 mz-ore = { path = "../ore", default-features = false, features = ["stack"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 serde = { version = "1.0.152", features = ["derive"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 uncased = "0.9.7"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2.63"
+lol_alloc = "0.4.0"
 
 [dev-dependencies]
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
@@ -28,3 +35,7 @@ default = ["workspace-hack"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
+
+[package.metadata.wasm-pack.profile.release]
+# Optimize for small code size. Verified this is better than 'Os'
+wasm-opt = ['-Oz']

--- a/src/sql-lexer/README.md
+++ b/src/sql-lexer/README.md
@@ -1,0 +1,3 @@
+# Materialize SQL lexer
+
+Tokenize a SQL string for parsing.

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -30,7 +30,7 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::option::OptionExt;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
 use mz_sql_lexer::keywords::*;
-use mz_sql_lexer::lexer::{self, LexerError, Token};
+use mz_sql_lexer::lexer::{self, LexerError, PosToken, Token};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 use IsLateral::*;
@@ -271,7 +271,7 @@ impl From<Keyword> for Ident {
 /// SQL Parser
 struct Parser<'a> {
     sql: &'a str,
-    tokens: Vec<(Token, usize)>,
+    tokens: Vec<PosToken>,
     /// The index of the first unprocessed token in `self.tokens`
     index: usize,
     recursion_guard: RecursionGuard,
@@ -306,7 +306,7 @@ enum SetPrecedence {
 
 impl<'a> Parser<'a> {
     /// Parse the specified tokens
-    fn new(sql: &'a str, tokens: Vec<(Token, usize)>) -> Self {
+    fn new(sql: &'a str, tokens: Vec<PosToken>) -> Self {
         Parser {
             sql,
             tokens,
@@ -1552,17 +1552,16 @@ impl<'a> Parser<'a> {
 
     /// Return the nth token that has not yet been processed.
     fn peek_nth_token(&self, n: usize) -> Option<Token> {
-        self.tokens.get(self.index + n).map(|(t, _)| t.clone())
+        self.tokens
+            .get(self.index + n)
+            .map(|token| token.kind.clone())
     }
 
     /// Return the next token that has not yet been processed, or None if
     /// reached end-of-file, and mark it as processed. OK to call repeatedly
     /// after reaching EOF.
     fn next_token(&mut self) -> Option<Token> {
-        let token = self
-            .tokens
-            .get(self.index)
-            .map(|(token, _range)| token.clone());
+        let token = self.tokens.get(self.index).map(|token| token.kind.clone());
         self.index += 1;
         token
     }
@@ -1579,7 +1578,7 @@ impl<'a> Parser<'a> {
     /// next token starts.
     fn peek_pos(&self) -> usize {
         match self.tokens.get(self.index) {
-            Some((_token, pos)) => *pos,
+            Some(token) => token.offset,
             None => self.sql.len(),
         }
     }
@@ -1592,7 +1591,7 @@ impl<'a> Parser<'a> {
     fn peek_prev_pos(&self) -> usize {
         assert!(self.index > 0);
         match self.tokens.get(self.index - 1) {
-            Some((_token, pos)) => *pos,
+            Some(token) => token.offset,
             None => self.sql.len(),
         }
     }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature: Fixes #20313 

Following #20345, let's publish the lexer to npm! This PR contains the three phases of the change, each in its own commit with details in the message. To summarize, they:

  1. **Enable WebAssembly (WASM) compilation of `mz-sql-lexer`**. Perform the necessary updates to be able to compile the lexer to WASM targets as well as make it ergonomic for JS/TS callers. This includes a special allocator that reduces the bundle size.
  2. **Enable WASM cross-compilation**. This updates ci-builder and xcompile to support WASM targets, as well as the `wasm-pack` tool. It also includes a wrapper script to codify invocation parameters.
  3. **Compile the Lexer to WASM and publish it to npm**. This brings it all together by using a deploy script to compile tracked crates to WebAssembly and publish them to npm. This requires a npm access token with write access to the `@materializinc` namespace` be added to the Buildkite environment. [A sample npm listing is here](https://www.npmjs.com/package/@arumz/mz-sql-lexer?activeTab=versions) (please ignore the incorrect package name held over from testing).

#### CI updates

Two additional CI jobs are added to the PR and deploy pipelines:

1. We validate that all WASM targets can be built with each PR.
2. We build and publish all WASM packages to npm with each merge to `main`.  For dev builds, this uses pre-release versioning with a build identifier derived from the Buildkite build ID.

#### cargo-deny exemption

The custom allocator (`lol_alloc`) depends on spin 0.9, while `ring` (a dependency of `aws-config`) depends on 0.5. This is fixed on `ring`'s main branch, but it has not yet made it to a stable release. The last stable release for `ring` is 2+ years old, and the last unstable release is 8 months old. [The ring dep may disappear altogether in a future version of aws-config](https://github.com/awslabs/smithy-rs/issues/2087). Given the alternate version of this crate is only used when targeting WASM, I believe this exemption is fine to carve out.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

These are grouped by commit, and each commit message includes additional information.

Unfortunately, I had to disable TypeScript definition autogeneration for the `lex` function as `js-sys` does not provide adequate support for container types (i.e., it would return `Array` instead of `Token[]`).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
