### PR TITLE
Don't push `error_if_null` through a Join

### DIFF
--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -850,9 +850,18 @@ impl PredicatePushdown {
             // equivalences allow the predicate to be rewritten
             // in terms of only columns from that input.
             for (index, push_down) in push_downs.iter_mut().enumerate() {
-                if predicate.is_literal_err() {
+                if predicate.is_literal_err() || predicate.contains_error_if_null() {
                     // Do nothing. We don't push down literal errors,
                     // as we can't know the join will be non-empty.
+                    //
+                    // We also don't want to push anything that involves `error_if_null`. This is
+                    // for the same reason why in theory we shouldn't really push anything that can
+                    // error, assuming that we want to preserve error semantics. (Because we would
+                    // create a spurious error if some other Join input ends up empty.) We can't fix
+                    // this problem in general (as we can't just not push anything that might
+                    // error), but we decided to fix the specific problem instance involving
+                    // `error_if_null`, because it was very painful:
+                    // <https://github.com/MaterializeInc/materialize/issues/20769>
                 } else {
                     let mut localized = predicate.clone();
                     if input_mapper.try_localize_to_input_with_bound_expr(

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -876,3 +876,29 @@ with
   )
 select * from v1
 WHERE credits_per_hour > credits_per_hour;
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/20199
+
+statement ok
+CREATE ROLE r2;
+
+statement ok
+SELECT
+    member.name AS grantee,
+    role.name AS role_name
+FROM mz_role_members membership
+JOIN mz_roles role ON membership.role_id = role.id
+JOIN mz_roles member ON membership.member = member.id
+WHERE pg_has_role('r2', member.oid, 'USAGE');
+
+query error db error: ERROR: role "r555" does not exist
+SELECT
+    member.name AS grantee,
+    role.name AS role_name
+FROM mz_role_members membership
+JOIN mz_roles role ON membership.role_id = role.id
+JOIN mz_roles member ON membership.member = member.id
+WHERE pg_has_role('r555', member.oid, 'USAGE');
+
+query error db error: ERROR: role "aaa" does not exist
+select * from (select 'aaa' as aaa) where pg_has_role('r2', aaa, 'USAGE');


### PR DESCRIPTION
Fixes #20769

Look at the 6th `predicate_pushdown` in this trace (counting from the top of the page): https://gist.github.com/ggevay/6645e66938ae515efb804b6e93fa7e75
It's pushing a predicate that involves `error_if_null` through several Joins. The second Join (the CrossJoin) is an instance of the empty-scalar-subquery-results-in-a-single-null pattern. The bug occurs in the CrossJoin as follows:
- The first input of the CrossJoin is usually empty (i.e., when the scalar subquery is not empty).
- The second Join input has a constant null at the bottom, coming from the above-mentioned pattern.
- Starting from that constant null, we const fold the second join input into an error.
- Unfortunately, both Join const folding and Join rendering will propagate an error from an input even when an other input is empty.

This PR prevents `PredicatePushdown` from pushing any such predicate through a Join that involves `error_if_null`.

@jkosh44, can you please check that the tests make sense (and maybe suggest more tests)?

### Motivation

  * This PR fixes a recognized bug: #20769

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
