### PR TITLE
adapter: Fix cascade semantics with DROP OWNED

### DIFF
--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -2619,6 +2619,90 @@ GRANT ALL PRIVILEGES ON SYSTEM TO materialize;
 ----
 COMPLETE 0
 
+## Testing dropping a cluster with bound objects
+
+statement ok
+CREATE CLUSTER c REPLICAS (r1 (SIZE '1'));
+
+statement ok
+CREATE MATERIALIZED VIEW mv IN CLUSTER c AS SELECT 1;
+
+query T
+SELECT name FROM mz_clusters WHERE name = 'c'
+----
+c
+
+query T
+SELECT name FROM mz_materialized_views WHERE name = 'mv'
+----
+mv
+
+statement ok
+DROP OWNED BY materialize
+
+query T
+SELECT name FROM mz_clusters WHERE name = 'c'
+----
+
+query T
+SELECT name FROM mz_materialized_views WHERE name = 'mv'
+----
+
+statement ok
+CREATE CLUSTER c REPLICAS (r1 (SIZE '1'));
+
+statement ok
+GRANT CREATE ON CLUSTER c TO joe
+
+simple conn=mz_system,user=mz_system
+GRANT CREATE ON SCHEMA public TO joe
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+CREATE MATERIALIZED VIEW mv IN CLUSTER c AS SELECT 1;
+----
+COMPLETE 0
+
+query T
+SELECT name FROM mz_clusters WHERE name = 'c'
+----
+c
+
+query T
+SELECT name FROM mz_materialized_views WHERE name = 'mv'
+----
+mv
+
+statement error cannot drop cluster "c" without CASCADE: still depended upon by non-owned catalog items "materialize.public.mv"
+DROP OWNED BY materialize
+
+query T
+SELECT name FROM mz_clusters WHERE name = 'c'
+----
+c
+
+query T
+SELECT name FROM mz_materialized_views WHERE name = 'mv'
+----
+mv
+
+statement ok
+DROP OWNED BY materialize CASCADE
+
+query T
+SELECT name FROM mz_clusters WHERE name = 'c'
+----
+
+query T
+SELECT name FROM mz_materialized_views WHERE name = 'mv'
+----
+
+simple conn=mz_system,user=mz_system
+REVOKE CREATE ON SCHEMA public FROM joe
+----
+COMPLETE 0
+
 # Test REASSIGN OWNED
 
 statement ok

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -2559,7 +2559,7 @@ COMPLETE 0
 simple conn=mz_system,user=mz_system
 DROP OWNED BY materialize;
 ----
-db error: ERROR: cannot drop cluster "c" without CASCADE while it contains active objects
+db error: ERROR: cannot drop cluster "c" without CASCADE: still depended upon by non-owned catalog items "materialize.public.mv"
 
 simple conn=mz_system,user=mz_system
 DROP OWNED BY materialize CASCADE;


### PR DESCRIPTION
Previously, when executing DROP OWNED, if the target role owned a cluster that contained bound objects then CASCADE was required, even if all bound objects were owned by the target role. This isn't correct. CASCADE should only be required if the bound objects are not owned by the target role.

This commit fixes the issue described above.

Fixes #20783

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix CASCADE semantics for clusters in `DROP OWNED`