### PR TITLE
rust: Bump MSRV to 1.71

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6260,9 +6260,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.68.2"
+rust-version = "1.71.0"
 
 [profile.dev]
 # TODO(gusywnn|benesch): remove this when incremental ice's are improved

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-NIGHTLY_RUST_DATE=2023-05-28
+NIGHTLY_RUST_DATE=2023-07-24
 
 cd "$(dirname "$0")/.."
 

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-NIGHTLY_RUST_DATE=2023-07-24
+NIGHTLY_RUST_DATE=2023-06-27
 
 cd "$(dirname "$0")/.."
 

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-NIGHTLY_RUST_DATE=2023-04-09
+NIGHTLY_RUST_DATE=2023-05-28
 
 cd "$(dirname "$0")/.."
 

--- a/src/expr-parser/Cargo.toml
+++ b/src/expr-parser/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 mz-expr = { path = "../expr" }
 mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
-proc-macro2 = { version = "1.0.47", features = ["span-locations"] }
+proc-macro2 = { version = "1.0.60", features = ["span-locations"] }
 syn = { version = "2.0.18", features = ["full"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/expr-test-util/Cargo.toml
+++ b/src/expr-test-util/Cargo.toml
@@ -12,7 +12,7 @@ mz-lowertest = { path = "../lowertest" }
 mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
 mz-repr-test-util = { path = "../repr-test-util" }
-proc-macro2 = "1.0.47"
+proc-macro2 = "1.0.60"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -57,7 +57,7 @@ criterion = { version = "0.4.0" }
 datadriven = "0.6.0"
 mz-expr-test-util = { path = "../expr-test-util" }
 mz-ore = { path = "../ore" }
-proc-macro2 = "1.0.47"
+proc-macro2 = "1.0.60"
 
 [build-dependencies]
 prost-build = "0.11.2"

--- a/src/lowertest-derive/Cargo.toml
+++ b/src/lowertest-derive/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.47"
+proc-macro2 = "1.0.60"
 quote = "1.0.23"
 syn = { version = "1.0.107", features = ["extra-traits", "printing"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/lowertest/Cargo.toml
+++ b/src/lowertest/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 mz-lowertest-derive = { path = "../lowertest-derive" }
 mz-ore = { path = "../ore" }
-proc-macro2 = "1.0.47"
+proc-macro2 = "1.0.60"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -965,8 +965,6 @@ impl<T: Timestamp + Lattice + Codec64> ReferencedBlobValidator<T> {
         }
     }
     fn validate_against_state(&mut self, x: &State<T>) {
-        use std::borrow::Borrow;
-
         use mz_ore::collections::HashSet;
         use timely::PartialOrder;
 
@@ -998,13 +996,13 @@ impl<T: Timestamp + Lattice + Codec64> ReferencedBlobValidator<T> {
             .inc_batches
             .iter()
             .flat_map(|x| x.parts.iter())
-            .map(|x| x.key.borrow())
+            .map(|x| &*x.key)
             .collect();
         let full_parts = self
             .full_batches
             .iter()
             .flat_map(|x| x.parts.iter())
-            .map(|x| x.key.borrow())
+            .map(|x| &*x.key)
             .collect();
         assert_eq!(inc_parts, full_parts);
 

--- a/src/prof/src/http/mod.rs
+++ b/src/prof/src/http/mod.rs
@@ -84,7 +84,7 @@ pub struct FlamegraphTemplate<'a> {
     pub mzfg: &'a str,
 }
 
-#[allow(clippy::drop_copy)]
+#[allow(dropping_copy_types)]
 async fn time_prof<'a>(
     merge_threads: bool,
     build_info: &BuildInfo,

--- a/src/repr-test-util/Cargo.toml
+++ b/src/repr-test-util/Cargo.toml
@@ -11,7 +11,7 @@ chrono = { version = "0.4.23", default-features = false, features = ["serde", "s
 mz-lowertest = { path = "../lowertest" }
 mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
-proc-macro2 = "1.0.47"
+proc-macro2 = "1.0.60"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/src/stash/src/upgrade/v28_to_v29.rs
+++ b/src/stash/src/upgrade/v28_to_v29.rs
@@ -251,11 +251,6 @@ mod tests {
                 value: Some(objects_v29::database_id::Value::User(42)),
             }),
         };
-        const DANGLING_DATABASE_ID_V29: objects_v29::DatabaseKey = objects_v29::DatabaseKey {
-            id: Some(objects_v29::DatabaseId {
-                value: Some(objects_v29::database_id::Value::User(1)),
-            }),
-        };
 
         const SCHEMA_ID_V28: objects_v28::SchemaKey = objects_v28::SchemaKey {
             id: Some(objects_v28::SchemaId {
@@ -270,11 +265,6 @@ mod tests {
         const SCHEMA_ID_V29: objects_v29::SchemaKey = objects_v29::SchemaKey {
             id: Some(objects_v29::SchemaId {
                 value: Some(objects_v29::schema_id::Value::User(42)),
-            }),
-        };
-        const DANGLING_SCHEMA_ID_V29: objects_v29::SchemaKey = objects_v29::SchemaKey {
-            id: Some(objects_v29::SchemaId {
-                value: Some(objects_v29::schema_id::Value::User(1)),
             }),
         };
 

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -204,6 +204,7 @@ mod tests {
 
     // Test suite
     #[mz_ore::test(tokio::test(start_paused = true))]
+    #[cfg_attr(miri, ignore)] //  unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn test_startup() {
         let persist_cache = persist_cache();
         let healthchecker = simple_healthchecker(ShardId::new(), 1, &persist_cache).await;
@@ -226,6 +227,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test(start_paused = true))]
+    #[cfg_attr(miri, ignore)] //  unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn test_bootstrap_different_sources() {
         let shard_id = ShardId::new();
         let persist_cache = persist_cache();
@@ -246,6 +248,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test(start_paused = true))]
+    #[cfg_attr(miri, ignore)] //  unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn test_repeated_update() {
         let shard_id = ShardId::new();
         let persist_cache = persist_cache();
@@ -285,6 +288,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test(start_paused = true))]
+    #[cfg_attr(miri, ignore)] //  unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn test_forbidden_transition() {
         let shard_id = ShardId::new();
         let persist_cache = persist_cache();

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -28,7 +28,7 @@ mz-expr-parser = { path = "../expr-parser" }
 mz-expr-test-util = { path = "../expr-test-util" }
 mz-lowertest = { path = "../lowertest" }
 mz-ore = { path = "../ore", features = ["test"] }
-proc-macro2 = "1.0.47"
+proc-macro2 = "1.0.60"
 serde_json = "1.0.89"
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -75,7 +75,7 @@ phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
-proc-macro2 = { version = "1.0.59", features = ["span-locations"] }
+proc-macro2 = { version = "1.0.66", features = ["span-locations"] }
 prost = { version = "0.11.9", features = ["no-recursion-limit"] }
 prost-reflect = { version = "0.11.4", default-features = false, features = ["serde"] }
 prost-types = { version = "0.11.9" }
@@ -176,7 +176,7 @@ phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
-proc-macro2 = { version = "1.0.59", features = ["span-locations"] }
+proc-macro2 = { version = "1.0.66", features = ["span-locations"] }
 prost = { version = "0.11.9", features = ["no-recursion-limit"] }
 prost-reflect = { version = "0.11.4", default-features = false, features = ["serde"] }
 prost-types = { version = "0.11.9" }


### PR DESCRIPTION
Bumps our MSRV to 1.71, the latest stable, and fixes any new lints that came because of this version.

### Motivation

I wanted to use `std::cell::OnceCell` which was stabilized in `1.70`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
