### PR TITLE
adapter: Fix DROP OWNED with linked clusters

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4034,7 +4034,7 @@ pub fn plan_drop_owned(
 
     // Clusters
     for cluster in scx.catalog.get_clusters() {
-        // We skip over linked cluster because they will be added later when collecting
+        // We skip over linked clusters because they will be added later when collecting
         // the dependencies of the linked object.
         if cluster.linked_object_id().is_none() && role_ids.contains(&cluster.owner_id()) {
             if !cascade && !cluster.bound_objects().is_empty() {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4034,7 +4034,7 @@ pub fn plan_drop_owned(
 
     // Clusters
     for cluster in scx.catalog.get_clusters() {
-        // We skip over linked cluster replicas because they will be added later when collecting
+        // We skip over linked cluster because they will be added later when collecting
         // the dependencies of the linked object.
         if cluster.linked_object_id().is_none() && role_ids.contains(&cluster.owner_id()) {
             if !cascade && !cluster.bound_objects().is_empty() {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4024,14 +4024,19 @@ pub fn plan_drop_owned(
 
     // Replicas
     for replica in scx.catalog.get_cluster_replicas() {
-        if role_ids.contains(&replica.owner_id()) {
+        let cluster = scx.catalog.get_cluster(replica.cluster_id());
+        // We skip over linked cluster replicas because they will be added later when collecting
+        // the dependencies of the linked object.
+        if cluster.linked_object_id().is_none() && role_ids.contains(&replica.owner_id()) {
             drop_ids.push((replica.cluster_id(), replica.replica_id()).into());
         }
     }
 
     // Clusters
     for cluster in scx.catalog.get_clusters() {
-        if role_ids.contains(&cluster.owner_id()) {
+        // We skip over linked cluster replicas because they will be added later when collecting
+        // the dependencies of the linked object.
+        if cluster.linked_object_id().is_none() && role_ids.contains(&cluster.owner_id()) {
             if !cascade && !cluster.bound_objects().is_empty() {
                 sql_bail!(
                     "cannot drop cluster {} without CASCADE while it contains active objects",

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -2624,7 +2624,7 @@ COMPLETE 0
 statement ok
 CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (SIZE '1')
 
-query T
+query TT
 SELECT name, type FROM mz_objects WHERE name = 's'
 ----
 s  source
@@ -2632,7 +2632,7 @@ s  source
 statement ok
 DROP OWNED BY materialize CASCADE
 
-query T
+query TT
 SELECT name, type FROM mz_objects WHERE name = 's'
 ----
 

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -2619,6 +2619,23 @@ GRANT ALL PRIVILEGES ON SYSTEM TO materialize;
 ----
 COMPLETE 0
 
+## Test linked clusters
+
+statement ok
+CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (SIZE '1')
+
+query T
+SELECT name, type FROM mz_objects WHERE name = 's'
+----
+s  source
+
+statement ok
+DROP OWNED BY materialize CASCADE
+
+query T
+SELECT name, type FROM mz_objects WHERE name = 's'
+----
+
 # Test REASSIGN OWNED
 
 statement ok


### PR DESCRIPTION
Previously, when trying to drop a source with a linked cluster via `DROP OWNED`, `environmentd` would panic. The issue was that the objects were being dropped in the wrong order. Linked clusters are properly added to the list of dropped IDs when collecting the source's dependencies, so we can skip over them when initially gathering objects owned by the target role.

Fixes #20780

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix `DROP OWNED`
